### PR TITLE
Expand Git repo URL normalization

### DIFF
--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -146,7 +146,7 @@ func repoURLToSecretName(repo string) string {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(repo))
 	parts := strings.Split(strings.TrimSuffix(repo, ".git"), "/")
-	return fmt.Sprintf("repo-%s-%v", strings.ToLower(parts[len(parts)-1]), h.Sum32())
+	return fmt.Sprintf("repo-%s-%v", parts[len(parts)-1], h.Sum32())
 }
 
 // repoToStringData converts a repository object to string data for serialization to a secret

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -142,7 +142,7 @@ func (s *Server) Delete(ctx context.Context, q *RepoQuery) (*RepoResponse, error
 // repoURLToSecretName hashes repo URL to the secret name using a formula.
 // Part of the original repo name is incorporated for debugging purposes
 func repoURLToSecretName(repo string) string {
-	repo = git.NormalizeGitURL(repo)
+	repo = strings.ToLower(git.NormalizeGitURL(repo))
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(repo))
 	parts := strings.Split(strings.TrimSuffix(repo, ".git"), "/")

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -7,6 +7,7 @@ func TestRepoURLToSecretName(t *testing.T) {
 		"git://git@github.com:argoproj/ARGO-cd.git": "repo-argo-cd-593837413",
 		"https://github.com/argoproj/ARGO-cd":       "repo-argo-cd-821842295",
 		"https://github.com/argoproj/argo-cd":       "repo-argo-cd-821842295",
+		"https://github.com/argoproj/argo-cd.git":   "repo-argo-cd-821842295",
 		"ssh://git@github.com/argoproj/argo-cd.git": "repo-argo-cd-1019298066",
 	}
 

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestRepoURLToSecretName(t *testing.T) {
 	tables := map[string]string{
-		"git://git@github.com:argoproj/ARGO-cd.git": "repo-argo-cd-83273445",
-		"https://github.com/argoproj/ARGO-cd":       "repo-argo-cd-1890113693",
-		"https://github.com/argoproj/argo-cd":       "repo-argo-cd-42374749",
-		"ssh://git@github.com/argoproj/argo-cd.git": "repo-argo-cd-3569564120",
+		"git://git@github.com:argoproj/ARGO-cd.git": "repo-argo-cd-593837413",
+		"https://github.com/argoproj/ARGO-cd":       "repo-argo-cd-821842295",
+		"https://github.com/argoproj/argo-cd":       "repo-argo-cd-821842295",
+		"ssh://git@github.com/argoproj/argo-cd.git": "repo-argo-cd-1019298066",
 	}
 
 	for k, v := range tables {

--- a/util/git/git.go
+++ b/util/git/git.go
@@ -21,7 +21,7 @@ func NormalizeGitURL(repo string) string {
 
 // IsSshURL returns true is supplied URL is SSH URL
 func IsSshURL(url string) bool {
-	return strings.Index(url, "git@") == 0
+	return strings.HasPrefix(url, "git@")
 }
 
 // GetGitCommandOptions returns URL and env options for git operation

--- a/util/git/git.go
+++ b/util/git/git.go
@@ -46,7 +46,7 @@ func NormalizeGitURL(repo string) string {
 	return strings.TrimPrefix(normalized, "ssh://")
 }
 
-// IsSshURL returns true is supplied URL is SSH URL
+// IsSshURL returns true if supplied URL is SSH URL
 func IsSshURL(url string) bool {
 	return strings.HasPrefix(url, "git@") || strings.HasPrefix(url, "ssh://")
 }

--- a/util/git/git.go
+++ b/util/git/git.go
@@ -21,6 +21,7 @@ func NormalizeGitURL(repo string) string {
 
 // IsSshURL returns true is supplied URL is SSH URL
 func IsSshURL(url string) bool {
+	// TODO: should probably support ssh:// scheme too, since that's a valid SSH URL
 	return strings.HasPrefix(url, "git@")
 }
 

--- a/util/git/git.go
+++ b/util/git/git.go
@@ -10,6 +10,14 @@ import (
 	"strings"
 )
 
+// EnsureSuffix idempotently ensures that a base string has a given suffix.
+func ensureSuffix(s, suffix string) string {
+	if !strings.HasSuffix(s, suffix) {
+		s += suffix
+	}
+	return s
+}
+
 // NormalizeGitURL normalizes a git URL for lookup and storage
 func NormalizeGitURL(repo string) string {
 	repoURL, err := url.Parse(repo)

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -9,7 +9,9 @@ import (
 func TestIsSSHUrl(t *testing.T) {
 	data := map[string]bool{
 		"git@GITHUB.com:argoproj/test.git":     true,
+		"git@github.com:test.git":              true,
 		"https://github.com/argoproj/test.git": false,
+		"git://github.com/argoproj/test.git":   false,
 	}
 	for k, v := range data {
 		assert.Equal(t, IsSshURL(k), v)

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -43,12 +43,15 @@ func TestEnsureSuffix(t *testing.T) {
 
 func TestIsSSHUrl(t *testing.T) {
 	data := map[string]bool{
+		"git://github.com/argoproj/test.git":     false,
 		"git@GITHUB.com:argoproj/test.git":       true,
+		"git@github.com:test":                    true,
 		"git@github.com:test.git":                true,
+		"https://github.com/argoproj/test":       false,
+		"https://github.com/argoproj/test.git":   false,
+		"ssh://git@GITHUB.com:argoproj/test":     true,
 		"ssh://git@GITHUB.com:argoproj/test.git": true,
 		"ssh://git@github.com:test.git":          true,
-		"https://github.com/argoproj/test.git":   false,
-		"git://github.com/argoproj/test.git":     false,
 	}
 	for k, v := range data {
 		assert.Equal(t, v, IsSshURL(k))
@@ -57,11 +60,18 @@ func TestIsSSHUrl(t *testing.T) {
 
 func TestNormalizeUrl(t *testing.T) {
 	data := map[string]string{
-		"git@GITHUB.com:test.git":                "git@github.com:test.git",
-		"https://github.com/TEST.git":            "https://github.com/TEST.git",
+		"git@GITHUB.com:argoproj/test":           "git@github.com:argoproj/test.git",
 		"git@GITHUB.com:argoproj/test.git":       "git@github.com:argoproj/test.git",
-		"ssh://git@GITHUB.com:argoproj/test.git": "git@github.com:argoproj/test.git",
+		"git@GITHUB.com:test":                    "git@github.com:test.git",
+		"git@GITHUB.com:test.git":                "git@github.com:test.git",
+		"https://GITHUB.com/argoproj/test":       "https://github.com/argoproj/test.git",
 		"https://GITHUB.com/argoproj/test.git":   "https://github.com/argoproj/test.git",
+		"https://github.com/TEST":                "https://github.com/TEST.git",
+		"https://github.com/TEST.git":            "https://github.com/TEST.git",
+		"ssh://git@GITHUB.com:argoproj/test":     "git@github.com:argoproj/test.git",
+		"ssh://git@GITHUB.com:argoproj/test.git": "git@github.com:argoproj/test.git",
+		"ssh://git@GITHUB.com:test.git":          "git@github.com:test.git",
+		"ssh://git@github.com:test":              "git@github.com:test.git",
 	}
 	for k, v := range data {
 		assert.Equal(t, v, NormalizeGitURL(k))

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -6,14 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReturnsTrueForSSHUrl(t *testing.T) {
-	assert.True(t, IsSshURL("git@github.com:test.git"))
-}
-
-func TestReturnsFalseForNonSSHUrl(t *testing.T) {
-	assert.False(t, IsSshURL("https://github.com/test.git"))
+func TestIsSSHUrl(t *testing.T) {
+	data := map[string]bool{
+		"git@GITHUB.com:argoproj/test.git":     true,
+		"https://github.com/argoproj/test.git": false,
+	}
+	for k, v := range data {
+		assert.Equal(t, IsSshURL(k), v)
+	}
 }
 
 func TestNormalizeUrl(t *testing.T) {
-	assert.Equal(t, NormalizeGitURL("git@GITHUB.com:test.git"), "git@github.com:test.git")
+	data := map[string]string{
+		"git@GITHUB.com:test.git": "git@github.com:test.git",
+	}
+	for k, v := range data {
+		assert.Equal(t, NormalizeGitURL(k), v)
+	}
 }

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -19,27 +19,33 @@ func TestEnsureSuffix(t *testing.T) {
 	}
 	for _, table := range data {
 		result := ensureSuffix(table[0], table[1])
-		assert.Equal(t, result, table[2])
+		assert.Equal(t, table[2], result)
 	}
 }
 
 func TestIsSSHUrl(t *testing.T) {
 	data := map[string]bool{
-		"git@GITHUB.com:argoproj/test.git":     true,
-		"git@github.com:test.git":              true,
-		"https://github.com/argoproj/test.git": false,
-		"git://github.com/argoproj/test.git":   false,
+		"git@GITHUB.com:argoproj/test.git":       true,
+		"git@github.com:test.git":                true,
+		"ssh://git@GITHUB.com:argoproj/test.git": true,
+		"ssh://git@github.com:test.git":          true,
+		"https://github.com/argoproj/test.git":   false,
+		"git://github.com/argoproj/test.git":     false,
 	}
 	for k, v := range data {
-		assert.Equal(t, IsSshURL(k), v)
+		assert.Equal(t, v, IsSshURL(k))
 	}
 }
 
 func TestNormalizeUrl(t *testing.T) {
 	data := map[string]string{
-		"git@GITHUB.com:test.git": "git@github.com:test.git",
+		"git@GITHUB.com:test.git":                "git@github.com:test.git",
+		"https://github.com/TEST.git":            "https://github.com/TEST.git",
+		"git@GITHUB.com:argoproj/test.git":       "git@github.com:argoproj/test.git",
+		"ssh://git@GITHUB.com:argoproj/test.git": "git@github.com:argoproj/test.git",
+		"https://GITHUB.com/argoproj/test.git":   "https://github.com/argoproj/test.git",
 	}
 	for k, v := range data {
-		assert.Equal(t, NormalizeGitURL(k), v)
+		assert.Equal(t, v, NormalizeGitURL(k))
 	}
 }

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -6,6 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEnsureSuffix(t *testing.T) {
+	data := [][]string{
+		{"hello", "world", "helloworld"},
+		{"helloworld", "world", "helloworld"},
+		{"repo", ".git", "repo.git"},
+		{"repo.git", ".git", "repo.git"},
+		{"", "repo.git", "repo.git"},
+		{"argo", "cd", "argocd"},
+		{"argocd", "cd", "argocd"},
+		{"argocd", "", "argocd"},
+	}
+	for _, table := range data {
+		result := ensureSuffix(table[0], table[1])
+		assert.Equal(t, result, table[2])
+	}
+}
+
 func TestIsSSHUrl(t *testing.T) {
 	data := map[string]bool{
 		"git@GITHUB.com:argoproj/test.git":     true,

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -6,6 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEnsurePrefix(t *testing.T) {
+	data := [][]string{
+		{"world", "hello", "helloworld"},
+		{"helloworld", "hello", "helloworld"},
+		{"example.com", "https://", "https://example.com"},
+		{"https://example.com", "https://", "https://example.com"},
+		{"cd", "argo", "argocd"},
+		{"argocd", "argo", "argocd"},
+		{"", "argocd", "argocd"},
+		{"argocd", "", "argocd"},
+	}
+	for _, table := range data {
+		result := ensurePrefix(table[0], table[1])
+		assert.Equal(t, table[2], result)
+	}
+}
+
 func TestEnsureSuffix(t *testing.T) {
 	data := [][]string{
 		{"hello", "world", "helloworld"},
@@ -16,6 +33,7 @@ func TestEnsureSuffix(t *testing.T) {
 		{"argo", "cd", "argocd"},
 		{"argocd", "cd", "argocd"},
 		{"argocd", "", "argocd"},
+		{"", "argocd", "argocd"},
 	}
 	for _, table := range data {
 		result := ensureSuffix(table[0], table[1])


### PR DESCRIPTION
To resolve #138:

1. Lowercase repo URLs before they are hashed for purposes of secret creation.  **This will break all existing repos that have ANY uppercase characters, thanks to hashing differences.**
2. Ensure that all added repos have a `.git` suffix during normalization.  **This will break all existing repos that were added without a `.git` suffix, thanks to hashing differences.**
3. Consider repo URLs to be SSH repos if they start with `git@` (existing behavior) **or** if they begin with `ssh://` (new behavior).  **All SSH prefixes will be stripped at the end of the normalization process.**
4. Normalization will now return an **empty string** if the URL does not parse.  Since rootless GitHub URLs won't parse as-is, an SSH scheme is added to these, then stripped at the end.
5. Refactor and add additional tests for Git- and Git-repo-related functionality in the `util/git` module.