### PR TITLE
Add password hashing

### DIFF
--- a/cmd/argocd/commands/install.go
+++ b/cmd/argocd/commands/install.go
@@ -28,7 +28,7 @@ func NewInstallCommand() *cobra.Command {
 	}
 	command.Flags().BoolVar(&installOpts.Upgrade, "upgrade", false, "upgrade controller/ui deployments and configmap if already installed")
 	command.Flags().BoolVar(&installOpts.DryRun, "dry-run", false, "print the kubernetes manifests to stdout instead of installing")
-	command.Flags().BoolVar(&installOpts.CreateSuperuser, "create-superuser", false, "create or update a superuser username and password")
+	command.Flags().BoolVar(&installOpts.ConfigSuperuser, "config-superuser", false, "create or update a superuser username and password")
 	command.Flags().StringVar(&installOpts.ConfigMap, "config-map", "", "apply settings from a Kubernetes config map")
 	command.Flags().StringVar(&installOpts.Namespace, "install-namespace", install.DefaultInstallNamespace, "install into a specific namespace")
 	command.Flags().StringVar(&installOpts.ControllerImage, "controller-image", install.DefaultControllerImage, "use a specified controller image")

--- a/cmd/argocd/commands/install.go
+++ b/cmd/argocd/commands/install.go
@@ -28,6 +28,7 @@ func NewInstallCommand() *cobra.Command {
 	}
 	command.Flags().BoolVar(&installOpts.Upgrade, "upgrade", false, "upgrade controller/ui deployments and configmap if already installed")
 	command.Flags().BoolVar(&installOpts.DryRun, "dry-run", false, "print the kubernetes manifests to stdout instead of installing")
+	command.Flags().BoolVar(&installOpts.CreateSuperuser, "create-superuser", false, "create or update a superuser username and password")
 	command.Flags().StringVar(&installOpts.ConfigMap, "config-map", "", "apply settings from a Kubernetes config map")
 	command.Flags().StringVar(&installOpts.Namespace, "install-namespace", install.DefaultInstallNamespace, "install into a specific namespace")
 	command.Flags().StringVar(&installOpts.ControllerImage, "controller-image", install.DefaultControllerImage, "use a specified controller image")

--- a/install/install.go
+++ b/install/install.go
@@ -169,12 +169,14 @@ func (i *Installer) InstallArgoCDServer() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		secretName = strings.Trim(secretName, "\n")
 
 		fmt.Print("*** Please enter a superuser username: ")
-		username, err := inputReader.ReadString('\n')
+		adminUsername, err := inputReader.ReadString('\n')
 		if err != nil {
 			log.Fatal(err)
 		}
+		adminUsername = strings.Trim(adminUsername, "\n")
 
 		fmt.Print("*** Please enter a superuser password: ")
 		adminPassword, err := terminal.ReadPassword(syscall.Stdin)
@@ -192,8 +194,8 @@ func (i *Installer) InstallArgoCDServer() {
 			log.Fatal(err)
 		}
 
-		superuserCredentials := map[string]string{
-			util.ConfigManagerRootUsernameKey: username,
+		adminCredentials := map[string]string{
+			util.ConfigManagerRootUsernameKey: adminUsername,
 			util.ConfigManagerRootPasswordKey: hashedPassword,
 		}
 		secret, err := kubeclientset.CoreV1().Secrets(i.Namespace).Get(secretName, metav1.GetOptions{})
@@ -203,14 +205,14 @@ func (i *Installer) InstallArgoCDServer() {
 					Name: secretName,
 				},
 			}
