### PR TITLE
build cli with packr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ codegen: protogen clientgen
 
 .PHONY: cli
 cli: clean-debug
-	go build -v -i -ldflags '${LDFLAGS} -extldflags "-static"' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
+	${PACKR_CMD} build -v -i -ldflags '${LDFLAGS} -extldflags "-static"' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 
 .PHONY: release-cli
 release-cli: clean-debug image


### PR DESCRIPTION
Much like #866 the CLI now needs to be built with packr or the following error message occurs: `FATA[0000] stat /go/src/github.com/argoproj/argo-cd/util/rbac/builtin-policy.csv: no such file or directory`