### PR TITLE
Make listener and metrics ports configurable

### DIFF
--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -45,6 +45,7 @@ func newCommand() *cobra.Command {
 		operationProcessors      int
 		logLevel                 string
 		glogLevel                int
+		metricsPort              int
 		cacheSrc                 func() (*cache.Cache, error)
 	)
 	var command = cobra.Command{
@@ -81,7 +82,8 @@ func newCommand() *cobra.Command {
 				appClient,
 				repoClientset,
 				cache,
-				resyncDuration)
+				resyncDuration,
+				metricsPort)
 			errors.CheckError(err)
 
 			log.Infof("Application Controller (version: %s) starting (namespace: %s)", argocd.GetVersion(), namespace)
@@ -104,6 +106,7 @@ func newCommand() *cobra.Command {
 	command.Flags().IntVar(&operationProcessors, "operation-processors", 1, "Number of application operation processors")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
+	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDMetrics, "Start metrics server on given port")
 	cacheSrc = cache.AddCacheFlagsToCmd(&command)
 	return &command
 }

--- a/cmd/argocd-repo-server/main.go
+++ b/cmd/argocd-repo-server/main.go
@@ -31,6 +31,8 @@ func newCommand() *cobra.Command {
 	var (
 		logLevel               string
 		parallelismLimit       int64
+		listenPort             int
+		metricsPort            int
 		cacheSrc               func() (*cache.Cache, error)
 		tlsConfigCustomizerSrc func() (tls.ConfigCustomizer, error)
 	)
@@ -49,11 +51,11 @@ func newCommand() *cobra.Command {
 			server, err := reposerver.NewServer(git.NewFactory(), cache, tlsConfigCustomizer, parallelismLimit)
 			errors.CheckError(err)
 			grpc := server.CreateGRPC()
-			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", common.PortRepoServer))
+			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", listenPort))
 			errors.CheckError(err)
 
 			http.Handle("/metrics", promhttp.Handler())
-			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf(":%d", common.PortRepoServerMetrics), nil)) }()
+			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)) }()
 
 			log.Infof("argocd-repo-server %s serving on %s", argocd.GetVersion(), listener.Addr())
 			stats.RegisterStackDumper()
@@ -67,6 +69,8 @@ func newCommand() *cobra.Command {
 
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().Int64Var(&parallelismLimit, "parallelismlimit", 0, "Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit.")
+	command.Flags().IntVar(&listenPort, "listen-port", common.DefaultPortRepoServer, "Listen on given port for incoming connections")
+	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortRepoServerMetrics, "Start metrics server on given port")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
 	cacheSrc = cache.AddCacheFlagsToCmd(&command)
 	return &command

--- a/cmd/argocd-repo-server/main.go
+++ b/cmd/argocd-repo-server/main.go
@@ -69,7 +69,7 @@ func newCommand() *cobra.Command {
 
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().Int64Var(&parallelismLimit, "parallelismlimit", 0, "Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit.")
-	command.Flags().IntVar(&listenPort, "listen-port", common.DefaultPortRepoServer, "Listen on given port for incoming connections")
+	command.Flags().IntVar(&listenPort, "port", common.DefaultPortRepoServer, "Listen on given port for incoming connections")
 	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortRepoServerMetrics, "Start metrics server on given port")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
 	cacheSrc = cache.AddCacheFlagsToCmd(&command)

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -101,7 +101,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&dexServerAddress, "dex-server", common.DefaultDexServerAddr, "Dex server address")
 	command.Flags().BoolVar(&disableAuth, "disable-auth", false, "Disable client authentication")
 	command.AddCommand(cli.NewVersionCmd(cliName))
