### PR TITLE
Exclude metrics.k8s.io from watch

### DIFF
--- a/util/kube/ctl.go
+++ b/util/kube/ctl.go
@@ -54,7 +54,7 @@ func (k KubectlCmd) GetAPIResources(config *rest.Config) ([]*metav1.APIResourceL
 func (k KubectlCmd) GetResources(config *rest.Config, namespace string) ([]*unstructured.Unstructured, error) {
 
 	listSupported := func(groupVersion string, apiResource *metav1.APIResource) bool {
-		return isSupportedVerb(apiResource, listVerb) && !isExcludedResourceGroup(*apiResource)
+		return isSupportedVerb(apiResource, listVerb) && !isExcludedResourceGroup(apiResource.Group)
 	}
 	apiResIfs, err := filterAPIResources(config, listSupported, namespace)
 	if err != nil {
@@ -97,7 +97,7 @@ func (k KubectlCmd) WatchResources(
 	namespace string,
 ) (chan watch.Event, error) {
 	watchSupported := func(groupVersion string, apiResource *metav1.APIResource) bool {
-		return isSupportedVerb(apiResource, watchVerb) && !isExcludedResourceGroup(*apiResource)
+		return isSupportedVerb(apiResource, watchVerb) && !isExcludedResourceGroup(apiResource.Group)
 	}
 	log.Infof("Start watching for resources changes with in cluster %s", config.Host)
 	apiResIfs, err := filterAPIResources(config, watchSupported, namespace)

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -246,8 +246,15 @@ func IsCRD(obj *unstructured.Unstructured) bool {
 	return IsCRDGroupVersionKind(obj.GroupVersionKind())
 }
 
-func isExcludedResourceGroup(resource metav1.APIResource) bool {
-	return false
+// excludedAPIGroups is a list of groups that we do not care to monitor
+var excludedAPIGroups = map[string]bool{
+	"events.k8s.io":  true,
+	"metrics.k8s.io": true,
+}
+
+func isExcludedResourceGroup(group string) bool {
+	_, ok := excludedAPIGroups[group]
+	return ok
 }
 
 type apiResourceInterface struct {
@@ -280,7 +287,7 @@ func filterAPIResources(config *rest.Config, filter filterFunc, namespace string
 		if err != nil {
 			gv = schema.GroupVersion{}
 		}
-		if gv.Group == "events.k8s.io" {
+		if isExcludedResourceGroup(gv.Group) {
 			continue
 		}
 		for _, apiResource := range apiResourcesList.APIResources {


### PR DESCRIPTION
Resolves #1127: 
`metrics.k8s.io` is not a resource that users ever manage or wish to see from UI, and should be excluded, just like `events.k8s.io`