### PR TITLE
Fix documentation on diffing customization

### DIFF
--- a/docs/diffing.md
+++ b/docs/diffing.md
@@ -53,7 +53,7 @@ of a `MutatingWebhookConfiguration` webhooks:
 data:
   resource.customizations: |
     admissionregistration.k8s.io/MutatingWebhookConfiguration:
-      ignoreDifferences:
+      ignoreDifferences: |
         jsonPointers:
-        - webhooks/0/clientConfig/caBundle
+        - /webhooks/0/clientConfig/caBundle
 ```


### PR DESCRIPTION
When I tried the configuration example, I got an error saying 

> Unable to parse updated settings: error unmarshaling JSON: json: cannot unmarshal object into Go struct field ResourceOverride.ignoreDifferences of type string

Modifying the configuration as shown in the commit fixed the problem.