### PR TITLE
Expire local superuser tokens when their password changes

### DIFF
--- a/server/account/account.go
+++ b/server/account/account.go
@@ -34,7 +34,7 @@ func NewServer(sessionMgr *session.SessionManager, settingsMgr *settings.Setting
 func (s *Server) UpdatePassword(ctx context.Context, q *UpdatePasswordRequest) (*UpdatePasswordResponse, error) {
 	username := getAuthenticatedUser(ctx)
 	if username != common.ArgoCDAdminUsername {
-		return nil, status.Errorf(codes.InvalidArgument, "password can only be changed for local users")
+		return nil, status.Errorf(codes.InvalidArgument, "password can only be changed for local users, not user %q", username)
 	}
 
 	cdSettings, err := s.settingsMgr.GetSettings()

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -53,7 +53,7 @@ func (s *Server) UpdatePassword(ctx context.Context, q *UpdatePasswordRequest) (
 	}
 
 	cdSettings.AdminPasswordHash = hashedPassword
-	cdSettings.AdminPasswordMtime = time.Now()
+	cdSettings.AdminPasswordMtime = time.Now().UTC()
 
 	err = s.settingsMgr.SaveSettings(cdSettings)
 	if err != nil {

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -36,7 +36,7 @@ func (s *Server) Create(ctx context.Context, q *SessionCreateRequest) (*SessionR
 		if err != nil {
 			return nil, err
 		}
-		tokenString, err = s.mgr.Create(q.Username)
+		tokenString, err = s.mgr.Create(q.Username, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -50,7 +50,7 @@ func (s *Server) Create(ctx context.Context, q *SessionCreateRequest) (*SessionR
 		if err != nil {
 			return nil, err
 		}
-		tokenString, err = s.mgr.ReissueClaims(claims)
+		tokenString, err = s.mgr.ReissueClaims(claims, 0)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to resign claims: %v", err)
 		}

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -68,7 +68,8 @@ func NewSessionManager(settings *settings.ArgoCDSettings) *SessionManager {
 }
 
 // Create creates a new token for a given subject (user) and returns it as a string.
-func (mgr *SessionManager) Create(subject string, expires int) (string, error) {
+// Passing a value of `0` for secondsBeforeExpiry creates a token that never expires.
+func (mgr *SessionManager) Create(subject string, secondsBeforeExpiry int) (string, error) {
 	// Create a new token object, specifying signing method and the claims
 	// you would like it to contain.
 	now := time.Now().Unix()
@@ -78,8 +79,8 @@ func (mgr *SessionManager) Create(subject string, expires int) (string, error) {
 		NotBefore: now,
 		Subject:   subject,
 	}
-	if expires > 0 {
-		claims.ExpiresAt = time.Now().Add(time.Duration(expires) * time.Second).Unix()
+	if secondsBeforeExpiry > 0 {
+		claims.ExpiresAt = time.Now().Add(time.Duration(secondsBeforeExpiry) * time.Second).Unix()
 	}
 	return mgr.signClaims(claims)
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -80,7 +80,8 @@ func (mgr *SessionManager) Create(subject string, secondsBeforeExpiry int) (stri
 		Subject:   subject,
 	}
 	if secondsBeforeExpiry > 0 {
-		claims.ExpiresAt = now.Add(time.Duration(secondsBeforeExpiry) * time.Second).Unix()
+		expires := now.Add(time.Duration(secondsBeforeExpiry) * time.Second)
+		claims.ExpiresAt = expires.Unix()
 	}
 	return mgr.signClaims(claims)
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -68,16 +68,18 @@ func NewSessionManager(settings *settings.ArgoCDSettings) *SessionManager {
 }
 
 // Create creates a new token for a given subject (user) and returns it as a string.
-func (mgr *SessionManager) Create(subject string) (string, error) {
+func (mgr *SessionManager) Create(subject string, expires int) (string, error) {
 	// Create a new token object, specifying signing method and the claims
 	// you would like it to contain.
 	now := time.Now().Unix()
 	claims := jwt.StandardClaims{
-		//ExpiresAt: time.Date(2015, 10, 10, 12, 0, 0, 0, time.UTC).Unix(),
 		IssuedAt:  now,
 		Issuer:    SessionManagerClaimsIssuer,
 		NotBefore: now,
 		Subject:   subject,
+	}
+	if expires > 0 {
+		claims.ExpiresAt = time.Now().Add(time.Duration(expires) * time.Second).Unix()
 	}
 	return mgr.signClaims(claims)
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -140,15 +140,7 @@ func (mgr *SessionManager) VerifyUsernamePassword(username, password string) err
 	if password == "" {
 		return status.Errorf(codes.Unauthenticated, blankPasswordError)
 	}
-	passwordHash, ok := mgr.settings.AdminPasswordHash
-	if !ok {
-		// Username was not found in local user store.
-		// Ensure we still send password to hashing algorithm for comparison.
-		// This mitigates potential for timing attacks that benefit from short-circuiting,
-		// provided the hashing library/algorithm in use doesn't itself short-circuit.
-		passwordHash = ""
-	}
-	valid, _ := passwordutil.VerifyPassword(password, passwordHash)
+	valid, _ := passwordutil.VerifyPassword(password, mgr.settings.AdminPasswordHash)
 	if !valid {
 		return status.Errorf(codes.Unauthenticated, invalidLoginError)
 	}

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -72,15 +72,15 @@ func NewSessionManager(settings *settings.ArgoCDSettings) *SessionManager {
 func (mgr *SessionManager) Create(subject string, secondsBeforeExpiry int) (string, error) {
 	// Create a new token object, specifying signing method and the claims
 	// you would like it to contain.
-	now := time.Now().Unix()
+	now := time.Now()
 	claims := jwt.StandardClaims{
-		IssuedAt:  now,
+		IssuedAt:  now.Unix(),
 		Issuer:    SessionManagerClaimsIssuer,
-		NotBefore: now,
+		NotBefore: now.Unix(),
 		Subject:   subject,
 	}
 	if secondsBeforeExpiry > 0 {
-		claims.ExpiresAt = time.Now().Add(time.Duration(secondsBeforeExpiry) * time.Second).Unix()
+		claims.ExpiresAt = now.Add(time.Duration(secondsBeforeExpiry) * time.Second).Unix()
 	}
 	return mgr.signClaims(claims)
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -94,16 +94,20 @@ func (mgr *SessionManager) signClaims(claims jwt.Claims) (string, error) {
 }
 
 // ReissueClaims re-issues and re-signs a new token signed by us, while preserving most of the claim values
-func (mgr *SessionManager) ReissueClaims(claims jwt.MapClaims) (string, error) {
-	now := time.Now().UTC().Unix()
+func (mgr *SessionManager) ReissueClaims(claims jwt.MapClaims, secondsBeforeExpiry int) (string, error) {
+	now := time.Now().UTC()
 	newClaims := make(jwt.MapClaims)
 	for k, v := range claims {
 		newClaims[k] = v
 	}
 	newClaims["iss"] = SessionManagerClaimsIssuer
-	newClaims["iat"] = now
-	newClaims["nbf"] = now
+	newClaims["iat"] = now.Unix()
+	newClaims["nbf"] = now.Unix()
 	delete(newClaims, "exp")
+	if secondsBeforeExpiry > 0 {
+		expires := now.Add(time.Duration(secondsBeforeExpiry) * time.Second)
+		claims["exp"] = expires.Unix()
+	}
 	return mgr.signClaims(newClaims)
 }
 

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -129,7 +129,7 @@ func (mgr *SessionManager) Parse(tokenString string) (jwt.Claims, error) {
 		return nil, err
 	}
 
-	issuedAt := time.Unix(claims["iat"].(int64), 0)
+	issuedAt := time.Unix(int64(claims["iat"].(float64)), 0)
 	if issuedAt.Before(mgr.settings.AdminPasswordMtime) {
 		return nil, fmt.Errorf("Password for superuser has changed since token issued")
 	}

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -118,6 +118,11 @@ func (mgr *SessionManager) Parse(tokenString string) (jwt.Claims, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
+		// CHECK CLAIMS HERE
+		// d := passwordUtil.LastChange(username)
+		// if d > iat {
+		// 	return nil, fmt.Errorf("Password for user %q has changed since token issued", username)
+		// }
 		return mgr.settings.ServerSignature, nil
 	})
 	if err != nil {

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -17,7 +17,7 @@ func TestSessionManager(t *testing.T) {
 	}
 	mgr := NewSessionManager(&set)
 
-	token, err := mgr.Create(defaultSubject)
+	token, err := mgr.Create(defaultSubject, 0)
 	if err != nil {
 		t.Errorf("Could not create token: %v", err)
 	}

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -117,10 +117,11 @@ func updateSettingsFromSecret(settings *ArgoCDSettings, argoCDSecret *apiv1.Secr
 		return fmt.Errorf("admin user not found")
 	}
 	settings.AdminPasswordHash = string(adminPasswordHash)
+	settings.AdminPasswordMtime = time.Now()
 	if adminPasswordMtimeBytes, ok := argoCDSecret.Data[settingAdminPasswordMtimeKey]; ok {
-		settings.AdminPasswordMtime = time.Parse(time.RFC3339, string(adminPasswordMtimeBytes))
-	} else {
-		settings.AdminPasswordMtime = time.Now()
+		if adminPasswordMtime, err := time.Parse(time.RFC3339, string(adminPasswordMtimeBytes)); err == nil {
+			settings.AdminPasswordMtime = adminPasswordMtime
+		}
 	}
 	secretKey, ok := argoCDSecret.Data[settingServerSignatureKey]
 	if !ok {

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -117,7 +117,7 @@ func updateSettingsFromSecret(settings *ArgoCDSettings, argoCDSecret *apiv1.Secr
 		return fmt.Errorf("admin user not found")
 	}
 	settings.AdminPasswordHash = string(adminPasswordHash)
-	settings.AdminPasswordMtime = time.Now()
+	settings.AdminPasswordMtime = time.Now().UTC()
 	if adminPasswordMtimeBytes, ok := argoCDSecret.Data[settingAdminPasswordMtimeKey]; ok {
 		if adminPasswordMtime, err := time.Parse(time.RFC3339, string(adminPasswordMtimeBytes)); err == nil {
 			settings.AdminPasswordMtime = adminPasswordMtime
@@ -440,7 +440,7 @@ func UpdateSettings(defaultPassword string, settingsMgr *SettingsManager, update
 		hashedPassword, err := password.HashPassword(passwordRaw)
 		errors.CheckError(err)
 		cdSettings.AdminPasswordHash = hashedPassword
-		cdSettings.AdminPasswordMtime = time.Now()
+		cdSettings.AdminPasswordMtime = time.Now().UTC()
 	}
 
 	if cdSettings.Certificate == nil {


### PR DESCRIPTION
Closes #424 

This does not tackle the following from #424, which I've broken out into #455:

> When users login via SSO via CLI, we should be giving the dex signed token (which expires), and stop issuing API server signed tokens (which don't expire). When tokens do expire, we need to allow the token to be refreshed as conveniently as possible. Re-logging in should be convenient as well.