### PR TITLE
Support manual token use for CLI commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -776,6 +776,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "04546dfcb4a6b5756f85134841cba8a155e5dbdc5036f870b3d963f27c97059c"
+  inputs-digest = "aa54676131ffb95f3083378fb031dcb29d714d82994b250c813cbd56022cfced"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -33,6 +33,7 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&clientOpts.ServerAddr, "server", "", "ArgoCD server address")
 	command.PersistentFlags().BoolVar(&clientOpts.Insecure, "insecure", false, "Disable transport security for the client connection, including host verification")
 	command.PersistentFlags().StringVar(&clientOpts.CertFile, "server-crt", "", "Server certificate file")
+	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", "", "Authentication token")
 
 	return command
 }

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -91,8 +91,7 @@ func (c jwtCredentials) GetRequestMetadata(context.Context, ...string) (map[stri
 // firstEndpointTokenFrom iterates through given endpoint names and returns the first non-blank token, if any, that it finds.
 // This function will always return a manually-specified auth token, if it is provided on the command-line.
 func (c *client) firstEndpointTokenFrom(endpoints ...string) string {
-	token := c.ClientOptions.AuthToken
-	if token != "" {
+	if token := c.ClientOptions.AuthToken; token != "" {
 		return token
 	}
 


### PR DESCRIPTION
This revises how tokens are provided by the CLI to the backend:

  * Rewrite token retrieval to be more functionalist and flexible, only wrapping in a credential object upon retrieval.
  * Short-circuit if the `--auth-token` flag (new in this PR) is provided to the CLI.
  * Update dependencies.

This resolves #88.