### PR TITLE
Add errgroup dependency for Packr

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -796,6 +796,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:b2ea75de0ccb2db2ac79356407f8a4cd8f798fe15d41b381c00abf3ae8e55ed1"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  pruneopts = ""
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+
+[[projects]]
+  branch = "master"
   digest = "1:ed900376500543ca05f2a2383e1f541b4606f19cd22f34acb81b17a0b90c7f3e"
   name = "golang.org/x/sys"
   packages = [
@@ -1420,6 +1428,7 @@
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",
+    "golang.org/x/sync/errgroup",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,6 +9,7 @@ required = [
   "k8s.io/code-generator/cmd/go-to-protobuf",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
+  "golang.org/x/sync/errgroup",
 ]
 
 [[constraint]]


### PR DESCRIPTION
Closes #647, but builds upon PR #626 to mitigate need to resolve Gopkg.toml conflicts.

Edit: This is a one-line addition to `Gopkg.toml` with line 12, plus related changes to `Gopkg.lock`.