### PR TITLE
Support cluster management using the internal k8s API address https://kubernetes.default.svc

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -20,6 +20,9 @@ const (
 	AuthCookieName = "argocd.token"
 	// ResourcesFinalizerName is a number of application CRD finalizer
 	ResourcesFinalizerName = "resources-finalizer." + MetadataPrefix
+
+	// KubernetesInternalAPIServerAddr is address of the k8s API server when accessing internal to the cluster
+	KubernetesInternalAPIServerAddr = "https://kubernetes.default.svc"
 )
 
 const (


### PR DESCRIPTION
I am able to deploy using this app.yaml

https://github.com/argoproj/argocd-example-apps/blob/master/guestbook/app.yaml