### PR TITLE
Add missing externalURL for networking.k8s.io Ingress type

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -31,7 +31,7 @@ func populateNodeInfo(un *unstructured.Unstructured, node *node) {
 			populateServiceInfo(un, node)
 			return
 		}
-	case "extensions":
+	case "extensions", "networking.k8s.io":
 		switch gvk.Kind {
 		case kube.IngressKind:
 			populateIngressInfo(un, node)

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -194,3 +194,29 @@ func TestExternalUrlWithNoSubPath(t *testing.T) {
 	expectedExternalUrls := []string{"https://107.178.210.11"}
 	assert.Equal(t, expectedExternalUrls, node.networkingInfo.ExternalURLs)
 }
+
+func TestExternalUrlWithNetworkingApi(t *testing.T) {
+	ingress := strToUnstructured(`
+  apiVersion: networking.k8s.io/v1beta1
+  kind: Ingress
+  metadata:
+    name: helm-guestbook
+    namespace: default
+  spec:
+    rules:
+    - http:
+        paths:
+        - backend:
+            serviceName: helm-guestbook
+            servicePort: 443
+  status:
+    loadBalancer:
+      ingress:
+      - ip: 107.178.210.11`)
+
+	node := &node{}
+	populateNodeInfo(ingress, node)
+
+	expectedExternalUrls := []string{"https://107.178.210.11"}
+	assert.Equal(t, expectedExternalUrls, node.networkingInfo.ExternalURLs)
+}


### PR DESCRIPTION
<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  
On the GUI the Ingress URL-s were missing when using networking.k8s.io/v1beta1 Ingress. With the older apiVersion (extensions/v1beta1) the links show up fine.
This pull request is solving this issue with the newer Ingress apiVersion.
