### PR TITLE
Prevent deletion hotloop. Improve reconciliation log for easier log queries

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -604,8 +604,9 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	}
 	startTime := time.Now()
 	defer func() {
-		logCtx := log.WithFields(log.Fields{"application": origApp.Name})
-		logCtx.Infof("Reconciliation completed in %v", time.Now().Sub(startTime))
+		durationMs := time.Now().Sub(startTime).Seconds() * 1e3
+		logCtx := log.WithFields(log.Fields{"application": origApp.Name, "time_ms": durationMs})
+		logCtx.Info("Reconciliation completed")
 	}()
 	// NOTE: normalization returns a copy
 	app := ctrl.normalizeApplication(origApp)


### PR DESCRIPTION
The act of deleting a resource would cause another immediate reconcile of the app, because the deletion timestamp of the resource would get updated, causing the app to get requeued, and thus a hot loop. This change only deletes resources which do not have a deletion timestamp. Attempting a second delete again did not serve any purpose anyways. 

Also resolves https://github.com/argoproj/argo-cd/issues/1112