### PR TITLE
Normalize app spec during controller reconciliation and API server create/update

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -11,19 +11,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
-
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -38,14 +39,12 @@ import (
 	"github.com/argoproj/argo-cd/util"
 	"github.com/argoproj/argo-cd/util/argo"
 	"github.com/argoproj/argo-cd/util/db"
+	"github.com/argoproj/argo-cd/util/diff"
 	grpc_util "github.com/argoproj/argo-cd/util/grpc"
 	"github.com/argoproj/argo-cd/util/health"
 	"github.com/argoproj/argo-cd/util/kube"
 	settings_util "github.com/argoproj/argo-cd/util/settings"
 	tlsutil "github.com/argoproj/argo-cd/util/tls"
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -614,15 +613,15 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	if !ctrl.needRefreshAppStatus(app, ctrl.statusRefreshTimeout) {
 		return
 	}
+	app = ctrl.normalizeApplication(app)
 
-	app = app.DeepCopy()
 	conditions, hasErrors := ctrl.refreshAppConditions(app)
 	if hasErrors {
 		comparisonResult := app.Status.ComparisonResult.DeepCopy()
 		comparisonResult.Status = appv1.ComparisonStatusUnknown
 		appHealth := app.Status.Health.DeepCopy()
 		appHealth.Status = appv1.HealthStatusUnknown
-		ctrl.updateAppStatus(app, comparisonResult, appHealth, nil, conditions)
+		ctrl.persistAppStatus(app, comparisonResult, appHealth, nil, conditions)
 		return
 	}
 
@@ -649,7 +648,7 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 		conditions = append(conditions, *syncErrCond)
 	}
 
-	ctrl.updateAppStatus(app, comparisonResult, healthState, parameters, conditions)
+	ctrl.persistAppStatus(app, comparisonResult, healthState, parameters, conditions)
 	return
 }
 
@@ -729,8 +728,30 @@ func (ctrl *ApplicationController) refreshAppConditions(app *appv1.Application) 
 	return appConditions, hasErrors
 }
 
