### PR TITLE
Add Deployment action for `kubectl rollout restart`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,6 +90,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:a6ee710e45210bafe11f2f28963571be2ac8809f9a7b675a6d2c02302a1ce1a9"
+  name = "github.com/bouk/monkey"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5df1f207ff77e025801505ae4d903133a0b4353f"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:e04162bd6a6d4950541bae744c968108e14913b1cebccf29f7650b573f44adb3"
   name = "github.com/casbin/casbin"
   packages = [
@@ -1589,6 +1597,7 @@
     "github.com/argoproj/pkg/errors",
     "github.com/argoproj/pkg/exec",
     "github.com/argoproj/pkg/time",
+    "github.com/bouk/monkey",
     "github.com/casbin/casbin",
     "github.com/casbin/casbin/model",
     "github.com/casbin/casbin/persist",

--- a/resource_customizations/apps/DaemonSet/actions/action_test.yaml
+++ b/resource_customizations/apps/DaemonSet/actions/action_test.yaml
@@ -1,0 +1,4 @@
+actionTests:
+- action: restart
+  inputPath: testdata/daemonset.yaml
+  expectedOutputPath: testdata/daemonset-restarted.yaml

--- a/resource_customizations/apps/DaemonSet/actions/discovery.lua
+++ b/resource_customizations/apps/DaemonSet/actions/discovery.lua
@@ -1,0 +1,3 @@
+actions = {}
+actions["restart"] = {}
+return actions

--- a/resource_customizations/apps/DaemonSet/actions/restart/action.lua
+++ b/resource_customizations/apps/DaemonSet/actions/restart/action.lua
@@ -1,0 +1,9 @@
+local os = require("os")
+if obj.spec.template.metadata == nil then
+    obj.spec.template.metadata = {}
+end
+if obj.spec.template.metadata.annotations == nil then
+    obj.spec.template.metadata.annotations = {}
+end
+obj.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"] = os.date("!%Y-%m-%dT%XZ")
+return obj

--- a/resource_customizations/apps/DaemonSet/actions/testdata/daemonset-restarted.yaml
+++ b/resource_customizations/apps/DaemonSet/actions/testdata/daemonset-restarted.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    deprecated.daemonset.template.generation: "3"
+  creationTimestamp: "2019-09-13T08:52:50Z"
+  generation: 3
+  labels:
+    app.kubernetes.io/instance: extensions
+  name: daemonset
+  namespace: statefulset
+  resourceVersion: "7472656"
+  selfLink: /apis/apps/v1/namespaces/statefulset/daemonsets/daemonset
+  uid: de04d075-d603-11e9-9e69-42010aa8005f
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: daemonset
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "0001-01-01T00:00:00Z"
+      labels:
+        name: daemonset
+    spec:
+      containers:
+      - image: k8s.gcr.io/nginx-slim:0.8
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  currentNumberScheduled: 4
+  desiredNumberScheduled: 4
+  numberAvailable: 4
+  numberMisscheduled: 0
+  numberReady: 4
+  observedGeneration: 3
+  updatedNumberScheduled: 4

--- a/resource_customizations/apps/DaemonSet/actions/testdata/daemonset.yaml
+++ b/resource_customizations/apps/DaemonSet/actions/testdata/daemonset.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    deprecated.daemonset.template.generation: "3"
+  creationTimestamp: "2019-09-13T08:52:50Z"
+  generation: 3
+  labels:
+    app.kubernetes.io/instance: extensions
+  name: daemonset
+  namespace: statefulset
+  resourceVersion: "7472656"
+  selfLink: /apis/apps/v1/namespaces/statefulset/daemonsets/daemonset
+  uid: de04d075-d603-11e9-9e69-42010aa8005f
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: daemonset
+  template:
+    metadata:
+      labels:
+        name: daemonset
+    spec:
+      containers:
+      - image: k8s.gcr.io/nginx-slim:0.8
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  currentNumberScheduled: 4
+  desiredNumberScheduled: 4
+  numberAvailable: 4
+  numberMisscheduled: 0
+  numberReady: 4
+  observedGeneration: 3
+  updatedNumberScheduled: 4

--- a/resource_customizations/apps/Deployment/actions/action_test.yaml
+++ b/resource_customizations/apps/Deployment/actions/action_test.yaml
@@ -1,0 +1,4 @@
+actionTests:
+- action: restart
+  inputPath: testdata/deployment.yaml
+  expectedOutputPath: testdata/deployment-restarted.yaml

--- a/resource_customizations/apps/Deployment/actions/discovery.lua
+++ b/resource_customizations/apps/Deployment/actions/discovery.lua
@@ -1,0 +1,3 @@
+actions = {}
+actions["restart"] = {}
+return actions

--- a/resource_customizations/apps/Deployment/actions/restart/action.lua
+++ b/resource_customizations/apps/Deployment/actions/restart/action.lua
@@ -1,0 +1,9 @@
+local os = require("os")
+if obj.spec.template.metadata == nil then
+    obj.spec.template.metadata = {}
+end
+if obj.spec.template.metadata.annotations == nil then
+    obj.spec.template.metadata.annotations = {}
+end
+obj.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"] = os.date("!%Y-%m-%dT%XZ")
+return obj

--- a/resource_customizations/apps/Deployment/actions/testdata/deployment-restarted.yaml
+++ b/resource_customizations/apps/Deployment/actions/testdata/deployment-restarted.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2019-09-12T01:33:53Z"
+  generation: 1
+  name: nginx-deploy
+  namespace: default
+  resourceVersion: "6897444"
+  selfLink: /apis/apps/v1/namespaces/default/deployments/nginx-deploy
+  uid: 61689d6d-d4fd-11e9-9e69-42010aa8005f
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "0001-01-01T00:00:00Z"
+    spec:
+      containers:
+      - image: nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  conditions:
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:33:53Z"
+    message: Deployment does not have minimum availability.
+    reason: MinimumReplicasUnavailable
+    status: "False"
+    type: Available
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:34:05Z"
+    message: ReplicaSet "nginx-deploy-9cb4784bd" is progressing.
+    reason: ReplicaSetUpdated
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 3
+  unavailableReplicas: 1
+  updatedReplicas: 3

--- a/resource_customizations/apps/Deployment/actions/testdata/deployment.yaml
+++ b/resource_customizations/apps/Deployment/actions/testdata/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2019-09-12T01:33:53Z"
+  generation: 1
+  name: nginx-deploy
+  namespace: default
+  resourceVersion: "6897444"
+  selfLink: /apis/apps/v1/namespaces/default/deployments/nginx-deploy
+  uid: 61689d6d-d4fd-11e9-9e69-42010aa8005f
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  conditions:
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:33:53Z"
+    message: Deployment does not have minimum availability.
+    reason: MinimumReplicasUnavailable
+    status: "False"
+    type: Available
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:34:05Z"
+    message: ReplicaSet "nginx-deploy-9cb4784bd" is progressing.
+    reason: ReplicaSetUpdated
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 3
+  unavailableReplicas: 1
+  updatedReplicas: 3

--- a/resource_customizations/apps/StatefulSet/actions/action_test.yaml
+++ b/resource_customizations/apps/StatefulSet/actions/action_test.yaml
@@ -1,0 +1,4 @@
+actionTests:
+- action: restart
+  inputPath: testdata/statefulset.yaml
+  expectedOutputPath: testdata/statefulset-restarted.yaml

--- a/resource_customizations/apps/StatefulSet/actions/discovery.lua
+++ b/resource_customizations/apps/StatefulSet/actions/discovery.lua
@@ -1,0 +1,3 @@
+actions = {}
+actions["restart"] = {}
+return actions

--- a/resource_customizations/apps/StatefulSet/actions/restart/action.lua
+++ b/resource_customizations/apps/StatefulSet/actions/restart/action.lua
@@ -1,0 +1,9 @@
+local os = require("os")
+if obj.spec.template.metadata == nil then
+    obj.spec.template.metadata = {}
+end
+if obj.spec.template.metadata.annotations == nil then
+    obj.spec.template.metadata.annotations = {}
+end
+obj.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"] = os.date("!%Y-%m-%dT%XZ")
+return obj

--- a/resource_customizations/apps/StatefulSet/actions/testdata/statefulset-restarted.yaml
+++ b/resource_customizations/apps/StatefulSet/actions/testdata/statefulset-restarted.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: "2019-09-13T08:52:54Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/instance: extensions
+  name: statefulset
+  namespace: statefulset
+  resourceVersion: "7471813"
+  selfLink: /apis/apps/v1/namespaces/statefulset/statefulsets/statefulset
+  uid: dfe8fadf-d603-11e9-9e69-42010aa8005f
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: statefulset
+  serviceName: statefulset
+  template:
+    metadata:
+      labels:
+        app: statefulset
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "0001-01-01T00:00:00Z"
+    spec:
+      containers:
+      - image: k8s.gcr.io/nginx-slim:0.8
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+status:
+  collisionCount: 0
+  currentReplicas: 3
+  currentRevision: statefulset-85b7f767c6
+  observedGeneration: 2
+  readyReplicas: 3
+  replicas: 3
+  updateRevision: statefulset-85b7f767c6
+  updatedReplicas: 3

--- a/resource_customizations/apps/StatefulSet/actions/testdata/statefulset.yaml
+++ b/resource_customizations/apps/StatefulSet/actions/testdata/statefulset.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: "2019-09-13T08:52:54Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/instance: extensions
+  name: statefulset
+  namespace: statefulset
+  resourceVersion: "7471813"
+  selfLink: /apis/apps/v1/namespaces/statefulset/statefulsets/statefulset
+  uid: dfe8fadf-d603-11e9-9e69-42010aa8005f
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: statefulset
+  serviceName: statefulset
+  template:
+    metadata:
+      labels:
+        app: statefulset
+    spec:
+      containers:
+      - image: k8s.gcr.io/nginx-slim:0.8
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+status:
+  collisionCount: 0
+  currentReplicas: 3
+  currentRevision: statefulset-85b7f767c6
+  observedGeneration: 2
+  readyReplicas: 3
+  replicas: 3
+  updateRevision: statefulset-85b7f767c6
+  updatedReplicas: 3

--- a/resource_customizations/custom_actions_test.go
+++ b/resource_customizations/custom_actions_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/argoproj/argo-cd/errors"
 	appsv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/util/diff"
 	"github.com/argoproj/argo-cd/util/lua"
@@ -48,14 +47,14 @@ func TestLuaResourceActionsScript(t *testing.T) {
 		if !strings.Contains(path, "action_test.yaml") {
 			return nil
 		}
-		errors.CheckError(err)
+		assert.NoError(t, err)
 		dir := filepath.Dir(path)
 		//TODO: Change to path
 		yamlBytes, err := ioutil.ReadFile(dir + "/action_test.yaml")
-		errors.CheckError(err)
+		assert.NoError(t, err)
 		var resourceTest ActionTestStructure
 		err = yaml.Unmarshal(yamlBytes, &resourceTest)
-		errors.CheckError(err)
+		assert.NoError(t, err)
 		for i := range resourceTest.DiscoveryTests {
 			test := resourceTest.DiscoveryTests[i]
 			testName := fmt.Sprintf("discovery/%s", test.InputPath)
@@ -65,9 +64,9 @@ func TestLuaResourceActionsScript(t *testing.T) {
 				}
 				obj := getObj(filepath.Join(dir, test.InputPath))
 				discoveryLua, err := vm.GetResourceActionDiscovery(obj)
-				errors.CheckError(err)
+				assert.NoError(t, err)
 				result, err := vm.ExecuteResourceActionDiscovery(obj, discoveryLua)
-				errors.CheckError(err)
+				assert.NoError(t, err)
 				assert.Equal(t, test.Result, result)
 			})
 		}
