### PR TITLE
Rename excludedResources config key to resource.exclusions. Support hot reload

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -893,6 +893,7 @@ func (ctrl *ApplicationController) watchSettings(ctx context.Context) {
 	updateCh := make(chan *settings_util.ArgoCDSettings, 1)
 	ctrl.settingsMgr.Subscribe(updateCh)
 	prevAppLabelKey := ctrl.settings.GetAppInstanceLabelKey()
+	prevResourceExclusions := ctrl.settings.ResourceExclusions
 	done := false
 	for !done {
 		select {
@@ -903,6 +904,11 @@ func (ctrl *ApplicationController) watchSettings(ctx context.Context) {
 				log.Infof("label key changed: %s -> %s", prevAppLabelKey, newAppLabelKey)
 				ctrl.stateCache.Invalidate()
 				prevAppLabelKey = newAppLabelKey
+			}
+			if !reflect.DeepEqual(prevResourceExclusions, newSettings.ResourceExclusions) {
+				log.Infof("resource exclusions modified")
+				ctrl.stateCache.Invalidate()
+				prevResourceExclusions = newSettings.ResourceExclusions
 			}
 		case <-ctx.Done():
 			done = true

--- a/docs/argocd-cm.yaml
+++ b/docs/argocd-cm.yaml
@@ -94,7 +94,7 @@ data:
   # These are globs, so a "*" will match all values.
   # If you omit groups/kinds/clusters then they will match all groups/kind/clusters.
   # NOTE: events.k8s.io and metrics.k8s.io are excluded by default
-  excludedResources: |
+  resource.exclusions: |
     - apiGroups:
       - repositories.stash.appscode.com
       kinds:

--- a/docs/declarative-setup.md
+++ b/docs/declarative-setup.md
@@ -234,12 +234,12 @@ To configure this, edit the `argcd-cm` config map:
 kubectl edit configmap argocd-cm -n argocdconfigmap/argocd-cm edited
 ```
 
-Add `excludedResources`, e.g.:
+Add `resource.exclusions`, e.g.:
 
 ```yaml
 apiVersion: v1
 data:
-  excludedResources: |
+  resource.exclusions: |
     - apiGroups:
       - "*"
       kinds:
@@ -249,7 +249,7 @@ data:
 kind: ConfigMap
 ```
 
-The `excludedResources` node is a list of objects. Each object can have:
+The `resource.exclusions` node is a list of objects. Each object can have:
 
 - `apiGroups` A list of globs to match the API group.
 - `kinds` A list of kinds to match. Can be "*" to match all.

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -3,7 +3,7 @@ package settings
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,21 +15,21 @@ func TestArgoCDSettings_IsExcludedResource(t *testing.T) {
 	assert.False(t, settings.IsExcludedResource("rubbish.io", "", ""))
 }
 
-func TestUpdateSettingsFromConfigMapExcludedResources(t *testing.T) {
+func TestUpdateSettingsFromConfigMapResourceExclusions(t *testing.T) {
 
 	settings := ArgoCDSettings{}
 	configMap := v1.ConfigMap{}
 	err := updateSettingsFromConfigMap(&settings, &configMap)
 
 	assert.NoError(t, err)
-	assert.Nil(t, settings.ExcludedResources)
+	assert.Nil(t, settings.ResourceExclusions)
 
 	configMap.Data = map[string]string{
-		"excludedResources": "\n  - apiGroups: []\n    kinds: []\n    clusters: []\n",
+		"resource.exclusions": "\n  - apiGroups: []\n    kinds: []\n    clusters: []\n",
 	}
 
 	err = updateSettingsFromConfigMap(&settings, &configMap)
 
 	assert.NoError(t, err)
-	assert.Equal(t, []ExcludedResource{{APIGroups: []string{}, Kinds: []string{}, Clusters: []string{}}}, settings.ExcludedResources)
+	assert.Equal(t, []ExcludedResource{{APIGroups: []string{}, Kinds: []string{}, Clusters: []string{}}}, settings.ResourceExclusions)
 }


### PR DESCRIPTION
Rename configuration key `excludedResources` to `resource.exclusions`
Also attempt to support hot-reload of settings when this key changes. @alexmt - will cache invalidation cause a restart of our watches anymore? From the logs, it doesn't appear to be the case.