### PR TITLE
Fix issue where dex restart could cause login failures

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 controller: go run ./cmd/argocd-application-controller/main.go --redis localhost:6379 --repo-server localhost:8081
-api-server: go run ./cmd/argocd-server/main.go --redis localhost:6379 --insecure --disable-auth --dex-server http://localhost:5556 --repo-server localhost:8081 --app-controller-server localhost:8083 --staticassets ../argo-cd-ui/dist/app
+api-server: go run ./cmd/argocd-server/main.go --redis localhost:6379 --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --app-controller-server localhost:8083 --staticassets ../argo-cd-ui/dist/app
 repo-server: go run ./cmd/argocd-repo-server/main.go --loglevel debug --redis localhost:6379
-dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p 5556:5556 -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/dexidp/dex:v2.12.0 serve /dex.yaml"
-redis: docker run --rm -i -p 6379:6379 redis:5.0.3-alpine
+dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p 5556:5556 -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/dexidp/dex:v2.14.0 serve /dex.yaml"
+redis: docker run --rm -i -p 6379:6379 redis:5.0.3-alpine --save "" --appendonly no

--- a/util/http/http.go
+++ b/util/http/http.go
@@ -2,7 +2,11 @@ package http
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httputil"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // MakeCookieMetadata generates a string representing a Web cookie.  Yum!
@@ -12,4 +16,30 @@ func MakeCookieMetadata(key, value string, flags ...string) string {
 	}
 	components = append(components, flags...)
 	return strings.Join(components, "; ")
+}
+
+// DebugTransport is a HTTP Client Transport to enable debugging
+type DebugTransport struct {
+	T http.RoundTripper
+}
+
+func (d DebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqDump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("%s", reqDump)
+
+	resp, err := d.T.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	respDump, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	log.Printf("%s", respDump)
+	return resp, nil
 }

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -2,7 +2,6 @@ package oidc
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -55,8 +54,8 @@ type ClientApp struct {
 	secureCookie bool
 	// settings holds Argo CD settings
 	settings *settings.ArgoCDSettings
-	// provider is the OIDC configuration
-	provider *gooidc.Provider
+	// provider is the OIDC provider
+	provider Provider
 	// cache holds temporary nonce tokens to which hold application state values
 	// See http://tools.ietf.org/html/rfc6749#section-10.12 for more info.
 	cache *cache.Cache
@@ -98,6 +97,11 @@ func NewClientApp(settings *settings.ArgoCDSettings, cache *cache.Cache) (*Clien
 			ExpectContinueTimeout: 1 * time.Second,
 		},
 	}
+	if os.Getenv(common.EnvVarSSODebug) == "1" {
+		a.client.Transport = httputil.DebugTransport{T: a.client.Transport}
+	}
+
+	a.provider = NewOIDCProvider(a.issuerURL, a.client)
 	// NOTE: if we ever have replicas of Argo CD, this needs to switch to Redis cache
 	a.secureCookie = bool(u.Scheme == "https")
 	a.settings = settings
