### PR TITLE
Add project get permission automatically to roles

### DIFF
--- a/pkg/apis/application/v1alpha1/generated.pb.go
+++ b/pkg/apis/application/v1alpha1/generated.pb.go
@@ -30,7 +30,7 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 func (m *AWSAuthConfig) Reset()      { *m = AWSAuthConfig{} }
 func (*AWSAuthConfig) ProtoMessage() {}
 func (*AWSAuthConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{0}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{0}
 }
 func (m *AWSAuthConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -58,7 +58,7 @@ var xxx_messageInfo_AWSAuthConfig proto.InternalMessageInfo
 func (m *AppProject) Reset()      { *m = AppProject{} }
 func (*AppProject) ProtoMessage() {}
 func (*AppProject) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{1}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{1}
 }
 func (m *AppProject) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -86,7 +86,7 @@ var xxx_messageInfo_AppProject proto.InternalMessageInfo
 func (m *AppProjectList) Reset()      { *m = AppProjectList{} }
 func (*AppProjectList) ProtoMessage() {}
 func (*AppProjectList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{2}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{2}
 }
 func (m *AppProjectList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -114,7 +114,7 @@ var xxx_messageInfo_AppProjectList proto.InternalMessageInfo
 func (m *AppProjectSpec) Reset()      { *m = AppProjectSpec{} }
 func (*AppProjectSpec) ProtoMessage() {}
 func (*AppProjectSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{3}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{3}
 }
 func (m *AppProjectSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -142,7 +142,7 @@ var xxx_messageInfo_AppProjectSpec proto.InternalMessageInfo
 func (m *Application) Reset()      { *m = Application{} }
 func (*Application) ProtoMessage() {}
 func (*Application) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{4}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{4}
 }
 func (m *Application) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -170,7 +170,7 @@ var xxx_messageInfo_Application proto.InternalMessageInfo
 func (m *ApplicationCondition) Reset()      { *m = ApplicationCondition{} }
 func (*ApplicationCondition) ProtoMessage() {}
 func (*ApplicationCondition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{5}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{5}
 }
 func (m *ApplicationCondition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -198,7 +198,7 @@ var xxx_messageInfo_ApplicationCondition proto.InternalMessageInfo
 func (m *ApplicationDestination) Reset()      { *m = ApplicationDestination{} }
 func (*ApplicationDestination) ProtoMessage() {}
 func (*ApplicationDestination) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{6}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{6}
 }
 func (m *ApplicationDestination) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -226,7 +226,7 @@ var xxx_messageInfo_ApplicationDestination proto.InternalMessageInfo
 func (m *ApplicationList) Reset()      { *m = ApplicationList{} }
 func (*ApplicationList) ProtoMessage() {}
 func (*ApplicationList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{7}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{7}
 }
 func (m *ApplicationList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -254,7 +254,7 @@ var xxx_messageInfo_ApplicationList proto.InternalMessageInfo
 func (m *ApplicationSource) Reset()      { *m = ApplicationSource{} }
 func (*ApplicationSource) ProtoMessage() {}
 func (*ApplicationSource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{8}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{8}
 }
 func (m *ApplicationSource) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -282,7 +282,7 @@ var xxx_messageInfo_ApplicationSource proto.InternalMessageInfo
 func (m *ApplicationSpec) Reset()      { *m = ApplicationSpec{} }
 func (*ApplicationSpec) ProtoMessage() {}
 func (*ApplicationSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{9}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{9}
 }
 func (m *ApplicationSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -310,7 +310,7 @@ var xxx_messageInfo_ApplicationSpec proto.InternalMessageInfo
 func (m *ApplicationStatus) Reset()      { *m = ApplicationStatus{} }
 func (*ApplicationStatus) ProtoMessage() {}
 func (*ApplicationStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{10}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{10}
 }
 func (m *ApplicationStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -338,7 +338,7 @@ var xxx_messageInfo_ApplicationStatus proto.InternalMessageInfo
 func (m *ApplicationWatchEvent) Reset()      { *m = ApplicationWatchEvent{} }
 func (*ApplicationWatchEvent) ProtoMessage() {}
 func (*ApplicationWatchEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{11}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{11}
 }
 func (m *ApplicationWatchEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -366,7 +366,7 @@ var xxx_messageInfo_ApplicationWatchEvent proto.InternalMessageInfo
 func (m *Cluster) Reset()      { *m = Cluster{} }
 func (*Cluster) ProtoMessage() {}
 func (*Cluster) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{12}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{12}
 }
 func (m *Cluster) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -394,7 +394,7 @@ var xxx_messageInfo_Cluster proto.InternalMessageInfo
 func (m *ClusterConfig) Reset()      { *m = ClusterConfig{} }
 func (*ClusterConfig) ProtoMessage() {}
 func (*ClusterConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{13}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{13}
 }
 func (m *ClusterConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -422,7 +422,7 @@ var xxx_messageInfo_ClusterConfig proto.InternalMessageInfo
 func (m *ClusterList) Reset()      { *m = ClusterList{} }
 func (*ClusterList) ProtoMessage() {}
 func (*ClusterList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{14}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{14}
 }
 func (m *ClusterList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -450,7 +450,7 @@ var xxx_messageInfo_ClusterList proto.InternalMessageInfo
 func (m *ComparisonResult) Reset()      { *m = ComparisonResult{} }
 func (*ComparisonResult) ProtoMessage() {}
 func (*ComparisonResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{15}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{15}
 }
 func (m *ComparisonResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -478,7 +478,7 @@ var xxx_messageInfo_ComparisonResult proto.InternalMessageInfo
 func (m *ComponentParameter) Reset()      { *m = ComponentParameter{} }
 func (*ComponentParameter) ProtoMessage() {}
 func (*ComponentParameter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{16}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{16}
 }
 func (m *ComponentParameter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -506,7 +506,7 @@ var xxx_messageInfo_ComponentParameter proto.InternalMessageInfo
 func (m *ConnectionState) Reset()      { *m = ConnectionState{} }
 func (*ConnectionState) ProtoMessage() {}
 func (*ConnectionState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{17}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{17}
 }
 func (m *ConnectionState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -534,7 +534,7 @@ var xxx_messageInfo_ConnectionState proto.InternalMessageInfo
 func (m *DeploymentInfo) Reset()      { *m = DeploymentInfo{} }
 func (*DeploymentInfo) ProtoMessage() {}
 func (*DeploymentInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{18}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{18}
 }
 func (m *DeploymentInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -562,7 +562,7 @@ var xxx_messageInfo_DeploymentInfo proto.InternalMessageInfo
 func (m *HealthStatus) Reset()      { *m = HealthStatus{} }
 func (*HealthStatus) ProtoMessage() {}
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{19}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{19}
 }
 func (m *HealthStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -590,7 +590,7 @@ var xxx_messageInfo_HealthStatus proto.InternalMessageInfo
 func (m *HookStatus) Reset()      { *m = HookStatus{} }
 func (*HookStatus) ProtoMessage() {}
 func (*HookStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{20}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{20}
 }
 func (m *HookStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -618,7 +618,7 @@ var xxx_messageInfo_HookStatus proto.InternalMessageInfo
 func (m *JWTToken) Reset()      { *m = JWTToken{} }
 func (*JWTToken) ProtoMessage() {}
 func (*JWTToken) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{21}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{21}
 }
 func (m *JWTToken) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -646,7 +646,7 @@ var xxx_messageInfo_JWTToken proto.InternalMessageInfo
 func (m *Operation) Reset()      { *m = Operation{} }
 func (*Operation) ProtoMessage() {}
 func (*Operation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{22}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{22}
 }
 func (m *Operation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -674,7 +674,7 @@ var xxx_messageInfo_Operation proto.InternalMessageInfo
 func (m *OperationState) Reset()      { *m = OperationState{} }
 func (*OperationState) ProtoMessage() {}
 func (*OperationState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{23}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{23}
 }
 func (m *OperationState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -702,7 +702,7 @@ var xxx_messageInfo_OperationState proto.InternalMessageInfo
 func (m *ParameterOverrides) Reset()      { *m = ParameterOverrides{} }
 func (*ParameterOverrides) ProtoMessage() {}
 func (*ParameterOverrides) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{24}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{24}
 }
 func (m *ParameterOverrides) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -730,7 +730,7 @@ var xxx_messageInfo_ParameterOverrides proto.InternalMessageInfo
 func (m *ProjectRole) Reset()      { *m = ProjectRole{} }
 func (*ProjectRole) ProtoMessage() {}
 func (*ProjectRole) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{25}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{25}
 }
 func (m *ProjectRole) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -758,7 +758,7 @@ var xxx_messageInfo_ProjectRole proto.InternalMessageInfo
 func (m *Repository) Reset()      { *m = Repository{} }
 func (*Repository) ProtoMessage() {}
 func (*Repository) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{26}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{26}
 }
 func (m *Repository) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -786,7 +786,7 @@ var xxx_messageInfo_Repository proto.InternalMessageInfo
 func (m *RepositoryList) Reset()      { *m = RepositoryList{} }
 func (*RepositoryList) ProtoMessage() {}
 func (*RepositoryList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{27}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{27}
 }
 func (m *RepositoryList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -814,7 +814,7 @@ var xxx_messageInfo_RepositoryList proto.InternalMessageInfo
 func (m *ResourceDetails) Reset()      { *m = ResourceDetails{} }
 func (*ResourceDetails) ProtoMessage() {}
 func (*ResourceDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{28}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{28}
 }
 func (m *ResourceDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -842,7 +842,7 @@ var xxx_messageInfo_ResourceDetails proto.InternalMessageInfo
 func (m *ResourceNode) Reset()      { *m = ResourceNode{} }
 func (*ResourceNode) ProtoMessage() {}
 func (*ResourceNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{29}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{29}
 }
 func (m *ResourceNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -870,7 +870,7 @@ var xxx_messageInfo_ResourceNode proto.InternalMessageInfo
 func (m *ResourceState) Reset()      { *m = ResourceState{} }
 func (*ResourceState) ProtoMessage() {}
 func (*ResourceState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{30}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{30}
 }
 func (m *ResourceState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -898,7 +898,7 @@ var xxx_messageInfo_ResourceState proto.InternalMessageInfo
 func (m *RollbackOperation) Reset()      { *m = RollbackOperation{} }
 func (*RollbackOperation) ProtoMessage() {}
 func (*RollbackOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{31}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{31}
 }
 func (m *RollbackOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -926,7 +926,7 @@ var xxx_messageInfo_RollbackOperation proto.InternalMessageInfo
 func (m *SyncOperation) Reset()      { *m = SyncOperation{} }
 func (*SyncOperation) ProtoMessage() {}
 func (*SyncOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{32}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{32}
 }
 func (m *SyncOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -954,7 +954,7 @@ var xxx_messageInfo_SyncOperation proto.InternalMessageInfo
 func (m *SyncOperationResult) Reset()      { *m = SyncOperationResult{} }
 func (*SyncOperationResult) ProtoMessage() {}
 func (*SyncOperationResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{33}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{33}
 }
 func (m *SyncOperationResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -982,7 +982,7 @@ var xxx_messageInfo_SyncOperationResult proto.InternalMessageInfo
 func (m *SyncPolicy) Reset()      { *m = SyncPolicy{} }
 func (*SyncPolicy) ProtoMessage() {}
 func (*SyncPolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{34}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{34}
 }
 func (m *SyncPolicy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1010,7 +1010,7 @@ var xxx_messageInfo_SyncPolicy proto.InternalMessageInfo
 func (m *SyncPolicyAutomated) Reset()      { *m = SyncPolicyAutomated{} }
 func (*SyncPolicyAutomated) ProtoMessage() {}
 func (*SyncPolicyAutomated) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{35}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{35}
 }
 func (m *SyncPolicyAutomated) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1038,7 +1038,7 @@ var xxx_messageInfo_SyncPolicyAutomated proto.InternalMessageInfo
 func (m *SyncStrategy) Reset()      { *m = SyncStrategy{} }
 func (*SyncStrategy) ProtoMessage() {}
 func (*SyncStrategy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{36}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{36}
 }
 func (m *SyncStrategy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1066,7 +1066,7 @@ var xxx_messageInfo_SyncStrategy proto.InternalMessageInfo
 func (m *SyncStrategyApply) Reset()      { *m = SyncStrategyApply{} }
 func (*SyncStrategyApply) ProtoMessage() {}
 func (*SyncStrategyApply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{37}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{37}
 }
 func (m *SyncStrategyApply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1094,7 +1094,7 @@ var xxx_messageInfo_SyncStrategyApply proto.InternalMessageInfo
 func (m *SyncStrategyHook) Reset()      { *m = SyncStrategyHook{} }
 func (*SyncStrategyHook) ProtoMessage() {}
 func (*SyncStrategyHook) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{38}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{38}
 }
 func (m *SyncStrategyHook) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1122,7 +1122,7 @@ var xxx_messageInfo_SyncStrategyHook proto.InternalMessageInfo
 func (m *TLSClientConfig) Reset()      { *m = TLSClientConfig{} }
 func (*TLSClientConfig) ProtoMessage() {}
 func (*TLSClientConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_110357f3c44c1b17, []int{39}
+	return fileDescriptor_generated_639498dd9e5881d3, []int{39}
 }
 func (m *TLSClientConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -9909,10 +9909,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1/generated.proto", fileDescriptor_generated_110357f3c44c1b17)
+	proto.RegisterFile("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1/generated.proto", fileDescriptor_generated_639498dd9e5881d3)
 }
 
-var fileDescriptor_generated_110357f3c44c1b17 = []byte{
+var fileDescriptor_generated_639498dd9e5881d3 = []byte{
 	// 2817 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x5a, 0x4d, 0x8c, 0x23, 0x47,
 	0xf5, 0x9f, 0xf6, 0xc7, 0x8c, 0xe7, 0xcd, 0xc7, 0xee, 0x56, 0x3e, 0xfe, 0xfe, 0x4f, 0xa4, 0x99,

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -492,6 +492,8 @@ type AppProject struct {
 func (proj *AppProject) ProjectPoliciesString() string {
 	var policies []string
 	for _, role := range proj.Spec.Roles {
+		projectPolicy := fmt.Sprintf("p, proj:%s:%s, projects, get, %s, allow", proj.ObjectMeta.Name, role.Name, proj.ObjectMeta.Name)
+		policies = append(policies, projectPolicy)
 		policies = append(policies, role.Policies...)
 	}
 	return strings.Join(policies, "\n")

--- a/reposerver/repository/repository.pb.go
+++ b/reposerver/repository/repository.pb.go
@@ -46,7 +46,7 @@ func (m *ManifestRequest) Reset()         { *m = ManifestRequest{} }
 func (m *ManifestRequest) String() string { return proto.CompactTextString(m) }
 func (*ManifestRequest) ProtoMessage()    {}
 func (*ManifestRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_49651600e73b0b40, []int{0}
+	return fileDescriptor_repository_e1170ea85be6baa9, []int{0}
 }
 func (m *ManifestRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -146,7 +146,7 @@ func (m *ManifestResponse) Reset()         { *m = ManifestResponse{} }
 func (m *ManifestResponse) String() string { return proto.CompactTextString(m) }
 func (*ManifestResponse) ProtoMessage()    {}
 func (*ManifestResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_49651600e73b0b40, []int{1}
+	return fileDescriptor_repository_e1170ea85be6baa9, []int{1}
 }
 func (m *ManifestResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -224,7 +224,7 @@ func (m *ListDirRequest) Reset()         { *m = ListDirRequest{} }
 func (m *ListDirRequest) String() string { return proto.CompactTextString(m) }
 func (*ListDirRequest) ProtoMessage()    {}
 func (*ListDirRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_49651600e73b0b40, []int{2}
+	return fileDescriptor_repository_e1170ea85be6baa9, []int{2}
 }
 func (m *ListDirRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -286,7 +286,7 @@ func (m *FileList) Reset()         { *m = FileList{} }
 func (m *FileList) String() string { return proto.CompactTextString(m) }
 func (*FileList) ProtoMessage()    {}
 func (*FileList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_49651600e73b0b40, []int{3}
+	return fileDescriptor_repository_e1170ea85be6baa9, []int{3}
 }
 func (m *FileList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -336,7 +336,7 @@ func (m *GetFileRequest) Reset()         { *m = GetFileRequest{} }
 func (m *GetFileRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFileRequest) ProtoMessage()    {}
 func (*GetFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_49651600e73b0b40, []int{4}
+	return fileDescriptor_repository_e1170ea85be6baa9, []int{4}
 }
 func (m *GetFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -398,7 +398,7 @@ func (m *GetFileResponse) Reset()         { *m = GetFileResponse{} }
 func (m *GetFileResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFileResponse) ProtoMessage()    {}
 func (*GetFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_49651600e73b0b40, []int{5}
+	return fileDescriptor_repository_e1170ea85be6baa9, []int{5}
 }
 func (m *GetFileResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2099,10 +2099,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("reposerver/repository/repository.proto", fileDescriptor_repository_49651600e73b0b40)
+	proto.RegisterFile("reposerver/repository/repository.proto", fileDescriptor_repository_e1170ea85be6baa9)
 }
 
-var fileDescriptor_repository_49651600e73b0b40 = []byte{
+var fileDescriptor_repository_e1170ea85be6baa9 = []byte{
 	// 584 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x55, 0xdd, 0x8a, 0xd3, 0x40,
 	0x14, 0xde, 0x6c, 0xbb, 0xdd, 0x76, 0x2a, 0xee, 0x3a, 0x14, 0x09, 0x69, 0x29, 0x21, 0xa0, 0xf4,

--- a/server/account/account.pb.go
+++ b/server/account/account.pb.go
@@ -37,7 +37,7 @@ func (m *UpdatePasswordRequest) Reset()         { *m = UpdatePasswordRequest{} }
 func (m *UpdatePasswordRequest) String() string { return proto.CompactTextString(m) }
 func (*UpdatePasswordRequest) ProtoMessage()    {}
 func (*UpdatePasswordRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_account_d27ff2bbd0f6944b, []int{0}
+	return fileDescriptor_account_c227670d8e34bf5f, []int{0}
 }
 func (m *UpdatePasswordRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -90,7 +90,7 @@ func (m *UpdatePasswordResponse) Reset()         { *m = UpdatePasswordResponse{}
 func (m *UpdatePasswordResponse) String() string { return proto.CompactTextString(m) }
 func (*UpdatePasswordResponse) ProtoMessage()    {}
 func (*UpdatePasswordResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_account_d27ff2bbd0f6944b, []int{1}
+	return fileDescriptor_account_c227670d8e34bf5f, []int{1}
 }
 func (m *UpdatePasswordResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -566,10 +566,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/account/account.proto", fileDescriptor_account_d27ff2bbd0f6944b)
+	proto.RegisterFile("server/account/account.proto", fileDescriptor_account_c227670d8e34bf5f)
 }
 
-var fileDescriptor_account_d27ff2bbd0f6944b = []byte{
+var fileDescriptor_account_c227670d8e34bf5f = []byte{
 	// 268 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x29, 0x4e, 0x2d, 0x2a,
 	0x4b, 0x2d, 0xd2, 0x4f, 0x4c, 0x4e, 0xce, 0x2f, 0xcd, 0x2b, 0x81, 0xd1, 0x7a, 0x05, 0x45, 0xf9,

--- a/server/application/application.pb.go
+++ b/server/application/application.pb.go
@@ -51,7 +51,7 @@ func (m *ApplicationQuery) Reset()         { *m = ApplicationQuery{} }
 func (m *ApplicationQuery) String() string { return proto.CompactTextString(m) }
 func (*ApplicationQuery) ProtoMessage()    {}
 func (*ApplicationQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{0}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{0}
 }
 func (m *ApplicationQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -115,7 +115,7 @@ func (m *ApplicationResourceEventsQuery) Reset()         { *m = ApplicationResou
 func (m *ApplicationResourceEventsQuery) String() string { return proto.CompactTextString(m) }
 func (*ApplicationResourceEventsQuery) ProtoMessage()    {}
 func (*ApplicationResourceEventsQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{1}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{1}
 }
 func (m *ApplicationResourceEventsQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -178,7 +178,7 @@ func (m *ApplicationManifestQuery) Reset()         { *m = ApplicationManifestQue
 func (m *ApplicationManifestQuery) String() string { return proto.CompactTextString(m) }
 func (*ApplicationManifestQuery) ProtoMessage()    {}
 func (*ApplicationManifestQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{2}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{2}
 }
 func (m *ApplicationManifestQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -231,7 +231,7 @@ func (m *ApplicationResponse) Reset()         { *m = ApplicationResponse{} }
 func (m *ApplicationResponse) String() string { return proto.CompactTextString(m) }
 func (*ApplicationResponse) ProtoMessage()    {}
 func (*ApplicationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{3}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{3}
 }
 func (m *ApplicationResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -272,7 +272,7 @@ func (m *ApplicationCreateRequest) Reset()         { *m = ApplicationCreateReque
 func (m *ApplicationCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*ApplicationCreateRequest) ProtoMessage()    {}
 func (*ApplicationCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{4}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{4}
 }
 func (m *ApplicationCreateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -326,7 +326,7 @@ func (m *ApplicationUpdateRequest) Reset()         { *m = ApplicationUpdateReque
 func (m *ApplicationUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*ApplicationUpdateRequest) ProtoMessage()    {}
 func (*ApplicationUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{5}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{5}
 }
 func (m *ApplicationUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -374,7 +374,7 @@ func (m *ApplicationDeleteRequest) Reset()         { *m = ApplicationDeleteReque
 func (m *ApplicationDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*ApplicationDeleteRequest) ProtoMessage()    {}
 func (*ApplicationDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{6}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{6}
 }
 func (m *ApplicationDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -434,7 +434,7 @@ func (m *ApplicationSyncRequest) Reset()         { *m = ApplicationSyncRequest{}
 func (m *ApplicationSyncRequest) String() string { return proto.CompactTextString(m) }
 func (*ApplicationSyncRequest) ProtoMessage()    {}
 func (*ApplicationSyncRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{7}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{7}
 }
 func (m *ApplicationSyncRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -518,7 +518,7 @@ func (m *ParameterOverrides) Reset()         { *m = ParameterOverrides{} }
 func (m *ParameterOverrides) String() string { return proto.CompactTextString(m) }
 func (*ParameterOverrides) ProtoMessage()    {}
 func (*ParameterOverrides) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{8}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{8}
 }
 func (m *ParameterOverrides) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -567,7 +567,7 @@ func (m *Parameter) Reset()         { *m = Parameter{} }
 func (m *Parameter) String() string { return proto.CompactTextString(m) }
 func (*Parameter) ProtoMessage()    {}
 func (*Parameter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{9}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{9}
 }
 func (m *Parameter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -630,7 +630,7 @@ func (m *ApplicationUpdateSpecRequest) Reset()         { *m = ApplicationUpdateS
 func (m *ApplicationUpdateSpecRequest) String() string { return proto.CompactTextString(m) }
 func (*ApplicationUpdateSpecRequest) ProtoMessage()    {}
 func (*ApplicationUpdateSpecRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{10}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{10}
 }
 func (m *ApplicationUpdateSpecRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -687,7 +687,7 @@ func (m *ApplicationRollbackRequest) Reset()         { *m = ApplicationRollbackR
 func (m *ApplicationRollbackRequest) String() string { return proto.CompactTextString(m) }
 func (*ApplicationRollbackRequest) ProtoMessage()    {}
 func (*ApplicationRollbackRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{11}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{11}
 }
 func (m *ApplicationRollbackRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -758,7 +758,7 @@ func (m *ApplicationDeleteResourceRequest) Reset()         { *m = ApplicationDel
 func (m *ApplicationDeleteResourceRequest) String() string { return proto.CompactTextString(m) }
 func (*ApplicationDeleteResourceRequest) ProtoMessage()    {}
 func (*ApplicationDeleteResourceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{12}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{12}
 }
 func (m *ApplicationDeleteResourceRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -832,7 +832,7 @@ func (m *ApplicationPodLogsQuery) Reset()         { *m = ApplicationPodLogsQuery
 func (m *ApplicationPodLogsQuery) String() string { return proto.CompactTextString(m) }
 func (*ApplicationPodLogsQuery) ProtoMessage()    {}
 func (*ApplicationPodLogsQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{13}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{13}
 }
 func (m *ApplicationPodLogsQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -922,7 +922,7 @@ func (m *LogEntry) Reset()         { *m = LogEntry{} }
 func (m *LogEntry) String() string { return proto.CompactTextString(m) }
 func (*LogEntry) ProtoMessage()    {}
 func (*LogEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{14}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{14}
 }
 func (m *LogEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -976,7 +976,7 @@ func (m *OperationTerminateRequest) Reset()         { *m = OperationTerminateReq
 func (m *OperationTerminateRequest) String() string { return proto.CompactTextString(m) }
 func (*OperationTerminateRequest) ProtoMessage()    {}
 func (*OperationTerminateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{15}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{15}
 }
 func (m *OperationTerminateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1022,7 +1022,7 @@ func (m *OperationTerminateResponse) Reset()         { *m = OperationTerminateRe
 func (m *OperationTerminateResponse) String() string { return proto.CompactTextString(m) }
 func (*OperationTerminateResponse) ProtoMessage()    {}
 func (*OperationTerminateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_application_7f078bb160e6090a, []int{16}
+	return fileDescriptor_application_7fcd602c2bf997a7, []int{16}
 }
 func (m *OperationTerminateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4877,10 +4877,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/application/application.proto", fileDescriptor_application_7f078bb160e6090a)
+	proto.RegisterFile("server/application/application.proto", fileDescriptor_application_7fcd602c2bf997a7)
 }
 
-var fileDescriptor_application_7f078bb160e6090a = []byte{
+var fileDescriptor_application_7fcd602c2bf997a7 = []byte{
 	// 1407 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x58, 0xcf, 0x6f, 0xdc, 0x44,
 	0x14, 0x66, 0x76, 0x37, 0x9b, 0xec, 0x4b, 0x85, 0x60, 0x68, 0x83, 0x31, 0x69, 0xb2, 0x9a, 0xa6,

--- a/server/cluster/cluster.pb.go
+++ b/server/cluster/cluster.pb.go
@@ -45,7 +45,7 @@ func (m *ClusterQuery) Reset()         { *m = ClusterQuery{} }
 func (m *ClusterQuery) String() string { return proto.CompactTextString(m) }
 func (*ClusterQuery) ProtoMessage()    {}
 func (*ClusterQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_0875510a34378ea0, []int{0}
+	return fileDescriptor_cluster_bf8d7367dfc95a3e, []int{0}
 }
 func (m *ClusterQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -91,7 +91,7 @@ func (m *ClusterResponse) Reset()         { *m = ClusterResponse{} }
 func (m *ClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterResponse) ProtoMessage()    {}
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_0875510a34378ea0, []int{1}
+	return fileDescriptor_cluster_bf8d7367dfc95a3e, []int{1}
 }
 func (m *ClusterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -132,7 +132,7 @@ func (m *ClusterCreateRequest) Reset()         { *m = ClusterCreateRequest{} }
 func (m *ClusterCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterCreateRequest) ProtoMessage()    {}
 func (*ClusterCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_0875510a34378ea0, []int{2}
+	return fileDescriptor_cluster_bf8d7367dfc95a3e, []int{2}
 }
 func (m *ClusterCreateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -189,7 +189,7 @@ func (m *ClusterCreateFromKubeConfigRequest) Reset()         { *m = ClusterCreat
 func (m *ClusterCreateFromKubeConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterCreateFromKubeConfigRequest) ProtoMessage()    {}
 func (*ClusterCreateFromKubeConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_0875510a34378ea0, []int{3}
+	return fileDescriptor_cluster_bf8d7367dfc95a3e, []int{3}
 }
 func (m *ClusterCreateFromKubeConfigRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -257,7 +257,7 @@ func (m *ClusterUpdateRequest) Reset()         { *m = ClusterUpdateRequest{} }
 func (m *ClusterUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterUpdateRequest) ProtoMessage()    {}
 func (*ClusterUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_0875510a34378ea0, []int{4}
+	return fileDescriptor_cluster_bf8d7367dfc95a3e, []int{4}
 }
 func (m *ClusterUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1393,10 +1393,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/cluster/cluster.proto", fileDescriptor_cluster_0875510a34378ea0)
+	proto.RegisterFile("server/cluster/cluster.proto", fileDescriptor_cluster_bf8d7367dfc95a3e)
 }
 
-var fileDescriptor_cluster_0875510a34378ea0 = []byte{
+var fileDescriptor_cluster_bf8d7367dfc95a3e = []byte{
 	// 564 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x95, 0xcd, 0x6e, 0x13, 0x31,
 	0x10, 0xc7, 0xe5, 0xb6, 0xda, 0x12, 0x83, 0xf8, 0xb0, 0x0a, 0x5a, 0xd2, 0x10, 0xa5, 0x3e, 0x54,

--- a/server/project/project.pb.go
+++ b/server/project/project.pb.go
@@ -46,7 +46,7 @@ func (m *ProjectCreateRequest) Reset()         { *m = ProjectCreateRequest{} }
 func (m *ProjectCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*ProjectCreateRequest) ProtoMessage()    {}
 func (*ProjectCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_project_082822b5d17b8c4e, []int{0}
+	return fileDescriptor_project_8d94583ca767d5b3, []int{0}
 }
 func (m *ProjectCreateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -96,7 +96,7 @@ func (m *ProjectTokenDeleteRequest) Reset()         { *m = ProjectTokenDeleteReq
 func (m *ProjectTokenDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*ProjectTokenDeleteRequest) ProtoMessage()    {}
 func (*ProjectTokenDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_project_082822b5d17b8c4e, []int{1}
+	return fileDescriptor_project_8d94583ca767d5b3, []int{1}
 }
 func (m *ProjectTokenDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -162,7 +162,7 @@ func (m *ProjectTokenCreateRequest) Reset()         { *m = ProjectTokenCreateReq
 func (m *ProjectTokenCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*ProjectTokenCreateRequest) ProtoMessage()    {}
 func (*ProjectTokenCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_project_082822b5d17b8c4e, []int{2}
+	return fileDescriptor_project_8d94583ca767d5b3, []int{2}
 }
 func (m *ProjectTokenCreateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -231,7 +231,7 @@ func (m *ProjectTokenResponse) Reset()         { *m = ProjectTokenResponse{} }
 func (m *ProjectTokenResponse) String() string { return proto.CompactTextString(m) }
 func (*ProjectTokenResponse) ProtoMessage()    {}
 func (*ProjectTokenResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_project_082822b5d17b8c4e, []int{3}
+	return fileDescriptor_project_8d94583ca767d5b3, []int{3}
 }
 func (m *ProjectTokenResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -279,7 +279,7 @@ func (m *ProjectQuery) Reset()         { *m = ProjectQuery{} }
 func (m *ProjectQuery) String() string { return proto.CompactTextString(m) }
 func (*ProjectQuery) ProtoMessage()    {}
 func (*ProjectQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_project_082822b5d17b8c4e, []int{4}
+	return fileDescriptor_project_8d94583ca767d5b3, []int{4}
 }
 func (m *ProjectQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -326,7 +326,7 @@ func (m *ProjectUpdateRequest) Reset()         { *m = ProjectUpdateRequest{} }
 func (m *ProjectUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*ProjectUpdateRequest) ProtoMessage()    {}
 func (*ProjectUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_project_082822b5d17b8c4e, []int{5}
+	return fileDescriptor_project_8d94583ca767d5b3, []int{5}
 }
 func (m *ProjectUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -372,7 +372,7 @@ func (m *EmptyResponse) Reset()         { *m = EmptyResponse{} }
 func (m *EmptyResponse) String() string { return proto.CompactTextString(m) }
 func (*EmptyResponse) ProtoMessage()    {}
 func (*EmptyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_project_082822b5d17b8c4e, []int{6}
+	return fileDescriptor_project_8d94583ca767d5b3, []int{6}
 }
 func (m *EmptyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1846,10 +1846,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/project/project.proto", fileDescriptor_project_082822b5d17b8c4e)
+	proto.RegisterFile("server/project/project.proto", fileDescriptor_project_8d94583ca767d5b3)
 }
 
-var fileDescriptor_project_082822b5d17b8c4e = []byte{
+var fileDescriptor_project_8d94583ca767d5b3 = []byte{
 	// 697 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x55, 0x5d, 0x6b, 0x13, 0x4d,
 	0x14, 0x66, 0x9a, 0xbe, 0x79, 0xdf, 0x4e, 0x5e, 0xb5, 0x0c, 0xad, 0xa6, 0xb1, 0x8d, 0x61, 0x2e,

--- a/server/repository/repository.pb.go
+++ b/server/repository/repository.pb.go
@@ -46,7 +46,7 @@ func (m *RepoAppsQuery) Reset()         { *m = RepoAppsQuery{} }
 func (m *RepoAppsQuery) String() string { return proto.CompactTextString(m) }
 func (*RepoAppsQuery) ProtoMessage()    {}
 func (*RepoAppsQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{0}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{0}
 }
 func (m *RepoAppsQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -102,7 +102,7 @@ func (m *AppInfo) Reset()         { *m = AppInfo{} }
 func (m *AppInfo) String() string { return proto.CompactTextString(m) }
 func (*AppInfo) ProtoMessage()    {}
 func (*AppInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{1}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{1}
 }
 func (m *AppInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -159,7 +159,7 @@ func (m *RepoAppDetailsQuery) Reset()         { *m = RepoAppDetailsQuery{} }
 func (m *RepoAppDetailsQuery) String() string { return proto.CompactTextString(m) }
 func (*RepoAppDetailsQuery) ProtoMessage()    {}
 func (*RepoAppDetailsQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{2}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{2}
 }
 func (m *RepoAppDetailsQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -224,7 +224,7 @@ func (m *RepoAppDetailsResponse) Reset()         { *m = RepoAppDetailsResponse{}
 func (m *RepoAppDetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*RepoAppDetailsResponse) ProtoMessage()    {}
 func (*RepoAppDetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{3}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{3}
 }
 func (m *RepoAppDetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -293,7 +293,7 @@ func (m *RepoAppsResponse) Reset()         { *m = RepoAppsResponse{} }
 func (m *RepoAppsResponse) String() string { return proto.CompactTextString(m) }
 func (*RepoAppsResponse) ProtoMessage()    {}
 func (*RepoAppsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{4}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{4}
 }
 func (m *RepoAppsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -344,7 +344,7 @@ func (m *KsonnetAppSpec) Reset()         { *m = KsonnetAppSpec{} }
 func (m *KsonnetAppSpec) String() string { return proto.CompactTextString(m) }
 func (*KsonnetAppSpec) ProtoMessage()    {}
 func (*KsonnetAppSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{5}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{5}
 }
 func (m *KsonnetAppSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -408,7 +408,7 @@ func (m *HelmAppSpec) Reset()         { *m = HelmAppSpec{} }
 func (m *HelmAppSpec) String() string { return proto.CompactTextString(m) }
 func (*HelmAppSpec) ProtoMessage()    {}
 func (*HelmAppSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{6}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{6}
 }
 func (m *HelmAppSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -470,7 +470,7 @@ func (m *KustomizeAppSpec) Reset()         { *m = KustomizeAppSpec{} }
 func (m *KustomizeAppSpec) String() string { return proto.CompactTextString(m) }
 func (*KustomizeAppSpec) ProtoMessage()    {}
 func (*KustomizeAppSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{7}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{7}
 }
 func (m *KustomizeAppSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -524,7 +524,7 @@ func (m *KsonnetEnvironment) Reset()         { *m = KsonnetEnvironment{} }
 func (m *KsonnetEnvironment) String() string { return proto.CompactTextString(m) }
 func (*KsonnetEnvironment) ProtoMessage()    {}
 func (*KsonnetEnvironment) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{8}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{8}
 }
 func (m *KsonnetEnvironment) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -595,7 +595,7 @@ func (m *KsonnetEnvironmentDestination) Reset()         { *m = KsonnetEnvironmen
 func (m *KsonnetEnvironmentDestination) String() string { return proto.CompactTextString(m) }
 func (*KsonnetEnvironmentDestination) ProtoMessage()    {}
 func (*KsonnetEnvironmentDestination) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{9}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{9}
 }
 func (m *KsonnetEnvironmentDestination) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -650,7 +650,7 @@ func (m *RepoQuery) Reset()         { *m = RepoQuery{} }
 func (m *RepoQuery) String() string { return proto.CompactTextString(m) }
 func (*RepoQuery) ProtoMessage()    {}
 func (*RepoQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{10}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{10}
 }
 func (m *RepoQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -696,7 +696,7 @@ func (m *RepoResponse) Reset()         { *m = RepoResponse{} }
 func (m *RepoResponse) String() string { return proto.CompactTextString(m) }
 func (*RepoResponse) ProtoMessage()    {}
 func (*RepoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{11}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{11}
 }
 func (m *RepoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -737,7 +737,7 @@ func (m *RepoCreateRequest) Reset()         { *m = RepoCreateRequest{} }
 func (m *RepoCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*RepoCreateRequest) ProtoMessage()    {}
 func (*RepoCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{12}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{12}
 }
 func (m *RepoCreateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -791,7 +791,7 @@ func (m *RepoUpdateRequest) Reset()         { *m = RepoUpdateRequest{} }
 func (m *RepoUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*RepoUpdateRequest) ProtoMessage()    {}
 func (*RepoUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_repository_31d36efd186d2b01, []int{13}
+	return fileDescriptor_repository_6cfdcc280f230e64, []int{13}
 }
 func (m *RepoUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3710,10 +3710,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/repository/repository.proto", fileDescriptor_repository_31d36efd186d2b01)
+	proto.RegisterFile("server/repository/repository.proto", fileDescriptor_repository_6cfdcc280f230e64)
 }
 
-var fileDescriptor_repository_31d36efd186d2b01 = []byte{
+var fileDescriptor_repository_6cfdcc280f230e64 = []byte{
 	// 911 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x56, 0x4f, 0x6f, 0x5b, 0x45,
 	0x10, 0xd7, 0xc6, 0xa9, 0x13, 0x8f, 0xdb, 0x2a, 0xdd, 0x96, 0x60, 0x1e, 0x8e, 0x1b, 0x2d, 0x12,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -80,6 +80,7 @@ func TestEnforceProjectToken(t *testing.T) {
 		s := NewServer(ArgoCDServerOpts{Namespace: fakeNamespace, KubeClientset: kubeclientset, AppClientset: apps.NewSimpleClientset(&existingProj)})
 		s.newGRPCServer()
 		claims := jwt.MapClaims{"sub": defaultSub, "iat": defaultIssuedAt}
+		assert.True(t, s.enf.EnforceClaims(claims, "projects", "get", existingProj.ObjectMeta.Name))
 		assert.True(t, s.enf.EnforceClaims(claims, "applications", "get", defaultTestObject))
 	})
 

--- a/server/session/session.pb.go
+++ b/server/session/session.pb.go
@@ -47,7 +47,7 @@ func (m *SessionCreateRequest) Reset()         { *m = SessionCreateRequest{} }
 func (m *SessionCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SessionCreateRequest) ProtoMessage()    {}
 func (*SessionCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_8e535ce77fc5e082, []int{0}
+	return fileDescriptor_session_217b926c109d1cc2, []int{0}
 }
 func (m *SessionCreateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -108,7 +108,7 @@ func (m *SessionDeleteRequest) Reset()         { *m = SessionDeleteRequest{} }
 func (m *SessionDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SessionDeleteRequest) ProtoMessage()    {}
 func (*SessionDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_8e535ce77fc5e082, []int{1}
+	return fileDescriptor_session_217b926c109d1cc2, []int{1}
 }
 func (m *SessionDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -149,7 +149,7 @@ func (m *SessionResponse) Reset()         { *m = SessionResponse{} }
 func (m *SessionResponse) String() string { return proto.CompactTextString(m) }
 func (*SessionResponse) ProtoMessage()    {}
 func (*SessionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_session_8e535ce77fc5e082, []int{2}
+	return fileDescriptor_session_217b926c109d1cc2, []int{2}
 }
 func (m *SessionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -827,10 +827,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/session/session.proto", fileDescriptor_session_8e535ce77fc5e082)
+	proto.RegisterFile("server/session/session.proto", fileDescriptor_session_217b926c109d1cc2)
 }
 
-var fileDescriptor_session_8e535ce77fc5e082 = []byte{
+var fileDescriptor_session_217b926c109d1cc2 = []byte{
 	// 356 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x92, 0xb1, 0x4e, 0xeb, 0x30,
 	0x14, 0x86, 0xe5, 0x5e, 0xdd, 0xde, 0x7b, 0x3d, 0xdc, 0x8a, 0x28, 0x82, 0x28, 0x2a, 0x15, 0xca,

--- a/server/settings/settings.pb.go
+++ b/server/settings/settings.pb.go
@@ -42,7 +42,7 @@ func (m *SettingsQuery) Reset()         { *m = SettingsQuery{} }
 func (m *SettingsQuery) String() string { return proto.CompactTextString(m) }
 func (*SettingsQuery) ProtoMessage()    {}
 func (*SettingsQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_settings_71506a99e4ff7448, []int{0}
+	return fileDescriptor_settings_0a30d430c5f54e91, []int{0}
 }
 func (m *SettingsQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -83,7 +83,7 @@ func (m *Settings) Reset()         { *m = Settings{} }
 func (m *Settings) String() string { return proto.CompactTextString(m) }
 func (*Settings) ProtoMessage()    {}
 func (*Settings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_settings_71506a99e4ff7448, []int{1}
+	return fileDescriptor_settings_0a30d430c5f54e91, []int{1}
 }
 func (m *Settings) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -137,7 +137,7 @@ func (m *DexConfig) Reset()         { *m = DexConfig{} }
 func (m *DexConfig) String() string { return proto.CompactTextString(m) }
 func (*DexConfig) ProtoMessage()    {}
 func (*DexConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_settings_71506a99e4ff7448, []int{2}
+	return fileDescriptor_settings_0a30d430c5f54e91, []int{2}
 }
 func (m *DexConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -185,7 +185,7 @@ func (m *Connector) Reset()         { *m = Connector{} }
 func (m *Connector) String() string { return proto.CompactTextString(m) }
 func (*Connector) ProtoMessage()    {}
 func (*Connector) Descriptor() ([]byte, []int) {
-	return fileDescriptor_settings_71506a99e4ff7448, []int{3}
+	return fileDescriptor_settings_0a30d430c5f54e91, []int{3}
 }
 func (m *Connector) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -974,10 +974,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/settings/settings.proto", fileDescriptor_settings_71506a99e4ff7448)
+	proto.RegisterFile("server/settings/settings.proto", fileDescriptor_settings_0a30d430c5f54e91)
 }
 
-var fileDescriptor_settings_71506a99e4ff7448 = []byte{
+var fileDescriptor_settings_0a30d430c5f54e91 = []byte{
 	// 322 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x91, 0x41, 0x4b, 0xc3, 0x40,
 	0x10, 0x85, 0xd9, 0x46, 0xac, 0x19, 0x91, 0xea, 0x22, 0x12, 0x8b, 0xc4, 0x92, 0x53, 0x41, 0x4c,

--- a/server/version/version.pb.go
+++ b/server/version/version.pb.go
@@ -51,7 +51,7 @@ func (m *VersionMessage) Reset()         { *m = VersionMessage{} }
 func (m *VersionMessage) String() string { return proto.CompactTextString(m) }
 func (*VersionMessage) ProtoMessage()    {}
 func (*VersionMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_version_cdcdf9fc14514c9b, []int{0}
+	return fileDescriptor_version_6f54499c257f90e5, []int{0}
 }
 func (m *VersionMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -781,10 +781,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/version/version.proto", fileDescriptor_version_cdcdf9fc14514c9b)
+	proto.RegisterFile("server/version/version.proto", fileDescriptor_version_6f54499c257f90e5)
 }
 
-var fileDescriptor_version_cdcdf9fc14514c9b = []byte{
+var fileDescriptor_version_6f54499c257f90e5 = []byte{
 	// 343 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x5c, 0x92, 0xcf, 0x4a, 0xc3, 0x40,
 	0x10, 0xc6, 0x49, 0xd5, 0xfe, 0x59, 0x4a, 0x0f, 0x8b, 0xd4, 0x25, 0x96, 0x22, 0x3d, 0x88, 0x08,


### PR DESCRIPTION
In order to update an application, the requester requires access to the application's project.  This permission is used to get the project while the server is validating the submitted application.  This prevents project roles from having the permission need to update applications because they only have policies with the `application` subject.  This PR automatically grants every project role access to it's project to allow the project to update an application. 