### PR TITLE
docs(app cmd): updating --local text to include helm and kustomize

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1032,7 +1032,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	}
 	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
-	command.Flags().StringVar(&local, "local", "", "Compare live app to a local ksonnet, helm, or kustomize app")
+	command.Flags().StringVar(&local, "local", "", "Compare live app to a local manifests")
 	return command
 }
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1032,7 +1032,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	}
 	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
-	command.Flags().StringVar(&local, "local", "", "Compare live app to a local ksonnet app")
+	command.Flags().StringVar(&local, "local", "", "Compare live app to a local ksonnet, helm, or kustomize app")
 	return command
 }
 


### PR DESCRIPTION
Just updating the text of `app diff --local` so that its more obvious to folks that they can use this with there helm charts or kustomize templates.