### PR TITLE
API clients may use the HTTP Authorization header for auth. 

### DIFF
--- a/docs/developer-guide/api-docs.md
+++ b/docs/developer-guide/api-docs.md
@@ -1,3 +1,21 @@
 # API Docs
 
-You can find Swagger docs but setting the path `/swagger-ui` to your Argo CD UI's. E.g. [http://localhost:8080/swagger-ui](http://localhost:8080/swagger-ui). 
+You can find Swagger docs but setting the path `/swagger-ui` to your Argo CD UI's. E.g. [http://localhost:8080/swagger-ui](http://localhost:8080/swagger-ui).
+
+## Authorization
+
+You'll need to authorize your API using a bearer token. To get a token:
+
+```bash
+$ curl $ARGOCD_SERVER/api/v1/session -d $'{"username":"admin","password":"Password1\u0021"}'
+{"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1Njc4MTIzODcsImlzcyI6ImFyZ29jZCIsIm5iZiI6MTU2NzgxMjM4Nywic3ViIjoiYWRtaW4ifQ.ejyTgFxLhuY9mOBtKhcnvobg3QZXJ4_RusN_KIdVwao"} 
+```
+
+Then pass using the HTTP `Authorization` header, prefixing with `Bearer `:
+
+```bash
+$ $ curl $ARGOCD_SERVER/api/v1/applications -H "Authorization: Bearer $ARGOCD_TOKEN" 
+{"metadata":{"selfLink":"/apis/argoproj.io/v1alpha1/namespaces/argocd/applications","resourceVersion":"37755"},"items":...}
+```
+ 
+ You sh

--- a/docs/developer-guide/api-docs.md
+++ b/docs/developer-guide/api-docs.md
@@ -7,7 +7,7 @@ You can find Swagger docs but setting the path `/swagger-ui` to your Argo CD UI'
 You'll need to authorize your API using a bearer token. To get a token:
 
 ```bash
-$ curl $ARGOCD_SERVER/api/v1/session -d $'{"username":"admin","password":"Password1\u0021"}'
+$ curl $ARGOCD_SERVER/api/v1/session -d $'{"username":"admin","password":"password"}'
 {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1Njc4MTIzODcsImlzcyI6ImFyZ29jZCIsIm5iZiI6MTU2NzgxMjM4Nywic3ViIjoiYWRtaW4ifQ.ejyTgFxLhuY9mOBtKhcnvobg3QZXJ4_RusN_KIdVwao"} 
 ```
 

--- a/server/server.go
+++ b/server/server.go
@@ -753,8 +753,7 @@ func (a *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, error) {
 
 // getToken extracts the token from gRPC metadata or cookie headers
 func getToken(md metadata.MD) string {
-	// check the "t" metadata
-	log.Debugf("ALEX md=%v", md)
+	// check the "token" metadata
 	{
 		tokens, ok := md[apiclient.MetaDataTokenKey]
 		if ok && len(tokens) > 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -753,22 +753,39 @@ func (a *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, error) {
 
 // getToken extracts the token from gRPC metadata or cookie headers
 func getToken(md metadata.MD) string {
-	// check the "token" metadata
-	tokens, ok := md[apiclient.MetaDataTokenKey]
-	if ok && len(tokens) > 0 {
-		return tokens[0]
+	// check the "t" metadata
+	log.Debugf("ALEX md=%v", md)
+	{
+		tokens, ok := md[apiclient.MetaDataTokenKey]
+		if ok && len(tokens) > 0 {
+			return tokens[0]
+		}
 	}
+
+	var tokens []string
+
+	// looks for the HTTP header `Authorization: Bearer ...`
+	for _, t := range md["authorization"] {
+		if strings.HasPrefix(t, "Bearer ") {
+			tokens = append(tokens, strings.TrimPrefix(t, "Bearer "))
+		}
+	}
+
 	// check the HTTP cookie
-	for _, cookieToken := range md["grpcgateway-cookie"] {
+	for _, t := range md["grpcgateway-cookie"] {
 		header := http.Header{}
-		header.Add("Cookie", cookieToken)
+		header.Add("Cookie", t)
 		request := http.Request{Header: header}
 		token, err := request.Cookie(common.AuthCookieName)
 		if err == nil {
-			value, err := zjwt.JWT(token.Value)
-			if err == nil {
-				return value
-			}
+			tokens = append(tokens, token.Value)
+		}
+	}
+
+	for _, t := range tokens {
+		value, err := zjwt.JWT(t)
+		if err == nil {
+			return value
 		}
 	}
 	return ""

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -461,3 +461,21 @@ func TestAuthenticate(t *testing.T) {
 		})
 	}
 }
+
+func Test_getToken(t *testing.T) {
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	t.Run("Empty", func(t *testing.T) {
+		assert.Empty(t, getToken(metadata.New(map[string]string{})))
+	})
+	t.Run("Token", func(t *testing.T) {
+		assert.Equal(t, token, getToken(metadata.New(map[string]string{"token": token})))
+	})
+	t.Run("Authorisation", func(t *testing.T) {
+		assert.Empty(t, getToken(metadata.New(map[string]string{"authorization": "Bearer invalid"})))
+		assert.Equal(t, token, getToken(metadata.New(map[string]string{"authorization": "Bearer " + token})))
+	})
+	t.Run("Cookie", func(t *testing.T) {
+		assert.Empty(t, getToken(metadata.New(map[string]string{"grpcgateway-cookie": "argocd.token=invalid"})))
+		assert.Equal(t, token, getToken(metadata.New(map[string]string{"grpcgateway-cookie": "argocd.token=" + token})))
+	})
+}


### PR DESCRIPTION
Closes #1642