### PR TITLE
Can we make builds faster by pulling the image rather than building each time?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,9 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
       - run:
+          name: Make dev tools
+          command: make dev-tools-image
+      - run:
           name: Generate code
           command: make codegen
       - run:


### PR DESCRIPTION
<!--
Thank you for submitting your PR! 

We'd love your organisation to be listed in the [README](https://github.com/argoproj/argo-cd). Don't forget to add it if you can!

To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
-->  
