### PR TITLE
Fix controller deadlock when checking for stale cache

### DIFF
--- a/test/e2e/functional/crd-creation/README.md
+++ b/test/e2e/functional/crd-creation/README.md
@@ -1,0 +1,7 @@
+```
+argocd app create crd-creation \
+  --repo https://github.com/argoproj/argo-cd.git \
+  --path test/e2e/functional/crd-creation \
+  --dest-server https://kubernetes.default.svc \
+  --dest-namespace default
+```

--- a/test/e2e/functional/crd-creation/crd-instances.yaml
+++ b/test/e2e/functional/crd-creation/crd-instances.yaml
@@ -8,7 +8,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Dummy
 metadata:
   name: dummy-crd-instance
-  namespace: default
+  namespace: kube-system
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ClusterDummy


### PR DESCRIPTION
Resolves #1044.

It was possible for getManagedLiveObjs() to attempt a re-entrant lock acquire when it received a NotFound error from the API server and subsequently went to check if we needed to invalidate our cache.