### PR TITLE
Handle case where OIDC settings become invalid after dex server restart (issue #710)

### DIFF
--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/coreos/dex/api"
 	oidc "github.com/coreos/go-oidc"
-	jwt "github.com/dgrijalva/jwt-go"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
@@ -325,15 +324,9 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	idToken, err := a.verify(rawIDToken)
+	claims, err := a.sessionMgr.VerifyToken(rawIDToken)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to verify ID token: %v", err), http.StatusInternalServerError)
-		return
-	}
-	var claims jwt.MapClaims
-	err = idToken.Claims(&claims)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to unmarshal claims: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("invalid session token: %v", err), http.StatusInternalServerError)
 		return
 	}
 	flags := []string{"path=/"}


### PR DESCRIPTION
This change makes it possible for the API server to detect a change in the dex JWST signing keys, (i.e. when dex server restarts), reinitializing the OIDC provider when token verification fails to verify the signature.