### PR TITLE
Setting Helm params with commas now updates local spec

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -1476,6 +1477,7 @@ func setParameterOverrides(app *argoappv1.Application, parameters []string) {
 		if app.Spec.Source.Helm == nil {
 			app.Spec.Source.Helm = &argoappv1.ApplicationSourceHelm{}
 		}
+		re := regexp.MustCompile(`([^\\]),`)
 		for _, paramStr := range parameters {
 			parts := strings.SplitN(paramStr, "=", 2)
 			if len(parts) != 2 {
@@ -1483,7 +1485,7 @@ func setParameterOverrides(app *argoappv1.Application, parameters []string) {
 			}
 			newParam := argoappv1.HelmParameter{
 				Name:  parts[0],
-				Value: parts[1],
+				Value: re.ReplaceAllString(parts[1], `$1\,`),
 			}
 			found := false
 			for i, cp := range app.Spec.Source.Helm.Parameters {

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -211,13 +211,13 @@ func (h *helm) GetParameters(valuesFiles []string) ([]*argoappv1.HelmParameter, 
 }
 
 func (h *helm) helmCmd(args ...string) (string, error) {
-	cleanHelmParameters(args)
 	return h.helmCmdExt(args, func(s string) string {
 		return s
 	})
 }
 
 func (h *helm) helmCmdExt(args []string, logFormat func(string) string) (string, error) {
+	cleanHelmParameters(args)
 	cmd := exec.Command("helm", args...)
 	cmd.Env = os.Environ()
 	cmd.Dir = h.path


### PR DESCRIPTION
When setting Helm parameters with commas (as per https://github.com/argoproj/argo-cd/pull/1720), commas are now also escaped in `app.Spec.Source.Helm.Parameters`. Otherwise, a `ComparisonError` would arise since the the local spec would be different.
