### PR TITLE
Don't run lint after running codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clientgen:
 	./hack/update-codegen.sh
 
 .PHONY: codegen
-codegen: protogen clientgen lint
+codegen: protogen clientgen
 
 .PHONY: cli
 cli: clean-debug


### PR DESCRIPTION
If `codegen` updates any existing structure (which is almost always the case ) then lint is guaranteed to fail. So every time I run `codegen` I have to run a few seconds longer and it is hard to understand if codegen failed or lint failed.
