### PR TITLE
Issue #527 - Support --in-cluster authentication without providing a kubeconfig

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -558,7 +558,6 @@ func (proj AppProject) IsSourcePermitted(src ApplicationSource) bool {
 
 // IsDestinationPermitted validiates if the provided application's destination is one of the allowed destinations for the project
 func (proj AppProject) IsDestinationPermitted(dst ApplicationDestination) bool {
-
 	for _, item := range proj.Spec.Destinations {
 		if item.Server == dst.Server || item.Server == "*" {
 			if item.Namespace == dst.Namespace || item.Namespace == "*" {
@@ -571,6 +570,13 @@ func (proj AppProject) IsDestinationPermitted(dst ApplicationDestination) bool {
 
 // RESTConfig returns a go-client REST config from cluster
 func (c *Cluster) RESTConfig() *rest.Config {
+	if c.Server == common.KubernetesInternalAPIServerAddr && c.Config.Username == "" && c.Config.Password == "" && c.Config.BearerToken == "" {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			panic("Unable to create in-cluster config")
+		}
+		return config
+	}
 	return &rest.Config{
 		Host:        c.Server,
 		Username:    c.Config.Username,

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/argoproj/argo-cd/common"
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
@@ -18,6 +19,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
+)
+
+var (
+	localCluster = appv1.Cluster{
+		Server:          common.KubernetesInternalAPIServerAddr,
+		ConnectionState: appv1.ConnectionState{Status: appv1.ConnectionStatusSuccessful},
+	}
 )
 
 // ListClusters returns list of clusters
@@ -37,8 +45,16 @@ func (s *db) ListClusters(ctx context.Context) (*appv1.ClusterList, error) {
 	clusterList := appv1.ClusterList{
 		Items: make([]appv1.Cluster, len(clusterSecrets.Items)),
 	}
+	hasInClusterCredentials := false
 	for i, clusterSecret := range clusterSecrets.Items {
-		clusterList.Items[i] = *SecretToCluster(&clusterSecret)
+		cluster := *SecretToCluster(&clusterSecret)
+		clusterList.Items[i] = cluster
+		if cluster.Server == common.KubernetesInternalAPIServerAddr {
+			hasInClusterCredentials = true
+		}
+	}
+	if !hasInClusterCredentials {
+		clusterList.Items = append(clusterList.Items, localCluster)
 	}
 	return &clusterList, nil
 }
@@ -129,7 +145,11 @@ func (s *db) getClusterSecret(server string) (*apiv1.Secret, error) {
 func (s *db) GetCluster(ctx context.Context, server string) (*appv1.Cluster, error) {
 	clusterSecret, err := s.getClusterSecret(server)
 	if err != nil {
-		return nil, err
+		if grpc.Code(err) == codes.NotFound && server == common.KubernetesInternalAPIServerAddr {
+			return &localCluster, nil
+		} else {
+			return nil, err
+		}
 	}
 	return SecretToCluster(clusterSecret), nil
 }

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -274,9 +274,13 @@ func WatchResourcesWithLabel(ctx context.Context, config *rest.Config, namespace
 }
 
 func copyEventsChannel(ctx context.Context, src <-chan watch.Event, dst chan watch.Event) {
+	stopped := false
 	done := make(chan bool)
 	go func() {
 		for event := range src {
+			if stopped {
+				break
+			}
 			dst <- event
 		}
 		done <- true
@@ -284,6 +288,7 @@ func copyEventsChannel(ctx context.Context, src <-chan watch.Event, dst chan wat
 	select {
 	case <-done:
 	case <-ctx.Done():
+		stopped = true
 	}
 }
 


### PR DESCRIPTION
Closes #527 . If local cluster is not configured argocd is trying to access it using in-cluster config. Local cluster is aways shown as configured