### PR TITLE
Serve CLI binaries directly from API server

### DIFF
--- a/.argo-ci/ci.yaml
+++ b/.argo-ci/ci.yaml
@@ -25,7 +25,7 @@ spec:
         arguments:
           parameters:
           - name: cmd
-            value: "dep ensure && make cli lint test && bash <(curl -s https://codecov.io/bash) -f coverage.out"
+            value: "dep ensure && make lint test && bash <(curl -s https://codecov.io/bash) -f coverage.out"
       - name: test-e2e
         template: ci-builder
         arguments:

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kusto
     chmod +x /usr/local/bin/kustomize
 
 ENV AWS_IAM_AUTHENTICATOR_VERSION=0.3.0
-RUN curl -L -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.3.0/heptio-authenticator-aws_${AWS_IAM_AUTHENTICATOR_VERSION}_linux_amd64 && \
+RUN curl -L -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_IAM_AUTHENTICATOR_VERSION}/heptio-authenticator-aws_${AWS_IAM_AUTHENTICATOR_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 
@@ -91,8 +91,8 @@ RUN cd ${GOPATH}/src/dummy && \
 # Perform the build
 WORKDIR /go/src/github.com/argoproj/argo-cd
 COPY . .
-ARG MAKE_TARGET="cli server controller repo-server argocd-util"
-RUN make ${MAKE_TARGET}
+RUN make cli server controller repo-server argocd-util && \
+    make CLI_NAME=argocd-darwin-amd64 GOOS=darwin cli
 
 
 ####################################################################################################

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -100,6 +100,10 @@ func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 				setAppOptions(c.Flags(), &app, &appOpts)
 				setParameterOverrides(&app, appOpts.parameters)
 			}
+			if app.Name == "" {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
+			}
 			conn, appIf := argocdclient.NewClientOrDie(clientOpts).NewApplicationClientOrDie()
 			defer util.Close(conn)
 			appCreateRequest := application.ApplicationCreateRequest{


### PR DESCRIPTION
This change updates the Dockerfile, Makefile, and API server such that it bundles the linux/darwin argocd binaries into argocd image so that the CLI can be downloaded directly from the API server, instead of linking to github.

Corresponding UI PR is here: https://github.com/argoproj/argo-cd-ui/pull/75