### PR TITLE
Switch to go-git for all remote git interactions including auth (issue #651)

### DIFF
--- a/cmd/argocd/commands/repo.go
+++ b/cmd/argocd/commands/repo.go
@@ -87,7 +87,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	}
 	command.Flags().StringVar(&repo.Username, "username", "", "username to the repository")
 	command.Flags().StringVar(&repo.Password, "password", "", "password to the repository")
-	command.Flags().StringVar(&sshPrivateKeyPath, "sshPrivateKeyPath", "", "path to the private ssh key (e.g. ~/.ssh/id_rsa)")
+	command.Flags().StringVar(&sshPrivateKeyPath, "ssh-private-key-path", "", "path to the private ssh key (e.g. ~/.ssh/id_rsa)")
 	command.Flags().BoolVar(&upsert, "upsert", false, "Override an existing repository with the same name even if the spec differs")
 	return command
 }

--- a/server/server.go
+++ b/server/server.go
@@ -367,6 +367,8 @@ func (a *ArgoCDServer) newGRPCServer() *grpc.Server {
 	sensitiveMethods := map[string]bool{
 		"/session.SessionService/Create":         true,
 		"/account.AccountService/UpdatePassword": true,
+		"/repository.RepositoryService/Create":   true,
+		"/repository.RepositoryService/Update":   true,
 	}
 	// NOTE: notice we do not configure the gRPC server here with TLS (e.g. grpc.Creds(creds))
 	// This is because TLS handshaking occurs in cmux handling

--- a/util/git/git.go
+++ b/util/git/git.go
@@ -1,12 +1,7 @@
 package git
 
 import (
-	"errors"
-	"fmt"
-	"io/ioutil"
 	"net/url"
-	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 )
@@ -67,69 +62,12 @@ func IsSSHURL(url string) bool {
 	return strings.HasPrefix(url, "git@") || strings.HasPrefix(url, "ssh://")
 }
 
-const gitSSHCommand = "ssh -q -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20"
-
-//TODO: Make sure every public method works with '*' repo
-
-// GetGitCommandEnvAndURL returns URL and env options for git operation
-func GetGitCommandEnvAndURL(repo, username, password string, sshPrivateKey string) (string, []string, error) {
-	cmdURL := repo
-	env := os.Environ()
-	if IsSSHURL(repo) {
-		sshCmd := gitSSHCommand
-		if sshPrivateKey != "" {
-			sshFile, err := ioutil.TempFile("", "")
-			if err != nil {
-				return "", nil, err
-			}
-			_, err = sshFile.WriteString(sshPrivateKey)
-			if err != nil {
-				return "", nil, err
-			}
-			err = sshFile.Close()
-			if err != nil {
-				return "", nil, err
-			}
-			sshCmd += " -i " + sshFile.Name()
-		}
-		env = append(env, fmt.Sprintf("GIT_SSH_COMMAND=%s", sshCmd))
-	} else {
-		env = append(env, "GIT_ASKPASS=")
-		repoURL, err := url.ParseRequestURI(repo)
-		if err != nil {
-			return "", nil, err
-		}
-
-		repoURL.User = url.UserPassword(username, password)
-		cmdURL = repoURL.String()
-	}
-	return cmdURL, env, nil
-}
-
 // TestRepo tests if a repo exists and is accessible with the given credentials
 func TestRepo(repo, username, password string, sshPrivateKey string) error {
-	repo, env, err := GetGitCommandEnvAndURL(repo, username, password, sshPrivateKey)
+	clnt, err := NewFactory().NewClient(repo, "", username, password, sshPrivateKey)
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("git", "ls-remote", repo, "HEAD")
-	cmd.Env = env
-	_, err = cmd.Output()
-	if err != nil {
-		if exErr, ok := err.(*exec.ExitError); ok {
-			errOutput := strings.Split(string(exErr.Stderr), "\n")[0]
-			errOutput = fmt.Sprintf("%s: %s", repo, errOutput)
-			return errors.New(redactPassword(errOutput, password))
-		}
-		return err
-	}
-	return nil
-}
-
-func redactPassword(msg string, password string) string {
-	if password != "" {
-		passwordRegexp := regexp.MustCompile("\\b" + regexp.QuoteMeta(password) + "\\b")
-		msg = passwordRegexp.ReplaceAllString(msg, "*****")
-	}
-	return msg
+	_, err = clnt.LsRemote("HEAD")
+	return err
 }


### PR DESCRIPTION
Switches all interactions with a git remote to use go-git (instead of git CLI) which provides the following benefits:
* resolves issue #651 where Google Source Repository credentials were not being accepted
* we never store credentials on disk in the repo server (or anywhere else for that matter)
* eliminates the extra git process forks we currently perform with respect to managing credentials

Also fixes an issue where argocd-server logged credentials in plain text during repo add (issue #653)

Performed the following tests:
* private credentials to GSR
* git with SSH private key
* public repos
* verified updates to HEAD, branch, and git tags were seen
