### PR TITLE
Introduce caching layer to repo server to improve query response times

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -102,6 +102,31 @@
   revision = "84f4bee7c0a6db40e3166044c7983c1c32125429"
 
 [[projects]]
+  name = "github.com/go-redis/cache"
+  packages = [
+    ".",
+    "internal/lrucache",
+    "internal/singleflight"
+  ]
+  revision = "c58ada1e23a3b66593f81c70572c20a0bb805a90"
+  version = "v6.3.5"
+
+[[projects]]
+  name = "github.com/go-redis/redis"
+  packages = [
+    ".",
+    "internal",
+    "internal/consistenthash",
+    "internal/hashtag",
+    "internal/pool",
+    "internal/proto",
+    "internal/singleflight",
+    "internal/util"
+  ]
+  revision = "877867d2845fbaf86798befe410b6ceb6f5c29a3"
+  version = "v6.10.2"
+
+[[projects]]
   name = "github.com/gobuffalo/packr"
   packages = ["."]
   revision = "6434a292ac52e6964adebfdce3f9ce6d9f16be01"
@@ -317,6 +342,12 @@
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
+  name = "github.com/patrickmn/go-cache"
+  packages = ["."]
+  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
+  version = "v2.1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
@@ -401,6 +432,15 @@
   ]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
+
+[[projects]]
+  name = "github.com/vmihailenco/msgpack"
+  packages = [
+    ".",
+    "codes"
+  ]
+  revision = "a053f3dac71df214bfe8b367f34220f0029c9c02"
+  version = "v3.3.1"
 
 [[projects]]
   name = "github.com/yudai/gojsondiff"
