### PR TITLE
Enable --auto-prune for app create if --sync-policy is automated

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -317,12 +317,6 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
-			if c.Flags().Changed("auto-prune") {
-				if app.Spec.SyncPolicy == nil || app.Spec.SyncPolicy.Automated == nil {
-					log.Fatal("Cannot set --auto-prune: application not configured with automatic sync")
-				}
-				app.Spec.SyncPolicy.Automated.Prune = appOpts.autoPrune
-			}
 			setParameterOverrides(app, appOpts.parameters)
 			_, err = appIf.UpdateSpec(context.Background(), &application.ApplicationUpdateSpecRequest{
 				Name: &app.Name,
@@ -371,6 +365,13 @@ func setAppOptions(flags *pflag.FlagSet, app *argoappv1.Application, appOpts *ap
 			}
 		}
 	})
+	if flags.Changed("auto-prune") {
+		if app.Spec.SyncPolicy == nil || app.Spec.SyncPolicy.Automated == nil {
+			log.Fatal("Cannot set --auto-prune: application not configured with automatic sync")
+		}
+		app.Spec.SyncPolicy.Automated.Prune = appOpts.autoPrune
+	}
+
 	return visited
 }
 


### PR DESCRIPTION
The --auto-prune flag is being ignored when creating an app using the CLI. I copied across the logic from the set command which was doing the right thing.