### PR TITLE
add metrics label for service monitor discovery

### DIFF
--- a/manifests/base/argocd-metrics-service.yaml
+++ b/manifests/base/argocd-metrics-service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: argocd-metrics
   name: argocd-metrics
 spec:
   ports:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -260,6 +260,8 @@ type: Opaque
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: argocd-metrics
   name: argocd-metrics
 spec:
   ports:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -193,6 +193,8 @@ type: Opaque
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: argocd-metrics
   name: argocd-metrics
 spec:
   ports:


### PR DESCRIPTION
ServiceMonitor, the [Prometheus operator's custom resource definition](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec) discovers Service's by label.

Currently the metrics service yaml defintions do not have any label, this pull request adds one so the Service can be use to be discovered by the Prometheus operator.