### PR TITLE
add support for --additional-headers cli flag

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -69,7 +69,6 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 				Insecure:   globalClientOpts.Insecure,
 				PlainText:  globalClientOpts.PlainText,
 				GRPCWeb:    globalClientOpts.GRPCWeb,
-				UserAgent:  globalClientOpts.UserAgent,
 			}
 			acdClient := argocdclient.NewClientOrDie(&clientOpts)
 			setConn, setIf := acdClient.NewSettingsClientOrDie()

--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -69,6 +69,7 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 				Insecure:   globalClientOpts.Insecure,
 				PlainText:  globalClientOpts.PlainText,
 				GRPCWeb:    globalClientOpts.GRPCWeb,
+				UserAgent:  globalClientOpts.UserAgent,
 			}
 			acdClient := argocdclient.NewClientOrDie(&clientOpts)
 			setConn, setIf := acdClient.NewSettingsClientOrDie()

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -59,6 +59,6 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", config.GetFlag("auth-token", ""), "Authentication token")
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", config.GetFlag("loglevel", "info"), "Set the logging level. One of: debug|info|warn|error")
-	command.PersistentFlags().StringSliceVar(&clientOpts.AddHeader, "add-header", []string{}, "Sets additional headers to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)")
+	command.PersistentFlags().StringSliceVar(&clientOpts.Headers, "header", []string{}, "Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)")
 	return command
 }

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -59,6 +59,6 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", config.GetFlag("auth-token", ""), "Authentication token")
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", config.GetFlag("loglevel", "info"), "Set the logging level. One of: debug|info|warn|error")
-	command.PersistentFlags().StringVar(&clientOpts.AdditionalHeaders, "additional-headers", config.GetFlag("additional-headers", ""), "Sets a comma separated list of additional headers.")
+	command.PersistentFlags().StringSliceVar(&clientOpts.AddHeader, "add-header", []string{}, "Sets one additional header to all requests made by Argo CD CLI. (Can be repeated multiple times)")
 	return command
 }

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -59,6 +59,6 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", config.GetFlag("auth-token", ""), "Authentication token")
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", config.GetFlag("loglevel", "info"), "Set the logging level. One of: debug|info|warn|error")
-	command.PersistentFlags().StringSliceVar(&clientOpts.Headers, "header", []string{}, "Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)")
+	command.PersistentFlags().StringSliceVarP(&clientOpts.Headers, "header", "H", []string{}, "Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)")
 	return command
 }

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -59,5 +59,6 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", config.GetFlag("auth-token", ""), "Authentication token")
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", config.GetFlag("loglevel", "info"), "Set the logging level. One of: debug|info|warn|error")
+	command.PersistentFlags().StringVar(&clientOpts.AdditionalHeaders, "additional-headers", config.GetFlag("additional-headers", ""), "Sets a comma separated list of additional headers.")
 	return command
 }

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -59,6 +59,6 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", config.GetFlag("auth-token", ""), "Authentication token")
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", config.GetFlag("loglevel", "info"), "Set the logging level. One of: debug|info|warn|error")
-	command.PersistentFlags().StringSliceVar(&clientOpts.AddHeader, "add-header", []string{}, "Sets one additional header to all requests made by Argo CD CLI. (Can be repeated multiple times)")
+	command.PersistentFlags().StringSliceVar(&clientOpts.AddHeader, "add-header", []string{}, "Sets additional headers to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)")
 	return command
 }

--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -158,10 +158,11 @@ $ argocd login <host>:<port> --grpc-web
 
 ## Authenticating through multiple layers of authenticating reverse proxies
 
-ArgoCD endpoints may be protected by one or more reverse proxies layers, in that case, you can provide additional headers through the `argocd` CLI `--additional-headers` parameter to authenticate through those layers.
+ArgoCD endpoints may be protected by one or more reverse proxies layers, in that case, you can provide additional headers through the `argocd` CLI `--add-header` parameter to authenticate through those layers.
 
 ```shell
-$ argocd login <host>:<port> --additional-headers 'x-token1:foo,x-token2:bar'
+$ argocd login <host>:<port> --add-header 'x-token1:foo' --add-header 'x-token2:bar' # can be repeated multiple times
+$ argocd login <host>:<port> --add-header 'x-token1:foo,x-token2:bar' # headers can also be comma separated
 ```
 
 ## UI Base Path

