### PR TITLE
more-information-needed

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,2 +1,1 @@
 # See https://github.com/probot/no-response
-responseRequiredLabel: question


### PR DESCRIPTION
Use the default label `more-information-needed', because I think`question` is confusing.