### PR TITLE
Rework installation process to apply from install.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ IMAGE_PREFIX=${IMAGE_NAMESPACE}/
 endif
 
 .PHONY: all
-all: cli server-image controller-image repo-server-image argocd-util
+all: cli server-image controller-image repo-server-image argocd-util install-manifest
 
 .PHONY: protogen
 protogen:
@@ -78,10 +78,14 @@ cli-darwin: clean-debug
 argocd-util: clean-debug
 	CGO_ENABLED=0 go build -v -i -ldflags '${LDFLAGS} -extldflags "-static"' -o ${DIST_DIR}/argocd-util ./cmd/argocd-util
 
+.PHONY: install-manifest
+install-manifest: clean-debug
+	cat manifests/components/*.yaml > manifests/install.yaml
+
 .PHONY: server
 server: clean-debug
 	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-server ./cmd/argocd-server
-
+	
 .PHONY: server-image
 server-image:
 	docker build --build-arg BINARY=argocd-server -t $(IMAGE_PREFIX)argocd-server:$(IMAGE_TAG) -f Dockerfile-argocd .

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,7 +18,8 @@ chmod +x /usr/local/bin/argocd
 
 ## 2. Install ArgoCD
 ```
-kubectl apply -f manifests/. --namespace argocd
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://github.com/argoproj/argo-cd/blob/master/manifests/install.yaml
 ```
 This will create a new namespace, `argocd`; where ArgoCD services and application resources will live.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -20,7 +20,7 @@ chmod +x /usr/local/bin/argocd
 ```
 kubectl apply -f manifests/. --namespace argocd
 ```
-This will create a new namespace, `argocd`, where ArgoCD services and application resources will live.
+This will create a new namespace, `argocd`; where ArgoCD services and application resources will live.
 
 ## 3. Open access to ArgoCD API server
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,11 +18,9 @@ chmod +x /usr/local/bin/argocd
 
 ## 2. Install ArgoCD
 ```
-kubectl create namespace argocd
-kubectl apply -n argocd -f https://github.com/argoproj/argo-cd/blob/master/manifests/install.yaml
+argocd install
 ```
-This will create a new namespace, `argocd` where ArgoCD services and application resources will live.
-This will also create key replicasets, deployments and services needed for ArgoCD
+This will create a new namespace, `argocd`, where ArgoCD services and application resources will live.
 
 ## 3. Open access to ArgoCD API server
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,7 +21,8 @@ chmod +x /usr/local/bin/argocd
 kubectl create namespace argocd
 kubectl apply -n argocd -f https://github.com/argoproj/argo-cd/blob/master/manifests/install.yaml
 ```
-This will create a new namespace, `argocd`; where ArgoCD services and application resources will live.
+This will create a new namespace, `argocd` where ArgoCD services and application resources will live.
+This will also create key replicasets, deployments and services needed for ArgoCD
 
 ## 3. Open access to ArgoCD API server
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,9 +18,10 @@ chmod +x /usr/local/bin/argocd
 
 ## 2. Install ArgoCD
 ```
-argocd install
+kubectl apply -f manifests/. --namespace argocd
 ```
 This will create a new namespace, `argocd`, where ArgoCD services and application resources will live.
+
 
 ## 3. Open access to ArgoCD API server
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -22,7 +22,6 @@ kubectl apply -f manifests/. --namespace argocd
 ```
 This will create a new namespace, `argocd`, where ArgoCD services and application resources will live.
 
-
 ## 3. Open access to ArgoCD API server
 
 By default, the ArgoCD API server is not exposed with an external IP. To expose the API server,

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: argocd

--- a/manifests/components/01a_application-crd.yaml
+++ b/manifests/components/01a_application-crd.yaml
@@ -1,14 +1,14 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: appprojects.argoproj.io
+  name: applications.argoproj.io
 spec:
   group: argoproj.io
   names:
-    kind: AppProject
-    plural: appprojects
+    kind: Application
+    plural: applications
     shortNames:
-    - appproj
-    - appprojs
+    - app
   scope: Namespaced
   version: v1alpha1

--- a/manifests/components/01b_appproject-crd.yaml
+++ b/manifests/components/01b_appproject-crd.yaml
@@ -1,13 +1,15 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: applications.argoproj.io
+  name: appprojects.argoproj.io
 spec:
   group: argoproj.io
   names:
-    kind: Application
-    plural: applications
+    kind: AppProject
+    plural: appprojects
     shortNames:
-    - app
+    - appproj
+    - appprojs
   scope: Namespaced
   version: v1alpha1

--- a/manifests/components/02a_argocd-cm.yaml
+++ b/manifests/components/02a_argocd-cm.yaml
@@ -1,3 +1,4 @@
+---
 # NOTE: the values here are just a example and are not the values used during an install.
 apiVersion: v1
 kind: ConfigMap
@@ -6,4 +7,3 @@ metadata:
 data:
   # please see https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso 
   # for more details about how to setup data config needed for sso
-  

--- a/manifests/components/02a_argocd-cm.yaml
+++ b/manifests/components/02a_argocd-cm.yaml
@@ -1,9 +1,14 @@
 ---
-# NOTE: the values here are just a example and are not the values used during an install.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
 data:
-  # please see https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso 
+  # See https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso 
   # for more details about how to setup data config needed for sso
+
+  # URL is the external URL of ArgoCD
+  #url: 
+
+  # A dex connector configuration
+  #dex.config:

--- a/manifests/components/02b_argocd-secret.yaml
+++ b/manifests/components/02b_argocd-secret.yaml
@@ -1,15 +1,24 @@
 ---
-# NOTE: the values in this secret are provided as working manifest example and are not the values
-# used during an install. New values will be generated as part of `argocd install`
+# NOTE: the values in this secret will be populated by the initial startup of the API
 apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-secret
 type: Opaque
-  # bcrypt hash of the string "password"
+  # bcrypt hash of the admin password
+  #admin.password: 
+
   # random server signature key for session validation
+  #server.secretkey:
+
+  # TLS certificate and private key for API server
+  #server.crt: 
+  #server.key:
 
   # The following keys hold the shared secret for authenticating GitHub/GitLab/BitBucket webhook
   # events. To enable webhooks, configure one or more of the following keys with the shared git
   # provider webhook secret. The payload URL configured in the git provider should use the 
   # /api/webhook endpoint of your ArgoCD instance (e.g. https://argocd.example.com/api/webhook)
+  #github.webhook.secret: 
+  #gitlab.webhook.secret:
+  #bitbucket.webhook.uuid: 

--- a/manifests/components/02b_argocd-secret.yaml
+++ b/manifests/components/02b_argocd-secret.yaml
@@ -1,3 +1,4 @@
+---
 # NOTE: the values in this secret are provided as working manifest example and are not the values
 # used during an install. New values will be generated as part of `argocd install`
 apiVersion: v1

--- a/manifests/components/02c_argocd-rbac-cm.yaml
+++ b/manifests/components/02c_argocd-rbac-cm.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/manifests/components/02c_argocd-rbac-cm.yaml
+++ b/manifests/components/02c_argocd-rbac-cm.yaml
@@ -9,19 +9,18 @@ data:
   # * role:readonly - readonly access to all objects
   # * role:admin - admin access to all objects
   # The built-in policy can be seen under util/rbac/builtin-policy.csv
-  #
-  # The policy definition format is:
+  #policy.csv: ""
+
+  # There are two policy formats:
+  # 1. Applications (which belong to a project):
   # p, <user/group>, <resource>, <action>, <project>/<object>
+  # 2. All other resources:
+  # p, <user/group>, <resource>, <action>, <object>
+
   # For example, the following rule gives all members of 'my-org:team1' the ability to sync
   # applications in the project named: my-project
   # p, my-org:team1, applications, sync, my-project/*
-  #
-  # The role definition format is:
-  # g, <user/group>, <group>
-  # For example, the following rule makes all members of 'my-org:team2' have the role:admin role:
-  # g, my-org:team2, role:admin
-  policy.csv: ""
 
   # policy.default holds the default policy which will ArgoCD will fall back to, when authorizing
-  # a user for API requests.
+  # a user for API requests
   policy.default: role:readonly

--- a/manifests/components/03a_application-controller-sa.yaml
+++ b/manifests/components/03a_application-controller-sa.yaml
@@ -1,4 +1,5 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: argocd-server
+  name: application-controller

--- a/manifests/components/03b_application-controller-role.yaml
+++ b/manifests/components/03b_application-controller-role.yaml
@@ -18,6 +18,7 @@ rules:
   - argoproj.io
   resources:
   - applications
+  - appprojects
   verbs:
   - create
   - get

--- a/manifests/components/03b_application-controller-role.yaml
+++ b/manifests/components/03b_application-controller-role.yaml
@@ -1,21 +1,19 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-server-role
+  name: application-controller-role
 rules:
 - apiGroups:
   - ""
   resources:
   - secrets
-  - configmaps
   verbs:
-  - create
   - get
-  - list
   - watch
-  - update
+  - list
   - patch
-  - delete
+  - update
 - apiGroups:
   - argoproj.io
   resources:
@@ -26,5 +24,5 @@ rules:
   - list
   - watch
   - update
-  - delete
   - patch
+  - delete

--- a/manifests/components/03c_application-controller-rolebinding.yaml
+++ b/manifests/components/03c_application-controller-rolebinding.yaml
@@ -1,11 +1,12 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-server-role-binding
+  name: application-controller-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-server-role
+  name: application-controller-role
 subjects:
 - kind: ServiceAccount
-  name: argocd-server
+  name: application-controller

--- a/manifests/components/03d_application-controller-deployment.yaml
+++ b/manifests/components/03d_application-controller-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:

--- a/manifests/components/04a_argocd-server-sa.yaml
+++ b/manifests/components/04a_argocd-server-sa.yaml
@@ -1,4 +1,5 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: application-controller
+  name: argocd-server

--- a/manifests/components/04b_argocd-server-role.yaml
+++ b/manifests/components/04b_argocd-server-role.yaml
@@ -1,18 +1,22 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: application-controller-role
+  name: argocd-server-role
 rules:
 - apiGroups:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
+  - create
   - get
-  - watch
   - list
-  - patch
+  - watch
   - update
+  - patch
+  - delete
 - apiGroups:
   - argoproj.io
   resources:
@@ -23,5 +27,5 @@ rules:
   - list
   - watch
   - update
-  - patch
   - delete
+  - patch

--- a/manifests/components/04b_argocd-server-role.yaml
+++ b/manifests/components/04b_argocd-server-role.yaml
@@ -21,6 +21,7 @@ rules:
   - argoproj.io
   resources:
   - applications
+  - appprojects
   verbs:
   - create
   - get

--- a/manifests/components/04c_argocd-server-rolebinding.yaml
+++ b/manifests/components/04c_argocd-server-rolebinding.yaml
@@ -1,11 +1,12 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: application-controller-role-binding
+  name: argocd-server-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: application-controller-role
+  name: argocd-server-role
 subjects:
 - kind: ServiceAccount
-  name: application-controller
+  name: argocd-server

--- a/manifests/components/04d_argocd-server-deployment.yaml
+++ b/manifests/components/04d_argocd-server-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:

--- a/manifests/components/04e_argocd-server-service.yaml
+++ b/manifests/components/04e_argocd-server-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/components/05a_argocd-repo-server-deployment.yaml
+++ b/manifests/components/05a_argocd-repo-server-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:

--- a/manifests/components/05b_argocd-repo-server-service.yaml
+++ b/manifests/components/05b_argocd-repo-server-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -1,0 +1,288 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Application
+    plural: applications
+    shortNames:
+    - app
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: appprojects.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: AppProject
+    plural: appprojects
+    shortNames:
+    - appproj
+    - appprojs
+  scope: Namespaced
+  version: v1alpha1
+---
+# NOTE: the values here are just a example and are not the values used during an install.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  # please see https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso 
+  # for more details about how to setup data config needed for sso
+---
+# NOTE: the values in this secret are provided as working manifest example and are not the values
+# used during an install. New values will be generated as part of `argocd install`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
+type: Opaque
+  # bcrypt hash of the string "password"
+  # random server signature key for session validation
+
+  # The following keys hold the shared secret for authenticating GitHub/GitLab/BitBucket webhook
+  # events. To enable webhooks, configure one or more of the following keys with the shared git
+  # provider webhook secret. The payload URL configured in the git provider should use the 
+  # /api/webhook endpoint of your ArgoCD instance (e.g. https://argocd.example.com/api/webhook)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+data:
+  # policy.csv holds the CSV file policy file which contains additional policy and role definitions.
+  # ArgoCD defines two built-in roles:
+  # * role:readonly - readonly access to all objects
+  # * role:admin - admin access to all objects
+  # The built-in policy can be seen under util/rbac/builtin-policy.csv
+  #
+  # The policy definition format is:
+  # p, <user/group>, <resource>, <action>, <project>/<object>
+  # For example, the following rule gives all members of 'my-org:team1' the ability to sync
+  # applications in the project named: my-project
+  # p, my-org:team1, applications, sync, my-project/*
+  #
+  # The role definition format is:
+  # g, <user/group>, <group>
+  # For example, the following rule makes all members of 'my-org:team2' have the role:admin role:
+  # g, my-org:team2, role:admin
+  policy.csv: ""
+
+  # policy.default holds the default policy which will ArgoCD will fall back to, when authorizing
+  # a user for API requests.
+  policy.default: role:readonly
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: application-controller-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: application-controller-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: application-controller-role
+subjects:
+- kind: ServiceAccount
+  name: application-controller
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: application-controller
+spec:
+  selector:
+    matchLabels:
+      app: application-controller
+  template:
+    metadata:
+      labels:
+        app: application-controller
+    spec:
+      containers:
+      - command: [/argocd-application-controller, --repo-server, 'argocd-repo-server:8081']
+        image: argoproj/argocd-application-controller:latest
+        name: application-controller
+      serviceAccountName: application-controller
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-server-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-server-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-server-role
+subjects:
+- kind: ServiceAccount
+  name: argocd-server
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: argocd-server
+spec:
+  selector:
+    matchLabels:
+      app: argocd-server
+  template:
+    metadata:
+      labels:
+        app: argocd-server
+    spec:
+      serviceAccountName: argocd-server
+      initContainers:
+      - name: copyutil
+        image: argoproj/argocd-server:latest
+        command: [cp, /argocd-util, /shared]
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      - name: ui
+        image: argoproj/argocd-ui:latest
+        command: [cp, -r, /app, /shared]
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      containers:
+      - name: argocd-server
+        image: argoproj/argocd-server:latest
+        command: [/argocd-server, --staticassets, /shared/app, --repo-server, 'argocd-repo-server:8081']
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      - name: dex
+        image: quay.io/coreos/dex:v2.10.0
+        command: [/shared/argocd-util, rundex]
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      volumes:
+      - emptyDir: {}
+        name: static-files
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 8080
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 8080
+  selector:
+    app: argocd-server
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+spec:
+  selector:
+    matchLabels:
+      app: argocd-repo-server
+  template:
+    metadata:
+      labels:
+        app: argocd-repo-server
+    spec:
+      containers:
+      - name: argocd-repo-server
+        image: argoproj/argocd-repo-server:latest
+        command: [/argocd-repo-server]
+        ports:
+          - containerPort: 8081
+      - name: redis
+        image: redis:3.2.11
+        ports:
+          - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-repo-server
+spec:
+  ports:
+  - port: 8081
+    targetPort: 8081
+  selector:
+    app: argocd-repo-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -28,29 +28,43 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-# NOTE: the values here are just a example and are not the values used during an install.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
 data:
-  # please see https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso 
+  # See https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso 
   # for more details about how to setup data config needed for sso
+
+  # URL is the external URL of ArgoCD
+  #url: 
+
+  # A dex connector configuration
+  #dex.config:
 ---
-# NOTE: the values in this secret are provided as working manifest example and are not the values
-# used during an install. New values will be generated as part of `argocd install`
+# NOTE: the values in this secret will be populated by the initial startup of the API
 apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-secret
 type: Opaque
-  # bcrypt hash of the string "password"
+  # bcrypt hash of the admin password
+  #admin.password: 
+
   # random server signature key for session validation
+  #server.secretkey:
+
+  # TLS certificate and private key for API server
+  #server.crt: 
+  #server.key:
 
   # The following keys hold the shared secret for authenticating GitHub/GitLab/BitBucket webhook
   # events. To enable webhooks, configure one or more of the following keys with the shared git
   # provider webhook secret. The payload URL configured in the git provider should use the 
   # /api/webhook endpoint of your ArgoCD instance (e.g. https://argocd.example.com/api/webhook)
+  #github.webhook.secret: 
+  #gitlab.webhook.secret:
+  #bitbucket.webhook.uuid: 
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -62,21 +76,20 @@ data:
   # * role:readonly - readonly access to all objects
   # * role:admin - admin access to all objects
   # The built-in policy can be seen under util/rbac/builtin-policy.csv
-  #
-  # The policy definition format is:
+  #policy.csv: ""
+
+  # There are two policy formats:
+  # 1. Applications (which belong to a project):
   # p, <user/group>, <resource>, <action>, <project>/<object>
+  # 2. All other resources:
+  # p, <user/group>, <resource>, <action>, <object>
+
   # For example, the following rule gives all members of 'my-org:team1' the ability to sync
   # applications in the project named: my-project
   # p, my-org:team1, applications, sync, my-project/*
-  #
-  # The role definition format is:
-  # g, <user/group>, <group>
-  # For example, the following rule makes all members of 'my-org:team2' have the role:admin role:
-  # g, my-org:team2, role:admin
-  policy.csv: ""
 
   # policy.default holds the default policy which will ArgoCD will fall back to, when authorizing
-  # a user for API requests.
+  # a user for API requests
   policy.default: role:readonly
 ---
 apiVersion: v1
@@ -103,6 +116,7 @@ rules:
   - argoproj.io
   resources:
   - applications
+  - appprojects
   verbs:
   - create
   - get
@@ -170,6 +184,7 @@ rules:
   - argoproj.io
   resources:
   - applications
+  - appprojects
   verbs:
   - create
   - get
@@ -271,10 +286,6 @@ spec:
         command: [/argocd-repo-server]
         ports:
           - containerPort: 8081
-      - name: redis
-        image: redis:3.2.11
-        ports:
-          - containerPort: 6379
 ---
 apiVersion: v1
 kind: Service

--- a/test/e2e/fixture.go
+++ b/test/e2e/fixture.go
@@ -89,7 +89,7 @@ func getFreePort() (int, error) {
 }
 
 func (f *Fixture) setup() error {
-	_, err := exec.Command("kubectl", "apply", "-f", "../../manifests/01a_application-crd.yaml", "-f", "../../manifests/01b_appproject-crd.yaml").Output()
+	_, err := exec.Command("kubectl", "apply", "-f", "../../manifests/components/01a_application-crd.yaml", "-f", "../../manifests/components/01b_appproject-crd.yaml").Output()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is an adaptation of @JazminGonzalez-Rivero changes to the installation process:
* Create install.yaml aggregate yaml for install instructions.
* Update roles required by api-server and application-controller to include CRUD on appproject CRD.
* Added back explanations of keys in the secret manifests.

NOTE: install.yaml will need change to use a hard wired version (e.g. v0.6.0) in a subsequent checkin.

