### PR TITLE
Add mapping to new canonical Ingress API group

### DIFF
--- a/test/e2e/testdata/deprecated-extensions/ingress.yaml
+++ b/test/e2e/testdata/deprecated-extensions/ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: extensions-ingress
+spec:
+  rules:
+  - host: extensions-ingress
+    http:
+      paths:
+      - backend:
+          serviceName: extensions-service
+          servicePort: 8080
+        path: /

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -59,6 +59,7 @@ var (
 		DaemonSetKind:         "apps",
 		ReplicaSetKind:        "apps",
 		DeploymentKind:        "apps",
+		IngressKind:           "networking.k8s.io",
 		NetworkPolicyKind:     "networking.k8s.io",
 		PodSecurityPolicyKind: "policy",
 	}


### PR DESCRIPTION
Since Kubernetes 1.14, Ingress resources are only available via networking.k8s.io/v1beta1.