### PR TITLE
Export cert settings and TLS client cert secrets in argocd-util (closes #2075)

### DIFF
--- a/cmd/argocd-util/main.go
+++ b/cmd/argocd-util/main.go
@@ -386,6 +386,12 @@ func NewExportCommand() *cobra.Command {
 			acdRBACConfigMap, err := acdClients.configMaps.Get(common.ArgoCDRBACConfigMapName, metav1.GetOptions{})
 			errors.CheckError(err)
 			export(writer, *acdRBACConfigMap)
+			acdKnownHostsConfigMap, err := acdClients.configMaps.Get(common.ArgoCDKnownHostsConfigMapName, metav1.GetOptions{})
+			errors.CheckError(err)
+			export(writer, *acdKnownHostsConfigMap)
+			acdTLSCertsConfigMap, err := acdClients.configMaps.Get(common.ArgoCDTLSCertsConfigMapName, metav1.GetOptions{})
+			errors.CheckError(err)
+			export(writer, *acdTLSCertsConfigMap)
 
 			referencedSecrets := getReferencedSecrets(*acdConfigMap)
 			secrets, err := acdClients.secrets.List(metav1.ListOptions{})
@@ -434,6 +440,12 @@ func getReferencedSecrets(un unstructured.Unstructured) map[string]bool {
 			}
 			if cred.UsernameSecret != nil {
 				referencedSecrets[cred.UsernameSecret.Name] = true
+			}
+			if cred.TLSClientCertDataSecret != nil {
+				referencedSecrets[cred.TLSClientCertDataSecret.Name] = true
+			}
+			if cred.TLSClientCertKeySecret != nil {
+				referencedSecrets[cred.TLSClientCertKeySecret.Name] = true
 			}
 		}
 	}


### PR DESCRIPTION
This PR makes argocd-util export TLS certificates and SSH known hosts data config maps as well as the TLS client cert secrets referenced from the repositories configuration.

Closes #2075 