### PR TITLE
Use default server addresses. Use an imagePullPolicy of Always for manifests

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-controller: go run ./cmd/argocd-application-controller/main.go
+controller: go run ./cmd/argocd-application-controller/main.go --repo-server localhost:8081
 api-server: go run ./cmd/argocd-server/main.go --insecure --disable-auth --dex-server http://localhost:5556 --repo-server localhost:8081 --app-controller-server localhost:8083
 repo-server: go run ./cmd/argocd-repo-server/main.go --loglevel debug
 dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p 5556:5556 -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/dexidp/dex:v2.12.0 serve /dex.yaml"

--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -18,6 +18,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"github.com/argoproj/argo-cd"
+	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/controller"
 	"github.com/argoproj/argo-cd/errors"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
@@ -99,7 +100,7 @@ func newCommand() *cobra.Command {
 
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
 	command.Flags().Int64Var(&appResyncPeriod, "app-resync", defaultAppResyncPeriod, "Time period in seconds for application resync.")
-	command.Flags().StringVar(&repoServerAddress, "repo-server", "localhost:8081", "Repo server address.")
+	command.Flags().StringVar(&repoServerAddress, "repo-server", common.DefaultRepoServerAddr, "Repo server address.")
 	command.Flags().IntVar(&statusProcessors, "status-processors", 1, "Number of application status processors")
 	command.Flags().IntVar(&operationProcessors, "operation-processors", 1, "Number of application operation processors")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/controller"
 	"github.com/argoproj/argo-cd/errors"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
@@ -16,17 +17,6 @@ import (
 	"github.com/argoproj/argo-cd/util/cli"
 	"github.com/argoproj/argo-cd/util/stats"
 	"github.com/argoproj/argo-cd/util/tls"
-)
-
-const (
-	// DefaultDexServerAddr is the HTTP address of the Dex OIDC server, which we run a reverse proxy against
-	DefaultDexServerAddr = "http://dex-server:5556"
-
-	// DefaultRepoServerAddr is the gRPC address of the Argo CD repo server
-	DefaultRepoServerAddr = "argocd-repo-server:8081"
-
-	// DefaultAppControllerServerAddr is the gRPC address of the Argo CD app controller server
-	DefaultAppControllerServerAddr = "application-controller:8083"
 )
 
 // NewCommand returns a new instance of an argocd command
@@ -97,9 +87,9 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&staticAssetsDir, "staticassets", "", "Static assets directory path")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
-	command.Flags().StringVar(&repoServerAddress, "repo-server", DefaultRepoServerAddr, "Repo server address")
-	command.Flags().StringVar(&appControllerServerAddress, "app-controller-server", DefaultAppControllerServerAddr, "App controller server address")
-	command.Flags().StringVar(&dexServerAddress, "dex-server", DefaultDexServerAddr, "Dex server address")
+	command.Flags().StringVar(&repoServerAddress, "repo-server", common.DefaultRepoServerAddr, "Repo server address")
+	command.Flags().StringVar(&appControllerServerAddress, "app-controller-server", common.DefaultAppControllerServerAddr, "App controller server address")
+	command.Flags().StringVar(&dexServerAddress, "dex-server", common.DefaultDexServerAddr, "Dex server address")
 	command.Flags().BoolVar(&disableAuth, "disable-auth", false, "Disable client authentication")
 	command.AddCommand(cli.NewVersionCmd(cliName))
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(command)

