### PR TITLE
Build argocd-repo-server and argocd-util with packr instead of go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ release-cli: clean-debug image
 .PHONY: argocd-util
 argocd-util: clean-debug
 	# Build argocd-util as a statically linked binary, so it could run within the alpine-based dex container (argoproj/argo-cd#844)
-	CGO_ENABLED=0 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-util ./cmd/argocd-util
+	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-util ./cmd/argocd-util
 
 .PHONY: dev-tools-image
 dev-tools-image:
@@ -104,7 +104,7 @@ server: clean-debug
 
 .PHONY: repo-server
 repo-server:
-	CGO_ENABLED=0 go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-repo-server ./cmd/argocd-repo-server
+	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-repo-server ./cmd/argocd-repo-server
 
 .PHONY: controller
 controller:


### PR DESCRIPTION
I noticed that since a while, `argoproj/argocd:latest` images were broken. In a fresh install:
```shell
$ kubectl get pods -n argocd
NAME                                            READY   STATUS    RESTARTS   AGE
argocd-application-controller-7659d64c9-pl7sm   1/1     Running   0          99s
argocd-dex-server-64757ffc56-bvjd9              0/1     Error     3          99s
argocd-redis-78c9595d44-pvvwx                   1/1     Running   0          99s
argocd-repo-server-58d84b8c97-wlgct             0/1     Error     3          99s
argocd-server-85ff769fb8-nb9gs                  1/1     Running   0          99s
$ kubectl logs argocd-repo-server-58d84b8c97-wlgct -n argocd
panic: stat /go/src/github.com/argoproj/argo-cd/assets/builtin-policy.csv: no such file or directory

goroutine 1 [running]:
github.com/argoproj/argo-cd/util/assets.init.0()
        /go/src/github.com/argoproj/argo-cd/util/assets/assets.go:19 +0x441
$ kubectl logs argocd-dex-server-64757ffc56-bvjd9 -n argocd
panic: stat /go/src/github.com/argoproj/argo-cd/assets/builtin-policy.csv: no such file or directory

goroutine 1 [running]:
github.com/argoproj/argo-cd/util/assets.init.0()
        /go/src/github.com/argoproj/argo-cd/util/assets/assets.go:19 +0x441
$ kubectl describe pod argocd-repo-server-58d84b8c97-wlgct -n argocd | grep Image
    Image:         argoproj/argocd:latest
    Image ID:      docker.io/argoproj/argocd@sha256:db2cadb0faccae2aacf34041e6b6fe31d60c52a710a882b7cda7f9259fd31c38
$ kubectl describe pod argocd-dex-server-64757ffc56-bvjd9 -n argocd | grep Image
    Image:         argoproj/argocd:latest
    Image ID:      docker.io/argoproj/argocd@sha256:db2cadb0faccae2aacf34041e6b6fe31d60c52a710a882b7cda7f9259fd31c38
    Image:         quay.io/dexidp/dex:v2.14.0
    Image ID:      sha256:2f275ccf02e6a04c0c07206a3becaf3fe8404620030b720a369761a73b91fb7c

```
I think that's because neither `argocd-repo-server` nor `argocd-util` are being build using `packr` and therefore don't contain the assets.

This PR fixes `Makefile` so that both binaries will be build using `packr` and the resulting Docker image will have working `argocd-repo-server` and `argocd-util` binaries again.