### PR TITLE
Add UI functionality for certificate management

### DIFF
--- a/docs/user-guide/private-repositories.md
+++ b/docs/user-guide/private-repositories.md
@@ -84,7 +84,7 @@ cat cert1.pem cert2.pem | argocd cert add-tls git.example.com --upsert
 
 You can also manage TLS certificates in a declarative, self-managed ArgoCD setup. All TLS certificates are stored in the ConfigMap object `argocd-tls-cert-cm`.
 
-Managing TLS certificates via the web UI is currently not possible.
+Managing TLS certificates via the web UI is currently not possible, but will be introduced with **v1.3**
 
 > Before v1.2
 
@@ -120,7 +120,7 @@ argocd cert add-ssh --batch --from /etc/ssh/ssh_known_hosts
 
 You can also manage SSH known hosts entries in a declarative, self-managed ArgoCD setup. All SSH public host keys are stored in the ConfigMap object `argocd-ssh-known-hosts-cm`.
 
-Managing SSH public host keys via the web UI is currently not possible.
+Managing SSH public host keys via the web UI is currently not possible, but will be introduced with **v1.3**
 
 > Before v1.2
 

--- a/ui/src/app/settings/components/certs-list/certs-list.scss
+++ b/ui/src/app/settings/components/certs-list/certs-list.scss
@@ -33,13 +33,12 @@
         }
     }
 
-
+    textarea.argo-field {
+        height: 25em;
+        width: 1024em;
+        white-space: pre;
+        overflow-wrap: normal;
+        overflow-x: scroll;
+    }
 }
 
-textarea.argo-field {
-    height: 25em;
-    width: 1024em;
-    white-space: pre;
-    overflow-wrap: normal;
-    overflow-x: scroll;
-}

--- a/ui/src/app/settings/components/certs-list/certs-list.scss
+++ b/ui/src/app/settings/components/certs-list/certs-list.scss
@@ -1,0 +1,45 @@
+@import 'node_modules/argo-ui/src/app/shared/styles/config';
+
+.certs-list {
+    &__top-panel {
+        padding: 1em;
+
+        & > .columns:first-child {
+            font-size: 8em;
+            text-align: center;
+        }
+
+        & > .columns:last-child {
+            text-align: center;
+            border-left: 2px solid $argo-color-gray-4;
+
+            & > p {
+                margin-bottom: 0;
+                margin-top: 24px;
+                &:first-of-type {
+                    font-size: 1.25em;
+                }
+            }
+
+            & > button {
+                width: 15em;
+            }
+        }
+    }
+
+    .argo-table-list {
+        .argo-dropdown {
+            float: right;
+        }
+    }
+
+
+}
+
+textarea.argo-field {
+    height: 25em;
+    width: 1024em;
+    white-space: pre;
+    overflow-wrap: normal;
+    overflow-x: scroll;
+}

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -28,7 +28,8 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
         history: PropTypes.object,
     };
 
