### PR TITLE
Nil out application sources if source spec is equal to their zero value

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -385,7 +385,7 @@ func setAppOptions(flags *pflag.FlagSet, app *argoappv1.Application, appOpts *ap
 		case "values":
 			setHelmOpt(&app.Spec.Source, appOpts.valuesFiles)
 		case "directory-recurse":
-			app.Spec.Source.Directory = &argoappv1.ApplicationSourceDirectory{Recurse: true}
+			app.Spec.Source.Directory = &argoappv1.ApplicationSourceDirectory{Recurse: appOpts.directoryRecurse}
 		case "dest-server":
 			app.Spec.Destination.Server = appOpts.destServer
 		case "dest-namespace":

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -113,12 +113,16 @@ type ApplicationSourceKsonnet struct {
 	Environment string `json:"environment,omitempty" protobuf:"bytes,1,opt,name=environment"`
 }
 
+func (k *ApplicationSourceKsonnet) IsZero() bool {
+	return k.Environment == ""
+}
+
 type ApplicationSourceDirectory struct {
 	Recurse bool `json:"recurse,omitempty" protobuf:"bytes,1,opt,name=recurse"`
 }
 
-func (k *ApplicationSourceKsonnet) IsZero() bool {
-	return k.Environment == ""
+func (d *ApplicationSourceDirectory) IsZero() bool {
+	return d.Recurse == false
 }
 
 // ApplicationDestination contains deployment destination information

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -485,7 +485,21 @@ func NormalizeApplicationSpec(spec *argoappv1.ApplicationSpec) *argoappv1.Applic
 	if spec.Source.Helm != nil {
 		spec.Source.ValuesFiles = spec.Source.Helm.ValueFiles
 	}
-	if spec.Source.Directory != nil && !spec.Source.Directory.Recurse {
+	// 3. If any app sources are their zero values, then nil out the pointers to the source spec.
+	// This makes it easier for users to switch between app source types if they are not using
+	// any of the source-specific parameters.
+	if spec.Source.Kustomize != nil && spec.Source.Kustomize.IsZero() {
+		spec.Source.Kustomize = nil
+	}
+	if spec.Source.Helm != nil && spec.Source.Helm.IsZero() {
+		spec.Source.Helm = nil
+		spec.Source.ValuesFiles = nil
+	}
+	if spec.Source.Ksonnet != nil && spec.Source.Ksonnet.IsZero() {
+		spec.Source.Ksonnet = nil
+		spec.Source.Environment = ""
+	}
+	if spec.Source.Directory != nil && spec.Source.Directory.IsZero() {
 		spec.Source.Directory = nil
 	}
 	return spec


### PR DESCRIPTION
This change makes the client side behavior of nil-ing out source specs if they are nothing but their zero-value.
Also fixes the ability to unset directory-recurse from the command line.