### PR TITLE
Remove git URL normalization in favor of fuzzy equivalence (issue #838)

### DIFF
--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -269,7 +269,7 @@ func NewProjectAddSourceCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 					fmt.Printf("Source repository '*' already allowed in project\n")
 					return
 				}
-				if item == git.NormalizeGitURL(url) {
+				if git.SameURL(item, url) {
 					fmt.Printf("Source repository '%s' already allowed in project\n", item)
 					return
 				}
@@ -400,11 +400,7 @@ func NewProjectRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *cobr
 
 			index := -1
 			for i, item := range proj.Spec.SourceRepos {
-				if item == "*" && item == url {
-					index = i
-					break
-				}
-				if item == git.NormalizeGitURL(url) {
+				if item == url {
 					index = i
 					break
 				}

--- a/controller/state.go
+++ b/controller/state.go
@@ -147,7 +147,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, revision st
 			if appLabelVal, ok := liveObj.GetLabels()[common.LabelApplicationName]; ok && appLabelVal != "" && appLabelVal != app.Name {
 				conditions = append(conditions, v1alpha1.ApplicationCondition{
 					Type:    v1alpha1.ApplicationConditionSharedResourceWarning,
-					Message: fmt.Sprintf("Resource %s/%s is controller by applications '%s' and '%s'", liveObj.GetKind(), liveObj.GetName(), app.Name, appLabelVal),
+					Message: fmt.Sprintf("%s/%s is part of multiple application: %s, %s", liveObj.GetKind(), liveObj.GetName(), app.Name, appLabelVal),
 				})
 			}
 		}

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -123,6 +123,11 @@ func NewClient(opts *ClientOptions) (Client, error) {
 			ctxName = configCtx.Name
 		}
 	}
+	if opts.UserAgent != "" {
+		c.UserAgent = opts.UserAgent
+	} else {
+		c.UserAgent = fmt.Sprintf("%s/%s", common.ArgoCDUserAgentName, argocd.GetVersion().Version)
+	}
 	// Override server address if specified in env or CLI flag
 	if serverFromEnv := os.Getenv(EnvArgoCDServer); serverFromEnv != "" {
 		c.ServerAddr = serverFromEnv
@@ -165,11 +170,6 @@ func NewClient(opts *ClientOptions) (Client, error) {
 		if err != nil {
 			return nil, err
 		}
-	}
-	if opts.UserAgent != "" {
-		c.UserAgent = opts.UserAgent
-	} else {
-		c.UserAgent = fmt.Sprintf("%s/%s", common.ArgoCDUserAgentName, argocd.GetVersion().Version)
 	}
 	return &c, nil
 }

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -713,12 +713,11 @@ func (proj AppProject) IsResourcePermitted(res metav1.GroupKind, namespaced bool
 
 // IsSourcePermitted validates if the provided application's source is a one of the allowed sources for the project.
 func (proj AppProject) IsSourcePermitted(src ApplicationSource) bool {
-	normalizedURL := git.NormalizeGitURL(src.RepoURL)
 	for _, repoURL := range proj.Spec.SourceRepos {
 		if repoURL == "*" {
 			return true
 		}
-		if git.NormalizeGitURL(repoURL) == normalizedURL {
+		if git.SameURL(repoURL, src.RepoURL) {
 			return true
 		}
 	}

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -455,8 +455,9 @@ func pathExists(ss ...string) bool {
 // newClientResolveRevision is a helper to perform the common task of instantiating a git client
 // and resolving a revision to a commit SHA
 func (s *Service) newClientResolveRevision(repo *v1alpha1.Repository, revision string) (git.Client, string, error) {
-	appRepoPath := tempRepoPath(repo.Repo)
-	gitClient, err := s.gitFactory.NewClient(repo.Repo, appRepoPath, repo.Username, repo.Password, repo.SSHPrivateKey)
+	repoURL := git.NormalizeGitURL(repo.Repo)
+	appRepoPath := tempRepoPath(repoURL)
+	gitClient, err := s.gitFactory.NewClient(repoURL, appRepoPath, repo.Username, repo.Password, repo.SSHPrivateKey)
 	if err != nil {
 		return nil, "", err
 	}

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -177,7 +177,7 @@ func (s *Server) GetManifests(ctx context.Context, q *ApplicationManifestQuery) 
 	if q.Revision != "" {
 		revision = q.Revision
 	}
-	manifestInfo, err := repoClient.GenerateManifest(context.Background(), &repository.ManifestRequest{
+	manifestInfo, err := repoClient.GenerateManifest(ctx, &repository.ManifestRequest{
 		Repo:                        repo,
 		Revision:                    revision,
 		ComponentParameterOverrides: overrides,

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -268,7 +268,7 @@ func (s *Server) Create(ctx context.Context, q *RepoCreateRequest) (*appsv1.Repo
 		return nil, grpc.ErrPermissionDenied
 	}
 	r := q.Repo
-	err := git.TestRepo(git.NormalizeGitURL(r.Repo), r.Username, r.Password, r.SSHPrivateKey)
+	err := git.TestRepo(r.Repo, r.Username, r.Password, r.SSHPrivateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestRepoURLToSecretName(t *testing.T) {
 	tables := map[string]string{
-		"git://git@github.com:argoproj/ARGO-cd.git": "repo-argo-cd-593837413",
-		"https://github.com/argoproj/ARGO-cd":       "repo-argo-cd-821842295",
-		"https://github.com/argoproj/argo-cd":       "repo-argo-cd-821842295",
+		"git://git@github.com:argoproj/ARGO-cd.git": "repo-argo-cd-83273445",
+		"https://github.com/argoproj/ARGO-cd":       "repo-argo-cd-1890113693",
+		"https://github.com/argoproj/argo-cd":       "repo-argo-cd-42374749",
 		"https://github.com/argoproj/argo-cd.git":   "repo-argo-cd-821842295",
 		"https://github.com/argoproj/argo_cd.git":   "repo-argo-cd-1049844989",
-		"ssh://git@github.com/argoproj/argo-cd.git": "repo-argo-cd-1019298066",
+		"ssh://git@github.com/argoproj/argo-cd.git": "repo-argo-cd-3569564120",
 	}
 
 	for k, v := range tables {

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -35,20 +35,14 @@ func TestEnsurePrefix(t *testing.T) {
 	}
 }
 
-func TestEnsureSuffix(t *testing.T) {
+func TestRemoveSuffix(t *testing.T) {
 	data := [][]string{
-		{"hello", "world", "helloworld"},
-		{"helloworld", "world", "helloworld"},
-		{"repo", ".git", "repo.git"},
-		{"repo.git", ".git", "repo.git"},
-		{"", "repo.git", "repo.git"},
-		{"argo", "cd", "argocd"},
-		{"argocd", "cd", "argocd"},
-		{"argocd", "", "argocd"},
-		{"", "argocd", "argocd"},
+		{"hello.git", ".git", "hello"},
+		{"hello", ".git", "hello"},
+		{".git", ".git", ""},
 	}
 	for _, table := range data {
-		result := ensureSuffix(table[0], table[1])
+		result := removeSuffix(table[0], table[1])
 		assert.Equal(t, table[2], result)
 	}
 }
@@ -70,7 +64,7 @@ func TestIsSSHURL(t *testing.T) {
 	}
 }
 
-func TestNormalizeUrl(t *testing.T) {
+func TestSameURL(t *testing.T) {
 	data := map[string]string{
 		"git@GITHUB.com:argoproj/test":                     "git@github.com:argoproj/test.git",
 		"git@GITHUB.com:argoproj/test.git":                 "git@github.com:argoproj/test.git",
@@ -78,6 +72,7 @@ func TestNormalizeUrl(t *testing.T) {
 		"git@GITHUB.com:test.git":                          "git@github.com:test.git",
 		"https://GITHUB.com/argoproj/test":                 "https://github.com/argoproj/test.git",
 		"https://GITHUB.com/argoproj/test.git":             "https://github.com/argoproj/test.git",
+		"https://github.com/FOO":                           "https://github.com/foo",
 		"https://github.com/TEST":                          "https://github.com/TEST.git",
 		"https://github.com/TEST.git":                      "https://github.com/TEST.git",
 		"ssh://git@GITHUB.com:argoproj/test":               "git@github.com:argoproj/test.git",
@@ -90,7 +85,7 @@ func TestNormalizeUrl(t *testing.T) {
 		"https://dev.azure.com/1234/myproj/_git/myrepo":    "https://dev.azure.com/1234/myproj/_git/myrepo",
 	}
 	for k, v := range data {
-		assert.Equal(t, v, NormalizeGitURL(k))
+		assert.True(t, SameURL(k, v))
 	}
 }
 

--- a/util/project/util.go
+++ b/util/project/util.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/util/git"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -41,19 +40,15 @@ func ValidateProject(p *v1alpha1.AppProject) error {
 		if _, ok := destKeys[key]; !ok {
 			destKeys[key] = true
 		} else {
-			return status.Errorf(codes.InvalidArgument, "destination %s should not be listed more than once.", key)
+			return status.Errorf(codes.InvalidArgument, "destination '%s' already added", key)
 		}
 	}
 	srcRepos := make(map[string]bool)
-	for i, src := range p.Spec.SourceRepos {
-		if src != "*" {
-			src = git.NormalizeGitURL(src)
-		}
-		p.Spec.SourceRepos[i] = src
+	for _, src := range p.Spec.SourceRepos {
 		if _, ok := srcRepos[src]; !ok {
 			srcRepos[src] = true
 		} else {
-			return status.Errorf(codes.InvalidArgument, "source repository %s should not be listed more than once.", src)
+			return status.Errorf(codes.InvalidArgument, "source repository '%s' already added", src)
 		}
 	}
 

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -139,7 +139,8 @@ func (mgr *SettingsManager) GetSettings() (*ArgoCDSettings, error) {
 	return &settings, nil
 }
 
-func (mgr *SettingsManager) LoadLegacyRepoSettings(settings *ArgoCDSettings) error {
+// MigrateLegacyRepoSettings migrates legacy (v0.10 and below) repo secrets into the v0.11 configmap
+func (mgr *SettingsManager) MigrateLegacyRepoSettings(settings *ArgoCDSettings) error {
 	listOpts := metav1.ListOptions{}
 	labelSelector := labels.NewSelector()
 	req, err := labels.NewRequirement(common.LabelKeySecretType, selection.Equals, []string{"repository"})
@@ -628,7 +629,7 @@ func UpdateSettings(defaultPassword string, settingsMgr *SettingsManager, update
 	}
 
 	if len(cdSettings.Repositories) == 0 {
-		err = settingsMgr.LoadLegacyRepoSettings(cdSettings)
+		err = settingsMgr.MigrateLegacyRepoSettings(cdSettings)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This removes repo URL normalization when storing repos in applications/projects/settings.
Normalization is still used in the following cases:
* when cloning repos, to prevent unnecessary clones
* when comparing two repos for equivalence