### PR TITLE
Change Helm repo URLs to argoproj/argo-cd/master

### DIFF
--- a/test/e2e/testdata/index.yaml
+++ b/test/e2e/testdata/index.yaml
@@ -3,5 +3,5 @@ entries:
   helm:
     - created: 2019-07-08T23:26:50.723856689Z
       urls:
-        - https://github.com/alexec/argo-cd/blob/helm-1st-class/test/e2e/testdata/helm-1.0.0.tgz?raw=true
+        - https://github.com/argoproj/argo-cd/blob/master/test/e2e/testdata/helm-1.0.0.tgz?raw=true
       version: 1.0.0

--- a/test/fixture/testrepos/helm_test_repo.go
+++ b/test/fixture/testrepos/helm_test_repo.go
@@ -1,3 +1,3 @@
 package testrepos
 
-const HelmTestRepo = "https://raw.githubusercontent.com/alexec/argo-cd/helm-1st-class/test/e2e/testdata"
+const HelmTestRepo = "https://raw.githubusercontent.com/argoproj/argo-cd/master/test/e2e/testdata"


### PR DESCRIPTION
I noticed that e2e tests are failing. This is somehow a chicken-and-egg problem at the moment ;)

<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  
