### PR TITLE
Avoid overwriting an existing configmap with empty data if the argocd secret is not found

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -114,7 +114,7 @@ func (mgr *SettingsManager) GetSettings() (*ArgoCDSettings, error) {
 	updateSettingsFromConfigMap(&settings, argoCDCM)
 	argoCDSecret, err := mgr.clientset.CoreV1().Secrets(mgr.namespace).Get(common.ArgoCDSecretName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return &settings, err
 	}
 	err = updateSettingsFromSecret(&settings, argoCDSecret)
 	if err != nil {


### PR DESCRIPTION
If a `configmap/argocd-cm` exists, but a `secret/argocd-secret` does not, the existing settings initialization will [use an empty settings object](https://github.com/argoproj/argo-cd/blob/75d2c5768887310d9aa4830ffd45b31eb079aaea/util/settings/settings.go#L496-L498) instead of the partially-configured one from the configmap, eventually causing the existing configmap to be overwritten with empty values.

This PR instead reuses a partially-configured settings object to retain existing configmap settings while still allowing a secret to be initialized.