### PR TITLE
Convert Kubernetes errors to gRPC errors

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -150,11 +150,13 @@ func (a *ArgoCDServer) newGRPCServer() *grpc.Server {
 	sOpts = append(sOpts, grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 		grpc_logrus.StreamServerInterceptor(a.log),
 		grpc_auth.StreamServerInterceptor(a.authenticate),
+		grpc_util.ErrorCodeStreamServerInterceptor(),
 		grpc_util.PanicLoggerStreamServerInterceptor(a.log),
 	)))
 	sOpts = append(sOpts, grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 		grpc_logrus.UnaryServerInterceptor(a.log),
 		grpc_auth.UnaryServerInterceptor(a.authenticate),
+		grpc_util.ErrorCodeUnaryServerInterceptor(),
 		grpc_util.PanicLoggerUnaryServerInterceptor(a.log),
 	)))
 

--- a/util/grpc/errors.go
+++ b/util/grpc/errors.go
@@ -1,0 +1,75 @@
+package grpc
+
+import (
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func kubeErrToGRPC(err error) error {
+	/*
+		Unmapped source Kubernetes API errors as of 2018-04-16:
+		* IsConflict => 409
+		* IsGone => 410
+		* IsResourceExpired => 410
+		* IsServerTimeout => 500
+		* IsTooManyRequests => 429
+		* IsUnexpectedServerError => should probably be a panic
+		* IsUnexpectedObjectError => should probably be a panic
+
+		Unmapped target gRPC codes as of 2018-04-16:
+		* Canceled Code = 1
+		* Unknown Code = 2
+		* ResourceExhausted Code = 8
+		* Aborted Code = 10
+		* OutOfRange Code = 11
+		* DataLoss Code = 15
+	*/
+
+	rewrapError := func(err error, code codes.Code) error {
+		return status.Errorf(code, err.Error())
+	}
+
+	switch {
+	case apierr.IsNotFound(err):
+		err = rewrapError(err, codes.NotFound)
+	case apierr.IsAlreadyExists(err):
+		err = rewrapError(err, codes.AlreadyExists)
+	case apierr.IsInvalid(err):
+		err = rewrapError(err, codes.InvalidArgument)
+	case apierr.IsMethodNotSupported(err):
+		err = rewrapError(err, codes.Unimplemented)
+	case apierr.IsServiceUnavailable(err):
+		err = rewrapError(err, codes.Unavailable)
+	case apierr.IsBadRequest(err):
+		err = rewrapError(err, codes.FailedPrecondition)
+	case apierr.IsUnauthorized(err):
+		err = rewrapError(err, codes.Unauthenticated)
+	case apierr.IsForbidden(err):
+		err = rewrapError(err, codes.PermissionDenied)
+	case apierr.IsTimeout(err):
+		err = rewrapError(err, codes.DeadlineExceeded)
+	case apierr.IsInternalError(err):
+		err = rewrapError(err, codes.Internal)
+
+	}
+	return err
+}
+
+// ErrorCodeUnaryServerInterceptor replaces Kubernetes errors with relevant gRPC equivalents, if any.
+func ErrorCodeUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		resp, err = handler(ctx, req)
+		return resp, kubeErrToGRPC(err)
+	}
+}
+
+// ErrorCodeStreamServerInterceptor replaces Kubernetes errors with relevant gRPC equivalents, if any.
+func ErrorCodeStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		err := handler(srv, ss)
+		return kubeErrToGRPC(err)
+	}
+}

--- a/util/grpc/grpc.go
+++ b/util/grpc/grpc.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 )
 
 // PanicLoggerUnaryServerInterceptor returns a new unary server interceptor for recovering from panics and returning error
@@ -18,7 +19,7 @@ func PanicLoggerUnaryServerInterceptor(log *logrus.Entry) grpc.UnaryServerInterc
 		defer func() {
 			if r := recover(); r != nil {
 				log.Errorf("Recovered from panic: %+v\n%s", r, debug.Stack())
-				err = grpc.Errorf(codes.Internal, "%s", r)
+				err = status.Errorf(codes.Internal, "%s", r)
 			}
 		}()
 		return handler(ctx, req)
@@ -31,7 +32,7 @@ func PanicLoggerStreamServerInterceptor(log *logrus.Entry) grpc.StreamServerInte
 		defer func() {
 			if r := recover(); r != nil {
 				log.Errorf("Recovered from panic: %+v\n%s", r, debug.Stack())
-				err = grpc.Errorf(codes.Internal, "%s", r)
+				err = status.Errorf(codes.Internal, "%s", r)
 			}
 		}()
 		return handler(srv, stream)


### PR DESCRIPTION
This resolves #30 by adding interceptors to convert error codes from Kubernetes errors (the identities of which may be tested using functions) into numeric codes for more appropriate gRPC responses.