### PR TITLE
Controller cache was susceptible to clock skew in managed cluster

### DIFF
--- a/test/e2e/functional/crd-creation/README.md
+++ b/test/e2e/functional/crd-creation/README.md
@@ -1,0 +1,7 @@
+```
+argocd app create crd-creation \
+  --repo https://github.com/argoproj/argo-cd.git \
+  --path test/e2e/functional/crd-creation \
+  --dest-server https://kubernetes.default.svc \
+  --dest-namespace default
+```

--- a/test/e2e/functional/crd-creation/crd-instances.yaml
+++ b/test/e2e/functional/crd-creation/crd-instances.yaml
@@ -8,7 +8,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Dummy
 metadata:
   name: dummy-crd-instance
-  namespace: default
+  namespace: kube-system
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ClusterDummy


### PR DESCRIPTION
Instead of relying on creationTimestamp, we remember all CRDs installed at the beginning of the watch, and restart the watch when we see a new CRD installed.