### PR TITLE
Support -f/--file flag in `argocd app add`

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ghodss/yaml"
 	"log"
 	"os"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/argoproj/argo-cd/errors"
@@ -67,7 +66,7 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 					fileContents []byte
 					err          error
 				)
-				if strings.HasPrefix(fileURL, "https://") || strings.HasPrefix(fileURL, "http://") {
+				if hasSupportedManifestURLScheme(fileURL) {
 					fileContents, err = readRemoteFile(fileURL)
 				} else {
 					fileContents, err = readLocalFile(fileURL)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -73,7 +73,6 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 				}
 				if err != nil {
 					log.Fatal(err)
-					os.Exit(1)
 				}
 				unmarshalApplication(fileContents, &app)
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"text/tabwriter"
 
@@ -64,10 +65,11 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 					fileContents []byte
 					err          error
 				)
-				if hasSupportedManifestURLScheme(fileURL) {
-					fileContents, err = readRemoteFile(fileURL)
-				} else {
+				_, err = url.ParseRequestURI(fileURL)
+				if err != nil {
 					fileContents, err = readLocalFile(fileURL)
+				} else {
+					fileContents, err = readRemoteFile(fileURL)
 				}
 				if err != nil {
 					log.Fatal(err)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -87,7 +87,7 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 				}
 				err = json.Unmarshal(fileContents, &app)
 				if err != nil {
-					log.Fatalf("Could not unmarshal Kubrnetes manifest: %s", fileURL)
+					log.Fatalf("Could not unmarshal Kubernetes manifest: %s", fileURL)
 				}
 			} else {
 				// all these params are required if we're here

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2,9 +2,7 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"github.com/ghodss/yaml"
 	"log"
 	"os"
 	"text/tabwriter"
@@ -75,20 +73,8 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 					log.Fatal(err)
 					os.Exit(1)
 				}
+				unmarshalApplication(fileContents, &app)
 
