### PR TITLE
Issue #1161 - Update resource version on every watch event

### DIFF
--- a/util/kube/ctl.go
+++ b/util/kube/ctl.go
@@ -115,7 +115,8 @@ func (k KubectlCmd) GetResources(config *rest.Config, resourceFilter ResourceFil
 
 const watchResourcesRetryTimeout = 1 * time.Second
 
-// WatchResources Watches all the existing resources with the provided label name in the provided namespace in the cluster provided by the config
+// WatchResources watches all the existing resources in the cluster provided by the config. Method retries watch with the most recent resource version stored in cache.
+// The WatchResources returns channel which container either watch event with updated resource info or new list of resources if cached resource version had expired.
 func (k KubectlCmd) WatchResources(
 	ctx context.Context,
 	config *rest.Config,
@@ -156,7 +157,7 @@ func (k KubectlCmd) WatchResources(
 							ResourceVersion: resourceVersion,
 						})
 						if apierr.IsGone(err) {
-							log.Infof("List resource version of %s has expired at cluster %s, reloading list", gvk, config.Host)
+							log.Infof("Resource version of %s has expired at cluster %s, reloading list", gvk, config.Host)
 							list, err := apiResIf.resourceIf.List(metav1.ListOptions{})
 							if err != nil {
 								return nil, err


### PR DESCRIPTION
PR add the change which was supposed to implement as part of https://github.com/argoproj/argo-cd/pull/1173 . 

The group kind resource version should be updated on every new watch event, otherwise retried watch would have to reprocess all events from most recent list, which is not necessary. 

Additionally renamed field `listVersion` to `resourceVersion` and added comment to WatchResources method