### PR TITLE
Upgrade casbin/casbin to 1.9.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -94,12 +94,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:e04162bd6a6d4950541bae744c968108e14913b1cebccf29f7650b573f44adb3"
+  digest = "1:6e2b0748ea11cffebe87b4a671a44ecfb243141cdd5df54cb44b7e8e93cb7ea3"
   name = "github.com/casbin/casbin"
   packages = [
     ".",
     "config",
     "effect",
+    "errors",
+    "log",
     "model",
     "persist",
     "persist/file-adapter",
@@ -108,8 +110,8 @@
     "util",
   ]
   pruneopts = ""
-  revision = "d71629e497929858300c38cd442098c178121c30"
-  version = "v1.5.0"
+  revision = "aaed1b7a7eac65d37ec4e15e308429fdf0bd6a9e"
+  version = "v1.9.1"
 
 [[projects]]
   branch = "v2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,6 +55,10 @@ required = [
   branch = "release-11.0"
   name = "k8s.io/client-go"
 
+[[override]]
+  name = "github.com/casbin/casbin"
+  version = "1.9.1"
+
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.2"

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -258,8 +258,6 @@ func TestAppProject_InvalidPolicyRules(t *testing.T) {
 		errmsg string
 	}
 	badPolicies := []badPolicy{
-		// should have spaces
-		{"p,proj:my-proj:my-role,applications,get,my-proj/*,allow", "syntax"},
 		// incorrect form
 		{"g, proj:my-proj:my-role, applications, get, my-proj/*, allow", "must be of the form: 'p, sub, res, act, obj, eft'"},
 		{"p, not, enough, parts", "must be of the form: 'p, sub, res, act, obj, eft'"},

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -298,6 +298,7 @@ func TestAppProject_ValidPolicyRules(t *testing.T) {
 	err := p.ValidateProject()
 	assert.NoError(t, err)
 	goodPolicies := []string{
+		"p,proj:my-proj:my-role,applications,get,my-proj/*,allow",
 		"p, proj:my-proj:my-role, applications, get, my-proj/*, allow",
 		"p, proj:my-proj:my-role, applications, get, my-proj/*, deny",
 		"p, proj:my-proj:my-role, applications, get, my-proj/foo, allow",

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -114,7 +114,7 @@ func TestResourceActionWildcards(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 	policy := `
-p,alice,*,get,foo/obj,allow
+p, alice, *, get, foo/obj, allow
 p, bob, repositories, *, foo/obj, allow
 p, cathy, *, *, foo/obj, allow
 p, dave, applications, get, foo/obj, allow

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -114,7 +114,7 @@ func TestResourceActionWildcards(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfgMapName, nil)
 	policy := `
-p, alice, *, get, foo/obj, allow
+p,alice,*,get,foo/obj,allow
 p, bob, repositories, *, foo/obj, allow
 p, cathy, *, *, foo/obj, allow
 p, dave, applications, get, foo/obj, allow


### PR DESCRIPTION
Checklist:

* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Additional:

Current version of casbin/casbin (1.5.0) contains bug – parsing policy with no-space after comma returns 'index out of range':

```
$ argocd app sync ABCD --async --grpc-web ...
FATA[0000] rpc error: code = Internal desc = runtime error: index out of range
```

```
time="2019-10-15T11:21:35Z" level=info msg="received unary call /application.ApplicationService/Sync" grpc.method=Sync grpc.request.claims="{\"iat\":1569573310,\"iss\":\"argocd\",\"nbf\":1569573310,\"sub\":\"proj:ABCD:ci-role\"}" grpc.request.content="name:\"ABCD\" revision:\"\" dryRun:false prune:false strategy:<hook:<syncStrategyApply:<force:false > > > " grpc.service=application.ApplicationService grpc.start_time="2019-10-15T11:21:35Z" span.kind=server system=grpc
time="2019-10-15T11:21:35Z" level=error msg="Recovered from panic: runtime error: index out of range\ngoroutine 335878 [running]:\nruntime/debug.Stack(0xc0009bbf00, 0x19c8740, 0x3048ca0)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/argoproj/argo-cd/util/grpc.PanicLoggerUnaryServerInterceptor.func1.1(0xc00037f3b0, 0xc0009bd3c0)\n\t/go/src/github.com/argoproj/argo-cd/util/grpc/grpc.go:23 +0x6e\npanic(0x19c8740, 0x3048ca0)\n\t/usr/local/go/src/runtime/panic.go:522 +0x1b5\ngithub.com/casbin/casbin.(*Enforcer).Enforce(0xc000e43810, 0xc00151d600, 0x4, 0x4, 0xc00151d590)\n\t/go/src/github.com/casbin/casbin/enforcer.go:328 +0x16d1\ngithub.com/argoproj/argo-cd/util/rbac.enforce(0xc000e43810, 0xc0007dfc50, 0xd, 0xc0005a9910, 0xc00151d580, 0x4, 0x4, 0x0)\n\t/go/src/github.com/argoproj/argo-cd/util/rbac/rbac.go:129 +0x50e\ngithub.com/argoproj/argo-cd/util/rbac.(*Enforcer).EnforceRuntimePolicy(0xc000763e00, 0xc000e76420, 0xab, 0xc00151d580, 0x4, 0x4, 0x3)\n\t/go/src/github.com/argoproj/argo-cd/util/rbac/rbac.go:122 +0x92\ngithub.com/argoproj/argo-cd/server/rbacpolicy.(*RBACPolicyEnforcer).enforceProjectToken(0xc0006e4ba0, 0xc001625110, 0x22, 0xc0015f35f0, 0xc0013948c0, 0xc00151d500, 0x4, 0x4, 0x509206ee00000000)\n\t/go/src/github.com/argoproj/argo-cd/server/rbacpolicy/rbacpolicy.go:149 +0x283\ngithub.com/argoproj/argo-cd/server/rbacpolicy.(*RBACPolicyEnforcer).EnforceClaims(0xc0006e4ba0, 0x1f70f80, 0xc001656628, 0xc00151d500, 0x4, 0x4, 0x1f70f80)\n\t/go/src/github.com/argoproj/argo-cd/server/rbacpolicy/rbacpolicy.go:70 +0x834\ngithub.com/argoproj/argo-cd/util/rbac.enforce(0xc0003048c0, 0xc0007dfc50, 0xd, 0xc0005a9910, 0xc00151d500, 0x4, 0x4, 0x4d082e)\n\t/go/src/github.com/argoproj/argo-cd/util/rbac/rbac.go:143 +0x29e\ngithub.com/argoproj/argo-cd/util/rbac.(*Enforcer).Enforce(...)\n\t/go/src/github.com/argoproj/argo-cd/util/rbac/rbac.go:88\ngithub.com/argoproj/argo-cd/util/rbac.(*Enforcer).EnforceErr(0xc000763e00, 0xc00151d500, 0x4, 0x4, 0x2, 0xc00080a2c0)\n\t/go/src/github.com/argoproj/argo-cd/util/rbac/rbac.go:93 +0x86\ngithub.com/argoproj/argo-cd/server/application.(*Server).Sync(0xc00057b900, 0x1fb1060, 0xc0015f2750, 0xc000c3fe00, 0xc00057b900, 0xc0014c79c0, 0x0)\n\t/go/src/github.com/argoproj/argo-cd/server/application/application.go:877 +0x353\ngithub.com/argoproj/argo-cd/pkg/apiclient/application._ApplicationService_Sync_Handler.func1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0x0, 0xc0009d5320, 0x42bb0f, 0xc0014c79f0)\n\t/go/src/github.com/argoproj/argo-cd/pkg/apiclient/application/application.pb.go:2187 +0x89\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0x0, 0x0, 0x0, 0x0)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:31 +0x111\ngithub.com/argoproj/argo-cd/util/grpc.PanicLoggerUnaryServerInterceptor.func1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0x0, 0x0, 0x0, 0x0)\n\t/go/src/github.com/argoproj/argo-cd/util/grpc/grpc.go:27 +0x97\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0x0, 0x0, 0x192b620, 0xc00097acd0)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0x99\ngithub.com/argoproj/argo-cd/util/grpc.ErrorCodeUnaryServerInterceptor.func1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0x0, 0x0, 0x0, 0x0)\n\t/go/src/github.com/argoproj/argo-cd/util/grpc/errors.go:64 +0x55\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0xc000c3fe00, 0x1fb1060, 0xc0015f2750, 0x1)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0x99\ngithub.com/argoproj/argo-cd/util/grpc.PayloadUnaryServerInterceptor.func1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0x1c46514, 0xc000c23980, 0xc000c23980, 0x192b620)\n\t/go/src/github.com/argoproj/argo-cd/util/grpc/logging.go:78 +0x1d4\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0x1a7ad60, 0xc001656628, 0x1fb1060, 0xc0015f2750)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0x99\ngithub.com/argoproj/argo-cd/util/grpc.UserAgentUnaryServerInterceptor.func1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0xc0015f2540, 0x1fb1060, 0xc0015f2750, 0x0)\n\t/go/src/github.com/argoproj/argo-cd/util/grpc/useragent.go:22 +0xa2\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2750, 0x1b947c0, 0xc000c3fe00, 0x0, 0x0, 0x0, 0x0)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0x99\ngithub.com/grpc-ecosystem/go-grpc-middleware/auth.UnaryServerInterceptor.func1(0x1fb1060, 0xc0015f2540, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0x5, 0x1c6c173, 0x1e, 0x1c6c192)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/auth/auth.go:46 +0x108\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2540, 0x1b947c0, 0xc000c3fe00, 0x24, 0xc00038e1e0, 0x0, 0x0)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0x99\ngithub.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1(0x1fb1060, 0xc0015f2540, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0x0, 0x0, 0x0, 0x0)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-prometheus/server_metrics.go:107 +0xad\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2540, 0x1b947c0, 0xc000c3fe00, 0x24, 0xbf6188cfe519d9b2, 0x110bdf63ffaaf, 0x306fce0)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0x99\ngithub.com/grpc-ecosystem/go-grpc-middleware/logging/logrus.UnaryServerInterceptor.func1(0x1fb1060, 0xc0015f2450, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0x50, 0x48, 0x1b37d00, 0x0)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/server_interceptors.go:32 +0x110\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1(0x1fb1060, 0xc0015f2450, 0x1b947c0, 0xc000c3fe00, 0x7f18876e1008, 0x0, 0xc000ba5b88, 0x40b899)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0x99\ngithub.com/argoproj/argo-cd/server.bug21955WorkaroundInterceptor(0x1fb1060, 0xc0015f2450, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000debea0, 0xc0015f2450, 0xc000c23720, 0xc000ba5bb8, 0x40c128)\n\t/go/src/github.com/argoproj/argo-cd/server/server.go:848 +0x11f\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1(0x1fb1060, 0xc0015f2450, 0x1b947c0, 0xc000c3fe00, 0xc000c23740, 0xc000c23760, 0xc000ba5c28, 0x4e0e2a, 0x1aeeb60, 0xc0015f2450)\n\t/go/src/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:39 +0x153\ngithub.com/argoproj/argo-cd/pkg/apiclient/application._ApplicationService_Sync_Handler(0x1bc8ea0, 0xc00057b900, 0x1fb1060, 0xc0015f2450, 0xc000e43650, 0xc0006e4d50, 0x1fb1060, 0xc0015f2450, 0x20300000000000, 0x7f18856cffff)\n\t/go/src/github.com/argoproj/argo-cd/pkg/apiclient/application/application.pb.go:2189 +0x158\ngoogle.golang.org/grpc.(*Server).processUnaryRPC(0xc000419b00, 0x1fdafc0, 0xc0009530e0, 0xc001305500, 0xc0006e51a0, 0x3058110, 0x0, 0x0, 0x0)\n\t/go/src/google.golang.org/grpc/server.go:982 +0x4c3\ngoogle.golang.org/grpc.(*Server).handleStream(0xc000419b00, 0x1fdafc0, 0xc0009530e0, 0xc001305500, 0x0)\n\t/go/src/google.golang.org/grpc/server.go:1208 +0x12b5\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000f7cbd0, 0xc000419b00, 0x1fdafc0, 0xc0009530e0, 0xc001305500)\n\t/go/src/google.golang.org/grpc/server.go:686 +0x9f\ncreated by google.golang.org/grpc.(*Server).serveStreams.func1\n\t/go/src/google.golang.org/grpc/server.go:684 +0xa1\n"
time="2019-10-15T11:21:35Z" level=error msg="finished unary call with code Internal" error="rpc error: code = Internal desc = runtime error: index out of range" grpc.code=Internal grpc.method=Sync grpc.service=application.ApplicationService grpc.start_time="2019-10-15T11:21:35Z" grpc.time_ms=18.828 span.kind=server system=grpc
```

<img width="883" alt="image" src="https://user-images.githubusercontent.com/2360290/67138242-cc977580-f259-11e9-88c9-d1484534a771.png">

That's was fixed in [1.8.1](https://github.com/casbin/casbin/commit/13c2894299cb93747ba599ea039c6555e81023de). So switch vendor package for last version without breaking changes (1.9.1).

List of changes: https://github.com/casbin/casbin/compare/v1.5.0...v1.9.1

Also documentation doesn't contains information about required Spaces in policy.