@@ -105,14 +109,14 @@ func NewClientApp(settings *settings.ArgoCDSettings, cache *cache.Cache) (*Clien
 }
 
 func (a *ClientApp) oauth2Config(scopes []string) (*oauth2.Config, error) {
-	provider, err := a.oidcProvider()
+	endpoint, err := a.provider.Endpoint()
 	if err != nil {
 		return nil, err
 	}
 	return &oauth2.Config{
 		ClientID:     a.clientID,
 		ClientSecret: a.clientSecret,
-		Endpoint:     provider.Endpoint(),
+		Endpoint:     *endpoint,
 		Scopes:       scopes,
 		RedirectURL:  a.redirectURI,
 	}, nil
@@ -149,12 +153,7 @@ func (a *ClientApp) verifyAppState(state string) (*cache.OIDCState, error) {
 // HandleLogin formulates the proper OAuth2 URL (auth code or implicit) and redirects the user to
 // the IDp login & consent page
 func (a *ClientApp) HandleLogin(w http.ResponseWriter, r *http.Request) {
-	provider, err := a.oidcProvider()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	oidcConf, err := ParseConfig(provider)
+	oidcConf, err := a.provider.ParseConfig()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -184,7 +183,6 @@ func (a *ClientApp) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 // HandleCallback is the callback handler for an OAuth2 login flow
 func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
-	ctx := gooidc.ClientContext(r.Context(), a.client)
 	oauth2Config, err := a.oauth2Config(nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -207,6 +205,7 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	ctx := gooidc.ClientContext(r.Context(), a.client)
 	token, err := oauth2Config.Exchange(ctx, code)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to get token: %v", err), http.StatusInternalServerError)
@@ -217,7 +216,7 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no id_token in token response", http.StatusInternalServerError)
 		return
 	}
-	idToken, err := a.verify(idTokenRAW)
+	idToken, err := a.provider.Verify(a.clientID, idTokenRAW)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("invalid session token: %v", err), http.StatusInternalServerError)
 		return
@@ -283,41 +282,6 @@ func (a *ClientApp) handleImplicitFlow(w http.ResponseWriter, r *http.Request, s
 	renderTemplate(w, implicitFlowTmpl, vals)
 }
 
-func (a *ClientApp) oidcProvider() (*gooidc.Provider, error) {
-	if a.provider != nil {
-		return a.provider, nil
-	}
-	provider, err := NewOIDCProvider(a.issuerURL, a.client)
-	if err != nil {
-		return nil, err
-	}
-	a.provider = provider
-	return a.provider, nil
-}
-
-func (a *ClientApp) verify(tokenString string) (*gooidc.IDToken, error) {
-	provider, err := a.oidcProvider()
-	if err != nil {
-		return nil, err
-	}
-	verifier := provider.Verifier(&gooidc.Config{ClientID: a.clientID})
-	return verifier.Verify(context.Background(), tokenString)
-}
-
-// NewOIDCProvider initializes an OIDC provider, querying the well known oidc configuration path
-// http://example-argocd.com/api/dex/.well-known/openid-configuration
-func NewOIDCProvider(issuerURL string, client *http.Client) (*gooidc.Provider, error) {
-	log.Infof("Initializing OIDC provider (issuer: %s)", issuerURL)
-	ctx := gooidc.ClientContext(context.Background(), client)
-	provider, err := gooidc.NewProvider(ctx, issuerURL)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to query provider %q: %v", issuerURL, err)
-	}
-	s, _ := ParseConfig(provider)
-	log.Infof("OIDC supported scopes: %v", s.ScopesSupported)
-	return provider, nil
-}
-
 // ImplicitFlowURL is an adaptation of oauth2.Config::AuthCodeURL() which returns a URL
 // appropriate for an OAuth2 implicit login flow (as opposed to authorization code flow).
 func ImplicitFlowURL(c *oauth2.Config, state string, opts ...oauth2.AuthCodeOption) string {
@@ -372,16 +336,6 @@ func OfflineAccess(scopes []string) bool {
 		}
 	}
 	return false
-}
-
-// ParseConfig parses the OIDC Config into the concrete datastructure
-func ParseConfig(provider *gooidc.Provider) (*OIDCConfiguration, error) {
-	var conf OIDCConfiguration
-	err := provider.Claims(&conf)
-	if err != nil {
-		return nil, err
-	}
-	return &conf, nil
 }
 
 // InferGrantType infers the proper grant flow depending on the OAuth2 client config and OIDC configuration.

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -5,9 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"golang.org/x/oauth2"
-
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
 )
 
 var (

--- a/util/oidc/provider.go
+++ b/util/oidc/provider.go
@@ -1,0 +1,133 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	gooidc "github.com/coreos/go-oidc"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+// Provider is a wrapper around go-oidc provider to also provide the following features:
+// 1. lazy initialization/querying of the provider
+// 2. automatic detection of change in signing keys
+// 3. convenience function for verifying tokens
+// We have to initialize the provider lazily since Argo CD can be an OIDC client to itself (in the
+// case of dex reverse proxy), which presents a chicken-and-egg problem of (1) serving dex over
+// HTTP, and (2) querying the OIDC provider (ourself) to initialize the OIDC client.
+type Provider interface {
+	Endpoint() (*oauth2.Endpoint, error)
+
+	ParseConfig() (*OIDCConfiguration, error)
+
+	Verify(clientID, tokenString string) (*gooidc.IDToken, error)
+}
+
+type providerImpl struct {
+	issuerURL      string
+	client         *http.Client
+	goOIDCProvider *gooidc.Provider
+}
+
+// NewOIDCProvider initializes an OIDC provider
+func NewOIDCProvider(issuerURL string, client *http.Client) Provider {
+	return &providerImpl{
+		issuerURL: issuerURL,
+		client:    client,
+	}
+}
+
+// oidcProvider lazily initializes, memoizes, and returns the OIDC provider.
+func (p *providerImpl) provider() (*gooidc.Provider, error) {
+	if p.goOIDCProvider != nil {
+		return p.goOIDCProvider, nil
+	}
+	prov, err := p.newGoOIDCProvider()
+	if err != nil {
+		return nil, err
+	}
+	p.goOIDCProvider = prov
+	return p.goOIDCProvider, nil
+}
+
+// newGoOIDCProvider creates a new instance of go-oidc.Provider querying the well known oidc
+// configuration path (http://example-argocd.com/api/dex/.well-known/openid-configuration)
+func (p *providerImpl) newGoOIDCProvider() (*gooidc.Provider, error) {
+	log.Infof("Initializing OIDC provider (issuer: %s)", p.issuerURL)
+	ctx := gooidc.ClientContext(context.Background(), p.client)
+	prov, err := gooidc.NewProvider(ctx, p.issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to query provider %q: %v", p.issuerURL, err)
+	}
+	s, _ := ParseConfig(prov)
+	log.Infof("OIDC supported scopes: %v", s.ScopesSupported)
+	return prov, nil
+}
+
+func (p *providerImpl) Verify(clientID, tokenString string) (*gooidc.IDToken, error) {
+	ctx := context.Background()
+	prov, err := p.provider()
+	if err != nil {
+		return nil, err
+	}
+	verifier := prov.Verifier(&gooidc.Config{ClientID: clientID})
+	idToken, err := verifier.Verify(ctx, tokenString)
+	if err != nil {
+		// HACK: if we failed token verification, it's possible the reason was because dex
+		// restarted and has new JWKS signing keys (we do not back dex with persistent storage
+		// so keys might be regenerated). Detect this by:
+		// 1. looking for the specific error message
+		// 2. re-initializing the OIDC provider
+		// 3. re-attempting token verification
+		// NOTE: the error message is sensitive to implementation of verifier.Verify()
+		if !strings.Contains(err.Error(), "failed to verify signature") {
+			return nil, err
+		}
+		newProvider, retryErr := p.newGoOIDCProvider()
+		if retryErr != nil {
+			// return original error if we fail to re-initialize OIDC
+			return nil, err
+		}
+		verifier = newProvider.Verifier(&gooidc.Config{ClientID: clientID})
+		idToken, err = verifier.Verify(ctx, tokenString)
+		if err != nil {
+			return nil, err
+		}
+		// If we get here, we successfully re-initialized OIDC and after re-initialization,
+		// the token is now valid.
+		log.Info("New OIDC settings detected")
+		p.goOIDCProvider = newProvider
+	}
+	return idToken, nil
+}
+
+func (p *providerImpl) Endpoint() (*oauth2.Endpoint, error) {
+	prov, err := p.provider()
+	if err != nil {
+		return nil, err
+	}
+	endpoint := prov.Endpoint()
+	return &endpoint, nil
+}
+
+// ParseConfig parses the OIDC Config into the concrete datastructure
+func (p *providerImpl) ParseConfig() (*OIDCConfiguration, error) {
+	prov, err := p.provider()
+	if err != nil {
+		return nil, err
+	}
+	return ParseConfig(prov)
+}
+
+// ParseConfig parses the OIDC Config into the concrete datastructure
+func ParseConfig(provider *gooidc.Provider) (*OIDCConfiguration, error) {
+	var conf OIDCConfiguration
+	err := provider.Claims(&conf)
+	if err != nil {
+		return nil, err
+	}
+	return &conf, nil
+}


### PR DESCRIPTION
This change introduces a Provider interface wrapper around go-oidc's Provider and adds the following features:
1. lazy initialization/querying of the provider
2. automatic detection of change in signing keys
3. convenience function for verifying tokens

Much of this code was already implemented, so this is mostly refactoring effort. However, until now, the logic was not shared between sessionmanager and the login callback. 

I was able to reproduce login failure after dex restart issue and verified the fix manually.