### PR TITLE
Fix goroutine leak in RetryUntilSucceed

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -85,10 +85,13 @@ func MakeSignature(size int) ([]byte, error) {
 // RetryUntilSucceed keep retrying given action with specified timeout until action succeed or specified context is done.
 func RetryUntilSucceed(action func() error, desc string, ctx context.Context, timeout time.Duration) {
 	ctxCompleted := false
+	stop := make(chan bool)
+	defer close(stop)
 	go func() {
 		select {
 		case <-ctx.Done():
 			ctxCompleted = true
+		case <-stop:
 		}
 	}()
 	for {


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-cd/issues/1313

RetryUntilSucceed would leak goroutines in the happy path, and would only stop the goroutine if it was explicitly cancelled.

Verified the fix by manually setting the stats ticker to print every 1 second. Before this change, every sync would bump up the goroutines permanently. After the change, it would return to the starting value.