### PR TITLE
 Prefix controller resource names with 'argocd-'

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -3,7 +3,7 @@ package common
 // Default service addresses and URLS of Argo CD internal services
 const (
 	// DefaultAppControllerServerAddr is the gRPC address of the Argo CD app controller server
-	DefaultAppControllerServerAddr = "application-controller:8083"
+	DefaultAppControllerServerAddr = "argocd-application-controller:8083"
 	// DefaultRepoServerAddr is the gRPC address of the Argo CD repo server
 	DefaultRepoServerAddr = "argocd-repo-server:8081"
 	// DefaultDexServerAddr is the HTTP address of the Dex OIDC server, which we run a reverse proxy against

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -102,7 +102,7 @@ func NewApplicationController(
 		statusRefreshTimeout:      appResyncPeriod,
 		refreshRequestedApps:      make(map[string]bool),
 		refreshRequestedAppsMutex: &sync.Mutex{},
-		auditLogger:               argo.NewAuditLogger(namespace, kubeClientset, "application-controller"),
+		auditLogger:               argo.NewAuditLogger(namespace, kubeClientset, "argocd-application-controller"),
 		managedResources:          make(map[string][]managedResource),
 		managedResourcesMutex:     &sync.Mutex{},
 	}
@@ -344,7 +344,7 @@ func (ctrl *ApplicationController) CreateGRPC(tlsConfCustomizer tlsutil.ConfigCu
 	// generate TLS cert
 	hosts := []string{
 		"localhost",
-		"application-controller",
+		"argocd-application-controller",
 	}
 	cert, err := tlsutil.GenerateX509KeyPair(tlsutil.CertOptions{
 		Hosts:        hosts,

--- a/manifests/base/argocd-application-controller-deployment.yaml
+++ b/manifests/base/argocd-application-controller-deployment.yaml
@@ -1,15 +1,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 spec:
   selector:
     matchLabels:
-      app: application-controller
+      app: argocd-application-controller
   template:
     metadata:
       labels:
-        app: application-controller
+        app: argocd-application-controller
     spec:
       containers:
       - command:
@@ -20,7 +20,7 @@ spec:
         - "10"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        name: application-controller
+        name: argocd-application-controller
         ports:
         - containerPort: 8083
         readinessProbe:
@@ -28,4 +28,4 @@ spec:
             port: 8083
           initialDelaySeconds: 5
           periodSeconds: 10
-      serviceAccountName: application-controller
+      serviceAccountName: argocd-application-controller

--- a/manifests/base/argocd-application-controller-role.yaml
+++ b/manifests/base/argocd-application-controller-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: application-controller-role
+  name: argocd-application-controller-role
 rules:
 - apiGroups:
   - ""

--- a/manifests/base/argocd-application-controller-role.yaml
+++ b/manifests/base/argocd-application-controller-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-application-controller-role
+  name: argocd-application-controller
 rules:
 - apiGroups:
   - ""

--- a/manifests/base/argocd-application-controller-rolebinding.yaml
+++ b/manifests/base/argocd-application-controller-rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-application-controller-role-binding
+  name: argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-application-controller-role
+  name: argocd-application-controller
 subjects:
 - kind: ServiceAccount
   name: argocd-application-controller

--- a/manifests/base/argocd-application-controller-rolebinding.yaml
+++ b/manifests/base/argocd-application-controller-rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: application-controller-role-binding
+  name: argocd-application-controller-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: application-controller-role
+  name: argocd-application-controller-role
 subjects:
 - kind: ServiceAccount
-  name: application-controller
+  name: argocd-application-controller

--- a/manifests/base/argocd-application-controller-sa.yaml
+++ b/manifests/base/argocd-application-controller-sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: application-controller
+  name: argocd-application-controller

--- a/manifests/base/argocd-application-controller-service.yaml
+++ b/manifests/base/argocd-application-controller-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 spec:
   ports:
   - port: 8083
     targetPort: 8083
   selector:
-    app: application-controller
+    app: argocd-application-controller

--- a/manifests/base/argocd-server-role.yaml
+++ b/manifests/base/argocd-server-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-server-role
+  name: argocd-server
 rules:
 - apiGroups:
   - ""

--- a/manifests/base/argocd-server-rolebinding.yaml
+++ b/manifests/base/argocd-server-rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-server-role-binding
+  name: argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-server-role
+  name: argocd-server
 subjects:
 - kind: ServiceAccount
   name: argocd-server

--- a/manifests/base/dex-server-role.yaml
+++ b/manifests/base/dex-server-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: dex-server-role
+  name: dex-server
 rules:
 - apiGroups:
   - ""

--- a/manifests/base/dex-server-rolebinding.yaml
+++ b/manifests/base/dex-server-rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: dex-server-role-binding
+  name: dex-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: dex-server-role
+  name: dex-server
 subjects:
 - kind: ServiceAccount
   name: dex-server

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -2,11 +2,11 @@ resources:
 - argocd-cm.yaml
 - argocd-secret.yaml
 - argocd-rbac-cm.yaml
-- application-controller-sa.yaml
-- application-controller-role.yaml
-- application-controller-rolebinding.yaml
-- application-controller-deployment.yaml
-- application-controller-service.yaml
+- argocd-application-controller-sa.yaml
+- argocd-application-controller-role.yaml
+- argocd-application-controller-rolebinding.yaml
+- argocd-application-controller-deployment.yaml
+- argocd-application-controller-service.yaml
 - argocd-server-sa.yaml
 - argocd-server-role.yaml
 - argocd-server-rolebinding.yaml

--- a/manifests/cluster-install/argocd-application-controller-clusterrole.yaml
+++ b/manifests/cluster-install/argocd-application-controller-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: argocd-application-controller-clusterrole
+  name: argocd-application-controller
 rules:
 - apiGroups:
   - '*'

--- a/manifests/cluster-install/argocd-application-controller-clusterrole.yaml
+++ b/manifests/cluster-install/argocd-application-controller-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: application-controller-clusterrole
+  name: argocd-application-controller-clusterrole
 rules:
 - apiGroups:
   - '*'

--- a/manifests/cluster-install/argocd-application-controller-clusterrolebinding.yaml
+++ b/manifests/cluster-install/argocd-application-controller-clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: argocd-application-controller-clusterrolebinding
+  name: argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argocd-application-controller-clusterrole
+  name: argocd-application-controller
 subjects:
 - kind: ServiceAccount
   name: argocd-application-controller

--- a/manifests/cluster-install/argocd-application-controller-clusterrolebinding.yaml
+++ b/manifests/cluster-install/argocd-application-controller-clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: application-controller-clusterrolebinding
+  name: argocd-application-controller-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: application-controller-clusterrole
+  name: argocd-application-controller-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: application-controller
+  name: argocd-application-controller
   namespace: argocd

--- a/manifests/cluster-install/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-install/argocd-server-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: argocd-server-clusterrole
+  name: argocd-server
 rules:
 - apiGroups:
   - '*'

--- a/manifests/cluster-install/argocd-server-clusterrolebinding.yaml
+++ b/manifests/cluster-install/argocd-server-clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: argocd-server-clusterrolebinding
+  name: argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argocd-server-clusterrole
+  name: argocd-server
 subjects:
 - kind: ServiceAccount
   name: argocd-server

--- a/manifests/cluster-install/kustomization.yaml
+++ b/manifests/cluster-install/kustomization.yaml
@@ -2,7 +2,7 @@ bases:
 - ../namespace-install
 
 resources:
-- application-controller-clusterrole.yaml
-- application-controller-clusterrolebinding.yaml
+- argocd-application-controller-clusterrole.yaml
+- argocd-application-controller-clusterrolebinding.yaml
 - argocd-server-clusterrole.yaml
 - argocd-server-clusterrolebinding.yaml

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -46,7 +46,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-application-controller-role
+  name: argocd-application-controller
 rules:
 - apiGroups:
   - ""
@@ -87,7 +87,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-server-role
+  name: argocd-server
 rules:
 - apiGroups:
   - ""
@@ -126,7 +126,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: dex-server-role
+  name: dex-server
 rules:
 - apiGroups:
   - ""
@@ -141,7 +141,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: argocd-application-controller-clusterrole
+  name: argocd-application-controller
 rules:
 - apiGroups:
   - '*'
@@ -157,7 +157,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: argocd-server-clusterrole
+  name: argocd-server
 rules:
 - apiGroups:
   - '*'
@@ -183,11 +183,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-application-controller-role-binding
+  name: argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-application-controller-role
+  name: argocd-application-controller
 subjects:
 - kind: ServiceAccount
   name: argocd-application-controller
@@ -195,11 +195,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-server-role-binding
+  name: argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-server-role
+  name: argocd-server
 subjects:
 - kind: ServiceAccount
   name: argocd-server
@@ -207,11 +207,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: dex-server-role-binding
+  name: dex-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: dex-server-role
+  name: dex-server
 subjects:
 - kind: ServiceAccount
   name: dex-server
@@ -219,11 +219,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: argocd-application-controller-clusterrolebinding
+  name: argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argocd-application-controller-clusterrole
+  name: argocd-application-controller
 subjects:
 - kind: ServiceAccount
   name: argocd-application-controller
@@ -232,11 +232,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: argocd-server-clusterrolebinding
+  name: argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argocd-server-clusterrole
+  name: argocd-server
 subjects:
 - kind: ServiceAccount
   name: argocd-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -46,7 +46,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: application-controller-role
+  name: argocd-application-controller-role
 rules:
 - apiGroups:
   - ""
@@ -141,7 +141,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: application-controller-clusterrole
+  name: argocd-application-controller-clusterrole
 rules:
 - apiGroups:
   - '*'
@@ -165,6 +165,7 @@ rules:
   - '*'
   verbs:
   - delete
+  - get
 - apiGroups:
   - ""
   resources:
@@ -182,14 +183,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: application-controller-role-binding
+  name: argocd-application-controller-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: application-controller-role
+  name: argocd-application-controller-role
 subjects:
 - kind: ServiceAccount
-  name: application-controller
+  name: argocd-application-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -218,14 +219,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: application-controller-clusterrolebinding
+  name: argocd-application-controller-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: application-controller-clusterrole
+  name: argocd-application-controller-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: application-controller
+  name: argocd-application-controller
   namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -260,13 +261,13 @@ type: Opaque
 apiVersion: v1
 kind: Service
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 spec:
   ports:
   - port: 8083
     targetPort: 8083
   selector:
-    app: application-controller
+    app: argocd-application-controller
 ---
 apiVersion: v1
 kind: Service
@@ -331,15 +332,15 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 spec:
   selector:
     matchLabels:
-      app: application-controller
+      app: argocd-application-controller
   template:
     metadata:
       labels:
-        app: application-controller
+        app: argocd-application-controller
     spec:
       containers:
       - command:
@@ -350,7 +351,7 @@ spec:
         - "10"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        name: application-controller
+        name: argocd-application-controller
         ports:
         - containerPort: 8083
         readinessProbe:
@@ -358,7 +359,7 @@ spec:
           periodSeconds: 10
           tcpSocket:
             port: 8083
-      serviceAccountName: application-controller
+      serviceAccountName: argocd-application-controller
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -46,7 +46,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: application-controller-role
+  name: argocd-application-controller-role
 rules:
 - apiGroups:
   - ""
@@ -141,14 +141,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: application-controller-role-binding
+  name: argocd-application-controller-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: application-controller-role
+  name: argocd-application-controller-role
 subjects:
 - kind: ServiceAccount
-  name: application-controller
+  name: argocd-application-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -193,13 +193,13 @@ type: Opaque
 apiVersion: v1
 kind: Service
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 spec:
   ports:
   - port: 8083
     targetPort: 8083
   selector:
-    app: application-controller
+    app: argocd-application-controller
 ---
 apiVersion: v1
 kind: Service
@@ -264,15 +264,15 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: application-controller
+  name: argocd-application-controller
 spec:
   selector:
     matchLabels:
-      app: application-controller
+      app: argocd-application-controller
   template:
     metadata:
       labels:
-        app: application-controller
+        app: argocd-application-controller
     spec:
       containers:
       - command:
@@ -283,7 +283,7 @@ spec:
         - "10"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        name: application-controller
+        name: argocd-application-controller
         ports:
         - containerPort: 8083
         readinessProbe:
@@ -291,7 +291,7 @@ spec:
           periodSeconds: 10
           tcpSocket:
             port: 8083
-      serviceAccountName: application-controller
+      serviceAccountName: argocd-application-controller
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -46,7 +46,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-application-controller-role
+  name: argocd-application-controller
 rules:
 - apiGroups:
   - ""
@@ -87,7 +87,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: argocd-server-role
+  name: argocd-server
 rules:
 - apiGroups:
   - ""
@@ -126,7 +126,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: dex-server-role
+  name: dex-server
 rules:
 - apiGroups:
   - ""
@@ -141,11 +141,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-application-controller-role-binding
+  name: argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-application-controller-role
+  name: argocd-application-controller
 subjects:
 - kind: ServiceAccount
   name: argocd-application-controller
@@ -153,11 +153,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-server-role-binding
+  name: argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-server-role
+  name: argocd-server
 subjects:
 - kind: ServiceAccount
   name: argocd-server
@@ -165,11 +165,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: dex-server-role-binding
+  name: dex-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: dex-server-role
+  name: dex-server
 subjects:
 - kind: ServiceAccount
   name: dex-server

--- a/util/diff/diff_test.go
+++ b/util/diff/diff_test.go
@@ -182,7 +182,7 @@ var demoConfig = `
     "labels": {
       "app.kubernetes.io/instance": "argocd-demo"
     },
-    "name": "application-controller"
+    "name": "argocd-application-controller"
   }
 }
 `
@@ -193,21 +193,21 @@ var demoLive = `
   "kind": "ServiceAccount",
   "metadata": {
     "annotations": {
-      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/instance\":\"argocd-demo\"},\"name\":\"application-controller\",\"namespace\":\"argocd-demo\"}}\n"
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/instance\":\"argocd-demo\"},\"name\":\"argocd-application-controller\",\"namespace\":\"argocd-demo\"}}\n"
     },
     "creationTimestamp": "2018-04-16T22:08:57Z",
     "labels": {
       "app.kubernetes.io/instance": "argocd-demo"
     },
-    "name": "application-controller",
+    "name": "argocd-application-controller",
     "namespace": "argocd-demo",
     "resourceVersion": "7584502",
-    "selfLink": "/api/v1/namespaces/argocd-demo/serviceaccounts/application-controller",
+    "selfLink": "/api/v1/namespaces/argocd-demo/serviceaccounts/argocd-application-controller",
     "uid": "c22bb2b4-41c2-11e8-978a-028445d52ec8"
   },
   "secrets": [
     {
-      "name": "application-controller-token-kfxct"
+      "name": "argocd-application-controller-token-kfxct"
     }
   ]
 }


### PR DESCRIPTION
This PR renames the various controller resources (and their corresponding YAML files) such that they'll be prefixed with 'argocd-', similarly to other core Argo CD resources.

Aside from improving consistency, this clarifies the origin of non-namespaced Argo CD resources such as `argocd-application-controller-clusterrole` (previously named `application-controller-clusterrole`).