### PR TITLE
Fix typo

### DIFF
--- a/docs/user-guide/resource_hooks.md
+++ b/docs/user-guide/resource_hooks.md
@@ -41,7 +41,7 @@ The following hooks are defined:
 
 ### Generate Name
 
-Named hooks (i.e. ones with `/metadata/name`) will only be created once. If you want a hook to be re-created each time either use `BeforeHookCreation` policy (see below) or `/metadata/generaName`. 
+Named hooks (i.e. ones with `/metadata/name`) will only be created once. If you want a hook to be re-created each time either use `BeforeHookCreation` policy (see below) or `/metadata/generateName`. 
 
 ## Selective Sync
 


### PR DESCRIPTION
> `/metadata/generaName`. 

Is generaName a mistake in generateName ?

<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  
