### PR TITLE
Make status.sync.revision an optional field. Always set sync.comparedTo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1497,7 +1497,7 @@
   version = "v0.3.3"
 
 [[projects]]
-  digest = "1:e5e6165f043c38f641355912f5bf94134531e82abceaa5f086a9008f1bea6655"
+  digest = "1:42ea993b351fdd39b9aad3c9ebe71f2fdb5d1f8d12eed24e71c3dff1a31b2a43"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen",
@@ -1509,7 +1509,7 @@
     "pkg/util/sets",
   ]
   pruneopts = ""
-  revision = "master"
+  revision = "411b2483e5034420675ebcdd4a55fc76fe5e55cf"
 
 [[projects]]
   branch = "release-1.14"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,6 +71,8 @@ required = [
   branch = "master"
   name = "github.com/yudai/gojsondiff"
 
+# TODO: move off of k8s.io/kube-openapi and use controller-tools for CRD spec generation
+# (override argoproj/argo contraint on master)
 [[override]]
-  revision = "master"
+  revision = "411b2483e5034420675ebcdd4a55fc76fe5e55cf"
   name = "k8s.io/kube-openapi"

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -629,6 +629,10 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	}()
 
 	app := origApp.DeepCopy()
+	app.Status.Sync.ComparedTo = appv1.ComparedTo{
+		Source:      app.Spec.Source,
+		Destination: app.Spec.Destination,
+	}
 	logCtx := log.WithFields(log.Fields{"application": app.Name})
 	if !fullRefresh {
 		if managedResources, err := ctrl.cache.GetAppManagedResources(app.Name); err != nil {

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -1421,7 +1421,6 @@ spec:
               required:
               - status
               - comparedTo
-              - revision
               type: object
           type: object
       type: object

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -1422,7 +1422,6 @@ spec:
               required:
               - status
               - comparedTo
-              - revision
               type: object
           type: object
       type: object

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1422,7 +1422,6 @@ spec:
               required:
               - status
               - comparedTo
-              - revision
               type: object
           type: object
       type: object

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -1422,7 +1422,6 @@ spec:
               required:
               - status
               - comparedTo
-              - revision
               type: object
           type: object
       type: object

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1422,7 +1422,6 @@ spec:
               required:
               - status
               - comparedTo
-              - revision
               type: object
           type: object
       type: object

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -2665,7 +2665,7 @@ func schema_pkg_apis_application_v1alpha1_SyncStatus(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"status", "comparedTo", "revision"},
+				Required: []string{"status", "comparedTo"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -559,7 +559,7 @@ type ComparedTo struct {
 type SyncStatus struct {
 	Status     SyncStatusCode `json:"status" protobuf:"bytes,1,opt,name=status,casttype=SyncStatusCode"`
 	ComparedTo ComparedTo     `json:"comparedTo" protobuf:"bytes,2,opt,name=comparedTo"`
-	Revision   string         `json:"revision" protobuf:"bytes,3,opt,name=revision"`
+	Revision   string         `json:"revision,omitempty" protobuf:"bytes,3,opt,name=revision"`
 }
 
 type HealthStatus struct {


### PR DESCRIPTION
Fixes a class of app-of-apps errors during bootstrapping