### PR TITLE
Correct "basehref " in the sample UI base path

### DIFF
--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -143,7 +143,7 @@ spec:
         - /shared/app
         - --repo-server
         - argocd-repo-server:8081
-        - --base-href
+        - --basehref
         - /argo-cd
 ```
 


### PR DESCRIPTION
The UI path example in  _https://github.com/argoproj/argo-cd/blob/master/docs/ingress.md#ui-base-path_  should be "**- --basehref**" instead of "**- --base-href**" in the ingress documentation.