### PR TITLE
Do not omit empty values for path in application source spec (fix #2374)

### DIFF
--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -512,7 +512,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSource(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"repoURL"},
+				Required: []string{"repoURL", "path"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -96,7 +96,7 @@ type ApplicationSource struct {
 	// RepoURL is the repository URL of the application manifests
 	RepoURL string `json:"repoURL" protobuf:"bytes,1,opt,name=repoURL"`
 	// Path is a directory path within the Git repository
-	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"`
+	Path string `json:"path" protobuf:"bytes,2,opt,name=path"`
 	// TargetRevision defines the commit, tag, or branch in which to sync the application to.
 	// If omitted, will sync to HEAD
 	TargetRevision string `json:"targetRevision,omitempty" protobuf:"bytes,4,opt,name=targetRevision"`


### PR DESCRIPTION
This fixes #2374, but I'm not sure about any other side effects. With this fix, both Git and Helm applications can be created in my test installation.