### PR TITLE
Add ability to specify insecure and LFS modes when adding repos via UI

### DIFF
--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {Form, FormApi, Text} from 'react-form';
 import {RouteComponentProps} from 'react-router';
 
-import {ConnectionStateIcon, DataLoader, EmptyState, ErrorNotification, Page} from '../../../shared/components';
+import {ConnectionStateIcon, DataLoader, EmptyState, ErrorNotification, Page, CheckboxField} from '../../../shared/components';
 import {Repo} from '../../../shared/components/repo';
 import {AppContext} from '../../../shared/context';
 import * as models from '../../../shared/models';
@@ -16,6 +16,8 @@ interface NewRepoParams {
     url: string;
     username: string;
     password: string;
+    insecure: boolean;
+    enableLfs: boolean;
 }
 
 export class ReposList extends React.Component<RouteComponentProps<any>> {
@@ -118,6 +120,12 @@ export class ReposList extends React.Component<RouteComponentProps<any>> {
                                 <div className='argo-form-row'>
                                     <FormField formApi={formApi} label='Password' field='password' component={Text}
                                                componentProps={{type: 'password'}}/>
+                                </div>
+                                <div className='argo-form-row'>
+                                    <FormField formApi={formApi} label='Skip server verification' field='insecure' component={CheckboxField}/>
+                                </div>
+                                <div className='argo-form-row'>
+                                    <FormField formApi={formApi} label='Enable LFS support' field='enableLfs' component={CheckboxField}/>
                                 </div>
                             </form>
                         )}

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {Form, FormApi, Text} from 'react-form';
 import {RouteComponentProps} from 'react-router';
 
-import {ConnectionStateIcon, DataLoader, EmptyState, ErrorNotification, Page, CheckboxField} from '../../../shared/components';
+import {CheckboxField, ConnectionStateIcon, DataLoader, EmptyState, ErrorNotification, Page} from '../../../shared/components';
 import {Repo} from '../../../shared/components/repo';
 import {AppContext} from '../../../shared/context';
 import * as models from '../../../shared/models';

--- a/ui/src/app/shared/services/repo-service.ts
+++ b/ui/src/app/shared/services/repo-service.ts
@@ -6,7 +6,8 @@ export class RepositoriesService {
         return requests.get('/repositories').then((res) => res.body as models.RepositoryList).then((list) => list.items || []);
     }
 
-    public create({url, username, password, insecure, enableLfs}: {url: string, username: string, password: string, insecure: boolean, enableLfs: boolean}): Promise<models.Repository> {
+    public create({url, username, password, insecure, enableLfs}:
+        {url: string, username: string, password: string, insecure: boolean, enableLfs: boolean}): Promise<models.Repository> {
         return requests.post('/repositories').send({ repo: url, username, password, insecure, enableLfs }).then((res) => res.body as models.Repository);
     }
 

--- a/ui/src/app/shared/services/repo-service.ts
+++ b/ui/src/app/shared/services/repo-service.ts
@@ -6,8 +6,8 @@ export class RepositoriesService {
         return requests.get('/repositories').then((res) => res.body as models.RepositoryList).then((list) => list.items || []);
     }
 
-    public create({url, username, password}: {url: string, username: string, password: string}): Promise<models.Repository> {
-        return requests.post('/repositories').send({ repo: url, username, password }).then((res) => res.body as models.Repository);
+    public create({url, username, password, insecure, enableLfs}: {url: string, username: string, password: string, insecure: boolean, enableLfs: boolean}): Promise<models.Repository> {
+        return requests.post('/repositories').send({ repo: url, username, password, insecure, enableLfs }).then((res) => res.body as models.Repository);
     }
 
     public delete(url: string): Promise<models.Repository> {


### PR DESCRIPTION
This PR enables the user to specify insecure repository connection mode as well as LFS support when adding repositories via ArgoCD UI.

Addresses part of #1670 