### PR TITLE
build application-controller with packr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ repo-server:
 
 .PHONY: controller
 controller:
-	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-application-controller ./cmd/argocd-application-controller
+	${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-application-controller ./cmd/argocd-application-controller
 
 .PHONY: image
 image:


### PR DESCRIPTION
It seems like the application-controller needs to be built with packr now otherwise I get the following error when starting the pod:

```
time="2018-12-03T22:20:35Z" level=fatal msg="stat /go/src/github.com/argoproj/argo-cd/util/rbac/builtin-policy.csv: no such file or directory"
```