### PR TITLE
Allow use of public repos without prior registration

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -138,7 +138,12 @@ func (ctrl *ApplicationController) tryRefreshAppStatus(app *appv1.Application) (
 	defer util.Close(conn)
 	repo, err := ctrl.apiRepoService.Get(context.Background(), &apireposerver.RepoQuery{Repo: app.Spec.Source.RepoURL})
 	if err != nil {
-		return nil, err
+		// If we couldn't retrieve from the repo service, assume public repositories
+		repo = &appv1.Repository{
+			Repo:     app.Spec.Source.RepoURL,
+			Username: "",
+			Password: "",
+		}
 	}
 	revision := app.Spec.Source.TargetRevision
 	manifestInfo, err := client.GenerateManifest(context.Background(), &repository.ManifestRequest{

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -49,7 +49,6 @@ token to perform its required management tasks (i.e. deploy/monitoring).
 2. Add the guestbook application and github repository containing the Guestbook application
 
 ```
-$ argocd repo add https://github.com/argoproj/argo-cd.git
 $ argocd app add --name guestbook --repo https://github.com/argoproj/argo-cd.git --path examples/guestbook --env minikube --dest-server https://$(minikube ip):8443
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -50,7 +50,7 @@ token to perform its required management tasks (i.e. deploy/monitoring).
 
 ```
 $ argocd repo add https://github.com/argoproj/argo-cd.git
-$ argocd app add guestbook --repo https://github.com/argoproj/argo-cd.git --path examples/guestbook --env minikube --dest-server https://$(minikube ip):8443
+$ argocd app add --name guestbook --repo https://github.com/argoproj/argo-cd.git --path examples/guestbook --env minikube --dest-server https://$(minikube ip):8443
 ```
 
 Once the application is added, you can now see its status:

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -122,10 +122,9 @@ func (s *Server) Sync(ctx context.Context, syncReq *ApplicationSyncRequest) (*Ap
 
 	repo, err := s.repoService.Get(ctx, &apirepository.RepoQuery{Repo: app.Spec.Source.RepoURL})
 	if err != nil {
-		// Handle public repos here...
-		// repo, err := ....
+		// If we couldn't retrieve from the repo service, assume public repositories
 		repo = &appv1.Repository{
-			Repo: app.Spec.Source.RepoURL,
+			Repo:     app.Spec.Source.RepoURL,
 			Username: "",
 			Password: "",
 		}

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -122,7 +122,13 @@ func (s *Server) Sync(ctx context.Context, syncReq *ApplicationSyncRequest) (*Ap
 
 	repo, err := s.repoService.Get(ctx, &apirepository.RepoQuery{Repo: app.Spec.Source.RepoURL})
 	if err != nil {
-		return nil, err
+		// Handle public repos here...
+		// repo, err := ....
+		repo = &appv1.Repository{
+			Repo: app.Spec.Source.RepoURL,
+			Username: "",
+			Password: "",
+		}
 	}
 
 	conn, repoClient, err := s.repoClientset.NewRepositoryClient()


### PR DESCRIPTION
# Background

This will close #28 by allowing public repos to be used without pre-registering them.

# Problem

The getting started guide refers to a guestbook app inside this repository, which is public.  Currently `argo-cd` doesn't support on-the-fly pulling from public repositories—advance registration `argo repo add` is required for all.

# Solution

Instead of exiting when the repo service doesn't return a repo for a query, default to a skeleton `Repository` struct—empty besides the `Repo` URL—during sync and refresh if the repository service doesn't return a `Repository` object for a given query.