-			newSecret.StringData = superuserCredentials
+			newSecret.StringData = adminCredentials
 			_, err = kubeclientset.CoreV1().Secrets(i.Namespace).Create(newSecret)
 			if err != nil {
 				log.Fatal(err)
 			}
 
 		} else {
-			secret.StringData = superuserCredentials
+			secret.StringData = adminCredentials
 			_, err := kubeclientset.CoreV1().Secrets(i.Namespace).Update(secret)
 			if err != nil {
 				log.Fatal(err)

--- a/install/install.go
+++ b/install/install.go
@@ -236,6 +236,7 @@ func (i *Installer) InstallArgoCDServer() {
 		fmt.Print("*** Please enter a superuser password: ")
 		rawPassword, err := terminal.ReadPassword(syscall.Stdin)
 		errors.CheckError(err)
+		fmt.Print("\n")
 
 		err = i.createOrUpdateLocalCredentials(rootCredentialsSecretName, rootUsername, string(rawPassword))
 		errors.CheckError(err)

--- a/install/install.go
+++ b/install/install.go
@@ -171,15 +171,15 @@ func (i *Installer) InstallArgoCDServer() {
 		}
 		secretName = strings.Trim(secretName, "\n")
 
-		// Namespace this input inside a self-executing anonymous function to ensure that the raw password isn't accidentally used elsewhere
-		rootUsername, rootHashedPassword := func() (username, hashedPassword string) {
-			fmt.Print("*** Please enter a superuser username: ")
-			username, err := inputReader.ReadString('\n')
-			if err != nil {
-				log.Fatal(err)
-			}
-			username = strings.Trim(username, "\n")
+		fmt.Print("*** Please enter a superuser username: ")
+		rootUsername, err := inputReader.ReadString('\n')
+		if err != nil {
+			log.Fatal(err)
+		}
+		rootUsername = strings.Trim(rootUsername, "\n")
 
+		// Namespace this input inside a self-executing anonymous function to ensure that the raw password isn't accidentally used elsewhere
+		rootHashedPassword := func() (hashedPassword string) {
 			fmt.Print("*** Please enter a superuser password: ")
 			rawPassword, err := terminal.ReadPassword(syscall.Stdin)
 			if err != nil {

--- a/install/install.go
+++ b/install/install.go
@@ -49,7 +49,7 @@ var (
 type InstallOptions struct {
 	DryRun          bool
 	Upgrade         bool
-	CreateSuperuser bool
+	ConfigSuperuser bool
 	ConfigMap       string
 	Namespace       string
 	ControllerImage string
@@ -161,7 +161,7 @@ func (i *Installer) InstallArgoCDServer() {
 	argoCDServerControllerDeployment.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = apiv1.PullPolicy(i.ImagePullPolicy)
 	argoCDServerControllerDeployment.Spec.Template.Spec.Containers[0].Image = i.ServerImage
 	argoCDServerControllerDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = apiv1.PullPolicy(i.ImagePullPolicy)
-	if i.InstallOptions.CreateSuperuser {
+	if i.InstallOptions.ConfigSuperuser {
 		inputReader := bufio.NewReader(os.Stdin)
 
 		fmt.Print("*** Please enter the name of a Kubernetes secret to store the user data: ")

--- a/server/server.go
+++ b/server/server.go
@@ -50,6 +50,10 @@ type ArgoCDServer struct {
 func NewServer(
 	kubeclientset kubernetes.Interface, appclientset appclientset.Interface, repoclientset reposerver.Clientset, namespace, staticAssetsDir, configMapName string) *ArgoCDServer {
 	configManager := util.NewConfigManager(kubeclientset, namespace, configMapName)
+	settings, err := configManager.GetSettings()
+	if err != nil {
+		log.Fatal(err)
+	}
 	return &ArgoCDServer{
 		ns:              namespace,
 		kubeclientset:   kubeclientset,
@@ -57,7 +61,7 @@ func NewServer(
 		repoclientset:   repoclientset,
 		log:             log.NewEntry(log.New()),
 		staticAssetsDir: staticAssetsDir,
-		settings:        configManager.GetSettings(),
+		settings:        settings,
 	}
 }
 

--- a/util/configmanager.go
+++ b/util/configmanager.go
@@ -18,6 +18,9 @@ const (
 	// rootCredentialsSecretNameKey designates the name of the config map field holding the name of a Kubernetes secret.
 	rootCredentialsSecretNameKey = "rootCredentialsSecretName"
 
+	// ConfigManagerDefaultRootCredentialsSecretName holds the default secret name for root credentials.
+	ConfigManagerDefaultRootCredentialsSecretName = "argocd-root-credentials-secret"
+
 	// ConfigManagerRootUsernameKey designates the root username inside a Kubernetes secret.
 	ConfigManagerRootUsernameKey = "root.username"
 

--- a/util/configmanager.go
+++ b/util/configmanager.go
@@ -15,8 +15,8 @@ type ArgoCDSettings struct {
 }
 
 const (
-	// rootCredentialsSecretNameKey designates the name of the config map field holding the name of a Kubernetes secret.
-	rootCredentialsSecretNameKey = "rootCredentialsSecretName"
+	// RootCredentialsSecretNameKey designates the name of the config map field holding the name of a Kubernetes secret.
+	RootCredentialsSecretNameKey = "rootCredentialsSecretName"
 
 	// ConfigManagerDefaultRootCredentialsSecretName holds the default secret name for root credentials.
 	ConfigManagerDefaultRootCredentialsSecretName = "argocd-root-credentials-secret"
@@ -43,7 +43,7 @@ func (mgr *ConfigManager) GetSettings() (settings ArgoCDSettings, err error) {
 	}
 
 	// Try to retrieve the name of a Kubernetes secret holding root credentials
-	rootCredentialsSecretName, ok := configMap.Data[rootCredentialsSecretNameKey]
+	rootCredentialsSecretName, ok := configMap.Data[RootCredentialsSecretNameKey]
 
 	if !ok {
 		return

--- a/util/password.go
+++ b/util/password.go
@@ -1,0 +1,100 @@
+package util
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// PasswordHasher is an interface type to declare a general-purpose password management tool.
+type PasswordHasher interface {
+	HashPassword(string) (string, error)
+	VerifyPassword(string, string) bool
+}
+
+// DummyPasswordHasher is for testing ONLY.  DO NOT USE in a production context.
+type DummyPasswordHasher struct{}
+
+// BcryptPasswordHasher handles password hashing with Bcrypt.  Create with `0` as the work factor to default to bcrypt.DefaultCost at hashing time.  The Cost field represents work factor.
+type BcryptPasswordHasher struct {
+	Cost int
+}
+
+var _ PasswordHasher = DummyPasswordHasher{}
+var _ PasswordHasher = BcryptPasswordHasher{0}
+
+// PreferredHashers holds the list of preferred hashing algorithms, in order of most to least preferred.  Any password that does not validate with the primary algorithm will be considered "stale."  DO NOT ADD THE DUMMY HASHER FOR USE IN PRODUCTION.
+var preferredHashers = []PasswordHasher{
+	BcryptPasswordHasher{},
+}
+
+// HashPasswordWithHashers hashes an entered password using the first hasher in the provided list of hashers.
+func hashPasswordWithHashers(password string, hashers []PasswordHasher) (string, error) {
+	return hashers[0].HashPassword(password)
+}
+
+// VerifyPasswordWithHashers verifies an entered password against a hashed password using one or more algorithms.  It returns whether the hash is "stale" (i.e., was verified using something other than the FIRST hasher specified).
+func verifyPasswordWithHashers(password, hashedPassword string, hashers []PasswordHasher) (valid, stale bool) {
+	// Be explicit here for security, even though zero values can be assumed.
+	valid = false
+	stale = false
+	for idx, hasher := range hashers {
+		if hasher.VerifyPassword(password, hashedPassword) {
+			valid = true
+			if idx > 0 {
+				stale = true
+			}
+			break
+		}
+	}
+	return
+}
+
+// HashPassword hashes against the current preferred hasher.
+func HashPassword(password string) (string, error) {
+	return hashPasswordWithHashers(password, preferredHashers)
+}
+
+// VerifyPassword verifies an entered password against a hashed password and returns whether the hash is "stale" (i.e., was verified using the FIRST preferred hasher above).
+func VerifyPassword(password, hashedPassword string) (valid, stale bool) {
+	valid, stale = verifyPasswordWithHashers(password, hashedPassword, preferredHashers)
+	return
+}
+
+// HashPassword creates a one-way digest ("hash") of a password.  In the case of Bcrypt, a pseudorandom salt is included automatically by the underlying library.
+func (h DummyPasswordHasher) HashPassword(password string) (string, error) {
+	return password, nil
+}
+
+// VerifyPassword validates whether a one-way digest ("hash") of a password was created from a given plaintext password.
+func (h DummyPasswordHasher) VerifyPassword(password, hashedPassword string) bool {
+	return password == hashedPassword
+}
+
+// HashPassword creates a one-way digest ("hash") of a password.  In the case of Bcrypt, a pseudorandom salt is included automatically by the underlying library.  For security reasons, the work factor is always at _least_ bcrypt.DefaultCost.
+func (h BcryptPasswordHasher) HashPassword(password string) (string, error) {
+	cost := h.Cost
+	if cost < bcrypt.DefaultCost {
+		cost = bcrypt.DefaultCost
+	}
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), cost)
+	if err != nil {
+		hashedPassword = []byte("")
+	}
+	return string(hashedPassword), err
+}
+
+// VerifyPassword validates whether a one-way digest ("hash") of a password was created from a given plaintext password.
+func (h BcryptPasswordHasher) VerifyPassword(password, hashedPassword string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
+	return err == nil
+}
+
+func main() {
+	testEnteredPassword := "hello, world"
+	testHashedPassword := "hello, worldx"
+	x, _ := HashPassword(testHashedPassword)
+	fmt.Println(x)
+	y, stale := VerifyPassword(testEnteredPassword, testHashedPassword)
+	fmt.Println("y and stale = ", y, stale)
+}

--- a/util/password.go
+++ b/util/password.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -88,13 +86,4 @@ func (h BcryptPasswordHasher) HashPassword(password string) (string, error) {
 func (h BcryptPasswordHasher) VerifyPassword(password, hashedPassword string) bool {
 	err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
 	return err == nil
-}
-
-func main() {
-	testEnteredPassword := "hello, world"
-	testHashedPassword := "hello, worldx"
-	x, _ := HashPassword(testHashedPassword)
-	fmt.Println(x)
-	y, stale := VerifyPassword(testEnteredPassword, testHashedPassword)
-	fmt.Println("y and stale = ", y, stale)
 }

--- a/util/password_test.go
+++ b/util/password_test.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"testing"
+)
+
+func testPasswordHasher(t *testing.T, h PasswordHasher) {
+	// Use the default work factor
+	const (
+		defaultPassword = "Hello, world!"
+		pollution       = "extradata12345"
+	)
+	hashedPassword, _ := h.HashPassword(defaultPassword)
+	if !h.VerifyPassword(defaultPassword, hashedPassword) {
+		t.Errorf("Password \"%s\" should have validated against hash \"%s\"", defaultPassword, hashedPassword)
+	}
+	if h.VerifyPassword(defaultPassword, pollution+hashedPassword) {
+		t.Errorf("Password \"%s\" should NOT have validated against hash \"%s\"", defaultPassword, pollution+hashedPassword)
+	}
+}
+
+func TestBcryptPasswordHasher(t *testing.T) {
+	// Use the default work factor
+	h := BcryptPasswordHasher{0}
+	testPasswordHasher(t, h)
+}
+
+func TestDummyPasswordHasher(t *testing.T) {
+	h := DummyPasswordHasher{}
+	testPasswordHasher(t, h)
+}
+
+func TestPasswordHashing(t *testing.T) {
+	const (
+		defaultPassword = "Hello, world!"
+	)
+	hashers := []PasswordHasher{
+		BcryptPasswordHasher{0},
+		DummyPasswordHasher{},
+	}
+
+	hashedPassword, _ := hashPasswordWithHashers(defaultPassword, hashers)
+	valid, stale := verifyPasswordWithHashers(defaultPassword, hashedPassword, hashers)
+	if !valid {
+		t.Errorf("Password \"%s\" should have validated against hash \"%s\"", defaultPassword, hashedPassword)
+	}
+	valid, stale = verifyPasswordWithHashers(defaultPassword, defaultPassword, hashers)
+	if !valid {
+		t.Errorf("Password \"%s\" should have validated against itself with dummy hasher", defaultPassword)
+	}
+	if !stale {
+		t.Errorf("Password \"%s\" should have been acknowledged stale against itself with dummy hasher", defaultPassword)
+	}
+
+}

--- a/util/password_test.go
+++ b/util/password_test.go
@@ -44,6 +44,9 @@ func TestPasswordHashing(t *testing.T) {
 	if !valid {
 		t.Errorf("Password \"%s\" should have validated against hash \"%s\"", defaultPassword, hashedPassword)
 	}
+	if stale {
+		t.Errorf("Password \"%s\" should not have been marked stale against hash \"%s\"", defaultPassword, hashedPassword)
+	}
 	valid, stale = verifyPasswordWithHashers(defaultPassword, defaultPassword, hashers)
 	if !valid {
 		t.Errorf("Password \"%s\" should have validated against itself with dummy hasher", defaultPassword)


### PR DESCRIPTION
To help us continue #29, allow specification of an admin username and password, as well as a namespace to store the secret, and hash passwords.  These are now stored in running memory in a `ArgoCDSettings.LocalUsers`, which gives us flexibility to add more users later.

In the process, add a password hasher very loosely inspired by the state of Django's password hashing several years ago, with a prioritized list of preferred hashing algorithms (only one, Bcrypt, is currently implemented, based on an [implementation from Argo](https://github.com/argoproj/argo/blob/1.1/saas/axops/src/applatix.io/axops/user/utils.go#L19).

@alexmt this queries for the secret name when running `argocd install`.  I realize that with `./argocd install --config-map <config map name> --config-superuser`, we will have the secret name in the config map specified, but if we don't have the config map name, we won't—is it worth seeing if we can skip the namespace input when the config map is specified, but including it when a config map is omitted?

@alexmt One other thing: it seems that `argocd-server` might start up with the `default` namespace if a namespace is not specified.  Should it default to `argocd`, or is that namespace for the command-line tools?