### PR TITLE
Issue #2022 - Support limiting number of concurrent kubectl fork/execs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,14 @@ commands:
           command: mkdir -p /tmp/dl
       - restore_cache:
           keys:
-            - dl-v6
+            - dl-v7
+      - run:
+          name: Install Kubectl v1.14.0
+          command: |
+            set -x
+            [ -e /tmp/dl/kubectl ] || curl -sLf -C - -o /tmp/dl/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+            sudo cp /tmp/dl/kubectl /usr/local/bin/kubectl
+            sudo chmod +x /usr/local/bin/kubectl
       - run:
           name: Install Kubectx v0.6.3
           command: |
@@ -119,7 +126,7 @@ commands:
             sudo chmod +x /usr/local/go/bin/kustomize
             kustomize version
       - save_cache:
-          key: dl-v6
+          key: dl-v7
           paths:
             - /tmp/dl
   save_go_cache:
@@ -208,14 +215,13 @@ jobs:
           name: Create namespace
           command: |
             set -x
+            cat /etc/rancher/k3s/k3s.yaml | sed "s/localhost/`hostname`/" | tee ~/.kube/config
+            echo "127.0.0.1 `hostname`" | sudo tee -a /etc/hosts
             kubectl create ns argocd-e2e
             kubens argocd-e2e
             # install the certificates (not 100% sure we need this)
             sudo cp /var/lib/rancher/k3s/server/tls/token-ca.crt /usr/local/share/ca-certificates/k3s.crt
             sudo update-ca-certificates
-            # create the kubecfg, again - not sure we need this
-            cat /etc/rancher/k3s/k3s.yaml | sed "s/localhost/`hostname`/" | tee ~/.kube/config
-            echo "127.0.0.1 `hostname`" | sudo tee -a /etc/hosts
       - run:
           name: Apply manifests
           command: kustomize build test/manifests/base | kubectl apply -f -

--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -46,6 +46,7 @@ func newCommand() *cobra.Command {
 		logLevel                 string
 		glogLevel                int
 		metricsPort              int
+		kubectlParallelismLimit  int64
 		cacheSrc                 func() (*cache.Cache, error)
 	)
 	var command = cobra.Command{
@@ -84,7 +85,8 @@ func newCommand() *cobra.Command {
 				cache,
 				resyncDuration,
 				time.Duration(selfHealTimeoutSeconds)*time.Second,
-				metricsPort)
+				metricsPort,
+				kubectlParallelismLimit)
 			errors.CheckError(err)
 
 			log.Infof("Application Controller (version: %s) starting (namespace: %s)", common.GetVersion(), namespace)
@@ -109,6 +111,7 @@ func newCommand() *cobra.Command {
 	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDMetrics, "Start metrics server on given port")
 	command.Flags().IntVar(&selfHealTimeoutSeconds, "self-heal-timeout-seconds", 5, "Specifies timeout between application self heal attempts")
