### PR TITLE
Diff library handles case where live object has null secret data

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -253,7 +253,7 @@ func hideSecretData(target *unstructured.Unstructured, live *unstructured.Unstru
 		if obj == nil {
 			continue
 		}
-		diff.EncodeSecretStringData(obj)
+		diff.NormalizeSecret(obj)
 		if data, found, err := unstructured.NestedMap(obj.Object, "data"); found && err == nil {
 			for k := range data {
 				keys[k] = true

--- a/util/diff/diff_test.go
+++ b/util/diff/diff_test.go
@@ -458,3 +458,22 @@ func TestInvalidSecretStringData(t *testing.T) {
 	dr := Diff(&configUn, nil)
 	assert.True(t, dr.Modified)
 }
+
+func TestNullSecretData(t *testing.T) {
+	configData, err := ioutil.ReadFile("testdata/wordpress-config.json")
+	assert.NoError(t, err)
+	liveData, err := ioutil.ReadFile("testdata/wordpress-live.json")
+	assert.NoError(t, err)
+	var configUn, liveUn unstructured.Unstructured
+	err = json.Unmarshal(configData, &configUn.Object)
+	assert.NoError(t, err)
+	err = json.Unmarshal(liveData, &liveUn.Object)
+	assert.NoError(t, err)
+
+	dr := Diff(&configUn, &liveUn)
+	if !assert.False(t, dr.Modified) {
+		ascii, err := dr.ASCIIFormat(&liveUn, formatOpts)
+		assert.Nil(t, err)
+		log.Println(ascii)
+	}
+}

--- a/util/diff/testdata/wordpress-config.json
+++ b/util/diff/testdata/wordpress-config.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": {
+    "name": "wordpress-wordpress",
+    "labels": {
+      "app": "wordpress-wordpress",
+      "chart": "wordpress-5.0.1",
+      "release": "wordpress",
+      "heritage": "Tiller"
+    }
+  },
+  "type": "Opaque",
+  "data": {
+    "wordpress-password": "Skt2T0tjMk5PdQ==",
+    "smtp-password": ""
+  }
+}

--- a/util/diff/testdata/wordpress-live.json
+++ b/util/diff/testdata/wordpress-live.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "v1",
+  "data": {
+    "smtp-password": null,
+    "wordpress-password": "Skt2T0tjMk5PdQ=="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"smtp-password\":\"\",\"wordpress-password\":\"Xkt2T0tjMk5PdQ==\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"wordpress-wordpress\",\"chart\":\"wordpress-5.0.1\",\"heritage\":\"Tiller\",\"release\":\"wordpress\"},\"name\":\"wordpress-wordpress\",\"namespace\":\"argocd\"},\"type\":\"Opaque\"}\n"
+    },
+    "creationTimestamp": "2018-12-19T09:15:40Z",
+    "labels": {
+      "app": "wordpress-wordpress",
+      "chart": "wordpress-5.0.1",
+      "heritage": "Tiller",
+      "release": "wordpress"
+    },
+    "name": "wordpress-wordpress",
+    "namespace": "argocd",
+    "resourceVersion": "27442",
+    "selfLink": "/api/v1/namespaces/argocd/secrets/wordpress-wordpress",
+    "uid": "a782f882-036e-11e9-92c4-ba8ba592c12d"
+  },
+  "type": "Opaque"
+}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-cd/issues/943

It's easy to get into a situation where kubernetes somehow converts a live object to have a null secret value, even though the submitted config objects were always applied with an empty string. This improves the diff library such that secrets are normalized before comparison.