### PR TITLE
Update aws-iam-authenticator to new version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,8 @@ ENV KUSTOMIZE_VERSION=1.0.11
 RUN curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kustomize
 
-ENV AWS_IAM_AUTHENTICATOR_VERSION=0.3.0
-RUN curl -L -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_IAM_AUTHENTICATOR_VERSION}/heptio-authenticator-aws_${AWS_IAM_AUTHENTICATOR_VERSION}_linux_amd64 && \
+ENV AWS_IAM_AUTHENTICATOR_VERSION=0.4.0-alpha.1
+RUN curl -L -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${AWS_IAM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AWS_IAM_AUTHENTICATOR_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 


### PR DESCRIPTION
This fixes the issue of getting "Unauthorized" error when argocd uses the aws-iam-authenticator v0.3.0.  #924 

The aws-iam-authenticator repo has changed the url a little for the download, those changes are reflected in the Dockerfile.

Tested on aws eks v3 kubernetes version 1.10.11