### PR TITLE
Clean up RBAC policy rule format for non-project based resources

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"fmt"
 	"reflect"
 
 	"golang.org/x/net/context"
@@ -35,7 +34,7 @@ func (s *Server) List(ctx context.Context, q *ClusterQuery) (*appv1.ClusterList,
 	if clusterList != nil {
 		newItems := make([]appv1.Cluster, 0)
 		for _, clust := range clusterList.Items {
-			if s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "get", fmt.Sprintf("*/%s", clust.Server)) {
+			if s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "get", clust.Server) {
 				newItems = append(newItems, *redact(&clust))
 			}
 		}
@@ -46,7 +45,7 @@ func (s *Server) List(ctx context.Context, q *ClusterQuery) (*appv1.ClusterList,
 
 // Create creates a cluster
 func (s *Server) Create(ctx context.Context, q *ClusterCreateRequest) (*appv1.Cluster, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "create", fmt.Sprintf("*/%s", q.Cluster.Server)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "create", q.Cluster.Server) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	c := q.Cluster
@@ -79,7 +78,7 @@ func (s *Server) Create(ctx context.Context, q *ClusterCreateRequest) (*appv1.Cl
 
 // Get returns a cluster from a query
 func (s *Server) Get(ctx context.Context, q *ClusterQuery) (*appv1.Cluster, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "get", fmt.Sprintf("*/%s", q.Server)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "get", q.Server) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	clust, err := s.db.GetCluster(ctx, q.Server)
@@ -88,7 +87,7 @@ func (s *Server) Get(ctx context.Context, q *ClusterQuery) (*appv1.Cluster, erro
 
 // Update updates a cluster
 func (s *Server) Update(ctx context.Context, q *ClusterUpdateRequest) (*appv1.Cluster, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "update", fmt.Sprintf("*/%s", q.Cluster.Server)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "update", q.Cluster.Server) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	err := kube.TestConfig(q.Cluster.RESTConfig())
@@ -101,7 +100,7 @@ func (s *Server) Update(ctx context.Context, q *ClusterUpdateRequest) (*appv1.Cl
 
 // Delete deletes a cluster by name
 func (s *Server) Delete(ctx context.Context, q *ClusterQuery) (*ClusterResponse, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "delete", fmt.Sprintf("*/%s", q.Server)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "clusters", "delete", q.Server) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	err := s.db.DeleteCluster(ctx, q.Server)

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/ghodss/yaml"
@@ -45,7 +44,7 @@ func (s *Server) List(ctx context.Context, q *RepoQuery) (*appsv1.RepositoryList
 	if repoList != nil {
 		newItems := make([]appsv1.Repository, 0)
 		for _, repo := range repoList.Items {
-			if s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "get", fmt.Sprintf("*/%s", repo.Repo)) {
+			if s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "get", repo.Repo) {
 				newItems = append(newItems, *redact(&repo))
 			}
 		}
@@ -56,7 +55,7 @@ func (s *Server) List(ctx context.Context, q *RepoQuery) (*appsv1.RepositoryList
 
 // ListKsonnetApps returns list of Ksonnet apps in the repo
 func (s *Server) ListKsonnetApps(ctx context.Context, q *RepoKsonnetQuery) (*RepoKsonnetResponse, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories/apps", "get", fmt.Sprintf("*/%s", q.Repo)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories/apps", "get", q.Repo) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	repo, err := s.db.GetRepository(ctx, q.Repo)
@@ -113,7 +112,7 @@ func (s *Server) ListKsonnetApps(ctx context.Context, q *RepoKsonnetQuery) (*Rep
 
 // Create creates a repository
 func (s *Server) Create(ctx context.Context, q *RepoCreateRequest) (*appsv1.Repository, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "create", fmt.Sprintf("*/%s", q.Repo.Repo)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "create", q.Repo.Repo) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	r := q.Repo
@@ -146,7 +145,7 @@ func (s *Server) Create(ctx context.Context, q *RepoCreateRequest) (*appsv1.Repo
 
 // Get returns a repository by URL
 func (s *Server) Get(ctx context.Context, q *RepoQuery) (*appsv1.Repository, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "get", fmt.Sprintf("*/%s", q.Repo)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "get", q.Repo) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	repo, err := s.db.GetRepository(ctx, q.Repo)
@@ -155,7 +154,7 @@ func (s *Server) Get(ctx context.Context, q *RepoQuery) (*appsv1.Repository, err
 
 // Update updates a repository
 func (s *Server) Update(ctx context.Context, q *RepoUpdateRequest) (*appsv1.Repository, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "update", fmt.Sprintf("*/%s", q.Repo.Repo)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "update", q.Repo.Repo) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	repo, err := s.db.UpdateRepository(ctx, q.Repo)
@@ -164,7 +163,7 @@ func (s *Server) Update(ctx context.Context, q *RepoUpdateRequest) (*appsv1.Repo
 
 // Delete updates a repository
 func (s *Server) Delete(ctx context.Context, q *RepoQuery) (*RepoResponse, error) {
-	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "delete", fmt.Sprintf("*/%s", q.Repo)) {
+	if !s.enf.EnforceClaims(ctx.Value("claims"), "repositories", "delete", q.Repo) {
 		return nil, grpc.ErrPermissionDenied
 	}
 	err := s.db.DeleteRepository(ctx, q.Repo)

--- a/util/rbac/builtin-policy.csv
+++ b/util/rbac/builtin-policy.csv
@@ -1,16 +1,19 @@
 # Built-in policy which defines two roles: role:readonly and role:admin,
 # and additionally assigns the admin user to the role:admin role.
-# The policy format is:
+# There are two policy formats:
+# 1. Applications (which belong to a project):
 # p, <user/group>, <resource>, <action>, <project>/<object>
+# 2. All other resources:
+# p, <user/group>, <resource>, <action>, <object>
 
 p, role:readonly, applications, get, */*
 p, role:readonly, applications/events, get, */*
 p, role:readonly, applications/manifests, get, */*
 p, role:readonly, applications/logs, get, */*
-p, role:readonly, clusters, get, */*
-p, role:readonly, repositories, get, */*
-p, role:readonly, repositories/apps, get, */*
-p, role:readonly, projects, get, */*
+p, role:readonly, clusters, get, *
+p, role:readonly, repositories, get, *
+p, role:readonly, repositories/apps, get, *
+p, role:readonly, projects, get, *
 
 p, role:admin, applications, create, */*
 p, role:admin, applications, update, */*
@@ -19,15 +22,15 @@ p, role:admin, applications, sync, */*
 p, role:admin, applications, rollback, */*
 p, role:admin, applications, terminateop, */*
 p, role:admin, applications/pods, delete, */*
-p, role:admin, clusters, create, */*
-p, role:admin, clusters, update, */*
-p, role:admin, clusters, delete, */*
-p, role:admin, repositories, create, */*
-p, role:admin, repositories, update, */*
-p, role:admin, repositories, delete, */*
-p, role:admin, projects, create, */*
-p, role:admin, projects, update, */*
-p, role:admin, projects, delete, */*
+p, role:admin, clusters, create, *
+p, role:admin, clusters, update, *
+p, role:admin, clusters, delete, *
+p, role:admin, repositories, create, *
+p, role:admin, repositories, update, *
+p, role:admin, repositories, delete, *
+p, role:admin, projects, create, *
+p, role:admin, projects, update, *
+p, role:admin, projects, delete, *
 
 g, role:admin, role:readonly
 g, admin, role:admin


### PR DESCRIPTION
This removes the `*/*` policy format for all of our resources which are not project based (i.e. applications).
