### PR TITLE
Revert readiness probe for now

### DIFF
--- a/manifests/components/04d_argocd-server-deployment.yaml
+++ b/manifests/components/04d_argocd-server-deployment.yaml
@@ -33,14 +33,6 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: static-files
-
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 30
-
       - name: dex
         image: quay.io/coreos/dex:v2.10.0
         command: [/shared/argocd-util, rundex]


### PR DESCRIPTION
Reverts part of argoproj/argo-cd#522

There's some sort of issue in further testing on my end.  @jessesuen After blowing away my whole environment and redoing all my tests, I'm getting one out of two `argocd-server` pods not coming up with this error in describe:

>  Warning  Unhealthy              1m (x8 over 4m)  kubelet, minikube  Readiness probe failed: HTTP probe failed with statuscode: 404

**I'm not sure why this HTTP endpoint wouldn't be working on just one of two replicas, since they should be the same product, and `/healthz` is being served from the latest codebase**:

```
$ curl 127.0.0.1:8080/healthz
ok
```

Proposing a rollback of the readiness probe for now unless this can be resolved or is determined to be a non-issue (i.e., my further tests are flawed).