### PR TITLE
Update base image for Docker to Debian buster (addresses #2425)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:9.5-slim
+ARG BASE_IMAGE=debian:10-slim
 ####################################################################################################
 # Builder image
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=debian:9.5-slim
 ####################################################################################################
 FROM golang:1.12.6 as builder
 
-RUN echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list
+RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \
     openssh-server \
@@ -72,7 +72,7 @@ FROM $BASE_IMAGE as argocd-base
 
 USER root
 
-RUN echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list
+RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 
 RUN groupadd -g 999 argocd && \
     useradd -r -u 999 -g argocd argocd && \


### PR DESCRIPTION
This PR updates the Docker file to use image `debian:10-slim` as the base for the resulting ArgoCD image in order to refresh the underlying system to an up-to-date condition, as a result of the issues addressed in #2425.

For discussion: should we follow the `10-slim` tag, or tag a specific version. For the latter option, we should take precautions against "staleness" or we'll end up in a situation like today.