### PR TITLE
Add cache-control HTTP header to badge response

### DIFF
--- a/server/badge/badge.go
+++ b/server/badge/badge.go
@@ -121,6 +121,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	badge = replaceFirstGroupSubMatch(rightText1Pattern, badge, rightText)
 	badge = replaceFirstGroupSubMatch(rightText2Pattern, badge, rightText)
 	w.Header().Set("Content-Type", "image/svg+xml")
+
+	//Ask cache's to not cache the contents in order prevent the badge from becoming stale
+	w.Header().Set("Cache-Control", "private, no-store")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(badge))
 }

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -54,6 +54,8 @@ func TestHandlerFeatureIsEnabled(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
+	assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
+
 	response := rr.Body.String()
 	assert.Equal(t, success, leftPathColorPattern.FindStringSubmatch(response)[1])
 	assert.Equal(t, success, rightPathColorPattern.FindStringSubmatch(response)[1])
@@ -73,6 +75,8 @@ func TestHandlerFeatureIsDisabled(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
 
 	response := rr.Body.String()
 	assert.Equal(t, unknown, leftPathColorPattern.FindStringSubmatch(response)[1])


### PR DESCRIPTION
Since we serve the badge as an image using HTTP GET, cache systems
(incl. GitHub's CDN - Fastly) like to cache the image thus the
badge becomes stale rendering it useless. Adding the appropriate
Cache-Control HTTP header we direct cache systems and web browsers
not to cache the contents of the response.

Closes #2317 