-	command.Flags().IntVar(&listenPort, "listen-port", common.DefaultPortAPIServer, "Listen on given port")
+	command.Flags().IntVar(&listenPort, "port", common.DefaultPortAPIServer, "Listen on given port")
 	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDAPIServerMetrics, "Start metrics on given port")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(command)
 	cacheSrc = cache.AddCacheFlagsToCmd(command)

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -23,6 +23,7 @@ import (
 func NewCommand() *cobra.Command {
 	var (
 		insecure               bool
+		listenPort             int
 		logLevel               string
 		glogLevel              int
 		clientConfig           clientcmd.ClientConfig
@@ -61,6 +62,7 @@ func NewCommand() *cobra.Command {
 
 			argoCDOpts := server.ArgoCDServerOpts{
 				Insecure:            insecure,
+				ListenPort:          listenPort,
 				Namespace:           namespace,
 				StaticAssetsDir:     staticAssetsDir,
 				BaseHRef:            baseHRef,
@@ -81,7 +83,7 @@ func NewCommand() *cobra.Command {
 				ctx := context.Background()
 				ctx, cancel := context.WithCancel(ctx)
 				argocd := server.NewServer(ctx, argoCDOpts)
-				argocd.Run(ctx, common.PortAPIServer)
+				argocd.Run(ctx, listenPort)
 				cancel()
 			}
 		},
@@ -97,6 +99,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&dexServerAddress, "dex-server", common.DefaultDexServerAddr, "Dex server address")
 	command.Flags().BoolVar(&disableAuth, "disable-auth", false, "Disable client authentication")
 	command.AddCommand(cli.NewVersionCmd(cliName))
+	command.Flags().IntVar(&listenPort, "listen-port", common.PortAPIServer, "Listen on given port")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(command)
 	cacheSrc = cache.AddCacheFlagsToCmd(command)
 	return command

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -24,6 +24,7 @@ func NewCommand() *cobra.Command {
 	var (
 		insecure               bool
 		listenPort             int
+		metricsPort            int
 		logLevel               string
 		glogLevel              int
 		clientConfig           clientcmd.ClientConfig
@@ -63,6 +64,7 @@ func NewCommand() *cobra.Command {
 			argoCDOpts := server.ArgoCDServerOpts{
 				Insecure:            insecure,
 				ListenPort:          listenPort,
+				MetricsPort:         metricsPort,
 				Namespace:           namespace,
 				StaticAssetsDir:     staticAssetsDir,
 				BaseHRef:            baseHRef,
@@ -83,7 +85,7 @@ func NewCommand() *cobra.Command {
 				ctx := context.Background()
 				ctx, cancel := context.WithCancel(ctx)
 				argocd := server.NewServer(ctx, argoCDOpts)
-				argocd.Run(ctx, listenPort)
+				argocd.Run(ctx, listenPort, metricsPort)
 				cancel()
 			}
 		},
@@ -99,7 +101,8 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&dexServerAddress, "dex-server", common.DefaultDexServerAddr, "Dex server address")
 	command.Flags().BoolVar(&disableAuth, "disable-auth", false, "Disable client authentication")
 	command.AddCommand(cli.NewVersionCmd(cliName))
-	command.Flags().IntVar(&listenPort, "listen-port", common.PortAPIServer, "Listen on given port")
+	command.Flags().IntVar(&listenPort, "listen-port", common.DefaultPortAPIServer, "Listen on given port")
+	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDAPIServerMetrics, "Start metrics on given port")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(command)
 	cacheSrc = cache.AddCacheFlagsToCmd(command)
 	return command

--- a/common/common.go
+++ b/common/common.go
@@ -18,12 +18,18 @@ const (
 )
 
 const (
-	PortAPIServer              = 8080
-	PortRepoServer             = 8081
-	PortArgoCDMetrics          = 8082
-	PortArgoCDAPIServerMetrics = 8083
-	PortRepoServerMetrics      = 8084
+	DefaultPortAPIServer              = 8080
+	DefaultPortRepoServer             = 8081
+	DefaultPortArgoCDMetrics          = 8082
+	DefaultPortArgoCDAPIServerMetrics = 8083
+	DefaultPortRepoServerMetrics      = 8084
 )
+
+var PortAPIServer = DefaultPortAPIServer
+var PortRepoServer = DefaultPortRepoServer
+var PortArgoCDMetrics = DefaultPortArgoCDMetrics
+var PortArgoCDAPIServerMetrics = DefaultPortArgoCDAPIServerMetrics
+var PortRepoServerMetrics = DefaultPortRepoServerMetrics
 
 // Argo CD application related constants
 const (

--- a/common/common.go
+++ b/common/common.go
@@ -17,6 +17,7 @@ const (
 	ArgoCDRBACConfigMapName = "argocd-rbac-cm"
 )
 
+// Default listener ports for ArgoCD components
 const (
 	DefaultPortAPIServer              = 8080
 	DefaultPortRepoServer             = 8081
@@ -24,12 +25,6 @@ const (
 	DefaultPortArgoCDAPIServerMetrics = 8083
 	DefaultPortRepoServerMetrics      = 8084
 )
-
-var PortAPIServer = DefaultPortAPIServer
-var PortRepoServer = DefaultPortRepoServer
-var PortArgoCDMetrics = DefaultPortArgoCDMetrics
-var PortArgoCDAPIServerMetrics = DefaultPortArgoCDAPIServerMetrics
-var PortRepoServerMetrics = DefaultPortRepoServerMetrics
 
 // Argo CD application related constants
 const (

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -86,6 +86,7 @@ func NewApplicationController(
 	repoClientset reposerver.Clientset,
 	argoCache *argocache.Cache,
 	appResyncPeriod time.Duration,
+	metricsPort int,
 ) (*ApplicationController, error) {
 	db := db.NewDB(namespace, settingsMgr, kubeClientset)
 	settings, err := settingsMgr.GetSettings()
@@ -112,7 +113,7 @@ func NewApplicationController(
 	}
 	appInformer, appLister := ctrl.newApplicationInformerAndLister()
 	projInformer := v1alpha1.NewAppProjectInformer(applicationClientset, namespace, appResyncPeriod, cache.Indexers{})
-	metricsAddr := fmt.Sprintf("0.0.0.0:%d", common.PortArgoCDMetrics)
+	metricsAddr := fmt.Sprintf("0.0.0.0:%d", metricsPort)
 	ctrl.metricsServer = metrics.NewMetricsServer(metricsAddr, appLister)
 	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settings, kubectlCmd, ctrl.metricsServer, ctrl.handleAppUpdated)
 	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectlCmd, ctrl.settings, stateCache, projInformer, ctrl.metricsServer)

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -76,6 +76,7 @@ func newFakeController(data *fakeData) *ApplicationController {
 		&mockRepoClientset,
 		utilcache.NewCache(utilcache.NewInMemoryCache(1*time.Hour)),
 		time.Minute,
+		8082,
 	)
 	if err != nil {
 		panic(err)

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -76,7 +76,7 @@ func newFakeController(data *fakeData) *ApplicationController {
 		&mockRepoClientset,
 		utilcache.NewCache(utilcache.NewInMemoryCache(1*time.Hour)),
 		time.Minute,
-		8082,
+		common.DefaultPortArgoCDMetrics,
 	)
 	if err != nil {
 		panic(err)

--- a/server/server.go
+++ b/server/server.go
@@ -122,6 +122,7 @@ type ArgoCDServer struct {
 type ArgoCDServerOpts struct {
 	DisableAuth         bool
 	Insecure            bool
+	ListenPort          int
 	Namespace           string
 	DexServerAddr       string
 	StaticAssetsDir     string

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -334,9 +334,11 @@ func TestUserAgent(t *testing.T) {
 	defer cancelInformer()
 	port, err := test.GetFreePort()
 	assert.NoError(t, err)
+	metricsport, err := test.GetFreePort()
+	assert.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go s.Run(ctx, port)
+	go s.Run(ctx, port, metricsport)
 
 	err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
 	assert.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -338,7 +338,7 @@ func TestUserAgent(t *testing.T) {
 	assert.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go s.Run(ctx, port, metricsport)
+	go s.Run(ctx, port, metricsPort)
 
 	err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
 	assert.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -334,7 +334,7 @@ func TestUserAgent(t *testing.T) {
 	defer cancelInformer()
 	port, err := test.GetFreePort()
 	assert.NoError(t, err)
-	metricsport, err := test.GetFreePort()
+	metricsPort, err := test.GetFreePort()
 	assert.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Add the ability to specify the listener ports for API server and repo server processes as well as the listener ports for the metrics server of API server, repo server and application conroller. I found having this possibility most useful on my local dev machine - especially for executing the E2E tests - where other processes are already listening on some of the default ports used by ArgoCD.

This change:
- Introduces `--port` parameter for `argocd-server` and `argocd-repo-server` 
- Introduces `--metrics-port` parameter for `argocd-server`, `argocd-repo-server` and `argocd-application-controller`

If none of the parameters are specified, previous default values are used, so this change should be non-breaking.