### PR TITLE
Relax validation to permit app with no manifests

### DIFF
--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -458,18 +458,17 @@ func verifyGenerateManifests(ctx context.Context, repoRes *argoappv1.Repository,
 		req.Repo.Password = repoRes.Password
 		req.Repo.SSHPrivateKey = repoRes.SSHPrivateKey
 	}
-	manRes, err := repoClient.GenerateManifest(ctx, &req)
+
+	// Only check whether we can access the application's path,
+	// and not whether it actually contains any manifests.
+	_, err := repoClient.GenerateManifest(ctx, &req)
 	if err != nil {
 		conditions = append(conditions, argoappv1.ApplicationCondition{
 			Type:    argoappv1.ApplicationConditionInvalidSpecError,
 			Message: fmt.Sprintf("Unable to generate manifests in %s: %v", spec.Source.Path, err),
 		})
-	} else if len(manRes.Manifests) == 0 {
-		conditions = append(conditions, argoappv1.ApplicationCondition{
-			Type:    argoappv1.ApplicationConditionInvalidSpecError,
-			Message: fmt.Sprintf("Path '%s' contained no kubernetes manifests", spec.Source.Path),
-		})
 	}
+
 	return conditions
 }
 


### PR DESCRIPTION
Following a recent [slack discussion](https://argoproj.slack.com/archives/CASHNF6MS/p1542876514189500), this PR modifies the application validation logic of the controller to permit applications with no manifest files. 

This change supports a scenario where all of the application's manifests are removed from git, but the application itself is kept in Argo CD. The desired behavior is that Argo CD will succeed in synchronizing (pruning, in this case) the now-empty application to Kubernetes - in contrast to the existing behavior, which fails with an `Path 'app-path' contained no kubernetes manifests` error.

I wanted to add a unit-test for this behavior, but wasn't sure where it would be best to add it. I'd appreciate any advice from the project's maintainers. In the meantime, I was able to build and deploy the controller in my own environment, and validate that it works as expected.