### PR TITLE
Enable docker buildkit in ci builds

### DIFF
--- a/.argo-ci/ci.yaml
+++ b/.argo-ci/ci.yaml
@@ -79,6 +79,8 @@ spec:
       env:
       - name: DOCKER_HOST
         value: 127.0.0.1
+      - name: DOCKER_BUILDKIT
+        value: "1"
       resources:
         requests:
           memory: 1024Mi

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # Install docker
-ENV DOCKER_VERSION=18.06.0
-RUN curl -O https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}-ce.tgz && \
-  tar -xzf docker-${DOCKER_VERSION}-ce.tgz && \
-  mv docker/docker /usr/local/bin/docker && \
-  rm -rf ./docker
+ENV DOCKER_CHANNEL stable
+ENV DOCKER_VERSION 18.09.1
+RUN wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" && \
+    tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \
+    rm docker.tgz
 
 # Install dep
 ENV DEP_VERSION=0.5.0

--- a/README.md
+++ b/README.md
@@ -90,17 +90,6 @@ For additional details, see [architecture overview](docs/architecture.md).
 * Argo CD is actively developed and is being used in production to deploy SaaS services at Intuit
 
 ## Roadmap
-### v0.11
-
-* New application controller architecture
-* Multi-namespaced applications
-* Large application support
-* Resource lifecycle hook improvements
-* K8s recommended application labels
-* External OIDC provider support
-* OIDC group claims bindings to Project Roles
-* Declarative Argo CD configuration
-* Helm repository support
 
 ### v0.12
 * Support for custom K8S manifest templating engines


### PR DESCRIPTION
I noticed that enabling DOCKER_BUILDKIT=1 in argo's CI improved the build speed. Would like the same treatment in CD.