### PR TITLE
Add `argocd relogin` command as a convenience around login to current context

### DIFF
--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-cd/errors"
+	argocdclient "github.com/argoproj/argo-cd/pkg/apiclient"
+	"github.com/argoproj/argo-cd/util/localconfig"
+	"github.com/argoproj/argo-cd/util/session"
+)
+
+// NewReloginCommand returns a new instance of `argocd relogin` command
+func NewReloginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Command {
+	var (
+		username string
+		password string
+	)
+	var command = &cobra.Command{
+		Use:   "relogin",
+		Short: "Refresh an expired authenticate token",
+		Long:  "Refresh an expired authenticate token",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) != 0 {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
+			}
+			localCfg, err := localconfig.ReadLocalConfig(globalClientOpts.ConfigPath)
+			errors.CheckError(err)
+			if localCfg == nil {
+				log.Fatalf("No context found. Login using `argocd login`")
+			}
+			configCtx, err := localCfg.ResolveContext(localCfg.CurrentContext)
+			errors.CheckError(err)
+
+			parser := &jwt.Parser{
+				SkipClaimsValidation: true,
+			}
+			claims := jwt.StandardClaims{}
+			_, _, err = parser.ParseUnverified(configCtx.User.AuthToken, &claims)
+			errors.CheckError(err)
+
+			var tokenString string
+			var refreshToken string
+			if claims.Issuer == session.SessionManagerClaimsIssuer {
+				clientOpts := argocdclient.ClientOptions{
+					ConfigPath: "",
+					ServerAddr: configCtx.Server.Server,
+					Insecure:   configCtx.Server.Insecure,
+					PlainText:  configCtx.Server.PlainText,
+				}
+				acdClient := argocdclient.NewClientOrDie(&clientOpts)
+				tokenString = passwordLogin(acdClient, username, password)
+			} else {
+				tokenString, refreshToken = oauth2Login(configCtx.Server.Server, configCtx.Server.PlainText)
+			}
+
+			localCfg.UpsertUser(localconfig.User{
+				Name:         localCfg.CurrentContext,
+				AuthToken:    tokenString,
+				RefreshToken: refreshToken,
+			})
+			err = localconfig.WriteLocalConfig(*localCfg, globalClientOpts.ConfigPath)
+			errors.CheckError(err)
+			fmt.Printf("Context '%s' updated\n", localCfg.CurrentContext)
+		},
+	}
+	command.Flags().StringVar(&username, "username", "", "the username of an account to authenticate")
+	command.Flags().StringVar(&password, "password", "", "the password of an account to authenticate")
+	return command
+}

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -27,6 +27,7 @@ func NewCommand() *cobra.Command {
 	command.AddCommand(NewClusterCommand(&clientOpts, pathOpts))
 	command.AddCommand(NewApplicationCommand(&clientOpts))
 	command.AddCommand(NewLoginCommand(&clientOpts))
+	command.AddCommand(NewReloginCommand(&clientOpts))
 	command.AddCommand(NewRepoCommand(&clientOpts))
 	command.AddCommand(NewContextCommand(&clientOpts))
 	command.AddCommand(NewProjectCommand(&clientOpts))


### PR DESCRIPTION
Now that tokens expire, I added a command `argocd relogin` to make logging in to the current context as convenient as possible. This command takes no arguments, and is meant to be used for Dex SSO tokens when both the token is invalid, and the refresh token is invalid (which will happen during an Dex server restart). It can be also be used for when admin password changes. Sample output below:

```
$ argocd relogin
INFO[0000] Opening browser for authentication
INFO[0000] Authentication URL: https://35.203.167.2/api/dex/auth?access_type=offline&client_id=argo-cd-cli&redirect_uri=http%3A%2F%2Flocalhost%3A57829%2Fauth%2Fcallback&response_type=code&scope=openid+profile+email+groups+offline_access&state=state
INFO[0003] Authentication successful
Context 'demo01' updated
```

Also fixed an annoyance where `argocd app create` had `--name` as a flag instead of a positional argument, which made it unsymmetrical to the other related commands. I left the `--name` flag in for backwards compatibility. But will update docs to stop using `--name`.