### PR TITLE
Issue #910 - Reconstruct tree structure on the flight to avoid inconsistent state

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -96,6 +96,7 @@ func (c *liveStateCache) getCluster(server string) (*clusterInfo, error) {
 			apis:         make(map[schema.GroupVersionKind]v1.APIResource),
 			lock:         &sync.Mutex{},
 			nodes:        make(map[kube.ResourceKey]*node),
+			nsIndex:      make(map[string]map[kube.ResourceKey]*node),
 			onAppUpdated: c.onAppUpdated,
 			kubectl:      c.kubectl,
 			cluster:      cluster,


### PR DESCRIPTION
PR closes issue #910 . 

Also should simplify https://github.com/argoproj/argo-cd/issues/910 implementation. Force app refresh should just drop cache for all app namespaces.