@@ -83,21 +82,21 @@ func TestLuaResourceActionsScript(t *testing.T) {
 				}
 				obj := getObj(filepath.Join(dir, test.InputPath))
 				action, err := vm.GetResourceAction(obj, test.Action)
-				errors.CheckError(err)
+				assert.NoError(t, err)
 
 				// freeze time so that lua test has predictable time output (will return 0001-01-01T00:00:00Z)
 				patch := monkey.Patch(time.Now, func() time.Time { return time.Time{} })
 				result, err := vm.ExecuteResourceAction(obj, action.ActionLua)
 				patch.Unpatch()
 
-				errors.CheckError(err)
+				assert.NoError(t, err)
 				expectedObj := getObj(filepath.Join(dir, test.ExpectedOutputPath))
 				// Ideally, we would use a assert.Equal to detect the difference, but the Lua VM returns a object with float64 instead of the original int32.  As a result, the assert.Equal is never true despite that the change has been applied.
 				diffResult := diff.Diff(expectedObj, result, testNormalizer{})
 				if diffResult.Modified {
 					t.Error("Output does not match input:")
 					err = diff.PrintDiff(test.Action, expectedObj, result)
-					errors.CheckError(err)
+					assert.NoError(t, err)
 				}
 			})
 		}

--- a/resource_customizations/extensions/DaemonSet/actions/action_test.yaml
+++ b/resource_customizations/extensions/DaemonSet/actions/action_test.yaml
@@ -1,0 +1,4 @@
+actionTests:
+- action: restart
+  inputPath: testdata/daemonset.yaml
+  expectedOutputPath: testdata/daemonset-restarted.yaml

