### PR TITLE
Allow codegen to run as non-root user in the Docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ codegen-local: protogen clientgen openapigen manifests
 
 .PHONY: codegen
 codegen: dev-tools-image
-	docker run --rm -it -v ${CURRENT_DIR}:/go/src/github.com/argoproj/argo-cd -w /go/src/github.com/argoproj/argo-cd argocd-dev-tools bash -c "GOPATH=/go make codegen-local"
+	docker run --rm -it -u $(shell id -u) -v ${CURRENT_DIR}:/go/src/github.com/argoproj/argo-cd -w /go/src/github.com/argoproj/argo-cd argocd-dev-tools bash -c "GOPATH=/go make codegen-local"
 
 .PHONY: cli
 cli: clean-debug

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ codegen-local: protogen clientgen openapigen manifests
 
 .PHONY: codegen
 codegen: dev-tools-image
-	docker run --rm -it -u $(shell id -u) -v ${CURRENT_DIR}:/go/src/github.com/argoproj/argo-cd -w /go/src/github.com/argoproj/argo-cd argocd-dev-tools bash -c "GOPATH=/go make codegen-local"
+	docker run --rm -it -u $(shell id -u) -e HOME=/home/user -v ${CURRENT_DIR}:/go/src/github.com/argoproj/argo-cd -w /go/src/github.com/argoproj/argo-cd argocd-dev-tools bash -c "GOPATH=/go make codegen-local"
 
 .PHONY: cli
 cli: clean-debug

--- a/hack/Dockerfile.dev-tools
+++ b/hack/Dockerfile.dev-tools
@@ -33,7 +33,8 @@ RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-li
     mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
     helm version --client
 
-RUN helm init --client-only
+RUN mkdir -p /.helm && chmod 777 /.helm
+RUN HELM_HOME=/.helm helm init --client-only
 
 RUN apt-get update && apt-get install -y \
     zip && \
@@ -55,3 +56,6 @@ RUN curl -sLf -C - -o /tmp/jq https://github.com/stedolan/jq/releases/download/j
     cp /tmp/jq /usr/local/bin/jq && \
     chmod +x /usr/local/bin/jq && \
     jq --version
+
+RUN mkdir -p /go/pkg && chmod 777 /go/pkg
+RUN mkdir -p /.cache && chmod 777 /.cache

--- a/hack/Dockerfile.dev-tools
+++ b/hack/Dockerfile.dev-tools
@@ -33,8 +33,8 @@ RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-li
     mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
     helm version --client
 
-RUN mkdir -p /.helm && chmod 777 /.helm
-RUN HELM_HOME=/.helm helm init --client-only
+RUN mkdir -p /home/user && chmod 777 /home/user
+RUN HELM_HOME=/home/user/.helm helm init --client-only
 
 RUN apt-get update && apt-get install -y \
     zip && \
@@ -58,4 +58,3 @@ RUN curl -sLf -C - -o /tmp/jq https://github.com/stedolan/jq/releases/download/j
     jq --version
 
 RUN mkdir -p /go/pkg && chmod 777 /go/pkg
-RUN mkdir -p /.cache && chmod 777 /.cache


### PR DESCRIPTION
The Docker container running `codegen` is executed as user `root`, but it creates files within the volume mount from the user executing `make codegen`, therefore breaking subsequent local executions of e.g. `make manifests`.

This is a small fix to run the Docker container with the same user ID as the user executing it.