### PR TITLE
Improve three-way diff to provide more accurate Sync status and diff result (issue #597)

### DIFF
--- a/util/diff/testdata/elasticsearch-config.json
+++ b/util/diff/testdata/elasticsearch-config.json
@@ -1,0 +1,217 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "labels": {
+      "app": "elasticsearch",
+      "applications.argoproj.io/app-name": "elasticsearch4",
+      "chart": "elasticsearch-1.7.0",
+      "component": "data",
+      "heritage": "Tiller",
+      "release": "elasticsearch4"
+    },
+    "name": "elasticsearch4-data"
+  },
+  "spec": {
+    "replicas": 2,
+    "selector": {
+      "matchLabels": {
+        "app": "elasticsearch",
+        "component": "data",
+        "release": "elasticsearch4"
+      }
+    },
+    "serviceName": "elasticsearch4-data",
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "elasticsearch",
+          "applications.argoproj.io/app-name": "elasticsearch4",
+          "component": "data",
+          "release": "elasticsearch4"
+        }
+      },
+      "spec": {
+        "affinity": {
+          "podAntiAffinity": {
+            "preferredDuringSchedulingIgnoredDuringExecution": [
+              {
+                "podAffinityTerm": {
+                  "labelSelector": {
+                    "matchLabels": {
+                      "app": "elasticsearch",
+                      "component": "data",
+                      "release": "elasticsearch4"
+                    }
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                },
+                "weight": 1
+              }
+            ]
+          }
+        },
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "DISCOVERY_SERVICE",
+                "value": "elasticsearch4-discovery"
+              },
+              {
+                "name": "NODE_MASTER",
+                "value": "false"
+              },
+              {
+                "name": "PROCESSORS",
+                "valueFrom": {
+                  "resourceFieldRef": {
+                    "resource": "limits.cpu"
+                  }
+                }
+              },
+              {
+                "name": "ES_JAVA_OPTS",
+                "value": "-Djava.net.preferIPv4Stack=true -Xms1536m -Xmx1536m"
+              },
+              {
+                "name": "MINIMUM_MASTER_NODES",
+                "value": "2"
+              }
+            ],
+            "image": "docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.0",
+            "imagePullPolicy": "IfNotPresent",
+            "lifecycle": {
+              "postStart": {
+                "exec": {
+                  "command": [
+                    "/bin/bash",
+                    "/post-start-hook.sh"
+                  ]
+                }
+              },
+              "preStop": {
+                "exec": {
+                  "command": [
+                    "/bin/bash",
+                    "/pre-stop-hook.sh"
+                  ]
+                }
+              }
+            },
+            "name": "elasticsearch",
+            "ports": [
+              {
+                "containerPort": 9300,
+                "name": "transport"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/_cluster/health?local=true",
+                "port": 9200
+              },
+              "initialDelaySeconds": 5
+            },
+            "resources": {
+              "limits": {
+                "cpu": "1"
+              },
+              "requests": {
+                "cpu": "25m",
+                "memory": "1536Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/usr/share/elasticsearch/data",
+                "name": "data"
+              },
+              {
+                "mountPath": "/usr/share/elasticsearch/config/elasticsearch.yml",
+                "name": "config",
+                "subPath": "elasticsearch.yml"
+              },
+              {
+                "mountPath": "/pre-stop-hook.sh",
+                "name": "config",
+                "subPath": "pre-stop-hook.sh"
+              },
+              {
+                "mountPath": "/post-start-hook.sh",
+                "name": "config",
+                "subPath": "post-start-hook.sh"
+              }
+            ]
+          }
+        ],
+        "initContainers": [
+          {
+            "command": [
+              "sysctl",
+              "-w",
+              "vm.max_map_count=262144"
+            ],
+            "image": "busybox",
+            "imagePullPolicy": "Always",
+            "name": "sysctl",
+            "securityContext": {
+              "privileged": true
+            }
+          },
+          {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data && chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/logs"
+            ],
+            "image": "docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.0",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "chown",
+            "securityContext": {
+              "runAsUser": 0
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/usr/share/elasticsearch/data",
+                "name": "data"
+              }
+            ]
+          }
+        ],
+        "securityContext": {
+          "fsGroup": 1000
+        },
+        "terminationGracePeriodSeconds": 3600,
+        "volumes": [
+          {
+            "configMap": {
+              "name": "elasticsearch4"
+            },
+            "name": "config"
+          }
+        ]
+      }
+    },
+    "updateStrategy": {
+      "type": "OnDelete"
+    },
+    "volumeClaimTemplates": [
+      {
+        "metadata": {
+          "name": "data"
+        },
+        "spec": {
+          "accessModes": [
+            "ReadWriteOnce"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "30Gi"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/util/diff/testdata/elasticsearch-live.json
+++ b/util/diff/testdata/elasticsearch-live.json
@@ -1,0 +1,261 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1beta1\",\"kind\":\"StatefulSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"elasticsearch\",\"applications.argoproj.io/app-name\":\"elasticsearch4\",\"chart\":\"elasticsearch-1.7.0\",\"component\"  :\"data\",\"heritage\":\"Tiller\",\"release\":\"elasticsearch4\"},\"name\":\"elasticsearch4-data\",\"namespace\":\"elasticsearch4\"},\"spec\":{\"replicas\":2,\"selector\":{\"matchLabels\":{\"app\":\"elasticsearch\",\"component\":\"data\",\"release\":\"elasticsearch4\"}},\"serviceName\":\"elasticsearch4-data\",\"template\":{\"metadata\":{\"labels\":{\"app\":\"elasticsearch\",\"applications.argoproj.io/app-name\":\"elasticsearch4\",\"component\":\"data\",\"release\":\"elasticsearch4\"}},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchLabels\":{\"app\":\"elasticsearch\",\"component\":\"data\",\"release\":\"elasticsearch4\"}},\"topologyKey\":\"kubernetes.io/hostname\"},\"weight\":1}]}},\"containers\":[{\"env\":[{\"name\":\"DISCOVERY_SERVICE\",\"value\":\"elasticsearch4-discovery\"},{\"name\":\"NODE_MASTER\",\"value\":\"false\"},{\"name\":\"PROCESSORS\",\"valueFrom\":{\"resourceFieldRef\":{\"resource\":\"limits.cpu\"}}},{\"name\":\"ES_JAVA_OPTS\",\"value\":\"-Djava.net.preferIPv4Stack=true -Xms1536m -Xmx1536m\"},{\"name\":\"MINIMUM_MASTER_NODES\",\"value\":\"2\"}],\"image\":\"docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.0\",\"imagePullPolicy\":\"IfNotPresent\",\"lifecycle\":{\"postStart\":{\"exec\":{\"command\":[\"/bin/bash\",\"/post-start-hook.sh\"]}},\"preStop\":{\"exec\":{\"command\":[\"/bin/bash\",\"/pre-stop-hook.sh\"]}}},\"name\":\"elasticsearch\",\"ports\":[{\"containerPort\":9300,\"name\":\"transport\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/_cluster/health?local=true\",\"port\":9200},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"1\"},\"requests\":{\"cpu\":\"25m\",\"memory\":\"1536Mi\"}},\"volumeMounts\":[{\"mountPath\":\"/usr/share/elasticsearch/data\",\"name\":\"data\"},{\"mountPath\":\"/usr/share/elasticsearch/config/elasticsearch.yml\",\"name\":\"config\",\"subPath\":\"elasticsearch.yml\"},{\"mountPath\":\"/pre-stop-hook.sh\",\"name\":\"config\",\"subPath\":\"pre-stop-hook.sh\"},{\"mountPath\":\"/post-start-hook.sh\",\"name\":\"config\",\"subPath\":\"post-start-hook.sh\"}]}],\"initContainers\":[{\"command\":[\"sysctl\",\"-w\",\"vm.max_map_count=262144\"],\"image\":\"busybox\",\"imagePullPolicy\":\"Always\",\"name\":\"sysctl\",\"securityContext\":{\"privileged\":true}},{\"command\":[\"/bin/bash\",\"-c\",\"chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data \\u0026\\u0026 chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/logs\"],\"image\":\"docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.0\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"chown\",\"securityContext\":{\"runAsUser\":0},\"volumeMounts\":[{\"mountPath\":\"/usr/share/elasticsearch/data\",\"name\":\"data\"}]}],\"securityContext\":{\"fsGroup\":1000},\"terminationGracePeriodSeconds\":3600,\"volumes\":[{\"configMap\":{\"name\":\"elasticsearch4\"},\"name\":\"config\"}]}},\"updateStrategy\":{\"type\":\"OnDelete\"},\"volumeClaimTemplates\":[{\"metadata\":{\"name\":\"data\"},\"spec\":{\"accessModes\":[\"ReadWriteOnce\"],\"resources\":{\"requests\":{\"storage\":\"30Gi\"}}}}]}}\n"
+    },
+    "creationTimestamp": "2018-09-14T22:20:41Z",
+    "generation": 1,
+    "labels": {
+      "app": "elasticsearch",
+      "applications.argoproj.io/app-name": "elasticsearch4",
+      "chart": "elasticsearch-1.7.0",
+      "component": "data",
+      "heritage": "Tiller",
+      "release": "elasticsearch4"
+    },
+    "name": "elasticsearch4-data",
+    "namespace": "elasticsearch4",
+    "resourceVersion": "10689842",
+    "selfLink": "/apis/apps/v1beta1/namespaces/elasticsearch4/statefulsets/elasticsearch4-data",
+    "uid": "6a850cf9-b86c-11e8-bbd2-42010a8a00bb"
+  },
+  "spec": {
+    "podManagementPolicy": "OrderedReady",
+    "replicas": 2,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app": "elasticsearch",
+        "component": "data",
+        "release": "elasticsearch4"
+      }
+    },
+    "serviceName": "elasticsearch4-data",
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "elasticsearch",
+          "applications.argoproj.io/app-name": "elasticsearch4",
+          "component": "data",
+          "release": "elasticsearch4"
+        }
+      },
+      "spec": {
+        "affinity": {
+          "podAntiAffinity": {
+            "preferredDuringSchedulingIgnoredDuringExecution": [
+              {
+                "podAffinityTerm": {
+                  "labelSelector": {
+                    "matchLabels": {
+                      "app": "elasticsearch",
+                      "component": "data",
+                      "release": "elasticsearch4"
+                    }
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                },
+                "weight": 1
+              }
+            ]
+          }
+        },
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "DISCOVERY_SERVICE",
+                "value": "elasticsearch4-discovery"
+              },
+              {
+                "name": "NODE_MASTER",
+                "value": "false"
+              },
+              {
+                "name": "PROCESSORS",
+                "valueFrom": {
+                  "resourceFieldRef": {
+                    "divisor": "0",
+                    "resource": "limits.cpu"
+                  }
+                }
+              },
+              {
+                "name": "ES_JAVA_OPTS",
+                "value": "-Djava.net.preferIPv4Stack=true -Xms1536m -Xmx1536m"
+              },
+              {
+                "name": "MINIMUM_MASTER_NODES",
+                "value": "2"
+              }
+            ],
+            "image": "docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.0",
+            "imagePullPolicy": "IfNotPresent",
+            "lifecycle": {
+              "postStart": {
+                "exec": {
+                  "command": [
+                    "/bin/bash",
+                    "/post-start-hook.sh"
+                  ]
+                }
+              },
+              "preStop": {
+                "exec": {
+                  "command": [
+                    "/bin/bash",
+                    "/pre-stop-hook.sh"
+                  ]
+                }
+              }
+            },
+            "name": "elasticsearch",
+            "ports": [
+              {
+                "containerPort": 9300,
+                "name": "transport",
+                "protocol": "TCP"
+              }
+            ],
+            "readinessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "path": "/_cluster/health?local=true",
+                "port": 9200,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 1
+            },
+            "resources": {
+              "limits": {
+                "cpu": "1"
+              },
+              "requests": {
+                "cpu": "25m",
+                "memory": "1536Mi"
+              }
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/usr/share/elasticsearch/data",
+                "name": "data"
+              },
+              {
+                "mountPath": "/usr/share/elasticsearch/config/elasticsearch.yml",
+                "name": "config",
+                "subPath": "elasticsearch.yml"
+              },
+              {
+                "mountPath": "/pre-stop-hook.sh",
+                "name": "config",
+                "subPath": "pre-stop-hook.sh"
+              },
+              {
+                "mountPath": "/post-start-hook.sh",
+                "name": "config",
+                "subPath": "post-start-hook.sh"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "initContainers": [
+          {
+            "command": [
+              "sysctl",
+              "-w",
+              "vm.max_map_count=262144"
+            ],
+            "image": "busybox",
+            "imagePullPolicy": "Always",
+            "name": "sysctl",
+            "resources": {},
+            "securityContext": {
+              "privileged": true
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          },
+          {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data && chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/logs"
+            ],
+            "image": "docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.0",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "chown",
+            "resources": {},
+            "securityContext": {
+              "runAsUser": 0
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/usr/share/elasticsearch/data",
+                "name": "data"
+              }
+            ]
+          }
+        ],
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {
+          "fsGroup": 1000
+        },
+        "terminationGracePeriodSeconds": 3600,
+        "volumes": [
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "name": "elasticsearch4"
+            },
+            "name": "config"
+          }
+        ]
+      }
+    },
+    "updateStrategy": {
+      "type": "OnDelete"
+    },
+    "volumeClaimTemplates": [
+      {
+        "metadata": {
+          "creationTimestamp": null,
+          "name": "data"
+        },
+        "spec": {
+          "accessModes": [
+            "ReadWriteOnce"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "30Gi"
+            }
+          }
+        },
+        "status": {
+          "phase": "Pending"
+        }
+      }
+    ]
+  },
+  "status": {
+    "collisionCount": 0,
+    "currentReplicas": 2,
+    "currentRevision": "elasticsearch4-data-74f6d9c899",
+    "observedGeneration": 1,
+    "readyReplicas": 2,
+    "replicas": 2,
+    "updateRevision": "elasticsearch4-data-74f6d9c899"
+  }
+}

--- a/util/json/json.go
+++ b/util/json/json.go
@@ -73,3 +73,12 @@ func removeListFields(config, live []interface{}) []interface{} {
 	}
 	return result
 }
+
+// MustMarshal is a convenience function to marshal an object successfully or panic
+func MustMarshal(v interface{}) []byte {
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
+}


### PR DESCRIPTION
This changes 3-way-diffing such that it relies entirely on K8s strategic merge patch to calculate the proper diff status and result.