### PR TITLE
Issue #1167 - Excluded known orphaned resources exceptions

### DIFF
--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -354,3 +354,32 @@ func TestReturnUnknownComparisonStateOnSettingLoadError(t *testing.T) {
 	assert.Equal(t, argoappv1.SyncStatusCodeUnknown, compRes.syncStatus.Status)
 	assert.NotNil(t, compRes.reconciledAt)
 }
+
+func TestSetManagedResourcesKnownOrphanedResourceExceptions(t *testing.T) {
+	proj := defaultProj.DeepCopy()
+	proj.Spec.OrphanedResources = &argoappv1.OrphanedResourcesMonitorSettings{}
+
+	app := newFakeApp()
+	app.Namespace = "default"
+
+	ctrl := newFakeController(&fakeData{
+		apps: []runtime.Object{app, proj},
+		namespacedResources: map[kube.ResourceKey]namespacedResource{
+			kube.NewResourceKey("apps", kube.DeploymentKind, app.Namespace, "guestbook"): {
+				ResourceNode: argoappv1.ResourceNode{ResourceRef: argoappv1.ResourceRef{Group: "apps", Kind: kube.DeploymentKind, Name: "guestbook", Namespace: app.Namespace}},
+			},
+			kube.NewResourceKey("", kube.ServiceAccountKind, app.Namespace, "default"): {
+				ResourceNode: argoappv1.ResourceNode{ResourceRef: argoappv1.ResourceRef{Kind: kube.ServiceAccountKind, Name: "default", Namespace: app.Namespace}},
+			},
+			kube.NewResourceKey("", kube.ServiceKind, app.Namespace, "kubernetes"): {
+				ResourceNode: argoappv1.ResourceNode{ResourceRef: argoappv1.ResourceRef{Kind: kube.ServiceAccountKind, Name: "kubernetes", Namespace: app.Namespace}},
+			},
+		},
+	})
+
+	tree, err := ctrl.setAppManagedResources(app, &comparisonResult{managedResources: make([]managedResource, 0)})
+
+	assert.NoError(t, err)
+	assert.Len(t, tree.OrphanedNodes, 1)
+	assert.Equal(t, "guestbook", tree.OrphanedNodes[0].Name)
+}

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -745,9 +745,6 @@ func TestOrphanedResource(t *testing.T) {
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: &OrphanedResourcesMonitorSettings{Warn: pointer.BoolPtr(true)},
-			NamespaceResourceBlacklist: []metav1.GroupKind{{
-				Kind: kube.ServiceAccountKind,
-			}},
 		}).
 		Path(guestbookPath).
 		When().


### PR DESCRIPTION
ref: #1167 

There are resources which are created in the namespace automatically and should not considered orphaned:
- default service account
- kubernetes service in default namespace

Such resources should be automatically ignored, instead of asking user to configure an exception 
