### PR TITLE
update to kustomize 1.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-li
     mv /tmp/linux-amd64/helm /usr/local/bin/helm
 
 # Install kustomize
-ENV KUSTOMIZE_VERSION=1.0.7
+ENV KUSTOMIZE_VERSION=1.0.8
 RUN curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kustomize
 


### PR DESCRIPTION
This is primarily to add support for digest in imageTags as per https://github.com/kubernetes-sigs/kustomize/releases/tag/v1.0.8