### PR TITLE
Improve remarshalling to use reflection/schema builders to handle all k8s core types

### DIFF
--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -257,3 +257,50 @@ func TestCleanKubectlOutput(t *testing.T) {
 	testString := `error: error validating "STDIN": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1beta2.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false`
 	assert.Equal(t, cleanKubectlOutput(testString), `error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1beta2.DeploymentSpec`)
 }
+
+func TestRemarshal(t *testing.T) {
+	manifest := []byte(`
+apiVersion: v1
+kind: ServiceAccount
+imagePullSecrets: []
+metadata:
+  name: my-sa
+`)
+	var un unstructured.Unstructured
+	err := yaml.Unmarshal(manifest, &un)
+	assert.NoError(t, err)
+	newUn, err := Remarshal(&un)
+	assert.NoError(t, err)
+	_, ok := newUn.Object["imagePullSecrets"]
+	assert.False(t, ok)
+	metadata := newUn.Object["metadata"].(map[string]interface{})
+	_, ok = metadata["creationTimestamp"]
+	assert.False(t, ok)
+}
+
+func TestRemarshalResources(t *testing.T) {
+	manifest := []byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  containers:
+  - image: nginx:1.7.9
+    name: nginx
+    resources:
+      requests:
+        cpu: 0.2
+`)
+	un := unstructured.Unstructured{}
+	err := yaml.Unmarshal(manifest, &un)
+	assert.NoError(t, err)
+	requestsBefore := un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
+	log.Println(requestsBefore)
+	newUn, err := Remarshal(&un)
+	assert.NoError(t, err)
+	requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
+	log.Println(requestsAfter)
+	assert.Equal(t, float64(0.2), requestsBefore["cpu"])
+	assert.Equal(t, "200m", requestsAfter["cpu"])
+}


### PR DESCRIPTION
Resolves #595. 

Uses the schema builder in kubectl which seemingly registers all k8s types. Then use reflection to create a concrete type of the GroupVersionKind. Unmarshals to the concrete type and then converts the concrete type to an Unstructured object.