### PR TITLE
Upgrade testify

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -689,15 +689,15 @@
   version = "v0.1"
 
 [[projects]]
-  digest = "1:a30066593578732a356dc7e5d7f78d69184ca65aeeff5939241a3ab10559bb06"
+  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "mock",
   ]
   pruneopts = ""
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   digest = "1:51cf0fca93f4866709ceaf01b750e51d997c299a7bd2edf7ccd79e3b428754ae"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@ required = [
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.1"
+  version = "1.2.2"
 
 [[constraint]]
   name = "github.com/gobuffalo/packr"


### PR DESCRIPTION
Upgrade [Testify](https://github.com/stretchr/testify) from 1.2.1 to 1.2.2, which was released in June 2018.