-// updateAppStatus persists updates to application status. Detects if there patch
-func (ctrl *ApplicationController) updateAppStatus(
+// normalizeApplication normalizes an application.spec and additionally persists updates if it changed
+// Always returns a copy of the application
+func (ctrl *ApplicationController) normalizeApplication(app *appv1.Application) *appv1.Application {
+	logCtx := log.WithFields(log.Fields{"application": app.Name})
+	appClient := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace)
+	modifiedApp := app.DeepCopy()
+	modifiedApp.Spec = *argo.NormalizeApplicationSpec(&app.Spec)
+	patch, modified, err := diff.CreateTwoWayMergePatch(app, modifiedApp, appv1.Application{})
+	if err != nil {
+		logCtx.Errorf("error constructing app spec patch: %v", err)
+		return modifiedApp
+	} else if modified {
+		_, err = appClient.Patch(app.Name, types.MergePatchType, patch)
+		if err != nil {
+			logCtx.Errorf("Error persisting normalized application spec: %v", err)
+		} else {
+			logCtx.Infof("Normalized app spec: %s", string(patch))
+		}
+	}
+	return modifiedApp
+}
+
+// persistAppStatus persists updates to application status. If no changes were made, it is a no-op
+func (ctrl *ApplicationController) persistAppStatus(
 	app *appv1.Application,
 	comparisonResult *appv1.ComparisonResult,
 	healthState *appv1.HealthStatus,
@@ -763,22 +784,12 @@ func (ctrl *ApplicationController) updateAppStatus(
 	if conditions != nil {
 		modifiedApp.Status.Conditions = conditions
 	}
-	origBytes, err := json.Marshal(app)
+	patch, modified, err := diff.CreateTwoWayMergePatch(app, modifiedApp, appv1.Application{})
 	if err != nil {
-		logCtx.Errorf("Error updating (marshal orig app): %v", err)
+		logCtx.Errorf("Error constructing app status patch: %v", err)
 		return
 	}
-	modifiedBytes, err := json.Marshal(modifiedApp)
-	if err != nil {
-		logCtx.Errorf("Error updating (marshal modified app): %v", err)
-		return
-	}
-	patch, err := strategicpatch.CreateTwoWayMergePatch(origBytes, modifiedBytes, appv1.Application{})
-	if err != nil {
-		logCtx.Errorf("Error calculating patch for update: %v", err)
-		return
-	}
-	if string(patch) == "{}" {
+	if !modified {
 		logCtx.Infof("No status changes. Skipping patch")
 		return
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,6 @@ spec:
     repoURL: https://github.com/argoproj/argocd-example-apps.git
     targetRevision: HEAD
     path: guestbook
-    environment: default
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/pkg/apis/application/v1alpha1/generated.pb.go
+++ b/pkg/apis/application/v1alpha1/generated.pb.go
@@ -30,7 +30,7 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 func (m *AWSAuthConfig) Reset()      { *m = AWSAuthConfig{} }
 func (*AWSAuthConfig) ProtoMessage() {}
 func (*AWSAuthConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{0}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{0}
 }
 func (m *AWSAuthConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -58,7 +58,7 @@ var xxx_messageInfo_AWSAuthConfig proto.InternalMessageInfo
 func (m *AppProject) Reset()      { *m = AppProject{} }
 func (*AppProject) ProtoMessage() {}
 func (*AppProject) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{1}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{1}
 }
 func (m *AppProject) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -86,7 +86,7 @@ var xxx_messageInfo_AppProject proto.InternalMessageInfo
 func (m *AppProjectList) Reset()      { *m = AppProjectList{} }
 func (*AppProjectList) ProtoMessage() {}
 func (*AppProjectList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{2}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{2}
 }
 func (m *AppProjectList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -114,7 +114,7 @@ var xxx_messageInfo_AppProjectList proto.InternalMessageInfo
 func (m *AppProjectSpec) Reset()      { *m = AppProjectSpec{} }
 func (*AppProjectSpec) ProtoMessage() {}
 func (*AppProjectSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{3}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{3}
 }
 func (m *AppProjectSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -142,7 +142,7 @@ var xxx_messageInfo_AppProjectSpec proto.InternalMessageInfo
 func (m *Application) Reset()      { *m = Application{} }
 func (*Application) ProtoMessage() {}
 func (*Application) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{4}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{4}
 }
 func (m *Application) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -170,7 +170,7 @@ var xxx_messageInfo_Application proto.InternalMessageInfo
 func (m *ApplicationCondition) Reset()      { *m = ApplicationCondition{} }
 func (*ApplicationCondition) ProtoMessage() {}
 func (*ApplicationCondition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{5}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{5}
 }
 func (m *ApplicationCondition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -198,7 +198,7 @@ var xxx_messageInfo_ApplicationCondition proto.InternalMessageInfo
 func (m *ApplicationDestination) Reset()      { *m = ApplicationDestination{} }
 func (*ApplicationDestination) ProtoMessage() {}
 func (*ApplicationDestination) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{6}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{6}
 }
 func (m *ApplicationDestination) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -226,7 +226,7 @@ var xxx_messageInfo_ApplicationDestination proto.InternalMessageInfo
 func (m *ApplicationList) Reset()      { *m = ApplicationList{} }
 func (*ApplicationList) ProtoMessage() {}
 func (*ApplicationList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{7}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{7}
 }
 func (m *ApplicationList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -254,7 +254,7 @@ var xxx_messageInfo_ApplicationList proto.InternalMessageInfo
 func (m *ApplicationSource) Reset()      { *m = ApplicationSource{} }
 func (*ApplicationSource) ProtoMessage() {}
 func (*ApplicationSource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{8}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{8}
 }
 func (m *ApplicationSource) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -282,7 +282,7 @@ var xxx_messageInfo_ApplicationSource proto.InternalMessageInfo
 func (m *ApplicationSourceHelm) Reset()      { *m = ApplicationSourceHelm{} }
 func (*ApplicationSourceHelm) ProtoMessage() {}
 func (*ApplicationSourceHelm) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{9}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{9}
 }
 func (m *ApplicationSourceHelm) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -310,7 +310,7 @@ var xxx_messageInfo_ApplicationSourceHelm proto.InternalMessageInfo
 func (m *ApplicationSourceKsonnet) Reset()      { *m = ApplicationSourceKsonnet{} }
 func (*ApplicationSourceKsonnet) ProtoMessage() {}
 func (*ApplicationSourceKsonnet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{10}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{10}
 }
 func (m *ApplicationSourceKsonnet) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -338,7 +338,7 @@ var xxx_messageInfo_ApplicationSourceKsonnet proto.InternalMessageInfo
 func (m *ApplicationSourceKustomize) Reset()      { *m = ApplicationSourceKustomize{} }
 func (*ApplicationSourceKustomize) ProtoMessage() {}
 func (*ApplicationSourceKustomize) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{11}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{11}
 }
 func (m *ApplicationSourceKustomize) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -366,7 +366,7 @@ var xxx_messageInfo_ApplicationSourceKustomize proto.InternalMessageInfo
 func (m *ApplicationSpec) Reset()      { *m = ApplicationSpec{} }
 func (*ApplicationSpec) ProtoMessage() {}
 func (*ApplicationSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{12}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{12}
 }
 func (m *ApplicationSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -394,7 +394,7 @@ var xxx_messageInfo_ApplicationSpec proto.InternalMessageInfo
 func (m *ApplicationStatus) Reset()      { *m = ApplicationStatus{} }
 func (*ApplicationStatus) ProtoMessage() {}
 func (*ApplicationStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{13}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{13}
 }
 func (m *ApplicationStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -422,7 +422,7 @@ var xxx_messageInfo_ApplicationStatus proto.InternalMessageInfo
 func (m *ApplicationWatchEvent) Reset()      { *m = ApplicationWatchEvent{} }
 func (*ApplicationWatchEvent) ProtoMessage() {}
 func (*ApplicationWatchEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{14}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{14}
 }
 func (m *ApplicationWatchEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -450,7 +450,7 @@ var xxx_messageInfo_ApplicationWatchEvent proto.InternalMessageInfo
 func (m *Cluster) Reset()      { *m = Cluster{} }
 func (*Cluster) ProtoMessage() {}
 func (*Cluster) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{15}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{15}
 }
 func (m *Cluster) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -478,7 +478,7 @@ var xxx_messageInfo_Cluster proto.InternalMessageInfo
 func (m *ClusterConfig) Reset()      { *m = ClusterConfig{} }
 func (*ClusterConfig) ProtoMessage() {}
 func (*ClusterConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{16}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{16}
 }
 func (m *ClusterConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -506,7 +506,7 @@ var xxx_messageInfo_ClusterConfig proto.InternalMessageInfo
 func (m *ClusterList) Reset()      { *m = ClusterList{} }
 func (*ClusterList) ProtoMessage() {}
 func (*ClusterList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{17}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{17}
 }
 func (m *ClusterList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -534,7 +534,7 @@ var xxx_messageInfo_ClusterList proto.InternalMessageInfo
 func (m *ComparisonResult) Reset()      { *m = ComparisonResult{} }
 func (*ComparisonResult) ProtoMessage() {}
 func (*ComparisonResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{18}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{18}
 }
 func (m *ComparisonResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -562,7 +562,7 @@ var xxx_messageInfo_ComparisonResult proto.InternalMessageInfo
 func (m *ComponentParameter) Reset()      { *m = ComponentParameter{} }
 func (*ComponentParameter) ProtoMessage() {}
 func (*ComponentParameter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{19}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{19}
 }
 func (m *ComponentParameter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -590,7 +590,7 @@ var xxx_messageInfo_ComponentParameter proto.InternalMessageInfo
 func (m *ConnectionState) Reset()      { *m = ConnectionState{} }
 func (*ConnectionState) ProtoMessage() {}
 func (*ConnectionState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{20}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{20}
 }
 func (m *ConnectionState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -618,7 +618,7 @@ var xxx_messageInfo_ConnectionState proto.InternalMessageInfo
 func (m *DeploymentInfo) Reset()      { *m = DeploymentInfo{} }
 func (*DeploymentInfo) ProtoMessage() {}
 func (*DeploymentInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{21}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{21}
 }
 func (m *DeploymentInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -646,7 +646,7 @@ var xxx_messageInfo_DeploymentInfo proto.InternalMessageInfo
 func (m *HealthStatus) Reset()      { *m = HealthStatus{} }
 func (*HealthStatus) ProtoMessage() {}
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{22}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{22}
 }
 func (m *HealthStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -674,7 +674,7 @@ var xxx_messageInfo_HealthStatus proto.InternalMessageInfo
 func (m *HookStatus) Reset()      { *m = HookStatus{} }
 func (*HookStatus) ProtoMessage() {}
 func (*HookStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{23}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{23}
 }
 func (m *HookStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -702,7 +702,7 @@ var xxx_messageInfo_HookStatus proto.InternalMessageInfo
 func (m *JWTToken) Reset()      { *m = JWTToken{} }
 func (*JWTToken) ProtoMessage() {}
 func (*JWTToken) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{24}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{24}
 }
 func (m *JWTToken) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -730,7 +730,7 @@ var xxx_messageInfo_JWTToken proto.InternalMessageInfo
 func (m *Operation) Reset()      { *m = Operation{} }
 func (*Operation) ProtoMessage() {}
 func (*Operation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{25}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{25}
 }
 func (m *Operation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -758,7 +758,7 @@ var xxx_messageInfo_Operation proto.InternalMessageInfo
 func (m *OperationState) Reset()      { *m = OperationState{} }
 func (*OperationState) ProtoMessage() {}
 func (*OperationState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{26}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{26}
 }
 func (m *OperationState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -786,7 +786,7 @@ var xxx_messageInfo_OperationState proto.InternalMessageInfo
 func (m *ParameterOverrides) Reset()      { *m = ParameterOverrides{} }
 func (*ParameterOverrides) ProtoMessage() {}
 func (*ParameterOverrides) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{27}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{27}
 }
 func (m *ParameterOverrides) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -814,7 +814,7 @@ var xxx_messageInfo_ParameterOverrides proto.InternalMessageInfo
 func (m *ProjectRole) Reset()      { *m = ProjectRole{} }
 func (*ProjectRole) ProtoMessage() {}
 func (*ProjectRole) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{28}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{28}
 }
 func (m *ProjectRole) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -842,7 +842,7 @@ var xxx_messageInfo_ProjectRole proto.InternalMessageInfo
 func (m *Repository) Reset()      { *m = Repository{} }
 func (*Repository) ProtoMessage() {}
 func (*Repository) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{29}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{29}
 }
 func (m *Repository) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -870,7 +870,7 @@ var xxx_messageInfo_Repository proto.InternalMessageInfo
 func (m *RepositoryList) Reset()      { *m = RepositoryList{} }
 func (*RepositoryList) ProtoMessage() {}
 func (*RepositoryList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{30}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{30}
 }
 func (m *RepositoryList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -898,7 +898,7 @@ var xxx_messageInfo_RepositoryList proto.InternalMessageInfo
 func (m *ResourceDetails) Reset()      { *m = ResourceDetails{} }
 func (*ResourceDetails) ProtoMessage() {}
 func (*ResourceDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{31}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{31}
 }
 func (m *ResourceDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -926,7 +926,7 @@ var xxx_messageInfo_ResourceDetails proto.InternalMessageInfo
 func (m *ResourceNode) Reset()      { *m = ResourceNode{} }
 func (*ResourceNode) ProtoMessage() {}
 func (*ResourceNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{32}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{32}
 }
 func (m *ResourceNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -954,7 +954,7 @@ var xxx_messageInfo_ResourceNode proto.InternalMessageInfo
 func (m *ResourceState) Reset()      { *m = ResourceState{} }
 func (*ResourceState) ProtoMessage() {}
 func (*ResourceState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{33}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{33}
 }
 func (m *ResourceState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -982,7 +982,7 @@ var xxx_messageInfo_ResourceState proto.InternalMessageInfo
 func (m *ResourceSummary) Reset()      { *m = ResourceSummary{} }
 func (*ResourceSummary) ProtoMessage() {}
 func (*ResourceSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{34}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{34}
 }
 func (m *ResourceSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1010,7 +1010,7 @@ var xxx_messageInfo_ResourceSummary proto.InternalMessageInfo
 func (m *SyncOperation) Reset()      { *m = SyncOperation{} }
 func (*SyncOperation) ProtoMessage() {}
 func (*SyncOperation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{35}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{35}
 }
 func (m *SyncOperation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1038,7 +1038,7 @@ var xxx_messageInfo_SyncOperation proto.InternalMessageInfo
 func (m *SyncOperationResource) Reset()      { *m = SyncOperationResource{} }
 func (*SyncOperationResource) ProtoMessage() {}
 func (*SyncOperationResource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{36}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{36}
 }
 func (m *SyncOperationResource) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1066,7 +1066,7 @@ var xxx_messageInfo_SyncOperationResource proto.InternalMessageInfo
 func (m *SyncOperationResult) Reset()      { *m = SyncOperationResult{} }
 func (*SyncOperationResult) ProtoMessage() {}
 func (*SyncOperationResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{37}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{37}
 }
 func (m *SyncOperationResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1094,7 +1094,7 @@ var xxx_messageInfo_SyncOperationResult proto.InternalMessageInfo
 func (m *SyncPolicy) Reset()      { *m = SyncPolicy{} }
 func (*SyncPolicy) ProtoMessage() {}
 func (*SyncPolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{38}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{38}
 }
 func (m *SyncPolicy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1122,7 +1122,7 @@ var xxx_messageInfo_SyncPolicy proto.InternalMessageInfo
 func (m *SyncPolicyAutomated) Reset()      { *m = SyncPolicyAutomated{} }
 func (*SyncPolicyAutomated) ProtoMessage() {}
 func (*SyncPolicyAutomated) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{39}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{39}
 }
 func (m *SyncPolicyAutomated) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1150,7 +1150,7 @@ var xxx_messageInfo_SyncPolicyAutomated proto.InternalMessageInfo
 func (m *SyncStrategy) Reset()      { *m = SyncStrategy{} }
 func (*SyncStrategy) ProtoMessage() {}
 func (*SyncStrategy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{40}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{40}
 }
 func (m *SyncStrategy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1178,7 +1178,7 @@ var xxx_messageInfo_SyncStrategy proto.InternalMessageInfo
 func (m *SyncStrategyApply) Reset()      { *m = SyncStrategyApply{} }
 func (*SyncStrategyApply) ProtoMessage() {}
 func (*SyncStrategyApply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{41}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{41}
 }
 func (m *SyncStrategyApply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1206,7 +1206,7 @@ var xxx_messageInfo_SyncStrategyApply proto.InternalMessageInfo
 func (m *SyncStrategyHook) Reset()      { *m = SyncStrategyHook{} }
 func (*SyncStrategyHook) ProtoMessage() {}
 func (*SyncStrategyHook) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{42}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{42}
 }
 func (m *SyncStrategyHook) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1234,7 +1234,7 @@ var xxx_messageInfo_SyncStrategyHook proto.InternalMessageInfo
 func (m *TLSClientConfig) Reset()      { *m = TLSClientConfig{} }
 func (*TLSClientConfig) ProtoMessage() {}
 func (*TLSClientConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_generated_0f09c0157ee56900, []int{43}
+	return fileDescriptor_generated_29ef40cfae3fce4d, []int{43}
 }
 func (m *TLSClientConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -11266,10 +11266,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1/generated.proto", fileDescriptor_generated_0f09c0157ee56900)
+	proto.RegisterFile("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1/generated.proto", fileDescriptor_generated_29ef40cfae3fce4d)
 }
 
-var fileDescriptor_generated_0f09c0157ee56900 = []byte{
+var fileDescriptor_generated_29ef40cfae3fce4d = []byte{
 	// 3058 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x3a, 0x5b, 0x8f, 0x1c, 0x47,
 	0xd5, 0xdb, 0x73, 0xd9, 0x9d, 0x39, 0x7b, 0xb1, 0x5d, 0xb9, 0x7c, 0xf3, 0x6d, 0x3e, 0xed, 0xae,

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -114,7 +114,7 @@ message ApplicationSource {
   optional string path = 2;
 
   // Environment is a ksonnet application environment name
-  // DEPRECATED: specify environment in ksonnet.environment instead
+  // DEPRECATED: specify environment in spec.source.ksonnet.environment instead
   optional string environment = 3;
 
   // TargetRevision defines the commit, tag, or branch in which to sync the application to.
@@ -125,7 +125,7 @@ message ApplicationSource {
   repeated ComponentParameter componentParameterOverrides = 5;
 
   // ValuesFiles is a list of Helm values files to use when generating a template
-  // DEPRECATED: specify values in helm.valueFiles instead
+  // DEPRECATED: specify values in spec.source.helm.valueFiles instead
   repeated string valuesFiles = 6;
 
   // Helm holds helm specific options

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -49,7 +49,7 @@ type ApplicationSource struct {
 	// Path is a directory path within the repository containing a
 	Path string `json:"path" protobuf:"bytes,2,opt,name=path"`
 	// Environment is a ksonnet application environment name
-	// DEPRECATED: specify environment in ksonnet.environment instead
+	// DEPRECATED: specify environment in spec.source.ksonnet.environment instead
 	Environment string `json:"environment,omitempty" protobuf:"bytes,3,opt,name=environment"`
 	// TargetRevision defines the commit, tag, or branch in which to sync the application to.
 	// If omitted, will sync to HEAD
@@ -57,7 +57,7 @@ type ApplicationSource struct {
 	// ComponentParameterOverrides are a list of parameter override values
 	ComponentParameterOverrides []ComponentParameter `json:"componentParameterOverrides,omitempty" protobuf:"bytes,5,opt,name=componentParameterOverrides"`
 	// ValuesFiles is a list of Helm values files to use when generating a template
-	// DEPRECATED: specify values in helm.valueFiles instead
+	// DEPRECATED: specify values in spec.source.helm.valueFiles instead
 	ValuesFiles []string `json:"valuesFiles,omitempty" protobuf:"bytes,6,opt,name=valuesFiles"`
 	// Helm holds helm specific options
 	Helm *ApplicationSourceHelm `json:"helm,omitempty" protobuf:"bytes,7,opt,name=helm"`
@@ -679,10 +679,7 @@ func (source ApplicationSource) Equals(other ApplicationSource) bool {
 	return reflect.DeepEqual(source, other)
 }
 
-func (spec ApplicationSpec) BelongsToDefaultProject() bool {
-	return spec.GetProject() == common.DefaultAppProjectName
-}
-
+// GetProject returns the application's project. This is preferred over spec.Project which may be empty
 func (spec ApplicationSpec) GetProject() string {
 	if spec.Project == "" {
 		return common.DefaultAppProjectName

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -105,10 +105,7 @@ func boolFloat64(b bool) float64 {
 
 func collectApps(ch chan<- prometheus.Metric, app *argoappv1.Application) {
 	addConstMetric := func(desc *prometheus.Desc, t prometheus.ValueType, v float64, lv ...string) {
-		project := app.Spec.Project
-		if project == "" {
-			project = "default"
-		}
+		project := app.Spec.GetProject()
 		lv = append([]string{app.Namespace, app.Name, project}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, t, v, lv...)
 	}

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2286,7 +2286,7 @@
         },
         "environment": {
           "type": "string",
-          "title": "Environment is a ksonnet application environment name\nDEPRECATED: specify environment in ksonnet.environment instead"
+          "title": "Environment is a ksonnet application environment name\nDEPRECATED: specify environment in spec.source.ksonnet.environment instead"
         },
         "helm": {
           "$ref": "#/definitions/v1alpha1ApplicationSourceHelm"
@@ -2311,7 +2311,7 @@
         },
         "valuesFiles": {
           "type": "array",
-          "title": "ValuesFiles is a list of Helm values files to use when generating a template\nDEPRECATED: specify values in helm.valueFiles instead",
+          "title": "ValuesFiles is a list of Helm values files to use when generating a template\nDEPRECATED: specify values in spec.source.helm.valueFiles instead",
           "items": {
             "type": "string"
           }

--- a/test/testutil.go
+++ b/test/testutil.go
@@ -1,0 +1,18 @@
+package test
+
+import (
+	"context"
+	"log"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// StartInformer is a helper to start an informer, wait for its cache to sync and return a cancel func
+func StartInformer(informer cache.SharedIndexInformer) context.CancelFunc {
+	ctx, cancel := context.WithCancel(context.Background())
+	go informer.Run(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		log.Fatal("Timed out waiting for informer cache to sync")
+	}
+	return cancel
+}

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -139,3 +139,40 @@ func TestVerifyOneSourceType(t *testing.T) {
 	}
 	assert.Nil(t, verifyOneSourceType(&src))
 }
+
+func TestNormalizeApplicationSpec(t *testing.T) {
+	spec := NormalizeApplicationSpec(&argoappv1.ApplicationSpec{})
+	assert.Equal(t, spec.Project, "default")
+
+	spec = NormalizeApplicationSpec(&argoappv1.ApplicationSpec{
+		Source: argoappv1.ApplicationSource{
+			Environment: "foo",
+		},
+	})
+	assert.Equal(t, spec.Source.Ksonnet.Environment, "foo")
+
+	spec = NormalizeApplicationSpec(&argoappv1.ApplicationSpec{
+		Source: argoappv1.ApplicationSource{
+			Ksonnet: &argoappv1.ApplicationSourceKsonnet{
+				Environment: "foo",
+			},
+		},
+	})
+	assert.Equal(t, spec.Source.Environment, "foo")
+
+	spec = NormalizeApplicationSpec(&argoappv1.ApplicationSpec{
+		Source: argoappv1.ApplicationSource{
+			ValuesFiles: []string{"values-prod.yaml"},
+		},
+	})
+	assert.Equal(t, spec.Source.Helm.ValueFiles[0], "values-prod.yaml")
+
+	spec = NormalizeApplicationSpec(&argoappv1.ApplicationSpec{
+		Source: argoappv1.ApplicationSource{
+			Helm: &argoappv1.ApplicationSourceHelm{
+				ValueFiles: []string{"values-prod.yaml"},
+			},
+		},
+	})
+	assert.Equal(t, spec.Source.ValuesFiles[0], "values-prod.yaml")
+}

--- a/util/diff/diff.go
+++ b/util/diff/diff.go
@@ -323,7 +323,7 @@ func encodeSecretStringData(un *unstructured.Unstructured) {
 	delete(un.Object, "stringData")
 }
 
-// UnmarshalDiffString Unmarshals diff string into a DiffResult struct
+// UnmarshalDiffString unmarshals diff string into a DiffResult struct
 func UnmarshalDiffString(diffStr string) (*DiffResult, error) {
 	diffUnmarshaller := gojsondiff.NewUnmarshaller()
 	diffResult := &DiffResult{}
@@ -345,4 +345,21 @@ func (d *DiffResult) JSONFormat() (string, error) {
 	}
 	jsonFmt := formatter.NewDeltaFormatter()
 	return jsonFmt.Format(d.Diff)
+}
+
+// CreateTwoWayMergePatch is a helper to construct a two-way merge patch from objects (instead of bytes)
+func CreateTwoWayMergePatch(orig, new, dataStruct interface{}) ([]byte, bool, error) {
+	origBytes, err := json.Marshal(orig)
+	if err != nil {
+		return nil, false, err
+	}
+	newBytes, err := json.Marshal(new)
+	if err != nil {
+		return nil, false, err
+	}
+	patch, err := strategicpatch.CreateTwoWayMergePatch(origBytes, newBytes, dataStruct)
+	if err != nil {
+		return nil, false, err
+	}
+	return patch, string(patch) != "{}", nil
 }


### PR DESCRIPTION
This change normalizes an application spec as part of controller reconciliation. This allows us to migrate specs into preferred states, and eventually drop legacy fields.