### PR TITLE
Introduce prometheus histogram for app reconcile performance

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -573,8 +573,9 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	}
 	startTime := time.Now()
 	defer func() {
-		durationMs := time.Now().Sub(startTime).Seconds() * 1e3
-		logCtx := log.WithFields(log.Fields{"application": origApp.Name, "time_ms": durationMs})
+		reconcileDuration := time.Now().Sub(startTime)
+		ctrl.metricsServer.IncReconcile(origApp, reconcileDuration)
+		logCtx := log.WithFields(log.Fields{"application": origApp.Name, "time_ms": reconcileDuration.Seconds() * 1e3})
 		logCtx.Info("Reconciliation completed")
 	}()
 	// NOTE: normalization returns a copy


### PR DESCRIPTION
Example stats:
```
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="0.25"} 0
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="0.5"} 0
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="1"} 0
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="2"} 2
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="4"} 2
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="8"} 2
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="16"} 2
argocd_app_reconcile_bucket{name="minio",namespace="argocd",project="default",le="+Inf"} 2
argocd_app_reconcile_sum{name="minio",namespace="argocd",project="default"} 3.038144384
argocd_app_reconcile_count{name="minio",namespace="argocd",project="default"} 2
```