### PR TITLE
Issue #1944 - Gracefully handle missing cached app state

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -765,7 +765,8 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	app := origApp.DeepCopy()
 	logCtx := log.WithFields(log.Fields{"application": app.Name})
 	if comparisonLevel == ComparisonWithNothing {
-		if managedResources, err := ctrl.cache.GetAppManagedResources(app.Name); err != nil {
+		managedResources := make([]*appv1.ResourceDiff, 0)
+		if err := ctrl.cache.GetAppManagedResources(app.Name, &managedResources); err != nil {
 			logCtx.Warnf("Failed to get cached managed resources for tree reconciliation, fallback to full reconciliation")
 		} else {
 			if tree, err := ctrl.getResourceTree(app, managedResources); err != nil {

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1816,6 +1816,17 @@ func (status *ApplicationStatus) GetErrorConditions() []ApplicationCondition {
 	return result
 }
 
+func (status *ApplicationStatus) GetConditions(conditionTypes map[ApplicationConditionType]bool) []ApplicationCondition {
+	result := make([]ApplicationCondition, 0)
+	for i := range status.Conditions {
+		condition := status.Conditions[i]
+		if ok := conditionTypes[condition.Type]; ok {
+			result = append(result, condition)
+		}
+	}
+	return result
+}
+
 // IsError returns true if condition is error condition
 func (condition *ApplicationCondition) IsError() bool {
 	return strings.HasSuffix(condition.Type, "Error")

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1216,6 +1216,19 @@ func TestSyncWindow_Validate(t *testing.T) {
 	})
 }
 
+func TestApplicationStatus_GetConditions(t *testing.T) {
+	status := ApplicationStatus{
+		Conditions: []ApplicationCondition{
+			{Type: ApplicationConditionInvalidSpecError},
+			{Type: ApplicationConditionRepeatedResourceWarning},
+		},
+	}
+	conditions := status.GetConditions(map[ApplicationConditionType]bool{
+		ApplicationConditionInvalidSpecError: true,
+	})
+	assert.EqualValues(t, []ApplicationCondition{{Type: ApplicationConditionInvalidSpecError}}, conditions)
+}
+
 func newTestProjectWithSyncWindows() *AppProject {
 	p := &AppProject{
 		ObjectMeta: v1.ObjectMeta{Name: "my-proj"},

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	coreerrors "errors"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/argoproj/argo-cd/test"
 	"github.com/argoproj/argo-cd/util"
 	"github.com/argoproj/argo-cd/util/assets"
+	"github.com/argoproj/argo-cd/util/cache"
 	"github.com/argoproj/argo-cd/util/db"
 	"github.com/argoproj/argo-cd/util/kube/kubetest"
 	"github.com/argoproj/argo-cd/util/rbac"
@@ -449,5 +452,55 @@ func TestServer_GetApplicationSyncWindowsState(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 		assert.Nil(t, active)
 	})
+}
 
+func TestGetCachedAppState(t *testing.T) {
+	testApp := newTestApp()
+	testApp.Spec.Project = "none"
+	appServer := newTestAppServer(testApp)
+
+	fakeClientSet := appServer.appclientset.(*apps.Clientset)
+
+	t.Run("NoError", func(t *testing.T) {
+		err := appServer.getCachedAppState(context.Background(), testApp, func() error {
+			return nil
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CacheMissErrorTriggersRefresh", func(t *testing.T) {
+		retryCount := 0
+		patched := false
+		watcher := watch.NewFakeWithChanSize(1, true)
+
+		fakeClientSet.ReactionChain = nil
+		fakeClientSet.WatchReactionChain = nil
+		fakeClientSet.AddReactor("patch", "applications", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+			patched = true
+			watcher.Modify(testApp)
+			return true, nil, nil
+		})
+		fakeClientSet.AddWatchReactor("applications", func(action kubetesting.Action) (handled bool, ret watch.Interface, err error) {
+			return true, watcher, nil
+		})
+		err := appServer.getCachedAppState(context.Background(), testApp, func() error {
+			res := cache.ErrCacheMiss
+			if retryCount == 1 {
+				res = nil
+			}
+			retryCount++
+			return res
+		})
+		assert.Equal(t, nil, err)
+		assert.Equal(t, 2, retryCount)
+		assert.True(t, patched)
+	})
+
+	t.Run("NonCacheErrorDoesNotTriggerRefresh", func(t *testing.T) {
+		randomError := coreerrors.New("random error")
+		err := appServer.getCachedAppState(context.Background(), testApp, func() error {
+			return randomError
+		})
+		assert.Equal(t, randomError, err)
+	})
 }

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -135,20 +135,18 @@ func (c *Cache) getItem(key string, item interface{}) error {
 	return c.client.Get(key, item)
 }
 
-func (c *Cache) GetAppManagedResources(appName string) ([]*appv1.ResourceDiff, error) {
-	res := make([]*appv1.ResourceDiff, 0)
+func (c *Cache) GetAppManagedResources(appName string, res *[]*appv1.ResourceDiff) error {
 	err := c.getItem(appManagedResourcesKey(appName), &res)
-	return res, err
+	return err
 }
 
 func (c *Cache) SetAppManagedResources(appName string, managedResources []*appv1.ResourceDiff) error {
 	return c.setItem(appManagedResourcesKey(appName), managedResources, appStateCacheExpiration, managedResources == nil)
 }
 
-func (c *Cache) GetAppResourcesTree(appName string) (*appv1.ApplicationTree, error) {
-	var res *appv1.ApplicationTree
+func (c *Cache) GetAppResourcesTree(appName string, res *appv1.ApplicationTree) error {
 	err := c.getItem(appResourcesTreeKey(appName), &res)
-	return res, err
+	return err
 }
 
 func (c *Cache) SetAppResourcesTree(appName string, resourcesTree *appv1.ApplicationTree) error {


### PR DESCRIPTION
Closes #1944 

PR implements graceful handling of cache miss error. If API server cannot find cache app state it triggers app refresh and wait for cache to be populated.