--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -156,6 +156,13 @@ passthrough mode is needed, or NLBs.
 $ argocd login <host>:<port> --grpc-web
 ```
 
+## Authenticating through multiple layers of authenticating reverse proxies
+
+ArgoCD endpoints may be protected by one or more reverse proxies layers, in that case, you can provide additional headers through the `argocd` CLI `--additional-headers` parameter to authenticate through those layers.
+
+```shell
+$ argocd login <host>:<port> --additional-headers 'x-token1:foo,x-token2:bar'
+```
 
 ## UI Base Path
 

--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -158,11 +158,11 @@ $ argocd login <host>:<port> --grpc-web
 
 ## Authenticating through multiple layers of authenticating reverse proxies
 
-ArgoCD endpoints may be protected by one or more reverse proxies layers, in that case, you can provide additional headers through the `argocd` CLI `--add-header` parameter to authenticate through those layers.
+ArgoCD endpoints may be protected by one or more reverse proxies layers, in that case, you can provide additional headers through the `argocd` CLI `--header` parameter to authenticate through those layers.
 
 ```shell
-$ argocd login <host>:<port> --add-header 'x-token1:foo' --add-header 'x-token2:bar' # can be repeated multiple times
-$ argocd login <host>:<port> --add-header 'x-token1:foo,x-token2:bar' # headers can also be comma separated
+$ argocd login <host>:<port> --header 'x-token1:foo' --header 'x-token2:bar' # can be repeated multiple times
+$ argocd login <host>:<port> --header 'x-token1:foo,x-token2:bar' # headers can also be comma separated
 ```
 
 ## UI Base Path

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -15,8 +15,6 @@ import (
 	"sync"
 	"time"
 
-	md "google.golang.org/grpc/metadata"
-
 	"github.com/coreos/go-oidc"
 	"github.com/dgrijalva/jwt-go"
 	log "github.com/sirupsen/logrus"
@@ -24,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/argoproj/argo-cd/common"
@@ -398,7 +397,7 @@ func (c *client) newConn() (*grpc.ClientConn, io.Closer, error) {
 			if len(strings.Split(kv, ":"))%2 == 1 {
 				return nil, nil, fmt.Errorf("additional headers must be colon(:)-separated: %s", kv)
 			}
-			ctx = md.AppendToOutgoingContext(ctx, strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
+			ctx = metadata.AppendToOutgoingContext(ctx, strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
 		}
 	}
 	if c.UserAgent != "" {

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -120,7 +120,7 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 			if c.AdditionalHeaders != "" {
 				for _, kv := range strings.Split(c.AdditionalHeaders, ",") {
 					if len(strings.Split(kv, ":"))%2 == 1 {
-						return fmt.Errorf("additional headers must be colon(:)-separated: %s", kv)
+						return fmt.Errorf("additional headers key/values must be separated by a colon(:): %s", kv)
 					}
 					ctx := metadata.AppendToOutgoingContext(context.Background(), strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
 					md, _ = metadata.FromOutgoingContext(ctx)

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -116,13 +116,11 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 
 			md, _ := metadata.FromIncomingContext(stream.Context())
 
-			if len(c.AdditionalHeaders) > 0 {
-				for _, kv := range c.AdditionalHeaders {
-					if len(strings.Split(kv, ":"))%2 == 1 {
-						return fmt.Errorf("additional headers key/values must be separated by a colon(:): %s", kv)
-					}
-					md.Append(strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
+			for _, kv := range c.Headers {
+				if len(strings.Split(kv, ":"))%2 == 1 {
+					return fmt.Errorf("additional headers key/values must be separated by a colon(:): %s", kv)
 				}
+				md.Append(strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
 			}
 
 			resp, err := c.executeRequest(fullMethodName, msg, md)

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -2,7 +2,6 @@ package apiclient
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
@@ -117,13 +116,12 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 
 			md, _ := metadata.FromIncomingContext(stream.Context())
 
-			if c.AdditionalHeaders != "" {
-				for _, kv := range strings.Split(c.AdditionalHeaders, ",") {
+			if len(c.AdditionalHeaders) > 0 {
+				for _, kv := range c.AdditionalHeaders {
 					if len(strings.Split(kv, ":"))%2 == 1 {
 						return fmt.Errorf("additional headers key/values must be separated by a colon(:): %s", kv)
 					}
-					ctx := metadata.AppendToOutgoingContext(context.Background(), strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
-					md, _ = metadata.FromOutgoingContext(ctx)
+					md.Append(strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
 				}
 			}
 


### PR DESCRIPTION
This PR adds the support to send additional headers through the ArgoCD CLI.
May be useful to authenticate through one or more network authentication layers.

Usage:
`argocd version --header 'x-token1:foo' --header 'x-token2:bar'`
or
`argocd version --header 'x-token1:foo,x-token2:bar'`

_(re-edited cli flag name and usage)_