### PR TITLE
Add connect timeouts when interacting with SSH git repos (resolves #131)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -122,7 +122,7 @@ func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 // NewApplicationGetCommand returns a new instance of an `argocd app get` command
 func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "get",
+		Use:   "get APPNAME",
 		Short: "Get application details",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {
@@ -171,7 +171,7 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 		appOpts appOptions
 	)
 	var command = &cobra.Command{
-		Use:   "set",
+		Use:   "set APPNAME",
 		Short: "Set application parameters",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) != 1 {
@@ -241,7 +241,7 @@ func addAppFlags(command *cobra.Command, opts *appOptions) {
 // NewApplicationDiffCommand returns a new instance of an `argocd app diff` command
 func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "diff",
+		Use:   "diff APPNAME",
 		Short: "Perform a diff against the target and live state",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {
@@ -283,7 +283,7 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 		force bool
 	)
 	var command = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete APPNAME",
 		Short: "Delete an application",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {
@@ -347,7 +347,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		dryRun   bool
 	)
 	var command = &cobra.Command{
-		Use:   "sync",
+		Use:   "sync APPNAME",
 		Short: "Sync an application to its target state",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) != 1 {
@@ -442,7 +442,7 @@ func setParameterOverrides(app *argoappv1.Application, parameters []string) {
 // NewApplicationHistoryCommand returns a new instance of an `argocd app history` command
 func NewApplicationHistoryCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "history",
+		Use:   "history APPNAME",
 		Short: "Show application deployment history",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) != 1 {
@@ -483,7 +483,7 @@ func NewApplicationRollbackCommand(clientOpts *argocdclient.ClientOptions) *cobr
 		prune bool
 	)
 	var command = &cobra.Command{
-		Use:   "rollback",
+		Use:   "rollback APPNAME",
 		Short: "Rollback application to a previous deployed version",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) != 2 {

--- a/cmd/argocd/commands/repo.go
+++ b/cmd/argocd/commands/repo.go
@@ -42,7 +42,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 		sshPrivateKeyPath string
 	)
 	var command = &cobra.Command{
-		Use:   "add",
+		Use:   "add REPO",
 		Short: "Add git repository credentials",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) != 1 {
@@ -59,7 +59,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			}
 			err := git.TestRepo(repo.Repo, repo.Username, repo.Password, repo.SSHPrivateKey)
 			if err != nil {
-				if repo.Username != "" && repo.Password != "" || git.IsSshURL(repo.Repo) {
+				if repo.Username != "" && repo.Password != "" || git.IsSSHURL(repo.Repo) {
 					// if everything was supplied or repo URL is SSH url, one of the inputs was definitely bad
 					log.Fatal(err)
 				}
@@ -84,7 +84,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 // NewRepoRemoveCommand returns a new instance of an `argocd repo list` command
 func NewRepoRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "rm",
+		Use:   "rm REPO",
 		Short: "Remove git repository credentials",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -1,9 +1,8 @@
 package repository
 
 import (
-	"github.com/argoproj/argo-cd/util/db"
-
 	appsv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/util/db"
 	"golang.org/x/net/context"
 )
 

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -112,15 +112,18 @@ func (m *nativeGitClient) setCredentials() error {
 			return err
 		}
 	}
-	if m.sshPrivateKey != "" {
-		log.Debug("Setting SSH credentials")
-		sshPrivateKeyFile := path.Join(".git", "ssh-private-key")
-		err := ioutil.WriteFile(sshPrivateKeyFile, []byte(m.sshPrivateKey), 0600)
-		if err != nil {
-			return fmt.Errorf("failed to set git credentials: %v", err)
+	if IsSSHURL(m.repoURL) {
+		sshCmd := gitSSHCommand
+		if m.sshPrivateKey != "" {
+			log.Debug("Setting SSH credentials")
+			sshPrivateKeyFile := path.Join(".git", "ssh-private-key")
+			err := ioutil.WriteFile(sshPrivateKeyFile, []byte(m.sshPrivateKey), 0600)
+			if err != nil {
+				return fmt.Errorf("failed to set git credentials: %v", err)
+			}
+			sshCmd += sshCmd + " -i " + sshPrivateKeyFile
 		}
-		sshCmd := fmt.Sprintf("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %s", sshPrivateKeyFile)
-		_, err = m.runCmd("git", "config", "--local", "core.sshCommand", sshCmd)
+		_, err := m.runCmd("git", "config", "--local", "core.sshCommand", sshCmd)
 		if err != nil {
 			return err
 		}

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -41,7 +41,7 @@ func TestEnsureSuffix(t *testing.T) {
 	}
 }
 
-func TestIsSSHUrl(t *testing.T) {
+func TestIsSSHURL(t *testing.T) {
 	data := map[string]bool{
 		"git://github.com/argoproj/test.git":     false,
 		"git@GITHUB.com:argoproj/test.git":       true,
@@ -54,7 +54,7 @@ func TestIsSSHUrl(t *testing.T) {
 		"ssh://git@github.com:test.git":          true,
 	}
 	for k, v := range data {
-		assert.Equal(t, v, IsSshURL(k))
+		assert.Equal(t, v, IsSSHURL(k))
 	}
 }
 


### PR DESCRIPTION
This resolves #131.
When we interact with git SSH repos, we currently don't add a ConnectTimeout. This results in git commands lasting indefinitely. This manifested itself in #131 as a terse `FATA[0060] rpc error: code = Unavailable desc = transport is closing` error. It was always 60 seconds because the client was likely hitting the connection on the ELB.