### PR TITLE
Use ksonnet CLI instead of ksonnet libs (#590)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -L -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kuberne
 # Option 1: build ksonnet ourselves
 #RUN go get -v -u github.com/ksonnet/ksonnet && mv ${GOPATH}/bin/ksonnet /usr/local/bin/ks
 # Option 2: use official tagged ksonnet release
-ENV KSONNET_VERSION=0.11.0
+ENV KSONNET_VERSION=0.13.0
 RUN wget https://github.com/ksonnet/ksonnet/releases/download/v${KSONNET_VERSION}/ks_${KSONNET_VERSION}_linux_amd64.tar.gz && \
     tar -C /tmp/ -xf ks_${KSONNET_VERSION}_linux_amd64.tar.gz && \
     mv /tmp/ks_${KSONNET_VERSION}_linux_amd64/ks /usr/local/bin/ks

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -483,6 +483,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:448b4a6e39e46d8740b00dc871f26d58dc39341b160e01267b7917132831a136"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = ""
+  revision = "b729f2633dfe35f4d1d8a32385f6685610ce1cb5"
+
+[[projects]]
+  branch = "master"
   digest = "1:ccc20cacf54eb16464dad02efa1c14fa7c0b9e124639b0d2a51dcc87b0154e4c"
   name = "github.com/mailru/easyjson"
   packages = [
@@ -621,12 +629,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
+  digest = "1:01d968ff6535945510c944983eee024e81f1c949043e9bbfe5ab206ebc3588a4"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = ""
-  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
-  version = "v1.0.6"
+  revision = "a67f783a3814b8729bd2dac5780b5f78f8dbd64d"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -785,14 +793,6 @@
   ]
   pruneopts = ""
   revision = "cce311a261e6fcf29de72ca96827bdb0b7d9c9e6"
-
-[[projects]]
-  branch = "master"
-  digest = "1:b2ea75de0ccb2db2ac79356407f8a4cd8f798fe15d41b381c00abf3ae8e55ed1"
-  name = "golang.org/x/sync"
-  packages = ["errgroup"]
-  pruneopts = ""
-  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
@@ -1420,7 +1420,6 @@
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",
-    "golang.org/x/sync/errgroup",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,16 +10,6 @@
   version = "v0.18.0"
 
 [[projects]]
-  digest = "1:6204a59b379aadf05380cf8cf3ae0f5867588ba028fe84f260312a79ae717272"
-  name = "github.com/GeertJohan/go.rice"
-  packages = [
-    ".",
-    "embedded",
-  ]
-  pruneopts = ""
-  revision = "c02ca9a983da5807ddf7d796784928f5be4afd09"
-
-[[projects]]
   digest = "1:8ec1618fc3ee146af104d6c13be250f25e5976e34557d4afbfe4b28035ce6c05"
   name = "github.com/Knetic/govaluate"
   packages = ["."]
@@ -81,14 +71,6 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:79421244ba5848aae4b0a5c41e633a04e4894cb0b164a219dc8c15ec7facb7f1"
-  name = "github.com/blang/semver"
-  packages = ["."]
-  pruneopts = ""
-  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
-  version = "v3.5.1"
-
-[[projects]]
   digest = "1:e04162bd6a6d4950541bae744c968108e14913b1cebccf29f7650b573f44adb3"
   name = "github.com/casbin/casbin"
   packages = [
@@ -121,14 +103,6 @@
   packages = ["."]
   pruneopts = ""
   revision = "1180514eaf4d9f38d0d19eef639a1d695e066e72"
-
-[[projects]]
-  branch = "master"
-  digest = "1:5fd5c4d4282935b7a575299494f2c09e9d2cacded7815c83aff7c1602aff3154"
-  name = "github.com/daaku/go.zipexe"
-  packages = ["."]
-  pruneopts = ""
-  revision = "a5fe2436ffcb3236e175e5149162b41cd28bd27d"
 
 [[projects]]
   digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
@@ -500,58 +474,12 @@
   version = "1.0.6"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2c5ad58492804c40bdaf5d92039b0cde8b5becd2b7feeb37d7d1cc36a8aa8dbe"
-  name = "github.com/kardianos/osext"
-  packages = ["."]
-  pruneopts = ""
-  revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
-
-[[projects]]
   digest = "1:41e0bed5df4f9fd04c418bf9b6b7179b3671e416ad6175332601ca1c8dc74606"
   name = "github.com/kevinburke/ssh_config"
   packages = ["."]
   pruneopts = ""
   revision = "81db2a75821ed34e682567d48be488a1c3121088"
   version = "0.5"
-
-[[projects]]
-  digest = "1:2fe45da14d25bce0a58c5a991967149cc5d07f94be327b928a9fd306466815a3"
-  name = "github.com/ksonnet/ksonnet"
-  packages = [
-    "metadata/params",
-    "pkg/app",
-    "pkg/component",
-    "pkg/docparser",
-    "pkg/lib",
-    "pkg/log",
-    "pkg/node",
-    "pkg/params",
-    "pkg/prototype",
-    "pkg/schema",
-    "pkg/util/jsonnet",
-    "pkg/util/kslib",
-    "pkg/util/strings",
-  ]
-  pruneopts = ""
-  revision = "e943ae55d4fe256c8330a047ce8426ad9dac110c"
-  version = "v0.11.0"
-
-[[projects]]
-  digest = "1:a345c560e5609bd71b1f54993f3b087ca45eb0e6226886c642ce519de81896cb"
-  name = "github.com/ksonnet/ksonnet-lib"
-  packages = [
-    "ksonnet-gen/astext",
-    "ksonnet-gen/jsonnet",
-    "ksonnet-gen/ksonnet",
-    "ksonnet-gen/kubespec",
-    "ksonnet-gen/kubeversion",
-    "ksonnet-gen/nodemaker",
-    "ksonnet-gen/printer",
-  ]
-  pruneopts = ""
-  revision = "83f20ee933bcd13fcf4ad1b49a40c92135c5569c"
-  version = "v0.1.10"
 
 [[projects]]
   branch = "master"
@@ -693,11 +621,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:c92f01303e3ab3b5da92657841639cb53d1548f0d2733d12ef3b9fd9d47c869e"
+  digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = ""
-  revision = "ea8897e79973357ba785ac2533559a6297e83c44"
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
   branch = "master"
@@ -714,16 +643,6 @@
   pruneopts = ""
   revision = "e09e9389d85d8492d313d73d1469c029e710623f"
   version = "v0.1.4"
-
-[[projects]]
-  digest = "1:a35a4db30a6094deac33fdb99de9ed99fefc39a7bf06b57d9f04bcaa425bb183"
-  name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem",
-  ]
-  pruneopts = ""
-  revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
 
 [[projects]]
   digest = "1:2208a80fc3259291e43b30f42f844d18f4218036dff510f42c653ec9890d460a"
@@ -866,6 +785,14 @@
   ]
   pruneopts = ""
   revision = "cce311a261e6fcf29de72ca96827bdb0b7d9c9e6"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b2ea75de0ccb2db2ac79356407f8a4cd8f798fe15d41b381c00abf3ae8e55ed1"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  pruneopts = ""
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
@@ -1473,8 +1400,6 @@
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
     "github.com/grpc-ecosystem/grpc-gateway/runtime",
     "github.com/grpc-ecosystem/grpc-gateway/utilities",
