### PR TITLE
Issue #2245 - Intermittent "git ls-remote" request failures should not fail app reconciliation

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -133,6 +133,8 @@ const (
 	EnvVarSSHDataPath = "ARGOCD_SSH_DATA_PATH"
 	// Overrides the location where TLS certificate for repo access data is stored
 	EnvVarTLSDataPath = "ARGOCD_TLS_DATA_PATH"
+	// Specifies number of git remote operations attempts count
+	EnvGitAttemptsCount = "ARGOCD_GIT_ATTEMPTS_COUNT"
 )
 
 const (

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -3,6 +3,7 @@ package git
 import (
 	"crypto/tls"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,6 +24,7 @@ import (
 	ssh2 "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 
+	"github.com/argoproj/argo-cd/common"
 	certutil "github.com/argoproj/argo-cd/util/cert"
 	argoconfig "github.com/argoproj/argo-cd/util/config"
 	"github.com/argoproj/argo-cd/util/repo/metrics"
@@ -48,12 +50,6 @@ type Client interface {
 	RevisionMetadata(revision string) (*RevisionMetadata, error)
 }
 
-// ClientFactory is a factory of Git Clients
-// Primarily used to support creation of mock git clients during unit testing
-type ClientFactory interface {
-	NewClient(rawRepoURL string, path string, creds Creds, insecure bool, enableLfs bool, eventReporter metrics.Reporter) (Client, error)
-}
-
 // nativeGitClient implements Client interface using git CLI
 type nativeGitClient struct {
 	// URL of the repository
@@ -70,13 +66,21 @@ type nativeGitClient struct {
 	reporter metrics.Reporter
 }
 
-type factory struct{}
+var (
+	maxAttemptsCount = 1
+)
 
-func NewFactory() ClientFactory {
-	return &factory{}
+func init() {
+	if countStr := os.Getenv(common.EnvGitAttemptsCount); countStr != "" {
+		if cnt, err := strconv.Atoi(countStr); err != nil {
+			panic(fmt.Sprintf("Invalid value in %s env variable: %v", common.EnvGitAttemptsCount, err))
+		} else {
+			maxAttemptsCount = int(math.Max(float64(cnt), 1))
+		}
+	}
 }
 
-func (f *factory) NewClient(rawRepoURL string, path string, creds Creds, insecure bool, enableLfs bool, reporter metrics.Reporter) (Client, error) {
+func NewClient(rawRepoURL string, path string, creds Creds, insecure bool, enableLfs bool, reporter metrics.Reporter) (Client, error) {
 	client := nativeGitClient{
 		repoURL:   rawRepoURL,
 		root:      path,
@@ -309,7 +313,16 @@ func (m *nativeGitClient) Checkout(revision string) error {
 // Otherwise, it returns an error indicating that the revision could not be resolved. This method
 // runs with in-memory storage and is safe to run concurrently, or to be run without a git
 // repository locally cloned.
-func (m *nativeGitClient) LsRemote(revision string) (string, error) {
+func (m *nativeGitClient) LsRemote(revision string) (res string, err error) {
+	for attempt := 0; attempt < maxAttemptsCount; attempt++ {
+		if res, err = m.lsRemote(revision); err == nil {
+			return
+		}
+	}
+	return
+}
+
+func (m *nativeGitClient) lsRemote(revision string) (string, error) {
 	if IsCommitSHA(revision) {
 		return revision, nil
 	}

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -177,7 +177,7 @@ func TestCustomHTTPClient(t *testing.T) {
 func TestLsRemote(t *testing.T) {
 	eventReporter := &mocks.EventReporter{}
 	eventReporter.On("Event", "https://github.com/argoproj/argo-cd.git", "GitRequestTypeLsRemote").Return()
-	clnt, err := NewFactory().NewClient("https://github.com/argoproj/argo-cd.git", "/tmp", NopCreds{}, false, false, eventReporter)
+	clnt, err := NewClient("https://github.com/argoproj/argo-cd.git", "/tmp", NopCreds{}, false, false, eventReporter)
 	assert.NoError(t, err)
 	xpass := []string{
 		"HEAD",
@@ -222,7 +222,7 @@ func TestLFSClient(t *testing.T) {
 		defer func() { _ = os.RemoveAll(tempDir) }()
 	}
 
-	client, err := NewFactory().NewClient("https://github.com/argoproj-labs/argocd-testrepo-lfs", tempDir, NopCreds{}, false, true, &mocks.EventReporter{})
+	client, err := NewClient("https://github.com/argoproj-labs/argocd-testrepo-lfs", tempDir, NopCreds{}, false, true, &mocks.EventReporter{})
 	assert.NoError(t, err)
 
 	commitSHA, err := client.LsRemote("HEAD")
@@ -284,7 +284,7 @@ func TestNewFactory(t *testing.T) {
 		metrics := &mocks.EventReporter{}
 		metrics.On("Event", tt.args.url, "GitRequestTypeLsRemote").Return()
 		metrics.On("Event", tt.args.url, "GitRequestTypeFetch").Return()
-		client, err := NewFactory().NewClient(tt.args.url, dirName, NopCreds{}, tt.args.insecureIgnoreHostKey, false, metrics)
+		client, err := NewClient(tt.args.url, dirName, NopCreds{}, tt.args.insecureIgnoreHostKey, false, metrics)
 		assert.NoError(t, err)
 		commitSHA, err := client.LsRemote("HEAD")
 		assert.NoError(t, err)

--- a/util/git/repo/repo.go
+++ b/util/git/repo/repo.go
@@ -68,7 +68,7 @@ func NewRepo(url string, creds git.Creds, insecure, enableLfs bool, disco func(r
 	if err != nil {
 		return nil, err
 	}
-	client, err := git.NewFactory().NewClient(url, workDir, creds, insecure, enableLfs, reporter)
+	client, err := git.NewClient(url, workDir, creds, insecure, enableLfs, reporter)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Resolves #2245