### PR TITLE
Allow adding certs for hostnames ending on a dot (fixes #2116)

### DIFF
--- a/util/cert/cert.go
+++ b/util/cert/cert.go
@@ -65,10 +65,10 @@ const (
 )
 
 // Regular expression that matches a valid hostname
-var validHostNameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))*$`)
+var validHostNameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))*(\.){0,1}$`)
 
 // Regular expression that matches a valid FQDN
-var validFQDNRegexp = regexp.MustCompile(`^([a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$`)
+var validFQDNRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))*(\.){1}$`)
 
 // Can be used to test whether a given string represents a valid hostname
 // If fqdn is true, given string must also be a FQDN representation.

--- a/util/db/certificate_test.go
+++ b/util/db/certificate_test.go
@@ -506,7 +506,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 	certList, err = db.CreateRepoCertificate(context.Background(), &v1alpha1.RepositoryCertificateList{
 		Items: []v1alpha1.RepositoryCertificate{
 			{
-				ServerName: "foo.example.",
+				ServerName: "foo..example",
 				CertType:   "https",
 				CertData:   []byte(Test_TLSValidSingleCert),
 			},


### PR DESCRIPTION
Small bugfix (and test adaptions), closes #2116 