### PR TITLE
Fix controller hot loop when app source contains bad manifests (issue #568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.8.1 (2018-09-10)
 - Fix issue where changes were not pulled when tracking a branch (issue #567)
+- Fix controller hot loop when app source contains bad manifests (issue #568)
 
 ## v0.8.0 (2018-09-04)
 


### PR DESCRIPTION
Resolves #568 where controller gets into a infinite hotloop when manifest generation results in an Unknown comparison status.