### PR TITLE
Apply logic was ignoring  `kubectl apply` failures

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -148,6 +148,10 @@ const (
 	ResourceDetailsPruningRequired ResourceSyncStatus = "PruningRequired"
 )
 
+func (s ResourceSyncStatus) Successful() bool {
+	return s != ResourceDetailsSyncFailed
+}
+
 type ResourceDetails struct {
 	Name      string             `json:"name" protobuf:"bytes,1,opt,name=name"`
 	Kind      string             `json:"kind" protobuf:"bytes,2,opt,name=kind"`

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -508,13 +508,22 @@ func ApplyResource(config *rest.Config, obj *unstructured.Unstructured, namespac
 	out, err := cmd.Output()
 	if err != nil {
 		if exErr, ok := err.(*exec.ExitError); ok {
-			// this makes the output a little better to read
-			errMsg := strings.Replace(strings.TrimSpace(string(exErr.Stderr)), ": error when creating \"STDIN\"", "", -1)
+			errMsg := cleanKubectlOutput(string(exErr.Stderr))
 			return "", errors.New(errMsg)
 		}
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// cleanKubectlOutput makes the error output of kubectl a little better to read
+func cleanKubectlOutput(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Replace(s, ": error validating \"STDIN\"", "", -1)
+	s = strings.Replace(s, ": error when creating \"STDIN\"", "", -1)
+	s = strings.Replace(s, "; if you choose to ignore these errors, turn validation off with --validate=false", "", -1)
+	s = strings.Replace(s, "error: error", "error", -1)
+	return s
 }
 
 // WriteKubeConfig takes a rest.Config and writes it as a kubeconfig at the specified path

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -232,3 +232,8 @@ func TestSetLabels(t *testing.T) {
 	}
 
 }
+
+func TestCleanKubectlOutput(t *testing.T) {
+	testString := `error: error validating "STDIN": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1beta2.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false`
+	assert.Equal(t, cleanKubectlOutput(testString), `error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1beta2.DeploymentSpec`)
+}


### PR DESCRIPTION
This fixes a critical issue where all apply operations were being marked successful, even when they weren't.