### PR TITLE
add validation to argocd app set -p

### DIFF
--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -36,6 +36,29 @@ func FilterByProjects(apps []argoappv1.Application, projects []string) []argoapp
 		}
 	}
 	return items
+
+}
+
+//ParamToMap convers a ComponentParameter list to a map for easy filtering
+func ParamToMap(params []argoappv1.ComponentParameter) map[string]map[string]bool {
+	validAppSet := make(map[string]map[string]bool)
+	for _, p := range params {
+		if validAppSet[p.Component] == nil {
+			validAppSet[p.Component] = make(map[string]bool)
+		}
+		validAppSet[p.Component][p.Name] = true
+	}
+	return validAppSet
+}
+
+// CheckValidParam checks if the parameter passed is overridable for the given appMap
+func CheckValidParam(appMap map[string]map[string]bool, newParam argoappv1.ComponentParameter) bool {
+	if val, ok := appMap[newParam.Component]; ok {
+		if _, ok2 := val[newParam.Name]; ok2 {
+			return true
+		}
+	}
+	return false
 }
 
 // RefreshApp updates the refresh annotation of an application to coerce the controller to process it

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -39,7 +39,7 @@ func FilterByProjects(apps []argoappv1.Application, projects []string) []argoapp
 
 }
 
-//ParamToMap convers a ComponentParameter list to a map for easy filtering
+//ParamToMap converts a ComponentParameter list to a map for easy filtering
 func ParamToMap(params []argoappv1.ComponentParameter) map[string]map[string]bool {
 	validAppSet := make(map[string]map[string]bool)
 	for _, p := range params {

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -29,6 +29,24 @@ func TestRefreshApp(t *testing.T) {
 	//assert.True(t, ok)
 }
 
+func TestCheckValidParam(t *testing.T) {
+	oldAppSet := make(map[string]map[string]bool)
+	oldAppSet["testComponent"] = make(map[string]bool)
+	oldAppSet["testComponent"]["overrideParam"] = true
+	newParam := argoappv1.ComponentParameter{
+		Component: "testComponent",
+		Name:      "overrideParam",
+		Value:     "new-value",
+	}
+	badParam := argoappv1.ComponentParameter{
+		Component: "testComponent",
+		Name:      "badParam",
+		Value:     "new-value",
+	}
+	assert.True(t, CheckValidParam(oldAppSet, newParam))
+	assert.False(t, CheckValidParam(oldAppSet, badParam))
+}
+
 func TestWaitForRefresh(t *testing.T) {
 	appClientset := appclientset.NewSimpleClientset()
 


### PR DESCRIPTION
This fixes #195 

I rebased to clean up commit history but change was contributed by @dthomson25 

Util function checks if a given parameter matches component and name to a parameter in the given application. 

server side "updateSpec" function uses util to verify passed override parameters along with all previous override parameters. 

client side "app set" function also uses util to verify passed override parameter before calling "updateSpec" 

throws error if passed parameter is illegal, warns users if any old overrides are dropped 