### PR TITLE
Don't overwrite application status in tryRefreshAppStatus, thanks @alexmt

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -173,9 +173,9 @@ func (ctrl *ApplicationController) tryRefreshAppStatus(app *appv1.Application) (
 		return nil, err
 	}
 	log.Infof("App %s comparison result: prev: %s. current: %s", app.Name, app.Status.ComparisonResult.Status, comparisonResult.Status)
-	return &appv1.ApplicationStatus{
-		ComparisonResult: *comparisonResult,
-	}, nil
+	newStatus := app.Status
+	newStatus.ComparisonResult = *comparisonResult
+	return &newStatus, nil
 }
 
 func (ctrl *ApplicationController) runWorker() {


### PR DESCRIPTION
The `tryRefreshAppStatus` method will overwrite the application deployment info before returning.  Fix that.