### PR TITLE
Issue #355 - Treat 'crd-install' hooks as normal k8s resource

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -78,6 +78,9 @@ var (
 	// AnnotationHelmHook is the helm hook annotation
 	AnnotationHelmHook = "helm.sh/hook"
 
+	// HelmHookCRDInstall is a value of crd helm hook
+	HelmHookCRDInstall = "crd-install"
+
 	// LabelKeyApplicationControllerInstanceID is the label which allows to separate application among multiple running application controllers.
 	LabelKeyApplicationControllerInstanceID = application.ApplicationFullName + "/controller-instanceid"
 

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -38,6 +38,9 @@ func TestIsHook(t *testing.T) {
 	pod.SetAnnotations(map[string]string{"helm.sh/hook": "post-install"})
 	assert.True(t, isHook(pod))
 
+	pod.SetAnnotations(map[string]string{"helm.sh/hook": "crd-install"})
+	assert.False(t, isHook(pod))
+
 	pod = newPod()
 	pod.SetAnnotations(map[string]string{"argocd.argoproj.io/hook": "PreSync"})
 	assert.True(t, isHook(pod))

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -722,8 +722,22 @@ func isHelmHook(obj *unstructured.Unstructured) bool {
 	if annotations == nil {
 		return false
 	}
-	_, ok := annotations[common.AnnotationHelmHook]
+	hooks, ok := annotations[common.AnnotationHelmHook]
+
+	if ok && hasHook(hooks, common.HelmHookCRDInstall) {
+		return false
+	}
+
 	return ok
+}
+
+func hasHook(hooks string, hook string) bool {
+	for _, item := range strings.Split(hooks, ",") {
+		if strings.TrimSpace(item) == hook {
+			return true
+		}
+	}
+	return false
 }
 
 // isArgoHook indicates if the supplied object is an Argo CD application lifecycle hook


### PR DESCRIPTION
Argo CD already has CRD installation handling, so we should treat  'crd-install' hook as a normal resource