### PR TITLE
Handle diff corner case where Role/ClusterRole rules are null

### DIFF
--- a/util/diff/testdata/grafana-clusterrole-config.json
+++ b/util/diff/testdata/grafana-clusterrole-config.json
@@ -1,0 +1,14 @@
+{
+  "kind": "ClusterRole",
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "metadata": {
+    "labels": {
+      "app": "grafana",
+      "chart": "grafana-1.21.2",
+      "release": "grafana",
+      "heritage": "Tiller"
+    },
+    "name": "grafana-clusterrole"
+  },
+  "rules": []
+}

--- a/util/diff/testdata/grafana-clusterrole-live.json
+++ b/util/diff/testdata/grafana-clusterrole-live.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "ClusterRole",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"grafana\",\"chart\":\"grafana-1.21.2\",\"heritage\":\"Tiller\",\"release\":\"grafana\"},\"name\":\"grafana-clusterrole\"},\"rules\":[]}\n"
+    },
+    "creationTimestamp": "2018-12-26T23:26:41Z",
+    "labels": {
+      "app": "grafana",
+      "chart": "grafana-1.21.2",
+      "heritage": "Tiller",
+      "release": "grafana"
+    },
+    "name": "grafana-clusterrole",
+    "resourceVersion": "13174",
+    "selfLink": "/apis/rbac.authorization.k8s.io/v1/clusterroles/grafana-clusterrole",
+    "uid": "b30316d3-0965-11e9-9673-ae0a6e5594a2"
+  },
+  "rules": null
+}


### PR DESCRIPTION
Partially addresses #941.

When diffing a Role/ClusterRole which have empty rules, we will not consider `null` vs `[]` as a difference.

Also removes this warning which would always happen in CLI when diffing secrets (which got redacted):
```
WARN[0000] object unable to convert to secret: error decoding from json: illegal base64 data at input byte 0
```