--- a/resource_customizations/extensions/DaemonSet/actions/discovery.lua
+++ b/resource_customizations/extensions/DaemonSet/actions/discovery.lua
@@ -1,0 +1,3 @@
+actions = {}
+actions["restart"] = {}
+return actions

--- a/resource_customizations/extensions/DaemonSet/actions/restart/action.lua
+++ b/resource_customizations/extensions/DaemonSet/actions/restart/action.lua
@@ -1,0 +1,9 @@
+local os = require("os")
+if obj.spec.template.metadata == nil then
+    obj.spec.template.metadata = {}
+end
+if obj.spec.template.metadata.annotations == nil then
+    obj.spec.template.metadata.annotations = {}
+end
+obj.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"] = os.date("!%Y-%m-%dT%XZ")
+return obj

--- a/resource_customizations/extensions/DaemonSet/actions/testdata/daemonset-restarted.yaml
+++ b/resource_customizations/extensions/DaemonSet/actions/testdata/daemonset-restarted.yaml
@@ -1,0 +1,47 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  annotations:
+  creationTimestamp: "2019-09-13T08:52:50Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/instance: extensions
+  name: extensions-daemonset
+  namespace: statefulset
+  resourceVersion: "7471358"
+  selfLink: /apis/extensions/v1beta1/namespaces/statefulset/daemonsets/extensions-daemonset
+  uid: de09964a-d603-11e9-9e69-42010aa8005f
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: extensions-daemonset
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "0001-01-01T00:00:00Z"
+      labels:
+        name: extensions-daemonset
+    spec:
+      containers:
+      - image: k8s.gcr.io/nginx-slim:0.8
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  templateGeneration: 2
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 4
+  desiredNumberScheduled: 4
+  numberAvailable: 4
+  numberMisscheduled: 0
+  numberReady: 4
+  observedGeneration: 2

