### PR TITLE
Added a button to select out of sync items in the sync panel

### DIFF
--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
@@ -77,6 +77,8 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {
                                 <label>Synchronize resources:</label>
                                 <div style={{float: 'right'}}>
                                     <a onClick={() => formApi.setValue('resources', formApi.values.resources.map(() => true))}>all</a> / <a
+                                        onClick={() => formApi.setValue('resources', application.status.resources.map(
+                                            (resource: models.ResourceStatus) => resource.status === models.SyncStatuses.OutOfSync))}>out of sync</a> / <a
                                         onClick={() => formApi.setValue('resources', formApi.values.resources.map(() => false))}>none</a></div>
                                 {!formApi.values.resources.every((item: boolean) => item) && (
                                     <div className='application-details__warning'>WARNING: partial synchronization is not recorded in history</div>


### PR DESCRIPTION
Added a button to select out of sync items in the sync panel.
This change is done at the frontend as suggested by @alexec , it should close issues #1902 and #1961
<img width="567" alt="Screen Shot 2019-07-24 at 6 37 50 PM" src="https://user-images.githubusercontent.com/19887812/61807424-2b5b7780-ae42-11e9-8ff1-aae8246f760c.png">

