### PR TITLE
Increase QPS and Burst used in K8s client configs to 25/50

### DIFF
--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -17,7 +17,7 @@ import (
 	// load the oidc plugin (required to authenticate with OpenID Connect).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	"github.com/argoproj/argo-cd"
+	argocd "github.com/argoproj/argo-cd"
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/controller"
 	"github.com/argoproj/argo-cd/errors"
@@ -54,6 +54,8 @@ func newCommand() *cobra.Command {
 			cli.SetGLogLevel(glogLevel)
 
 			config, err := clientConfig.ClientConfig()
+			config.QPS = common.K8sClientConfigQPS
+			config.Burst = common.K8sClientConfigBurst
 			errors.CheckError(err)
 
 			kubeClient := kubernetes.NewForConfigOrDie(config)

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -44,6 +44,8 @@ func NewCommand() *cobra.Command {
 
 			config, err := clientConfig.ClientConfig()
 			errors.CheckError(err)
+			config.QPS = common.K8sClientConfigQPS
+			config.Burst = common.K8sClientConfigBurst
 
 			namespace, _, err := clientConfig.Namespace()
 			errors.CheckError(err)

--- a/common/common.go
+++ b/common/common.go
@@ -31,6 +31,10 @@ const (
 	AuthCookieName = "argocd.token"
 	// RevisionHistoryLimit is the max number of successful sync to keep in history
 	RevisionHistoryLimit = 10
+	// K8sClientConfigQPS controls the QPS to be used in K8s REST client configs
+	K8sClientConfigQPS = 25
+	// K8sClientConfigBurst controls the burst to be used in K8s REST client configs
+	K8sClientConfigBurst = 50
 )
 
 // Dex related constants
@@ -88,4 +92,7 @@ const (
 	EnvVarSSODebug = "ARGOCD_SSO_DEBUG"
 	// EnvVarRBACDebug is an environment variable to enable additional RBAC debugging in the API server
 	EnvVarRBACDebug = "ARGOCD_RBAC_DEBUG"
+	// EnvVarFakeInClusterConfig is an environment variable to fake an in-cluster RESTConfig using
+	// the current kubectl context (for development purposes)
+	EnvVarFakeInClusterConfig = "ARGOCD_FAKE_IN_CLUSTER"
 )


### PR DESCRIPTION
This sets QPS and Burst to 25/50 respectively for K8s clients.
Also adds a developer environment variable `ARGOCD_FAKE_IN_CLUSTER` which allows a remote desktop environment to pretend to use the in-cluster config using the current kubectl context instead.

This builds off of PR https://github.com/argoproj/argo-cd/pull/982 so only look at last commit to see relevant changes.
