### PR TITLE
Add new dependency to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@ Make sure you have following tools installed [golang](https://golang.org/), [dep
 [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 ```
-$  brew install go dep protobuf kubectl
+$ brew install go dep protobuf kubectl
+$ go get -u github.com/golang/protobuf/protoc-gen-go
 ```
 
 Nice to have [gometalinter](https://github.com/alecthomas/gometalinter) and [goreman](https://github.com/mattn/goreman):


### PR DESCRIPTION
# Problem

When running `make codegen`, which in turn invokes the equivalent of `make protogen` and then `make clientgen`, the binary `protoc-gen-go` is invoked during the `protogen` build phase—and is not installed through `brew install protobuf`.

# Solution

Rectify by adding `go get -u github.com/golang/protobuf/protoc-gen-go` to `CONTRIBUTING.md`, per the [protobuf installation steps](https://github.com/golang/protobuf#installation).