### PR TITLE
use kustomize v2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN curl -L -o /usr/local/bin/kustomize1 https://github.com/kubernetes-sigs/kust
     kustomize1 version
 
 
-ENV KUSTOMIZE_VERSION=2.0.1
+ENV KUSTOMIZE_VERSION=2.0.2
 RUN curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kustomize && \
     kustomize version


### PR DESCRIPTION
# What it does

It uses `kustmize v2.0.2`. This version includes fix [#811](https://github.com/kubernetes-sigs/kustomize/pull/811) to be able to install `argocd` declaratively ([issue #810](https://github.com/kubernetes-sigs/kustomize/issues/810))