### PR TITLE
Make argo-cd docker images openshift friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,9 @@ RUN echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/s
 RUN groupadd -g 999 argocd && \
     useradd -r -u 999 -g argocd argocd && \
     mkdir -p /home/argocd && \
-    chown argocd:argocd /home/argocd && \
+    chown argocd:0 /home/argocd && \
+    chmod g=u /home/argocd && \
+    chmod g=u /etc/passwd && \
     apt-get update && \
     apt-get install -y git git-lfs && \
     apt-get clean && \
@@ -89,6 +91,9 @@ COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=builder /usr/local/bin/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
+# script to add current (possibly arbitrary) user to /etc/passwd at runtime
+# (if it's not already there, to be openshift friendly)
+COPY uid_entrypoint.sh /usr/local/bin/uid_entrypoint.sh
 
 # support for mounting configuration from a configmap
 RUN mkdir -p /app/config/ssh && \

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         image: argoproj/argocd:latest
         imagePullPolicy: Always
         command:
+        - uid_entrypoint.sh
         - argocd-repo-server
         - --redis
         - argocd-redis:6379

--- a/manifests/ha/base/overlays/argocd-repo-server-deployment.yaml
+++ b/manifests/ha/base/overlays/argocd-repo-server-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
       - name: argocd-repo-server
         command:
+        - uid_entrypoint.sh
         - argocd-repo-server
         - --sentinel
         - argocd-redis-ha-announce-0:26379

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3031,6 +3031,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
+        - uid_entrypoint.sh
         - argocd-repo-server
         - --sentinel
         - argocd-redis-ha-announce-0:26379

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2946,6 +2946,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
+        - uid_entrypoint.sh
         - argocd-repo-server
         - --sentinel
         - argocd-redis-ha-announce-0:26379

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2809,6 +2809,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
+        - uid_entrypoint.sh
         - argocd-repo-server
         - --redis
         - argocd-redis:6379

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2724,6 +2724,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
+        - uid_entrypoint.sh
         - argocd-repo-server
         - --redis
         - argocd-redis:6379

--- a/uid_entrypoint.sh
+++ b/uid_entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Make sure that if we are using an arbitrary UID that it appears in /etc/passwd,
+# otherwise this will cause issues with things like cloning with git+ssh
+# reference: https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/creating_images/creating-images-guidelines#use-uid
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:/home/argocd:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec "$@"


### PR DESCRIPTION
In openshift clusters, the user id of your container can be arbitrary,
so you need to make the running images compatible with this behavior.

The problematic application for argo-cd was the repo server. When trying
to clone the repos it was getting the error "No user exists for uid
100083000" (100083000 was the random user id being injected by
openshift in my case). This was because the user 100083000 wasn't in the
/etc/passwd file.

The changes in this commit add a uid_entrypoint.sh script that, when the
container starts, modifies the /etc/passwd file to add an entry with the
current UID _only_ if the current UID isn't there.

References:
* Problematic behavior of ssh when user id isn't in the /etc/passwd file:
  https://unix.stackexchange.com/questions/524268/running-git-or-ssh-client-in-docker-as-user-no-user-exists-for-uid
* OpenShift guidelines on how to make your docker image runnable by
  arbitrary user ids:
  https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/creating_images/creating-images-guidelines#use-uid


