### PR TITLE
If manifest query is a commit sha, check cache first to prevent locking git repo

### DIFF
--- a/util/git/git.go
+++ b/util/git/git.go
@@ -27,6 +27,13 @@ func ensureSuffix(s, suffix string) string {
 	return s
 }
 
+var commitSHARegex = regexp.MustCompile("^[0-9A-Fa-f]{40}$")
+
+// IsCommitSHA returns whether or not a string is a 40 character SHA-1
+func IsCommitSHA(sha string) bool {
+	return commitSHARegex.MatchString(sha)
+}
+
 // NormalizeGitURL normalizes a git URL for lookup and storage
 func NormalizeGitURL(repo string) string {
 	// preprocess

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsCommitSHA(t *testing.T) {
+	assert.True(t, IsCommitSHA("9d921f65f3c5373b682e2eb4b37afba6592e8f8b"))
+	assert.True(t, IsCommitSHA("9D921F65F3C5373B682E2EB4B37AFBA6592E8F8B"))
+	assert.False(t, IsCommitSHA("gd921f65f3c5373b682e2eb4b37afba6592e8f8b"))
+	assert.False(t, IsCommitSHA("master"))
+	assert.False(t, IsCommitSHA("HEAD"))
+	assert.False(t, IsCommitSHA("9d921f6")) // only consider 40 characters hex strings as a commit-sha
+}
+
 func TestEnsurePrefix(t *testing.T) {
 	data := [][]string{
 		{"world", "hello", "helloworld"},


### PR DESCRIPTION
Resolves #380