### PR TITLE
Expose the Git repo commit hash to helm

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -722,7 +722,9 @@ func getLocalObjectsString(app *argoappv1.Application, local string, appLabelKey
 		AppLabelValue:     app.Name,
 		Namespace:         app.Spec.Destination.Namespace,
 		KustomizeOptions:  kustomizeOptions,
-	})
+	},
+		app.Status.Sync.Revision,
+	)
 	errors.CheckError(err)
 
 	return res.Manifests

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -14,7 +14,7 @@ import (
 	"github.com/TomOnTime/utfutil"
 	argoexec "github.com/argoproj/pkg/exec"
 	"github.com/ghodss/yaml"
-	"github.com/google/go-jsonnet"
+	jsonnet "github.com/google/go-jsonnet"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
@@ -176,7 +176,7 @@ func (s *Service) GenerateManifest(c context.Context, q *apiclient.ManifestReque
 		return nil, err
 	}
 
-	genRes, err := GenerateManifests(gitClient.Root(), q.ApplicationSource.Path, q)
+	genRes, err := GenerateManifests(gitClient.Root(), q.ApplicationSource.Path, q, commitSHA)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func appPath(root, path string) (string, error) {
 }
 
 // GenerateManifests generates manifests from a path
-func GenerateManifests(root, path string, q *apiclient.ManifestRequest) (*apiclient.ManifestResponse, error) {
+func GenerateManifests(root, path string, q *apiclient.ManifestRequest, commitSHA string) (*apiclient.ManifestResponse, error) {
 	appPath, err := appPath(root, path)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func GenerateManifests(root, path string, q *apiclient.ManifestRequest) (*apicli
 			return nil, err
 		}
 		defer h.Dispose()
-		targetObjs, err = h.Template(q.AppLabelValue, q.Namespace, q.ApplicationSource.Helm)
+		targetObjs, err = h.Template(q.AppLabelValue, q.Namespace, q.ApplicationSource.Helm, commitSHA)
 		if err != nil {
 			if !helm.IsMissingDependencyErr(err) {
 				return nil, err
@@ -244,7 +244,7 @@ func GenerateManifests(root, path string, q *apiclient.ManifestRequest) (*apicli
 			if err != nil {
 				return nil, err
 			}
-			targetObjs, err = h.Template(q.AppLabelValue, q.Namespace, q.ApplicationSource.Helm)
+			targetObjs, err = h.Template(q.AppLabelValue, q.Namespace, q.ApplicationSource.Helm, commitSHA)
 			if err != nil {
 				return nil, err
 			}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -70,12 +70,12 @@ func TestGenerateYamlManifestInDir(t *testing.T) {
 	q := apiclient.ManifestRequest{
 		ApplicationSource: &argoappv1.ApplicationSource{},
 	}
-	res1, err := GenerateManifests("../../manifests", "base", &q)
+	res1, err := GenerateManifests("../../manifests", "base", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, countOfManifests, len(res1.Manifests))
 
 	// this will test concatenated manifests to verify we split YAMLs correctly
-	res2, err := GenerateManifests("./testdata", "concatenated", &q)
+	res2, err := GenerateManifests("./testdata", "concatenated", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(res2.Manifests))
 }
@@ -85,7 +85,7 @@ func TestRecurseManifestsInDir(t *testing.T) {
 		ApplicationSource: &argoappv1.ApplicationSource{},
 	}
 	q.ApplicationSource.Directory = &argoappv1.ApplicationSourceDirectory{Recurse: true}
-	res1, err := GenerateManifests("./testdata", "recurse", &q)
+	res1, err := GenerateManifests("./testdata", "recurse", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(res1.Manifests))
 }
@@ -131,7 +131,7 @@ func TestPathNotDir(t *testing.T) {
 }
 
 func TestGenerateManifests_NonExistentPath(t *testing.T) {
-	_, err := GenerateManifests("./testdata", "does-not-exist", nil)
+	_, err := GenerateManifests("./testdata", "does-not-exist", nil, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.EqualError(t, err, "does-not-exist: app path does not exist")
 }
 
@@ -146,7 +146,7 @@ func TestGenerateJsonnetManifestInDir(t *testing.T) {
 			},
 		},
 	}
-	res1, err := GenerateManifests("./testdata", "jsonnet", &q)
+	res1, err := GenerateManifests("./testdata", "jsonnet", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(res1.Manifests))
 }
@@ -165,7 +165,7 @@ func TestGenerateHelmChartWithDependencies(t *testing.T) {
 	q := apiclient.ManifestRequest{
 		ApplicationSource: &argoappv1.ApplicationSource{},
 	}
-	res1, err := GenerateManifests("../../util/helm/testdata", "wordpress", &q)
+	res1, err := GenerateManifests("../../util/helm/testdata", "wordpress", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, 12, len(res1.Manifests))
 }
@@ -174,17 +174,17 @@ func TestGenerateNullList(t *testing.T) {
 	q := apiclient.ManifestRequest{
 		ApplicationSource: &argoappv1.ApplicationSource{},
 	}
-	res1, err := GenerateManifests("./testdata", "null-list", &q)
+	res1, err := GenerateManifests("./testdata", "null-list", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, len(res1.Manifests), 1)
 	assert.Contains(t, res1.Manifests[0], "prometheus-operator-operator")
 
-	res1, err = GenerateManifests("./testdata", "empty-list", &q)
+	res1, err = GenerateManifests("./testdata", "empty-list", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, len(res1.Manifests), 1)
 	assert.Contains(t, res1.Manifests[0], "prometheus-operator-operator")
 
-	res2, err := GenerateManifests("./testdata", "weird-list", &q)
+	res2, err := GenerateManifests("./testdata", "weird-list", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(res2.Manifests))
 }
@@ -222,7 +222,8 @@ func TestRunCustomTool(t *testing.T) {
 		Repo: &argoappv1.Repository{
 			Username: "foo", Password: "bar",
 		},
-	})
+	},
+		"2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(res.Manifests))
@@ -241,7 +242,7 @@ func TestGenerateFromUTF16(t *testing.T) {
 	q := apiclient.ManifestRequest{
 		ApplicationSource: &argoappv1.ApplicationSource{},
 	}
-	res1, err := GenerateManifests("./testdata", "utf-16", &q)
+	res1, err := GenerateManifests("./testdata", "utf-16", &q, "2c94c18e8404a2466e8438cc5cb1edaa57d9da1")
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(res1.Manifests))
 }

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -25,7 +25,7 @@ import (
 // Helm provides wrapper functionality around the `helm` command.
 type Helm interface {
 	// Template returns a list of unstructured objects from a `helm template` command
-	Template(appName string, namespace string, opts *argoappv1.ApplicationSourceHelm) ([]*unstructured.Unstructured, error)
+	Template(appName string, namespace string, opts *argoappv1.ApplicationSourceHelm, commitSHA string) ([]*unstructured.Unstructured, error)
 	// GetParameters returns a list of chart parameters taking into account values in provided YAML files.
 	GetParameters(valuesFiles []string) ([]*argoappv1.HelmParameter, error)
 	// DependencyBuild runs `helm dependency build` to download a chart's dependencies
@@ -56,7 +56,7 @@ func IsMissingDependencyErr(err error) bool {
 	return strings.Contains(err.Error(), "found in requirements.yaml, but missing in charts")
 }
 
-func (h *helm) Template(appName string, namespace string, opts *argoappv1.ApplicationSourceHelm) ([]*unstructured.Unstructured, error) {
+func (h *helm) Template(appName string, namespace string, opts *argoappv1.ApplicationSourceHelm, commitSHA string) ([]*unstructured.Unstructured, error) {
 	args := []string{
 		"template", ".",
 	}
@@ -94,6 +94,8 @@ func (h *helm) Template(appName string, namespace string, opts *argoappv1.Applic
 				args = append(args, "--set", fmt.Sprintf("%s=%s", p.Name, p.Value))
 			}
 		}
+
+		args = append(args, "--set", fmt.Sprintf("argocd_revision=%s", commitSHA))
 	}
 
 	if setReleaseName {

--- a/util/helm/testdata/minio/templates/deployment.yaml
+++ b/util/helm/testdata/minio/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    deployed-commit-hash: {{ .Values.argocd_revision }}
 spec:
   {{- if .Values.nasgateway.enabled }}
   replicas: {{ .Values.nasgateway.replicas }}


### PR DESCRIPTION
This commit exposes the currently referenced commit SHA to helm via
setting a parameter on the command line.

Mainly, this is done so that users can reference their upstream repo,
e.g.:

Setting the image deployed via your manifests:

```
image: quay.io/foobar/baz:{{ .Values.argocd_revision }}
```

Useful in cases where you can't set your CI system to do things like
`argocd app set`, or developers don't want separate repositories for
their code + helm templates.