### PR TITLE
TLS support. HTTP/HTTPS/gRPC all serving on single port

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 controller: go run ./cmd/argocd-application-controller/main.go --app-resync 10
-api-server: go run ./cmd/argocd-server/main.go
+api-server: go run ./cmd/argocd-server/main.go --insecure
 repo-server: go run ./cmd/argocd-repo-server/main.go

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -30,7 +30,8 @@ func NewCommand() *cobra.Command {
 	command.AddCommand(NewUninstallCommand())
 
 	command.PersistentFlags().StringVar(&clientOpts.ServerAddr, "server", "", "ArgoCD server address")
-	command.PersistentFlags().BoolVar(&clientOpts.Insecure, "insecure", true, "Disable transport security for the client connection")
+	command.PersistentFlags().BoolVar(&clientOpts.Insecure, "insecure", false, "Disable transport security for the client connection, including host verification")
+	command.PersistentFlags().StringVar(&clientOpts.CertFile, "server-crt", "", "Server certificate file")
 
 	return command
 }

--- a/util/grpc/grpc.go
+++ b/util/grpc/grpc.go
@@ -1,12 +1,15 @@
 package grpc
 
 import (
+	"net"
 	"runtime/debug"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 )
 
 // PanicLoggerUnaryServerInterceptor returns a new unary server interceptor for recovering from panics and returning error
@@ -32,5 +35,74 @@ func PanicLoggerStreamServerInterceptor(log *logrus.Entry) grpc.StreamServerInte
 			}
 		}()
 		return handler(srv, stream)
+	}
+}
+
+// BlockingDial is a helper method to dial the given address, using optional TLS credentials,
+// and blocking until the returned connection is ready. If the given credentials are nil, the
+// connection will be insecure (plain-text).
+// Lifted from: https://github.com/fullstorydev/grpcurl/blob/master/grpcurl.go
+func BlockingDial(ctx context.Context, network, address string, creds credentials.TransportCredentials, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	// grpc.Dial doesn't provide any information on permanent connection errors (like
+	// TLS handshake failures). So in order to provide good error messages, we need a
+	// custom dialer that can provide that info. That means we manage the TLS handshake.
+	result := make(chan interface{}, 1)
+
+	writeResult := func(res interface{}) {
+		// non-blocking write: we only need the first result
+		select {
+		case result <- res:
+		default:
+		}
+	}
+
+	dialer := func(address string, timeout time.Duration) (net.Conn, error) {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		conn, err := (&net.Dialer{Cancel: ctx.Done()}).Dial(network, address)
+		if err != nil {
+			writeResult(err)
+			return nil, err
+		}
+		if creds != nil {
+			conn, _, err = creds.ClientHandshake(ctx, address, conn)
+			if err != nil {
+				writeResult(err)
+				return nil, err
+			}
+		}
+		return conn, nil
+	}
+
+	// Even with grpc.FailOnNonTempDialError, this call will usually timeout in
+	// the face of TLS handshake errors. So we can't rely on grpc.WithBlock() to
+	// know when we're done. So we run it in a goroutine and then use result
+	// channel to either get the channel or fail-fast.
+	go func() {
+		opts = append(opts,
+			grpc.WithBlock(),
+			grpc.FailOnNonTempDialError(true),
+			grpc.WithDialer(dialer),
+			grpc.WithInsecure(), // we are handling TLS, so tell grpc not to
+		)
+		conn, err := grpc.DialContext(ctx, address, opts...)
+		var res interface{}
+		if err != nil {
+			res = err
+		} else {
+			res = conn
+		}
+		writeResult(res)
+	}()
+
+	select {
+	case res := <-result:
+		if conn, ok := res.(*grpc.ClientConn); ok {
+			return conn, nil
+		}
+		return nil, res.(error)
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -1,0 +1,182 @@
+package tls
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultRSABits = 2048
+)
+
+type CertOptions struct {
+	// Comma-separated hostnames and IPs to generate a certificate for
+	Host string
+	// Name of organization in certificate
+	Organization string
+	// Creation date
+	ValidFrom time.Time
+	// Duration that certificate is valid for
+	ValidFor time.Duration
+	// whether this cert should be its own Certificate Authority
+	IsCA bool
+	// Size of RSA key to generate. Ignored if --ecdsa-curve is set
+	RSABits int
+	// ECDSA curve to use to generate a key. Valid values are P224, P256 (recommended), P384, P521
+	ECDSACurve string
+}
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}
+
+func pemBlockForKey(priv interface{}) *pem.Block {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to marshal ECDSA private key: %v", err)
+			os.Exit(2)
+		}
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	default:
+		return nil
+	}
+}
+
+func generate(opts CertOptions) ([]byte, crypto.PrivateKey, error) {
+	if opts.Host == "" {
+		return nil, nil, fmt.Errorf("host not supplied")
+	}
+
+	var privateKey crypto.PrivateKey
+	var err error
+	switch opts.ECDSACurve {
+	case "":
+		rsaBits := DefaultRSABits
+		if opts.RSABits != 0 {
+			rsaBits = opts.RSABits
+		}
+		privateKey, err = rsa.GenerateKey(rand.Reader, rsaBits)
+	case "P224":
+		privateKey, err = ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	case "P256":
+		privateKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case "P384":
+		privateKey, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case "P521":
+		privateKey, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	default:
+		return nil, nil, fmt.Errorf("Unrecognized elliptic curve: %q", opts.ECDSACurve)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %s", err)
+	}
+
+	var notBefore time.Time
+	if opts.ValidFrom.IsZero() {
+		notBefore = time.Now()
+	} else {
+		notBefore = opts.ValidFrom
+	}
+	var validFor time.Duration
+	if opts.ValidFor == 0 {
+		validFor = 365 * 24 * time.Hour
+	}
+	notAfter := notBefore.Add(validFor)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %s", err)
+	}
+
+	if opts.Organization == "" {
+		return nil, nil, fmt.Errorf("organization not supplied")
+	}
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{opts.Organization},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(opts.Host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	if opts.IsCA {
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(privateKey), privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create certificate: %s", err)
+	}
+	return certBytes, privateKey, nil
+}
+
+// generatePEM generates a new certificate and key and returns it as PEM encoded bytes
+func generatePEM(opts CertOptions) ([]byte, []byte, error) {
+	certBytes, privateKey, err := generate(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	certpem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	keypem := pem.EncodeToMemory(pemBlockForKey(privateKey))
+	return certpem, keypem, nil
+}
+
+// GenerateX509KeyPair generates a X509 key pair
+func GenerateX509KeyPair(opts CertOptions) (*tls.Certificate, error) {
+	certpem, keypem, err := generatePEM(opts)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := tls.X509KeyPair(certpem, keypem)
+	if err != nil {
+		return nil, err
+	}
+	return &cert, nil
+}
+
+// EncodeX509KeyPair encodes a TLS Certificate into its pem encoded for storage
+func EncodeX509KeyPair(cert tls.Certificate) ([]byte, []byte) {
+	certpem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+	keypem := pem.EncodeToMemory(pemBlockForKey(cert.PrivateKey))
+	return certpem, keypem
+}


### PR DESCRIPTION
This generates a self-signed certificate during install and stores it in the argocd-secret. The server will run with HTTP/HTTPS/gRPC all serving on port 8080.

TODO:
* The HTTP handler should do a 302 redirect to HTTPS
* copy the cert to the users home .argocd directory so that argocd CLI can use it