@@ -505,6 +545,7 @@
   name = "google.golang.org/appengine"
   packages = [
     ".",
+    "datastore",
     "internal",
     "internal/app_identity",
     "internal/base",
@@ -809,6 +850,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ef728e9142c17bf99d3472c5d4ad97e0fd4a991f757c6f4f8d6950625882f767"
+  inputs-digest = "fe567a52d46df8bc00753d90df816ad4a102d0752427b3f1a46020f581ecdde9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
-controller: go run ./cmd/argocd-application-controller/main.go
+controller: go run ./cmd/argocd-application-controller/main.go --app-resync 10
 api-server: go run ./cmd/argocd-server/main.go --insecure --disable-auth
-repo-server: go run ./cmd/argocd-repo-server/main.go
+repo-server: go run ./cmd/argocd-repo-server/main.go --loglevel debug
 dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p 5556:5556 -p 5557:5557 -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/coreos/dex:v2.10.0 serve /dex.yaml"
+redis: docker run --rm -p 6379:6379 redis:3.2.11

--- a/install/manifests/05a_argocd-repo-server-deployment.yaml
+++ b/install/manifests/05a_argocd-repo-server-deployment.yaml
@@ -13,8 +13,12 @@ spec:
         app: argocd-repo-server
     spec:
       containers:
-      - command: [/argocd-repo-server]
+      - name: argocd-repo-server
         image: argoproj/argocd-repo-server:latest
-        name: argocd-repo-server
+        command: [/argocd-repo-server]
         ports:
           - containerPort: 8081
+      - name: redis
+        image: redis:3.2.11
+        ports:
+          - containerPort: 6379

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -3,6 +3,7 @@ package reposerver
 import (
 	"github.com/argoproj/argo-cd/reposerver/repository"
 	"github.com/argoproj/argo-cd/server/version"
+	"github.com/argoproj/argo-cd/util/cache"
 	"github.com/argoproj/argo-cd/util/git"
 	grpc_util "github.com/argoproj/argo-cd/util/grpc"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
@@ -16,13 +17,15 @@ import (
 type ArgoCDRepoServer struct {
 	log        *log.Entry
 	gitFactory git.ClientFactory
+	cache      cache.Cache
 }
 
 // NewServer returns a new instance of the ArgoCD Repo server
-func NewServer(gitFactory git.ClientFactory) *ArgoCDRepoServer {
+func NewServer(gitFactory git.ClientFactory, cache cache.Cache) *ArgoCDRepoServer {
 	return &ArgoCDRepoServer{
 		log:        log.NewEntry(log.New()),
 		gitFactory: gitFactory,
+		cache:      cache,
 	}
 }
 
@@ -39,7 +42,7 @@ func (a *ArgoCDRepoServer) CreateGRPC() *grpc.Server {
 		)),
 	)
 	version.RegisterVersionServiceServer(server, &version.Server{})
-	manifestService := repository.NewService(a.gitFactory)
+	manifestService := repository.NewService(a.gitFactory, a.cache)
 	repository.RegisterRepositoryServiceServer(server, manifestService)
 
 	// Register reflection service on gRPC server.

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -1,0 +1,20 @@
+package cache
+
+import (
+	"errors"
+	"time"
+)
+
+var ErrCacheMiss = errors.New("cache: key is missing")
+
+type Item struct {
+	Key    string
+	Object interface{}
+	// Expiration is the cache expiration time.
+	Expiration time.Duration
+}
+
+type Cache interface {
+	Set(item *Item) error
+	Get(key string, obj interface{}) error
+}

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -1,0 +1,34 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	Foo string
+	Bar []byte
+}
+
+func TestCache(t *testing.T) {
+	c := NewInMemoryCache(time.Hour)
+	var obj testStruct
+	err := c.Get("key", &obj)
+	assert.Equal(t, err, ErrCacheMiss)
+	cacheObj := testStruct{
+		Foo: "foo",
+		Bar: []byte("bar"),
+	}
+	c.Set(&Item{
+		Key:    "key",
+		Object: &cacheObj,
+	})
+	cacheObj.Foo = "baz"
+	err = c.Get("key", &obj)
+	assert.Nil(t, err)
+	assert.EqualValues(t, string(obj.Foo), "foo")
+	assert.EqualValues(t, string(obj.Bar), "bar")
+
+}

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"bytes"
+	"encoding/gob"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+func NewInMemoryCache(expiration time.Duration) Cache {
+	return &inMemoryCache{
+		memCache: gocache.New(expiration, 1*time.Minute),
+	}
+}
+
+type inMemoryCache struct {
+	memCache *gocache.Cache
+}
+
+func (i *inMemoryCache) Set(item *Item) error {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(item.Object)
+	if err != nil {
+		return err
+	}
+	i.memCache.Set(item.Key, buf, item.Expiration)
+	return nil
+}
+
+func (i *inMemoryCache) Get(key string, obj interface{}) error {
+	bufIf, found := i.memCache.Get(key)
+	if !found {
+		return ErrCacheMiss
+	}
+	buf := bufIf.(bytes.Buffer)
+	return gob.NewDecoder(&buf).Decode(obj)
+}

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"time"
+
+	rediscache "github.com/go-redis/cache"
+	"github.com/go-redis/redis"
+	"github.com/vmihailenco/msgpack"
+)
+
+func NewRedisCache(client *redis.Client, expiration time.Duration) Cache {
+	return &redisCache{
+		expiration: expiration,
+		codec: &rediscache.Codec{
+			Redis: client,
+			Marshal: func(v interface{}) ([]byte, error) {
+				return msgpack.Marshal(v)
+			},
+			Unmarshal: func(b []byte, v interface{}) error {
+				return msgpack.Unmarshal(b, v)
+			},
+		},
+	}
+}
+
+type redisCache struct {
+	expiration time.Duration
+	codec      *rediscache.Codec
+}
+
+func (r *redisCache) Set(item *Item) error {
+	expiration := item.Expiration
+	if expiration == 0 {
+		expiration = r.expiration
+	}
+	return r.codec.Set(&rediscache.Item{
+		Key:        item.Key,
+		Object:     item.Object,
+		Expiration: expiration,
+	})
+}
+
+func (r *redisCache) Get(key string, obj interface{}) error {
+	err := r.codec.Get(key, obj)
+	if err == rediscache.ErrCacheMiss {
+		return ErrCacheMiss
+	}
+	return nil
+}


### PR DESCRIPTION
Resolves issue #143. 

This change adds a caching interface with two implementations: redis and in-memory. Both can be used interchangeably. The repo server will first look at the remote heads to resolve the commit SHA for a branch/tag using `git ls-remote`. It then checks the cache for any cached result incorporating the commitSHA, path, and environment as the key. 

During testing, this improves the response times for the guestbook app from ~1500ms to 350ms. For larger ksonnet apps where `ks show` takes a long time, it will be much better.