### PR TITLE
Fix reconcile hotloop due to incorrect app source equality check

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -631,7 +631,7 @@ func (ctrl *ApplicationController) needRefreshAppStatus(app *appv1.Application, 
 	} else if !app.Spec.Source.Equals(app.Status.Sync.ComparedTo.Source) {
 		reason = "spec.source differs"
 	} else if !app.Spec.Destination.Equals(app.Status.Sync.ComparedTo.Destination) {
-		reason = "spec.source differs"
+		reason = "spec.destination differs"
 	} else if expired {
 		reason = fmt.Sprintf("comparison expired. observedAt: %v, expiry: %v", app.Status.ObservedAt, statusRefreshTimeout)
 	}
@@ -748,6 +748,7 @@ func (ctrl *ApplicationController) persistAppStatus(orig *appv1.Application, new
 		logCtx.Infof("No status changes. Skipping patch")
 		return
 	}
+	logCtx.Debugf("patch: %s", string(patch))
 	appClient := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(orig.Namespace)
 	_, err = appClient.Patch(orig.Name, types.MergePatchType, patch)
 	if err != nil {

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -781,7 +781,7 @@ func (condition *ApplicationCondition) IsError() bool {
 
 // Equals compares two instances of ApplicationSource and return true if instances are equal.
 func (source *ApplicationSource) Equals(other ApplicationSource) bool {
-	return reflect.DeepEqual(source, other)
+	return reflect.DeepEqual(*source, other)
 }
 
 func (source *ApplicationSource) ExplicitType() (*ApplicationSourceType, error) {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -148,3 +148,26 @@ func TestExplicitTypeWithDirectory(t *testing.T) {
 	_, err := src.ExplicitType()
 	assert.NotNil(t, err, "cannot add directory with any other types")
 }
+
+func TestAppSourceEquality(t *testing.T) {
+	left := &ApplicationSource{
+		Directory: &ApplicationSourceDirectory{
+			Recurse: true,
+		},
+	}
+	right := left.DeepCopy()
+	assert.True(t, left.Equals(*right))
+	right.Directory.Recurse = false
+	assert.False(t, left.Equals(*right))
+}
+
+func TestAppDestinationEquality(t *testing.T) {
+	left := &ApplicationDestination{
+		Server:    "https://kubernetes.default.svc",
+		Namespace: "default",
+	}
+	right := left.DeepCopy()
+	assert.True(t, left.Equals(*right))
+	right.Namespace = "kube-system"
+	assert.False(t, left.Equals(*right))
+}

--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -9,8 +9,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/packr"
-	log "github.com/sirupsen/logrus"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	luajson "layeh.com/gopher-json"
 
@@ -123,7 +122,6 @@ func (vm VM) getPredefinedLuaScripts(objKey string, scriptType string) (string, 
 	data, err := box.MustBytes(filepath.Join(objKey, scriptType))
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Debugf("No Lua Script found for resource key '%s'", objKey)
 			return "", nil
 		}
 		return "", err


### PR DESCRIPTION
We were reconciling all apps in a hotloop because the equality check for app source was comparing a pointer to a non-pointer when sending to DeepEqual.