### PR TITLE
Issue #1065 - Support using grpc-web in argocd cli

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -401,6 +401,14 @@
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:09aa5dd1332b93c96bde671bafb053249dc813febf7d5ca84e8f382ba255d67d"
+  name = "github.com/gorilla/websocket"
+  packages = ["."]
+  pruneopts = ""
+  revision = "66b9c49e59c6c48f0ffce28c2d8b8a5678502c6d"
+  version = "v1.4.0"
+
+[[projects]]
   branch = "master"
   digest = "1:009a1928b8c096338b68b5822d838a72b4d8520715c1463614476359f3282ec8"
   name = "github.com/gregjones/httpcache"
@@ -466,6 +474,14 @@
   pruneopts = ""
   revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
   version = "0.3.2"
+
+[[projects]]
+  digest = "1:6f7a8f1f3e04174c426eea1c8661ef49a6b4c63bd2e40c0ad74b5ba9051f4812"
+  name = "github.com/improbable-eng/grpc-web"
+  packages = ["go/grpcweb"]
+  pruneopts = ""
+  revision = "16092bd1d58ae1b3c2d8be1cb67e65956f945dea"
+  version = "0.7.0"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -660,6 +676,14 @@
   ]
   pruneopts = ""
   revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
+
+[[projects]]
+  digest = "1:5f47c69f85311c4dc292be6cc995a0a3fe8337a6ce38ef4f71e5b7efd5ad42e0"
+  name = "github.com/rs/cors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "9a47f48565a795472d43519dd49aac781f3034fb"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
@@ -1425,6 +1449,7 @@
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
     "github.com/grpc-ecosystem/grpc-gateway/runtime",
     "github.com/grpc-ecosystem/grpc-gateway/utilities",
+    "github.com/improbable-eng/grpc-web/go/grpcweb",
     "github.com/patrickmn/go-cache",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",

--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -112,6 +112,7 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 				Server:    server,
 				PlainText: globalClientOpts.PlainText,
 				Insecure:  globalClientOpts.Insecure,
