### PR TITLE
Trim spaces server-side in GitHub usernames

### DIFF
--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -64,6 +64,7 @@ func (s *Server) Create(ctx context.Context, r *appsv1.Repository) (*appsv1.Repo
 	shallowCopy := *r
 	r = &shallowCopy
 	r.Repo = git.NormalizeGitURL(r.Repo)
+	r.Username = strings.TrimSpace(r.Username)
 	err := git.TestRepo(r.Repo, r.Username, r.Password, r.SSHPrivateKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Close #161 

Trim spaces serverside in repo usernames in case of issues with the client's validation.