### PR TITLE
Move remarshaling to happen only during comparison, instead of manifest generation

### DIFF
--- a/test/e2e/sync_options_test.go
+++ b/test/e2e/sync_options_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -25,6 +26,10 @@ func TestSyncOptionsValidateFalse(t *testing.T) {
 // TestSyncOptionsValidateTrue verifies when 'argocd.argoproj.io/sync-options: Validate=false' is
 // not present, then validation is performed and we fail during the apply
 func TestSyncOptionsValidateTrue(t *testing.T) {
+	// k3s does not validate at all, so this test does not work
+	if os.Getenv("ARGOCD_E2E_K3S") == "true" {
+		t.SkipNow()
+	}
 	Given(t).
 		Path("sync-options-validate-false").
 		When().

--- a/test/e2e/sync_options_test.go
+++ b/test/e2e/sync_options_test.go
@@ -1,0 +1,36 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	. "github.com/argoproj/argo-cd/test/e2e/fixture/app"
+)
+
+// TestSyncOptionsValidateFalse verifies we can disable validation during kubectl apply, using the
+// 'argocd.argoproj.io/sync-options: Validate=false' sync option
+func TestSyncOptionsValidateFalse(t *testing.T) {
+	Given(t).
+		Path("sync-options-validate-false").
+		When().
+		Create().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded))
+	// NOTE: it is a bug that we do not detect this as OutOfSync. This is because we
+	// are dropping fields as part of remarshalling. See: https://github.com/argoproj/argo-cd/issues/1787
+	// Expect(SyncStatusIs(SyncStatusCodeOutOfSync))
+}
+
+// TestSyncOptionsValidateTrue verifies when 'argocd.argoproj.io/sync-options: Validate=false' is
+// not present, then validation is performed and we fail during the apply
+func TestSyncOptionsValidateTrue(t *testing.T) {
+	Given(t).
+		Path("sync-options-validate-false").
+		When().
+		Create().
+		PatchFile("invalid-cm.yaml", `[{"op": "remove", "path": "/metadata/annotations"}]`).
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationFailed))
+}

--- a/test/e2e/testdata/sync-options-validate-false/invalid-cm.yaml
+++ b/test/e2e/testdata/sync-options-validate-false/invalid-cm.yaml
@@ -1,0 +1,8 @@
+# This configmap fails when running `kubectl apply`, but succeeds when running `kubectl apply --validate=false`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: invalid-cm
+  annotations:
+    argocd.argoproj.io/sync-options: Validate=false
+invalidKey: this-fails

--- a/util/diff/diff.go
+++ b/util/diff/diff.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/yudai/gojsondiff"
@@ -36,11 +37,11 @@ type Normalizer interface {
 // "kubectl.kubernetes.io/last-applied-configuration", then perform a three way diff.
 func Diff(config, live *unstructured.Unstructured, normalizer Normalizer) *DiffResult {
 	if config != nil {
-		config = stripTypeInformation(config)
+		config = remarshal(config)
 		Normalize(config, normalizer)
 	}
 	if live != nil {
-		live = stripTypeInformation(live)
+		live = remarshal(live)
 		Normalize(live, normalizer)
 	}
 	orig := GetLastAppliedConfigAnnotation(live)
@@ -438,4 +439,40 @@ func toString(val interface{}) string {
 		return ""
 	}
 	return fmt.Sprintf("%s", val)
+}
+
+// remarshal checks resource kind and version and re-marshal using corresponding struct custom marshaller.
+// This ensures that expected resource state is formatter same as actual resource state in kubernetes
+// and allows to find differences between actual and target states more accurately.
+// Remarshalling also strips any type information (e.g. float64 vs. int) from the unstructured
+// object. This is important for diffing since it will cause godiff to report a false difference.
+func remarshal(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	obj = stripTypeInformation(obj)
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	gvk := obj.GroupVersionKind()
+	item, err := scheme.Scheme.New(obj.GroupVersionKind())
+	if err != nil {
+		// this is common. the scheme is not registered
+		log.Debugf("Could not create new object of type %s: %v", gvk, err)
+		return obj
+	}
+	// This will drop any omitempty fields, perform resource conversion etc...
+	unmarshalledObj := reflect.New(reflect.TypeOf(item).Elem()).Interface()
+	err = json.Unmarshal(data, &unmarshalledObj)
+	if err != nil {
+		// User may have specified an invalid spec in git. Return original object
+		log.Warnf("Could not unmarshal to object of type %s: %v", gvk, err)
+		return obj
+	}
+	unstrBody, err := runtime.DefaultUnstructuredConverter.ToUnstructured(unmarshalledObj)
+	if err != nil {
+		log.Warnf("Could not unmarshal to object of type %s: %v", gvk, err)
+		return obj
+	}
+	// remove all default values specified by custom formatter (e.g. creationTimestamp)
+	unstrBody = jsonutil.RemoveMapFields(obj.Object, unstrBody)
+	return &unstructured.Unstructured{Object: unstrBody}
 }

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -202,53 +202,6 @@ func TestCleanKubectlOutput(t *testing.T) {
 	assert.Equal(t, cleanKubectlOutput(testString), `error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1beta2.DeploymentSpec`)
 }
 
-func TestRemarshal(t *testing.T) {
-	manifest := []byte(`
-apiVersion: v1
-kind: ServiceAccount
-imagePullSecrets: []
-metadata:
-  name: my-sa
-`)
-	var un unstructured.Unstructured
-	err := yaml.Unmarshal(manifest, &un)
-	assert.NoError(t, err)
-	newUn, err := Remarshal(&un)
-	assert.NoError(t, err)
-	_, ok := newUn.Object["imagePullSecrets"]
-	assert.False(t, ok)
-	metadata := newUn.Object["metadata"].(map[string]interface{})
-	_, ok = metadata["creationTimestamp"]
-	assert.False(t, ok)
-}
-
-func TestRemarshalResources(t *testing.T) {
-	manifest := []byte(`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: my-pod
-spec:
-  containers:
-  - image: nginx:1.7.9
-    name: nginx
-    resources:
-      requests:
-        cpu: 0.2
-`)
-	un := unstructured.Unstructured{}
-	err := yaml.Unmarshal(manifest, &un)
-	assert.NoError(t, err)
-	requestsBefore := un.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
-	log.Println(requestsBefore)
-	newUn, err := Remarshal(&un)
-	assert.NoError(t, err)
-	requestsAfter := newUn.Object["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["resources"].(map[string]interface{})["requests"].(map[string]interface{})
-	log.Println(requestsAfter)
-	assert.Equal(t, float64(0.2), requestsBefore["cpu"])
-	assert.Equal(t, "200m", requestsAfter["cpu"])
-}
-
 func TestInClusterKubeConfig(t *testing.T) {
 	restConfig := &rest.Config{}
 	kubeConfig := NewKubeConfig(restConfig, "")


### PR DESCRIPTION
Part 1 of the solution to https://github.com/argoproj/argo-cd/issues/1781.

It moves remarshalling to only happen during diffing, and not during manifest generation. Meaning we should be able to honor what is defined in git during deploys.