### PR TITLE
Revert "Validate Ksonnet apps through component dir presence (#708)"

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -118,7 +118,7 @@ func (s *Service) GetFile(ctx context.Context, q *GetFileRequest) (*GetFileRespo
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(filepath.Join(gitClient.Root(), q.Path))
+	data, err := ioutil.ReadFile(path.Join(gitClient.Root(), q.Path))
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (s *Service) GenerateManifest(c context.Context, q *ManifestRequest) (*Mani
 	if err != nil {
 		return nil, err
 	}
-	appPath := filepath.Join(gitClient.Root(), q.Path)
+	appPath := path.Join(gitClient.Root(), q.Path)
 
 	genRes, err := generateManifests(appPath, q)
 	if err != nil {
@@ -262,18 +262,18 @@ func generateManifests(appPath string, q *ManifestRequest) (*ManifestResponse, e
 
 // tempRepoPath returns a formulated temporary directory location to clone a repository
 func tempRepoPath(repo string) string {
-	return filepath.Join(os.TempDir(), strings.Replace(repo, "/", "_", -1))
+	return path.Join(os.TempDir(), strings.Replace(repo, "/", "_", -1))
 }
 
 // IdentifyAppSourceTypeByAppDir examines a directory and determines its application source type
 func IdentifyAppSourceTypeByAppDir(appDirPath string) AppSourceType {
-	if pathExists(appDirPath, "app.yaml") {
+	if pathExists(path.Join(appDirPath, "app.yaml")) {
 		return AppSourceKsonnet
 	}
-	if pathExists(appDirPath, "Chart.yaml") {
+	if pathExists(path.Join(appDirPath, "Chart.yaml")) {
 		return AppSourceHelm
 	}
-	if pathExists(appDirPath, "kustomization.yaml") {
+	if pathExists(path.Join(appDirPath, "kustomization.yaml")) {
 		return AppSourceKustomize
 	}
 	return AppSourceDirectory
@@ -367,7 +367,7 @@ func findManifests(appPath string) ([]*unstructured.Unstructured, error) {
 		if f.IsDir() || !manifestFile.MatchString(f.Name()) {
 			continue
 		}
-		out, err := ioutil.ReadFile(filepath.Join(appPath, f.Name()))
+		out, err := ioutil.ReadFile(path.Join(appPath, f.Name()))
 		if err != nil {
 			return nil, err
 		}
@@ -419,9 +419,8 @@ func findManifests(appPath string) ([]*unstructured.Unstructured, error) {
 	return objs, nil
 }
 
-// pathExists reports whether the file or directory at the named concatenation of paths exists.
-func pathExists(ss ...string) bool {
-	name := filepath.Join(ss...)
+// pathExists reports whether the named file or directory exists.
+func pathExists(name string) bool {
 	if _, err := os.Stat(name); err != nil {
 		if os.IsNotExist(err) {
 			return false

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -87,10 +87,6 @@ func (s *Server) ListApps(ctx context.Context, q *RepoAppsQuery) (*RepoAppsRespo
 	if err != nil {
 		return nil, err
 	}
-	componentRes, err := repoClient.ListDir(ctx, &repository.ListDirRequest{Repo: repo, Revision: revision, Path: "components"})
-	if err != nil {
-		return nil, err
-	}
 
 	helmRes, err := repoClient.ListDir(ctx, &repository.ListDirRequest{Repo: repo, Revision: revision, Path: "*Chart.yaml"})
 	if err != nil {
@@ -102,18 +98,10 @@ func (s *Server) ListApps(ctx context.Context, q *RepoAppsQuery) (*RepoAppsRespo
 		return nil, err
 	}
 
-	componentDirs := make(map[string]interface{})
-	for _, i := range componentRes.Items {
-		d := filepath.Dir(i)
-		componentDirs[d] = struct{}{}
-	}
-
 	items := make([]*AppInfo, 0)
-	for _, i := range ksonnetRes.Items {
-		d := filepath.Dir(i)
-		if _, ok := componentDirs[d]; ok {
-			items = append(items, &AppInfo{Type: string(repository.AppSourceKsonnet), Path: i})
-		}
+
+	for i := range ksonnetRes.Items {
+		items = append(items, &AppInfo{Type: string(repository.AppSourceKsonnet), Path: ksonnetRes.Items[i]})
 	}
 
 	for i := range helmRes.Items {


### PR DESCRIPTION
This reverts commit 1844be638bdadd02090f40371be4551b2319aaac from #708, which has demonstrated output inconsistent with the testing performed.