### PR TITLE
Remove temporary SSH key files after use.

### DIFF
--- a/util/git/git.go
+++ b/util/git/git.go
@@ -82,6 +82,9 @@ func GetGitCommandEnvAndURL(repo, username, password string, sshPrivateKey strin
 			if err != nil {
 				return "", nil, err
 			}
+
+			defer os.Remove(sshFile.Name())
+
 			_, err = sshFile.WriteString(sshPrivateKey)
 			if err != nil {
 				return "", nil, err


### PR DESCRIPTION
They just piled up in the temporary directory before.