### PR TITLE
Support explicit deny

### DIFF
--- a/util/rbac/builtin-policy.csv
+++ b/util/rbac/builtin-policy.csv
@@ -6,31 +6,31 @@
 # 2. All other resources:
 # p, <user/group>, <resource>, <action>, <object>
 
-p, role:readonly, applications, get, */*
-p, role:readonly, applications/events, get, */*
-p, role:readonly, applications/manifests, get, */*
-p, role:readonly, applications/logs, get, */*
-p, role:readonly, clusters, get, *
-p, role:readonly, repositories, get, *
-p, role:readonly, repositories/apps, get, *
-p, role:readonly, projects, get, *
+p, role:readonly, applications, get, */*, allow
+p, role:readonly, applications/events, get, */*, allow
+p, role:readonly, applications/manifests, get, */*, allow
+p, role:readonly, applications/logs, get, */*, allow
+p, role:readonly, clusters, get, *, allow
+p, role:readonly, repositories, get, *, allow
+p, role:readonly, repositories/apps, get, *, allow
+p, role:readonly, projects, get, *, allow
 
-p, role:admin, applications, create, */*
-p, role:admin, applications, update, */*
-p, role:admin, applications, delete, */*
-p, role:admin, applications, sync, */*
-p, role:admin, applications, rollback, */*
-p, role:admin, applications, terminateop, */*
-p, role:admin, applications/pods, delete, */*
-p, role:admin, clusters, create, *
-p, role:admin, clusters, update, *
-p, role:admin, clusters, delete, *
-p, role:admin, repositories, create, *
-p, role:admin, repositories, update, *
-p, role:admin, repositories, delete, *
-p, role:admin, projects, create, *
-p, role:admin, projects, update, *
-p, role:admin, projects, delete, *
+p, role:admin, applications, create, */*, allow
+p, role:admin, applications, update, */*, allow
+p, role:admin, applications, delete, */*, allow
+p, role:admin, applications, sync, */*, allow
+p, role:admin, applications, rollback, */*, allow
+p, role:admin, applications, terminateop, */*, allow
+p, role:admin, applications/pods, delete, */*, allow
+p, role:admin, clusters, create, *, allow
+p, role:admin, clusters, update, *, allow
+p, role:admin, clusters, delete, *, allow
+p, role:admin, repositories, create, *, allow
+p, role:admin, repositories, update, *, allow
+p, role:admin, repositories, delete, *, allow
+p, role:admin, projects, create, *, allow
+p, role:admin, projects, update, *, allow
+p, role:admin, projects, delete, *, allow
 
 g, role:admin, role:readonly
 g, admin, role:admin

--- a/util/rbac/model.conf
+++ b/util/rbac/model.conf
@@ -8,7 +8,7 @@ p = sub, res, act, obj
 g = _, _
 
 [policy_effect]
-e = some(where (p.eft == allow))
+e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
 m = g(r.sub, p.sub) && keyMatch(r.res, p.res) && keyMatch(r.act, p.act) && keyMatch(r.obj, p.obj)

--- a/util/rbac/model.conf
+++ b/util/rbac/model.conf
@@ -2,7 +2,7 @@
 r = sub, res, act, obj
 
 [policy_definition]
