### PR TITLE
Overlay selector of argocd-redis-ha service

### DIFF
--- a/manifests/ha/base/redis-ha/kustomization.yaml
+++ b/manifests/ha/base/redis-ha/kustomization.yaml
@@ -84,3 +84,8 @@ patchesJson6902:
     kind: Service
     name: argocd-redis-ha-announce-2
   path: overlays/service-selector.yaml
+- target:
+    version: v1
+    kind: Service
+    name: argocd-redis-ha
+  path: overlays/service-selector.yaml

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -600,8 +600,7 @@ spec:
     protocol: TCP
     targetPort: sentinel
   selector:
-    app: redis-ha
-    release: argocd
+    app.kubernetes.io/name: argocd-redis-ha
   type: ClusterIP
 ---
 apiVersion: v1

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -515,8 +515,7 @@ spec:
     protocol: TCP
     targetPort: sentinel
   selector:
-    app: redis-ha
-    release: argocd
+    app.kubernetes.io/name: argocd-redis-ha
   type: ClusterIP
 ---
 apiVersion: v1


### PR DESCRIPTION
The selector of the argocd-redis-ha service wasn't being overlayed and the service never got to have endpoints