-				// first, try unmarshaling as JSON
-				// Based on technique from Kubectl, which supports both YAML and JSON:
-				//   https://mlafeldt.github.io/blog/teaching-go-programs-to-love-json-and-yaml/
-				// Short version: JSON unmarshaling won't zero out null fields; YAML unmarshaling will.
-				// This may have unintended effects or hard-to-catch issues when populating our application object.
-				fileContents, err = yaml.YAMLToJSON(fileContents)
-				if err != nil {
-					log.Fatalf("Could not decode valid JSON or YAML from Kubernetes manifest: %s", fileURL)
-				}
-				err = json.Unmarshal(fileContents, &app)
-				if err != nil {
-					log.Fatalf("Could not unmarshal Kubernetes manifest: %s", fileURL)
-				}
 			} else {
 				// all these params are required if we're here
 				if repoURL == "" || appPath == "" || appName == "" {
@@ -120,7 +106,7 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename, directory, or URL to Kubernetes manifests for the app")
+	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the app")
 	command.Flags().StringVar(&appName, "name", "", "A name for the app, ignored if a file is set")
 	command.Flags().StringVar(&repoURL, "repo", "", "Repository URL, ignored if a file is set")
 	command.Flags().StringVar(&appPath, "path", "", "Path in repository to the ksonnet app directory, ignored if a file is set")

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -55,6 +55,10 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 		Use:   "add",
 		Short: fmt.Sprintf("%s app add", cliName),
 		Run: func(c *cobra.Command, args []string) {
+			if len(args) != 0 {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
+			}
 			var app argoappv1.Application
 			if fileURL != "" {
 				fileContents := readLocalFile(fileURL)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -41,6 +41,7 @@ func NewApplicationCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 // NewApplicationAddCommand returns a new instance of an `argocd app add` command
 func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
+		fileURL       string
 		repoURL       string
 		appPath       string
 		env           string
@@ -79,6 +80,7 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename, directory, or URL to Kubernetes manifests for the app")
 	command.Flags().StringVar(&repoURL, "repo", "", "Repository URL")
 	errors.CheckError(command.MarkFlagRequired("repo"))
 	command.Flags().StringVar(&appPath, "path", "", "Path in repository to the ksonnet app directory")

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"log"
@@ -75,10 +76,15 @@ func NewApplicationAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 					log.Fatal(err)
 					os.Exit(1)
 				}
-				err = yaml.Unmarshal(fileContents, &app)
+
+				// first, try unmarshaling as JSON
+				err = json.Unmarshal(fileContents, &app)
 				if err != nil {
-					log.Fatal(err)
-					os.Exit(1)
+					// next, try unmarshaling as YAML
+					err = yaml.Unmarshal(fileContents, &app)
+					if err != nil {
+						log.Fatalf("Could not decode valid JSON or YAML from Kubernetes manifest: %s", fileURL)
+					}
 				}
 			} else {
 				// all these params are required if we're here

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -3,13 +3,31 @@ package commands
 import (
 	"io/ioutil"
 	"log"
+	"net/http"
 )
 
-// readLocalFile reads a file from disk and returns its contents as a string.
-func readLocalFile(path string) []byte {
-	data, err := ioutil.ReadFile(path)
+// readLocalFile reads a file from disk and returns its contents as a byte array.
+func readLocalFile(path string) (data []byte, err error) {
+	data, err = ioutil.ReadFile(path)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return data
+	return
+}
+
+// readRemoteFile issues a GET request to retrieve the contents of the specified URL as a byte array.
+func readRemoteFile(url string) (data []byte, err error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+		data, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	return
 }

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 )
 
 // unmarshalApplication tries to convert a YAML or JSON byte array into an Application struct.

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -20,7 +20,7 @@ func unmarshalApplication(data []byte, app *argoappv1.Application) {
 	// This may have unintended effects or hard-to-catch issues when populating our application object.
 	data, err := yaml.YAMLToJSON(data)
 	if err != nil {
-		log.Fatalf("Could not decode valid JSON or YAML from Kubernetes manifest: %s", string(data))
+		log.Fatal("Could not decode valid JSON or YAML Kubernetes manifest")
 	}
 	err = json.Unmarshal(data, &app)
 	if err != nil {
@@ -28,37 +28,22 @@ func unmarshalApplication(data []byte, app *argoappv1.Application) {
 	}
 }
 
-// isSupportedURL checks if a URL is of a supported type for loading manifests.
-func hasSupportedManifestURLScheme(url string) bool {
-	for _, scheme := range []string{"https://", "http://"} {
-		if lowercaseURL := strings.ToLower(url); strings.HasPrefix(lowercaseURL, scheme) {
-			return true
-		}
-	}
-	return false
-}
-
 // readLocalFile reads a file from disk and returns its contents as a byte array.
+// The caller is responsible for checking error return values.
 func readLocalFile(path string) (data []byte, err error) {
 	data, err = ioutil.ReadFile(path)
-	if err != nil {
-		log.Fatal(err)
-	}
 	return
 }
 
 // readRemoteFile issues a GET request to retrieve the contents of the specified URL as a byte array.
+// The caller is responsible for checking error return values.
 func readRemoteFile(url string) (data []byte, err error) {
 	resp, err := http.Get(url)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Fatal(err)
+	if err == nil {
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+		data, err = ioutil.ReadAll(resp.Body)
 	}
 	return
 }

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -20,14 +20,13 @@ func readRemoteFile(url string) (data []byte, err error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		defer func() {
-			_ = resp.Body.Close()
-		}()
-		data, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Fatal(err)
-		}
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	data, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
 	}
 	return
 }

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -31,7 +31,7 @@ func unmarshalApplication(data []byte, app *argoappv1.Application) {
 // isSupportedURL checks if a URL is of a supported type for loading manifests.
 func hasSupportedManifestURLScheme(url string) bool {
 	for _, scheme := range []string{"https://", "http://"} {
-		if lowercaseUrl := strings.ToLower(url); strings.HasPrefix(lowercaseUrl, scheme) {
+		if lowercaseURL := strings.ToLower(url); strings.HasPrefix(lowercaseURL, scheme) {
 			return true
 		}
 	}

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -6,10 +6,10 @@ import (
 )
 
 // readLocalFile reads a file from disk and returns its contents as a string.
-func readLocalFile(path string) string {
+func readLocalFile(path string) []byte {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return string(data)
+	return data
 }

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -1,11 +1,32 @@
 package commands
 
 import (
+	"encoding/json"
+	argoappv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
 )
+
+// unmarshalApplication tries to convert a YAML or JSON byte array into an Application struct.
+func unmarshalApplication(data []byte, app *argoappv1.Application) {
+	// first, try unmarshaling as JSON
+	// Based on technique from Kubectl, which supports both YAML and JSON:
+	//   https://mlafeldt.github.io/blog/teaching-go-programs-to-love-json-and-yaml/
+	//   http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/
+	// Short version: JSON unmarshaling won't zero out null fields; YAML unmarshaling will.
+	// This may have unintended effects or hard-to-catch issues when populating our application object.
+	data, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		log.Fatalf("Could not decode valid JSON or YAML from Kubernetes manifest: %s", string(data))
+	}
+	err = json.Unmarshal(data, &app)
+	if err != nil {
+		log.Fatalf("Could not unmarshal Kubernetes manifest: %s", string(data))
+	}
+}
 
 // isSupportedURL checks if a URL is of a supported type for loading manifests.
 func hasSupportedManifestURLScheme(url string) bool {

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -1,0 +1,15 @@
+package commands
+
+import (
+	"io/ioutil"
+	"log"
+)
+
+// readLocalFile reads a file from disk and returns its contents as a string.
+func readLocalFile(path string) string {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return string(data)
+}

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -4,7 +4,18 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 )
+
+// isSupportedURL checks if a URL is of a supported type for loading manifests.
+func hasSupportedManifestURLScheme(url string) bool {
+	for _, scheme := range []string{"https://", "http://"} {
+		if lowercaseUrl := strings.ToLower(url); strings.HasPrefix(lowercaseUrl, scheme) {
+			return true
+		}
+	}
+	return false
+}
 
 // readLocalFile reads a file from disk and returns its contents as a byte array.
 func readLocalFile(path string) (data []byte, err error) {

--- a/cmd/argocd/commands/util.go
+++ b/cmd/argocd/commands/util.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"encoding/json"
-	argoappv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	argoappv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/ghodss/yaml"
 )
 
 // unmarshalApplication tries to convert a YAML or JSON byte array into an Application struct.

--- a/cmd/argocd/commands/util_test.go
+++ b/cmd/argocd/commands/util_test.go
@@ -32,7 +32,7 @@ func TestReadLocalFile(t *testing.T) {
 func TestReadRemoteFile(t *testing.T) {
 	sentinel := "Hello, world!"
 
-	server := func(c chan<- string) {
+	serve := func(c chan<- string) {
 		listener, err := net.Listen("tcp", ":0")
 		if err != nil {
 			panic(err)
@@ -50,7 +50,7 @@ func TestReadRemoteFile(t *testing.T) {
 	c := make(chan string, 1)
 
 	// run a local webserver to test data retrieval
-	go server(c)
+	go serve(c)
 
 	address := <-c
 	data, err := readRemoteFile("http://" + address)

--- a/cmd/argocd/commands/util_test.go
+++ b/cmd/argocd/commands/util_test.go
@@ -9,26 +9,6 @@ import (
 	"testing"
 )
 
-func TestHasSupportedManifestURLScheme(t *testing.T) {
-	data := []struct {
-		input    string
-		expected bool
-	}{
-		{"http://www.example.com", true},
-		{"HTTP://www.EXAMPLE.com", true},
-		{"HTTPS://localhost:8443", true},
-		{"http://www.example.org", true},
-		{"ftp://www.example.com", false},
-		{"gopher://gopher.something/", false},
-		{"file:///etc/passwd", false},
-	}
-	for _, datum := range data {
-		if output := hasSupportedManifestURLScheme(datum.input); output != datum.expected {
-			t.Errorf("Invalid output for URL \"%s\"; was expecting %v and received %v", datum.input, datum.expected, output)
-		}
-	}
-}
-
 func TestReadLocalFile(t *testing.T) {
 	sentinel := "Hello, world!"
 

--- a/cmd/argocd/commands/util_test.go
+++ b/cmd/argocd/commands/util_test.go
@@ -33,14 +33,17 @@ func TestReadRemoteFile(t *testing.T) {
 	sentinel := "Hello, world!"
 
 	serve := func(c chan<- string) {
+		// listen on first available dynamic (unprivileged) port
 		listener, err := net.Listen("tcp", ":0")
 		if err != nil {
 			panic(err)
 		}
 
+		// send back the address so that it can be used
 		c <- listener.Addr().String()
 
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			// return the sentinel text at root URL
 			fmt.Fprint(w, sentinel)
 		})
 

--- a/cmd/argocd/commands/util_test.go
+++ b/cmd/argocd/commands/util_test.go
@@ -21,7 +21,7 @@ func TestReadLocalFile(t *testing.T) {
 	_ = file.Sync()
 
 	data := readLocalFile(file.Name())
-	if data != sentinel {
-		t.Errorf("Test data did not match! Expected \"%s\" and received \"%s\"", sentinel, data)
+	if string(data) != sentinel {
+		t.Errorf("Test data did not match! Expected \"%s\" and received \"%s\"", sentinel, string(data))
 	}
 }

--- a/cmd/argocd/commands/util_test.go
+++ b/cmd/argocd/commands/util_test.go
@@ -13,15 +13,15 @@ func TestReadLocalFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not write test data")
 	}
-	defer os.Remove(file.Name())
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
 
-	file.WriteString(sentinel)
-	file.Sync()
+	_, _ = file.WriteString(sentinel)
+	_ = file.Sync()
 
 	data := readLocalFile(file.Name())
 	if data != sentinel {
 		t.Errorf("Test data did not match! Expected \"%s\" and received \"%s\"", sentinel, data)
 	}
-
-	
 }

--- a/cmd/argocd/commands/util_test.go
+++ b/cmd/argocd/commands/util_test.go
@@ -9,6 +9,26 @@ import (
 	"testing"
 )
 
+func TestHasSupportedManifestURLScheme(t *testing.T) {
+	data := []struct {
+		input    string
+		expected bool
+	}{
+		{"http://www.example.com", true},
+		{"HTTP://www.EXAMPLE.com", true},
+		{"HTTPS://localhost:8443", true},
+		{"http://www.example.org", true},
+		{"ftp://www.example.com", false},
+		{"gopher://gopher.something/", false},
+		{"file:///etc/passwd", false},
+	}
+	for _, datum := range data {
+		if output := hasSupportedManifestURLScheme(datum.input); output != datum.expected {
+			t.Errorf("Invalid output for URL \"%s\"; was expecting %v and received %v", datum.input, datum.expected, output)
+		}
+	}
+}
+
 func TestReadLocalFile(t *testing.T) {
 	sentinel := "Hello, world!"
 

--- a/cmd/argocd/commands/util_test.go
+++ b/cmd/argocd/commands/util_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestReadLocalFile(t *testing.T) {
+	sentinel := "Hello, world!"
+
+	file, err := ioutil.TempFile(os.TempDir(), "")
+	if err != nil {
+		t.Errorf("Could not write test data")
+	}
+	defer os.Remove(file.Name())
+
+	file.WriteString(sentinel)
+	file.Sync()
+
+	data := readLocalFile(file.Name())
+	if data != sentinel {
+		t.Errorf("Test data did not match! Expected \"%s\" and received \"%s\"", sentinel, data)
+	}
+
+	
+}


### PR DESCRIPTION
# Summary

This adds an `-f` flag to (mostly) mirror Kubernetes' `kubectl create -f` flag, and in the process resolves #31.

# Problem

Currently a GitHub repo and a path to a manifest inside the repo are required.  It would be nice to be able to use a `-f` flag to point to a local file or URL containing a Kubernetes Application manifest that can be used directly.  The repo and path can be recovered from inside the file.

# Solution

  * Add util methods for reading remote/local files.
  * Add tests for remote/local file reading methods.
  * Add util method for unmarshaling byte data into an `argoappv1.Application` struct.
  * Update `NewApplicationAddCommand`:
    1. Don't require `path` and `repo` args at the `FlagSet` level.
    2. Accept an `-f`/`--file` flag that contains either a local path or a remote URL.
    3. If the flag points to a valid JSON or YAML file, try unmarshaling it with the aforementioned util method.
    4. Error out if this fails.

# Notes

@alexmt and any other reviewers:

  * Because the K8s manifest is assumed to contain a name in the metedata, this PR takes the liberty of removing the `APPNAME` positional parameter and replaces it with a named parameter.
  * File extensions are not checked, since it's really just the contents we're interested in.  This may or may not match `kubectl create -f` directly.
  * `kubectl create -f` also allows local directories to be specified.  Since Application manifests are small for now and not generally divided between files, directories are not currently supported.