### PR TITLE
Build argocd-util as a statically linked binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ release-cli: clean-debug image
 
 .PHONY: argocd-util
 argocd-util: clean-debug
-	go build -v -i -ldflags '${LDFLAGS} -extldflags "-static"' -o ${DIST_DIR}/argocd-util ./cmd/argocd-util
+	# Build argocd-util as a statically linked binary, so it could run within the alpine-based dex container (argoproj/argo-cd#844)
+	CGO_ENABLED=0 go build -v -i -ldflags '${LDFLAGS} -extldflags "-static"' -o ${DIST_DIR}/argocd-util ./cmd/argocd-util
 
 .PHONY: manifests
 manifests:


### PR DESCRIPTION
Fixes #844.