-p = sub, res, act, obj
+p = sub, res, act, obj, eft
 
 [role_definition]
 g = _, _

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -122,6 +122,8 @@ p, dave, applications, get, foo/obj, allow
 p, dave, applications/*, get, foo/obj, allow
 p, eve, *, get, foo/obj, deny
 p, mallory, repositories, *, foo/obj, deny
+p, mallory, repositories, *, foo/obj, allow
+p, mike, *, *, foo/obj, allow
 p, mike, *, *, foo/obj, deny
 p, trudy, applications, get, foo/obj, allow
 p, trudy, applications/*, get, foo/obj, allow

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -84,7 +84,7 @@ func TestBuiltinPolicyEnforcer(t *testing.T) {
 // TestPolicyInformer verifies the informer will get updated with a new configmap
 func TestPolicyInformer(t *testing.T) {
 	cm := fakeConfigMap()
-	cm.Data[ConfigMapPolicyCSVKey] = "p, admin, applications, delete, */*"
+	cm.Data[ConfigMapPolicyCSVKey] = "p, admin, applications, delete, */*, allow"
 	kubeclientset := fake.NewSimpleClientset(cm)
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 
@@ -115,11 +115,11 @@ func TestResourceActionWildcards(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 	policy := `
-p, alice, *, get, foo/obj
-p, bob, repositories, *, foo/obj
-p, cathy, *, *, foo/obj
-p, dave, applications, get, foo/obj
-p, dave, applications/*, get, foo/obj
+p, alice, *, get, foo/obj, allow
+p, bob, repositories, *, foo/obj, allow
+p, cathy, *, *, foo/obj, allow
+p, dave, applications, get, foo/obj, allow
+p, dave, applications/*, get, foo/obj, allow
 `
 	enf.SetUserPolicy(policy)
 
@@ -149,8 +149,8 @@ func TestProjectIsolationEnforcement(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 	policy := `
-p, role:foo-admin, *, *, foo/*
-p, role:bar-admin, *, *, bar/*
+p, role:foo-admin, *, *, foo/*, allow
+p, role:bar-admin, *, *, bar/*, allow
 g, alice, role:foo-admin
 g, bob, role:bar-admin
 `
@@ -169,7 +169,7 @@ func TestProjectReadOnly(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 	policy := `
-p, role:foo-readonly, *, get, foo/*
+p, role:foo-readonly, *, get, foo/*, allow
 g, alice, role:foo-readonly
 `
 	enf.SetBuiltinPolicy(policy)
@@ -234,9 +234,9 @@ func TestURLAsObjectName(t *testing.T) {
 	err := enf.syncUpdate(fakeConfigMap())
 	assert.Nil(t, err)
 	policy := `
-p, alice, repositories, *, foo/*
-p, bob, repositories, *, foo/https://github.com/argoproj/argo-cd.git
-p, cathy, repositories, *, foo/*
+p, alice, repositories, *, foo/*, allow
+p, bob, repositories, *, foo/https://github.com/argoproj/argo-cd.git, allow
+p, cathy, repositories, *, foo/*, allow
 `
 	enf.SetUserPolicy(policy)
 
@@ -261,7 +261,7 @@ func TestEnableDisableEnforce(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 	policy := `
-p, alice, *, get, foo/obj
+p, alice, *, get, foo/obj, allow
 `
 	enf.SetUserPolicy(policy)
 
@@ -277,11 +277,11 @@ func TestUpdatePolicy(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 
-	enf.SetUserPolicy("p, alice, *, get, foo/obj")
+	enf.SetUserPolicy("p, alice, *, get, foo/obj, allow")
 	assert.True(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.False(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 
-	enf.SetUserPolicy("p, bob, *, get, foo/obj")
+	enf.SetUserPolicy("p, bob, *, get, foo/obj, allow")
 	assert.False(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.True(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 
@@ -289,11 +289,11 @@ func TestUpdatePolicy(t *testing.T) {
 	assert.False(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.False(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 
-	enf.SetBuiltinPolicy("p, alice, *, get, foo/obj")
+	enf.SetBuiltinPolicy("p, alice, *, get, foo/obj, allow")
 	assert.True(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.False(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 
-	enf.SetBuiltinPolicy("p, bob, *, get, foo/obj")
+	enf.SetBuiltinPolicy("p, bob, *, get, foo/obj, allow")
 	assert.False(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.True(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 


### PR DESCRIPTION
Closes #322.  Add an additional column, `eft`, to the RBAC policy model, and add it to all principals in the RBAC default policy CSV and the RBAC test.  