### PR TITLE
Fix a goroutine leak in api-server application.PodLogs and application.Watch

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -33,7 +33,9 @@ type Closer interface {
 // Close is a convenience function to close a object that has a Close() method, ignoring any errors
 // Used to satisfy errcheck lint
 func Close(c Closer) {
-	_ = c.Close()
+	if err := c.Close(); err != nil {
+		log.Warnf("failed to close %v: %v", c, err)
+	}
 }
 
 // DeleteFile is best effort deletion of a file


### PR DESCRIPTION
Unconditionally call w.Stop() and stream.Close(). Close the done channel instead of trying to emit to it.