### PR TITLE
Who uses ArgoCD: Add Lytt to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Organizations below are **officially** using Argo CD. Please send a PR with your
 1. [Yieldlab](https://www.yieldlab.de/)
 1. [UBIO](https://ub.io/)
 1. [Volvo Cars](https://www.volvocars.com/)
+1. [Lytt](https://www.lytt.co/)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Organizations below are **officially** using Argo CD. Please send a PR with your
 1. [Intuit](https://www.intuit.com/)
 1. [KintoHub](https://www.kintohub.com/)
 1. [KompiTech GmbH](https://www.kompitech.com/)
+1. [Lytt](https://www.lytt.co/)
 1. [Mambu](https://www.mambu.com/) 
 1. [Mirantis](https://mirantis.com/)
 1. [OpenSaaS Studio](https://opensaas.studio)
@@ -42,7 +43,6 @@ Organizations below are **officially** using Argo CD. Please send a PR with your
 1. [Yieldlab](https://www.yieldlab.de/)
 1. [UBIO](https://ub.io/)
 1. [Volvo Cars](https://www.volvocars.com/)
-1. [Lytt](https://www.lytt.co/)
 
 ## Documentation
 


### PR DESCRIPTION
Adds lytt.co to the list of organisations using ArgoCD in their Kubernetes clusters.

<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  
