### PR TITLE
Support subscribing to settings updates and auto-restart of dex and API server (resolves #174)

### DIFF
--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -53,10 +53,13 @@ func NewCommand() *cobra.Command {
 				DisableAuth:     disableAuth,
 			}
 			argocd := server.NewServer(argoCDOpts)
-			ctx := context.Background()
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			argocd.Run(ctx, 8080)
+
+			for {
+				ctx := context.Background()
+				ctx, cancel := context.WithCancel(ctx)
+				argocd.Run(ctx, 8080)
+				cancel()
+			}
 		},
 	}
 


### PR DESCRIPTION
This resolves issue #174.
In this change, a kubernetes watch is established against the argocd-cm and argocd-secret. If any changes to the config or secret warrant a restart, argocd-util will restart dex, and API server will shutdown and restart its gRPC and HTTP listeners.