### PR TITLE
Add path to externalURLs

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -126,14 +126,23 @@ func populateIngressInfo(un *unstructured.Unstructured, node *node) {
 						stringPort = fmt.Sprintf("%v", port)
 					}
 
+					var externalURL string
 					switch stringPort {
 					case "80", "http":
-						urlsSet[fmt.Sprintf("http://%s", host)] = true
+						externalURL = fmt.Sprintf("http://%s", host)
 					case "443", "https":
-						urlsSet[fmt.Sprintf("https://%s", host)] = true
+						externalURL = fmt.Sprintf("https://%s", host)
 					default:
-						urlsSet[fmt.Sprintf("http://%s:%s", host, stringPort)] = true
+						externalURL = fmt.Sprintf("http://%s:%s", host, stringPort)
 					}
+
+					subPath := ""
+					if nestedPath, ok, err := unstructured.NestedString(path, "path"); ok && err == nil {
+						subPath = nestedPath
+					}
+
+					externalURL += subPath
+					urlsSet[externalURL] = true
 				}
 			}
 		}


### PR DESCRIPTION
The "path" property  (beside the "backend" property in the Ingress rule) is now considered while building the url, in addition to the host.

**Please be aware**  : 
- it's my first attempt with golang
- I have added some unit tests, but was not able to test the ui locally. I gave up for the moment

<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  
