### PR TITLE
util/localconfig: prefer HOME env var over os/user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,15 @@ builder-image:
 dep-ensure:
 	dep ensure -no-vendor
 
-.PHONY: lint
-lint:
+.PHONY: lint-local
+lint-local: build
 	# golangci-lint does not do a good job of formatting imports
 	goimports -local github.com/argoproj/argo-cd -w `find . ! -path './vendor/*' ! -path './pkg/client/*' -type f -name '*.go'`
 	GOGC=$(LINT_GOGC) golangci-lint run --fix --verbose --concurrency $(LINT_CONCURRENCY) --deadline $(LINT_DEADLINE)
+
+.PHONY: lint
+lint: dev-tools-image
+	$(call run-in-dev-tool,make lint-local LINT_CONCURRENCY=$(LINT_CONCURRENCY) LINT_DEADLINE=$(LINT_DEADLINE) LINT_GOGC=$(LINT_GOGC))
 
 .PHONY: build
 build:

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -234,11 +234,15 @@ func (l *LocalConfig) IsEmpty() bool {
 
 // DefaultConfigDir returns the local configuration path for settings such as cached authentication tokens.
 func DefaultConfigDir() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		usr, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		homeDir = usr.HomeDir
 	}
-	return path.Join(usr.HomeDir, ".argocd"), nil
+	return path.Join(homeDir, ".argocd"), nil
 }
 
 // DefaultLocalConfigPath returns the local configuration path for settings such as cached authentication tokens.


### PR DESCRIPTION
The os/user package is a rather hard-handed approach to acquiring the current user's home directory: it forces the current user to be in /etc/passwd combined with a `USER` environment variable, or other workarounds.

That complicates executing the argocd command in a docker container
when the UID:GID of the executing user is overridden.

This is often done in order to have files generated inside a docker
container have their ownership set to match the uid/gid of the host
user.

For example,

```sh
docker run -ti -u "$(id -u "${USER}"):$(id -g "${USER}")" argocd:latest ...
```

This PR also modifies the `make lint` target to execute inside the `dev-tools` docker container. This ensures that the tools are pinned to the correct versions and avoids moving dependencies leading to unexpected code generation changes and triggering linting errors in CI.