-    private formApi: FormApi;
+    private formApiTLS: FormApi;
+    private formApiSSH: FormApi;
     private loader: DataLoader;
 
     public render() {
@@ -99,7 +100,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                 </div>
                 <SlidingPanel isShown={this.showAddTLSCertificate} onClose={() => this.showAddTLSCertificate = false} header={(
                     <div>
-                        <button className='argo-button argo-button--base' onClick={() => this.formApi.submitForm(null)}>
+                        <button className='argo-button argo-button--base' onClick={() => this.formApiTLS.submitForm(null)}>
                             Create
                         </button>
                         <button onClick={() => this.showAddTLSCertificate = false}
@@ -110,7 +111,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                 )}>
                     <h4>Create TLS repository certificate</h4>
                     <Form onSubmit={(params) => this.addTLSCertificate(params as NewTLSCertParams)}
-                          getApi={(api) => this.formApi = api}
+                          getApi={(api) => this.formApiTLS = api}
                           preSubmit={(params: NewTLSCertParams) => ({
                               servername: params.servername,
                               certdata: btoa(params.certdata),
@@ -119,13 +120,13 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                               servername: !params.servername && 'Repository server name is required',
                               certdata: !params.certdata && 'Certificate data is required',
                           })}>
-                        {(formApi) => (
-                            <form onSubmit={formApi.submitForm} role='form' className='width-control' encType='multipart/form-data'>
+                        {(formApiTLS) => (
+                            <form onSubmit={formApiTLS.submitForm} role='form' className='width-control' encType='multipart/form-data'>
                                 <div className='argo-form-row'>
-                                    <FormField formApi={formApi} label='Repository server name' field='servername' component={Text}/>
+                                    <FormField formApi={formApiTLS} label='Repository server name' field='servername' component={Text}/>
                                 </div>
                                 <div className='argo-form-row'>
-                                    <FormField formApi={formApi} label='TLS certificate (PEM format)' field='certdata' component={TextArea}/>
+                                    <FormField formApi={formApiTLS} label='TLS certificate (PEM format)' field='certdata' component={TextArea}/>
                                 </div>
                            </form>
                         )}
@@ -133,7 +134,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                 </SlidingPanel>
                 <SlidingPanel isShown={this.showAddSSHKnownHosts} onClose={() => this.showAddSSHKnownHosts = false} header={(
                     <div>
-                        <button className='argo-button argo-button--base' onClick={() => this.formApi.submitForm(null)}>
+                        <button className='argo-button argo-button--base' onClick={() => this.formApiSSH.submitForm(null)}>
                             Create
                         </button>
                         <button onClick={() => this.showAddSSHKnownHosts = false}
@@ -145,17 +146,17 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                     <h4>Create SSH known host entries</h4>
                     <p>Paste SSH known hosts data below, one entry per line. Make sure there are no linebreaks in the keys.</p>
                     <Form onSubmit={(params) => this.addSSHKnownHosts(params as NewSSHKnownHostParams)}
-                          getApi={(api) => this.formApi = api}
+                          getApi={(api) => this.formApiSSH = api}
                           preSubmit={(params: NewSSHKnownHostParams) => ({
                               data: btoa(params.data),
                           })}
                           validateError={(params: NewSSHKnownHostParams) => ({
                               data: !params.data && 'SSH known hosts data is required',
                           })}>
-                        {(formApi) => (
-                            <form onSubmit={formApi.submitForm} role='form' className='width-control' encType='multipart/form-data'>
+                        {(formApiSSH) => (
+                            <form onSubmit={formApiSSH.submitForm} role='form' className='width-control' encType='multipart/form-data'>
                                 <div className='argo-form-row'>
-                                    <FormField formApi={formApi} label='SSH known hosts data' field='data' component={TextArea}/>
+                                    <FormField formApi={formApiSSH} label='SSH known hosts data' field='data' component={TextArea}/>
                                 </div>
                            </form>
                         )}

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -143,6 +143,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                     </div>
                 )}>
                     <h4>Create SSH known host entries</h4>
+                    <p>Paste SSH known hosts data below, one entry per line. Make sure there are no linebreaks in the keys.</p>
                     <Form onSubmit={(params) => this.addSSHKnownHosts(params as NewSSHKnownHostParams)}
                           getApi={(api) => this.formApi = api}
                           preSubmit={(params: NewSSHKnownHostParams) => ({

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -88,8 +88,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                                         <h5>You can add further certificates below..</h5>
                                         <button className='argo-button argo-button--base'
                                                 onClick={() => this.showAddTLSCertificate = true}>Add TLS certificates
-                                        </button>
-                                        <button className='argo-button argo-button--base'
+                                        </button> <button className='argo-button argo-button--base'
                                                 onClick={() => this.showAddSSHKnownHosts = true}>Add SSH known hosts
                                         </button>
                                     </EmptyState>
@@ -102,8 +101,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                     <div>
                         <button className='argo-button argo-button--base' onClick={() => this.formApiTLS.submitForm(null)}>
                             Create
-                        </button>
-                        <button onClick={() => this.showAddTLSCertificate = false}
+                        </button> <button onClick={() => this.showAddTLSCertificate = false}
                                 className='argo-button argo-button--base-o'>
                             Cancel
                         </button>
@@ -136,8 +134,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                     <div>
                         <button className='argo-button argo-button--base' onClick={() => this.formApiSSH.submitForm(null)}>
                             Create
-                        </button>
-                        <button onClick={() => this.showAddSSHKnownHosts = false}
+                        </button> <button onClick={() => this.showAddSSHKnownHosts = false}
                                 className='argo-button argo-button--base-o'>
                             Cancel
                         </button>

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -188,7 +188,13 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                 if (trimmedLine.startsWith('#') === false) {
                     const knownHosts =  trimmedLine.split(' ', 3);
                     if (knownHosts.length === 3) {
-                        knownHostEntries = knownHostEntries.concat({servername: knownHosts[0], type: 'ssh', cipher: knownHosts[1], certdata: btoa(knownHosts[2]), certinfo: '' });
+                        // Perform a little sanity check on the data - server
+                        // checks too, but let's not send it invalid data in
+                        // the first place.
+                        const subType = knownHosts[1].match(/^(ssh\-[a-z0-9]+|ecdsa-[a-z0-9\-]+)$/ig)
+                        if (subType != null) {
+                            knownHostEntries = knownHostEntries.concat({servername: knownHosts[0], type: 'ssh', cipher: knownHosts[1], certdata: btoa(knownHosts[2]), certinfo: '' });
+                        }
                     }
                 }
             });

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -144,7 +144,14 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                     </div>
                 )}>
                     <h4>Create SSH known host entries</h4>
-                    <p>Paste SSH known hosts data below, one entry per line. Make sure there are no linebreaks in the keys.</p>
+                    <p>
+                        Paste SSH known hosts data in the text area below, one entry per line. You can use output
+                        from e.g. <code>ssh-keyscan</code> or the contents of an <code>ssh_known_hosts</code> file in a
+                        verbatim way. Lines starting with <code>#</code> will be treated as comments and be ignored.
+                    </p>
+                    <p>
+                        <strong>Make sure there are no linebreaks in the keys.</strong>
+                    </p>
                     <Form onSubmit={(params) => this.addSSHKnownHosts(params as NewSSHKnownHostParams)}
                           getApi={(api) => this.formApiSSH = api}
                           preSubmit={(params: NewSSHKnownHostParams) => ({

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -121,7 +121,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                               certdata: !params.certdata && 'Certificate data is required',
                           })}>
                         {(formApiTLS) => (
-                            <form onSubmit={formApiTLS.submitForm} role='form' className='width-control' encType='multipart/form-data'>
+                            <form onSubmit={formApiTLS.submitForm} role='form' className='certs-list width-control' encType='multipart/form-data'>
                                 <div className='argo-form-row'>
                                     <FormField formApi={formApiTLS} label='Repository server name' field='servername' component={Text}/>
                                 </div>
@@ -154,7 +154,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                               data: !params.data && 'SSH known hosts data is required',
                           })}>
                         {(formApiSSH) => (
-                            <form onSubmit={formApiSSH.submitForm} role='form' className='width-control' encType='multipart/form-data'>
+                            <form onSubmit={formApiSSH.submitForm} role='form' className='certs-list width-control' encType='multipart/form-data'>
                                 <div className='argo-form-row'>
                                     <FormField formApi={formApiSSH} label='SSH known hosts data' field='data' component={TextArea}/>
                                 </div>

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -205,7 +205,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
 
     private async removeCert(serverName: string, certType: string, certSubType: string) {
         const confirmed = await this.appContext.apis.popup.confirm(
-            'Remove certificate', 'Are you sure you want to remove ' + certType + 'certificate for ' + serverName + '?');
+            'Remove certificate', 'Are you sure you want to remove ' + certType + ' certificate for ' + serverName + '?');
         if (confirmed) {
             await services.certs.delete(serverName, certType, certSubType);
             this.loader.reload();

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -54,21 +54,21 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                                     <div className='argo-table-list'>
                                         <div className='argo-table-list__head'>
                                             <div className='row'>
-                                                <div className='columns small-6'>SERVER NAME</div>
+                                                <div className='columns small-3'>SERVER NAME</div>
                                                 <div className='columns small-3'>CERT TYPE</div>
-                                                <div className='columns small-3'>CERT INFO</div>
+                                                <div className='columns small-6'>CERT INFO</div>
                                             </div>
                                         </div>
                                         {certs.map((cert) => (
                                             <div className='argo-table-list__row' key={cert.type + "_" + cert.cipher + "_" + cert.servername}>
                                                 <div className='row'>
-                                                    <div className='columns small-6'>
+                                                    <div className='columns small-3'>
                                                         <i className='icon argo-icon-git'/> {cert.servername}
                                                     </div>
                                                     <div className='columns small-3'>
                                                         {cert.type} {cert.cipher}
                                                     </div>
-                                                    <div className='columns small-3'>
+                                                    <div className='columns small-6'>
                                                             {cert.certinfo}
                                                         <DropDownMenu anchor={() => <button
                                                             className='argo-button argo-button--light argo-button--lg argo-button--short'>
@@ -203,10 +203,9 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
 
     private async removeCert(serverName: string, certType: string, certSubType: string) {
         const confirmed = await this.appContext.apis.popup.confirm(
-            "Remove certificate", "Are you sure you want to remove certificate?");
+            "Remove certificate", "Are you sure you want to remove " + certType + "certificate for " + serverName + "?");
         if (confirmed) {
             await services.certs.delete(serverName, certType, certSubType)
-            this.appContext.apis.popup.confirm("Ok", "OK")
             this.loader.reload();
         }
     }

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -40,7 +40,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                     items: [{
                         title: 'Add TLS certificate',
                         action: () => this.showAddTLSCertificate = true,
-                    },{
+                    }, {
                         title: 'Add SSH known hosts',
                         action: () => this.showAddSSHKnownHosts = true,
                     }],
@@ -60,7 +60,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                                             </div>
                                         </div>
                                         {certs.map((cert) => (
-                                            <div className='argo-table-list__row' key={cert.type + "_" + cert.cipher + "_" + cert.servername}>
+                                            <div className='argo-table-list__row' key={cert.type + '_' + cert.cipher + '_' + cert.servername}>
                                                 <div className='row'>
                                                     <div className='columns small-3'>
                                                         <i className='icon argo-icon-git'/> {cert.servername}
@@ -168,7 +168,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
 
     private async addTLSCertificate(params: NewTLSCertParams) {
         try {
-            await services.certs.create({items: [{servername: params.servername, type: "https", certdata: (params.certdata), cipher: "", certinfo: ""}], metadata: null})
+            await services.certs.create({items: [{servername: params.servername, type: 'https', certdata: (params.certdata), cipher: '', certinfo: ''}], metadata: null});
             this.showAddTLSCertificate = false;
             this.loader.reload();
         } catch (e) {
@@ -181,13 +181,13 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
 
     private async addSSHKnownHosts(params: NewSSHKnownHostParams) {
         try {
-            var knownHostEntries : models.RepoCert[] = [];
-            atob(params.data).split("\n").forEach(function(item, index) {
-                var trimmedLine = item.trimLeft(); 
-                if (trimmedLine.startsWith("#") == false) {
-                    var knownHosts =  trimmedLine.split(" ", 3);
-                    if (knownHosts.length == 3) {
-                        knownHostEntries = knownHostEntries.concat({servername: knownHosts[0], type: "ssh", cipher: knownHosts[1], certdata: btoa(knownHosts[2]), certinfo: "" });
+            let knownHostEntries: models.RepoCert[] = [];
+            atob(params.data).split('\n').forEach(function processEntry(item, index) {
+                const trimmedLine = item.trimLeft();
+                if (trimmedLine.startsWith('#') === false) {
+                    const knownHosts =  trimmedLine.split(' ', 3);
+                    if (knownHosts.length === 3) {
+                        knownHostEntries = knownHostEntries.concat({servername: knownHosts[0], type: 'ssh', cipher: knownHosts[1], certdata: btoa(knownHosts[2]), certinfo: '' });
                     }
                 }
             });
@@ -204,9 +204,9 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
 
     private async removeCert(serverName: string, certType: string, certSubType: string) {
         const confirmed = await this.appContext.apis.popup.confirm(
-            "Remove certificate", "Are you sure you want to remove " + certType + "certificate for " + serverName + "?");
+            'Remove certificate', 'Are you sure you want to remove ' + certType + 'certificate for ' + serverName + '?');
         if (confirmed) {
-            await services.certs.delete(serverName, certType, certSubType)
+            await services.certs.delete(serverName, certType, certSubType);
             this.loader.reload();
         }
     }

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -166,9 +166,13 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                         )}
                     </Form>
                 </SlidingPanel>
-
             </Page>
         );
+    }
+
+    private clearForms() {
+        this.formApiSSH.setAllValues({data: ''});
+        this.formApiTLS.setAllValues({servername: '', certdata: ''});
     }
 
     private async addTLSCertificate(params: NewTLSCertParams) {
@@ -236,6 +240,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
     }
 
     private set showAddTLSCertificate(val: boolean) {
+        this.clearForms();
         this.appContext.router.history.push(`${this.props.match.url}?addTLSCert=${val}`);
     }
 
@@ -244,6 +249,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
     }
 
     private set showAddSSHKnownHosts(val: boolean) {
+        this.clearForms();
         this.appContext.router.history.push(`${this.props.match.url}?addSSHKnownHosts=${val}`);
     }
 

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -208,6 +208,9 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                     }
                 }
             });
+            if (knownHostEntries.length === 0) {
+                throw new Error('No valid known hosts data entered');
+            }
             await services.certs.create({items: knownHostEntries, metadata: null});
             this.showAddSSHKnownHosts = false;
             this.loader.reload();

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -198,9 +198,15 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                         // Perform a little sanity check on the data - server
                         // checks too, but let's not send it invalid data in
                         // the first place.
-                        const subType = knownHosts[1].match(/^(ssh\-[a-z0-9]+|ecdsa-[a-z0-9\-]+)$/ig)
+                        const subType = knownHosts[1].match(/^(ssh\-[a-z0-9]+|ecdsa-[a-z0-9\-]+)$/ig);
                         if (subType != null) {
-                            knownHostEntries = knownHostEntries.concat({servername: knownHosts[0], type: 'ssh', cipher: knownHosts[1], certdata: btoa(knownHosts[2]), certinfo: '' });
+                            knownHostEntries = knownHostEntries.concat({
+                                servername: knownHosts[0],
+                                type: 'ssh',
+                                cipher: knownHosts[1],
+                                certdata: btoa(knownHosts[2]),
+                                certinfo: '',
+                            });
                         }
                     }
                 }

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -62,14 +62,11 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                                         {certs.map((cert) => (
                                             <div className='argo-table-list__row' key={cert.type + "_" + cert.cipher + "_" + cert.servername}>
                                                 <div className='row'>
-                                                    <div className='columns small-3'>
+                                                    <div className='columns small-6'>
                                                         <i className='icon argo-icon-git'/> {cert.servername}
                                                     </div>
                                                     <div className='columns small-3'>
-                                                        {cert.type}
-                                                    </div>
-                                                    <div className='columns small-3'>
-                                                        {cert.cipher}
+                                                        {cert.type} {cert.cipher}
                                                     </div>
                                                     <div className='columns small-3'>
                                                             {cert.certinfo}

--- a/ui/src/app/settings/components/settings-container.tsx
+++ b/ui/src/app/settings/components/settings-container.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router';
 
+import { CertsList } from './certs-list/certs-list';
 import { ClustersList } from './clusters-list/clusters-list';
 import { ProjectDetails } from './project-details/project-details';
 import { ProjectsList } from './projects-list/projects-list';
 import { ReposList } from './repos-list/repos-list';
 import { SettingsOverview } from './settings-overview/settings-overview';
-import { CertsList } from './certs-list/certs-list';
 
 export const SettingsContainer = (props: RouteComponentProps<any>) => (
     <Switch>

--- a/ui/src/app/settings/components/settings-container.tsx
+++ b/ui/src/app/settings/components/settings-container.tsx
@@ -6,11 +6,13 @@ import { ProjectDetails } from './project-details/project-details';
 import { ProjectsList } from './projects-list/projects-list';
 import { ReposList } from './repos-list/repos-list';
 import { SettingsOverview } from './settings-overview/settings-overview';
+import { CertsList } from './certs-list/certs-list';
 
 export const SettingsContainer = (props: RouteComponentProps<any>) => (
     <Switch>
         <Route exact={true} path={`${props.match.path}`} component={SettingsOverview}/>
         <Route exact={true} path={`${props.match.path}/repos`} component={ReposList}/>
+        <Route exact={true} path={`${props.match.path}/certs`} component={CertsList}/>
         <Route exact={true} path={`${props.match.path}/clusters`} component={ClustersList}/>
         <Route exact={true} path={`${props.match.path}/projects`} component={ProjectsList}/>
         <Route exact={true} path={`${props.match.path}/projects/:name`} component={ProjectDetails}/>

--- a/ui/src/app/settings/components/settings-overview/settings-overview.tsx
+++ b/ui/src/app/settings/components/settings-overview/settings-overview.tsx
@@ -9,6 +9,8 @@ require('./settings-overview.scss');
 const settings = [{
     title: 'Repositories', description: 'Configure connected Git repositories', path: './repos',
 }, {
+    title: 'Certificates', description: 'Configure certificates for connecting Git repositories', path: './certs',
+}, {
     title: 'Clusters', description: 'Configure connected Kubernetes clusters', path: './clusters',
 }, {
     title: 'Projects', description: 'Configure Argo CD projects', path: './projects',

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -343,6 +343,16 @@ export interface ConnectionState {
     attemptedAt: models.Time;
 }
 
+export interface RepoCert {
+    servername: string;
+    type: string;
+    cipher: string;
+    certdata: string;
+    certinfo: string;
+}
+
+export interface RepoCertList extends ItemsList<RepoCert> { }
+
 export interface Repository {
     repo: string;
     connectionState: ConnectionState;

--- a/ui/src/app/shared/services/cert-service.ts
+++ b/ui/src/app/shared/services/cert-service.ts
@@ -11,7 +11,7 @@ export class CertificatesService {
     }
 
     public delete(serverName: string, certType: string, certSubType: string): Promise<models.RepoCert> {
-        return requests.delete('/certificates').query({hostNamePattern: serverName, certType: certType, certSubType: certSubType})
+        return requests.delete('/certificates').query({hostNamePattern: serverName, certType, certSubType})
             .send().then((res) => res.body as models.RepoCert);
     }
 

--- a/ui/src/app/shared/services/cert-service.ts
+++ b/ui/src/app/shared/services/cert-service.ts
@@ -11,7 +11,8 @@ export class CertificatesService {
     }
 
     public delete(serverName: string, certType: string, certSubType: string): Promise<models.RepoCert> {
-        return requests.delete(`/certificates?hostNamePattern=${encodeURIComponent(serverName)}&certType=${encodeURIComponent(certType)}&certSubType=${encodeURIComponent(certSubType)}`).send().then((res) => res.body as models.RepoCert);
+        return requests.delete(`/certificates?hostNamePattern=${encodeURIComponent(serverName)}` +
+            `&certType=${encodeURIComponent(certType)}&certSubType=${encodeURIComponent(certSubType)}`).send().then((res) => res.body as models.RepoCert);
     }
 
 }

--- a/ui/src/app/shared/services/cert-service.ts
+++ b/ui/src/app/shared/services/cert-service.ts
@@ -1,0 +1,17 @@
+import * as models from '../models';
+import requests from './requests';
+
+export class CertificatesService {
+    public list(): Promise<models.RepoCert[]> {
+        return requests.get('/certificates').then((res) => res.body as models.RepoCertList).then((list) => list.items || []);
+    }
+
+    public create(certificates: models.RepoCertList): Promise<models.RepoCertList> {
+        return requests.post('/certificates').send(certificates).then((res) => res.body as models.RepoCertList);
+    }
+
+    public delete(serverName: string, certType: string, certSubType: string): Promise<models.RepoCert> {
+        return requests.delete(`/certificates?hostNamePattern=${encodeURIComponent(serverName)}&certType=${encodeURIComponent(certType)}&certSubType=${encodeURIComponent(certSubType)}`).send().then((res) => res.body as models.RepoCert);
+    }
+
+}

--- a/ui/src/app/shared/services/cert-service.ts
+++ b/ui/src/app/shared/services/cert-service.ts
@@ -11,8 +11,8 @@ export class CertificatesService {
     }
 
     public delete(serverName: string, certType: string, certSubType: string): Promise<models.RepoCert> {
-        return requests.delete(`/certificates?hostNamePattern=${encodeURIComponent(serverName)}` +
-            `&certType=${encodeURIComponent(certType)}&certSubType=${encodeURIComponent(certSubType)}`).send().then((res) => res.body as models.RepoCert);
+        return requests.delete('/certificates').query({hostNamePattern: serverName, certType: certType, certSubType: certSubType})
+            .send().then((res) => res.body as models.RepoCert);
     }
 
 }

--- a/ui/src/app/shared/services/index.ts
+++ b/ui/src/app/shared/services/index.ts
@@ -5,11 +5,13 @@ import { ProjectsService } from './projects-service';
 import { RepositoriesService } from './repo-service';
 import { UserService } from './user-service';
 import { ViewPreferencesService } from './view-preferences-service';
+import { CertificatesService } from './cert-service';
 
 export interface Services {
     applications: ApplicationsService;
     users: UserService;
     authService: AuthService;
+    certs: CertificatesService;
     repos: RepositoriesService;
     clusters: ClustersService;
     projects: ProjectsService;
@@ -21,6 +23,7 @@ export const services: Services = {
     authService: new AuthService(),
     clusters: new ClustersService(),
     users: new UserService(),
+    certs: new CertificatesService(),
     repos: new RepositoriesService(),
     projects: new ProjectsService(),
     viewPreferences: new ViewPreferencesService(),

--- a/ui/src/app/shared/services/index.ts
+++ b/ui/src/app/shared/services/index.ts
@@ -1,11 +1,11 @@
 import { ApplicationsService } from './applications-service';
 import { AuthService } from './auth-service';
+import { CertificatesService } from './cert-service';
 import { ClustersService } from './clusters-service';
 import { ProjectsService } from './projects-service';
 import { RepositoriesService } from './repo-service';
 import { UserService } from './user-service';
 import { ViewPreferencesService } from './view-preferences-service';
-import { CertificatesService } from './cert-service';
 
 export interface Services {
     applications: ApplicationsService;


### PR DESCRIPTION
This PR aims to bring the UI closer to feature parity with the CLI by adding certificate management and addresses feature request #1670 .

It adds the ability to list, create and remove TLS certificates and SSH known hosts data via the UI.

Note: The "Certificate Info" field in the certificate list - which should contain either SSH public key fingerprint or TLS certificate CN field - is left blank for now, since the server does not generate it yet. Right now the CLI has it, but generates it itself. This will be addressed by a separate PR in the future.