--- a/resource_customizations/extensions/DaemonSet/actions/testdata/daemonset.yaml
+++ b/resource_customizations/extensions/DaemonSet/actions/testdata/daemonset.yaml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  annotations:
+  creationTimestamp: "2019-09-13T08:52:50Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/instance: extensions
+  name: extensions-daemonset
+  namespace: statefulset
+  resourceVersion: "7471358"
+  selfLink: /apis/extensions/v1beta1/namespaces/statefulset/daemonsets/extensions-daemonset
+  uid: de09964a-d603-11e9-9e69-42010aa8005f
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: extensions-daemonset
+  template:
+    metadata:
+      labels:
+        name: extensions-daemonset
+    spec:
+      containers:
+      - image: k8s.gcr.io/nginx-slim:0.8
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  templateGeneration: 2
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 4
+  desiredNumberScheduled: 4
+  numberAvailable: 4
+  numberMisscheduled: 0
+  numberReady: 4
+  observedGeneration: 2

--- a/resource_customizations/extensions/Deployment/actions/action_test.yaml
+++ b/resource_customizations/extensions/Deployment/actions/action_test.yaml
@@ -1,0 +1,4 @@
+actionTests:
+- action: restart
+  inputPath: testdata/deployment.yaml
+  expectedOutputPath: testdata/deployment-restarted.yaml

