### PR TITLE
Use correct healthcheck for Rollout with empty steps list

### DIFF
--- a/resource_customizations/argoproj.io/Rollout/health.lua
+++ b/resource_customizations/argoproj.io/Rollout/health.lua
@@ -99,7 +99,7 @@ if obj.status ~= nil then
     end
     if obj.spec.strategy.canary ~= nil then
       currentRSIsStable = obj.status.canary.stableRS == obj.status.currentPodHash
-      if obj.spec.strategy.canary.steps ~= nil then
+      if obj.spec.strategy.canary.steps ~= nil and table.getn(obj.spec.strategy.canary.steps) > 0 then
         stepCount = table.getn(obj.spec.strategy.canary.steps)
         if obj.status.currentStepIndex ~= nil then
           currentStepIndex = obj.status.currentStepIndex

--- a/resource_customizations/argoproj.io/Rollout/health_test.yaml
+++ b/resource_customizations/argoproj.io/Rollout/health_test.yaml
@@ -57,3 +57,7 @@ tests:
     status: Healthy
     message: The rollout has completed canary deployment
   inputPath: testdata/canary/healthy_noSteps.yaml
+- healthStatus:
+    status: Healthy
+    message: The rollout has completed canary deployment
+  inputPath: testdata/canary/healthy_emptyStepsList.yaml

--- a/resource_customizations/argoproj.io/Rollout/testdata/canary/healthy_emptyStepsList.yaml
+++ b/resource_customizations/argoproj.io/Rollout/testdata/canary/healthy_emptyStepsList.yaml
@@ -1,0 +1,67 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: >
+      {"apiVersion":"argoproj.io/v1alpha1","kind":"Rollout","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-canary","ksonnet.io/component":"guestbook-ui"},"name":"guestbook-canary","namespace":"default"},"spec":{"minReadySeconds":10,"replicas":5,"selector":{"matchLabels":{"app":"guestbook-canary"}},"strategy":{"canary":{"maxSurge":1,"maxUnavailable":0,"steps":[{"setWeight":20},{"pause":{"duration":30}},{"setWeight":40},{"pause":{}}]}},"template":{"metadata":{"labels":{"app":"guestbook-canary"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.1","name":"guestbook-canary","ports":[{"containerPort":80}]}]}}}}
+    rollout.argoproj.io/revision: '2'
+  clusterName: ''
+  creationTimestamp: '2019-05-01T21:55:30Z'
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: guestbook-canary
+    ksonnet.io/component: guestbook-ui
+  name: guestbook-canary
+  namespace: default
+  resourceVersion: '956205'
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/rollouts/guestbook-canary
+  uid: d6105ccd-6c5b-11e9-b8d7-025000000001
+spec:
+  minReadySeconds: 10
+  replicas: 5
+  selector:
+    matchLabels:
+      app: guestbook-canary
+  strategy:
+    canary:
+      maxSurge: 1
+      maxUnavailable: 0
+      steps: []
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: guestbook-canary
+    spec:
+      containers:
+        - image: 'gcr.io/heptio-images/ks-guestbook-demo:0.2'
+          name: guestbook-canary
+          ports:
+            - containerPort: 80
+          resources: {}
+status:
+  HPAReplicas: 5
+  availableReplicas: 5
+  blueGreen: {}
+  canary:
+    stableRS: 567dd56d89
+  conditions:
+    - lastTransitionTime: '2019-05-01T22:00:16Z'
+      lastUpdateTime: '2019-05-01T22:00:16Z'
+      message: Rollout has minimum availability
+      reason: AvailableReason
+      status: 'True'
+      type: Available
+    - lastTransitionTime: '2019-05-01T21:55:30Z'
+      lastUpdateTime: '2019-05-01T22:00:16Z'
+      message: ReplicaSet "guestbook-canary-567dd56d89" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: 'True'
+      type: Progressing
+  currentPodHash: 567dd56d89
+  currentStepHash: 6c9545789c
+  observedGeneration: 6886f85bff
+  readyReplicas: 5
+  replicas: 5
+  selector: app=guestbook-canary
+  updatedReplicas: 5


### PR DESCRIPTION
If the user submits the following Rollout without this fix, the Rollout will never be healthy:
```kind: Rollout
apiVersion: argoproj.io/v1alpha1
spec:
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.7.9
        ports:
        - containerPort: 80
  strategy:
    canary:
      steps: []
````

This PR address this issue