### PR TITLE
docs/user-guide/projects.md: fix example policy

### DIFF
--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -94,7 +94,7 @@ data:
   policy.default: ""
   policy.csv: |
     p, some-github-org:team1, applications, *, project-a/*, allow
-    p, some-github-org:team2, applications, *, project-a/*, allow
+    p, some-github-org:team2, applications, *, project-b/*, allow
 
     p, role:org-admin, repositories, get, *, allow
     p, role:org-admin, repositories, create, *, allow


### PR DESCRIPTION
I'm reading through the documentation. The example under the https://argoproj.github.io/argo-cd/user-guide/projects/#configuring-rbac-with-projects section has a typo, which this PR fixes.