### PR TITLE
issue #1202: docs(help examples): adding template and first examples …

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1496,7 +1496,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:aae856b28533bfdb39112514290f7722d00a55a99d2d0b897c6ee82e6feb87b3"
+  digest = "1:199c4a3508ac049896ac06f518c99113e8404723ecf1891dd0c81c3cc17ba410"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen",

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -43,13 +43,27 @@ import (
 	"github.com/argoproj/argo-cd/util/git"
 	"github.com/argoproj/argo-cd/util/hook"
 	"github.com/argoproj/argo-cd/util/kube"
+	"github.com/argoproj/argo-cd/util/templates"
+)
+
+var (
+	appExample = templates.Examples(`
+	# List all the applications.
+	argocd app list
+
+	# Get the details of a application
+	argocd app get my-app
+
+	# Set an override parameter
+	argocd app set my-app -p image.tag=v1.0.1`)
 )
 
 // NewApplicationCommand returns a new instance of an `argocd app` command
 func NewApplicationCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "app",
-		Short: "Manage applications",
+		Use:     "app",
+		Short:   "Manage applications",
+		Example: appExample,
 		Run: func(c *cobra.Command, args []string) {
 			c.HelpFunc()(c, args)
 			os.Exit(1)

--- a/util/templates/normalizers.go
+++ b/util/templates/normalizers.go
@@ -1,0 +1,35 @@
+package templates
+
+import (
+	"strings"
+)
+
+const Indentation = `  `
+
+// Examples normalizes a command's examples to follow the conventions.
+func Examples(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return normalizer{s}.trim().indent().string
+}
+
+type normalizer struct {
+	string
+}
+
+func (s normalizer) trim() normalizer {
+	s.string = strings.TrimSpace(s.string)
+	return s
+}
+
+func (s normalizer) indent() normalizer {
+	indentedLines := []string{}
+	for _, line := range strings.Split(s.string, "\n") {
+		trimmed := strings.TrimSpace(line)
+		indented := Indentation + trimmed
+		indentedLines = append(indentedLines, indented)
+	}
+	s.string = strings.Join(indentedLines, "\n")
+	return s
+}


### PR DESCRIPTION
…for the app command

shameless ripoff of kubectl example templating