### PR TITLE
Make E2E tests more configurable locally

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
-controller: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true go run ./cmd/argocd-application-controller/main.go --loglevel debug --redis localhost:6379 --repo-server localhost:8081"
-api-server: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true go run ./cmd/argocd-server/main.go --loglevel debug --redis localhost:6379 --disable-auth --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ui/dist/app"
-dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p 5556:5556 -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/dexidp/dex:v2.14.0 serve /dex.yaml"
-redis: docker run --rm --name argocd-redis -i -p 6379:6379 redis:5.0.3-alpine --save "" --appendonly no
-repo-server: sh -c "FORCE_LOG_COLORS=1 go run ./cmd/argocd-repo-server/main.go --loglevel debug --redis localhost:6379"
-ui: sh -c 'cd ui && yarn start'
+controller: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true go run ./cmd/argocd-application-controller/main.go --loglevel debug --redis localhost:${ARGOCD_E2E_REDIS_PORT:-6379} --repo-server localhost:${ARGOCD_E2E_REPOSERVER_PORT:-8081}"
+api-server: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true go run ./cmd/argocd-server/main.go --loglevel debug --redis localhost:${ARGOCD_E2E_REDIS_PORT:-6379} --disable-auth --insecure --dex-server http://localhost:${ARGOCD_E2E_DEX_PORT:-5556} --repo-server localhost:${ARGOCD_E2E_REPOSERVER_PORT:-8081} --port ${ARGOCD_E2E_APISERVER_PORT:-8080} --staticassets ui/dist/app"
+dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p ${ARGOCD_E2E_DEX_PORT:-5556}:${ARGOCD_E2E_DEX_PORT:-5556} -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/dexidp/dex:v2.14.0 serve /dex.yaml"
+redis: docker run --rm --name argocd-redis -i -p ${ARGOCD_E2E_REDIS_PORT:-6379}:${ARGOCD_E2E_REDIS_PORT:-6379} redis:5.0.3-alpine --save "" --appendonly no --port ${ARGOCD_E2E_REDIS_PORT:-6379}
+repo-server: sh -c "FORCE_LOG_COLORS=1 go run ./cmd/argocd-repo-server/main.go --loglevel debug --port ${ARGOCD_E2E_REPOSERVER_PORT:-8081} --redis localhost:${ARGOCD_E2E_REDIS_PORT:-6379}"
+ui: sh -c 'cd ui && ${ARGOCD_E2E_YARN_CMD:-yarn} start'

--- a/docs/developer-guide/test-e2e.md
+++ b/docs/developer-guide/test-e2e.md
@@ -13,6 +13,18 @@ Git repository via file url: `file:///tmp/argocd-e2e***`.
 
 You can observe the tests by using the UI [http://localhost:8080/applications](http://localhost:8080/applications).
 
+## Configuration of E2E Tests execution
+
+The Makefile's `start-e2e` target starts instances of ArgoCD on your local machine, of which the most will require a network listener. If for whatever reason you already have network services on your machine listening on the same ports, the e2e tests will not be able to run. You can derive from the defaults by setting the following environment variables before you run `make start-e2e`:
+
+* `ARGOCD_E2E_APISERVER_PORT`: Listener port for `argocd-server` component (default: `8080`)
+* `ARGOCD_E2E_REPOSERVER_PORT`: Listener port for `argocd-reposerver` component (default: `8081`)
+* `ARGOCD_E2E_DEX_PORT`: Listener port for `dex` component (default: `5556`)
+* `ARGOCD_E2E_REDIS_PORT`: Listener port for `redisr` component (default: `6379`)
+* `ARGOCD_E2E_YARN_CMD`: Command to use for starting the UI via Yarn (default: `yarn`)
+
+If you have changed the port for `argocd-server`, be sure to also set `ARGOCD_SERVER` environment variable to point to that port, e.g. `export ARGOCD_SERVER=localhost:8888` before running `make test-e2e` so that the test will communicate to the correct server component.
+
 ## CI Set-up
 
 The tests are executed by Argo Workflow defined at `.argo-ci/ci.yaml`. CI job The builds an Argo CD image, deploy argo cd components into throw-away kubernetes cluster provisioned
@@ -21,7 +33,7 @@ using k3s and run e2e tests against it.
 ## Test Isolation
 
 Some effort has been made to balance test isolation with speed. Tests are isolated as follows as each test gets:
- 
+
 * A random 5 character ID.
 * A unique Git repository containing the `testdata` in `/tmp/argocd-e2e/${id}`.
 * A namespace `argocd-e2e-ns-${id}`.
@@ -34,7 +46,7 @@ Some effort has been made to balance test isolation with speed. Tests are isolat
 This maybe due to the metrics server, run this:
 
 ```bash
-kubectl api-resources 
+kubectl api-resources
 ```
 
 If it exits with status code 1, run:

--- a/docs/developer-guide/test-e2e.md
+++ b/docs/developer-guide/test-e2e.md
@@ -17,10 +17,10 @@ You can observe the tests by using the UI [http://localhost:8080/applications](h
 
 The Makefile's `start-e2e` target starts instances of ArgoCD on your local machine, of which the most will require a network listener. If for whatever reason you already have network services on your machine listening on the same ports, the e2e tests will not be able to run. You can derive from the defaults by setting the following environment variables before you run `make start-e2e`:
 
-* `ARGOCD_E2E_APISERVER_PORT`: Listener port for `argocd-server` component (default: `8080`)
-* `ARGOCD_E2E_REPOSERVER_PORT`: Listener port for `argocd-reposerver` component (default: `8081`)
-* `ARGOCD_E2E_DEX_PORT`: Listener port for `dex` component (default: `5556`)
-* `ARGOCD_E2E_REDIS_PORT`: Listener port for `redisr` component (default: `6379`)
+* `ARGOCD_E2E_APISERVER_PORT`: Listener port for `argocd-server` (default: `8080`)
+* `ARGOCD_E2E_REPOSERVER_PORT`: Listener port for `argocd-reposerver` (default: `8081`)
+* `ARGOCD_E2E_DEX_PORT`: Listener port for `dex` (default: `5556`)
+* `ARGOCD_E2E_REDIS_PORT`: Listener port for `redis` (default: `6379`)
 * `ARGOCD_E2E_YARN_CMD`: Command to use for starting the UI via Yarn (default: `yarn`)
 
 If you have changed the port for `argocd-server`, be sure to also set `ARGOCD_SERVER` environment variable to point to that port, e.g. `export ARGOCD_SERVER=localhost:8888` before running `make test-e2e` so that the test will communicate to the correct server component.


### PR DESCRIPTION
This change adds the possibility to configure execution of E2E tests on the local machine by using the following environment variables:

* ARGOCD_E2E_APISERVER_PORT (default 8080)
* ARGOCD_E2E_REPOSERVER_PORT (default 8081)
* ARGOCD_E2E_DEX_PORT (default 5556)
* ARGOCD_E2E_REDIS_PORT (default 6379)
* ARGOCD_E2E_YARN_CMD (default 'yarn')

If env is not set, goreman will use the defaults.

Saves me a lot of time on my local setup, because I have to use different ports for running the E2E test suite.