### PR TITLE
Allows Helm charts to have arbitrary file names. Fixes #2549

### DIFF
--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -147,7 +147,7 @@ func (c *nativeHelmChart) ExtractChart(chart string, version string) (string, ut
 		if len(infos) != 1 {
 			return "", nil, fmt.Errorf("expected 1 file, found %v", len(infos))
 		}
-		err = os.Rename(infos[0].Name(), chartPath)
+		err = os.Rename(filepath.Join(tempDest, infos[0].Name()), chartPath)
 		if err != nil {
 			return "", nil, err
 		}

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -128,14 +128,33 @@ func (c *nativeHelmChart) ExtractChart(chart string, version string) (string, ut
 			return "", nil, err
 		}
 
-		// download chart tar file into persistent helm repository directory
-		_, err = helmCmd.Fetch(c.repoURL, chart, version, c.creds)
+		// (1) because `helm fetch` downloads an arbitrary file name, we download to an empty temp directory
+		tempDest, err := ioutil.TempDir("", "helm")
+		defer func() { _ = os.RemoveAll(tempDest) }()
+		if err != nil {
+			return "", nil, err
+		}
+		_, err = helmCmd.Fetch(c.repoURL, chart, version, tempDest, c.creds)
+		if err != nil {
+			return "", nil, err
+		}
+		// (2) then we assume that the only file downloaded into the directory is the tgz file
+		// and we move that to where we want it
+		err = filepath.Walk(tempDest, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if strings.HasSuffix(path, ".tgz") {
+				return os.Rename(path, chartPath)
+			}
+			return nil
+		})
 		if err != nil {
 			return "", nil, err
 		}
 	}
 	// untar helm chart into throw away temp directory which should be deleted as soon as no longer needed
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := ioutil.TempDir("", "helm")
 	if err != nil {
 		return "", nil, err
 	}
@@ -144,6 +163,7 @@ func (c *nativeHelmChart) ExtractChart(chart string, version string) (string, ut
 	_, err = argoexec.RunCommandExt(cmd, argoexec.CmdOpts{})
 	if err != nil {
 		_ = os.RemoveAll(tempDir)
+		return "", nil, err
 	}
 	return path.Join(tempDir, chart), util.NewCloser(func() error {
 		return os.RemoveAll(tempDir)

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -1,27 +1,43 @@
 package helm
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-cd/util"
 )
 
 func TestIndex(t *testing.T) {
 	t.Run("Invalid", func(t *testing.T) {
-		_, err := NewClient("", Creds{}).GetIndex()
+		client := NewClient("", Creds{})
+		_, err := client.GetIndex()
 		assert.Error(t, err)
 	})
 	t.Run("Stable", func(t *testing.T) {
-		index, err := NewClient("https://kubernetes-charts.storage.googleapis.com", Creds{}).GetIndex()
+		client := NewClient("https://argoproj.github.io/argo-helm", Creds{})
+		index, err := client.GetIndex()
 		assert.NoError(t, err)
 		assert.NotNil(t, index)
 	})
 	t.Run("BasicAuth", func(t *testing.T) {
-		index, err := NewClient("https://kubernetes-charts.storage.googleapis.com", Creds{
+		client := NewClient("https://argoproj.github.io/argo-helm", Creds{
 			Username: "my-password",
 			Password: "my-username",
-		}).GetIndex()
+		})
+		index, err := client.GetIndex()
 		assert.NoError(t, err)
 		assert.NotNil(t, index)
 	})
+}
+
+func Test_nativeHelmChart_ExtractChart(t *testing.T) {
+	client := NewClient("https://argoproj.github.io/argo-helm", Creds{})
+	path, closer, err := client.ExtractChart("argo-cd", "0.7.1")
+	defer util.Close(closer)
+	assert.NoError(t, err)
+	info, err := os.Stat(path)
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
 }

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -117,31 +117,31 @@ func writeToTmp(data []byte) (string, io.Closer, error) {
 	}), nil
 }
 
-func (c *Cmd) Fetch(repo, chartName string, version string, opts Creds) (string, error) {
-	args := []string{"fetch"}
+func (c *Cmd) Fetch(repo, chartName, version, destination string, creds Creds) (string, error) {
+	args := []string{"fetch", "--destination", destination}
 
 	if version != "" {
 		args = append(args, "--version", version)
 	}
-	if opts.Username != "" {
-		args = append(args, "--username", opts.Username)
+	if creds.Username != "" {
+		args = append(args, "--username", creds.Username)
 	}
-	if opts.Password != "" {
-		args = append(args, "--password", opts.Password)
+	if creds.Password != "" {
+		args = append(args, "--password", creds.Password)
 	}
-	if opts.CAPath != "" {
-		args = append(args, "--ca-file", opts.CAPath)
+	if creds.CAPath != "" {
+		args = append(args, "--ca-file", creds.CAPath)
 	}
-	if len(opts.CertData) > 0 {
-		filePath, closer, err := writeToTmp(opts.CertData)
+	if len(creds.CertData) > 0 {
+		filePath, closer, err := writeToTmp(creds.CertData)
 		if err != nil {
 			return "", err
 		}
 		defer util.Close(closer)
 		args = append(args, "--cert-file", filePath)
 	}
-	if len(opts.KeyData) > 0 {
-		filePath, closer, err := writeToTmp(opts.KeyData)
+	if len(creds.KeyData) > 0 {
+		filePath, closer, err := writeToTmp(creds.KeyData)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Overview:

In v1.3 we assume that charts are name `{chartName}-{version}.tgz'. This is false. They can be named anything.

Fixes #2549
