### PR TITLE
Support top level arguments for jsonnet on app create cli

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -411,6 +411,8 @@ func setAppOptions(flags *pflag.FlagSet, app *argoappv1.Application, appOpts *ap
 			app.Spec.Project = appOpts.project
 		case "nameprefix":
 			setKustomizeOpt(&app.Spec.Source, &appOpts.namePrefix)
+		case "jsonnet-tlas":
+			setJsonnetOpt(&app.Spec.Source, appOpts.jsonnetTlaParameters)
 		case "sync-policy":
 			switch appOpts.syncPolicy {
 			case "automated":
@@ -473,6 +475,33 @@ func setHelmOpt(src *argoappv1.ApplicationSource, valueFiles []string, releaseNa
 	}
 }
 
+func setJsonnetOpt(src *argoappv1.ApplicationSource, tlaParameters []string) {
+	if src.Directory == nil {
+		src.Directory = &argoappv1.ApplicationSourceDirectory{}
+	}
+
+	if len(tlaParameters) != 0 {
+		tlas := make([]argoappv1.JsonnetVar, len(tlaParameters))
+		for index, paramStr := range tlaParameters {
+			parts := strings.SplitN(paramStr, "=", 2)
+			if len(parts) != 2 {
+				log.Fatalf("Expected parameter of the form: param=value. Received: %s", paramStr)
+				break
+			}
+			tlas[index] = argoappv1.JsonnetVar{
+				Name:  parts[0],
+				Value: parts[1],
+				Code:  true}
+		}
+		src.Directory.Jsonnet.TLAs = tlas
+	}
+
+	if src.Directory.IsZero() {
+		src.Directory = nil
+	}
+
+}
+
 type appOptions struct {
 	repoURL                string
 	appPath                string
@@ -489,6 +518,7 @@ type appOptions struct {
 	namePrefix             string
 	directoryRecurse       bool
 	configManagementPlugin string
+	jsonnetTlaParameters   []string
 }
 
 func addAppFlags(command *cobra.Command, opts *appOptions) {
@@ -507,6 +537,7 @@ func addAppFlags(command *cobra.Command, opts *appOptions) {
 	command.Flags().StringVar(&opts.namePrefix, "nameprefix", "", "Kustomize nameprefix")
 	command.Flags().BoolVar(&opts.directoryRecurse, "directory-recurse", false, "Recurse directory")
 	command.Flags().StringVar(&opts.configManagementPlugin, "config-management-plugin", "", "Config management plugin name")
+	command.Flags().StringArrayVar(&opts.jsonnetTlaParameters, "jsonnet-tlas", []string{}, "Jsonnet top level arguments")
 }
 
 // NewApplicationUnsetCommand returns a new instance of an `argocd app unset` command

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -47,6 +47,10 @@ func (a *Actions) Create() *Actions {
 
 	args = append(args, "--project", a.context.project)
 
+	for _, jsonnetTLAParameter := range a.context.jsonnetTLAS {
+		args = append(args, "--jsonnet-tlas", jsonnetTLAParameter)
+	}
+
 	if a.context.namePrefix != "" {
 		args = append(args, "--nameprefix", a.context.namePrefix)
 	}

--- a/test/e2e/fixture/app/context.go
+++ b/test/e2e/fixture/app/context.go
@@ -17,6 +17,7 @@ type Context struct {
 	destServer             string
 	env                    string
 	parameters             []string
+	jsonnetTLAS            []string
 	namePrefix             string
 	resource               string
 	prune                  bool
@@ -61,6 +62,11 @@ func (c *Context) Env(env string) *Context {
 
 func (c *Context) Parameter(parameter string) *Context {
 	c.parameters = append(c.parameters, parameter)
+	return c
+}
+
+func (c *Context) JsonnetTlaParameter(parameter string) *Context {
+	c.jsonnetTLAS = append(c.jsonnetTLAS, parameter)
 	return c
 }
 

--- a/test/e2e/jsonnet_test.go
+++ b/test/e2e/jsonnet_test.go
@@ -1,0 +1,74 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/test/e2e/fixture"
+	. "github.com/argoproj/argo-cd/test/e2e/fixture/app"
+	"github.com/argoproj/argo-cd/util/kube"
+)
+
+func TestJsonnetAppliedCorrectly(t *testing.T) {
+	Given(t).
+		Path("jsonnet-tla").
+		When().
+		Create().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			manifests, err := fixture.RunCli("app", "manifests", app.Name, "--source", "live")
+			assert.NoError(t, err)
+			resources, err := kube.SplitYAML(manifests)
+			assert.NoError(t, err)
+
+			index := -1
+			for i := range resources {
+				if resources[i].GetKind() == kube.DeploymentKind {
+					index = i
+					break
+				}
+			}
+
+			assert.True(t, index > -1)
+
+			deployment := resources[index]
+			assert.Equal(t, "jsonnet-guestbook-ui", deployment.GetName())
+			assert.Equal(t, int64(1), *kube.GetDeploymentReplicas(deployment))
+		})
+}
+
+func TestJsonnetTlaParameterAppliedCorrectly(t *testing.T) {
+	Given(t).
+		Path("jsonnet-tla").
+		JsonnetTlaParameter("name=\"testing-tla\"").
+		JsonnetTlaParameter("replicas=3").
+		When().
+		Create().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			manifests, err := fixture.RunCli("app", "manifests", app.Name, "--source", "live")
+			assert.NoError(t, err)
+			resources, err := kube.SplitYAML(manifests)
+			assert.NoError(t, err)
+
+			index := -1
+			for i := range resources {
+				if resources[i].GetKind() == kube.DeploymentKind {
+					index = i
+					break
+				}
+			}
+
+			assert.True(t, index > -1)
+
+			deployment := resources[index]
+			assert.Equal(t, "testing-tla", deployment.GetName())
+			assert.Equal(t, int64(3), *kube.GetDeploymentReplicas(deployment))
+		})
+}

--- a/test/e2e/testdata/jsonnet-tla/guestbook-template.jsonnet
+++ b/test/e2e/testdata/jsonnet-tla/guestbook-template.jsonnet
@@ -1,0 +1,65 @@
+function (
+    containerPort=80, 
+    image="gcr.io/heptio-images/ks-guestbook-demo:0.2", 
+    name="jsonnet-guestbook-ui",
+    replicas=1,
+    servicePort=80, 
+    type="LoadBalancer"
+)
+    [
+    {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": name
+        },
+        "spec": {
+            "ports": [
+                {
+                "port": servicePort,
+                "targetPort": containerPort
+                }
+            ],
+            "selector": {
+                "app": name
+            },
+            "type": type
+        }
+    },
+    {
+        "apiVersion": "apps/v1beta2",
+        "kind": "Deployment",
+        "metadata": {
+            "name": name
+        },
+        "spec": {
+            "replicas": replicas,
+            "revisionHistoryLimit": 3,
+            "selector": {
+                "matchLabels": {
+                "app": name
+                },
+            },
+            "template": {
+                "metadata": {
+                "labels": {
+                    "app": name
+                }
+                },
+                "spec": {
+                "containers": [
+                    {
+                        "image": image,
+                        "name": name,
+                        "ports": [
+                        {
+                            "containerPort": containerPort
+                        }
+                        ]
+                    }
+                ]
+                }
+            }
+        }
+    }
+    ]

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -457,3 +457,11 @@ func WatchWithRetry(ctx context.Context, getWatch func() (watch.Interface, error
 	}()
 	return ch
 }
+
+func GetDeploymentReplicas(u *unstructured.Unstructured) *int64 {
+	val, found, err := unstructured.NestedInt64(u.Object, "spec", "replicas")
+	if !found || err != nil {
+		return nil
+	}
+	return &val
+}


### PR DESCRIPTION
### Description of change

Support for --tla-parameters in the `argocd app create` cli
There was already builtin support for jsonnet on top level arguments, they were passed in the application yaml.

Added e2e tests for jsonnet functions with top level arguments passed through the cli.

Closes #1626 