### PR TITLE
Adds Traefik v2 documentation to ingress options

### DIFF
--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -120,6 +120,32 @@ the API server -- one for gRPC and the other for HTTP/HTTPS. However it allows T
 happen at the ingress controller.
 
 
+## [Traefik (v2.0)](https://docs.traefik.io/)
+
+Traefik can be used as an edge router and provide [TLS](https://docs.traefik.io/user-guides/crd-acme/) termination within the same deployment.
+
+It currently has an advantage over NGINX in that it can terminate both TCP and HTTP connections _on the same port_ meaning you do not require multiple ingress objects and hosts.
+
+```yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server-ingress
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`argocd.example.com`)
+      kind: Rule
+      services:
+        - name: argocd-server
+          port: 80
+  tls:
+    certResolver: default
+    options: {}
+```
+
+
 ## AWS Application Load Balancers (ALBs) And Classic ELB (HTTP Mode)
 
 ALBs and Classic ELBs don't fully support HTTP2/gRPC, which is used by the `argocd` CLI.


### PR DESCRIPTION
We have our production ArgoCD setup with Traefik v2 which avoids a lot of the complexity of NGINX termination on multiple ingress objects.

There's a bit more about the release here which references this feature: https://blog.containo.us/traefik-2-0-6531ec5196c2 

YAML has been lifted and adapted from our production manifest.

Hope this helps broaden the options 🎉 