### PR TITLE
Issue #2114 - Fix history api fallback implementation to support app names with dots

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -660,6 +660,14 @@ func newAPIServerMetricsServer(port int) *http.Server {
 	}
 }
 
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
 // newStaticAssetsHandler returns an HTTP handler to serve UI static assets
 func newStaticAssetsHandler(dir string, baseHRef string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -670,7 +678,7 @@ func newStaticAssetsHandler(dir string, baseHRef string) func(http.ResponseWrite
 				break
 			}
 		}
-		fileRequest := r.URL.Path != "/index.html" && strings.Contains(r.URL.Path, ".")
+		fileRequest := r.URL.Path != "/index.html" && fileExists(path.Join(dir, r.URL.Path))
 
 		// serve index.html for non file requests to support HTML5 History API
 		if acceptHTML && !fileRequest && (r.Method == "GET" || r.Method == "HEAD") {


### PR DESCRIPTION
Closes #2114

PR https://github.com/argoproj/argo-cd/issues/2114 fixes 404 error in dev mode but the error still might occur in production. PR fixes production issue as well.
