### PR TITLE
Add application sync counters as new prometheus metric. Add API-server metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -498,6 +498,14 @@
   revision = "bc372cc64f55abd91995ba3f219b380ffbc59e9d"
 
 [[projects]]
+  digest = "1:e24dc5ef44694848785de507f439a24e9e6d96d7b43b8cf3d6cfa857aa1e2186"
+  name = "github.com/grpc-ecosystem/go-grpc-prometheus"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c225b8c3b01faf2899099b768856a9e916e5087b"
+  version = "v1.2.0"
+
+[[projects]]
   digest = "1:9feb7485bc57adbcbc1e1037ca05588e9d8b0a3a1875fbf730021fc118859b75"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
@@ -1567,6 +1575,7 @@
     "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus",
     "github.com/grpc-ecosystem/go-grpc-middleware/retry",
     "github.com/grpc-ecosystem/go-grpc-middleware/tags/logrus",
+    "github.com/grpc-ecosystem/go-grpc-prometheus",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
     "github.com/grpc-ecosystem/grpc-gateway/runtime",

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 controller: go run ./cmd/argocd-application-controller/main.go --redis localhost:6379 --repo-server localhost:8081
-api-server: go run ./cmd/argocd-server/main.go --redis localhost:6379 --disable-auth --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --app-controller-server localhost:8083 --staticassets ../argo-cd-ui/dist/app
+api-server: go run ./cmd/argocd-server/main.go --redis localhost:6379 --disable-auth --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ../argo-cd-ui/dist/app
 repo-server: go run ./cmd/argocd-repo-server/main.go --loglevel debug --redis localhost:6379
 dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p 5556:5556 -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/dexidp/dex:v2.14.0 serve /dex.yaml"
 redis: docker run --rm -i -p 6379:6379 redis:5.0.3-alpine --save "" --appendonly no

--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/argoproj/argo-cd/util/cache"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -24,6 +22,7 @@ import (
 	"github.com/argoproj/argo-cd/errors"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-cd/reposerver"