+	command.Flags().Int64Var(&kubectlParallelismLimit, "kubectl-parallelism-limit", 0, "Number of allowed concurrent kubectl fork/execs.")
 
 	cacheSrc = cache.AddCacheFlagsToCmd(&command)
 	return &command

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -89,6 +89,7 @@ func newFakeController(data *fakeData) *ApplicationController {
 		time.Minute,
 		time.Minute,
 		common.DefaultPortArgoCDMetrics,
+		0,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -36,6 +36,7 @@ import (
 	versionpkg "github.com/argoproj/argo-cd/pkg/apiclient/version"
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	argoappv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/util"
 	grpc_util "github.com/argoproj/argo-cd/util/grpc"
 	"github.com/argoproj/argo-cd/util/localconfig"
 	oidcutil "github.com/argoproj/argo-cd/util/oidc"
@@ -387,7 +388,7 @@ func (c *client) newConn() (*grpc.ClientConn, io.Closer, error) {
 	}
 	conn, e := grpc_util.BlockingDial(context.Background(), network, serverAddr, creds, dialOpts...)
 	closers = append(closers, conn)
-	return conn, &inlineCloser{close: func() error {
+	return conn, util.NewCloser(func() error {
 		var firstErr error
 		for i := range closers {
 			err := closers[i].Close()
@@ -396,7 +397,7 @@ func (c *client) newConn() (*grpc.ClientConn, io.Closer, error) {
 			}
 		}
 		return firstErr
-	}}, e
+	}), e
 }
 
 func (c *client) tlsConfig() (*tls.Config, error) {

--- a/util/kube/ctl.go
+++ b/util/kube/ctl.go
@@ -33,7 +33,9 @@ type Kubectl interface {
 	GetAPIResources(config *rest.Config, resourceFilter ResourceFilter) ([]APIResourceInfo, error)
 }
 
-type KubectlCmd struct{}
+type KubectlCmd struct {
+	OnKubectlRun func(command string) (util.Closer, error)
+}
 
 type APIResourceInfo struct {
 	GroupKind schema.GroupKind
@@ -214,7 +216,7 @@ func (k KubectlCmd) ApplyResource(config *rest.Config, obj *unstructured.Unstruc
 				return "", err
 			}
 		}
-		outReconcile, err := runKubectl(f.Name(), namespace, []string{"auth", "reconcile"}, manifestBytes, dryRun)
+		outReconcile, err := k.runKubectl(f.Name(), namespace, []string{"auth", "reconcile"}, manifestBytes, dryRun)
 		if err != nil {
 			return "", err
 		}
@@ -231,7 +233,7 @@ func (k KubectlCmd) ApplyResource(config *rest.Config, obj *unstructured.Unstruc
 	if !validate {
 		applyArgs = append(applyArgs, "--validate=false")
 	}
-	outApply, err := runKubectl(f.Name(), namespace, applyArgs, manifestBytes, dryRun)
+	outApply, err := k.runKubectl(f.Name(), namespace, applyArgs, manifestBytes, dryRun)
 	if err != nil {
 		return "", err
 	}
@@ -251,7 +253,27 @@ func convertKubectlError(err error) error {
 	return fmt.Errorf(errorStr)
 }
 
-func runKubectl(kubeconfigPath string, namespace string, args []string, manifestBytes []byte, dryRun bool) (string, error) {
+func (k *KubectlCmd) processKubectlRun(args []string) (util.Closer, error) {
+	if k.OnKubectlRun != nil {
+		cmd := "unknown"
+		if len(args) > 0 {
+			cmd = args[0]
+		}
+		return k.OnKubectlRun(cmd)
+	}
+	return util.NewCloser(func() error {
+		return nil
+		// do nothing
+	}), nil
+}
+
+func (k *KubectlCmd) runKubectl(kubeconfigPath string, namespace string, args []string, manifestBytes []byte, dryRun bool) (string, error) {
+	closer, err := k.processKubectlRun(args)
+	if err != nil {
+		return "", err
+	}
+	defer util.Close(closer)
+
 	cmdArgs := append([]string{"--kubeconfig", kubeconfigPath, "-f", "-"}, args...)
 	if namespace != "" {
 		cmdArgs = append(cmdArgs, "-n", namespace)
@@ -304,6 +326,13 @@ func (k KubectlCmd) ConvertToVersion(obj *unstructured.Unstructured, group strin
 		return nil, err
 	}
 	defer util.DeleteFile(f.Name())
+
+	closer, err := k.processKubectlRun([]string{"convert"})
+	if err != nil {
+		return nil, err
+	}
+	defer util.Close(closer)
+
 	outputVersion := fmt.Sprintf("%s/%s", group, version)
 	cmd := exec.Command("kubectl", "convert", "--output-version", outputVersion, "-o", "json", "--local=true", "-f", f.Name())
 	cmd.Stdin = bytes.NewReader(manifestBytes)

--- a/util/util.go
+++ b/util/util.go
@@ -30,6 +30,18 @@ type Closer interface {
 	Close() error
 }
 
+type inlineCloser struct {
+	close func() error
+}
+
+func (c *inlineCloser) Close() error {
+	return c.close()
+}
+
+func NewCloser(close func() error) Closer {
+	return &inlineCloser{close: close}
+}
+
 // Close is a convenience function to close a object that has a Close() method, ignoring any errors
 // Used to satisfy errcheck lint
 func Close(c Closer) {


### PR DESCRIPTION
PR implements the ability to limit number of concurrent kubectl fork/execs to partially resolve issue https://github.com/argoproj/argo-cd/issues/2022 . 

Additionally adds two prometheus counters: total number of kubectl execs; number of pending kubectl execs.

Documentation is coming in next PR.