### PR TITLE
Improve tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
             ARGOCD_FAKE_IN_CLUSTER: "true"
       - run:
           name: Start API server
-          command: go run ./cmd/argocd-server/main.go --loglevel debug --redis localhost:6379 --disable-auth --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ../argo-cd-ui/dist/app
+          command: go run ./cmd/argocd-server/main.go --loglevel debug --redis localhost:6379 --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ../argo-cd-ui/dist/app
           background: true
           environment:
             ARGOCD_FAKE_IN_CLUSTER: "true"
@@ -283,9 +283,7 @@ jobs:
           name: Wait for API server
           command: |
             set -x
-            # TODO - try to reduce to 20
-            sleep 60
-            curl -v --retry 5 localhost:8080
+            until curl -v http://localhost:8080/healthz; do sleep 3; done
       - run:
           name: Start controller
           command: go run ./cmd/argocd-application-controller/main.go --loglevel debug --redis localhost:6379 --repo-server localhost:8081 --kubeconfig ~/.kube/config
@@ -296,11 +294,10 @@ jobs:
           name: Smoke test
           command: |
             set -x
+            argocd login localhost:8080 --plaintext  --username admin --password password
             argocd app create guestbook --dest-namespace default --dest-server https://kubernetes.default.svc --repo https://github.com/argoproj/argocd-example-apps.git --path guestbook
             argocd app sync guestbook
             argocd app delete guestbook
-          environment:
-            ARGOCD_OPTS: "--server localhost:8080 --plaintext"
       - run:
           name: Run e2e tests
           command: |

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -65,13 +65,11 @@ func TestAppDeletion(t *testing.T) {
 		Delete(true).
 		Then().
 		Expect(DoesNotExist()).
-		Expect(Event(EventReasonResourceDeleted, "delete")).
-		And(func(_ *Application) {
-			// app should NOT be listed
-			output, err := fixture.RunCli("app", "list")
-			assert.NoError(t, err)
-			assert.NotContains(t, output, fixture.Name())
-		})
+		Expect(Event(EventReasonResourceDeleted, "delete"))
+
+	output, err := fixture.RunCli("app", "list")
+	assert.NoError(t, err)
+	assert.NotContains(t, output, fixture.Name())
 }
 
 func TestTrackAppStateAndSyncApp(t *testing.T) {
@@ -484,6 +482,7 @@ func TestPermissions(t *testing.T) {
 	proj.Spec.SourceRepos = []string{}
 	_, err = fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.ArgoCDNamespace).Update(proj)
 	assert.NoError(t, err)
+	time.Sleep(1 * time.Second)
 	closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 	assert.NoError(t, err)
 	defer util.Close(closer)

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -1,11 +1,10 @@
 package app
 
 import (
-	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/errors"
 	. "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -52,15 +51,7 @@ func (c *Consequences) app() *Application {
 }
 
 func (c *Consequences) get() (*Application, error) {
-	output, err := fixture.RunCli("app", "get", c.context.name, "-o", "yaml")
-	if err != nil {
-		if strings.Contains(output, "NotFound") {
-			return nil, nil
-		}
-		return nil, err
-	}
-	app := &Application{}
-	return app, yaml.Unmarshal([]byte(output), app)
+	return fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.ArgoCDNamespace).Get(c.context.name, v1.GetOptions{})
 }
 
 func (c *Consequences) resource(name string) ResourceStatus {

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 
@@ -83,12 +84,12 @@ func ResourceHealthIs(resource string, expected HealthStatusCode) Expectation {
 
 func DoesNotExist() Expectation {
 	return func(c *Consequences) (state, string) {
-		app, err := c.get()
+		_, err := c.get()
 		if err != nil {
+			if apierr.IsNotFound(err) {
+				return succeeded, "app does not exist"
+			}
 			return failed, err.Error()
-		}
-		if app == nil {
-			return succeeded, "app does not exist"
 		}
 		return pending, "app should not exist"
 	}

--- a/test/e2e/fixture/cmd.go
+++ b/test/e2e/fixture/cmd.go
@@ -1,6 +1,7 @@
 package fixture
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ func Run(workDir, name string, args ...string) (string, error) {
 	log.WithFields(log.Fields{"name": name, "args": args, "workDir": workDir}).Info("running command")
 
 	cmd := exec.Command(name, args...)
+	cmd.Env = os.Environ()
 	cmd.Dir = workDir
 
 	outBytes, err := cmd.Output()

--- a/test/e2e/repo_creds_test.go
+++ b/test/e2e/repo_creds_test.go
@@ -47,7 +47,9 @@ func TestCanAddAppFromPrivateRepoWithCredConfig(t *testing.T) {
 		Path(appPath).
 		And(func() {
 			secretName := fixture.CreateSecret("blah", accessToken)
-			FailOnErr(fixture.Run("", "kubectl", "patch", "cm", "argocd-cm", "-p", fmt.Sprintf(`{"data": {"repository.credentials": "- passwordSecret:\n    key: password\n    name: %s\n  url: %s\n  usernameSecret:\n    key: username\n    name: %s\n"}}`, secretName, repoUrl, secretName)))
+			FailOnErr(fixture.Run("", "kubectl", "patch", "cm", "argocd-cm",
+				"-n", fixture.ArgoCDNamespace,
+				"-p", fmt.Sprintf(`{"data": {"repository.credentials": "- passwordSecret:\n    key: password\n    name: %s\n  url: %s\n  usernameSecret:\n    key: username\n    name: %s\n"}}`, secretName, repoUrl, secretName)))
 		}).
 		When().
 		Create().


### PR DESCRIPTION
PR has following CI improvements:


- enables auth in circle ci: https://github.com/argoproj/argo-cd/pull/1667/files#diff-1d37e48f9ceff6d8030570cd36286a61L278
- remove hardcoded 60 seconds timeout: https://github.com/argoproj/argo-cd/pull/1667/files#diff-1d37e48f9ceff6d8030570cd36286a61R286
- It appears that each `kubectl` command takes at least 100ms. Tried to switch to k8s api and it saved 40 seconds: https://github.com/argoproj/argo-cd/pull/1667/files#diff-908ea2b2aac0dffff86c703e913175b4L140 
- fixes test fixture initialization bug: https://github.com/argoproj/argo-cd/pull/1667/files#diff-908ea2b2aac0dffff86c703e913175b4R153