+	"github.com/argoproj/argo-cd/util/cache"
 	"github.com/argoproj/argo-cd/util/cli"
 	"github.com/argoproj/argo-cd/util/settings"
 	"github.com/argoproj/argo-cd/util/stats"

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -22,18 +22,17 @@ import (
 // NewCommand returns a new instance of an argocd command
 func NewCommand() *cobra.Command {
 	var (
-		insecure                   bool
-		logLevel                   string
-		glogLevel                  int
-		clientConfig               clientcmd.ClientConfig
-		staticAssetsDir            string
-		baseHRef                   string
-		repoServerAddress          string
-		appControllerServerAddress string
-		dexServerAddress           string
-		disableAuth                bool
-		tlsConfigCustomizerSrc     func() (tls.ConfigCustomizer, error)
-		cacheSrc                   func() (*cache.Cache, error)
+		insecure               bool
+		logLevel               string
+		glogLevel              int
+		clientConfig           clientcmd.ClientConfig
+		staticAssetsDir        string
+		baseHRef               string
+		repoServerAddress      string
+		dexServerAddress       string
+		disableAuth            bool
+		tlsConfigCustomizerSrc func() (tls.ConfigCustomizer, error)
+		cacheSrc               func() (*cache.Cache, error)
 	)
 	var command = &cobra.Command{
 		Use:   cliName,
@@ -95,7 +94,6 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().StringVar(&repoServerAddress, "repo-server", common.DefaultRepoServerAddr, "Repo server address")
-	command.Flags().StringVar(&appControllerServerAddress, "app-controller-server", common.DefaultAppControllerServerAddr, "App controller server address")
 	command.Flags().StringVar(&dexServerAddress, "dex-server", common.DefaultDexServerAddr, "Dex server address")
 	command.Flags().BoolVar(&disableAuth, "disable-auth", false, "Disable client authentication")
 	command.AddCommand(cli.NewVersionCmd(cliName))

--- a/common/common.go
+++ b/common/common.go
@@ -2,8 +2,6 @@ package common
 
 // Default service addresses and URLS of Argo CD internal services
 const (
-	// DefaultAppControllerServerAddr is the gRPC address of the Argo CD app controller server
-	DefaultAppControllerServerAddr = "argocd-application-controller:8083"
 	// DefaultRepoServerAddr is the gRPC address of the Argo CD repo server
 	DefaultRepoServerAddr = "argocd-repo-server:8081"
 	// DefaultDexServerAddr is the HTTP address of the Dex OIDC server, which we run a reverse proxy against
@@ -17,6 +15,13 @@ const (
 	ArgoCDConfigMapName     = "argocd-cm"
 	ArgoCDSecretName        = "argocd-secret"
 	ArgoCDRBACConfigMapName = "argocd-rbac-cm"
+)
+
+const (
+	PortAPIServer              = 8080
+	PortRepoServer             = 8081
+	PortArgoCDMetrics          = 8082
+	PortArgoCDAPIServerMetrics = 8083
 )
 
 // Argo CD application related constants

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -13,8 +13,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,6 +26,8 @@ import (
 
 	"github.com/argoproj/argo-cd/common"
 	statecache "github.com/argoproj/argo-cd/controller/cache"
+	"github.com/argoproj/argo-cd/controller/metrics"
+	"github.com/argoproj/argo-cd/errors"
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	appinformers "github.com/argoproj/argo-cd/pkg/client/informers/externalversions"
@@ -56,6 +58,7 @@ type ApplicationController struct {
 	appRefreshQueue           workqueue.RateLimitingInterface
 	appOperationQueue         workqueue.RateLimitingInterface
 	appInformer               cache.SharedIndexInformer
+	appLister                 applisters.ApplicationLister
 	projInformer              cache.SharedIndexInformer
 	appStateManager           AppStateManager
 	stateCache                statecache.LiveStateCache
@@ -66,6 +69,7 @@ type ApplicationController struct {
 	settingsMgr               *settings_util.SettingsManager
 	refreshRequestedApps      map[string]bool
 	refreshRequestedAppsMutex *sync.Mutex
+	metricsServer             *metrics.MetricsServer
 }
 
 type ApplicationControllerConfig struct {
@@ -106,7 +110,7 @@ func NewApplicationController(
 		settingsMgr:               settingsMgr,
 		settings:                  settings,
 	}
-	appInformer := ctrl.newApplicationInformer()
+	appInformer, appLister := ctrl.newApplicationInformerAndLister()
 	projInformer := v1alpha1.NewAppProjectInformer(applicationClientset, namespace, appResyncPeriod, cache.Indexers{})
 	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settings, kubectlCmd, func(appName string) {
 		ctrl.requestAppRefresh(appName)
@@ -114,9 +118,12 @@ func NewApplicationController(
 	})
 	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectlCmd, ctrl.settings, stateCache, projInformer)
 	ctrl.appInformer = appInformer
+	ctrl.appLister = appLister
 	ctrl.projInformer = projInformer
 	ctrl.appStateManager = appStateManager
 	ctrl.stateCache = stateCache
+	metricsAddr := fmt.Sprintf("0.0.0.0:%d", common.PortArgoCDMetrics)
+	ctrl.metricsServer = metrics.NewMetricsServer(metricsAddr, ctrl.appLister)
 	return &ctrl, nil
 }
 
@@ -243,6 +250,7 @@ func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int
 	}
 
 	go ctrl.stateCache.Run(ctx)
+	go func() { errors.CheckError(ctrl.metricsServer.ListenAndServe()) }()
 
 	for i := 0; i < statusProcessors; i++ {
 		go wait.Until(func() {
@@ -327,7 +335,7 @@ func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Applic
 	// Get refreshed application info, since informer app copy might be stale
 	app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(app.Name, metav1.GetOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierr.IsNotFound(err) {
 			logCtx.Errorf("Unable to get refreshed application info prior deleting resources: %v", err)
 		}
 		return nil
@@ -524,6 +532,7 @@ func (ctrl *ApplicationController) setOperationState(app *appv1.Application, sta
 				messages = append(messages, "failed:", state.Message)
 			}
 			ctrl.auditLogger.LogAppEvent(app, eventInfo, strings.Join(messages, " "))
+			ctrl.metricsServer.IncSync(app, state)
 		}
 		return nil
 	}, "Update application operation state", context.Background(), updateOperationStateTimeout)
@@ -637,7 +646,7 @@ func (ctrl *ApplicationController) refreshAppConditions(app *appv1.Application) 
 	conditions := make([]appv1.ApplicationCondition, 0)
 	proj, err := argo.GetAppProject(&app.Spec, applisters.NewAppProjectLister(ctrl.projInformer.GetIndexer()), ctrl.namespace)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierr.IsNotFound(err) {
 			conditions = append(conditions, appv1.ApplicationCondition{
 				Type:    appv1.ApplicationConditionInvalidSpecError,
 				Message: fmt.Sprintf("Application referencing project %s which does not exist", app.Spec.Project),
@@ -814,7 +823,7 @@ func alreadyAttemptedSync(app *appv1.Application, commitSHA string) bool {
 	return true
 }
 
-func (ctrl *ApplicationController) newApplicationInformer() cache.SharedIndexInformer {
+func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.SharedIndexInformer, applisters.ApplicationLister) {
 	appInformerFactory := appinformers.NewFilteredSharedInformerFactory(
 		ctrl.applicationClientset,
 		ctrl.statusRefreshTimeout,
@@ -822,6 +831,7 @@ func (ctrl *ApplicationController) newApplicationInformer() cache.SharedIndexInf
 		func(options *metav1.ListOptions) {},
 	)
 	informer := appInformerFactory.Argoproj().V1alpha1().Applications().Informer()
+	lister := appInformerFactory.Argoproj().V1alpha1().Applications().Lister()
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -857,7 +867,7 @@ func (ctrl *ApplicationController) newApplicationInformer() cache.SharedIndexInf
 			},
 		},
 	)
-	return informer
+	return informer, lister
 }
 
 func isOperationInProgress(app *appv1.Application) bool {

--- a/manifests/base/application-controller/argocd-application-controller-deployment.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-deployment.yaml
@@ -25,10 +25,10 @@ spec:
         imagePullPolicy: Always
         name: argocd-application-controller
         ports:
-        - containerPort: 8083
+        - containerPort: 8082
         readinessProbe:
           tcpSocket:
-            port: 8083
+            port: 8082
           initialDelaySeconds: 5
           periodSeconds: 10
       serviceAccountName: argocd-application-controller

--- a/manifests/base/application-controller/argocd-metrics.yaml
+++ b/manifests/base/application-controller/argocd-metrics.yaml
@@ -2,12 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/component: argocd-metrics
     app.kubernetes.io/name: argo-cd
-  name: argocd-application-controller
+  name: argocd-metrics
 spec:
   ports:
-  - port: 8083
-    targetPort: 8083
+  - name: metrics
+    protocol: TCP
+    port: 8082
+    targetPort: 8082
   selector:
     app.kubernetes.io/component: application-controller

--- a/manifests/base/application-controller/kustomization.yaml
+++ b/manifests/base/application-controller/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 - argocd-application-controller-role.yaml
 - argocd-application-controller-rolebinding.yaml
 - argocd-application-controller-deployment.yaml
-- argocd-application-controller-service.yaml
+- argocd-metrics.yaml

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -33,6 +33,7 @@ spec:
           name: static-files
         ports:
         - containerPort: 8080
+        - containerPort: 8083
         readinessProbe:
           httpGet:
             path: /healthz

--- a/manifests/base/server/argocd-server-metrics-service.yaml
+++ b/manifests/base/server/argocd-server-metrics-service.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argo-cd
-  name: argocd-metrics
+  name: argocd-server-metrics
 spec:
   ports:
-  - name: http
+  - name: metrics
     protocol: TCP
-    port: 8082
-    targetPort: 8082
+    port: 8083
+    targetPort: 8083
   selector:
     app.kubernetes.io/component: server

--- a/manifests/base/server/kustomization.yaml
+++ b/manifests/base/server/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
-- argocd-metrics-service.yaml
 - argocd-server-deployment.yaml
 - argocd-server-role.yaml
 - argocd-server-rolebinding.yaml
 - argocd-server-sa.yaml
 - argocd-server-service.yaml
+- argocd-server-metrics-service.yaml

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -306,20 +306,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argo-cd
-  name: argocd-application-controller
-spec:
-  ports:
-  - port: 8083
-    targetPort: 8083
-  selector:
-    app.kubernetes.io/component: application-controller
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/name: argo-cd
   name: argocd-dex-server
@@ -340,17 +326,17 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: argocd-metrics
     app.kubernetes.io/name: argo-cd
   name: argocd-metrics
 spec:
   ports:
-  - name: http
+  - name: metrics
     port: 8082
     protocol: TCP
     targetPort: 8082
   selector:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: application-controller
 ---
 apiVersion: v1
 kind: Service
@@ -380,6 +366,22 @@ spec:
     targetPort: 8081
   selector:
     app.kubernetes.io/component: repo-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argo-cd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  selector:
+    app.kubernetes.io/component: server
 ---
 apiVersion: v1
 kind: Service
@@ -428,12 +430,12 @@ spec:
         imagePullPolicy: Always
         name: argocd-application-controller
         ports:
-        - containerPort: 8083
+        - containerPort: 8082
         readinessProbe:
           initialDelaySeconds: 5
           periodSeconds: 10
           tcpSocket:
-            port: 8083
+            port: 8082
       serviceAccountName: argocd-application-controller
 ---
 apiVersion: apps/v1
@@ -561,6 +563,7 @@ spec:
         name: argocd-server
         ports:
         - containerPort: 8080
+        - containerPort: 8083
         readinessProbe:
           httpGet:
             path: /healthz

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -226,20 +226,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argo-cd
-  name: argocd-application-controller
-spec:
-  ports:
-  - port: 8083
-    targetPort: 8083
-  selector:
-    app.kubernetes.io/component: application-controller
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/name: argo-cd
   name: argocd-dex-server
@@ -260,17 +246,17 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: argocd-metrics
     app.kubernetes.io/name: argo-cd
   name: argocd-metrics
 spec:
   ports:
-  - name: http
+  - name: metrics
     port: 8082
     protocol: TCP
     targetPort: 8082
   selector:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: application-controller
 ---
 apiVersion: v1
 kind: Service
@@ -300,6 +286,22 @@ spec:
     targetPort: 8081
   selector:
     app.kubernetes.io/component: repo-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argo-cd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  selector:
+    app.kubernetes.io/component: server
 ---
 apiVersion: v1
 kind: Service
@@ -348,12 +350,12 @@ spec:
         imagePullPolicy: Always
         name: argocd-application-controller
         ports:
-        - containerPort: 8083
+        - containerPort: 8082
         readinessProbe:
           initialDelaySeconds: 5
           periodSeconds: 10
           tcpSocket:
-            port: 8083
+            port: 8082
       serviceAccountName: argocd-application-controller
 ---
 apiVersion: apps/v1
@@ -481,6 +483,7 @@ spec:
         name: argocd-server
         ports:
         - containerPort: 8080
+        - containerPort: 8083
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
argocd-metrics service is now served by the controller
argocd-server-metrics is gRPC metrics served by the API server

A new prometheus counter for application syncs is produced like so:
```
argocd_app_sync_total{name="guestbook",namespace="argocd",phase="Failed",project="default"} 2
argocd_app_sync_total{name="guestbook",namespace="argocd",phase="Succeeded",project="default"} 1
```