### PR TITLE
Support kustomize apps with remote bases in private repos in the same host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN curl -L -o /usr/local/bin/kustomize1 https://github.com/kubernetes-sigs/kust
     kustomize1 version
 
 
-ENV KUSTOMIZE_VERSION=2.0.2
+ENV KUSTOMIZE_VERSION=2.0.3
 RUN curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kustomize && \
     kustomize version

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -215,7 +215,7 @@ func GenerateManifests(appPath string, q *ManifestRequest) (*ManifestResponse, e
 			}
 		}
 	case v1alpha1.ApplicationSourceTypeKustomize:
-		k := kustomize.NewKustomizeApp(appPath)
+		k := kustomize.NewKustomizeApp(appPath, kustomizeCredentials(q.Repo))
 		targetObjs, _, err = k.Build(q.ApplicationSource.Kustomize)
 	case v1alpha1.ApplicationSourceTypePlugin:
 		targetObjs, err = runConfigManagementPlugin(appPath, q, q.Plugins)
@@ -635,7 +635,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *RepoServerAppDetailsQuer
 	case v1alpha1.ApplicationSourceTypeKustomize:
 		res.Kustomize = &KustomizeAppSpec{}
 		res.Kustomize.Path = q.Path
-		k := kustomize.NewKustomizeApp(appPath)
+		k := kustomize.NewKustomizeApp(appPath, kustomizeCredentials(q.Repo))
 		_, params, err := k.Build(nil)
 		if err != nil {
 			return nil, err
@@ -650,4 +650,14 @@ func (q *RepoServerAppDetailsQuery) valueFiles() []string {
 		return nil
 	}
 	return q.Helm.ValueFiles
+}
+
+func kustomizeCredentials(repo *v1alpha1.Repository) *kustomize.GitCredentials {
+	if repo == nil || repo.Password == "" {
+		return nil
+	}
+	return &kustomize.GitCredentials{
+		Username: repo.Username,
+		Password: repo.Password,
+	}
 }

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -10,6 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TODO: move this into shared test package after resolving import cycle
+const (
+	// This is a throwaway gitlab test account/repo with a read-only personal access token for the
+	// purposes of testing private git repos
+	PrivateGitRepo     = "https://gitlab.com/argo-cd-test/test-apps.git"
+	PrivateGitUsername = "blah"
+	PrivateGitPassword = "B5sBDeoqAVUouoHkrovy"
+)
+
 func TestIsCommitSHA(t *testing.T) {
 	assert.True(t, IsCommitSHA("9d921f65f3c5373b682e2eb4b37afba6592e8f8b"))
 	assert.True(t, IsCommitSHA("9D921F65F3C5373B682E2EB4B37AFBA6592E8F8B"))
@@ -145,12 +154,6 @@ func TestGitClient(t *testing.T) {
 
 // TestPrivateGitRepo tests the ability to operate on a private git repo.
 func TestPrivateGitRepo(t *testing.T) {
-	repo := "https://gitlab.com/argo-cd-test/argocd-example-apps.git"
-	username := "blah"
-	// This is a personal access token generated with read only access in a throwaway gitlab test
-	// account/repo
-	password := "B5sBDeoqAVUouoHkrovy"
-
 	// add the hack path which has the git-ask-pass.sh shell script
 	osPath := os.Getenv("PATH")
 	hackPath, err := filepath.Abs("../../hack")
@@ -163,7 +166,7 @@ func TestPrivateGitRepo(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = os.RemoveAll(dirName) }()
 
-	clnt, err := NewFactory().NewClient(repo, dirName, username, password, "")
+	clnt, err := NewFactory().NewClient(PrivateGitRepo, dirName, PrivateGitUsername, PrivateGitPassword, "")
 	assert.NoError(t, err)
 
 	testGitClient(t, clnt)

--- a/util/kustomize/testdata/private-remote-base/kustomization.yaml
+++ b/util/kustomize/testdata/private-remote-base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- https://gitlab.com/argo-cd-test/test-apps//remote-base
+
+namePrefix: child-


### PR DESCRIPTION
We already support private repos, but until this PR, we did not support kustomize apps which had a remote base which was also under that same *private* repo. This fixes that by using the GIT_ASKPASS technique of supplying credentials to git, when indirectly invoked through a `kustomize build`.

Also update kustomize to v2.0.3 (from v2.0.2)