### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Make sure you have following tools installed [golang](https://golang.org/), [dep
 $  brew install go dep protobuf kubectl
 ```
 
-Nice to have [gometaliter](https://github.com/alecthomas/gometalinter) and [goreman](https://github.com/mattn/goreman):
+Nice to have [gometalinter](https://github.com/alecthomas/gometalinter) and [goreman](https://github.com/mattn/goreman):
 
 ```
 $ go get -u gopkg.in/alecthomas/gometalinter.v2 github.com/mattn/goreman && gometalinter.v2 --install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,6 @@ Nice to have [gometalinter](https://github.com/alecthomas/gometalinter) and [gor
 $ go get -u gopkg.in/alecthomas/gometalinter.v2 github.com/mattn/goreman && gometalinter.v2 --install
 ```
 
-You'll also need [errgroup](https://godoc.org/golang.org/x/sync/errgroup) to run `make`:
-
-```
-go get -u golang.org/x/sync/errgroup
-```
-
-
 ## Building
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,13 @@ Nice to have [gometalinter](https://github.com/alecthomas/gometalinter) and [gor
 $ go get -u gopkg.in/alecthomas/gometalinter.v2 github.com/mattn/goreman && gometalinter.v2 --install
 ```
 
+You'll also need [errgroup](https://godoc.org/golang.org/x/sync/errgroup) to run `make`:
+
+```
+go get -u golang.org/x/sync/errgroup
+```
+
+
 ## Building
 
 ```

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -152,7 +152,7 @@
     "ast",
     "parser"
   ]
-  revision = "e8f6d25f61d163deee16a78b545f4aaa0f295c01"
+  revision = "405726fae23ace72b22c410a77b7bd825608f2c8"
 
 [[projects]]
   branch = "master"
@@ -246,6 +246,7 @@
   version = "1.0.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/ksonnet/ksonnet"
   packages = [
     "component",
@@ -260,8 +261,7 @@
     "prototype",
     "strings"
   ]
-  revision = "e3806408e605eff0259aaba23bdf7aa13dbc6b5c"
-  version = "v0.9.1"
+  revision = "e570bff822d88b12f1841aa6e0069713d7e066c5"
 
 [[projects]]
   name = "github.com/ksonnet/ksonnet-lib"
@@ -420,6 +420,12 @@
     "jwt"
   ]
   revision = "cce311a261e6fcf29de72ca96827bdb0b7d9c9e6"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
 
 [[projects]]
   branch = "master"
@@ -747,6 +753,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9ba583cf1108531ecfba2a463b3092be28cdfb5360d7c18854ab6b10965d5004"
+  inputs-digest = "f1502665746a2148c56270e7a28dfbd393d56047b20dcee363c9e0202f651001"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,6 @@
 required = [
   "github.com/gogo/protobuf/protoc-gen-gofast",
+  "golang.org/x/sync/errgroup",
   "k8s.io/code-generator/cmd/go-to-protobuf",
 ]
 


### PR DESCRIPTION
# Summary 

Fix a tiny typo and ensure that `errgroup` is installed.

# Problem

When trying to run `make` for the first time, the following error appears on my machine:

```$ make
CGO_ENABLED=0 go run vendor/github.com/gobuffalo/packr/packr/main.go build -v -i -ldflags '-X github.com/argoproj/argo-cd.version=0.1.0 -X github.com/argoproj/argo-cd.buildDate=2018-03-12T22:29:44Z -X github.com/argoproj/argo-cd.gitCommit=1247c2264dace02a81bf474a2a7a5eea3be9962a -X github.com/argoproj/argo-cd.gitTreeState=clean -X github.com/argoproj/argo-cd/install.imageTag=latest -extldflags "-static"' -o /Users/amerenbach/go/src/github.com/argoproj/argo-cd/dist/argocd ./cmd/argocd
vendor/github.com/gobuffalo/packr/builder/builder.go:12:2: cannot find package "golang.org/x/sync/errgroup" in any of:
	/Users/amerenbach/go/src/github.com/argoproj/argo-cd/vendor/golang.org/x/sync/errgroup (vendor tree)
	/usr/local/Cellar/go/1.10/libexec/src/golang.org/x/sync/errgroup (from $GOROOT)
	/Users/amerenbach/go/src/golang.org/x/sync/errgroup (from $GOPATH)
make: *** [cli] Error 1
```


# Solution

`errgroup` is required by https://github.com/gobuffalo/packr, which is installed with `install/install.go`.  For some reason this is not recursively installed with `dep ensure`.  Adding it to `install/install.go` had the effect of ensuring it would be installed with `dep ensure`, but then `make` errors out with an imported-but-not-used error since this then constitutes a direct import.

This looks like a simple missing library, so I've added `errgroup` to the list of prerequisites in the README.  @alexmt Please let me know if I may refactor this.