### PR TITLE
Disable codecov/patch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,8 @@ coverage:
     # allow test coverage to drop by 1%, assume that it's typically due to CI problems
     patch:
       default:
-        threshold: 1
+        enabled: no
+        if_not_found: success
     project:
       default:
         threshold: 1


### PR DESCRIPTION
Looks like codecov/patch is not reliable and keep failiing. I've noticed some other projects having the same issue: https://github.com/mozilla-mobile/firefox-tv/issues/778, https://github.com/kata-containers/tests/issues/508

I think it is easier to disable it and keep project check only