### PR TITLE
Use subcommand `list` instead of `add` in docu

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -84,7 +84,7 @@ https://kubernetes.default.svc should be used as the application's K8s API serve
 
 First list all clusters contexts in your current kubconfig:
 ```bash
-argocd cluster add
+argocd cluster list
 ```
 
 Choose a context name from the list and supply it to `argocd cluster add CONTEXTNAME`. For example,


### PR DESCRIPTION
Fix argocd list command in docu. It uses subcommand`add` but it must be `list`