### PR TITLE
Redis mastergroup name should be resolvable and argocd-redis-ha is

### DIFF
--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -2,6 +2,6 @@ redis-ha:
   persistentVolume:
     enabled: false
   redis:
-    masterGroupName: argocd
+    masterGroupName: argocd-redis-ha
     config:
       save: "\"\""


### PR DESCRIPTION
the mastergroup name of redis was set as argocd since this is not
resolvable because no service has this name, this should be
renamed to the service which selects all redis pods