+				GRPCWeb:   globalClientOpts.GRPCWeb,
 			})
 			localCfg.UpsertUser(localconfig.User{
 				Name:         ctxName,

--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -46,6 +46,7 @@ func NewReloginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comm
 				ConfigPath: "",
 				ServerAddr: configCtx.Server.Server,
 				Insecure:   configCtx.Server.Insecure,
+				GRPCWeb:    globalClientOpts.GRPCWeb,
 				PlainText:  configCtx.Server.PlainText,
 			}
 			acdClient := argocdclient.NewClientOrDie(&clientOpts)

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -54,6 +54,7 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().BoolVar(&clientOpts.Insecure, "insecure", false, "Skip server certificate and domain verification")
 	command.PersistentFlags().StringVar(&clientOpts.CertFile, "server-crt", "", "Server certificate file")
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", "", "Authentication token")
+	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", false, "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	return command
 }

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -1,0 +1,202 @@
+package apiclient
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	argocderrors "github.com/argoproj/argo-cd/errors"
+	"github.com/argoproj/argo-cd/util"
+)
+
+const (
+	frameHeaderLength = 5
+	endOfStreamFlag   = 128
+)
+
+type noopCodec struct{}
+
+func (noopCodec) Marshal(v interface{}) ([]byte, error) {
+	return v.([]byte), nil
+}
+
+func (noopCodec) Unmarshal(data []byte, v interface{}) error {
+	pointer := v.(*[]byte)
+	*pointer = data
+	return nil
+}
+
+func (noopCodec) String() string {
+	return "bytes"
+}
+
+type inlineCloser struct {
+	close func() error
+}
+
+func (c *inlineCloser) Close() error {
+	return c.close()
+}
+
+func toFrame(msg []byte) []byte {
+	frame := append([]byte{0, 0, 0, 0}, msg...)
+	binary.BigEndian.PutUint32(frame, uint32(len(msg)))
+	frame = append([]byte{0}, frame...)
+	return frame
+}
+
+func (c *client) executeRequest(fullMethodName string, msg []byte, md metadata.MD) (*http.Response, error) {
+	schema := "https"
+	if c.PlainText {
+		schema = "http"
+	}
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s://%s%s", schema, c.ServerAddr, fullMethodName), bytes.NewReader(toFrame(msg)))
+	if err != nil {
+		return nil, err
+	}
+	if md != nil {
+		for k, v := range md {
+			if strings.HasPrefix(k, ":") {
+				continue
+			}
+			for i := range v {
+				req.Header.Set(k, v[i])
+			}
+		}
+	}
+	req.Header.Set("content-type", "application/grpc-web+proto")
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: c.Insecure},
+	}}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	var code codes.Code
+	if statusStr := resp.Header.Get("Grpc-Status"); statusStr != "" {
+		statusInt, err := strconv.Atoi(statusStr)
+		if err != nil {
+			code = codes.Unknown
+		} else {
+			code = codes.Code(statusInt)
+		}
+		if code != codes.OK {
+			return nil, status.Error(code, resp.Header.Get("Grpc-Message"))
+		}
+	}
+	return resp, nil
+}
+
+func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
+	serverAddr := fmt.Sprintf("%s/argocd-%d.sock", os.TempDir(), time.Now().Unix())
+	ln, err := net.Listen("unix", serverAddr)
+
+	if err != nil {
+		return nil, nil, err
+	}
+	proxySrv := grpc.NewServer(
+		grpc.CustomCodec(&noopCodec{}),
+		grpc.UnknownServiceHandler(func(srv interface{}, stream grpc.ServerStream) error {
+			fullMethodName, ok := grpc.MethodFromServerStream(stream)
+			if !ok {
+				return fmt.Errorf("Unable to get method name from stream context.")
+			}
+			msg := make([]byte, 0)
+			err = stream.RecvMsg(&msg)
+			if err != nil {
+				return err
+			}
+			md, _ := metadata.FromIncomingContext(stream.Context())
+			resp, err := c.executeRequest(fullMethodName, msg, md)
+			if err != nil {
+				return err
+			}
+
+			go func() {
+				select {
+				case <-stream.Context().Done():
+					util.Close(resp.Body)
+				}
+			}()
+			defer util.Close(resp.Body)
+
+			for {
+				header := make([]byte, frameHeaderLength)
+				if _, err := resp.Body.Read(header); err != nil {
+					if err == io.EOF {
+						err = io.ErrUnexpectedEOF
+					}
+					return err
+				}
+
+				if header[0] == endOfStreamFlag {
+					return nil
+				}
+				length := int(binary.BigEndian.Uint32(header[1:frameHeaderLength]))
+				data := make([]byte, length)
+				if read, err := resp.Body.Read(data); err != nil {
+					if err != io.EOF {
+						return err
+					} else if read < length {
+						return io.ErrUnexpectedEOF
+					} else {
+						return nil
+					}
+				}
+
+				if err := stream.SendMsg(data); err != nil {
+					return err
+				}
+
+			}
+		}))
+	go func() {
+		err := proxySrv.Serve(ln)
+		argocderrors.CheckError(err)
+	}()
+	return proxySrv, ln, nil
+}
+
+// useGRPCProxy ensures that grpc proxy server is started and return closer which stops server when no one uses it
+func (c *client) useGRPCProxy() (net.Addr, io.Closer, error) {
+	c.proxyMutex.Lock()
+	defer c.proxyMutex.Unlock()
+
+	if c.proxyListener == nil {
+		var err error
+		c.proxyServer, c.proxyListener, err = c.startGRPCProxy()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	c.proxyUsersCount = c.proxyUsersCount + 1
+
+	return c.proxyListener.Addr(), &inlineCloser{close: func() error {
+		c.proxyMutex.Lock()
+		defer c.proxyMutex.Unlock()
+		c.proxyUsersCount = c.proxyUsersCount - 1
+		if c.proxyUsersCount == 0 {
+			c.proxyServer.Stop()
+			err := c.proxyListener.Close()
+			c.proxyListener = nil
+			c.proxyServer = nil
+			return err
+		}
+		return nil
+	}}, nil
+}

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -38,6 +38,8 @@ type Server struct {
 	Server string `json:"server"`
 	// Insecure indicates to connect to the server over TLS insecurely
 	Insecure bool `json:"insecure,omitempty"`
+	// GRPCWeb indicates to connect to the server using gRPC Web protocol
+	GRPCWeb bool `json:"grpc-web,omitempty"`
 	// CACertificateAuthorityData is the base64 string of a PEM encoded certificate
 	// TODO: not yet implemented
 	CACertificateAuthorityData string `json:"certificate-authority-data,omitempty"`


### PR DESCRIPTION
Closes #1065 

The generated swagger client is not great ( partially because  it is generated from generated swagger.json ) 

Instead of swagger client, this PR introduces grpc-web protocol support in argocd cli. The [grpc-web](https://github.com/grpc/grpc-web) is grpc for browsers and it works on top of http1.0. 

Server-side support is already implemented by https://github.com/improbable-eng/grpc-web/. Unfortunately, there is no golang client for grpc-web. As workaround following trick we implemented:
if grpc-web is enabled then cli starts local grpc server which listens to socket file and points the regular grpc client to the socket file. Local grpc server works as a reverse proxy: receives grpc requests, converts requests to grpc-web and forward to Argo CD server.