### PR TITLE
Work-around golang cilint error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,9 @@ jobs:
             # When this fails, it will, create a patch file you can apply locally to fix it.
             # To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
             git diff --exit-code -- . ':!Gopkg.lock'  ':!assets/swagger.json' | tee codegen.patch
+      - store_artifacts:
+          path: codegen.patch
+          destination: .
   test:
     working_directory: /home/circleci/.go_workspace/src/github.com/argoproj/argo-cd
     machine:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,4 +19,4 @@ linters-settings:
   goimports:
     local-prefixes: github.com/argoproj/argo-cd
 service:
-  golangci-lint-version: 1.20.0
+  golangci-lint-version: 1.21.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,4 +19,4 @@ linters-settings:
   goimports:
     local-prefixes: github.com/argoproj/argo-cd
 service:
-  golangci-lint-version: 1.18.0
+  golangci-lint-version: 1.20.0

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -16,7 +16,6 @@ import (
 	"github.com/argoproj/argo-cd/util/healthz"
 )
 
-
 type MetricsServer struct {
 	*http.Server
 	syncCounter             *prometheus.CounterVec
@@ -105,7 +104,7 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, health
 			// Buckets chosen after observing a ~2100ms mean reconcile time
 			Buckets: []float64{0.25, .5, 1, 2, 4, 8, 16},
 		},
-		append(descAppDefaultLabels),
+		descAppDefaultLabels,
 	)
 
 	appRegistry.MustRegister(reconcileHistogram)

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/argoproj/argo-cd/util/healthz"
 )
 
