### PR TITLE
Improve refresh button on applications tiles view

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -19,7 +19,8 @@ import { ApplicationTiles } from './applications-tiles';
 
 require('./applications-list.scss');
 
-const APP_FIELDS = ['metadata.name', 'metadata.resourceVersion', 'metadata.creationTimestamp', 'spec', 'status.sync.status', 'status.health', 'status.summary'];
+const APP_FIELDS = [
+    'metadata.name', 'metadata.annotations', 'metadata.resourceVersion', 'metadata.creationTimestamp', 'spec', 'status.sync.status', 'status.health', 'status.summary'];
 const APP_LIST_FIELDS = APP_FIELDS.map((field) => `items.${field}`);
 const APP_WATCH_FIELDS = ['result.type', ...APP_FIELDS.map((field) => `result.application.${field}`)];
 

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from 'argo-ui';
+import * as classNames from 'classnames';
 import * as React from 'react';
 
 import { Consumer } from '../../../shared/context';
@@ -78,11 +79,12 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                             syncApplication(app.metadata.name);
                                         }}><i className='fa fa-sync'/> Sync</a>
                                     &nbsp;
-                                    <a className='argo-button argo-button--base'
+                                    <a className='argo-button argo-button--base' {...AppUtils.refreshLinkAttrs(app)}
                                        onClick={(e) => {
                                            e.stopPropagation();
                                            refreshApplication(app.metadata.name);
-                                       }}><i className='fa fa-redo'/> Refresh</a>
+                                       }}><i className={classNames('fa fa-redo', { 'status-icon--spin': AppUtils.isAppRefreshing(app) })}/> <span className='show-for-xlarge'>
+                                           Refresh</span></a>
                                     &nbsp;
                                     <a className='argo-button argo-button--base' onClick={(e) => {
                                         e.stopPropagation();

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -350,3 +350,11 @@ export function getAppOverridesCount(app: appModels.Application) {
     }
     return 0;
 }
+
+export function isAppRefreshing(app: appModels.Application) {
+    return !!(app.metadata.annotations && app.metadata.annotations[appModels.AnnotationRefreshKey]);
+}
+
+export function refreshLinkAttrs(app: appModels.Application) {
+    return { disabled: isAppRefreshing(app) };
+}


### PR DESCRIPTION
Minor improvements:

1. Make sure buttons fit into app panel on a small screen
![Screen Shot 2019-07-30 at 1 02 53 PM](https://user-images.githubusercontent.com/426437/62161332-c7fe9900-b2ca-11e9-93c1-1763c35daaea.png)
->
![Screen Shot 2019-07-30 at 1 03 28 PM](https://user-images.githubusercontent.com/426437/62161348-cdf47a00-b2ca-11e9-8b00-a92521aa5671.png)

2. Disable refresh and add animation when refresh is in progress.