### PR TITLE
add project label to all metrics

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -24,7 +24,7 @@ var (
 	descAppInfo = prometheus.NewDesc(
 		"argocd_app_info",
 		"Information about application.",
-		append(descAppDefaultLabels,"repo", "dest_server", "dest_namespace"),
+		append(descAppDefaultLabels, "repo", "dest_server", "dest_namespace"),
 		nil,
 	)
 	descAppCreated = prometheus.NewDesc(

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -136,18 +136,18 @@ func testApp(t *testing.T, fakeApp string, expectedResponse string) {
 }
 
 type testCombination struct {
-	application string
+	application      string
 	expectedResponse string
 }
 
 func TestMetrics(t *testing.T) {
 	combinations := []testCombination{
 		{
-			application: fakeApp,
+			application:      fakeApp,
 			expectedResponse: expectedResponse,
 		},
 		{
-			application: fakeDefaultApp,
+			application:      fakeDefaultApp,
 			expectedResponse: expectedDefaultResponse,
 		},
 	}

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -2,13 +2,13 @@ package metrics
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/ghodss/yaml"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -18,7 +18,7 @@ import (
 	applister "github.com/argoproj/argo-cd/pkg/client/listers/application/v1alpha1"
 )
 
-var fakeApp = `
+const fakeApp = `
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -28,7 +28,7 @@ spec:
   destination:
     namespace: dummy-namespace
     server: https://localhost:6443
-  project: default
+  project: important-project
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
@@ -39,27 +39,67 @@ status:
     status: Healthy
 `
 
-var expectedResponse = `# HELP argocd_app_created_time Creation time in unix timestamp for an application.
+const expectedResponse = `# HELP argocd_app_created_time Creation time in unix timestamp for an application.
 # TYPE argocd_app_created_time gauge
-argocd_app_created_time{name="my-app",namespace="argocd"} -6.21355968e+10
+argocd_app_created_time{name="my-app",namespace="argocd",project="important-project"} -6.21355968e+10
 # HELP argocd_app_health_status The application current health status.
 # TYPE argocd_app_health_status gauge
-argocd_app_health_status{health_status="Degraded",name="my-app",namespace="argocd"} 0
-argocd_app_health_status{health_status="Healthy",name="my-app",namespace="argocd"} 1
-argocd_app_health_status{health_status="Missing",name="my-app",namespace="argocd"} 0
-argocd_app_health_status{health_status="Progressing",name="my-app",namespace="argocd"} 0
-argocd_app_health_status{health_status="Unknown",name="my-app",namespace="argocd"} 0
+argocd_app_health_status{health_status="Degraded",name="my-app",namespace="argocd",project="important-project"} 0
+argocd_app_health_status{health_status="Healthy",name="my-app",namespace="argocd",project="important-project"} 1
+argocd_app_health_status{health_status="Missing",name="my-app",namespace="argocd",project="important-project"} 0
+argocd_app_health_status{health_status="Progressing",name="my-app",namespace="argocd",project="important-project"} 0
+argocd_app_health_status{health_status="Unknown",name="my-app",namespace="argocd",project="important-project"} 0
+# HELP argocd_app_info Information about application.
+# TYPE argocd_app_info gauge
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",name="my-app",namespace="argocd",project="important-project",repo="https://github.com/argoproj/argocd-example-apps.git"} 1
+# HELP argocd_app_sync_status The application current sync status.
+# TYPE argocd_app_sync_status gauge
+argocd_app_sync_status{name="my-app",namespace="argocd",project="important-project",sync_status="OutOfSync"} 0
+argocd_app_sync_status{name="my-app",namespace="argocd",project="important-project",sync_status="Synced"} 1
+argocd_app_sync_status{name="my-app",namespace="argocd",project="important-project",sync_status="Unknown"} 0
+`
+
+const fakeDefaultApp = `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+spec:
+  destination:
+    namespace: dummy-namespace
+    server: https://localhost:6443
+  source:
+    path: some/path
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+status:
+  comparisonResult:
+    status: Synced
+  health:
+    status: Healthy
+`
+
+const expectedDefaultResponse = `# HELP argocd_app_created_time Creation time in unix timestamp for an application.
+# TYPE argocd_app_created_time gauge
+argocd_app_created_time{name="my-app",namespace="argocd",project="default"} -6.21355968e+10
+# HELP argocd_app_health_status The application current health status.
+# TYPE argocd_app_health_status gauge
+argocd_app_health_status{health_status="Degraded",name="my-app",namespace="argocd",project="default"} 0
+argocd_app_health_status{health_status="Healthy",name="my-app",namespace="argocd",project="default"} 1
+argocd_app_health_status{health_status="Missing",name="my-app",namespace="argocd",project="default"} 0
+argocd_app_health_status{health_status="Progressing",name="my-app",namespace="argocd",project="default"} 0
+argocd_app_health_status{health_status="Unknown",name="my-app",namespace="argocd",project="default"} 0
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
 argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",name="my-app",namespace="argocd",project="default",repo="https://github.com/argoproj/argocd-example-apps.git"} 1
 # HELP argocd_app_sync_status The application current sync status.
 # TYPE argocd_app_sync_status gauge
-argocd_app_sync_status{name="my-app",namespace="argocd",sync_status="OutOfSync"} 0
-argocd_app_sync_status{name="my-app",namespace="argocd",sync_status="Synced"} 1
-argocd_app_sync_status{name="my-app",namespace="argocd",sync_status="Unknown"} 0
+argocd_app_sync_status{name="my-app",namespace="argocd",project="default",sync_status="OutOfSync"} 0
+argocd_app_sync_status{name="my-app",namespace="argocd",project="default",sync_status="Synced"} 1
+argocd_app_sync_status{name="my-app",namespace="argocd",project="default",sync_status="Unknown"} 0
 `
 
-func newFakeApp() *argoappv1.Application {
+func newFakeApp(fakeApp string) *argoappv1.Application {
 	var app argoappv1.Application
 	err := yaml.Unmarshal([]byte(fakeApp), &app)
 	if err != nil {
@@ -68,10 +108,10 @@ func newFakeApp() *argoappv1.Application {
 	return &app
 }
 
-func newFakeLister() (context.CancelFunc, applister.ApplicationLister) {
+func newFakeLister(fakeApp string) (context.CancelFunc, applister.ApplicationLister) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	appClientset := appclientset.NewSimpleClientset(newFakeApp())
+	appClientset := appclientset.NewSimpleClientset(newFakeApp(fakeApp))
 	factory := appinformer.NewFilteredSharedInformerFactory(appClientset, 0, "argocd", func(options *metav1.ListOptions) {})
 	appInformer := factory.Argoproj().V1alpha1().Applications().Informer()
 	go appInformer.Run(ctx.Done())
@@ -81,8 +121,8 @@ func newFakeLister() (context.CancelFunc, applister.ApplicationLister) {
 	return cancel, factory.Argoproj().V1alpha1().Applications().Lister()
 }
 
-func TestMetrics(t *testing.T) {
-	cancel, appLister := newFakeLister()
+func testApp(t *testing.T, fakeApp string, expectedResponse string) {
+	cancel, appLister := newFakeLister(fakeApp)
 	defer cancel()
 	metricsServ := NewMetricsServer(8082, appLister)
 	req, err := http.NewRequest("GET", "/metrics", nil)
@@ -93,4 +133,26 @@ func TestMetrics(t *testing.T) {
 	body := rr.Body.String()
 	log.Println(body)
 	assert.Equal(t, expectedResponse, body)
+}
+
+type testCombination struct {
+	application string
+	expectedResponse string
+}
+
+func TestMetrics(t *testing.T) {
+	combinations := []testCombination{
+		{
+			application: fakeApp,
+			expectedResponse: expectedResponse,
+		},
+		{
+			application: fakeDefaultApp,
+			expectedResponse: expectedDefaultResponse,
+		},
+	}
+
+	for _, combination := range combinations {
+		testApp(t, combination.application, combination.expectedResponse)
+	}
 }


### PR DESCRIPTION
I have built a Grafana dashboard from the metrics endpoints exposed.

This pull request adds the label project to every metric. From the Grafana dashboard below, you can see that all the projects are lumped into one, I would like the ability to filter by project from the dashboard. 

Also when a project was not specified in the spec it did not produce the label as default
 
![screen shot 2018-11-13 at 11 58 16](https://user-images.githubusercontent.com/520376/48412164-bcb70d80-e73b-11e8-9fa2-3d7b13f9f51b.png)
