### PR TITLE
Resolves 398 -> errors set status to known, status details set to error message

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -553,7 +553,6 @@ func (ctrl *ApplicationController) refreshAppConditions(app *appv1.Application) 
 
 // setApplicationHealth updates the health statuses of all resources performed in the comparison
 func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.HealthStatus, error) {
-	var err error
 	appHealth := appv1.HealthStatus{Status: appv1.HealthStatusHealthy}
 	if comparisonResult.Status == appv1.ComparisonStatusUnknown {
 		appHealth.Status = appv1.HealthStatusUnknown
@@ -567,10 +566,7 @@ func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.Heal
 			if err != nil {
 				return nil, err
 			}
-			healthState, erre := health.GetAppHealth(&obj)
-			if erre != nil {
-				err = erre
-			}
+			healthState, _ := health.GetAppHealth(&obj)
 			resource.Health = *healthState
 		}
 		comparisonResult.Resources[i] = resource
@@ -578,7 +574,7 @@ func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.Heal
 			appHealth.Status = resource.Health.Status
 		}
 	}
-	return &appHealth, err
+	return &appHealth, nil
 }
 
 // updateAppStatus persists updates to application status. Detects if there patch

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -553,7 +553,7 @@ func (ctrl *ApplicationController) refreshAppConditions(app *appv1.Application) 
 
 // setApplicationHealth updates the health statuses of all resources performed in the comparison
 func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.HealthStatus, error) {
-	var poErr, savedErr error
+	var savedErr error
 	appHealth := appv1.HealthStatus{Status: appv1.HealthStatusHealthy}
 	if comparisonResult.Status == appv1.ComparisonStatusUnknown {
 		appHealth.Status = appv1.HealthStatusUnknown
@@ -568,15 +568,14 @@ func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.Heal
 				return nil, err
 			}
 			healthState, err := health.GetAppHealth(&obj)
-			poErr = err
+			if err != nil && savedErr == nil {
+				savedErr = err
+			}
 			resource.Health = *healthState
 		}
 		comparisonResult.Resources[i] = resource
 		if health.IsWorse(appHealth.Status, resource.Health.Status) {
 			appHealth.Status = resource.Health.Status
-			if poErr != nil {
-				savedErr = poErr
-			}
 		}
 	}
 	return &appHealth, savedErr

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -553,6 +553,7 @@ func (ctrl *ApplicationController) refreshAppConditions(app *appv1.Application) 
 
 // setApplicationHealth updates the health statuses of all resources performed in the comparison
 func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.HealthStatus, error) {
+	var err error
 	appHealth := appv1.HealthStatus{Status: appv1.HealthStatusHealthy}
 	if comparisonResult.Status == appv1.ComparisonStatusUnknown {
 		appHealth.Status = appv1.HealthStatusUnknown
@@ -566,7 +567,10 @@ func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.Heal
 			if err != nil {
 				return nil, err
 			}
-			healthState, err := health.GetAppHealth(&obj)
+			healthState, erre := health.GetAppHealth(&obj)
+			if erre != nil {
+				err = erre
+			}
 			resource.Health = *healthState
 		}
 		comparisonResult.Resources[i] = resource
@@ -574,7 +578,7 @@ func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.Heal
 			appHealth.Status = resource.Health.Status
 		}
 	}
-	return &appHealth, nil
+	return &appHealth, err
 }
 
 // updateAppStatus persists updates to application status. Detects if there patch

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -567,9 +567,6 @@ func setApplicationHealth(comparisonResult *appv1.ComparisonResult) (*appv1.Heal
 				return nil, err
 			}
 			healthState, err := health.GetAppHealth(&obj)
-			if err != nil {
-				return nil, err
-			}
 			resource.Health = *healthState
 		}
 		comparisonResult.Resources[i] = resource


### PR DESCRIPTION
Tested by: 

forced  runtime.DefaultUnstructuredConverter.FromUnstructured to return an error

result: health was set to unknown. 
