### PR TITLE
Update kustomize base when setting image tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,6 @@ ifneq (${GIT_TAG},)
 IMAGE_TAG=${GIT_TAG}
 LDFLAGS += -X ${PACKAGE}.gitTag=${GIT_TAG}
 endif
-ifneq (${IMAGE_NAMESPACE},)
-override LDFLAGS += -X ${PACKAGE}/install.imageNamespace=${IMAGE_NAMESPACE}
-endif
-ifneq (${IMAGE_TAG},)
-override LDFLAGS += -X ${PACKAGE}/install.imageTag=${IMAGE_TAG}
-endif
 
 ifeq (${DOCKER_PUSH},true)
 ifndef IMAGE_NAMESPACE

--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -7,12 +7,14 @@ AUTOGENMSG="# This is an auto-generated file. DO NOT EDIT"
 
 update_image () {
   if [ ! -z "${IMAGE_NAMESPACE}" ]; then
-    sed -i -- 's| image: \(.*\)/\(argocd.*\)| image: '"${IMAGE_NAMESPACE}"'/\2|g' "${1}"
-  fi
-  if [ ! -z "${IMAGE_TAG}" ]; then
-    sed -i -- 's|\( image: .*/argocd.*\)\:.*|\1:'"${IMAGE_TAG}"'|g' "${1}"
+    sed 's| image: \(.*\)/\(argocd.*\)| image: '"${IMAGE_NAMESPACE}"'/\2|g' "${1}" > "${1}.bak"
+    mv "${1}.bak" "${1}"
   fi
 }
+
+if [ ! -z "${IMAGE_TAG}" ]; then
+  (cd ${SRCROOT}/manifests/base && kustomize edit set imagetag argoproj/argocd:${IMAGE_TAG} argoproj/argocd-ui:${IMAGE_TAG})
+fi
 
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install.yaml"
 kustomize build "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifests/install.yaml"


### PR DESCRIPTION
* The kustomize base will be updated with new image tags when `make manifests` is invoked
* Also fixes the sed command which broke on Mac OS X