### PR TITLE
Add repo browsing endpoint

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -41,18 +41,6 @@ func NewService(gitFactory git.ClientFactory, cache cache.Cache) *Service {
 	}
 }
 
-type GitFileEntry struct {
-	Name        string `json:"name"`
-	Path        string `json:"path"`
-	SHA         string `json:"sha"`
-	Size        uint64 `json:"size"`
-	URL         string `json:"url"`
-	HtmlURL     string `json:"html_url"`
-	GitURL      string `json:"git_url"`
-	DownloadURL string `json:"download_url"`
-	Type        string `json:"type"`
-}
-
 // ListDir lists the contents of a GitHub repo
 func (s *Service) ListDir(ctx context.Context, q *ListDirRequest) (*ListDirResponse, error) {
 	appRepoPath := tempRepoPath(q.Repo.Repo)

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -41,6 +41,13 @@ func NewService(gitFactory git.ClientFactory, cache cache.Cache) *Service {
 	}
 }
 
+// ListDir lists the contents of a GitHub repo
+func (s *Service) ListDir(ctx context.Context, q *ListDirRequest) (*ListDirResponse, error) {
+	return &ListDirResponse{
+		[]string{"Hello", "world!"},
+	}, nil
+}
+
 func (s *Service) GetFile(ctx context.Context, q *GetFileRequest) (*GetFileResponse, error) {
 	appRepoPath := tempRepoPath(q.Repo.Repo)
 	s.repoLock.Lock(appRepoPath)

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -83,6 +83,9 @@ func (s *Service) ListDir(ctx context.Context, q *ListDirRequest) (*ListDirRespo
 		Object:     &res,
 		Expiration: DefaultRepoCacheExpiration,
 	})
+	if err != nil {
+		return nil, err
+	}
 	return &res, nil
 }
 

--- a/reposerver/repository/repository.pb.go
+++ b/reposerver/repository/repository.pb.go
@@ -10,6 +10,8 @@
 	It has these top-level messages:
 		ManifestRequest
 		ManifestResponse
+		ListDirRequest
+		ListDirResponse
 		GetFileRequest
 		GetFileResponse
 */
@@ -144,6 +146,56 @@ func (m *ManifestResponse) GetParams() []*github_com_argoproj_argo_cd_pkg_apis_a
 	return nil
 }
 