--- a/common/common.go
+++ b/common/common.go
@@ -28,6 +28,17 @@ const (
 )
 
 const (
+	// DefaultDexServerAddr is the HTTP address of the Dex OIDC server, which we run a reverse proxy against
+	DefaultDexServerAddr = "http://dex-server:5556"
+
+	// DefaultRepoServerAddr is the gRPC address of the Argo CD repo server
+	DefaultRepoServerAddr = "argocd-repo-server:8081"
+
+	// DefaultAppControllerServerAddr is the gRPC address of the Argo CD app controller server
+	DefaultAppControllerServerAddr = "application-controller:8083"
+)
+
+const (
 	ArgoCDAdminUsername     = "admin"
 	ArgoCDSecretName        = "argocd-secret"
 	ArgoCDConfigMapName     = "argocd-cm"

--- a/manifests/base/application-controller-deployment.yaml
+++ b/manifests/base/application-controller-deployment.yaml
@@ -14,12 +14,18 @@ spec:
       containers:
       - command:
         - argocd-application-controller
-        - --repo-server
-        - argocd-repo-server:8081
         - --status-processors
         - "20"
         - --operation-processors
         - "10"
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: application-controller
+        ports:
+        - containerPort: 8083
+        readinessProbe:
+          tcpSocket:
+            port: 8083
+          initialDelaySeconds: 5
+          periodSeconds: 10
       serviceAccountName: application-controller

--- a/manifests/base/argocd-repo-server-deployment.yaml
+++ b/manifests/base/argocd-repo-server-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
       - name: argocd-repo-server
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         command: [argocd-repo-server]
         ports:
         - containerPort: 8081

--- a/manifests/base/argocd-server-deployment.yaml
+++ b/manifests/base/argocd-server-deployment.yaml
@@ -22,10 +22,13 @@ spec:
       containers:
       - name: argocd-server
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         command: [argocd-server, --staticassets, /shared/app]
         volumeMounts:
         - mountPath: /shared
           name: static-files
+        ports:
+        - containerPort: 8080
         readinessProbe:
           httpGet:
             path: /healthz

--- a/manifests/base/dex-server-deployment.yaml
+++ b/manifests/base/dex-server-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       initContainers:
       - name: copyutil
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         command: [cp, /usr/local/bin/argocd-util, /shared]
         volumeMounts:
         - mountPath: /shared
@@ -22,6 +23,7 @@ spec:
       containers:
       - name: dex
         image: quay.io/dexidp/dex:v2.12.0
+        imagePullPolicy: Always
         command: [/shared/argocd-util, rundex]
         ports:
         - containerPort: 5556

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -344,14 +344,20 @@ spec:
       containers:
       - command:
         - argocd-application-controller
-        - --repo-server
-        - argocd-repo-server:8081
         - --status-processors
         - "20"
         - --operation-processors
         - "10"
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: application-controller
+        ports:
+        - containerPort: 8083
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 8083
       serviceAccountName: application-controller
 ---
 apiVersion: apps/v1
@@ -372,6 +378,7 @@ spec:
       - command:
         - argocd-repo-server
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -400,7 +407,10 @@ spec:
         - --staticassets
         - /shared/app
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: argocd-server
+        ports:
+        - containerPort: 8080
         readinessProbe:
           httpGet:
             path: /healthz
@@ -444,6 +454,7 @@ spec:
         - /shared/argocd-util
         - rundex
         image: quay.io/dexidp/dex:v2.12.0
+        imagePullPolicy: Always
         name: dex
         ports:
         - containerPort: 5556
@@ -457,6 +468,7 @@ spec:
         - /usr/local/bin/argocd-util
         - /shared
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: copyutil
         volumeMounts:
         - mountPath: /shared

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -277,14 +277,20 @@ spec:
       containers:
       - command:
         - argocd-application-controller
-        - --repo-server
-        - argocd-repo-server:8081
         - --status-processors
         - "20"
         - --operation-processors
         - "10"
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: application-controller
+        ports:
+        - containerPort: 8083
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 8083
       serviceAccountName: application-controller
 ---
 apiVersion: apps/v1
@@ -305,6 +311,7 @@ spec:
       - command:
         - argocd-repo-server
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -333,7 +340,10 @@ spec:
         - --staticassets
         - /shared/app
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: argocd-server
+        ports:
+        - containerPort: 8080
         readinessProbe:
           httpGet:
             path: /healthz
@@ -377,6 +387,7 @@ spec:
         - /shared/argocd-util
         - rundex
         image: quay.io/dexidp/dex:v2.12.0
+        imagePullPolicy: Always
         name: dex
         ports:
         - containerPort: 5556
@@ -390,6 +401,7 @@ spec:
         - /usr/local/bin/argocd-util
         - /shared
         image: argoproj/argocd:latest
+        imagePullPolicy: Always
         name: copyutil
         volumeMounts:
         - mountPath: /shared


### PR DESCRIPTION
- Add a readiness probe to application-controller
- Use `imagePullPolicy: Always`
- Default the server addresses to well known service names.