### PR TITLE
Handle nil obj when processing custom actions

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1767,6 +1767,9 @@ func filterResources(command *cobra.Command, resources []*argoappv1.ResourceDiff
 	filteredObjects := make([]*unstructured.Unstructured, 0)
 	for i := range liveObjs {
 		obj := liveObjs[i]
+		if obj == nil {
+			continue
+		}
 		gvk := obj.GroupVersionKind()
 		if command.Flags().Changed("group") && group != gvk.Group {
 			continue


### PR DESCRIPTION
If an application has a missing resource, running a custom action CLI command will cause a panic on the CLI. The CLI will make a call to the ManageResource endpoint, and the server will return a nil object that the CLI will try to operate on. This PR addresses the panic by adding a nil check on the CLI. Before the fix, the CLI will produce a stacktrace like the following:

```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b7f09a]

goroutine 1 [running]:
github.com/argoproj/argo-cd/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetAPIVersion(0x0, 0xc0007e5ad4, 0x9)
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:200 +0x3a
github.com/argoproj/argo-cd/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GroupVersionKind(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:396 +0x5b
github.com/argoproj/argo-cd/cmd/argocd/commands.filterResources(0xc000448000, 0xc000368700, 0x18, 0x20, 0x7ffeefbff728, 0xb, 0x7ffeefbff718, 0x7, 0x0, 0x0, ...)
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/cmd/argocd/commands/app.go:1794 +0x107
github.com/argoproj/argo-cd/cmd/argocd/commands.NewApplicationResourceActionsListCommand.func1(0xc000448000, 0xc00038a5a0, 0x1, 0x5)
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/cmd/argocd/commands/app_actions.go:56 +0x2d8
github.com/argoproj/argo-cd/vendor/github.com/spf13/cobra.(*Command).execute(0xc000448000, 0xc00038a550, 0x5, 0x5, 0xc000448000, 0xc00038a550)
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/vendor/github.com/spf13/cobra/command.go:702 +0x2d3
github.com/argoproj/argo-cd/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0004aa480, 0xc0004aad80, 0xc0000d5d10, 0xc0001d5ab0)
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/vendor/github.com/spf13/cobra/command.go:783 +0x2dc
github.com/argoproj/argo-cd/vendor/github.com/spf13/cobra.(*Command).Execute(0xc0004aa480, 0xc0004c1f88, 0xc00009e058)
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/vendor/github.com/spf13/cobra/command.go:736 +0x2b
main.main()
    /Users/dthomson/go/src/github.com/argoproj/argo-cd/cmd/argocd/main.go:14 +0x27```