### PR TITLE
Bump Kustomize v2.1.0 to v3.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,10 @@ commands:
             sudo chmod +x /usr/local/go/bin/kustomize1
             kustomize1 version
       - run:
-          name: Install Kustomize v3.0.0
+          name: Install Kustomize v3.0.2
           command: |
             set -x
-            export VER=3.0.0
+            export VER=3.0.2
             [ -e /tmp/dl/kustomize_${VER} ] || curl -sLf -C - -o /tmp/dl/kustomize_${VER} https://github.com/kubernetes-sigs/kustomize/releases/download/v${VER}/kustomize_${VER}_linux_amd64
             sudo cp /tmp/dl/kustomize_${VER} /usr/local/go/bin/kustomize
             sudo chmod +x /usr/local/go/bin/kustomize

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,9 @@ commands:
           name: Install Kustomize v3.0.0
           command: |
             set -x
-            [ -e /tmp/dl/kustomize ] || curl -sLf -C - -o /tmp/dl/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v3.0.0/kustomize_3.0.0_linux_amd64
-            sudo cp /tmp/dl/kustomize /usr/local/go/bin/
+            export VER=3.0.0
+            [ -e /tmp/dl/kustomize_${VER} ] || curl -sLf -C - -o /tmp/dl/kustomize_${VER} https://github.com/kubernetes-sigs/kustomize/releases/download/v${VER}/kustomize_${VER}_linux_amd64
+            sudo cp /tmp/dl/kustomize_${VER} /usr/local/go/bin/kustomize
             sudo chmod +x /usr/local/go/bin/kustomize
             kustomize version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ commands:
           command: mkdir -p /tmp/dl
       - restore_cache:
           keys:
+						- dl-v6
             - dl-v5
             - dl-v4
             - dl-v3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ commands:
           command: mkdir -p /tmp/dl
       - restore_cache:
           keys:
-						- dl-v6
+            - dl-v6
             - dl-v5
             - dl-v4
             - dl-v3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ commands:
           command: mkdir -p /tmp/dl
       - restore_cache:
           keys:
+            - dl-v5
             - dl-v4
             - dl-v3
       - run:
@@ -132,10 +133,10 @@ commands:
             sudo chmod +x /usr/local/go/bin/kustomize1
             kustomize1 version
       - run:
-          name: Install Kustomize v2.0.3
+          name: Install Kustomize v3.0.0
           command: |
             set -x
-            [ -e /tmp/dl/kustomize ] || curl -sLf -C - -o /tmp/dl/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64
+            [ -e /tmp/dl/kustomize ] || curl -sLf -C - -o /tmp/dl/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v3.0.0/kustomize_3.0.0_linux_amd64
             sudo cp /tmp/dl/kustomize /usr/local/go/bin/
             sudo chmod +x /usr/local/go/bin/kustomize
             kustomize version

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN curl -L -o /usr/local/bin/kustomize1 https://github.com/kubernetes-sigs/kust
     kustomize1 version
 
 
-ENV KUSTOMIZE_VERSION=3.0.0
+ENV KUSTOMIZE_VERSION=3.0.2
 RUN curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kustomize && \
     kustomize version

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN curl -L -o /usr/local/bin/kustomize1 https://github.com/kubernetes-sigs/kust
     kustomize1 version
 
 
-ENV KUSTOMIZE_VERSION=2.0.3
+ENV KUSTOMIZE_VERSION=3.0.0
 RUN curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     chmod +x /usr/local/bin/kustomize && \
     kustomize version

--- a/docs/user-guide/kustomize.md
+++ b/docs/user-guide/kustomize.md
@@ -1,14 +1,14 @@
 # Kustomize
 
-!!! warning Kustomize 1 vs 2
+!!! warning Kustomize 1 vs 3
     Argo CD supports both versions, and auto-detects then by looking for `apiVersion/kind` is `kustomize.yaml`. 
-    You're probably using version 2 now, so make sure you you have those fields.
+    You're probably using version 3 now, so make sure you you have those fields.
     
 You have three configuration options for Kustomize:
 
 * `namePrefix` is a prefix appended to resources for Kustomize apps
 * `imageTags` is a list of Kustomize 1.0 image tag overrides