--- a/resource_customizations/extensions/Deployment/actions/discovery.lua
+++ b/resource_customizations/extensions/Deployment/actions/discovery.lua
@@ -1,0 +1,3 @@
+actions = {}
+actions["restart"] = {}
+return actions

--- a/resource_customizations/extensions/Deployment/actions/restart/action.lua
+++ b/resource_customizations/extensions/Deployment/actions/restart/action.lua
@@ -1,0 +1,9 @@
+local os = require("os")
+if obj.spec.template.metadata == nil then
+    obj.spec.template.metadata = {}
+end
+if obj.spec.template.metadata.annotations == nil then
+    obj.spec.template.metadata.annotations = {}
+end
+obj.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"] = os.date("!%Y-%m-%dT%XZ")
+return obj

--- a/resource_customizations/extensions/Deployment/actions/testdata/deployment-restarted.yaml
+++ b/resource_customizations/extensions/Deployment/actions/testdata/deployment-restarted.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2019-09-12T01:33:53Z"
+  generation: 1
+  name: nginx-deploy
+  namespace: default
+  resourceVersion: "6897444"
+  selfLink: /apis/apps/v1/namespaces/default/deployments/nginx-deploy
+  uid: 61689d6d-d4fd-11e9-9e69-42010aa8005f
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "0001-01-01T00:00:00Z"
+    spec:
+      containers:
+      - image: nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  conditions:
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:33:53Z"
+    message: Deployment does not have minimum availability.
+    reason: MinimumReplicasUnavailable
+    status: "False"
+    type: Available
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:34:05Z"
+    message: ReplicaSet "nginx-deploy-9cb4784bd" is progressing.
+    reason: ReplicaSetUpdated
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 3
+  unavailableReplicas: 1
+  updatedReplicas: 3

--- a/resource_customizations/extensions/Deployment/actions/testdata/deployment.yaml
+++ b/resource_customizations/extensions/Deployment/actions/testdata/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2019-09-12T01:33:53Z"
+  generation: 1
+  name: nginx-deploy
+  namespace: default
+  resourceVersion: "6897444"
+  selfLink: /apis/apps/v1/namespaces/default/deployments/nginx-deploy
+  uid: 61689d6d-d4fd-11e9-9e69-42010aa8005f
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  conditions:
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:33:53Z"
+    message: Deployment does not have minimum availability.
+    reason: MinimumReplicasUnavailable
+    status: "False"
+    type: Available
+  - lastTransitionTime: "2019-09-12T01:33:53Z"
+    lastUpdateTime: "2019-09-12T01:34:05Z"
+    message: ReplicaSet "nginx-deploy-9cb4784bd" is progressing.
+    reason: ReplicaSetUpdated
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 3
+  unavailableReplicas: 1
+  updatedReplicas: 3