+// ListDirRequest requests a repository directory structure
+type ListDirRequest struct {
+	Repo     *github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository `protobuf:"bytes,1,opt,name=repo" json:"repo,omitempty"`
+	Revision string                                                                `protobuf:"bytes,2,opt,name=revision,proto3" json:"revision,omitempty"`
+	Path     string                                                                `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
+}
+
+func (m *ListDirRequest) Reset()                    { *m = ListDirRequest{} }
+func (m *ListDirRequest) String() string            { return proto.CompactTextString(m) }
+func (*ListDirRequest) ProtoMessage()               {}
+func (*ListDirRequest) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{2} }
+
+func (m *ListDirRequest) GetRepo() *github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository {
+	if m != nil {
+		return m.Repo
+	}
+	return nil
+}
+
+func (m *ListDirRequest) GetRevision() string {
+	if m != nil {
+		return m.Revision
+	}
+	return ""
+}
+
+func (m *ListDirRequest) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+// ListDirResponse returns the contents of the repo of a ListDir request
+type ListDirResponse struct {
+	Data []string `protobuf:"bytes,1,rep,name=data" json:"data,omitempty"`
+}
+
+func (m *ListDirResponse) Reset()                    { *m = ListDirResponse{} }
+func (m *ListDirResponse) String() string            { return proto.CompactTextString(m) }
+func (*ListDirResponse) ProtoMessage()               {}
+func (*ListDirResponse) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{3} }
+
+func (m *ListDirResponse) GetData() []string {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
 // GetFileRequest return
 type GetFileRequest struct {
 	Repo     *github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository `protobuf:"bytes,1,opt,name=repo" json:"repo,omitempty"`
@@ -154,7 +206,7 @@ type GetFileRequest struct {
 func (m *GetFileRequest) Reset()                    { *m = GetFileRequest{} }
 func (m *GetFileRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetFileRequest) ProtoMessage()               {}
-func (*GetFileRequest) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{2} }
+func (*GetFileRequest) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{4} }
 
 func (m *GetFileRequest) GetRepo() *github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository {
 	if m != nil {
@@ -185,7 +237,7 @@ type GetFileResponse struct {
 func (m *GetFileResponse) Reset()                    { *m = GetFileResponse{} }
 func (m *GetFileResponse) String() string            { return proto.CompactTextString(m) }
 func (*GetFileResponse) ProtoMessage()               {}
-func (*GetFileResponse) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{3} }
+func (*GetFileResponse) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{5} }
 
 func (m *GetFileResponse) GetData() []byte {
 	if m != nil {
@@ -197,6 +249,8 @@ func (m *GetFileResponse) GetData() []byte {
 func init() {
 	proto.RegisterType((*ManifestRequest)(nil), "repository.ManifestRequest")
 	proto.RegisterType((*ManifestResponse)(nil), "repository.ManifestResponse")
+	proto.RegisterType((*ListDirRequest)(nil), "repository.ListDirRequest")
+	proto.RegisterType((*ListDirResponse)(nil), "repository.ListDirResponse")
 	proto.RegisterType((*GetFileRequest)(nil), "repository.GetFileRequest")
 	proto.RegisterType((*GetFileResponse)(nil), "repository.GetFileResponse")
 }
@@ -214,6 +268,8 @@ const _ = grpc.SupportPackageIsVersion4
 type RepositoryServiceClient interface {
 	// Generate manifest for application in specified repo name and revision
 	GenerateManifest(ctx context.Context, in *ManifestRequest, opts ...grpc.CallOption) (*ManifestResponse, error)
+	// ListDir returns the file contents at the specified repo and path
+	ListDir(ctx context.Context, in *ListDirRequest, opts ...grpc.CallOption) (*ListDirResponse, error)
 	// GetFile returns the file contents at the specified repo and path
 	GetFile(ctx context.Context, in *GetFileRequest, opts ...grpc.CallOption) (*GetFileResponse, error)
 }
@@ -235,6 +291,15 @@ func (c *repositoryServiceClient) GenerateManifest(ctx context.Context, in *Mani
 	return out, nil
 }
 
+func (c *repositoryServiceClient) ListDir(ctx context.Context, in *ListDirRequest, opts ...grpc.CallOption) (*ListDirResponse, error) {
+	out := new(ListDirResponse)
+	err := grpc.Invoke(ctx, "/repository.RepositoryService/ListDir", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *repositoryServiceClient) GetFile(ctx context.Context, in *GetFileRequest, opts ...grpc.CallOption) (*GetFileResponse, error) {
 	out := new(GetFileResponse)
 	err := grpc.Invoke(ctx, "/repository.RepositoryService/GetFile", in, out, c.cc, opts...)
@@ -249,6 +314,8 @@ func (c *repositoryServiceClient) GetFile(ctx context.Context, in *GetFileReques
 type RepositoryServiceServer interface {
 	// Generate manifest for application in specified repo name and revision
 	GenerateManifest(context.Context, *ManifestRequest) (*ManifestResponse, error)
+	// ListDir returns the file contents at the specified repo and path
+	ListDir(context.Context, *ListDirRequest) (*ListDirResponse, error)
 	// GetFile returns the file contents at the specified repo and path
 	GetFile(context.Context, *GetFileRequest) (*GetFileResponse, error)
 }
@@ -271,6 +338,24 @@ func _RepositoryService_GenerateManifest_Handler(srv interface{}, ctx context.Co
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RepositoryServiceServer).GenerateManifest(ctx, req.(*ManifestRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RepositoryService_ListDir_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListDirRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RepositoryServiceServer).ListDir(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/repository.RepositoryService/ListDir",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RepositoryServiceServer).ListDir(ctx, req.(*ListDirRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -300,6 +385,10 @@ var _RepositoryService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GenerateManifest",
 			Handler:    _RepositoryService_GenerateManifest_Handler,
+		},
+		{
+			MethodName: "ListDir",
+			Handler:    _RepositoryService_ListDir_Handler,
 		},
 		{
 			MethodName: "GetFile",
@@ -437,6 +526,79 @@ func (m *ManifestResponse) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *ListDirRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListDirRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Repo != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(m.Repo.Size()))
+		n2, err := m.Repo.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if len(m.Revision) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Revision)))
+		i += copy(dAtA[i:], m.Revision)
+	}
+	if len(m.Path) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Path)))
+		i += copy(dAtA[i:], m.Path)
+	}
+	return i, nil
+}
+
+func (m *ListDirResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListDirResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Data) > 0 {
+		for _, s := range m.Data {
+			dAtA[i] = 0xa
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	return i, nil
+}
+
 func (m *GetFileRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -456,11 +618,11 @@ func (m *GetFileRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintRepository(dAtA, i, uint64(m.Repo.Size()))
-		n2, err := m.Repo.MarshalTo(dAtA[i:])
+		n3, err := m.Repo.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i += n3
 	}
 	if len(m.Revision) > 0 {
 		dAtA[i] = 0x12
@@ -566,6 +728,36 @@ func (m *ManifestResponse) Size() (n int) {
 	if len(m.Params) > 0 {
 		for _, e := range m.Params {
 			l = e.Size()
+			n += 1 + l + sovRepository(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *ListDirRequest) Size() (n int) {
+	var l int
+	_ = l
+	if m.Repo != nil {
+		l = m.Repo.Size()
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	l = len(m.Revision)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	l = len(m.Path)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	return n
+}
+
+func (m *ListDirResponse) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Data) > 0 {
+		for _, s := range m.Data {
+			l = len(s)
 			n += 1 + l + sovRepository(uint64(l))
 		}
 	}
@@ -1040,6 +1232,226 @@ func (m *ManifestResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *ListDirRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRepository
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListDirRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListDirRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Repo", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Repo == nil {
+				m.Repo = &github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository{}
+			}
+			if err := m.Repo.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Revision", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Revision = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Path", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Path = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRepository(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRepository
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListDirResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRepository
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListDirResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListDirResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Data = append(m.Data, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRepository(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRepository
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *GetFileRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1370,38 +1782,40 @@ var (
 func init() { proto.RegisterFile("reposerver/repository/repository.proto", fileDescriptorRepository) }
 
 var fileDescriptorRepository = []byte{
-	// 518 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x54, 0xdd, 0x8a, 0x13, 0x31,
-	0x18, 0x35, 0xbb, 0xdd, 0x6a, 0x53, 0x71, 0xd7, 0x20, 0x32, 0x4c, 0x4b, 0x29, 0x03, 0x4a, 0x6f,
-	0x4c, 0x68, 0xbd, 0xf1, 0x4e, 0xf0, 0x6f, 0x11, 0x5c, 0x56, 0xc6, 0x2b, 0xbd, 0x91, 0x74, 0xfa,
-	0x39, 0x8d, 0xed, 0x24, 0x31, 0xc9, 0x0e, 0xf8, 0x14, 0x3e, 0x80, 0x6f, 0xe0, 0x93, 0x78, 0xe9,
-	0x23, 0x48, 0xef, 0x04, 0x1f, 0x42, 0x26, 0x4d, 0x3b, 0xb3, 0xbb, 0x65, 0x6f, 0x44, 0xf0, 0xee,
-	0xe4, 0x7c, 0x99, 0x73, 0xbe, 0x39, 0x49, 0x3e, 0x7c, 0xdf, 0x80, 0x56, 0x16, 0x4c, 0x09, 0x86,
-	0x79, 0x28, 0x9c, 0x32, 0x9f, 0x1b, 0x90, 0x6a, 0xa3, 0x9c, 0x22, 0xb8, 0x66, 0xe2, 0x3b, 0xb9,
-	0xca, 0x95, 0xa7, 0x59, 0x85, 0xd6, 0x3b, 0xe2, 0x7e, 0xae, 0x54, 0xbe, 0x04, 0xc6, 0xb5, 0x60,
-	0x5c, 0x4a, 0xe5, 0xb8, 0x13, 0x4a, 0xda, 0x50, 0x4d, 0x16, 0x8f, 0x2c, 0x15, 0xca, 0x57, 0x33,
-	0x65, 0x80, 0x95, 0x63, 0x96, 0x83, 0x04, 0xc3, 0x1d, 0xcc, 0xc2, 0x9e, 0x97, 0xb9, 0x70, 0xf3,
-	0xb3, 0x29, 0xcd, 0x54, 0xc1, 0xb8, 0xf1, 0x16, 0x1f, 0x3d, 0x78, 0x90, 0xcd, 0x98, 0x5e, 0xe4,
-	0xd5, 0xc7, 0x96, 0x71, 0xad, 0x97, 0x22, 0xf3, 0xe2, 0xac, 0x1c, 0xf3, 0xa5, 0x9e, 0xf3, 0x4b,
-	0x52, 0xc9, 0xef, 0x3d, 0x7c, 0x78, 0xc2, 0xa5, 0xf8, 0x00, 0xd6, 0xa5, 0xf0, 0xe9, 0x0c, 0xac,
-	0x23, 0x6f, 0x71, 0xab, 0xfa, 0x89, 0x08, 0x0d, 0xd1, 0xa8, 0x3b, 0x79, 0x4e, 0x6b, 0x37, 0xba,
-	0x71, 0xf3, 0xe0, 0x7d, 0x36, 0xa3, 0x7a, 0x91, 0xd3, 0xca, 0x8d, 0x36, 0xdc, 0xe8, 0xc6, 0x8d,
-	0xa6, 0xdb, 0x2c, 0x52, 0x2f, 0x49, 0x62, 0x7c, 0xc3, 0x40, 0x29, 0xac, 0x50, 0x32, 0xda, 0x1b,
-	0xa2, 0x51, 0x27, 0xdd, 0xae, 0x09, 0xc1, 0x2d, 0xcd, 0xdd, 0x3c, 0xda, 0xf7, 0xbc, 0xc7, 0x64,
-	0x88, 0xbb, 0x20, 0x4b, 0x61, 0x94, 0x2c, 0x40, 0xba, 0xa8, 0xe5, 0x4b, 0x4d, 0xaa, 0x52, 0xe4,
-	0x5a, 0xbf, 0xe2, 0x53, 0x58, 0x46, 0x07, 0x6b, 0xc5, 0xcd, 0x9a, 0x7c, 0x41, 0xb8, 0x97, 0xa9,
-	0x42, 0x2b, 0x09, 0xd2, 0xbd, 0xe6, 0x86, 0x17, 0xe0, 0xc0, 0x9c, 0x96, 0x60, 0x8c, 0x98, 0x81,
-	0x8d, 0xda, 0xc3, 0xfd, 0x51, 0x77, 0x72, 0xf2, 0x17, 0x3f, 0xf8, 0xf4, 0x92, 0x7a, 0x7a, 0x95,
-	0x63, 0xf2, 0x0b, 0xe1, 0xa3, 0x3a, 0x6e, 0xab, 0x95, 0xb4, 0x40, 0xfa, 0xb8, 0x53, 0x04, 0xce,
-	0x46, 0x68, 0xb8, 0x3f, 0xea, 0xa4, 0x35, 0x51, 0x55, 0x25, 0x2f, 0xc0, 0x6a, 0x9e, 0x41, 0xc8,
-	0xac, 0x26, 0xc8, 0x5d, 0xdc, 0x5e, 0x5f, 0xca, 0x10, 0x5b, 0x58, 0x9d, 0x0b, 0xba, 0x75, 0x21,
-	0x68, 0xc0, 0x6d, 0x5d, 0xb5, 0x66, 0xa3, 0x83, 0x7f, 0x11, 0x40, 0x10, 0x4f, 0xbe, 0x22, 0x7c,
-	0xeb, 0x18, 0xdc, 0x0b, 0xb1, 0x84, 0xff, 0xef, 0x66, 0x25, 0xf7, 0xf0, 0xe1, 0xb6, 0xb9, 0x70,
-	0x0e, 0x04, 0xb7, 0x66, 0xdc, 0x71, 0xdf, 0xdd, 0xcd, 0xd4, 0xe3, 0xc9, 0x37, 0x84, 0x6f, 0xd7,
-	0x5e, 0x6f, 0xc0, 0x94, 0x22, 0x03, 0x72, 0x8a, 0x8f, 0x8e, 0xc3, 0x43, 0xda, 0x9c, 0x26, 0xe9,
-	0xd1, 0xc6, 0x2c, 0xb8, 0xf0, 0xa4, 0xe2, 0xfe, 0xee, 0xe2, 0xda, 0x38, 0xb9, 0x46, 0x9e, 0xe1,
-	0xeb, 0xa1, 0x1b, 0x12, 0x37, 0xb7, 0x9e, 0xcf, 0x2f, 0xee, 0xed, 0xac, 0x6d, 0x54, 0x9e, 0x3c,
-	0xfe, 0xbe, 0x1a, 0xa0, 0x1f, 0xab, 0x01, 0xfa, 0xb9, 0x1a, 0xa0, 0x77, 0xe3, 0xab, 0xa6, 0xc4,
-	0xce, 0x69, 0x36, 0x6d, 0xfb, 0xa1, 0xf0, 0xf0, 0x4f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x37, 0x1e,
-	0x65, 0x64, 0xed, 0x04, 0x00, 0x00,
+	// 548 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x54, 0x4d, 0x8b, 0x13, 0x31,
+	0x18, 0xde, 0xec, 0x76, 0xab, 0x9b, 0x8a, 0xbb, 0x06, 0x91, 0x61, 0x5a, 0x4a, 0x19, 0x50, 0x7a,
+	0x31, 0x43, 0xeb, 0xc5, 0x9b, 0xa0, 0xab, 0x8b, 0xb0, 0xcb, 0xca, 0x78, 0xd2, 0x8b, 0xa4, 0xd3,
+	0xd7, 0x69, 0x6c, 0x27, 0x89, 0x49, 0x76, 0xc0, 0x5f, 0xe1, 0x0f, 0xf0, 0x0f, 0x79, 0xf4, 0x27,
+	0x48, 0x6f, 0x82, 0x07, 0x7f, 0x82, 0x4c, 0x9a, 0x76, 0xa6, 0x1f, 0xec, 0x45, 0x84, 0xbd, 0xbd,
+	0xf3, 0xbc, 0x99, 0xe7, 0xc9, 0xf3, 0xe4, 0xe5, 0xc5, 0x8f, 0x34, 0x28, 0x69, 0x40, 0x17, 0xa0,
+	0x63, 0x57, 0x72, 0x2b, 0xf5, 0x97, 0x5a, 0x49, 0x95, 0x96, 0x56, 0x12, 0x5c, 0x21, 0xe1, 0xfd,
+	0x4c, 0x66, 0xd2, 0xc1, 0x71, 0x59, 0x2d, 0x4e, 0x84, 0x9d, 0x4c, 0xca, 0x6c, 0x06, 0x31, 0x53,
+	0x3c, 0x66, 0x42, 0x48, 0xcb, 0x2c, 0x97, 0xc2, 0xf8, 0x6e, 0x34, 0x7d, 0x6a, 0x28, 0x97, 0xae,
+	0x9b, 0x4a, 0x0d, 0x71, 0x31, 0x88, 0x33, 0x10, 0xa0, 0x99, 0x85, 0xb1, 0x3f, 0xf3, 0x3a, 0xe3,
+	0x76, 0x72, 0x35, 0xa2, 0xa9, 0xcc, 0x63, 0xa6, 0x9d, 0xc4, 0x27, 0x57, 0x3c, 0x4e, 0xc7, 0xb1,
+	0x9a, 0x66, 0xe5, 0xcf, 0x26, 0x66, 0x4a, 0xcd, 0x78, 0xea, 0xc8, 0xe3, 0x62, 0xc0, 0x66, 0x6a,
+	0xc2, 0xb6, 0xa8, 0xa2, 0xdf, 0xfb, 0xf8, 0xf8, 0x82, 0x09, 0xfe, 0x11, 0x8c, 0x4d, 0xe0, 0xf3,
+	0x15, 0x18, 0x4b, 0xde, 0xe1, 0x46, 0x69, 0x22, 0x40, 0x3d, 0xd4, 0x6f, 0x0d, 0x5f, 0xd2, 0x4a,
+	0x8d, 0x2e, 0xd5, 0x5c, 0xf1, 0x21, 0x1d, 0x53, 0x35, 0xcd, 0x68, 0xa9, 0x46, 0x6b, 0x6a, 0x74,
+	0xa9, 0x46, 0x93, 0x55, 0x16, 0x89, 0xa3, 0x24, 0x21, 0xbe, 0xad, 0xa1, 0xe0, 0x86, 0x4b, 0x11,
+	0xec, 0xf7, 0x50, 0xff, 0x28, 0x59, 0x7d, 0x13, 0x82, 0x1b, 0x8a, 0xd9, 0x49, 0x70, 0xe0, 0x70,
+	0x57, 0x93, 0x1e, 0x6e, 0x81, 0x28, 0xb8, 0x96, 0x22, 0x07, 0x61, 0x83, 0x86, 0x6b, 0xd5, 0xa1,
+	0x92, 0x91, 0x29, 0x75, 0xce, 0x46, 0x30, 0x0b, 0x0e, 0x17, 0x8c, 0xcb, 0x6f, 0xf2, 0x15, 0xe1,
+	0x76, 0x2a, 0x73, 0x25, 0x05, 0x08, 0xfb, 0x86, 0x69, 0x96, 0x83, 0x05, 0x7d, 0x59, 0x80, 0xd6,
+	0x7c, 0x0c, 0x26, 0x68, 0xf6, 0x0e, 0xfa, 0xad, 0xe1, 0xc5, 0x3f, 0x18, 0x7c, 0xb1, 0xc5, 0x9e,
+	0x5c, 0xa7, 0x18, 0xfd, 0x42, 0xf8, 0xa4, 0x8a, 0xdb, 0x28, 0x29, 0x0c, 0x90, 0x0e, 0x3e, 0xca,
+	0x3d, 0x66, 0x02, 0xd4, 0x3b, 0xe8, 0x1f, 0x25, 0x15, 0x50, 0x76, 0x05, 0xcb, 0xc1, 0x28, 0x96,
+	0x82, 0xcf, 0xac, 0x02, 0xc8, 0x03, 0xdc, 0x5c, 0x0c, 0xa5, 0x8f, 0xcd, 0x7f, 0xad, 0x05, 0xdd,
+	0xd8, 0x08, 0x1a, 0x70, 0x53, 0x95, 0x57, 0x33, 0xc1, 0xe1, 0xff, 0x08, 0xc0, 0x93, 0x47, 0xdf,
+	0x10, 0xbe, 0x7b, 0xce, 0x8d, 0x3d, 0xe5, 0xfa, 0xe6, 0x4d, 0x56, 0xf4, 0x10, 0x1f, 0xaf, 0x2e,
+	0xe7, 0xdf, 0x81, 0xe0, 0xc6, 0x98, 0x59, 0xe6, 0x9f, 0xc0, 0xd5, 0xce, 0xc4, 0x19, 0xd8, 0x57,
+	0x7c, 0x06, 0x37, 0xd3, 0xc4, 0xea, 0x72, 0x5b, 0x26, 0x50, 0xff, 0xce, 0xc2, 0xc4, 0xf0, 0x0f,
+	0xc2, 0xf7, 0x2a, 0xad, 0xb7, 0xa0, 0x0b, 0x9e, 0x02, 0xb9, 0xc4, 0x27, 0x67, 0x7e, 0x1b, 0x2c,
+	0x47, 0x92, 0xb4, 0x69, 0x6d, 0xa1, 0x6d, 0xec, 0x85, 0xb0, 0xb3, 0xbb, 0xb9, 0x10, 0x8e, 0xf6,
+	0xc8, 0x29, 0xbe, 0xe5, 0x23, 0x25, 0x61, 0xfd, 0xe8, 0xfa, 0x10, 0x84, 0xed, 0x9d, 0xbd, 0x3a,
+	0x8b, 0xf7, 0xb4, 0xce, 0xb2, 0xfe, 0x0a, 0xeb, 0x2c, 0x1b, 0x21, 0x44, 0x7b, 0xcf, 0x9f, 0x7d,
+	0x9f, 0x77, 0xd1, 0x8f, 0x79, 0x17, 0xfd, 0x9c, 0x77, 0xd1, 0xfb, 0xc1, 0x75, 0x0b, 0x73, 0xe7,
+	0x62, 0x1f, 0x35, 0xdd, 0x7e, 0x7c, 0xf2, 0x37, 0x00, 0x00, 0xff, 0xff, 0xb2, 0x14, 0x02, 0x2f,
+	0xf8, 0x05, 0x00, 0x00,
 }

--- a/reposerver/repository/repository.proto
+++ b/reposerver/repository/repository.proto
@@ -26,6 +26,18 @@ message ManifestResponse {
     repeated github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.ComponentParameter params = 5;
 }
 
+// ListDirRequest requests a repository directory structure
+message ListDirRequest {
+    github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Repository repo = 1;
+    string revision = 2;
+}
+
+
+// ListDirResponse returns the contents of the repo of a ListDir request
+message ListDirResponse {
+    repeated string data = 1;
+}
+
 // GetFileRequest return
 message GetFileRequest {
     github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Repository repo = 1;
@@ -44,6 +56,10 @@ service RepositoryService {
 
     // Generate manifest for application in specified repo name and revision
     rpc GenerateManifest(ManifestRequest) returns (ManifestResponse) {
+    }
+
+    // ListDir returns the file contents at the specified repo and path
+    rpc ListDir(ListDirRequest) returns (ListDirResponse) {
     }
 
     // GetFile returns the file contents at the specified repo and path

--- a/reposerver/repository/repository.proto
+++ b/reposerver/repository/repository.proto
@@ -30,8 +30,8 @@ message ManifestResponse {
 message ListDirRequest {
     github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Repository repo = 1;
     string revision = 2;
+    string path = 3;
 }
-
 
 // ListDirResponse returns the contents of the repo of a ListDir request
 message ListDirResponse {

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -81,6 +81,9 @@ func (s *Server) ListKsonnetApps(ctx context.Context, q *RepoKsonnetQuery) (*Rep
 
 		var appSpec KsonnetAppSpec
 		err = yaml.Unmarshal(getFileRes.Data, &appSpec)
+		if err != nil {
+			return nil, err
+		}
 		out = append(out, &appSpec)
 	}
 

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -38,9 +38,12 @@ func (s *Server) List(ctx context.Context, q *RepoQuery) (*appsv1.RepositoryList
 	return repoList, err
 }
 
-// List returns list of repositories
-func (s *Server) GetKsonnetApps(ctx context.Context, q *RepoKsonnetQuery) (*RepoKsonnetResponse, error) {
+// ListKsonnetApps returns list of Ksonnet apps in the repo
+func (s *Server) ListKsonnetApps(ctx context.Context, q *RepoKsonnetQuery) (*RepoKsonnetResponse, error) {
 	repo, err := s.db.GetRepository(ctx, q.Repo)
+	if err != nil {
+		return nil, err
+	}
 
 	// Test the repo
 	conn, repoClient, err := s.repoClientset.NewRepositoryClient()

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -17,9 +17,13 @@ type Server struct {
 }
 
 // NewServer returns a new instance of the Repository service
-func NewServer(db db.ArgoDB) *Server {
+func NewServer(
+	repoClientset reposerver.Clientset,
+	db db.ArgoDB,
+) *Server {
 	return &Server{
-		db: db,
+		db:            db,
+		repoClientset: repoClientset,
 	}
 }
 

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -81,10 +81,9 @@ func (s *Server) ListKsonnetApps(ctx context.Context, q *RepoKsonnetQuery) (*Rep
 
 		var appSpec KsonnetAppSpec
 		err = yaml.Unmarshal(getFileRes.Data, &appSpec)
-		if err != nil {
-			return nil, err
+		if err == nil && appSpec.Name != "" && len(appSpec.Environments) > 0 {
+			out = append(out, &appSpec)
 		}
-		out = append(out, &appSpec)
 	}
 
 	return &RepoKsonnetResponse{

--- a/server/repository/repository.pb.go
+++ b/server/repository/repository.pb.go
@@ -12,6 +12,11 @@
 		server/repository/repository.proto
 
 	It has these top-level messages:
+		RepoKsonnetQuery
+		RepoKsonnetResponse
+		KsonnetAppSpec
+		KsonnetEnvironment
+		KsonnetEnvironmentDestination
 		RepoQuery
 		RepoResponse
 		RepoUpdateRequest
@@ -42,6 +47,146 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
+// RepoKsonnetQuery is a query for Repository contents matching a particular path
+type RepoKsonnetQuery struct {
+	Repo     string `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
+	Revision string `protobuf:"bytes,2,opt,name=revision,proto3" json:"revision,omitempty"`
+}
+
+func (m *RepoKsonnetQuery) Reset()                    { *m = RepoKsonnetQuery{} }
+func (m *RepoKsonnetQuery) String() string            { return proto.CompactTextString(m) }
+func (*RepoKsonnetQuery) ProtoMessage()               {}
+func (*RepoKsonnetQuery) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{0} }
+
+func (m *RepoKsonnetQuery) GetRepo() string {
+	if m != nil {
+		return m.Repo
+	}
+	return ""
+}
+
+func (m *RepoKsonnetQuery) GetRevision() string {
+	if m != nil {
+		return m.Revision
+	}
+	return ""
+}
+
+// RepoKsonnetResponse is a response for Repository contents matching a particular path
+type RepoKsonnetResponse struct {
+	Data []*KsonnetAppSpec `protobuf:"bytes,1,rep,name=data" json:"data,omitempty"`
+}
+
+func (m *RepoKsonnetResponse) Reset()                    { *m = RepoKsonnetResponse{} }
+func (m *RepoKsonnetResponse) String() string            { return proto.CompactTextString(m) }
+func (*RepoKsonnetResponse) ProtoMessage()               {}
+func (*RepoKsonnetResponse) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{1} }
+
+func (m *RepoKsonnetResponse) GetData() []*KsonnetAppSpec {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
+// KsonnetAppSpec contains Ksonnet app response
+// This roughly reflects: ksonnet/ksonnet/metadata/app/schema.go
+type KsonnetAppSpec struct {
+	Name         string                         `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Environments map[string]*KsonnetEnvironment `protobuf:"bytes,2,rep,name=environments" json:"environments,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value"`
+}
+
+func (m *KsonnetAppSpec) Reset()                    { *m = KsonnetAppSpec{} }
+func (m *KsonnetAppSpec) String() string            { return proto.CompactTextString(m) }
+func (*KsonnetAppSpec) ProtoMessage()               {}
+func (*KsonnetAppSpec) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{2} }
+
+func (m *KsonnetAppSpec) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *KsonnetAppSpec) GetEnvironments() map[string]*KsonnetEnvironment {
+	if m != nil {
+		return m.Environments
+	}
+	return nil
+}
+
+type KsonnetEnvironment struct {
+	// Name is the user defined name of an environment
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// KubernetesVersion is the kubernetes version the targetted cluster is running on.
+	K8SVersion string `protobuf:"bytes,2,opt,name=k8sVersion,proto3" json:"k8sVersion,omitempty"`
+	// Path is the relative project path containing metadata for this environment.
+	Path string `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
+	// Destination stores the cluster address that this environment points to.
+	Destination *KsonnetEnvironmentDestination `protobuf:"bytes,4,opt,name=destination" json:"destination,omitempty"`
+}
+
+func (m *KsonnetEnvironment) Reset()                    { *m = KsonnetEnvironment{} }
+func (m *KsonnetEnvironment) String() string            { return proto.CompactTextString(m) }
+func (*KsonnetEnvironment) ProtoMessage()               {}
+func (*KsonnetEnvironment) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{3} }
+
+func (m *KsonnetEnvironment) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *KsonnetEnvironment) GetK8SVersion() string {
+	if m != nil {
+		return m.K8SVersion
+	}
+	return ""
+}
+
+func (m *KsonnetEnvironment) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+func (m *KsonnetEnvironment) GetDestination() *KsonnetEnvironmentDestination {
+	if m != nil {
+		return m.Destination
+	}
+	return nil
+}
+
+type KsonnetEnvironmentDestination struct {
+	// Server is the Kubernetes server that the cluster is running on.
+	Server string `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty"`
+	// Namespace is the namespace of the Kubernetes server that targets should be deployed to
+	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+}
+
+func (m *KsonnetEnvironmentDestination) Reset()         { *m = KsonnetEnvironmentDestination{} }
+func (m *KsonnetEnvironmentDestination) String() string { return proto.CompactTextString(m) }
+func (*KsonnetEnvironmentDestination) ProtoMessage()    {}
+func (*KsonnetEnvironmentDestination) Descriptor() ([]byte, []int) {
+	return fileDescriptorRepository, []int{4}
+}
+
+func (m *KsonnetEnvironmentDestination) GetServer() string {
+	if m != nil {
+		return m.Server
+	}
+	return ""
+}
+
+func (m *KsonnetEnvironmentDestination) GetNamespace() string {
+	if m != nil {
+		return m.Namespace
+	}
+	return ""
+}
+
 // RepoQuery is a query for Repository resources
 type RepoQuery struct {
 	Repo string `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
@@ -50,7 +195,7 @@ type RepoQuery struct {
 func (m *RepoQuery) Reset()                    { *m = RepoQuery{} }
 func (m *RepoQuery) String() string            { return proto.CompactTextString(m) }
 func (*RepoQuery) ProtoMessage()               {}
-func (*RepoQuery) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{0} }
+func (*RepoQuery) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{5} }
 
 func (m *RepoQuery) GetRepo() string {
 	if m != nil {
@@ -65,7 +210,7 @@ type RepoResponse struct {
 func (m *RepoResponse) Reset()                    { *m = RepoResponse{} }
 func (m *RepoResponse) String() string            { return proto.CompactTextString(m) }
 func (*RepoResponse) ProtoMessage()               {}
-func (*RepoResponse) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{1} }
+func (*RepoResponse) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{6} }
 
 type RepoUpdateRequest struct {
 	Url  string                                                                `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
@@ -75,7 +220,7 @@ type RepoUpdateRequest struct {
 func (m *RepoUpdateRequest) Reset()                    { *m = RepoUpdateRequest{} }
 func (m *RepoUpdateRequest) String() string            { return proto.CompactTextString(m) }
 func (*RepoUpdateRequest) ProtoMessage()               {}
-func (*RepoUpdateRequest) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{2} }
+func (*RepoUpdateRequest) Descriptor() ([]byte, []int) { return fileDescriptorRepository, []int{7} }
 
 func (m *RepoUpdateRequest) GetUrl() string {
 	if m != nil {
@@ -92,6 +237,11 @@ func (m *RepoUpdateRequest) GetRepo() *github_com_argoproj_argo_cd_pkg_apis_appl
 }
 
 func init() {
+	proto.RegisterType((*RepoKsonnetQuery)(nil), "repository.RepoKsonnetQuery")
+	proto.RegisterType((*RepoKsonnetResponse)(nil), "repository.RepoKsonnetResponse")
+	proto.RegisterType((*KsonnetAppSpec)(nil), "repository.KsonnetAppSpec")
+	proto.RegisterType((*KsonnetEnvironment)(nil), "repository.KsonnetEnvironment")
+	proto.RegisterType((*KsonnetEnvironmentDestination)(nil), "repository.KsonnetEnvironmentDestination")
 	proto.RegisterType((*RepoQuery)(nil), "repository.RepoQuery")
 	proto.RegisterType((*RepoResponse)(nil), "repository.RepoResponse")
 	proto.RegisterType((*RepoUpdateRequest)(nil), "repository.RepoUpdateRequest")
@@ -110,6 +260,8 @@ const _ = grpc.SupportPackageIsVersion4
 type RepositoryServiceClient interface {
 	// List returns list of repos
 	List(ctx context.Context, in *RepoQuery, opts ...grpc.CallOption) (*github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.RepositoryList, error)
+	// ListKsonnetApps returns list of Ksonnet apps in the repo
+	ListKsonnetApps(ctx context.Context, in *RepoKsonnetQuery, opts ...grpc.CallOption) (*RepoKsonnetResponse, error)
 	// Create creates a repo
 	Create(ctx context.Context, in *github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository, opts ...grpc.CallOption) (*github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository, error)
 	// Get returns a repo by name
@@ -133,6 +285,15 @@ func NewRepositoryServiceClient(cc *grpc.ClientConn) RepositoryServiceClient {
 func (c *repositoryServiceClient) List(ctx context.Context, in *RepoQuery, opts ...grpc.CallOption) (*github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.RepositoryList, error) {
 	out := new(github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.RepositoryList)
 	err := grpc.Invoke(ctx, "/repository.RepositoryService/List", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *repositoryServiceClient) ListKsonnetApps(ctx context.Context, in *RepoKsonnetQuery, opts ...grpc.CallOption) (*RepoKsonnetResponse, error) {
+	out := new(RepoKsonnetResponse)
+	err := grpc.Invoke(ctx, "/repository.RepositoryService/ListKsonnetApps", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -189,6 +350,8 @@ func (c *repositoryServiceClient) Delete(ctx context.Context, in *RepoQuery, opt
 type RepositoryServiceServer interface {
 	// List returns list of repos
 	List(context.Context, *RepoQuery) (*github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.RepositoryList, error)
+	// ListKsonnetApps returns list of Ksonnet apps in the repo
+	ListKsonnetApps(context.Context, *RepoKsonnetQuery) (*RepoKsonnetResponse, error)
 	// Create creates a repo
 	Create(context.Context, *github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository) (*github_com_argoproj_argo_cd_pkg_apis_application_v1alpha1.Repository, error)
 	// Get returns a repo by name
@@ -219,6 +382,24 @@ func _RepositoryService_List_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RepositoryServiceServer).List(ctx, req.(*RepoQuery))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RepositoryService_ListKsonnetApps_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RepoKsonnetQuery)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RepositoryServiceServer).ListKsonnetApps(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/repository.RepositoryService/ListKsonnetApps",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RepositoryServiceServer).ListKsonnetApps(ctx, req.(*RepoKsonnetQuery))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -322,6 +503,10 @@ var _RepositoryService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _RepositoryService_List_Handler,
 		},
 		{
+			MethodName: "ListKsonnetApps",
+			Handler:    _RepositoryService_ListKsonnetApps_Handler,
+		},
+		{
 			MethodName: "Create",
 			Handler:    _RepositoryService_Create_Handler,
 		},
@@ -344,6 +529,194 @@ var _RepositoryService_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "server/repository/repository.proto",
+}
+
+func (m *RepoKsonnetQuery) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RepoKsonnetQuery) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Repo) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Repo)))
+		i += copy(dAtA[i:], m.Repo)
+	}
+	if len(m.Revision) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Revision)))
+		i += copy(dAtA[i:], m.Revision)
+	}
+	return i, nil
+}
+
+func (m *RepoKsonnetResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RepoKsonnetResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Data) > 0 {
+		for _, msg := range m.Data {
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintRepository(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	return i, nil
+}
+
+func (m *KsonnetAppSpec) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *KsonnetAppSpec) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Name)))
+		i += copy(dAtA[i:], m.Name)
+	}
+	if len(m.Environments) > 0 {
+		for k, _ := range m.Environments {
+			dAtA[i] = 0x12
+			i++
+			v := m.Environments[k]
+			msgSize := 0
+			if v != nil {
+				msgSize = v.Size()
+				msgSize += 1 + sovRepository(uint64(msgSize))
+			}
+			mapSize := 1 + len(k) + sovRepository(uint64(len(k))) + msgSize
+			i = encodeVarintRepository(dAtA, i, uint64(mapSize))
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintRepository(dAtA, i, uint64(len(k)))
+			i += copy(dAtA[i:], k)
+			if v != nil {
+				dAtA[i] = 0x12
+				i++
+				i = encodeVarintRepository(dAtA, i, uint64(v.Size()))
+				n1, err := v.MarshalTo(dAtA[i:])
+				if err != nil {
+					return 0, err
+				}
+				i += n1
+			}
+		}
+	}
+	return i, nil
+}
+
+func (m *KsonnetEnvironment) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *KsonnetEnvironment) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Name)))
+		i += copy(dAtA[i:], m.Name)
+	}
+	if len(m.K8SVersion) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.K8SVersion)))
+		i += copy(dAtA[i:], m.K8SVersion)
+	}
+	if len(m.Path) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Path)))
+		i += copy(dAtA[i:], m.Path)
+	}
+	if m.Destination != nil {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(m.Destination.Size()))
+		n2, err := m.Destination.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	return i, nil
+}
+
+func (m *KsonnetEnvironmentDestination) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *KsonnetEnvironmentDestination) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Server) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Server)))
+		i += copy(dAtA[i:], m.Server)
+	}
+	if len(m.Namespace) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintRepository(dAtA, i, uint64(len(m.Namespace)))
+		i += copy(dAtA[i:], m.Namespace)
+	}
+	return i, nil
 }
 
 func (m *RepoQuery) Marshal() (dAtA []byte, err error) {
@@ -413,11 +786,11 @@ func (m *RepoUpdateRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintRepository(dAtA, i, uint64(m.Repo.Size()))
-		n1, err := m.Repo.MarshalTo(dAtA[i:])
+		n3, err := m.Repo.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n1
+		i += n3
 	}
 	return i, nil
 }
