### PR TITLE
Cluster registration inadvertently carried forward client-cert auth credentials

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1496,7 +1496,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:d2aae07aa745223592ae668f6eb6c2ca0242d66a6dcf16b1e8e2711a79aad0f1"
+  digest = "1:aae856b28533bfdb39112514290f7722d00a55a99d2d0b897c6ee82e6feb87b3"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen",

--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -787,33 +787,6 @@
         }
       }
     },
-    "/api/v1/clusters-kubeconfig": {
-      "post": {
-        "tags": [
-          "ClusterService"
-        ],
-        "summary": "CreateFromKubeConfig installs the argocd-manager service account into the cluster specified in the given kubeconfig and context",
-        "operationId": "CreateFromKubeConfig",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/clusterClusterCreateFromKubeConfigRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "(empty)",
-            "schema": {
-              "$ref": "#/definitions/v1alpha1Cluster"
-            }
-          }
-        }
-      }
-    },
     "/api/v1/clusters/{cluster.server}": {
       "put": {
         "tags": [
@@ -1552,29 +1525,6 @@
           "items": {
             "$ref": "#/definitions/v1alpha1ResourceAction"
           }
-        }
-      }
-    },
-    "clusterClusterCreateFromKubeConfigRequest": {
-      "type": "object",
-      "properties": {
-        "context": {
-          "type": "string"
-        },
-        "inCluster": {
-          "type": "boolean",
-          "format": "boolean"
-        },
-        "kubeconfig": {
-          "type": "string"
-        },
-        "systemNamespace": {
-          "type": "string",
-          "title": "Optional alternative system namespace to use (defaults to \"kube-system\")"
-        },
-        "upsert": {
-          "type": "boolean",
-          "format": "boolean"
         }
       }
     },

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -156,19 +156,7 @@ func NewCluster(name string, conf *rest.Config, managerBearerToken string, awsAu
 	tlsClientConfig := argoappv1.TLSClientConfig{
 		Insecure:   conf.TLSClientConfig.Insecure,
 		ServerName: conf.TLSClientConfig.ServerName,
-		CertData:   conf.TLSClientConfig.CertData,
-		KeyData:    conf.TLSClientConfig.KeyData,
 		CAData:     conf.TLSClientConfig.CAData,
-	}
-	if len(conf.TLSClientConfig.CertData) == 0 && conf.TLSClientConfig.CertFile != "" {
-		data, err := ioutil.ReadFile(conf.TLSClientConfig.CertFile)
-		errors.CheckError(err)
-		tlsClientConfig.CertData = data
-	}
-	if len(conf.TLSClientConfig.KeyData) == 0 && conf.TLSClientConfig.KeyFile != "" {
-		data, err := ioutil.ReadFile(conf.TLSClientConfig.KeyFile)
-		errors.CheckError(err)
-		tlsClientConfig.KeyData = data
 	}
 	if len(conf.TLSClientConfig.CAData) == 0 && conf.TLSClientConfig.CAFile != "" {
 		data, err := ioutil.ReadFile(conf.TLSClientConfig.CAFile)

--- a/pkg/apiclient/cluster/cluster.pb.go
+++ b/pkg/apiclient/cluster/cluster.pb.go
@@ -45,7 +45,7 @@ func (m *ClusterQuery) Reset()         { *m = ClusterQuery{} }
 func (m *ClusterQuery) String() string { return proto.CompactTextString(m) }
 func (*ClusterQuery) ProtoMessage()    {}
 func (*ClusterQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_f1fe593bfbefdde6, []int{0}
+	return fileDescriptor_cluster_63d48da351ddefcc, []int{0}
 }
 func (m *ClusterQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -91,7 +91,7 @@ func (m *ClusterResponse) Reset()         { *m = ClusterResponse{} }
 func (m *ClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterResponse) ProtoMessage()    {}
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_f1fe593bfbefdde6, []int{1}
+	return fileDescriptor_cluster_63d48da351ddefcc, []int{1}
 }
 func (m *ClusterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -132,7 +132,7 @@ func (m *ClusterCreateRequest) Reset()         { *m = ClusterCreateRequest{} }
 func (m *ClusterCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterCreateRequest) ProtoMessage()    {}
 func (*ClusterCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_f1fe593bfbefdde6, []int{2}
+	return fileDescriptor_cluster_63d48da351ddefcc, []int{2}
 }
 func (m *ClusterCreateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -175,86 +175,6 @@ func (m *ClusterCreateRequest) GetUpsert() bool {
 	return false
 }
 
-type ClusterCreateFromKubeConfigRequest struct {
-	Kubeconfig string `protobuf:"bytes,1,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
-	Context    string `protobuf:"bytes,2,opt,name=context,proto3" json:"context,omitempty"`
-	Upsert     bool   `protobuf:"varint,3,opt,name=upsert,proto3" json:"upsert,omitempty"`
-	InCluster  bool   `protobuf:"varint,4,opt,name=inCluster,proto3" json:"inCluster,omitempty"`
-	// Optional alternative system namespace to use (defaults to "kube-system")
-	SystemNamespace      string   `protobuf:"bytes,5,opt,name=systemNamespace,proto3" json:"systemNamespace,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *ClusterCreateFromKubeConfigRequest) Reset()         { *m = ClusterCreateFromKubeConfigRequest{} }
-func (m *ClusterCreateFromKubeConfigRequest) String() string { return proto.CompactTextString(m) }
-func (*ClusterCreateFromKubeConfigRequest) ProtoMessage()    {}
-func (*ClusterCreateFromKubeConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_f1fe593bfbefdde6, []int{3}
-}
-func (m *ClusterCreateFromKubeConfigRequest) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *ClusterCreateFromKubeConfigRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_ClusterCreateFromKubeConfigRequest.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (dst *ClusterCreateFromKubeConfigRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterCreateFromKubeConfigRequest.Merge(dst, src)
-}
-func (m *ClusterCreateFromKubeConfigRequest) XXX_Size() int {
-	return m.Size()
-}
-func (m *ClusterCreateFromKubeConfigRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterCreateFromKubeConfigRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ClusterCreateFromKubeConfigRequest proto.InternalMessageInfo
-
-func (m *ClusterCreateFromKubeConfigRequest) GetKubeconfig() string {
-	if m != nil {
-		return m.Kubeconfig
-	}
-	return ""
-}
-
-func (m *ClusterCreateFromKubeConfigRequest) GetContext() string {
-	if m != nil {
-		return m.Context
-	}
-	return ""
-}
-
-func (m *ClusterCreateFromKubeConfigRequest) GetUpsert() bool {
-	if m != nil {
-		return m.Upsert
-	}
-	return false
-}
-
-func (m *ClusterCreateFromKubeConfigRequest) GetInCluster() bool {
-	if m != nil {
-		return m.InCluster
-	}
-	return false
-}
-
-func (m *ClusterCreateFromKubeConfigRequest) GetSystemNamespace() string {
-	if m != nil {
-		return m.SystemNamespace
-	}
-	return ""
-}
-
 type ClusterUpdateRequest struct {
 	Cluster              *v1alpha1.Cluster `protobuf:"bytes,1,opt,name=cluster" json:"cluster,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
@@ -266,7 +186,7 @@ func (m *ClusterUpdateRequest) Reset()         { *m = ClusterUpdateRequest{} }
 func (m *ClusterUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterUpdateRequest) ProtoMessage()    {}
 func (*ClusterUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cluster_f1fe593bfbefdde6, []int{4}
+	return fileDescriptor_cluster_63d48da351ddefcc, []int{3}
 }
 func (m *ClusterUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -306,7 +226,6 @@ func init() {
 	proto.RegisterType((*ClusterQuery)(nil), "cluster.ClusterQuery")
 	proto.RegisterType((*ClusterResponse)(nil), "cluster.ClusterResponse")
 	proto.RegisterType((*ClusterCreateRequest)(nil), "cluster.ClusterCreateRequest")
-	proto.RegisterType((*ClusterCreateFromKubeConfigRequest)(nil), "cluster.ClusterCreateFromKubeConfigRequest")
 	proto.RegisterType((*ClusterUpdateRequest)(nil), "cluster.ClusterUpdateRequest")
 }
 
@@ -325,8 +244,6 @@ type ClusterServiceClient interface {
 	List(ctx context.Context, in *ClusterQuery, opts ...grpc.CallOption) (*v1alpha1.ClusterList, error)
 	// Create creates a cluster
 	Create(ctx context.Context, in *ClusterCreateRequest, opts ...grpc.CallOption) (*v1alpha1.Cluster, error)
-	// CreateFromKubeConfig installs the argocd-manager service account into the cluster specified in the given kubeconfig and context
-	CreateFromKubeConfig(ctx context.Context, in *ClusterCreateFromKubeConfigRequest, opts ...grpc.CallOption) (*v1alpha1.Cluster, error)
 	// Get returns a cluster by server address
 	Get(ctx context.Context, in *ClusterQuery, opts ...grpc.CallOption) (*v1alpha1.Cluster, error)
 	// Update updates a cluster
@@ -355,15 +272,6 @@ func (c *clusterServiceClient) List(ctx context.Context, in *ClusterQuery, opts 
 func (c *clusterServiceClient) Create(ctx context.Context, in *ClusterCreateRequest, opts ...grpc.CallOption) (*v1alpha1.Cluster, error) {
 	out := new(v1alpha1.Cluster)
 	err := c.cc.Invoke(ctx, "/cluster.ClusterService/Create", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *clusterServiceClient) CreateFromKubeConfig(ctx context.Context, in *ClusterCreateFromKubeConfigRequest, opts ...grpc.CallOption) (*v1alpha1.Cluster, error) {
-	out := new(v1alpha1.Cluster)
-	err := c.cc.Invoke(ctx, "/cluster.ClusterService/CreateFromKubeConfig", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -404,8 +312,6 @@ type ClusterServiceServer interface {
 	List(context.Context, *ClusterQuery) (*v1alpha1.ClusterList, error)
 	// Create creates a cluster
 	Create(context.Context, *ClusterCreateRequest) (*v1alpha1.Cluster, error)
-	// CreateFromKubeConfig installs the argocd-manager service account into the cluster specified in the given kubeconfig and context
-	CreateFromKubeConfig(context.Context, *ClusterCreateFromKubeConfigRequest) (*v1alpha1.Cluster, error)
 	// Get returns a cluster by server address
 	Get(context.Context, *ClusterQuery) (*v1alpha1.Cluster, error)
 	// Update updates a cluster
@@ -450,24 +356,6 @@ func _ClusterService_Create_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ClusterServiceServer).Create(ctx, req.(*ClusterCreateRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _ClusterService_CreateFromKubeConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ClusterCreateFromKubeConfigRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(ClusterServiceServer).CreateFromKubeConfig(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/cluster.ClusterService/CreateFromKubeConfig",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ClusterServiceServer).CreateFromKubeConfig(ctx, req.(*ClusterCreateFromKubeConfigRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -537,10 +425,6 @@ var _ClusterService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Create",
 			Handler:    _ClusterService_Create_Handler,
-		},
-		{
-			MethodName: "CreateFromKubeConfig",
-			Handler:    _ClusterService_CreateFromKubeConfig_Handler,
 		},
 		{
 			MethodName: "Get",
@@ -648,65 +532,6 @@ func (m *ClusterCreateRequest) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func (m *ClusterCreateFromKubeConfigRequest) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *ClusterCreateFromKubeConfigRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if len(m.Kubeconfig) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintCluster(dAtA, i, uint64(len(m.Kubeconfig)))
-		i += copy(dAtA[i:], m.Kubeconfig)
-	}
-	if len(m.Context) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintCluster(dAtA, i, uint64(len(m.Context)))
-		i += copy(dAtA[i:], m.Context)
-	}
-	if m.Upsert {
-		dAtA[i] = 0x18
-		i++
-		if m.Upsert {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.InCluster {
-		dAtA[i] = 0x20
-		i++
-		if m.InCluster {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if len(m.SystemNamespace) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintCluster(dAtA, i, uint64(len(m.SystemNamespace)))
-		i += copy(dAtA[i:], m.SystemNamespace)
-	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
-}
-
 func (m *ClusterUpdateRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -778,33 +603,6 @@ func (m *ClusterCreateRequest) Size() (n int) {
 	}
 	if m.Upsert {
 		n += 2
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
-	return n
-}
-
-func (m *ClusterCreateFromKubeConfigRequest) Size() (n int) {
-	var l int
-	_ = l
-	l = len(m.Kubeconfig)
-	if l > 0 {
-		n += 1 + l + sovCluster(uint64(l))
-	}
-	l = len(m.Context)
-	if l > 0 {
-		n += 1 + l + sovCluster(uint64(l))
-	}
-	if m.Upsert {
-		n += 2
-	}
-	if m.InCluster {
-		n += 2
-	}
-	l = len(m.SystemNamespace)
-	if l > 0 {
-		n += 1 + l + sovCluster(uint64(l))
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -1073,184 +871,6 @@ func (m *ClusterCreateRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *ClusterCreateFromKubeConfigRequest) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowCluster
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: ClusterCreateFromKubeConfigRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ClusterCreateFromKubeConfigRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Kubeconfig", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowCluster
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthCluster
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Kubeconfig = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Context", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowCluster
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthCluster
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Context = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Upsert", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowCluster
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.Upsert = bool(v != 0)
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field InCluster", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowCluster
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.InCluster = bool(v != 0)
-		case 5:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field SystemNamespace", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowCluster
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthCluster
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.SystemNamespace = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipCluster(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthCluster
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
 func (m *ClusterUpdateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1441,46 +1061,39 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/cluster/cluster.proto", fileDescriptor_cluster_f1fe593bfbefdde6)
+	proto.RegisterFile("server/cluster/cluster.proto", fileDescriptor_cluster_63d48da351ddefcc)
 }
 
-var fileDescriptor_cluster_f1fe593bfbefdde6 = []byte{
-	// 589 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_cluster_63d48da351ddefcc = []byte{
+	// 475 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x94, 0x4f, 0x8b, 0x13, 0x31,
-	0x18, 0xc6, 0xc9, 0xee, 0x3a, 0xeb, 0x46, 0x71, 0x35, 0xac, 0x32, 0x76, 0x6b, 0xe9, 0xce, 0x61,
-	0x29, 0xab, 0x3b, 0x43, 0xeb, 0x45, 0xf6, 0x22, 0x6c, 0x65, 0x45, 0x14, 0xc1, 0x8a, 0x17, 0x59,
-	0x90, 0x69, 0xfa, 0x3a, 0x3b, 0x76, 0x3a, 0x89, 0x49, 0xa6, 0xb8, 0x88, 0x08, 0x7a, 0x15, 0x2f,
-	0x7e, 0x00, 0x3f, 0x82, 0xdf, 0xc0, 0xb3, 0x47, 0xc1, 0x9b, 0x27, 0x29, 0x7e, 0x10, 0x99, 0x4c,
-	0xd2, 0xff, 0x05, 0xc1, 0xe2, 0xa9, 0xc9, 0x93, 0xf4, 0x79, 0x7f, 0x79, 0xf3, 0x4c, 0x70, 0x59,
-	0x82, 0xe8, 0x83, 0x08, 0x68, 0x92, 0x49, 0x35, 0xfa, 0xf5, 0xb9, 0x60, 0x8a, 0x91, 0x75, 0x33,
-	0x2d, 0x6d, 0x45, 0x2c, 0x62, 0x5a, 0x0b, 0xf2, 0x51, 0xb1, 0x5c, 0x2a, 0x47, 0x8c, 0x45, 0x09,
-	0x04, 0x21, 0x8f, 0x83, 0x30, 0x4d, 0x99, 0x0a, 0x55, 0xcc, 0x52, 0x69, 0x56, 0xbd, 0xee, 0x2d,
-	0xe9, 0xc7, 0x4c, 0xaf, 0x52, 0x26, 0x20, 0xe8, 0xd7, 0x83, 0x08, 0x52, 0x10, 0xa1, 0x82, 0x8e,
-	0xd9, 0x73, 0x2f, 0x8a, 0xd5, 0x49, 0xd6, 0xf6, 0x29, 0xeb, 0x05, 0xa1, 0xd0, 0x25, 0x5e, 0xe8,
-	0xc1, 0x3e, 0xed, 0x04, 0xbc, 0x1b, 0xe5, 0x7f, 0x96, 0x41, 0xc8, 0x79, 0x12, 0x53, 0x6d, 0x1e,
-	0xf4, 0xeb, 0x61, 0xc2, 0x4f, 0xc2, 0x19, 0x2b, 0x6f, 0x17, 0x9f, 0x6f, 0x16, 0xb4, 0x8f, 0x32,
-	0x10, 0xa7, 0xe4, 0x0a, 0x76, 0x8a, 0xb3, 0xb9, 0xa8, 0x8a, 0x6a, 0x1b, 0x2d, 0x33, 0xf3, 0x2e,
-	0xe1, 0x4d, 0xb3, 0xaf, 0x05, 0x92, 0xb3, 0x54, 0x82, 0xf7, 0x01, 0xe1, 0x2d, 0xa3, 0x35, 0x05,
-	0x84, 0x0a, 0x5a, 0xf0, 0x32, 0x03, 0xa9, 0xc8, 0x31, 0xb6, 0x1d, 0xd0, 0x26, 0xe7, 0x1a, 0x87,
-	0xfe, 0x08, 0xd8, 0xb7, 0xc0, 0x7a, 0xf0, 0x8c, 0x76, 0x7c, 0xde, 0x8d, 0xfc, 0x1c, 0xd8, 0x1f,
-	0x03, 0xf6, 0x2d, 0xb0, 0x6f, 0xab, 0x5a, 0xcb, 0x9c, 0x30, 0xe3, 0x12, 0x84, 0x72, 0x57, 0xaa,
-	0xa8, 0x76, 0xb6, 0x65, 0x66, 0xde, 0x57, 0x84, 0xbd, 0x09, 0x9c, 0x23, 0xc1, 0x7a, 0xf7, 0xb3,
-	0x36, 0x34, 0x59, 0xfa, 0x3c, 0x8e, 0x2c, 0x5c, 0x05, 0xe3, 0x6e, 0xd6, 0x06, 0xaa, 0x45, 0x73,
-	0xc8, 0x31, 0x85, 0xb8, 0x78, 0x9d, 0xb2, 0x54, 0xc1, 0xab, 0xc2, 0x7f, 0xa3, 0x65, 0xa7, 0x63,
-	0x85, 0x57, 0xc7, 0x0b, 0x93, 0x32, 0xde, 0x88, 0x53, 0x53, 0xd9, 0x5d, 0xd3, 0x4b, 0x23, 0x81,
-	0xd4, 0xf0, 0xa6, 0x3c, 0x95, 0x0a, 0x7a, 0x0f, 0xc3, 0x1e, 0x48, 0x1e, 0x52, 0x70, 0xcf, 0x68,
-	0xdf, 0x69, 0xd9, 0x53, 0xc3, 0x76, 0x3e, 0xe1, 0x9d, 0xff, 0xd5, 0xce, 0xc6, 0x4f, 0x07, 0x5f,
-	0x30, 0xe2, 0x63, 0x10, 0xfd, 0x98, 0x02, 0x79, 0x8b, 0xd7, 0x1e, 0xc4, 0x52, 0x91, 0xcb, 0xbe,
-	0xcd, 0xf5, 0x78, 0x44, 0x4a, 0x47, 0xff, 0x5e, 0x3e, 0xb7, 0xf7, 0xdc, 0x77, 0x3f, 0x7e, 0x7f,
-	0x5a, 0x21, 0xe4, 0xa2, 0xce, 0x7a, 0xbf, 0x6e, 0xbf, 0x22, 0x49, 0x3e, 0x22, 0xec, 0x14, 0x77,
-	0x48, 0xae, 0x4d, 0x33, 0x4c, 0x44, 0xad, 0xb4, 0x84, 0x56, 0x78, 0x3b, 0x9a, 0x63, 0xdb, 0x9b,
-	0xe1, 0x38, 0x18, 0x66, 0xee, 0x4b, 0x1e, 0xf5, 0x39, 0xa1, 0x22, 0xd7, 0xe7, 0xe3, 0xcd, 0x8d,
-	0xde, 0x52, 0x60, 0x77, 0x35, 0x6c, 0xd5, 0xdb, 0x9e, 0x86, 0xdd, 0x1f, 0x65, 0xf8, 0x00, 0xed,
-	0x91, 0xf7, 0x08, 0xaf, 0xde, 0x85, 0x85, 0x77, 0xb8, 0xc4, 0xbe, 0x91, 0xab, 0xd3, 0x28, 0xc1,
-	0xeb, 0xe2, 0xd1, 0x78, 0x43, 0x3e, 0x23, 0xec, 0x14, 0x61, 0x9e, 0xbd, 0xc8, 0x89, 0x90, 0x2f,
-	0x05, 0xa8, 0xa1, 0x81, 0x6e, 0x94, 0x76, 0x66, 0x81, 0x6c, 0x6d, 0x03, 0x36, 0xba, 0xd9, 0x63,
-	0xec, 0xdc, 0x81, 0x04, 0x14, 0x2c, 0xea, 0x94, 0x3b, 0x2d, 0x0f, 0xdf, 0x3f, 0x73, 0xfe, 0xbd,
-	0xc5, 0xe7, 0x3f, 0xbc, 0xfd, 0x6d, 0x50, 0x41, 0xdf, 0x07, 0x15, 0xf4, 0x6b, 0x50, 0x41, 0x4f,
-	0xeb, 0x7f, 0xf1, 0x6c, 0xd3, 0x24, 0x86, 0x54, 0x59, 0xab, 0xb6, 0xa3, 0x5f, 0xe9, 0x9b, 0x7f,
-	0x02, 0x00, 0x00, 0xff, 0xff, 0x12, 0x39, 0xbc, 0xb6, 0x71, 0x06, 0x00, 0x00,
+	0x18, 0xc6, 0xc9, 0xaa, 0xa3, 0x46, 0xf1, 0x4f, 0x58, 0xa5, 0x8e, 0x6b, 0xd9, 0x9d, 0x83, 0x2c,
+	0xa2, 0x09, 0xad, 0x17, 0xf1, 0x22, 0xec, 0x8a, 0x22, 0x78, 0xb1, 0xe2, 0x45, 0x16, 0x24, 0x3b,
+	0x7d, 0xc9, 0xc6, 0x8e, 0x93, 0x98, 0x64, 0x06, 0x44, 0x44, 0xd0, 0xab, 0x78, 0xf1, 0x03, 0x78,
+	0xf5, 0xa3, 0x78, 0x14, 0xfc, 0x02, 0x52, 0xfc, 0x20, 0x32, 0x99, 0xa4, 0xdd, 0xed, 0x50, 0x10,
+	0x2c, 0x9e, 0x9a, 0xbc, 0x49, 0x9f, 0xf7, 0x97, 0x27, 0xcf, 0x04, 0x6f, 0x58, 0x30, 0x35, 0x18,
+	0x96, 0x17, 0x95, 0x75, 0xf3, 0x5f, 0xaa, 0x8d, 0x72, 0x8a, 0x9c, 0x0c, 0xd3, 0x74, 0x5d, 0x28,
+	0xa1, 0x7c, 0x8d, 0x35, 0xa3, 0x76, 0x39, 0xdd, 0x10, 0x4a, 0x89, 0x02, 0x18, 0xd7, 0x92, 0xf1,
+	0xb2, 0x54, 0x8e, 0x3b, 0xa9, 0x4a, 0x1b, 0x56, 0xb3, 0xc9, 0x1d, 0x4b, 0xa5, 0xf2, 0xab, 0xb9,
+	0x32, 0xc0, 0xea, 0x01, 0x13, 0x50, 0x82, 0xe1, 0x0e, 0xc6, 0x61, 0xcf, 0x23, 0x21, 0xdd, 0x41,
+	0xb5, 0x4f, 0x73, 0xf5, 0x8a, 0x71, 0xe3, 0x5b, 0xbc, 0xf4, 0x83, 0x5b, 0xf9, 0x98, 0xe9, 0x89,
+	0x68, 0xfe, 0x6c, 0x19, 0xd7, 0xba, 0x90, 0xb9, 0x17, 0x67, 0xf5, 0x80, 0x17, 0xfa, 0x80, 0x77,
+	0xa4, 0xb2, 0xeb, 0xf8, 0xec, 0x6e, 0x4b, 0xfb, 0xa4, 0x02, 0xf3, 0x86, 0x5c, 0xc6, 0x49, 0x7b,
+	0xb6, 0x1e, 0xda, 0x44, 0xdb, 0xa7, 0x47, 0x61, 0x96, 0x5d, 0xc4, 0xe7, 0xc3, 0xbe, 0x11, 0x58,
+	0xad, 0x4a, 0x0b, 0xd9, 0x27, 0x84, 0xd7, 0x43, 0x6d, 0xd7, 0x00, 0x77, 0x30, 0x82, 0xd7, 0x15,
+	0x58, 0x47, 0xf6, 0x70, 0x74, 0xc0, 0x8b, 0x9c, 0x19, 0xee, 0xd0, 0x39, 0x30, 0x8d, 0xc0, 0x7e,
+	0xf0, 0x22, 0x1f, 0x53, 0x3d, 0x11, 0xb4, 0x01, 0xa6, 0x87, 0x80, 0x69, 0x04, 0xa6, 0xb1, 0x6b,
+	0x94, 0x6c, 0x08, 0x2b, 0x6d, 0xc1, 0xb8, 0xde, 0xda, 0x26, 0xda, 0x3e, 0x35, 0x0a, 0xb3, 0xcc,
+	0xcd, 0x68, 0x9e, 0xe9, 0xf1, 0xff, 0xa2, 0x19, 0x7e, 0x3b, 0x81, 0xcf, 0x85, 0xe2, 0x53, 0x30,
+	0xb5, 0xcc, 0x81, 0xbc, 0xc7, 0xc7, 0x1f, 0x4b, 0xeb, 0xc8, 0x25, 0x1a, 0x63, 0x71, 0xd8, 0xe1,
+	0xf4, 0xc1, 0xbf, 0xb7, 0x6f, 0xe4, 0xb3, 0xde, 0x87, 0x9f, 0xbf, 0xbf, 0xac, 0x11, 0x72, 0xc1,
+	0x47, 0xa5, 0x1e, 0xc4, 0x10, 0x5a, 0xf2, 0x19, 0xe1, 0xa4, 0xbd, 0x11, 0x72, 0x6d, 0x91, 0xe1,
+	0xc8, 0x4d, 0xa5, 0x2b, 0xb0, 0x22, 0xdb, 0xf2, 0x1c, 0x57, 0xb3, 0x0e, 0xc7, 0xdd, 0xd9, 0x95,
+	0x7d, 0x44, 0xf8, 0xd8, 0x43, 0x58, 0xea, 0xc8, 0x0a, 0x29, 0xc8, 0x95, 0x45, 0x0a, 0xf6, 0xb6,
+	0x4d, 0xf0, 0x3b, 0xf2, 0x15, 0xe1, 0xa4, 0x8d, 0x46, 0xd7, 0x96, 0x23, 0x91, 0x59, 0x09, 0xd0,
+	0xd0, 0x03, 0xdd, 0x4c, 0xb7, 0xba, 0x40, 0xb1, 0x77, 0x00, 0x9b, 0xfb, 0xb4, 0x87, 0x93, 0xfb,
+	0x50, 0x80, 0x83, 0x65, 0x4e, 0xf5, 0x16, 0xcb, 0xb3, 0x8f, 0x31, 0x9c, 0xff, 0xc6, 0xf2, 0xf3,
+	0xef, 0xdc, 0xfb, 0x3e, 0xed, 0xa3, 0x1f, 0xd3, 0x3e, 0xfa, 0x35, 0xed, 0xa3, 0xe7, 0x83, 0xbf,
+	0x78, 0x43, 0xf2, 0x42, 0x42, 0xe9, 0xa2, 0xd4, 0x7e, 0xe2, 0x9f, 0x8c, 0xdb, 0x7f, 0x02, 0x00,
+	0x00, 0xff, 0xff, 0x9f, 0x92, 0x8b, 0xe2, 0xfe, 0x04, 0x00, 0x00,
 }

--- a/pkg/apiclient/cluster/cluster.pb.gw.go
+++ b/pkg/apiclient/cluster/cluster.pb.gw.go
@@ -66,19 +66,6 @@ func request_ClusterService_Create_0(ctx context.Context, marshaler runtime.Mars
 
 }
 
-func request_ClusterService_CreateFromKubeConfig_0(ctx context.Context, marshaler runtime.Marshaler, client ClusterServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ClusterCreateFromKubeConfigRequest
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := client.CreateFromKubeConfig(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-
-}
-
 func request_ClusterService_Get_0(ctx context.Context, marshaler runtime.Marshaler, client ClusterServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ClusterQuery
 	var metadata runtime.ServerMetadata
@@ -260,35 +247,6 @@ func RegisterClusterServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 
 	})
 
-	mux.Handle("POST", pattern_ClusterService_CreateFromKubeConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		if cn, ok := w.(http.CloseNotifier); ok {
-			go func(done <-chan struct{}, closed <-chan bool) {
-				select {
-				case <-done:
-				case <-closed:
-					cancel()
-				}
-			}(ctx.Done(), cn.CloseNotify())
-		}
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		rctx, err := runtime.AnnotateContext(ctx, mux, req)
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_ClusterService_CreateFromKubeConfig_0(rctx, inboundMarshaler, client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, md)
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_ClusterService_CreateFromKubeConfig_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
 	mux.Handle("GET", pattern_ClusterService_Get_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -384,8 +342,6 @@ var (
 
 	pattern_ClusterService_Create_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "clusters"}, ""))
 
-	pattern_ClusterService_CreateFromKubeConfig_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "clusters-kubeconfig"}, ""))
-
 	pattern_ClusterService_Get_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "clusters", "server"}, ""))
 
 	pattern_ClusterService_Update_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "clusters", "cluster.server"}, ""))
@@ -397,8 +353,6 @@ var (
 	forward_ClusterService_List_0 = runtime.ForwardResponseMessage
 
 	forward_ClusterService_Create_0 = runtime.ForwardResponseMessage
-
-	forward_ClusterService_CreateFromKubeConfig_0 = runtime.ForwardResponseMessage
 
 	forward_ClusterService_Get_0 = runtime.ForwardResponseMessage
 

--- a/pkg/apiclient/cluster/mocks/ClusterServiceServer.go
+++ b/pkg/apiclient/cluster/mocks/ClusterServiceServer.go
@@ -35,29 +35,6 @@ func (_m *ClusterServiceServer) Create(_a0 context.Context, _a1 *cluster.Cluster
 	return r0, r1
 }
 
-// CreateFromKubeConfig provides a mock function with given fields: _a0, _a1
-func (_m *ClusterServiceServer) CreateFromKubeConfig(_a0 context.Context, _a1 *cluster.ClusterCreateFromKubeConfigRequest) (*v1alpha1.Cluster, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *v1alpha1.Cluster
-	if rf, ok := ret.Get(0).(func(context.Context, *cluster.ClusterCreateFromKubeConfigRequest) *v1alpha1.Cluster); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1alpha1.Cluster)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *cluster.ClusterCreateFromKubeConfigRequest) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // Delete provides a mock function with given fields: _a0, _a1
 func (_m *ClusterServiceServer) Delete(_a0 context.Context, _a1 *cluster.ClusterQuery) (*cluster.ClusterResponse, error) {
 	ret := _m.Called(_a0, _a1)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -11,9 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/pkg/apiclient/cluster"
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/server/rbacpolicy"
@@ -143,61 +141,6 @@ func (s *Server) Create(ctx context.Context, q *cluster.ClusterCreateRequest) (*
 		}
 	}
 	return redact(clust), err
-}
-
-// Create creates a cluster
-func (s *Server) CreateFromKubeConfig(ctx context.Context, q *cluster.ClusterCreateFromKubeConfigRequest) (*appv1.Cluster, error) {
-	kubeconfig, err := clientcmd.Load([]byte(q.Kubeconfig))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not unmarshal kubeconfig: %v", err)
-	}
-
-	var clusterServer string
-	var clusterInsecure bool
-	var systemNamespace string
-
-	if q.InCluster {
-		clusterServer = common.KubernetesInternalAPIServerAddr
-	} else if cluster, ok := kubeconfig.Clusters[q.Context]; ok {
-		clusterServer = cluster.Server
-		clusterInsecure = cluster.InsecureSkipTLSVerify
-	} else {
-		return nil, status.Errorf(codes.Internal, "Context %s does not exist in kubeconfig", q.Context)
-	}
-
-	if q.SystemNamespace != "" {
-		systemNamespace = q.SystemNamespace
-	} else {
-		systemNamespace = common.DefaultSystemNamespace
-	}
-
-	c := &appv1.Cluster{
-		Server: clusterServer,
-		Name:   q.Context,
-		Config: appv1.ClusterConfig{
-			TLSClientConfig: appv1.TLSClientConfig{
-				Insecure: clusterInsecure,
-			},
-		},
-	}
-
-	// Temporarily install RBAC resources for managing the cluster
-	clientset, err := kubernetes.NewForConfig(c.RESTConfig())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not create Kubernetes clientset: %v", err)
-	}
-
-	bearerToken, err := common.InstallClusterManagerRBAC(clientset, systemNamespace)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not install cluster manager RBAC: %v", err)
-	}
-
-	c.Config.BearerToken = bearerToken
-
-	return s.Create(ctx, &cluster.ClusterCreateRequest{
-		Cluster: c,
-		Upsert:  q.Upsert,
-	})
 }
 
 // Get returns a cluster from a query

--- a/server/cluster/cluster.proto
+++ b/server/cluster/cluster.proto
@@ -24,15 +24,6 @@ message ClusterCreateRequest {
 	bool upsert = 2;
 }
 
-message ClusterCreateFromKubeConfigRequest {
-	string kubeconfig = 1;
-	string context = 2;
-	bool upsert = 3;
-	bool inCluster = 4;
-	// Optional alternative system namespace to use (defaults to "kube-system")
-	string systemNamespace = 5; 
-}
-
 message ClusterUpdateRequest {
 	github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Cluster cluster = 1;
 }
@@ -53,14 +44,6 @@ service ClusterService {
 		};
 	}
 
-	// CreateFromKubeConfig installs the argocd-manager service account into the cluster specified in the given kubeconfig and context
-	rpc CreateFromKubeConfig(ClusterCreateFromKubeConfigRequest) returns (github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Cluster) {
-		option (google.api.http) = {
-			post: "/api/v1/clusters-kubeconfig"
-			body: "*"
-		};
-	}
-	
 	// Get returns a cluster by server address
 	rpc Get(ClusterQuery) returns (github.com.argoproj.argo_cd.pkg.apis.application.v1alpha1.Cluster) {
 		option (google.api.http).get = "/api/v1/clusters/{server}";


### PR DESCRIPTION
This fixes a security flaw where Argo CD would inadvertently store client-certificate auth credentials into the cluster secret (in addition to the bearer token). The consequence of doing so, is that even when the user rotated or revoked bearer token from the managed cluster, cluster interactions would still be possible from Argo CD because it would still be able to use the client-certificate method of authentication. This fix ensure we only store bearer tokens during cluster registration (`argocd cluster add`).