### PR TITLE
Do not allow app-of-app child app's Missing status to affect parent

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1606,6 +1606,7 @@
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/protoc-gen-gofast",
     "github.com/gogo/protobuf/protoc-gen-gogofast",
+    "github.com/gogo/protobuf/sortkeys",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",
     "github.com/golang/protobuf/ptypes/empty",

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Using app-of-apps pattern, when child app is Synced/deployed, but that child app itself is Missing, it causes the parent app to be considered Missing, despite all of it's child apps having been deployed. This fixes it such that child apps with a Missing status in the app-of-apps pattern, does not affect the parent.