### PR TITLE
invalidate repo cache on delete

### DIFF
--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -351,6 +351,12 @@ func (s *Server) Delete(ctx context.Context, q *RepoQuery) (*RepoResponse, error
 	if !s.enf.Enforce(ctx.Value("claims"), rbacpolicy.ResourceRepositories, rbacpolicy.ActionDelete, q.Repo) {
 		return nil, grpc.ErrPermissionDenied
 	}
+
+	// invalidate cache
+	if err := s.cache.SetRepoConnectionState(q.Repo, nil); err == nil {
+		log.Errorf("error invalidating cache: %v", err)
+	}
+
 	err := s.db.DeleteRepository(ctx, q.Repo)
 	return &RepoResponse{}, err
 }


### PR DESCRIPTION
# What it does

- Invalidate repo cache on delete

# What it solves

when a repo is added successfuly but it is invalid ( either with invalid settings using a declarative approach or e.g. ssh key is no longer valid), it was not possible to remove the repo and and add it again with correct settings, because the cache of the `ConnectionState` was not inmmediately invalidated. This PR invalidates on deletion