@@ -431,6 +804,91 @@ func encodeVarintRepository(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
+func (m *RepoKsonnetQuery) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Repo)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	l = len(m.Revision)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	return n
+}
+
+func (m *RepoKsonnetResponse) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Data) > 0 {
+		for _, e := range m.Data {
+			l = e.Size()
+			n += 1 + l + sovRepository(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *KsonnetAppSpec) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	if len(m.Environments) > 0 {
+		for k, v := range m.Environments {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.Size()
+				l += 1 + sovRepository(uint64(l))
+			}
+			mapEntrySize := 1 + len(k) + sovRepository(uint64(len(k))) + l
+			n += mapEntrySize + 1 + sovRepository(uint64(mapEntrySize))
+		}
+	}
+	return n
+}
+
+func (m *KsonnetEnvironment) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	l = len(m.K8SVersion)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	l = len(m.Path)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	if m.Destination != nil {
+		l = m.Destination.Size()
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	return n
+}
+
+func (m *KsonnetEnvironmentDestination) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Server)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	l = len(m.Namespace)
+	if l > 0 {
+		n += 1 + l + sovRepository(uint64(l))
+	}
+	return n
+}
+
 func (m *RepoQuery) Size() (n int) {
 	var l int
 	_ = l
@@ -473,6 +931,675 @@ func sovRepository(x uint64) (n int) {
 }
 func sozRepository(x uint64) (n int) {
 	return sovRepository(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *RepoKsonnetQuery) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRepository
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RepoKsonnetQuery: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RepoKsonnetQuery: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Repo", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Repo = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Revision", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Revision = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRepository(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRepository
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RepoKsonnetResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRepository
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RepoKsonnetResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RepoKsonnetResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Data = append(m.Data, &KsonnetAppSpec{})
+			if err := m.Data[len(m.Data)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRepository(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRepository
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *KsonnetAppSpec) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRepository
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: KsonnetAppSpec: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: KsonnetAppSpec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Environments", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Environments == nil {
+				m.Environments = make(map[string]*KsonnetEnvironment)
+			}
+			var mapkey string
+			var mapvalue *KsonnetEnvironment
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowRepository
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= (uint64(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowRepository
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthRepository
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowRepository
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= (int(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return ErrInvalidLengthRepository
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if mapmsglen < 0 {
+						return ErrInvalidLengthRepository
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &KsonnetEnvironment{}
+					if err := mapvalue.Unmarshal(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipRepository(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthRepository
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Environments[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRepository(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRepository
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *KsonnetEnvironment) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRepository
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: KsonnetEnvironment: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: KsonnetEnvironment: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field K8SVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.K8SVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Path", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Path = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Destination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Destination == nil {
+				m.Destination = &KsonnetEnvironmentDestination{}
+			}
+			if err := m.Destination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRepository(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRepository
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *KsonnetEnvironmentDestination) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRepository
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: KsonnetEnvironmentDestination: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: KsonnetEnvironmentDestination: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Server", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Server = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRepository
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthRepository
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Namespace = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRepository(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRepository
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *RepoQuery) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -823,36 +1950,52 @@ var (
 func init() { proto.RegisterFile("server/repository/repository.proto", fileDescriptorRepository) }
 
 var fileDescriptorRepository = []byte{
-	// 486 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x94, 0x41, 0x6b, 0x14, 0x31,
-	0x14, 0xc7, 0x4d, 0x5b, 0x06, 0x1a, 0x45, 0x34, 0x54, 0xa9, 0x63, 0xbb, 0x2d, 0xf1, 0xb2, 0x14,
-	0x9a, 0xb0, 0xf5, 0x22, 0xf5, 0xa6, 0x16, 0x29, 0x78, 0x71, 0xaa, 0x07, 0x3d, 0x28, 0xe9, 0xcc,
-	0x63, 0x1a, 0x77, 0x9c, 0xc4, 0x24, 0x33, 0x50, 0xa4, 0x20, 0x1e, 0xc4, 0xbb, 0x17, 0x0f, 0x7e,
-	0x0f, 0xbf, 0x82, 0x47, 0xc1, 0x2f, 0x20, 0x8b, 0xdf, 0xc2, 0x8b, 0x24, 0x33, 0xdd, 0x5d, 0xdb,
-	0x6d, 0x4f, 0x73, 0xe8, 0xed, 0x3f, 0x6f, 0x92, 0x97, 0x5f, 0xfe, 0x2f, 0xef, 0x61, 0x6a, 0xc1,
-	0xd4, 0x60, 0xb8, 0x01, 0xad, 0xac, 0x74, 0xca, 0x1c, 0x4e, 0x49, 0xa6, 0x8d, 0x72, 0x8a, 0xe0,
-	0x49, 0x24, 0x5e, 0xca, 0x55, 0xae, 0x42, 0x98, 0x7b, 0xd5, 0xac, 0x88, 0x57, 0x72, 0xa5, 0xf2,
-	0x02, 0xb8, 0xd0, 0x92, 0x8b, 0xb2, 0x54, 0x4e, 0x38, 0xa9, 0x4a, 0xdb, 0xfe, 0xa5, 0xc3, 0x7b,
-	0x96, 0x49, 0x15, 0xfe, 0xa6, 0xca, 0x00, 0xaf, 0x07, 0x3c, 0x87, 0x12, 0x8c, 0x70, 0x90, 0xb5,
-	0x6b, 0x76, 0x73, 0xe9, 0x0e, 0xaa, 0x7d, 0x96, 0xaa, 0xb7, 0x5c, 0x98, 0x70, 0xc4, 0x9b, 0x20,
-	0x36, 0xd3, 0x8c, 0xeb, 0x61, 0xee, 0x37, 0x5b, 0x2e, 0xb4, 0x2e, 0x64, 0x1a, 0x92, 0xf3, 0x7a,
-	0x20, 0x0a, 0x7d, 0x20, 0x4e, 0xa5, 0xa2, 0x6b, 0x78, 0x31, 0x01, 0xad, 0x9e, 0x56, 0x60, 0x0e,
-	0x09, 0xc1, 0x0b, 0x9e, 0x7e, 0x19, 0xad, 0xa3, 0xfe, 0x62, 0x12, 0x34, 0xbd, 0x8a, 0xaf, 0xf8,
-	0x05, 0x09, 0x58, 0xad, 0x4a, 0x0b, 0xf4, 0x03, 0xc2, 0xd7, 0x7d, 0xe0, 0xb9, 0xce, 0x84, 0x83,
-	0x04, 0xde, 0x55, 0x60, 0x1d, 0xb9, 0x86, 0xe7, 0x2b, 0x53, 0xb4, 0x1b, 0xbd, 0x24, 0x2f, 0xda,
-	0x5c, 0x73, 0xeb, 0xa8, 0x7f, 0x79, 0x6b, 0x87, 0x4d, 0x90, 0xd9, 0x31, 0x72, 0x10, 0xaf, 0xd3,
-	0x8c, 0xe9, 0x61, 0xce, 0x3c, 0x32, 0x9b, 0x42, 0x66, 0xc7, 0xc8, 0x2c, 0x19, 0x1b, 0xda, 0x20,
-	0x6d, 0xfd, 0x8d, 0x1a, 0x84, 0x26, 0xb8, 0x07, 0xa6, 0x96, 0x29, 0x90, 0x4f, 0x08, 0x2f, 0x3c,
-	0x91, 0xd6, 0x91, 0x1b, 0x6c, 0xaa, 0x28, 0xe3, 0xcb, 0xc5, 0xbb, 0x9d, 0x20, 0xf8, 0x13, 0xe8,
-	0xca, 0xc7, 0x5f, 0x7f, 0xbe, 0xcc, 0xdd, 0x24, 0x4b, 0xa1, 0x4a, 0xf5, 0x60, 0xf2, 0x0a, 0x24,
-	0x58, 0xf2, 0x1d, 0xe1, 0xe8, 0xa1, 0x01, 0xe1, 0x80, 0x74, 0x73, 0xed, 0xb8, 0x9b, 0x34, 0x74,
-	0x2d, 0x60, 0xdf, 0xa2, 0x33, 0xb1, 0xb7, 0xd1, 0x06, 0xf9, 0x8c, 0xf0, 0xfc, 0x63, 0x38, 0xd3,
-	0xc1, 0x8e, 0x30, 0xee, 0x04, 0x8c, 0x55, 0x72, 0x7b, 0x16, 0x06, 0x7f, 0xef, 0xbf, 0x8e, 0xc8,
-	0x57, 0x84, 0xa3, 0xe6, 0x89, 0x5d, 0x30, 0x13, 0x2f, 0x91, 0x6f, 0x08, 0xe3, 0xf6, 0xf5, 0xef,
-	0xec, 0x3d, 0x23, 0xab, 0x27, 0xcd, 0xfa, 0xaf, 0x33, 0xba, 0x3a, 0xb6, 0x1f, 0x4c, 0xa3, 0x71,
-	0x3c, 0xdb, 0xb4, 0xca, 0x14, 0x47, 0xdb, 0xa1, 0x3b, 0xc8, 0x2b, 0x1c, 0x3d, 0x82, 0x02, 0x1c,
-	0x9c, 0x55, 0xc6, 0xe5, 0x93, 0xe1, 0x71, 0x6f, 0xb7, 0x95, 0xd9, 0x38, 0xaf, 0x32, 0x0f, 0xee,
-	0xff, 0x18, 0xf5, 0xd0, 0xcf, 0x51, 0x0f, 0xfd, 0x1e, 0xf5, 0xd0, 0xcb, 0xcd, 0xf3, 0x46, 0xd1,
-	0xa9, 0x71, 0xb9, 0x1f, 0x85, 0xa9, 0x73, 0xf7, 0x5f, 0x00, 0x00, 0x00, 0xff, 0xff, 0xd4, 0xa0,
-	0x05, 0x80, 0x4a, 0x05, 0x00, 0x00,
+	// 740 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x56, 0xcd, 0x6e, 0xd3, 0x40,
+	0x10, 0x66, 0x93, 0x10, 0xe8, 0xb6, 0x2a, 0xed, 0x52, 0xaa, 0x60, 0xd2, 0xb4, 0x32, 0x1c, 0x4a,
+	0x45, 0x6d, 0xb5, 0x70, 0xa8, 0xca, 0x89, 0xd2, 0x08, 0x55, 0xe5, 0x00, 0x2e, 0x45, 0x82, 0x03,
+	0xd5, 0xd6, 0x19, 0xb9, 0x26, 0xae, 0x77, 0xd9, 0xdd, 0x58, 0x8a, 0x50, 0x25, 0xc4, 0x01, 0x71,
+	0xe7, 0xc2, 0x81, 0x17, 0xe0, 0x09, 0x78, 0x05, 0x8e, 0x48, 0x1c, 0xb8, 0xa2, 0x8a, 0x37, 0xe0,
+	0x05, 0xd0, 0xae, 0x9d, 0xc4, 0x6d, 0x7e, 0x4e, 0x39, 0x70, 0x9b, 0x9d, 0xfd, 0x76, 0xe6, 0xdb,
+	0x6f, 0x66, 0xbc, 0xc6, 0xb6, 0x04, 0x91, 0x80, 0x70, 0x05, 0x70, 0x26, 0x43, 0xc5, 0x44, 0x3b,
+	0x67, 0x3a, 0x5c, 0x30, 0xc5, 0x08, 0xee, 0x79, 0xac, 0xb9, 0x80, 0x05, 0xcc, 0xb8, 0x5d, 0x6d,
+	0xa5, 0x08, 0xab, 0x1a, 0x30, 0x16, 0x44, 0xe0, 0x52, 0x1e, 0xba, 0x34, 0x8e, 0x99, 0xa2, 0x2a,
+	0x64, 0xb1, 0xcc, 0x76, 0xed, 0xe6, 0x86, 0x74, 0x42, 0x66, 0x76, 0x7d, 0x26, 0xc0, 0x4d, 0xd6,
+	0xdc, 0x00, 0x62, 0x10, 0x54, 0x41, 0x23, 0xc3, 0xec, 0x04, 0xa1, 0x3a, 0x6a, 0x1d, 0x3a, 0x3e,
+	0x3b, 0x76, 0xa9, 0x30, 0x29, 0x5e, 0x1b, 0x63, 0xd5, 0x6f, 0xb8, 0xbc, 0x19, 0xe8, 0xc3, 0xd2,
+	0xa5, 0x9c, 0x47, 0xa1, 0x6f, 0x82, 0xbb, 0xc9, 0x1a, 0x8d, 0xf8, 0x11, 0xed, 0x0b, 0x65, 0x6f,
+	0xe1, 0x19, 0x0f, 0x38, 0xdb, 0x95, 0x2c, 0x8e, 0x41, 0x3d, 0x6d, 0x81, 0x68, 0x13, 0x82, 0x4b,
+	0xfa, 0x12, 0x15, 0xb4, 0x84, 0x96, 0x27, 0x3c, 0x63, 0x13, 0x0b, 0x5f, 0x16, 0x90, 0x84, 0x32,
+	0x64, 0x71, 0xa5, 0x60, 0xfc, 0xdd, 0xb5, 0x5d, 0xc7, 0x57, 0x73, 0x31, 0x3c, 0x90, 0x9c, 0xc5,
+	0x12, 0x88, 0x83, 0x4b, 0x0d, 0xaa, 0x68, 0x05, 0x2d, 0x15, 0x97, 0x27, 0xd7, 0x2d, 0x27, 0x27,
+	0x55, 0x06, 0x7d, 0xc0, 0xf9, 0x1e, 0x07, 0xdf, 0x33, 0x38, 0xfb, 0x17, 0xc2, 0xd3, 0x67, 0x37,
+	0x34, 0x93, 0x98, 0x1e, 0x43, 0x87, 0x89, 0xb6, 0xc9, 0x13, 0x3c, 0x05, 0x71, 0x12, 0x0a, 0x16,
+	0x1f, 0x43, 0xac, 0x64, 0xa5, 0x60, 0xc2, 0xdf, 0x19, 0x1e, 0xde, 0xa9, 0xe7, 0xe0, 0xf5, 0x58,
+	0x89, 0xb6, 0x77, 0x26, 0x82, 0x75, 0x80, 0x67, 0xfb, 0x20, 0x64, 0x06, 0x17, 0x9b, 0xd0, 0xce,
+	0x32, 0x6b, 0x93, 0xdc, 0xc3, 0x17, 0x13, 0x1a, 0xb5, 0xc0, 0xdc, 0x7f, 0x72, 0xbd, 0x36, 0x20,
+	0x63, 0x2e, 0x8c, 0x97, 0x82, 0x37, 0x0b, 0x1b, 0xc8, 0xfe, 0x8a, 0x30, 0xe9, 0x47, 0x0c, 0xbc,
+	0x5d, 0x0d, 0xe3, 0xe6, 0x86, 0x7c, 0x0e, 0x22, 0xa7, 0x74, 0xce, 0xa3, 0xcf, 0x70, 0xaa, 0x8e,
+	0x2a, 0xc5, 0xf4, 0x8c, 0xb6, 0xc9, 0x2e, 0x9e, 0x6c, 0x80, 0x54, 0x61, 0x6c, 0x6a, 0x5d, 0x29,
+	0x19, 0x7a, 0xb7, 0x47, 0xd3, 0xdb, 0xee, 0x1d, 0xf0, 0xf2, 0xa7, 0xed, 0x7d, 0xbc, 0x30, 0x12,
+	0x4d, 0xe6, 0x71, 0x39, 0x1d, 0x83, 0x8c, 0x77, 0xb6, 0x22, 0x55, 0x3c, 0xa1, 0x6f, 0x20, 0x39,
+	0xf5, 0x21, 0x23, 0xde, 0x73, 0xd8, 0x8b, 0x78, 0x42, 0xf7, 0xc8, 0xd0, 0x06, 0xb3, 0xa7, 0xf1,
+	0x94, 0x06, 0x74, 0xba, 0xc7, 0x7e, 0x87, 0xf0, 0xac, 0x76, 0xec, 0xf3, 0x06, 0x55, 0xe0, 0xc1,
+	0x9b, 0x16, 0x48, 0xa5, 0xab, 0xd2, 0x12, 0x51, 0xa7, 0x2a, 0x2d, 0x11, 0x91, 0x17, 0x59, 0xac,
+	0xb4, 0x28, 0x75, 0xa7, 0x37, 0x1a, 0x4e, 0x67, 0x34, 0x8c, 0x71, 0xe0, 0x37, 0x1c, 0xde, 0x0c,
+	0x1c, 0x3d, 0x1a, 0x4e, 0x6e, 0x34, 0x9c, 0xce, 0x68, 0x38, 0x5e, 0x57, 0xaf, 0x94, 0xd2, 0xfa,
+	0xdf, 0x4b, 0x29, 0x85, 0xd4, 0xb9, 0x07, 0x22, 0x09, 0x7d, 0x20, 0x1f, 0x10, 0x2e, 0x3d, 0x0e,
+	0xa5, 0x22, 0xd7, 0xf2, 0x0a, 0x77, 0x2f, 0x67, 0xed, 0x8c, 0x85, 0x82, 0xce, 0x60, 0x57, 0xdf,
+	0xff, 0xfc, 0xf3, 0xa9, 0x30, 0x4f, 0xe6, 0xcc, 0xd7, 0x20, 0x59, 0xeb, 0x7d, 0x6d, 0x42, 0x90,
+	0x24, 0xc1, 0x57, 0x34, 0xaa, 0xd7, 0xec, 0x92, 0x54, 0xcf, 0x53, 0xca, 0xcf, 0xb5, 0xb5, 0x38,
+	0x64, 0xb7, 0xab, 0xf9, 0x2d, 0x93, 0xaf, 0x46, 0xaa, 0x83, 0xf2, 0xb9, 0xcd, 0x14, 0x4d, 0xbe,
+	0x21, 0x5c, 0x7e, 0x28, 0x80, 0x2a, 0x20, 0xe3, 0x91, 0xdb, 0x1a, 0x4f, 0x18, 0x7b, 0xd1, 0xd0,
+	0xbf, 0x6e, 0x0f, 0x94, 0x6b, 0x13, 0xad, 0x90, 0x8f, 0x08, 0x17, 0x1f, 0xc1, 0xd0, 0xca, 0x8d,
+	0x89, 0xc6, 0x4d, 0x43, 0x63, 0x81, 0xdc, 0x18, 0xa8, 0xe2, 0x5b, 0xbd, 0x3a, 0x21, 0x9f, 0x11,
+	0x2e, 0xa7, 0xad, 0xfd, 0x9f, 0x89, 0x78, 0x81, 0x7c, 0x41, 0x18, 0x67, 0x53, 0x57, 0xdf, 0x7b,
+	0x46, 0x16, 0xce, 0x8b, 0x75, 0x66, 0x22, 0xc7, 0x95, 0x76, 0xd9, 0x88, 0x66, 0x5b, 0xd6, 0x60,
+	0xd1, 0x5a, 0x22, 0x3a, 0xd9, 0x4c, 0x5f, 0xa2, 0x57, 0xb8, 0xbc, 0x0d, 0x11, 0x28, 0x18, 0x56,
+	0xc6, 0xca, 0x79, 0x77, 0xb7, 0xbf, 0xb3, 0xca, 0xac, 0x8c, 0xaa, 0xcc, 0xd6, 0xfd, 0xef, 0xa7,
+	0x35, 0xf4, 0xe3, 0xb4, 0x86, 0x7e, 0x9f, 0xd6, 0xd0, 0xcb, 0xd5, 0x51, 0x4f, 0x6d, 0xdf, 0xef,
+	0xc0, 0x61, 0xd9, 0xbc, 0xaa, 0x77, 0xff, 0x05, 0x00, 0x00, 0xff, 0xff, 0xa3, 0x80, 0x63, 0xc1,
+	0x2a, 0x08, 0x00, 0x00,
 }

--- a/server/repository/repository.pb.gw.go
+++ b/server/repository/repository.pb.gw.go
@@ -46,6 +46,23 @@ func request_RepositoryService_List_0(ctx context.Context, marshaler runtime.Mar
 
 }
 
+var (
+	filter_RepositoryService_ListKsonnetApps_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
+func request_RepositoryService_ListKsonnetApps_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RepoKsonnetQuery
+	var metadata runtime.ServerMetadata
+
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_RepositoryService_ListKsonnetApps_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ListKsonnetApps(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
 func request_RepositoryService_Create_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq v1alpha1.Repository
 	var metadata runtime.ServerMetadata
@@ -211,6 +228,35 @@ func RegisterRepositoryServiceHandlerClient(ctx context.Context, mux *runtime.Se
 
 	})
 
+	mux.Handle("GET", pattern_RepositoryService_ListKsonnetApps_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		if cn, ok := w.(http.CloseNotifier); ok {
+			go func(done <-chan struct{}, closed <-chan bool) {
+				select {
+				case <-done:
+				case <-closed:
+					cancel()
+				}
+			}(ctx.Done(), cn.CloseNotify())
+		}
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_RepositoryService_ListKsonnetApps_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_RepositoryService_ListKsonnetApps_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("POST", pattern_RepositoryService_Create_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -333,6 +379,8 @@ func RegisterRepositoryServiceHandlerClient(ctx context.Context, mux *runtime.Se
 var (
 	pattern_RepositoryService_List_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "repositories"}, ""))
 
+	pattern_RepositoryService_ListKsonnetApps_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "repositories", "ksonnet"}, ""))
+
 	pattern_RepositoryService_Create_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "repositories"}, ""))
 
 	pattern_RepositoryService_Get_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "repositories", "repo"}, ""))
@@ -344,6 +392,8 @@ var (
 
 var (
 	forward_RepositoryService_List_0 = runtime.ForwardResponseMessage
+
+	forward_RepositoryService_ListKsonnetApps_0 = runtime.ForwardResponseMessage
 
 	forward_RepositoryService_Create_0 = runtime.ForwardResponseMessage
 

--- a/server/repository/repository.proto
+++ b/server/repository/repository.proto
@@ -11,6 +11,44 @@ import "google/api/annotations.proto";
 import "k8s.io/api/core/v1/generated.proto";
 import "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1/generated.proto";
 
+// RepoKsonnetQuery is a query for Repository contents matching a particular path
+message RepoKsonnetQuery {
+	string repo = 1;
+	string revision = 2;
+}
+
+// RepoKsonnetResponse is a response for Repository contents matching a particular path
+message RepoKsonnetResponse {
+	repeated KsonnetAppSpec data = 1;
+}
+
+// KsonnetAppSpec contains Ksonnet app response
+// This roughly reflects: ksonnet/ksonnet/metadata/app/schema.go
+message KsonnetAppSpec {
+    string name = 1;
+    map<string, KsonnetEnvironment> environments = 2;
+}
+
+message KsonnetEnvironment {
+    // Name is the user defined name of an environment
+    string name = 1;
+    // KubernetesVersion is the kubernetes version the targetted cluster is running on.
+    string k8sVersion = 2;
+    // Path is the relative project path containing metadata for this environment.
+    string path = 3;
+    // Destination stores the cluster address that this environment points to.
+    KsonnetEnvironmentDestination destination = 4;
+
+    // Targets contain the relative component paths that this environment
+    //repeated string targets = X;
+}
+
+message KsonnetEnvironmentDestination {
+    // Server is the Kubernetes server that the cluster is running on.
+    string server = 1;
+    // Namespace is the namespace of the Kubernetes server that targets should be deployed to
+    string namespace = 2;
+}
 
 // RepoQuery is a query for Repository resources
 message RepoQuery {

--- a/server/repository/repository.proto
+++ b/server/repository/repository.proto
@@ -70,6 +70,11 @@ service RepositoryService {
 		option (google.api.http).get = "/api/v1/repositories";
 	}
 
+	// GetKsonnetApps returns list of Ksonnet apps in the repo
+	rpc GetKsonnetApps(RepoKsonnetQuery) returns (RepoKsonnetResponse) {
+		option (google.api.http).get = "/api/v1/repositories/{repo}/ksonnet";
+	}
+
 	// Create creates a repo
 	rpc Create(github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Repository) returns (github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Repository) {
 		option (google.api.http) = {

--- a/server/repository/repository.proto
+++ b/server/repository/repository.proto
@@ -70,9 +70,9 @@ service RepositoryService {
 		option (google.api.http).get = "/api/v1/repositories";
 	}
 
-	// GetKsonnetApps returns list of Ksonnet apps in the repo
-	rpc GetKsonnetApps(RepoKsonnetQuery) returns (RepoKsonnetResponse) {
-		option (google.api.http).get = "/api/v1/repositories/{repo}/ksonnet";
+	// ListKsonnetApps returns list of Ksonnet apps in the repo
+	rpc ListKsonnetApps(RepoKsonnetQuery) returns (RepoKsonnetResponse) {
+		option (google.api.http).get = "/api/v1/repositories/ksonnet";
 	}
 
 	// Create creates a repo

--- a/server/repository/repository.proto
+++ b/server/repository/repository.proto
@@ -38,9 +38,6 @@ message KsonnetEnvironment {
     string path = 3;
     // Destination stores the cluster address that this environment points to.
     KsonnetEnvironmentDestination destination = 4;
-
-    // Targets contain the relative component paths that this environment
-    //repeated string targets = X;
 }
 
 message KsonnetEnvironmentDestination {

--- a/server/server.go
+++ b/server/server.go
@@ -286,7 +286,7 @@ func (a *ArgoCDServer) newGRPCServer() *grpc.Server {
 	grpcS := grpc.NewServer(sOpts...)
 	db := db.NewDB(a.Namespace, a.KubeClientset)
 	clusterService := cluster.NewServer(db)
-	repoService := repository.NewServer(db)
+	repoService := repository.NewServer(a.RepoClientset, db)
 	sessionService := session.NewServer(a.sessionMgr)
 	applicationService := application.NewServer(a.Namespace, a.KubeClientset, a.AppClientset, a.RepoClientset, db)
 	settingsService := settings.NewServer(a.settingsMgr)

--- a/test/e2e/fixture.go
+++ b/test/e2e/fixture.go
@@ -370,6 +370,10 @@ func (c *FakeGitClient) LsRemote(s string) (string, error) {
 	return "abcdef123456890", nil
 }
 
+func (c *FakeGitClient) LsFiles(s string) ([]string, error) {
+	return []string{"abcdef123456890"}, nil
+}
+
 func (c *FakeGitClient) CommitSHA() (string, error) {
 	return "abcdef123456890", nil
 }

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -19,6 +19,7 @@ type Client interface {
 	Fetch() error
 	Checkout(revision string) error
 	LsRemote(revision string) (string, error)
+	LsFiles() (string, error)
 	CommitSHA() (string, error)
 	Reset() error
 }
@@ -145,6 +146,11 @@ func (m *nativeGitClient) Fetch() error {
 		return err
 	}
 	return nil
+}
+
+// LsFiles lists the local working tree, including only files that are under source control
+func (m *nativeGitClient) LsFiles() (string, error) {
+	return m.runCmd("git", "ls-files")
 }
 
 // Reset resets local changes in a repository

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -19,7 +19,7 @@ type Client interface {
 	Fetch() error
 	Checkout(revision string) error
 	LsRemote(revision string) (string, error)
-	LsFiles() (string, error)
+	LsFiles(path string) ([]string, error)
 	CommitSHA() (string, error)
 	Reset() error
 }
@@ -149,8 +149,14 @@ func (m *nativeGitClient) Fetch() error {
 }
 
 // LsFiles lists the local working tree, including only files that are under source control
-func (m *nativeGitClient) LsFiles() (string, error) {
-	return m.runCmd("git", "ls-files")
+func (m *nativeGitClient) LsFiles(path string) ([]string, error) {
+	out, err := m.runCmd("git", "ls-files", "--full-name", "-z", "--", path)
+	if err != nil {
+		return nil, err
+	}
+	// remove last element, which is blank regardless of whether we're using nullbyte or newline
+	ss := strings.Split(out, "\000")
+	return ss[:len(ss)-1], nil
 }
 
 // Reset resets local changes in a repository


### PR DESCRIPTION
Addresses the API endpoint creation for #71.

1. Add repo server endpoint for querying for filenames in a given dir or matching a particular pattern.  Query is for repo, revision, and path.
2. Before responding, results are cached in Redis, if it is available.
3. The API server exposes an endpoint that accepts repo and revision and forwards a request for repo, revision, and path `*app.yaml` to repo server endpoint added above.
4. Results from repo server, will be iterated and then the repo server `GetFile` endpoint will be called on each.
5. The resulting byte data will be unmarshaled into Ksonnet spec objects (thanks, @jessesuen!) and returned to the caller.

If nothing is found, an empty object will be returned to the frontend.