### PR TITLE
Show a tooltip on an application value

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-table.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-table.tsx
@@ -1,4 +1,4 @@
-import { DropDownMenu } from 'argo-ui';
+import { DropDownMenu, Tooltip } from 'argo-ui';
 import * as React from 'react';
 
 import { Consumer } from '../../../shared/context';
@@ -30,16 +30,24 @@ export const ApplicationsTable = (props: {
             }>
                 <div className='row applications-list__table-row' onClick={(e) => ctx.navigation.goto(`/applications/${app.metadata.name}`, {}, { event: e })}>
                     <div className='columns large-2 small-6'>
-                        <i className='icon argo-icon-application'/> {app.spec.project}/{app.metadata.name} <ApplicationURLs urls={app.status.summary.externalURLs}/>
+                        <Tooltip content={`${app.spec.project}/${app.metadata.name}`}>
+                            <span>
+                                <i className='icon argo-icon-application'/> {app.spec.project}/{app.metadata.name} <ApplicationURLs urls={app.status.summary.externalURLs}/>
+                            </span>
+                        </Tooltip>
                     </div>
                     <div className='columns large-3 show-for-large'>
-                        {app.spec.source.repoURL}/{app.spec.source.path}
+                        <Tooltip content={`${app.spec.source.repoURL}/${app.spec.source.path}`}>
+                            <span>{app.spec.source.repoURL}/{app.spec.source.path}</span>
+                        </Tooltip>
                     </div>
                     <div className='columns large-1 small-2'>
                         {app.spec.source.targetRevision || 'HEAD'}
                     </div>
                     <div className='columns large-3 show-for-large'>
-                        {app.spec.destination.server}/{app.spec.destination.namespace}
+                        <Tooltip content={`${app.spec.destination.server}/${app.spec.destination.namespace}`}>
+                            <span>{app.spec.destination.server}/{app.spec.destination.namespace}</span>
+                        </Tooltip>
                     </div>
                     <div className='columns large-3 small-4'>
                         <div className='applications-list__table-icon'>

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -33,7 +33,11 @@ export const ApplicationTiles = ({applications, syncApplication, deleteApplicati
                             </div>
                             <div className='row'>
                                 <div className='columns small-3'>Project:</div>
-                                <div className='columns small-9'>{app.spec.project}</div>
+                                <div className='columns small-9'>
+                                    <Tooltip content={app.spec.project}>
+                                        <span>{app.spec.project}</span>
+                                    </Tooltip>
+                                </div>
                             </div>
                             <div className='row'>
                                 <div className='columns small-3'>Status:</div>
@@ -59,7 +63,11 @@ export const ApplicationTiles = ({applications, syncApplication, deleteApplicati
                             </div>
                             <div className='row'>
                                 <div className='columns small-3'>Destination:</div>
-                                <div className='columns small-9'>{app.spec.destination.server}</div>
+                                <div className='columns small-9'>
+                                    <Tooltip content={app.spec.destination.server}>
+                                        <span>{app.spec.destination.server}</span>
+                                    </Tooltip>
+                                </div>
                             </div>
                             <div className='row'>
                                 <div className='columns small-3'>Namespace:</div>


### PR DESCRIPTION
If an application value is long, it's truncated and hard to check. I added a tooltip on an application value.

<img width="1356" alt="Screen Shot 2019-07-27 at 12 48 07 AM" src="https://user-images.githubusercontent.com/1162120/61964186-42e45d00-b008-11e9-8954-574d4eaf216a.png">

I don't know if this is the best way to show entire strings of the values, but at least we can see them.
