### PR TITLE
Issue #1841 Make the health check for APIService a built in

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -335,7 +335,7 @@ func TestFailedConversion(t *testing.T) {
 		errors.FailOnErr(fixture.Run("", "kubectl", "delete", "apiservice", "v1beta1.metrics.k8s.io"))
 	}()
 
-	testEdgeCasesApplicationResources(t, "failed-conversion", HealthStatusHealthy)
+	testEdgeCasesApplicationResources(t, "failed-conversion", HealthStatusProgressing)
 }
 
 func testEdgeCasesApplicationResources(t *testing.T, appPath string, statusCode HealthStatusCode) {

--- a/util/health/health_test.go
+++ b/util/health/health_test.go
@@ -131,5 +131,11 @@ func TestSetApplicationHealth(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, appv1.HealthStatusHealthy, healthStatus.Status)
+}
 
+func TestAPIService(t *testing.T) {
+	assertAppHealth(t, "./testdata/apiservice-v1-true.yaml", appv1.HealthStatusHealthy)
+	assertAppHealth(t, "./testdata/apiservice-v1-false.yaml", appv1.HealthStatusProgressing)
+	assertAppHealth(t, "./testdata/apiservice-v1beta1-true.yaml", appv1.HealthStatusHealthy)
+	assertAppHealth(t, "./testdata/apiservice-v1beta1-false.yaml", appv1.HealthStatusProgressing)
 }

--- a/util/health/testdata/apiservice-v1-false.yaml
+++ b/util/health/testdata/apiservice-v1-false.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.admission.certmanager.k8s.io
+  labels:
+    app: webhook
+    app.kubernetes.io/instance: external-dns
+spec:
+  group: admission.certmanager.k8s.io
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: cert-manager-webhook
+    namespace: external-dns
+  version: v1beta1
+status:
+  conditions:
+    - lastTransitionTime: "2019-06-26T07:17:09Z"
+      message: endpoints for service/cert-manager-webhook in "external-dns" have no
+        addresses
+      reason: MissingEndpoints
+      status: "False"
+      type: Available

--- a/util/health/testdata/apiservice-v1-true.yaml
+++ b/util/health/testdata/apiservice-v1-true.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.admission.certmanager.k8s.io
+  labels:
+    app: webhook
+    app.kubernetes.io/instance: external-dns
+spec:
+  group: admission.certmanager.k8s.io
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: cert-manager-webhook
+    namespace: external-dns
+  version: v1beta1
+status:
+  conditions:
+    - lastTransitionTime: "2019-07-09T14:48:15Z"
+      message: all checks passed
+      reason: Passed
+      status: "True"
+      type: Available

--- a/util/health/testdata/apiservice-v1beta1-false.yaml
+++ b/util/health/testdata/apiservice-v1beta1-false.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.admission.certmanager.k8s.io
+  labels:
+    app: webhook
+    app.kubernetes.io/instance: external-dns
+spec:
+  group: admission.certmanager.k8s.io
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: cert-manager-webhook
+    namespace: external-dns
+  version: v1beta1
+status:
+  conditions:
+    - lastTransitionTime: "2019-06-26T07:17:09Z"
+      message: endpoints for service/cert-manager-webhook in "external-dns" have no
+        addresses
+      reason: MissingEndpoints
+      status: "False"
+      type: Available

--- a/util/health/testdata/apiservice-v1beta1-true.yaml
+++ b/util/health/testdata/apiservice-v1beta1-true.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.admission.certmanager.k8s.io
+  labels:
+    app: webhook
+    app.kubernetes.io/instance: external-dns
+spec:
+  group: admission.certmanager.k8s.io
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: cert-manager-webhook
+    namespace: external-dns
+  version: v1beta1
+status:
+  conditions:
+    - lastTransitionTime: "2019-07-09T14:48:15Z"
+      message: all checks passed
+      reason: Passed
+      status: "True"
+      type: Available

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -47,6 +47,7 @@ const (
 	PersistentVolumeClaimKind    = "PersistentVolumeClaim"
 	CustomResourceDefinitionKind = "CustomResourceDefinition"
 	PodKind                      = "Pod"
+	APIServiceKind               = "APIService"
 )
 
 type ResourceKey struct {


### PR DESCRIPTION
Fix for #1841. Please review.

`APIService` has 3 states: `True`, `False` or `Unknown`.
In this fix, when the state is `True`, it is judged as `Healthy`. In another state, it is judged as `Progressing`.
ref: https://godoc.org/k8s.io/kube-aggregator/pkg/apis/apiregistration#ConditionStatus


And `APIService` has 2 versions: `v1` and `v1beta1`. (`v1beta1` is old..)
Some application (like CertManager) suppose to use `v1beta1`. So I want to support `v1beta1` for convenience.