### PR TITLE
Set session cookies, errors appropriately

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	jsonutil "github.com/argoproj/argo-cd/util/json"
 	util_session "github.com/argoproj/argo-cd/util/session"
 	tlsutil "github.com/argoproj/argo-cd/util/tls"
+	golang_proto "github.com/golang/protobuf/proto"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
@@ -39,7 +40,8 @@ import (
 )
 
 const (
-	port = 8080
+	port           = 8080
+	authCookieName = "argocd.argoproj.io/auth-token"
 )
 
 var (
@@ -174,6 +176,27 @@ func (a *ArgoCDServer) newGRPCServer() *grpc.Server {
 	return grpcS
 }
 
+// MakeCookieMetadata generates a string representing a Web cookie.  Yum!
+func makeCookieMetadata(key, value string, flags ...string) string {
+	components := []string{
+		fmt.Sprintf("%s=%s", key, value),
+		"Secure",
+		"HttpOnly",
+	}
+	components = append(components, flags...)
+	return strings.Join(components, "; ")
+}
+
+// TranslateGrpcCookieHeader conditionally sets a cookie on the response.
+func translateGrpcCookieHeader(ctx context.Context, w http.ResponseWriter, resp golang_proto.Message) error {
+	if sessionResp, ok := resp.(*session.SessionResponse); ok {
+		cookie := makeCookieMetadata(authCookieName, sessionResp.Token, "path=/")
+		w.Header().Set("Set-Cookie", cookie)
+		sessionResp.Token = ""
+	}
+	return nil
+}
+
 // newHTTPServer returns the HTTP server to serve HTTP/HTTPS requests. This is implemented
 // using grpc-gateway as a proxy to the gRPC server.
 func (a *ArgoCDServer) newHTTPServer(ctx context.Context) *http.Server {
@@ -210,7 +233,8 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context) *http.Server {
 	// time.Time, but does not support custom UnmarshalJSON() and MarshalJSON() methods. Therefore
 	// we use our own Marshaler
 	gwMuxOpts := runtime.WithMarshalerOption(runtime.MIMEWildcard, new(jsonutil.JSONMarshaler))
-	gwmux := runtime.NewServeMux(gwMuxOpts)
+	gwCookieOpts := runtime.WithForwardResponseOption(translateGrpcCookieHeader)
+	gwmux := runtime.NewServeMux(gwMuxOpts, gwCookieOpts)
 	mux.Handle("/api/", gwmux)
 	mustRegisterGWHandler(version.RegisterVersionServiceHandlerFromEndpoint, ctx, gwmux, endpoint, dOpts)
 	mustRegisterGWHandler(cluster.RegisterClusterServiceHandlerFromEndpoint, ctx, gwmux, endpoint, dOpts)


### PR DESCRIPTION
1. Use proper `Set-Cookie` response header when returning cookies to HTTP clients.

2. Fix 500 errors on invalid login (was my newbie error in returning non-gRPC errors from session service on invalid login).  Now returning gRPC errors as needed.

3. Don't do anything with gRPC headers.  Simply intercept all session service requests and set a cookie based on the token from any successful response, which is going to be either a login (`Create`) or logout (`Delete`).

~4. Security improvement: Don't return token as text in response if client is HTTP: the HTTP client never gets to see the token now, except in the cookie (which, being `HttpOnly`, cannot be accessed by JavaScript).~

5. Set `Secure` flag on cookie only when `--insecure` is `false`.