+
 type MetricsServer struct {
 	*http.Server
 	syncCounter             *prometheus.CounterVec

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -4,6 +4,4 @@ set -eux -o pipefail
 mkdir -p $DOWNLOADS/codegen-tools
 cd $DOWNLOADS/codegen-tools
 
-# later versions seem to need go1.13
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
-GO111MODULE=on go get golang.org/x/tools/cmd/goimports@v0.0.0-20190627203933-19ff4fff8850
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0

--- a/pkg/apis/api-rules/violation_exceptions.list
+++ b/pkg/apis/api-rules/violation_exceptions.list
@@ -8,4 +8,3 @@ API rule violation: names_match,github.com/argoproj/argo-cd/pkg/apis/application
 API rule violation: names_match,github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1,ResourceActions,ActionDiscoveryLua
 API rule violation: names_match,github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1,ResourceOverride,HealthLua
 API rule violation: names_match,github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1,objectMeta,Name
-API rule violation: omitempty_match_case,github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1,ResourceActions,Definitions

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -2080,7 +2080,6 @@ func schema_pkg_apis_application_v1alpha1_ResourceActions(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"definitions"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1,5 +1,6 @@
 package v1alpha1
 
+
 import (
 	"encoding/json"
 	"fmt"

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1,6 +1,5 @@
 package v1alpha1
 
-
 import (
 	"encoding/json"
 	"fmt"
@@ -959,7 +958,7 @@ func (o *ResourceOverride) GetActions() (ResourceActions, error) {
 
 type ResourceActions struct {
 	ActionDiscoveryLua string                     `json:"discovery.lua,omitempty" yaml:"discovery.lua,omitempty" protobuf:"bytes,1,opt,name=actionDiscoveryLua"`
-	Definitions        []ResourceActionDefinition `json:"definitions,omitEmpty" protobuf:"bytes,2,rep,name=definitions"`
+	Definitions        []ResourceActionDefinition `json:"definitions,omitempty" protobuf:"bytes,2,rep,name=definitions"`
 }
 
 type ResourceActionDefinition struct {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -45,6 +45,7 @@ import (
 	"github.com/argoproj/argo-cd/util/settings"
 )
 
+
 // Server provides a Application service
 type Server struct {
 	ns            string

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -45,7 +45,6 @@ import (
 	"github.com/argoproj/argo-cd/util/settings"
 )
 
-
 // Server provides a Application service
 type Server struct {
 	ns            string
@@ -289,7 +288,7 @@ func (s *Server) ListResourceEvents(ctx context.Context, q *application.Applicat
 	} else {
 		namespace = q.ResourceNamespace
 		var config *rest.Config
-		config, _, err = s.getApplicationClusterConfig(*q.Name)
+		config, err = s.getApplicationClusterConfig(*q.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -608,17 +607,17 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 	return nil
 }
 
-func (s *Server) getApplicationClusterConfig(applicationName string) (*rest.Config, string, error) {
-	server, namespace, err := s.getApplicationDestination(applicationName)
+func (s *Server) getApplicationClusterConfig(applicationName string) (*rest.Config, error) {
+	server, _, err := s.getApplicationDestination(applicationName)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	clst, err := s.db.GetCluster(context.Background(), server)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	config := clst.RESTConfig()
-	return config, namespace, err
+	return config, err
 }
 
 // getCachedAppState loads the cached state and trigger app refresh if cache is missing
@@ -670,7 +669,7 @@ func (s *Server) getAppResource(ctx context.Context, action string, q *applicati
 	if found == nil {
 		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "%s %s %s not found as part of application %s", q.Kind, q.Group, q.ResourceName, *q.Name)
 	}
-	config, _, err := s.getApplicationClusterConfig(*q.Name)
+	config, err := s.getApplicationClusterConfig(*q.Name)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/util/config/reader_test.go
+++ b/util/config/reader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+
 func TestUnmarshalLocalFile(t *testing.T) {
 	const (
 		field1 = "Hello, world!"

--- a/util/config/reader_test.go
+++ b/util/config/reader_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestUnmarshalLocalFile(t *testing.T) {
 	const (
 		field1 = "Hello, world!"
@@ -101,7 +100,7 @@ func TestUnmarshalRemoteFile(t *testing.T) {
 
 func TestUnmarshalReader(t *testing.T) {
 	type testStruct struct {
-		value string
+		Value string
 	}
 	value := "test-reader"
 	instance := testStruct{value}
@@ -110,5 +109,5 @@ func TestUnmarshalReader(t *testing.T) {
 	var reader io.Reader = bytes.NewReader(data)
 	err = UnmarshalReader(reader, &instance)
 	assert.NoError(t, err)
-	assert.Equal(t, value, instance.value)
+	assert.Equal(t, value, instance.Value)
 }

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -37,7 +37,6 @@ type RevisionMetadata struct {
 	Message string
 }
 
-
 // Client is a generic git client interface
 type Client interface {
 	Root() string
@@ -248,12 +247,12 @@ func (m *nativeGitClient) IsLFSEnabled() bool {
 
 // Fetch fetches latest updates from origin
 func (m *nativeGitClient) Fetch() error {
-	_, err := m.runCredentialedCmd("git", "fetch", "origin", "--tags", "--force")
+	err := m.runCredentialedCmd("git", "fetch", "origin", "--tags", "--force")
 	// When we have LFS support enabled, check for large files and fetch them too.
 	if err == nil && m.IsLFSEnabled() {
 		largeFiles, err := m.LsLargeFiles()
 		if err == nil && len(largeFiles) > 0 {
-			_, err = m.runCredentialedCmd("git", "lfs", "fetch", "--all")
+			err = m.runCredentialedCmd("git", "lfs", "fetch", "--all")
 			if err != nil {
 				return err
 			}
@@ -435,15 +434,16 @@ func (m *nativeGitClient) runCmd(args ...string) (string, error) {
 }
 
 // runCredentialedCmd is a convenience function to run a git command with username/password credentials
-func (m *nativeGitClient) runCredentialedCmd(command string, args ...string) (string, error) {
+func (m *nativeGitClient) runCredentialedCmd(command string, args ...string) error {
 	cmd := exec.Command(command, args...)
 	closer, environ, err := m.creds.Environ()
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer func() { _ = closer.Close() }()
 	cmd.Env = append(cmd.Env, environ...)
-	return m.runCmdOutput(cmd)
+	_, err = m.runCmdOutput(cmd)
+	return err
 }
 
 func (m *nativeGitClient) runCmdOutput(cmd *exec.Cmd) (string, error) {

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -37,6 +37,7 @@ type RevisionMetadata struct {
 	Message string
 }
 
+
 // Client is a generic git client interface
 type Client interface {
 	Root() string

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -17,7 +17,6 @@ import (
 	"github.com/argoproj/argo-cd/util/config"
 )
 
-
 type HelmRepository struct {
 	Creds
 	Name string
@@ -112,7 +111,7 @@ func (h *helm) GetParameters(valuesFiles []string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	values := append([]string{out})
+	values := []string{out}
 	for _, file := range valuesFiles {
 		var fileValues []byte
 		parsedURL, err := url.ParseRequestURI(file)

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-cd/util/config"
 )
 
+
 type HelmRepository struct {
 	Creds
 	Name string


### PR DESCRIPTION
Checklist:

* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
* [x] Optional. My organisation is added to the README.

The `--timeout` flag is deprecated, but the SAAS is not backwards compatible. See https://github.com/golangci/golangci/issues/48.

```
$ GOLANGCI_COM_RUN=1 golangci-lint run --out-format=json --issues-exit-code=0 --timeout=5m --new=false --new-from-rev= --new-from-patch=
    Can't get config for command line: can't parse args: unknown flag: --timeout
Error: can't run golangci-lint: build command for req &build.Request{TimeoutMs:0x440e3, WorkDir:"/go/src/github.com/argoproj/argo-cd", Env:[]string{"GOPATH=/go", "GOLANGCI_COM_RUN=1"}, Kind:"run", Args:[]string{"golangci-lint", "run", "--out-format=json", "--issues-exit-code=0", "--timeout=5m", "--new=false", "--new-from-rev=", "--new-from-patch="}} complete with error: exit status 3
```