### PR TITLE
Attempts to make CI builds more robust by increasing the expect timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,7 @@ jobs:
             make test-e2e | tee /tmp/test-results/go-e2e.out
           environment:
             ARGOCD_OPTS: "--server localhost:8080 --plaintext"
+            ARGOCD_E2E_EXPECT_TIMEOUT: "30"
       - store_test_results:
           path: /tmp/test-results
   ui:

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -11,6 +11,7 @@ import (
 
 // when a app gets stuck in sync, and we try to delete it, it won't delete, instead we must then terminate it
 // and deletion will then just happen
+// NOTE: this test is being flaky on CI, so don't assume failure means the PR is bad
 func TestDeletingAppStuckInSync(t *testing.T) {
 	Given(t).
 		Path("hook").


### PR DESCRIPTION
<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  
