### PR TITLE
Fix Failing Linter

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -252,5 +252,5 @@ func TestGetAppDetailsKustomize(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Nil(t, res.Kustomize.Images)
-	assert.Equal(t, []*argoappv1.KustomizeImageTag{{"nginx", "1.15.4"}, {"k8s.gcr.io/nginx-slim", "0.8"}}, res.Kustomize.ImageTags)
+	assert.Equal(t, []*argoappv1.KustomizeImageTag{{Name: "nginx", Value: "1.15.4"}, {Name: "k8s.gcr.io/nginx-slim", Value: "0.8"}}, res.Kustomize.ImageTags)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -101,14 +101,12 @@ func RetryUntilSucceed(action func() error, desc string, ctx context.Context, ti
 			log.Infof("Completed %s", desc)
 			return
 		}
-		if err != nil {
-			if ctxCompleted {
-				log.Infof("Stop retrying %s", desc)
-				return
-			}
-			log.Warnf("Failed to %s: %+v, retrying in %v", desc, err, timeout)
-			time.Sleep(timeout)
+		if ctxCompleted {
+			log.Infof("Stop retrying %s", desc)
+			return
 		}
+		log.Warnf("Failed to %s: %+v, retrying in %v", desc, err, timeout)
+		time.Sleep(timeout)
 
 	}
 }


### PR DESCRIPTION
I got the following errors when I run the linter on master:
```golangci-lint run --fix
reposerver/repository/repository_test.go:255:49: composites: `*github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.KustomizeImageTag` composite literal uses unkeyed fields (govet)
	assert.Equal(t, []*argoappv1.KustomizeImageTag{{"nginx", "1.15.4"}, {"k8s.gcr.io/nginx-slim", "0.8"}}, res.Kustomize.ImageTags)
	                                               ^
util/util.go:104:10: nilness: tautological condition: non-nil != nil (govet)
		if err != nil {
		       ^
make: *** [lint] Error 1```
The following PR address these issues.