### PR TITLE
Fix typo in documentation for hook delete policy

### DIFF
--- a/docs/resource_hooks.md
+++ b/docs/resource_hooks.md
@@ -50,12 +50,12 @@ metadata:
   generateName: integration-test-
   annotations:
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: OnSuccess
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 ```
 
 The following policies define when the hook will be deleted.
 
 | Policy | Description |
 |--------|-------------|
-| `OnSuccess` | The hook resource is deleted after the hook succeeded (e.g. Job/Workflow completed successfully). |
-| `OnFailure` | The hook resource is deleted after the hook failed. |
+| `HookSucceeded` | The hook resource is deleted after the hook succeeded (e.g. Job/Workflow completed successfully). |
+| `HookFailed` | The hook resource is deleted after the hook failed. |


### PR DESCRIPTION
Documentation on the constants for the hook-delete-policy annotation had a small typo, the actual values are found [here](https://github.com/argoproj/argo-cd/blob/3f7a0d3c97767af66d7a017e27f546c517d5b345/pkg/apis/application/v1alpha1/types.go#L158-L161) and the logic that references them [here](https://github.com/argoproj/argo-cd/blob/3f7a0d3c97767af66d7a017e27f546c517d5b345/controller/sync.go#L680-L697).

Alternatively we could change the code to match the documentation. `OnSuccess` and `OnFailure` sound a little nicer to me than `HookSucceeded` and `HookFailed`.