### PR TITLE
Allow setting timeout for golangci-lint in build process from external

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
           name: Lint code
           # use GOGC to limit memory usage in exchange for CPU usage, https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
           # we have 8GB RAM, 2CPUs https://circleci.com/docs/2.0/executor-types/#using-machine
-          command: LINT_GOGC=50 LINT_CONCURRENCY=2 make lint
+          command: LINT_GOGC=50 LINT_CONCURRENCY=2 LINT_DEADLINE=2m0s make lint
       - run:
           name: Check nothing has changed
           command: |

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DEV_IMAGE?=false
 LINT_GOGC?=off
 LINT_CONCURRENCY?=8
 # Set timeout for linter
-LINT_DEADLINE?=2m0s
+LINT_DEADLINE?=1m0s
 
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ DEV_IMAGE?=false
 # lint is memory and CPU intensive, so we can limit on CI to mitigate OOM
 LINT_GOGC?=off
 LINT_CONCURRENCY?=8
+LINT_DEADLINE?=1m0s
 
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \
@@ -138,7 +139,7 @@ dep-ensure:
 lint:
 	# golangci-lint does not do a good job of formatting imports
 	goimports -local github.com/argoproj/argo-cd -w `find . ! -path './vendor/*' ! -path './pkg/client/*' -type f -name '*.go'`
-	GOGC=$(LINT_GOGC) golangci-lint run --fix --verbose --concurrency $(LINT_CONCURRENCY)
+	GOGC=$(LINT_GOGC) golangci-lint run --fix --verbose --concurrency $(LINT_CONCURRENCY) --deadline $(LINT_DEADLINE)
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DEV_IMAGE?=false
 # lint is memory and CPU intensive, so we can limit on CI to mitigate OOM
 LINT_GOGC?=off
 LINT_CONCURRENCY?=8
-LINT_DEADLINE?=1m0s
+LINT_DEADLINE?=2m0s
 
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ DEV_IMAGE?=false
 # lint is memory and CPU intensive, so we can limit on CI to mitigate OOM
 LINT_GOGC?=off
 LINT_CONCURRENCY?=8
+# Set timeout for linter
 LINT_DEADLINE?=2m0s
 
 override LDFLAGS += \


### PR DESCRIPTION
On my rather small development VM, the "lint" step of the build cycle fails because it takes too long. Increasing the time limit value using the --deadline switch to golangci-lint helps this.

This PR lets you specify the time limit value from external by setting LINT_DEADLINE env var to something reasonable. The default for --deadline option is 1m0s, so I used this as well.