### PR TITLE
Check that TLS is enabled when registering DEX Handlers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -576,8 +576,10 @@ func (a *ArgoCDServer) registerDexHandlers(mux *http.ServeMux) {
 	// Run dex OpenID Connect Identity Provider behind a reverse proxy (served at /api/dex)
 	var err error
 	mux.HandleFunc(common.DexAPIEndpoint+"/", dexutil.NewDexHTTPReverseProxy(a.DexServerAddr))
-	tlsConfig := a.settings.TLSConfig()
-	tlsConfig.InsecureSkipVerify = true
+	if a.useTLS() {
+		tlsConfig := a.settings.TLSConfig()
+		tlsConfig.InsecureSkipVerify = true
+	}
 	a.ssoClientApp, err = oidc.NewClientApp(a.settings, a.Cache, a.DexServerAddr)
 	errors.CheckError(err)
 	mux.HandleFunc(common.LoginEndpoint, a.ssoClientApp.HandleLogin)


### PR DESCRIPTION
This commit makes it so that `registerDexHandlers` in `server/server.go`
only attempts to modify `a.TLSConfig` if TLS is enabled.

Without this, deployments of ArgoCD that don't have a certificate
enabled (in the case where a LB/Ingress Controller is handling SSL
connections as a reverse proxy) end up having a nil pointer reference
panic on start.
