### PR TITLE
Add golang prometheus metrics to controller and repo-server

### DIFF
--- a/cmd/argocd-repo-server/main.go
+++ b/cmd/argocd-repo-server/main.go
@@ -3,19 +3,21 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	argocd "github.com/argoproj/argo-cd"
+	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/errors"
 	"github.com/argoproj/argo-cd/reposerver"
 	"github.com/argoproj/argo-cd/util/cache"
 	"github.com/argoproj/argo-cd/util/cli"
 	"github.com/argoproj/argo-cd/util/git"
-	"github.com/argoproj/argo-cd/util/ksonnet"
 	"github.com/argoproj/argo-cd/util/stats"
 	"github.com/argoproj/argo-cd/util/tls"
 )
@@ -23,7 +25,6 @@ import (
 const (
 	// CLIName is the name of the CLI
 	cliName = "argocd-repo-server"
-	port    = 8081
 )
 
 func newCommand() *cobra.Command {
@@ -48,14 +49,13 @@ func newCommand() *cobra.Command {
 			server, err := reposerver.NewServer(git.NewFactory(), cache, tlsConfigCustomizer, parallelismLimit)
 			errors.CheckError(err)
 			grpc := server.CreateGRPC()
-			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", common.PortRepoServer))
 			errors.CheckError(err)
 
-			ksVers, err := ksonnet.KsonnetVersion()
-			errors.CheckError(err)
+			http.Handle("/metrics", promhttp.Handler())
+			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf(":%d", common.PortRepoServerMetrics), nil)) }()
 
 			log.Infof("argocd-repo-server %s serving on %s", argocd.GetVersion(), listener.Addr())
-			log.Infof("ksonnet version: %s", ksVers)
 			stats.RegisterStackDumper()
 			stats.StartStatsTicker(10 * time.Minute)
 			stats.RegisterHeapDumper("memprofile")

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -81,7 +81,7 @@ func NewCommand() *cobra.Command {
 				ctx := context.Background()
 				ctx, cancel := context.WithCancel(ctx)
 				argocd := server.NewServer(ctx, argoCDOpts)
-				argocd.Run(ctx, 8080)
+				argocd.Run(ctx, common.PortAPIServer)
 				cancel()
 			}
 		},

--- a/common/common.go
+++ b/common/common.go
@@ -22,6 +22,7 @@ const (
 	PortRepoServer             = 8081
 	PortArgoCDMetrics          = 8082
 	PortArgoCDAPIServerMetrics = 8083
+	PortRepoServerMetrics      = 8084
 )
 
 // Argo CD application related constants

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -60,6 +60,8 @@ var (
 func NewMetricsServer(addr string, appLister applister.ApplicationLister) *MetricsServer {
 	mux := http.NewServeMux()
 	appRegistry := NewAppRegistry(appLister)
+	appRegistry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	appRegistry.MustRegister(prometheus.NewGoCollector())
 	mux.Handle(MetricsPath, promhttp.HandlerFor(appRegistry, promhttp.HandlerOpts{}))
 
 	syncCounter := prometheus.NewCounterVec(

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         - argocd-redis:6379
         ports:
         - containerPort: 8081
+        - containerPort: 8084
         readinessProbe:
           tcpSocket:
             port: 8081

--- a/manifests/base/repo-server/argocd-repo-server-service.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-service.yaml
@@ -8,7 +8,13 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - port: 8081
+  - name: server
+    protocol: TCP
+    port: 8081
     targetPort: 8081
+  - name: metrics
+    protocol: TCP
+    port: 8084
+    targetPort: 8084
   selector:
     app.kubernetes.io/name: argocd-repo-server

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -571,8 +571,14 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - port: 8081
+  - name: server
+    port: 8081
+    protocol: TCP
     targetPort: 8081
+  - name: metrics
+    port: 8084
+    protocol: TCP
+    targetPort: 8084
   selector:
     app.kubernetes.io/name: argocd-repo-server
 ---
@@ -753,6 +759,7 @@ spec:
         name: argocd-repo-server
         ports:
         - containerPort: 8081
+        - containerPort: 8084
         readinessProbe:
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -487,8 +487,14 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - port: 8081
+  - name: server
+    port: 8081
+    protocol: TCP
     targetPort: 8081
+  - name: metrics
+    port: 8084
+    protocol: TCP
+    targetPort: 8084
   selector:
     app.kubernetes.io/name: argocd-repo-server
 ---
@@ -669,6 +675,7 @@ spec:
         name: argocd-repo-server
         ports:
         - containerPort: 8081
+        - containerPort: 8084
         readinessProbe:
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -384,8 +384,14 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - port: 8081
+  - name: server
+    port: 8081
+    protocol: TCP
     targetPort: 8081
+  - name: metrics
+    port: 8084
+    protocol: TCP
+    targetPort: 8084
   selector:
     app.kubernetes.io/name: argocd-repo-server
 ---
@@ -566,6 +572,7 @@ spec:
         name: argocd-repo-server
         ports:
         - containerPort: 8081
+        - containerPort: 8084
         readinessProbe:
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -300,8 +300,14 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - port: 8081
+  - name: server
+    port: 8081
+    protocol: TCP
     targetPort: 8081
+  - name: metrics
+    port: 8084
+    protocol: TCP
+    targetPort: 8084
   selector:
     app.kubernetes.io/name: argocd-repo-server
 ---
@@ -482,6 +488,7 @@ spec:
         name: argocd-repo-server
         ports:
         - containerPort: 8081
+        - containerPort: 8084
         readinessProbe:
           initialDelaySeconds: 5
           periodSeconds: 10


### PR DESCRIPTION
This change adds standard golang prometheus metrics to application-controller and repo-server. This metrics provide some additional useful information over pod-level metrics, and will let us get graphs like the following with golang specific information (e.g. GC and goroutines):

![image](https://user-images.githubusercontent.com/12677113/54481971-313cae80-47f9-11e9-8562-80947098f980.png)
