### PR TITLE
Make use of dex refresh tokens and store them into local config

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,6 @@ import (
 	"github.com/argoproj/argo-cd"
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/errors"
-
 	"github.com/argoproj/argo-cd/pkg/apiclient"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-cd/reposerver"
@@ -500,11 +499,6 @@ func (a *ArgoCDServer) authenticate(ctx context.Context) (context.Context, error
 func getToken(md metadata.MD) string {
 	// check the "token" metadata
 	tokens, ok := md[apiclient.MetaDataTokenKey]
-	if ok && len(tokens) > 0 {
-		return tokens[0]
-	}
-	// check the legacy key (v0.3.2 and below). 'tokens' was renamed to 'token'
-	tokens, ok = md["tokens"]
 	if ok && len(tokens) > 0 {
 		return tokens[0]
 	}

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -46,8 +46,9 @@ type Server struct {
 
 // User contains user authentication information
 type User struct {
-	Name      string `json:"name"`
-	AuthToken string `json:"auth-token,omitempty"`
+	Name         string `json:"name"`
+	AuthToken    string `json:"auth-token,omitempty"`
+	RefreshToken string `json:"refresh-token,omitempty"`
 }
 
 // ReadLocalConfig loads up the local configuration file. Returns nil if config does not exist


### PR DESCRIPTION
Resolves issue #455
- Make use of dex refresh tokens and store them into local config.
- API client will automatically perform OIDC token refresh if auth token expired.
- Stop the practice of reissuing/resigning non-expiring dex claims in API server.