### PR TITLE
Eliminate reconcile hotloop by prevent Endpoint updates from requeuing apps

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -721,9 +721,9 @@ func (ctrl *ApplicationController) needRefreshAppStatus(app *appv1.Application, 
 	expired := app.Status.ObservedAt.Add(statusRefreshTimeout).Before(time.Now().UTC())
 	if requestedType, ok := app.IsRefreshRequested(); ok {
 		refreshType = requestedType
-		reason = fmt.Sprintf("refresh requested (%s)", refreshType)
+		reason = fmt.Sprintf("%s refresh requested", refreshType)
 	} else if ctrl.isRefreshRequested(app.Name) {
-		reason = fmt.Sprintf("refresh requested (%s)", refreshType)
+		reason = fmt.Sprintf("controller refresh requested")
 	} else if app.Status.Sync.Status == appv1.SyncStatusCodeUnknown && expired {
 		reason = "comparison status unknown"
 	} else if !app.Spec.Source.Equals(app.Status.Sync.ComparedTo.Source) {


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-cd/issues/985

This change ignores any Endpoint updates from causing an app to get queued for reconciliation. The endpoint metadata will still get saved to live state cache.

Endpoints are not managed resources for users and have no Sync or Health status, so it's unnecessary to have them cause an app refresh. Note that we may encounter more resources like this.