### PR TITLE
gotestsum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 go get -u github.com/golangci/golangci-lint/cmd/golangci-lint 
 go get -u github.com/mattn/goreman 
+go get -u gotest.tools/gotestsum
 ```
 
 ## Building


### PR DESCRIPTION
When testing locally, use `gotestsum` instead of `go test` as this has output that is much easier to read.

https://circleci.com/blog/level-up-go-test-with-gotestsum/

I've also update the goals I'd previously combined as that was a mistake.