### PR TITLE
Consolidate printing of hook resources with application resources

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -181,7 +181,7 @@ func (m *nativeGitClient) Reset() error {
 			return err
 		}
 	}
-	if _, err := m.runCmd("git", "clean", "-f"); err != nil {
+	if _, err := m.runCmd("git", "clean", "-fd"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
New output format of `argocd app sync` and `argocd app get --show-operation`:
```
$ argocd app sync bg-guestbook --strategy hook
Application:        bg-guestbook
Operation:          Sync
Phase:              Succeeded
Start:              2018-07-09 04:02:09 -0700 PDT
Finished:           2018-07-09 04:03:27 -0700 PDT
Duration:           1m18s
Message:            successfully synced

HOOK  KIND        NAME                                   STATUS     HEALTH   OPERATIONMSG
      Service     bg-guestbook                           Synced     Healthy  Skipped
      Deployment  bg-guestbook                           Synced     Healthy  Skipped
Sync  Workflow    k8s-bluegreen-sync-96a019c-1531134129  Succeeded
```

```
$ argocd app get bg-guestbook --show-operation
Name:               bg-guestbook
Server:             https://35.230.36.236
Namespace:          default
URL:                http://localhost:8080/applications/bg-guestbook
Environment:        default
Repo:               https://github.com/argoproj/argocd-example-apps.git
Path:               blue-green-deploy
Target:             HEAD

Operation:          Sync
Phase:              Succeeded
Start:              2018-07-09 04:02:09 -0700 PDT
Finished:           2018-07-09 04:03:27 -0700 PDT
Duration:           1m18s
Message:            successfully synced

HOOK  KIND        NAME                                   STATUS     HEALTH   OPERATIONMSG
      Service     bg-guestbook                           Synced     Healthy  Skipped
      Deployment  bg-guestbook                           Synced     Healthy  Skipped
Sync  Workflow    k8s-bluegreen-sync-96a019c-1531134129  Succeeded
```

```
$ argocd app sync pre-post-sync --strategy hook
Application:        pre-post-sync
Operation:          Sync
Phase:              Succeeded
Start:              2018-07-09 04:04:25 -0700 PDT
Finished:           2018-07-09 04:05:27 -0700 PDT
Duration:           1m2s
Message:            successfully synced

HOOK      KIND        NAME                               STATUS     HEALTH   OPERATIONMSG
PreSync   Job         before-presync-16d8fca-1531134265  Succeeded
          Service     pre-post-sync                      Synced     Healthy  service "pre-post-sync" unchanged
          Deployment  pre-post-sync                      Synced     Healthy  deployment.apps "pre-post-sync" unchanged
PostSync  Job         after-postsync-16d8fca-1531134265  Succeeded
```