### PR TITLE
gRPC API client and gateway now supply user-agent. Require client min version as v0.11

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v3.0.0"
 
 [[projects]]
+  digest = "1:b856d8248663c39265a764561c1a1a149783f6cc815feb54a1f3a591b91f6eca"
+  name = "github.com/Masterminds/semver"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c7af12943936e8c39859482e61f0574c2fd7fc75"
+  version = "v1.4.2"
+
+[[projects]]
   digest = "1:71c0dfb843260bfb9b03357cae8eac261b8d82e149ad8f76938b87a23aa47c43"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
@@ -1358,6 +1366,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Masterminds/semver",
     "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1",
     "github.com/argoproj/pkg/exec",
     "github.com/argoproj/pkg/time",

--- a/common/common.go
+++ b/common/common.go
@@ -60,6 +60,8 @@ const (
 	ArgoCDCLIClientAppName = "Argo CD CLI"
 	// ArgoCDCLIClientAppID is the Oauth client ID we will use when registering our CLI to dex
 	ArgoCDCLIClientAppID = "argo-cd-cli"
+	// ArgoCDUserAgentName is the default user-agent name used by the gRPC API client library and grpc-gateway
+	ArgoCDUserAgentName = "argocd-client"
 	// EnvVarSSODebug is an environment variable to enable additional OAuth debugging in the API server
 	EnvVarSSODebug = "ARGOCD_SSO_DEBUG"
 	// EnvVarRBACDebug is an environment variable to enable additional RBAC debugging in the API server

--- a/util/grpc/useragent.go
+++ b/util/grpc/useragent.go
@@ -1,0 +1,87 @@
+package grpc
+
+import (
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// UserAgentUnaryServerInterceptor returns a UnaryServerInterceptor which enforces a minimum client
+// version in the user agent
+func UserAgentUnaryServerInterceptor(clientName, constraintStr string) grpc.UnaryServerInterceptor {
+	userAgentEnforcer := newUserAgentEnforcer(clientName, constraintStr)
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if err := userAgentEnforcer(ctx); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// UserAgentStreamServerInterceptor returns a StreamServerInterceptor which enforces a minimum client
+// version in the user agent
+func UserAgentStreamServerInterceptor(clientName, constraintStr string) grpc.StreamServerInterceptor {
+	userAgentEnforcer := newUserAgentEnforcer(clientName, constraintStr)
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := userAgentEnforcer(stream.Context()); err != nil {
+			return err
+		}
+		return handler(srv, stream)
+	}
+}
+
+func newUserAgentEnforcer(clientName, constraintStr string) func(context.Context) error {
+	semVerConstraint, err := semver.NewConstraint(constraintStr)
+	if err != nil {
+		panic(err)
+	}
+	return func(ctx context.Context) error {
+		var userAgents []string
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			for _, ua := range md["user-agent"] {
+				// ua is a string like "argocd-client/v0.11.0+cde040e grpc-go/1.15.0"
+				userAgents = append(userAgents, strings.Fields(ua)...)
+				break
+			}
+		}
+		if isLegacyClient(userAgents) {
+			return status.Errorf(codes.FailedPrecondition, "unsatisfied client version constraint: %s", constraintStr)
+		}
+
+		for _, userAgent := range userAgents {
+			uaSplit := strings.Split(userAgent, "/")
+			if len(uaSplit) != 2 || uaSplit[0] != clientName {
+				// User-agent was supplied, but client/format is not one we care about (e.g. grpc-go)
+				continue
+			}
+			// We have matched the client name to the one we care about
+			uaVers, err := semver.NewVersion(uaSplit[1])
+			if err != nil {
+				return status.Errorf(codes.InvalidArgument, "could not parse version from user-agent: %s", userAgent)
+			}
+			if ok, errs := semVerConstraint.Validate(uaVers); !ok {
+				return status.Errorf(codes.FailedPrecondition, "unsatisfied client version constraint: %s", errs[0].Error())
+			}
+			return nil
+		}
+		// If we get here, the caller either did not supply user-agent, supplied one which we don't
+		// care about. This implies it is a from a custom generated client, so we permit the request.
+		// We really only want to enforce user-agent version constraints for clients under our
+		// control which we know to have compatibility issues
+		return nil
+	}
+}
+
+// isLegacyClient checks if the request was made from a legacy Argo CD client (i.e. v0.10 CLI).
+// The heuristic is that a single default 'grpc-go' user-agent was specified with one of the
+// previous versions of grpc-go we used in the past (1.15.0, 1.10.0).
+// Starting in v0.11, both of the gRPC clients we maintain (pkg/apiclient and grpc-gateway) started
+// supplying a explicit user-agent tied to the Argo CD version.
+func isLegacyClient(userAgents []string) bool {
+	return len(userAgents) == 1 && (userAgents[0] == "grpc-go/1.15.0" || userAgents[0] == "grpc-go/1.10.0")
+}

--- a/version.go
+++ b/version.go
@@ -6,9 +6,9 @@ import (
 )
 
 // Version information set by link flags during build. We fall back to these sane
-// default values when we build outside the Makefile context (e.g. go build or go test).
+// default values when we build outside the Makefile context (e.g. go run, go build, or go test).
 var (
-	version      = "0.0.0"                // value from VERSION file
+	version      = "99.99.99"             // value from VERSION file
 	buildDate    = "1970-01-01T00:00:00Z" // output from `date -u +'%Y-%m-%dT%H:%M:%SZ'`
 	gitCommit    = ""                     // output from `git rev-parse HEAD`
 	gitTag       = ""                     // output from `git describe --exact-match --tags HEAD` (if clean tree state)


### PR DESCRIPTION
With this change, the gRPC api client and grpc-gateway now supply user-agent, `argocd-client`, with their all requests. This enables us to discern various versions of the CLI as the requestor and reject requests from incompatible clients. For legacy clients which do not supply user-agent, we are assuming looking for the default `grpc-go/1.15.0` as the only user-agent.