### PR TITLE
Issue #1375 - Error view instead of blank page in UI

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -74,7 +74,7 @@ requests.onError.subscribe(async (err) => {
     }
 });
 
-export class App extends React.Component<{}, { popupProps: PopupProps }> {
+export class App extends React.Component<{}, { popupProps: PopupProps, error: Error }> {
     public static childContextTypes = {
         history: PropTypes.object,
         apis: PropTypes.object,
@@ -86,7 +86,7 @@ export class App extends React.Component<{}, { popupProps: PopupProps }> {
 
     constructor(props: {}) {
         super(props);
-        this.state = { popupProps: null };
+        this.state = { popupProps: null, error: null };
         this.popupManager = new PopupManager();
         this.notificationsManager = new NotificationsManager();
         this.navigationManager = new NavigationManager(history);
@@ -96,7 +96,25 @@ export class App extends React.Component<{}, { popupProps: PopupProps }> {
         this.popupManager.popupProps.subscribe((popupProps) => this.setState({ popupProps }));
     }
 
+    static getDerivedStateFromError(error: Error) {
+        return { error: error };
+    }
+
     public render() {
+        if (this.state.error != null) {
+            let stack = this.state.error.stack;
+            let url = "https://github.com/argoproj/argo-cd/issues/new?labels=bug&template=bug_report.md";
+
+            return (
+                <React.Fragment>
+                    <p>Something went wrong!</p>
+                    <p>Consider submitting an issue <a href={url}>here</a>.</p><br />
+                    <p>Stacktrace:</p>
+                    <p style={{ fontFamily: "monospace" }}>{stack}</p>
+                </React.Fragment>
+            );
+        }
+
         return (
             <React.Fragment>
                 <Helmet>

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -80,6 +80,10 @@ export class App extends React.Component<{}, { popupProps: PopupProps, error: Er
         apis: PropTypes.object,
     };
 
+    public static getDerivedStateFromError(error: Error) {
+        return { error };
+    }
+
     private popupManager: PopupManager;
     private notificationsManager: NotificationsManager;
     private navigationManager: NavigationManager;
@@ -96,14 +100,10 @@ export class App extends React.Component<{}, { popupProps: PopupProps, error: Er
         this.popupManager.popupProps.subscribe((popupProps) => this.setState({ popupProps }));
     }
 
-    static getDerivedStateFromError(error: Error) {
-        return { error: error };
-    }
-
     public render() {
         if (this.state.error != null) {
-            let stack = this.state.error.stack;
-            let url = "https://github.com/argoproj/argo-cd/issues/new?labels=bug&template=bug_report.md";
+            const stack = this.state.error.stack;
+            const url = 'https://github.com/argoproj/argo-cd/issues/new?labels=bug&template=bug_report.md';
 
             return (
                 <React.Fragment>

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -110,7 +110,7 @@ export class App extends React.Component<{}, { popupProps: PopupProps, error: Er
                     <p>Something went wrong!</p>
                     <p>Consider submitting an issue <a href={url}>here</a>.</p><br />
                     <p>Stacktrace:</p>
-                    <p style={{ fontFamily: "monospace" }}>{stack}</p>
+                    <pre>{stack}</pre>
                 </React.Fragment>
             );
         }


### PR DESCRIPTION
<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  

Closes #1375

If an error causes the UI to crash, a page with the stacktrace and a link to submit a new issue is shown, for example:

![image](https://user-images.githubusercontent.com/3106877/59230372-1ed0d780-8b92-11e9-899c-42bab98400ed.png)