### PR TITLE
make proj windows commands consistent

### DIFF
--- a/cmd/argocd/commands/projectwindows.go
+++ b/cmd/argocd/commands/projectwindows.go
@@ -40,20 +40,20 @@ func NewProjectWindowsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 
 // NewProjectSyncWindowsDisableManualSyncCommand returns a new instance of an `argocd proj windows disable-manual-sync` command
 func NewProjectWindowsDisableManualSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var (
-		id int
-	)
 	var command = &cobra.Command{
-		Use:   "disable-manual-sync PROJECT",
+		Use:   "disable-manual-sync PROJECT ID",
 		Short: "Disable manual sync for a sync window",
-		Long:  "Disable manual sync for a sync window. Requires --id",
+		Long:  "Disable manual sync for a sync window. Requires ID which can be found by running \"argocd proj windows list PROJECT\"",
 		Run: func(c *cobra.Command, args []string) {
-			if len(args) != 1 || id == 999 {
+			if len(args) != 2 {
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
 
 			projName := args[0]
+			id, err := strconv.Atoi(args[1])
+			errors.CheckError(err)
+
 			conn, projIf := argocdclient.NewClientOrDie(clientOpts).NewProjectClientOrDie()
 			defer util.Close(conn)
 
@@ -70,26 +70,25 @@ func NewProjectWindowsDisableManualSyncCommand(clientOpts *argocdclient.ClientOp
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().IntVar(&id, "id", 999, "Sync window ID, run \"argocd proj windows list\" to get ID")
 	return command
 }
 
 // NewProjectWindowsEnableManualSyncCommand returns a new instance of an `argocd proj windows enable-manual-sync` command
 func NewProjectWindowsEnableManualSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var (
-		id int
-	)
 	var command = &cobra.Command{
-		Use:   "enable-manual-sync PROJECT",
+		Use:   "enable-manual-sync PROJECT ID",
 		Short: "Enable manual sync for a sync window",
-		Long:  "Enable manual sync for a sync window. Requires --id",
+		Long:  "Enable manual sync for a sync window. Requires ID which can be found by running \"argocd proj windows list PROJECT\"",
 		Run: func(c *cobra.Command, args []string) {
-			if len(args) != 1 || id == 999 {
+			if len(args) != 2 {
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
 
 			projName := args[0]
+			id, err := strconv.Atoi(args[1])
+			errors.CheckError(err)
+
 			conn, projIf := argocdclient.NewClientOrDie(clientOpts).NewProjectClientOrDie()
 			defer util.Close(conn)
 
@@ -106,7 +105,6 @@ func NewProjectWindowsEnableManualSyncCommand(clientOpts *argocdclient.ClientOpt
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().IntVar(&id, "id", 999, "Sync window ID, run \"argocd proj windows list\" to get ID")
 	return command
 }
 
@@ -156,19 +154,19 @@ func NewProjectWindowsAddWindowCommand(clientOpts *argocdclient.ClientOptions) *
 
 // NewProjectWindowsAddWindowCommand returns a new instance of an `argocd proj windows delete` command
 func NewProjectWindowsDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var (
-		id int
-	)
 	var command = &cobra.Command{
-		Use:   "delete PROJECT",
-		Short: "Delete a sync window from a project. Requires --id",
+		Use:   "delete PROJECT ID",
+		Short: "Delete a sync window from a project. Requires ID which can be found by running \"argocd proj windows list PROJECT\"",
 		Run: func(c *cobra.Command, args []string) {
-			if len(args) != 1 || id == 999 {
+			if len(args) != 2 {
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
 
 			projName := args[0]
+			id, err := strconv.Atoi(args[1])
+			errors.CheckError(err)
+
 			conn, projIf := argocdclient.NewClientOrDie(clientOpts).NewProjectClientOrDie()
 			defer util.Close(conn)
 
@@ -182,14 +180,12 @@ func NewProjectWindowsDeleteCommand(clientOpts *argocdclient.ClientOptions) *cob
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().IntVar(&id, "id", 999, "Sync window ID, run \"argocd proj windows list\" to get ID")
 	return command
 }
 
 // NewProjectWindowsUpdateCommand returns a new instance of an `argocd proj windows update` command
 func NewProjectWindowsUpdateCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		id           int
 		schedule     string
 		duration     string
 		applications []string
@@ -197,16 +193,19 @@ func NewProjectWindowsUpdateCommand(clientOpts *argocdclient.ClientOptions) *cob
 		clusters     []string
 	)
 	var command = &cobra.Command{
-		Use:   "update PROJECT",
+		Use:   "update PROJECT ID",
 		Short: "Update a project sync window",
-		Long:  "Update a project sync window. Requires --id",
+		Long:  "Update a project sync window. Requires ID which can be found by running \"argocd proj windows list PROJECT\"",
 		Run: func(c *cobra.Command, args []string) {
-			if len(args) != 1 || id == 999 {
+			if len(args) != 2 {
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
 
 			projName := args[0]
+			id, err := strconv.Atoi(args[1])
+			errors.CheckError(err)
+
 			conn, projIf := argocdclient.NewClientOrDie(clientOpts).NewProjectClientOrDie()
 			defer util.Close(conn)
 
@@ -226,7 +225,6 @@ func NewProjectWindowsUpdateCommand(clientOpts *argocdclient.ClientOptions) *cob
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().IntVar(&id, "id", 999, "Sync window ID, run \"argocd proj windows list\" to get ID")
 	command.Flags().StringVar(&schedule, "schedule", "", "Sync window schedule in cron format. (e.g. --schedule \"0 22 * * *\")")
 	command.Flags().StringVar(&duration, "duration", "", "Sync window duration. (e.g. --duration 1h)")
 	command.Flags().StringSliceVar(&applications, "applications", []string{}, "Applications that the schedule will be applied to. Comma separated, wildcards supported (e.g. --applications prod-\\*,website)")

--- a/docs/user-guide/sync_windows.md
+++ b/docs/user-guide/sync_windows.md
@@ -9,13 +9,14 @@ in preventing automated syncs or if you need to temporarily override a window to
 If an application has matching allow windows then it will only be able to sync during those windows. If is has 
 has matching deny windows then they will override any matching allows if the windows are active at the same time.
 
-Windows can be create using the CLI:
+Windows can be created using the CLI:
+
 ```bash
-argocd proj windows add projectName \
+argocd proj windows add PROJECT \
     --kind allow \
-    --schedule "* * * * *" \
+    --schedule "0 22 * * *" \
     --duration 1h \
-    --applications "*" 
+    --applications "*"
 ```
 
 Alternatively, they can be created directly in the `AppProject` manifest:
@@ -27,38 +28,42 @@ metadata:
   name: default
 spec:
   syncWindows:
-    - schedule: '10 1 * * *'
-      duration: 1h
-      applications:
-      - '*-prod'
-    - schedule: '0 22 * * *'
-      duration: 1h
-      namespaces:
-      - default   
-     - schedule: '0 23 * * *'
-       duration: 1h
-       clusters:
-       - in-cluster
-       - cluster1  
+  - kind: allow
+    schedule: '10 1 * * *'
+    duration: 1h
+    applications:
+    - '*-prod'
+    manualSync: true
+  - kind: deny
+    schedule: '0 22 * * *'
+    duration: 1h
+    namespaces:
+    - default
+   - kind: allow
+     schedule: '0 23 * * *'
+     duration: 1h
+     clusters:
+     - in-cluster
+     - cluster1
 ```
 
 In order to perform a sync when syncs are being prevented by a window, you can configure the window to allow manual syncs
 using the CLI, UI or directly in the `AppProject` manifest:
 
 ```bash
-argocd proj windows enable-manual-sync projectName
+argocd proj windows enable-manual-sync PROJECT ID
 ```
 
 To disable
 
 ```bash
-argocd proj windows disable-manual-sync projectName
+argocd proj windows disable-manual-sync PROJECT ID
 ```
 
 Windows can be listed using the CLI or viewed in the UI:
- 
+
 ```bash
-argocd proj windows list projectName
+argocd proj windows list PROJECT
 ```
 
 ```bash
@@ -67,4 +72,12 @@ ID  STATUS    KIND   SCHEDULE    DURATION  APPLICATIONS  NAMESPACES  CLUSTERS  M
 1   Inactive  deny   * * * * 1   3h        -             default     -         Disabled
 2   Inactive  allow  1 2 * * *   1h        prod-*        -           -         Enabled
 3   Active    deny   * * * * *   1h        -             default     -         Disabled
+```
+
+All fields of a window can be updated using either the CLI or UI. The `applications`, `namespaces` and `clusters` fields
+require the update to contain all of the required values. For example if updating the `namespaces` field and it already
+contains default and kube-system then the new value would have to include those in the list. 
+
+```bash
+argocd proj windows update PROJECT ID --namespaces default,kube-system,prod1
 ```


### PR DESCRIPTION
This resolves #2443. It is to make the proj windows commands consistent with other commands that also require and ID.

Currently the commands require an id flag, I would like to change this to be an argument instead.