### PR TITLE
Support talking to Dex using local cluster address instead of public address

### DIFF
--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -42,7 +42,7 @@ func newTestAccountServer(ctx context.Context, objects ...runtime.Object) (*fake
 		},
 	})
 	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, testNamespace)
-	sessionMgr := sessionutil.NewSessionManager(settingsMgr)
+	sessionMgr := sessionutil.NewSessionManager(settingsMgr, "")
 	return kubeclientset, NewServer(sessionMgr, settingsMgr), session.NewServer(sessionMgr)
 }
 

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -160,7 +160,7 @@ func TestProjectServer(t *testing.T) {
 	})
 
 	t.Run("TestCreateTokenSuccesfully", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr)
+		sessionMgr := session.NewSessionManager(settingsMgr, "")
 		projectWithRole := existingProj.DeepCopy()
 		tokenName := "testToken"
 		projectWithRole.Spec.Roles = []v1alpha1.ProjectRole{{Name: tokenName}}
@@ -179,7 +179,7 @@ func TestProjectServer(t *testing.T) {
 	})
 
 	t.Run("TestDeleteTokenSuccesfully", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr)
+		sessionMgr := session.NewSessionManager(settingsMgr, "")
 		projWithToken := existingProj.DeepCopy()
 		tokenName := "testToken"
 		issuedAt := int64(1)
@@ -198,7 +198,7 @@ func TestProjectServer(t *testing.T) {
 	})
 
 	t.Run("TestCreateTwoTokensInRoleSuccess", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr)
+		sessionMgr := session.NewSessionManager(settingsMgr, "")
 		projWithToken := existingProj.DeepCopy()
 		tokenName := "testToken"
 		token := v1alpha1.ProjectRole{Name: tokenName, JWTTokens: []v1alpha1.JWTToken{{IssuedAt: 1}}}

--- a/server/server.go
+++ b/server/server.go
@@ -154,7 +154,7 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts) *ArgoCDServer {
 	errors.CheckError(err)
 	err = initializeDefaultProject(opts)
 	errors.CheckError(err)
-	sessionMgr := util_session.NewSessionManager(settingsMgr)
+	sessionMgr := util_session.NewSessionManager(settingsMgr, opts.DexServerAddr)
 
 	factory := appinformer.NewFilteredSharedInformerFactory(opts.AppClientset, 0, opts.Namespace, func(options *metav1.ListOptions) {})
 	projInformer := factory.Argoproj().V1alpha1().AppProjects().Informer()
@@ -529,7 +529,7 @@ func (a *ArgoCDServer) registerDexHandlers(mux *http.ServeMux) {
 	mux.HandleFunc(common.DexAPIEndpoint+"/", dexutil.NewDexHTTPReverseProxy(a.DexServerAddr))
 	tlsConfig := a.settings.TLSConfig()
 	tlsConfig.InsecureSkipVerify = true
-	a.ssoClientApp, err = oidc.NewClientApp(a.settings, a.Cache)
+	a.ssoClientApp, err = oidc.NewClientApp(a.settings, a.Cache, a.DexServerAddr)
 	errors.CheckError(err)
 	mux.HandleFunc(common.LoginEndpoint, a.ssoClientApp.HandleLogin)
 	mux.HandleFunc(common.CallbackEndpoint, a.ssoClientApp.HandleCallback)

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/util/dex"
 	httputil "github.com/argoproj/argo-cd/util/http"
 	jwtutil "github.com/argoproj/argo-cd/util/jwt"
 	oidcutil "github.com/argoproj/argo-cd/util/oidc"
@@ -39,7 +40,7 @@ const (
 )
 
 // NewSessionManager creates a new session manager from Argo CD settings
-func NewSessionManager(settingsMgr *settings.SettingsManager) *SessionManager {
+func NewSessionManager(settingsMgr *settings.SettingsManager, dexServerAddr string) *SessionManager {
 	s := SessionManager{
 		settingsMgr: settingsMgr,
 	}
@@ -62,6 +63,9 @@ func NewSessionManager(settingsMgr *settings.SettingsManager) *SessionManager {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},
+	}
+	if settings.DexConfig != "" {
+		s.client.Transport = dex.NewDexRewriteURLRoundTripper(dexServerAddr, s.client.Transport)
 	}
 	if os.Getenv(common.EnvVarSSODebug) == "1" {
 		s.client.Transport = httputil.DebugTransport{T: s.client.Transport}

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -40,7 +40,7 @@ func TestSessionManager(t *testing.T) {
 	})
 
 	settingsMgr := settings.NewSettingsManager(context.Background(), kubeclientset, "argocd")
-	mgr := sessionutil.NewSessionManager(settingsMgr)
+	mgr := sessionutil.NewSessionManager(settingsMgr, "")
 
 	token, err := mgr.Create(defaultSubject, 0)
 	if err != nil {


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-cd/issues/1062.

This allows Argo CD to talk to dex over the cluster address instead of external address by having a custom HTTP client with a roundtripper that rewrite the URL when communicating through the OIDC client.