### PR TITLE
Fix Helm parameters with comma

### DIFF
--- a/pkg/apiclient/account/account.pb.go
+++ b/pkg/apiclient/account/account.pb.go
@@ -3,23 +3,16 @@
 
 package account // import "github.com/argoproj/argo-cd/pkg/apiclient/account"
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/application/application.pb.go
+++ b/pkg/apiclient/application/application.pb.go
@@ -9,33 +9,22 @@ package application // import "github.com/argoproj/argo-cd/pkg/apiclient/applica
 	Application Service API performs CRUD actions against application resources
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import apiclient "github.com/argoproj/argo-cd/reposerver/apiclient"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+import v11 "k8s.io/api/core/v1"
+import v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
 
-	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	apiclient "github.com/argoproj/argo-cd/reposerver/apiclient"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	v11 "k8s.io/api/core/v1"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/certificate/certificate.pb.go
+++ b/pkg/apiclient/certificate/certificate.pb.go
@@ -10,25 +10,17 @@ package certificate // import "github.com/argoproj/argo-cd/pkg/apiclient/certifi
 	resources.
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/cluster/cluster.pb.go
+++ b/pkg/apiclient/cluster/cluster.pb.go
@@ -9,27 +9,18 @@ package cluster // import "github.com/argoproj/argo-cd/pkg/apiclient/cluster"
 	Cluster Service API performs CRUD actions against cluster resources
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+import _ "k8s.io/api/core/v1"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	_ "k8s.io/api/core/v1"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/project/project.pb.go
+++ b/pkg/apiclient/project/project.pb.go
@@ -9,29 +9,19 @@ package project // import "github.com/argoproj/argo-cd/pkg/apiclient/project"
 	Project Service API performs CRUD actions against project resources
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+import v1 "k8s.io/api/core/v1"
+import _ "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	v1 "k8s.io/api/core/v1"
-
-	_ "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/repository/repository.pb.go
+++ b/pkg/apiclient/repository/repository.pb.go
@@ -9,29 +9,19 @@ package repository // import "github.com/argoproj/argo-cd/pkg/apiclient/reposito
 	Repository Service API performs CRUD actions against repository resources
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import apiclient "github.com/argoproj/argo-cd/reposerver/apiclient"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+import _ "k8s.io/api/core/v1"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	apiclient "github.com/argoproj/argo-cd/reposerver/apiclient"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	_ "k8s.io/api/core/v1"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/session/session.pb.go
+++ b/pkg/apiclient/session/session.pb.go
@@ -9,27 +9,18 @@ package session // import "github.com/argoproj/argo-cd/pkg/apiclient/session"
 	Session Service API performs CRUD actions against session resources
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import _ "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+import _ "k8s.io/api/core/v1"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	_ "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	_ "k8s.io/api/core/v1"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/settings/settings.pb.go
+++ b/pkg/apiclient/settings/settings.pb.go
@@ -9,27 +9,18 @@ package settings // import "github.com/argoproj/argo-cd/pkg/apiclient/settings"
 	Settings Service API retrieves Argo CD settings
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import oidc "github.com/argoproj/argo-cd/server/settings/oidc"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	oidc "github.com/argoproj/argo-cd/server/settings/oidc"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apiclient/version/version.pb.go
+++ b/pkg/apiclient/version/version.pb.go
@@ -9,23 +9,16 @@ package version // import "github.com/argoproj/argo-cd/pkg/apiclient/version"
 	Version Service API returns the version of the API server.
 */
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import empty "github.com/golang/protobuf/ptypes/empty"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	empty "github.com/golang/protobuf/ptypes/empty"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/pkg/apis/application/v1alpha1/generated.pb.go
+++ b/pkg/apis/application/v1alpha1/generated.pb.go
@@ -3,27 +3,21 @@
 
 package v1alpha1
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-	proto "github.com/gogo/protobuf/proto"
+import v11 "k8s.io/api/core/v1"
+import v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	math "math"
+import k8s_io_apimachinery_pkg_watch "k8s.io/apimachinery/pkg/watch"
 
-	v11 "k8s.io/api/core/v1"
+import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import strings "strings"
+import reflect "reflect"
 
-	k8s_io_apimachinery_pkg_watch "k8s.io/apimachinery/pkg/watch"
-
-	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
-
-	strings "strings"
-
-	reflect "reflect"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/reposerver/apiclient/repository.pb.go
+++ b/reposerver/apiclient/repository.pb.go
@@ -3,27 +3,18 @@
 
 package apiclient // import "github.com/argoproj/argo-cd/reposerver/apiclient"
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+import _ "github.com/gogo/protobuf/gogoproto"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+import _ "k8s.io/api/core/v1"
 
-	proto "github.com/gogo/protobuf/proto"
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-	math "math"
-
-	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	_ "k8s.io/api/core/v1"
-
-	context "golang.org/x/net/context"
-
-	grpc "google.golang.org/grpc"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/server/settings/oidc/claims.pb.go
+++ b/server/settings/oidc/claims.pb.go
@@ -3,15 +3,11 @@
 
 package oidc // import "github.com/argoproj/argo-cd/server/settings/oidc"
 
-import (
-	fmt "fmt"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-	proto "github.com/gogo/protobuf/proto"
-
-	math "math"
-
-	io "io"
-)
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -78,6 +78,7 @@ func (h *helm) Template(appName, namespace, kubeVersion string, opts *argoappv1.
 			}
 			templateOpts.values = append(templateOpts.values, p)
 		}
+		cleanHelmParameters(opts.Parameters)
 		for _, p := range opts.Parameters {
 			if p.ForceString {
 				templateOpts.setString[p.Name] = p.Value
@@ -183,9 +184,13 @@ func flatVals(input map[string]interface{}, output map[string]string, prefixes .
 	}
 }
 
-func cleanHelmParameters(params []string) {
+func cleanHelmParameters(params []argoappv1.HelmParameter) {
 	re := regexp.MustCompile(`([^\\]),`)
 	for i, param := range params {
-		params[i] = re.ReplaceAllString(param, `$1\,`)
+		params[i] = argoappv1.HelmParameter{
+			Name:        param.Name,
+			Value:       re.ReplaceAllString(param.Value, `$1\,`),
+			ForceString: param.ForceString,
+		}
 	}
 }


### PR DESCRIPTION
This commit fixes Helm parsing of parameters values containing a comma.

The issue was first found as #1660, and fixed in #1720. However, commit 4e9772e19b, in #1865, removed the call to `cleanHelmParameters`, hence the regression.