-    "github.com/ksonnet/ksonnet/pkg/app",
-    "github.com/ksonnet/ksonnet/pkg/component",
     "github.com/patrickmn/go-cache",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
@@ -1483,7 +1408,6 @@
     "github.com/sirupsen/logrus",
     "github.com/skratchdot/open-golang/open",
     "github.com/soheilhy/cmux",
-    "github.com/spf13/afero",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
@@ -1496,6 +1420,7 @@
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",
+    "golang.org/x/sync/errgroup",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,6 +9,7 @@ required = [
   "k8s.io/code-generator/cmd/go-to-protobuf",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
+  "golang.org/x/sync/errgroup",
 ]
 
 [[constraint]]
@@ -37,11 +38,6 @@ required = [
   branch = "release-1.10"
   name = "k8s.io/api"
 
-# override ksonnet dependency
-[[override]]
-  branch = "release-1.10"
-  name = "k8s.io/apimachinery"
-
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
   branch = "release-1.10"
@@ -59,17 +55,8 @@ required = [
   version = "1.2.1"
 
 [[constraint]]
-  name = "github.com/ksonnet/ksonnet"
-  version = "v0.11.0"
-
-[[constraint]]
   name = "github.com/gobuffalo/packr"
   version = "v1.11.0"
-
-# override ksonnet's logrus dependency
-[[override]]
-  name = "github.com/sirupsen/logrus"
-  revision = "ea8897e79973357ba785ac2533559a6297e83c44"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,6 @@ required = [
   "k8s.io/code-generator/cmd/go-to-protobuf",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
-  "golang.org/x/sync/errgroup",
 ]
 
 [[constraint]]

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -809,7 +809,7 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *OperationTer
 		if !apierr.IsConflict(err) {
 			return nil, err
 		}
-		log.Warnf("Failed to set operation for app '%s' due to update conflict. Retrying again...", termOpReq.Name)
+		log.Warnf("Failed to set operation for app '%s' due to update conflict. Retrying again...", *termOpReq.Name)
 		time.Sleep(100 * time.Millisecond)
 		a, err = s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(*termOpReq.Name, metav1.GetOptions{})
 		if err != nil {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -88,7 +88,7 @@ func (c *appCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *appCollector) Collect(ch chan<- prometheus.Metric) {
 	apps, err := c.store.List(labels.NewSelector())
 	if err != nil {
-		log.Warn("Failed to collect applications: %v", err)
+		log.Warnf("Failed to collect applications: %v", err)
 		return
 	}
 	for _, app := range apps {

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -325,6 +325,11 @@ func queryAppSourceType(ctx context.Context, spec *argoappv1.ApplicationSpec, re
 
 // verifyAppYAML verifies that a ksonnet app.yaml is functional
 func verifyAppYAML(ctx context.Context, repoRes *argoappv1.Repository, spec *argoappv1.ApplicationSpec, repoClient repository.RepositoryServiceClient) error {
+	// Default revision to HEAD if unspecified
+	if spec.Source.TargetRevision == "" {
+		spec.Source.TargetRevision = "HEAD"
+	}
+
 	req := repository.GetFileRequest{
 		Repo: &argoappv1.Repository{
 			Repo: spec.Source.RepoURL,
@@ -340,11 +345,6 @@ func verifyAppYAML(ctx context.Context, repoRes *argoappv1.Repository, spec *arg
 	getRes, err := repoClient.GetFile(ctx, &req)
 	if err != nil {
 		return fmt.Errorf("Unable to load app.yaml: %v", err)
-	}
-
-	// Default revision to HEAD if unspecified
-	if spec.Source.TargetRevision == "" {
-		spec.Source.TargetRevision = "HEAD"
 	}
 
 	// Verify the specified environment is defined in the app spec

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
-	"github.com/ksonnet/ksonnet/pkg/app"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -29,6 +27,7 @@ import (
 	"github.com/argoproj/argo-cd/util"
 	"github.com/argoproj/argo-cd/util/db"
 	"github.com/argoproj/argo-cd/util/git"
+	"github.com/argoproj/argo-cd/util/ksonnet"
 )
 
 const (
@@ -223,9 +222,13 @@ func GetSpecErrors(
 		} else {
 			switch appSourceType {
 			case repository.AppSourceKsonnet:
-				appYamlConditions := verifyAppYAML(ctx, repoRes, spec, repoClient)
-				if len(appYamlConditions) > 0 {
-					conditions = append(conditions, appYamlConditions...)
+				err := verifyAppYAML(ctx, repoRes, spec, repoClient)
+				if err != nil {
+					conditions = append(conditions, argoappv1.ApplicationCondition{
+						Type:    argoappv1.ApplicationConditionInvalidSpecError,
+						Message: err.Error(),
+					})
+
 				}
 			case repository.AppSourceHelm:
 				helmConditions := verifyHelmChart(ctx, repoRes, spec, repoClient)
@@ -321,7 +324,7 @@ func queryAppSourceType(ctx context.Context, spec *argoappv1.ApplicationSpec, re
 }
 
 // verifyAppYAML verifies that a ksonnet app.yaml is functional
-func verifyAppYAML(ctx context.Context, repoRes *argoappv1.Repository, spec *argoappv1.ApplicationSpec, repoClient repository.RepositoryServiceClient) []argoappv1.ApplicationCondition {
+func verifyAppYAML(ctx context.Context, repoRes *argoappv1.Repository, spec *argoappv1.ApplicationSpec, repoClient repository.RepositoryServiceClient) error {
 	req := repository.GetFileRequest{
 		Repo: &argoappv1.Repository{
 			Repo: spec.Source.RepoURL,
@@ -335,47 +338,30 @@ func verifyAppYAML(ctx context.Context, repoRes *argoappv1.Repository, spec *arg
 		req.Repo.SSHPrivateKey = repoRes.SSHPrivateKey
 	}
 	getRes, err := repoClient.GetFile(ctx, &req)
-	var conditions []argoappv1.ApplicationCondition
 	if err != nil {
-		conditions = append(conditions, argoappv1.ApplicationCondition{
-			Type:    argoappv1.ApplicationConditionInvalidSpecError,
-			Message: fmt.Sprintf("Unable to load app.yaml: %v", err),
-		})
-	} else {
-		var appSpec app.Spec
-		err = yaml.Unmarshal(getRes.Data, &appSpec)
-		if err != nil {
-			conditions = append(conditions, argoappv1.ApplicationCondition{
-				Type:    argoappv1.ApplicationConditionInvalidSpecError,
-				Message: "app.yaml is not a valid ksonnet app spec",
-			})
-		} else {
-			// Default revision to HEAD if unspecified
-			if spec.Source.TargetRevision == "" {
-				spec.Source.TargetRevision = "HEAD"
-			}
-
-			// Verify the specified environment is defined in it
-			envSpec, ok := appSpec.Environments[spec.Source.Environment]
-			if !ok || envSpec == nil {
-				conditions = append(conditions, argoappv1.ApplicationCondition{
-					Type:    argoappv1.ApplicationConditionInvalidSpecError,
-					Message: fmt.Sprintf("environment '%s' does not exist in ksonnet app", spec.Source.Environment),
-				})
-			}
-
-			if envSpec != nil {
-				// If server and namespace are not supplied, pull it from the app.yaml
-				if spec.Destination.Server == "" {
-					spec.Destination.Server = envSpec.Destination.Server
-				}
-				if spec.Destination.Namespace == "" {
-					spec.Destination.Namespace = envSpec.Destination.Namespace
-				}
-			}
-		}
+		return fmt.Errorf("Unable to load app.yaml: %v", err)
 	}
-	return conditions
+
+	// Default revision to HEAD if unspecified
+	if spec.Source.TargetRevision == "" {
+		spec.Source.TargetRevision = "HEAD"
+	}
+
+	// Verify the specified environment is defined in the app spec
+	dest, err := ksonnet.Destination(getRes.Data, spec.Source.Environment)
+	if err != nil {
+		return err
+	}
+
+	// If server and namespace are not supplied, pull it from the app.yaml
+	if spec.Destination.Server == "" {
+		spec.Destination.Server = dest.Server
+	}
+	if spec.Destination.Namespace == "" {
+		spec.Destination.Namespace = dest.Namespace
+	}
+
+	return nil
 }
 
 // verifyHelmChart verifies a helm chart is functional

--- a/util/ksonnet/ksonnet.go
+++ b/util/ksonnet/ksonnet.go
@@ -1,86 +1,26 @@
 package ksonnet
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	"github.com/ksonnet/ksonnet/pkg/app"
-	"github.com/ksonnet/ksonnet/pkg/component"
+	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/util/config"
 	"github.com/argoproj/argo-cd/util/kube"
 )
 
-// KsonnetApp represents a ksonnet application directory and provides wrapper functionality around
-// the `ks` command.
-type KsonnetApp interface {
-	// Root is the root path ksonnet application directory
-	Root() string
-
-	// App is the Ksonnet application
-	App() app.App
-
-	// Spec is the Ksonnet application spec
-	Spec() *app.Spec
-
-	// Show returns a list of unstructured objects that would be applied to an environment
-	Show(environment string) ([]*unstructured.Unstructured, error)
-
-	// ListEnvParams returns list of environment parameters
-	ListEnvParams(environment string) ([]*v1alpha1.ComponentParameter, error)
-
-	// SetComponentParams updates component parameter in specified environment.
-	SetComponentParams(environment string, component string, param string, value string) error
-}
-
-// KsonnetVersion returns the version of ksonnet used when running ksonnet commands
-func KsonnetVersion() (string, error) {
-	cmd := exec.Command("ks", "version")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("unable to determine ksonnet version: %v", err)
-	}
-	ksonnetVersionStr := strings.Split(string(out), "\n")[0]
-	parts := strings.SplitN(ksonnetVersionStr, ":", 2)
-	if len(parts) != 2 {
-		return "", fmt.Errorf("unexpected version string format: %s", ksonnetVersionStr)
-	}
-	return strings.TrimSpace(parts[1]), nil
-}
-
-type ksonnetApp struct {
-	app  app.App
-	spec app.Spec
-}
-
-// NewKsonnetApp tries to create a new wrapper to run commands on the `ks` command-line tool.
-func NewKsonnetApp(path string) (KsonnetApp, error) {
-	ksApp := ksonnetApp{}
-	a, err := app.Load(afero.NewOsFs(), path, false)
-	if err != nil {
-		return nil, err
-	}
-	ksApp.app = a
-
-	var spec app.Spec
-	err = config.UnmarshalLocalFile(filepath.Join(a.Root(), "app.yaml"), &spec)
-	if err != nil {
-		return nil, err
-	}
-	ksApp.spec = spec
-	return &ksApp, nil
-}
-
-func (k *ksonnetApp) ksCmd(args ...string) (string, error) {
+func ksCmd(cwd string, args ...string) (string, error) {
 	cmd := exec.Command("ks", args...)
-	cmd.Dir = k.Root()
+	cmd.Dir = cwd
 
 	cmdStr := strings.Join(cmd.Args, " ")
 	log.Debug(cmdStr)
@@ -99,23 +39,93 @@ func (k *ksonnetApp) ksCmd(args ...string) (string, error) {
 	return out, nil
 }
 
+// Destination returns the deployment destination for an environment in app spec data
+func Destination(data []byte, environment string) (*v1alpha1.ApplicationDestination, error) {
+	var appSpec struct {
+		Environments map[string]struct {
+			Destination v1alpha1.ApplicationDestination
+		}
+	}
+	err := yaml.Unmarshal(data, &appSpec)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal ksonnet spec app.yaml: %v", err)
+	}
+
+	envSpec, ok := appSpec.Environments[environment]
+	if !ok {
+		return nil, fmt.Errorf("environment '%s' does not exist in ksonnet app", environment)
+	}
+
+	return &envSpec.Destination, nil
+}
+
+// KsonnetApp represents a ksonnet application directory and provides wrapper functionality around
+// the `ks` command.
+type KsonnetApp interface {
+	// Root is the root path ksonnet application directory
+	Root() string
+
+	// Show returns a list of unstructured objects that would be applied to an environment
+	Show(environment string) ([]*unstructured.Unstructured, error)
+
+	// Destination returns the deployment destination for an environment
+	Destination(environment string) (*v1alpha1.ApplicationDestination, error)
+
+	// ListEnvParams returns list of environment parameters
+	ListEnvParams(environment string) ([]*v1alpha1.ComponentParameter, error)
+
+	// SetComponentParams updates component parameter in specified environment.
+	SetComponentParams(environment string, component string, param string, value string) error
+}
+
+// KsonnetVersion returns the version of ksonnet used when running ksonnet commands
+func KsonnetVersion() (string, error) {
+	out, err := ksCmd("", "version")
+	if err != nil {
+		return "", fmt.Errorf("unable to determine ksonnet version: %v", err)
+	}
+	ksonnetVersionStr := strings.Split(string(out), "\n")[0]
+	parts := strings.SplitN(ksonnetVersionStr, ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected version string format: %s", ksonnetVersionStr)
+	}
+	return strings.TrimSpace(parts[1]), nil
+}
+
+type ksonnetApp struct {
+	rootDir string
+}
+
+// NewKsonnetApp tries to create a new wrapper to run commands on the `ks` command-line tool.
+func NewKsonnetApp(path string) (KsonnetApp, error) {
+	ksApp := ksonnetApp{rootDir: path}
+	// ensure that the file exists
+	if _, err := ksApp.appYamlPath(); err != nil {
+		return nil, err
+	}
+	return &ksApp, nil
+}
+
+func (k *ksonnetApp) appYamlPath() (string, error) {
+	const appYamlName = "app.yaml"
+	p := filepath.Join(k.rootDir, appYamlName)
+	if _, err := os.Stat(p); err != nil {
+		return "", err
+	}
+	return p, nil
+}
+
+func (k *ksonnetApp) ksCmd(args ...string) (string, error) {
+	return ksCmd(k.rootDir, args...)
+}
+
 func (k *ksonnetApp) Root() string {
-	return k.app.Root()
-}
-
-// App is the Ksonnet application
-func (k *ksonnetApp) App() app.App {
-	return k.app
-}
-
-// Spec is the Ksonnet application spec
-func (k *ksonnetApp) Spec() *app.Spec {
-	return &k.spec
+	return k.rootDir
 }
 
 // Show generates a concatenated list of Kubernetes manifests in the given environment.
 func (k *ksonnetApp) Show(environment string) ([]*unstructured.Unstructured, error) {
-	out, err := k.ksCmd("show", environment)
+	out, err := ksCmd(k.rootDir, "show", environment)
 	if err != nil {
 		return nil, fmt.Errorf("`ks show` failed: %v", err)
 	}
@@ -129,19 +139,41 @@ func (k *ksonnetApp) Show(environment string) ([]*unstructured.Unstructured, err
 	return data, err
 }
 
+// Destination returns the deployment destination for an environment
+func (k *ksonnetApp) Destination(environment string) (*v1alpha1.ApplicationDestination, error) {
+	p, err := k.appYamlPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := ioutil.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	return Destination(data, environment)
+}
+
 // ListEnvParams returns list of environment parameters
 func (k *ksonnetApp) ListEnvParams(environment string) ([]*v1alpha1.ComponentParameter, error) {
 	log.Infof("listing environment '%s' parameters", environment)
-	mod, err := component.DefaultManager.Module(k.app, "")
+	out, err := ksCmd(k.rootDir, "param", "list", "--output", "json", "--env", environment)
 	if err != nil {
 		return nil, err
 	}
-	ksParams, err := mod.Params(environment)
-	if err != nil {
+
+	// Auxiliary data to hold unmarshaled JSON output, which may use different field names
+	var ksParams struct {
+		Data []struct {
+			Component string `json:"component"`
+			Key       string `json:"param"`
+			Value     string `json:"value"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &ksParams); err != nil {
 		return nil, err
 	}
+
 	var params []*v1alpha1.ComponentParameter
-	for _, ksParam := range ksParams {
+	for _, ksParam := range ksParams.Data {
 		value, err := strconv.Unquote(ksParam.Value)
 		if err != nil {
 			value = ksParam.Value
@@ -158,6 +190,6 @@ func (k *ksonnetApp) ListEnvParams(environment string) ([]*v1alpha1.ComponentPar
 
 // SetComponentParams updates component parameter in specified environment.
 func (k *ksonnetApp) SetComponentParams(environment string, component string, param string, value string) error {
-	_, err := k.ksCmd("param", "set", component, param, value, "--env", environment)
+	_, err := ksCmd(k.rootDir, "param", "set", component, param, value, "--env", environment)
 	return err
 }

--- a/util/ksonnet/ksonnet.go
+++ b/util/ksonnet/ksonnet.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -174,10 +173,7 @@ func (k *ksonnetApp) ListEnvParams(environment string) ([]*v1alpha1.ComponentPar
 
 	var params []*v1alpha1.ComponentParameter
 	for _, ksParam := range ksParams.Data {
-		value, err := strconv.Unquote(ksParam.Value)
-		if err != nil {
-			value = ksParam.Value
-		}
+		value := strings.Trim(ksParam.Value, `'"`)
 		componentParam := v1alpha1.ComponentParameter{
 			Component: ksParam.Component,
 			Name:      ksParam.Key,

--- a/util/ksonnet/ksonnet.go
+++ b/util/ksonnet/ksonnet.go
@@ -83,7 +83,7 @@ func KsonnetVersion() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to determine ksonnet version: %v", err)
 	}
-	ksonnetVersionStr := strings.Split(string(out), "\n")[0]
+	ksonnetVersionStr := strings.Split(out, "\n")[0]
 	parts := strings.SplitN(ksonnetVersionStr, ":", 2)
 	if len(parts) != 2 {
 		return "", fmt.Errorf("unexpected version string format: %s", ksonnetVersionStr)

--- a/util/ksonnet/ksonnet_test.go
+++ b/util/ksonnet/ksonnet_test.go
@@ -2,7 +2,7 @@ package ksonnet
 
 import (
 	"encoding/json"
-	"path"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
@@ -23,20 +23,19 @@ const (
 
 func init() {
 	_, filename, _, _ := runtime.Caller(0)
-	testDataDir = path.Join(path.Dir(filename), "testdata")
+	testDataDir = filepath.Join(filepath.Dir(filename), "testdata")
 }
 
 func TestKsonnet(t *testing.T) {
-	ksApp, err := NewKsonnetApp(path.Join(testDataDir, testAppName))
+	ksApp, err := NewKsonnetApp(filepath.Join(testDataDir, testAppName))
 	assert.Nil(t, err)
-	app := ksApp.App()
-	defaultEnv, err := app.Environment(testEnvName)
+	defaultEnv, err := ksApp.GetEnvironment(testEnvName)
 	assert.True(t, err == nil)
 	assert.Equal(t, "https://1.2.3.4", defaultEnv.Destination.Server)
 }
 
 func TestShow(t *testing.T) {
-	ksApp, err := NewKsonnetApp(path.Join(testDataDir, testAppName))
+	ksApp, err := NewKsonnetApp(filepath.Join(testDataDir, testAppName))
 	assert.Nil(t, err)
 	objs, err := ksApp.Show(testEnvName)
 	assert.Nil(t, err)
@@ -49,7 +48,7 @@ func TestShow(t *testing.T) {
 }
 
 func TestListEnvParams(t *testing.T) {
-	ksApp, err := NewKsonnetApp(path.Join(testDataDir, testAppName))
+	ksApp, err := NewKsonnetApp(filepath.Join(testDataDir, testAppName))
 	assert.Nil(t, err)
 	paramPointers, err := ksApp.ListEnvParams(testEnvName)
 	assert.Nil(t, err)

--- a/util/ksonnet/ksonnet_test.go
+++ b/util/ksonnet/ksonnet_test.go
@@ -29,9 +29,9 @@ func init() {
 func TestKsonnet(t *testing.T) {
 	ksApp, err := NewKsonnetApp(filepath.Join(testDataDir, testAppName))
 	assert.Nil(t, err)
-	defaultEnv, err := ksApp.GetEnvironment(testEnvName)
+	defaultDest, err := ksApp.Destination(testEnvName)
 	assert.True(t, err == nil)
-	assert.Equal(t, "https://1.2.3.4", defaultEnv.Destination.Server)
+	assert.Equal(t, "https://1.2.3.4", defaultDest.Server)
 }
 
 func TestShow(t *testing.T) {

--- a/util/stats/stats.go
+++ b/util/stats/stats.go
@@ -45,18 +45,18 @@ func RegisterHeapDumper(filePath string) {
 			if _, err := os.Stat(filePath); err == nil {
 				err = os.Remove(filePath)
 				if err != nil {
-					log.Warnf("could not delete heap profile file: ", err)
+					log.Warnf("could not delete heap profile file: %v", err)
 					return
 				}
 			}
 			f, err := os.Create(filePath)
 			if err != nil {
-				log.Warnf("could not create heap profile file: ", err)
+				log.Warnf("could not create heap profile file: %v", err)
 				return
 			}
 
 			if err := pprof.WriteHeapProfile(f); err != nil {
-				log.Warnf("could not write heap profile: ", err)
+				log.Warnf("could not write heap profile: %v", err)
 				return
 			} else {
 				log.Infof("dumped heap profile to %s", filePath)


### PR DESCRIPTION
Closes #590.

Major points:

* Completely removes the Ksonnet client libs as a dependency.
* Removes the `ksonnetApp` struct and `KsonnetApp` interface types and replaces with utility functions that accept a root dir path.
* Upgrades to Ksonnet 0.13.0, which purports to fix https://github.com/ksonnet/ksonnet/issues/861 (which prevented us from upgrading to 0.12.0).  @jessesuen I have tested the new version and it appears to satisfy the repro tests you put into the bug you submitted, so I am so far satisfied that the issue with 0.12.0 is resolved.

Other points:

* Replaces use of `path` lib with `filepath` since we're working with file paths, not just serialized object paths.