### PR TITLE
Fix TestImmutableChange for running locally in microk8s

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -66,8 +66,8 @@ func TestImmutableChange(t *testing.T) {
 	text := errors.FailOnErr(fixture.Run(".", "kubectl", "get", "service", "-n", "kube-system", "kube-dns", "-o", "jsonpath={.spec.clusterIP}")).(string)
 	parts := strings.Split(text, ".")
 	n := rand.Intn(254)
-	ip1 := fmt.Sprintf("%s.%s.10.%d", parts[0], parts[1], n)
-	ip2 := fmt.Sprintf("%s.%s.10.%d", parts[0], parts[1], n+1)
+	ip1 := fmt.Sprintf("%s.%s.%s.%d", parts[0], parts[1], parts[2], n)
+	ip2 := fmt.Sprintf("%s.%s.%s.%d", parts[0], parts[1], parts[2], n+1)
 	Given(t).
 		Path("service").
 		When().


### PR DESCRIPTION
My microk8s I run locally for developing ArgoCD has only a /24 network for cluster IPs, i.e. `--service-cluster-ip-range=10.152.183.0/24`

The `TestImmutableChange` end-to-end test changes third octet of the service IP to be `10`, so effectively changing the IP to outside of my cluster IP range, thus test is failing locally with:

```
kubectl failed exit status 1: The Service "my-service" is invalid: spec.clusterIP: Invalid value: "10.152.10.156": provided IP is not in the valid range. The range of valid IPs is 10.152.183.0/24'
```

We should use IP address of same /24 network (most likely the smallest used anywhere) for the patch operation, and then test succeeds also locally.