### PR TITLE
Fixed routing issue for periods

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -70,7 +70,9 @@ const config = {
         new MonacoWebpackPlugin(),
     ],
     devServer: {
-        historyApiFallback: true,
+        historyApiFallback: {
+            disableDotRule: true
+        },
         port: 4000,
         proxy: {
             '/api': proxyConf,


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/2114.

After much searching I was able to pinpoint the issue to a webpack-dev-server rule that does not forward URLs containing periods to the React app: https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback. A simple disabling of that "feature" was enough to fix the issue.

Note that this issue was only encountered when typing the URL directly into the address bar -- therefore triggering webpack. If an application with a period is clicked from within the argo applications list, this issue should not come up. (@servo1x could you confirm this?) 