--- a/util/diff/diff.go
+++ b/util/diff/diff.go
@@ -4,8 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
 	"reflect"
 
+	"github.com/ghodss/yaml"
+	"github.com/google/shlex"
 	log "github.com/sirupsen/logrus"
 	"github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
@@ -476,4 +482,51 @@ func remarshal(obj *unstructured.Unstructured) *unstructured.Unstructured {
 	// remove all default values specified by custom formatter (e.g. creationTimestamp)
 	unstrBody = jsonutil.RemoveMapFields(obj.Object, unstrBody)
 	return &unstructured.Unstructured{Object: unstrBody}
+}
+
+// PrintDiff prints a diff between two unstructured objects to stdout using an external diff utility
+// Honors the diff utility set in the KUBECTL_EXTERNAL_DIFF environment variable
+func PrintDiff(name string, live *unstructured.Unstructured, target *unstructured.Unstructured) error {
+	tempDir, err := ioutil.TempDir("", "argocd-diff")
+	if err != nil {
+		return err
+	}
+	targetFile := path.Join(tempDir, name)
+	targetData := []byte("")
+	if target != nil {
+		targetData, err = yaml.Marshal(target)
+		if err != nil {
+			return err
+		}
+	}
+	err = ioutil.WriteFile(targetFile, targetData, 0644)
+	if err != nil {
+		return err
+	}
+	liveFile := path.Join(tempDir, fmt.Sprintf("%s-live.yaml", name))
+	liveData := []byte("")
+	if live != nil {
+		liveData, err = yaml.Marshal(live)
+		if err != nil {
+			return err
+		}
+	}
+	err = ioutil.WriteFile(liveFile, liveData, 0644)
+	if err != nil {
+		return err
+	}
+	cmdBinary := "diff"
+	var args []string
+	if envDiff := os.Getenv("KUBECTL_EXTERNAL_DIFF"); envDiff != "" {
+		parts, err := shlex.Split(envDiff)
+		if err != nil {
+			return err
+		}
+		cmdBinary = parts[0]
+		args = parts[1:]
+	}
+	cmd := exec.Command(cmdBinary, append(args, liveFile, targetFile)...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
 }

--- a/util/lua/oslib_safe.go
+++ b/util/lua/oslib_safe.go
@@ -35,13 +35,13 @@ func osTime(L *lua.LState) int {
 		L.Push(lua.LNumber(time.Now().Unix()))
 	} else {
 		tbl := L.CheckTable(1)
-		sec := getIntField(L, tbl, "sec", 0)
-		min := getIntField(L, tbl, "min", 0)
-		hour := getIntField(L, tbl, "hour", 12)
-		day := getIntField(L, tbl, "day", -1)
-		month := getIntField(L, tbl, "month", -1)
-		year := getIntField(L, tbl, "year", -1)
-		isdst := getBoolField(L, tbl, "isdst", false)
+		sec := getIntField(tbl, "sec", 0)
+		min := getIntField(tbl, "min", 0)
+		hour := getIntField(tbl, "hour", 12)
+		day := getIntField(tbl, "day", -1)
+		month := getIntField(tbl, "month", -1)
+		year := getIntField(tbl, "year", -1)
+		isdst := getBoolField(tbl, "isdst", false)
 		t := time.Date(year, time.Month(month), day, hour, min, sec, 0, time.Local)
 		// TODO dst
 		if false {
@@ -52,7 +52,7 @@ func osTime(L *lua.LState) int {
 	return 1
 }
 
-func getIntField(L *lua.LState, tb *lua.LTable, key string, v int) int {
+func getIntField(tb *lua.LTable, key string, v int) int {
 	ret := tb.RawGetString(key)
 	if ln, ok := ret.(lua.LNumber); ok {
 		return int(ln)
@@ -60,7 +60,7 @@ func getIntField(L *lua.LState, tb *lua.LTable, key string, v int) int {
 	return v
 }
 
-func getBoolField(L *lua.LState, tb *lua.LTable, key string, v bool) bool {
+func getBoolField(tb *lua.LTable, key string, v bool) bool {
 	ret := tb.RawGetString(key)
 	if lb, ok := ret.(lua.LBool); ok {
 		return bool(lb)

--- a/util/lua/oslib_safe.go
+++ b/util/lua/oslib_safe.go
@@ -1,0 +1,184 @@
+package lua
+
+// oslib_safe contains a subset of the lua os library. For security reasons, we do not expose
+// the entirety of lua os library to custom actions, such as ones which can exit, read files, etc.
+// Only the safe functions like os.time(), os.date() are exposed. Implementation was copied from
+// github.com/yuin/gopher-lua.
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+func OpenSafeOs(L *lua.LState) int {
+	tabmod := L.RegisterModule(lua.TabLibName, osFuncs)
+	L.Push(tabmod)
+	return 1
+}
+
+func SafeOsLoader(L *lua.LState) int {
+	mod := L.SetFuncs(L.NewTable(), osFuncs)
+	L.Push(mod)
+	return 1
+}
+
+var osFuncs = map[string]lua.LGFunction{
+	"time": osTime,
+	"date": osDate,
+}
+
+func osTime(L *lua.LState) int {
+	if L.GetTop() == 0 {
+		L.Push(lua.LNumber(time.Now().Unix()))
+	} else {
+		tbl := L.CheckTable(1)
+		sec := getIntField(L, tbl, "sec", 0)
+		min := getIntField(L, tbl, "min", 0)
+		hour := getIntField(L, tbl, "hour", 12)
+		day := getIntField(L, tbl, "day", -1)
+		month := getIntField(L, tbl, "month", -1)
+		year := getIntField(L, tbl, "year", -1)
+		isdst := getBoolField(L, tbl, "isdst", false)
+		t := time.Date(year, time.Month(month), day, hour, min, sec, 0, time.Local)
+		// TODO dst
+		if false {
+			print(isdst)
+		}
+		L.Push(lua.LNumber(t.Unix()))
+	}
+	return 1
+}
+
+func getIntField(L *lua.LState, tb *lua.LTable, key string, v int) int {
+	ret := tb.RawGetString(key)
+	if ln, ok := ret.(lua.LNumber); ok {
+		return int(ln)
+	}
+	return v
+}
+
+func getBoolField(L *lua.LState, tb *lua.LTable, key string, v bool) bool {
+	ret := tb.RawGetString(key)
+	if lb, ok := ret.(lua.LBool); ok {
+		return bool(lb)
+	}
+	return v
+}
+
+func osDate(L *lua.LState) int {
+	t := time.Now()
+	cfmt := "%c"
+	if L.GetTop() >= 1 {
+		cfmt = L.CheckString(1)
+		if strings.HasPrefix(cfmt, "!") {
+			t = time.Now().UTC()
+			cfmt = strings.TrimLeft(cfmt, "!")
+		}
+		if L.GetTop() >= 2 {
+			t = time.Unix(L.CheckInt64(2), 0)
+		}
+		if strings.HasPrefix(cfmt, "*t") {
+			ret := L.NewTable()
+			ret.RawSetString("year", lua.LNumber(t.Year()))
+			ret.RawSetString("month", lua.LNumber(t.Month()))
+			ret.RawSetString("day", lua.LNumber(t.Day()))
+			ret.RawSetString("hour", lua.LNumber(t.Hour()))
+			ret.RawSetString("min", lua.LNumber(t.Minute()))
+			ret.RawSetString("sec", lua.LNumber(t.Second()))
+			ret.RawSetString("wday", lua.LNumber(t.Weekday()+1))
+			// TODO yday & dst
+			ret.RawSetString("yday", lua.LNumber(0))
+			ret.RawSetString("isdst", lua.LFalse)
+			L.Push(ret)
+			return 1
+		}
+	}
+	L.Push(lua.LString(strftime(t, cfmt)))
+	return 1
+}
+
+var cDateFlagToGo = map[byte]string{
+	'a': "mon", 'A': "Monday", 'b': "Jan", 'B': "January", 'c': "02 Jan 06 15:04 MST", 'd': "02",
+	'F': "2006-01-02", 'H': "15", 'I': "03", 'm': "01", 'M': "04", 'p': "PM", 'P': "pm", 'S': "05",
+	'x': "15/04/05", 'X': "15:04:05", 'y': "06", 'Y': "2006", 'z': "-0700", 'Z': "MST"}
+
+func strftime(t time.Time, cfmt string) string {
+	sc := newFlagScanner('%', "", "", cfmt)
+	for c, eos := sc.Next(); !eos; c, eos = sc.Next() {
+		if !sc.ChangeFlag {
+			if sc.HasFlag {
+				if v, ok := cDateFlagToGo[c]; ok {
+					sc.AppendString(t.Format(v))
+				} else {
+					switch c {
+					case 'w':
+						sc.AppendString(fmt.Sprint(int(t.Weekday())))
+					default:
+						sc.AppendChar('%')
+						sc.AppendChar(c)
+					}
+				}
+				sc.HasFlag = false
+			} else {
+				sc.AppendChar(c)
+			}
+		}
+	}
+
+	return sc.String()
+}
+
+type flagScanner struct {
+	flag       byte
+	start      string
+	end        string
+	buf        []byte
+	str        string
+	Length     int
+	Pos        int
+	HasFlag    bool
+	ChangeFlag bool
+}
+
+func newFlagScanner(flag byte, start, end, str string) *flagScanner {
+	return &flagScanner{flag, start, end, make([]byte, 0, len(str)), str, len(str), 0, false, false}
+}
+
+func (fs *flagScanner) AppendString(str string) { fs.buf = append(fs.buf, str...) }
+
+func (fs *flagScanner) AppendChar(ch byte) { fs.buf = append(fs.buf, ch) }
+
+func (fs *flagScanner) String() string { return string(fs.buf) }
+
+func (fs *flagScanner) Next() (byte, bool) {
+	c := byte('\000')
+	fs.ChangeFlag = false
+	if fs.Pos == fs.Length {
+		if fs.HasFlag {
+			fs.AppendString(fs.end)
+		}
+		return c, true
+	} else {
+		c = fs.str[fs.Pos]
+		if c == fs.flag {
+			if fs.Pos < (fs.Length-1) && fs.str[fs.Pos+1] == fs.flag {
+				fs.HasFlag = false
+				fs.AppendChar(fs.flag)
+				fs.Pos += 2
+				return fs.Next()
+			} else if fs.Pos != fs.Length-1 {
+				if fs.HasFlag {
+					fs.AppendString(fs.end)
+				}
+				fs.AppendString(fs.start)
+				fs.ChangeFlag = true
+				fs.HasFlag = true
+			}
+		}
+	}
+	fs.Pos++
+	return c, false
+}


### PR DESCRIPTION
Adds a "restart" action to deployments (resolves https://github.com/argoproj/argo-cd/issues/2177):

![image](https://user-images.githubusercontent.com/12677113/64771917-9ea96d80-d504-11e9-8399-cd6900491cd4.png)

The restart action sets `kubectl.kubernetes.io/restartedAt` to be the current timestamp. Retrieving the timestamp in lua was problematic, because os.date() resides in the `os` lua library. The entire Lua 'os' library is a security risk because  the `os` library can also do things like call os.exit() and read local files.

So in order to support restarts, we had to expose a **_subset_** of the lua `os` library to the Lua VM. The subset of functionality was copied from the go-lua implementation.