### PR TITLE
Fix key generation loop when running server on insecure mode

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -315,7 +315,7 @@ func (a *ArgoCDServer) watchSettings(ctx context.Context) {
 	prevGitLabSecret := a.settings.WebhookGitLabSecret
 	prevBitBucketUUID := a.settings.WebhookBitbucketUUID
 	var prevCert, prevCertKey string
-	if a.settings.Certificate != nil {
+	if a.settings.Certificate != nil && !a.ArgoCDServerOpts.Insecure {
 		prevCert, prevCertKey = tlsutil.EncodeX509KeyPairString(*a.settings.Certificate)
 	}
 
@@ -348,13 +348,15 @@ func (a *ArgoCDServer) watchSettings(ctx context.Context) {
 			log.Infof("bitbucket uuid modified. restarting")
 			break
 		}
-		var newCert, newCertKey string
-		if a.settings.Certificate != nil {
-			newCert, newCertKey = tlsutil.EncodeX509KeyPairString(*a.settings.Certificate)
-		}
-		if newCert != prevCert || newCertKey != prevCertKey {
-			log.Infof("tls certificate modified. restarting")
-			break
+		if !a.ArgoCDServerOpts.Insecure {
+			var newCert, newCertKey string
+			if a.settings.Certificate != nil {
+				newCert, newCertKey = tlsutil.EncodeX509KeyPairString(*a.settings.Certificate)
+			}
+			if newCert != prevCert || newCertKey != prevCertKey {
+				log.Infof("tls certificate modified. restarting")
+				break
+			}
 		}
 	}
 	log.Info("shutting down settings watch")

--- a/server/server.go
+++ b/server/server.go
@@ -163,7 +163,7 @@ func initializeDefaultProject(opts ArgoCDServerOpts) error {
 // NewServer returns a new instance of the Argo CD API server
 func NewServer(ctx context.Context, opts ArgoCDServerOpts) *ArgoCDServer {
 	settingsMgr := settings_util.NewSettingsManager(ctx, opts.KubeClientset, opts.Namespace)
-	settings, err := settingsMgr.InitializeSettings()
+	settings, err := settingsMgr.InitializeSettings(opts.Insecure)
 	errors.CheckError(err)
 	err = initializeDefaultProject(opts)
 	errors.CheckError(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -395,3 +395,9 @@ func TestUserAgent(t *testing.T) {
 		_ = conn.Close()
 	}
 }
+
+func TestCertsAreNotGeneratedInInsecureMode(t *testing.T) {
+	s := fakeServer()
+	assert.True(t, s.Insecure)
+	assert.Nil(t, s.settings.Certificate)
+}

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -801,7 +801,7 @@ func isIncompleteSettingsError(err error) bool {
 }
 
 // InitializeSettings is used to initialize empty admin password, signature, certificate etc if missing
-func (mgr *SettingsManager) InitializeSettings() (*ArgoCDSettings, error) {
+func (mgr *SettingsManager) InitializeSettings(insecureModeEnabled bool) (*ArgoCDSettings, error) {
 	cdSettings, err := mgr.GetSettings()
 	if err != nil && !isIncompleteSettingsError(err) {
 		return nil, err
@@ -836,7 +836,7 @@ func (mgr *SettingsManager) InitializeSettings() (*ArgoCDSettings, error) {
 		log.Info("Initialized admin mtime")
 	}
 
-	if cdSettings.Certificate == nil {
+	if cdSettings.Certificate == nil && !insecureModeEnabled {
 		// generate TLS cert
 		hosts := []string{
 			"localhost",


### PR DESCRIPTION
Re: https://github.com/argoproj/argo-cd/issues/1581. @alexmt could you take a look at this please?

I made this change to `server.go` since only this level of abstraction is aware of the fact that the server was run in insecure mode. Keys will still be generated by `settings.go` and if the keys are changed they will still trigger a settings update via `notifySubscribers` however these changes will be ignored by the server. I decided not to add any logic to `settings.go` because it should be agnostic to the fact that the server was run on insecure mode in this particular instance.