-* `images` is a list of Kustomize 2.0 image overrides
+* `images` is a list of Kustomize 3.0 image overrides
     
 To use Kustomize with an overlay, point your path to the overlay.
 

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,13 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-- ./application-controller
-- ./dex
-- ./repo-server
-- ./server
-- ./config
-- ./redis
 
 images:
 - name: argoproj/argocd
@@ -16,3 +9,10 @@ images:
 - name: argoproj/argocd-ui
   newName: argoproj/argocd-ui
   newTag: latest
+resources:
+- ./application-controller
+- ./dex
+- ./repo-server
+- ./server
+- ./config
+- ./redis

--- a/manifests/ha/base/kustomization.yaml
+++ b/manifests/ha/base/kustomization.yaml
@@ -1,13 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-- ../../base/application-controller
-- ../../base/dex
-- ../../base/repo-server
-- ../../base/server
-- ../../base/config
-- ./redis-ha
 
 patchesStrategicMerge:
 - overlays/argocd-repo-server-deployment.yaml
@@ -21,3 +14,10 @@ images:
 - name: argoproj/argocd-ui
   newName: argoproj/argocd-ui
   newTag: latest
+resources:
+- ../../base/application-controller
+- ../../base/dex
+- ../../base/repo-server
+- ../../base/server
+- ../../base/config
+- ./redis-ha

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2795,6 +2795,30 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis-ha
+spec:
+  clusterIP: None
+  ports:
+  - name: server
+    port: 6379
+    protocol: TCP
+    targetPort: redis
+  - name: sentinel
+    port: 26379
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    app.kubernetes.io/name: argocd-redis-ha
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   labels:
@@ -2873,30 +2897,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: null
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
-spec:
-  clusterIP: None
-  ports:
-  - name: server
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: sentinel
-  selector:
-    app.kubernetes.io/name: argocd-redis-ha
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
@@ -2920,23 +2920,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
-spec:
-  ports:
-  - name: metrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
-  selector:
-    app.kubernetes.io/name: argocd-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2950,6 +2933,23 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8080
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2710,6 +2710,30 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis-ha
+spec:
+  clusterIP: None
+  ports:
+  - name: server
+    port: 6379
+    protocol: TCP
+    targetPort: redis
+  - name: sentinel
+    port: 26379
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    app.kubernetes.io/name: argocd-redis-ha
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   labels:
@@ -2788,30 +2812,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: null
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
-spec:
-  clusterIP: None
-  ports:
-  - name: server
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: sentinel
-  selector:
-    app.kubernetes.io/name: argocd-redis-ha
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
@@ -2835,23 +2835,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
-spec:
-  ports:
-  - name: metrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
-  selector:
-    app.kubernetes.io/name: argocd-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2865,6 +2848,23 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8080
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2692,23 +2692,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
-spec:
-  ports:
-  - name: metrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
-  selector:
-    app.kubernetes.io/name: argocd-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2722,6 +2705,23 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8080
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2607,23 +2607,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
-spec:
-  ports:
-  - name: metrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
-  selector:
-    app.kubernetes.io/name: argocd-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2637,6 +2620,23 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8080
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---

--- a/test/manifests_test.go
+++ b/test/manifests_test.go
@@ -16,7 +16,7 @@ func TestBuildManifests(t *testing.T) {
 
 	out, err := argoexec.RunCommand("kustomize", argoexec.CmdOpts{}, "version")
 	assert.NoError(t, err)
-	assert.True(t, Contains(out, "KustomizeVersion:2") || Contains(out, "KustomizeVersion:v2"), "kustomize should be version 2")
+	assert.True(t, Contains(out, "KustomizeVersion:3") || Contains(out, "KustomizeVersion:v3"), "kustomize should be version 3")
 
 	err = filepath.Walk("../manifests", func(path string, f os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
This commit bumps the version of kustomize from v2.1.0 to v3.0.0

This is pretty much the same PR as #1804, but just for v3.0.0. Shout outs and credit to @gobengo

According to Kustomize's own documentation v.3.0.0 doesn't have any break changes from 2.1.0.

EDIT: Generated manifests seem to have shuffled around a bit. Might take worth an extra eye or two to make sure it didn't nuke anything important, but it all seems okay.