### PR TITLE
Optimize linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,11 +169,6 @@ jobs:
           name: Generate code
           command: make codegen
       - run:
-          name: Lint code
-          # use GOGC to limit memory usage in exchange for CPU usage, https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-          # we have 8GB RAM, 2CPUs https://circleci.com/docs/2.0/executor-types/#using-machine
-          command: LINT_GOGC=20 LINT_CONCURRENCY=1 LINT_DEADLINE=4m0s make lint
-      - run:
           name: Check nothing has changed
           command: |
             set -xo pipefail

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,20 @@ run:
   skip-files:
     - ".*\\.pb\\.go"
   skip-dirs:
-    - pkg/client
-    - vendor
+    - pkg/client/
+    - vendor/
 linters:
   enable:
     - vet
     - deadcode
+    - goimports
     - varcheck
     - structcheck
     - ineffassign
     - unconvert
     - unparam
+linters-settings:
+  goimports:
+    local-prefixes: github.com/argoproj/argo-cd
+service:
+  golangci-lint-version: 1.18.0

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PATH:=$(PATH):$(PWD)/hack
 
 # docker image publishing options
 DOCKER_PUSH?=false
-IMAGE_TAG?=latest
+IMAGE_TAG?=
 # perform static compilation
 STATIC_BUILD?=true
 # build development images

--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,11 @@ PATH:=$(PATH):$(PWD)/hack
 
 # docker image publishing options
 DOCKER_PUSH?=false
-IMAGE_TAG?=
+IMAGE_TAG?=latest
 # perform static compilation
 STATIC_BUILD?=true
 # build development images
 DEV_IMAGE?=false
-# lint is memory and CPU intensive, so we can limit on CI to mitigate OOM
-LINT_GOGC?=off
-LINT_CONCURRENCY?=8
-# Set timeout for linter
-LINT_DEADLINE?=1m0s
 
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \
@@ -159,15 +154,14 @@ dep:
 dep-ensure:
 	dep ensure -no-vendor
 
-.PHONY: lint-local
-lint-local: build
-	# golangci-lint does not do a good job of formatting imports
-	goimports -local github.com/argoproj/argo-cd -w `find . ! -path './vendor/*' ! -path './pkg/client/*' ! -path '*.pb.go' ! -path '*.gw.go' -type f -name '*.go'`
-	GOGC=$(LINT_GOGC) golangci-lint run --fix --verbose --concurrency $(LINT_CONCURRENCY) --deadline $(LINT_DEADLINE)
+.PHONY: install-lint-tools
+install-lint-tools:
+	./hack/install.sh lint-tools
 
 .PHONY: lint
-lint: dev-tools-image
-	$(call run-in-dev-tool,make lint-local LINT_CONCURRENCY=$(LINT_CONCURRENCY) LINT_DEADLINE=$(LINT_DEADLINE) LINT_GOGC=$(LINT_GOGC))
+lint:
+	golangci-lint --version
+	golangci-lint run --fix --verbose
 
 .PHONY: build
 build:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Ensure dependencies are up to date first:
 
 ```shell
 dep ensure
+make install-lint-tools
 ```
 
 Build `cli`, `image`, and `argocd-util` as default targets by running make:

--- a/hack/Dockerfile.dev-tools
+++ b/hack/Dockerfile.dev-tools
@@ -14,7 +14,6 @@ RUN GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0
     GO111MODULE=on go get github.com/gogo/protobuf/gogoproto@v1.2.1 && \
     GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-beta.2 && \
     GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
-    GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1 && \
     GO111MODULE=on go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.9.2 && \
     GO111MODULE=on go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.9.2 && \
     GO111MODULE=on go get github.com/jstemmer/go-junit-report@v0.0.0-20190106144839-af01ea7f8024 && \

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eux -o pipefail
+
+export DOWNLOADS=/tmp/dl
+export BIN=${BIN:-/usr/local/bin}
+
+mkdir -p $DOWNLOADS
+
+for product in $*; do
+  "$(dirname $0)/installers/install-${product}.sh"
+done

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eux -o pipefail
+
+mkdir -p $DOWNLOADS/lint-tools
+cd $DOWNLOADS/lint-tools
+
+# later versions seem to need go1.13
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0


### PR DESCRIPTION
1. Remove linting from CI.
2. Use binary rather than Docker locally.

Reduces `build` to 8m.