### PR TITLE
Upgrade kustomize to 3.2.1 #2609

### DIFF
--- a/hack/installers/install-kustomize-linux.sh
+++ b/hack/installers/install-kustomize-linux.sh
@@ -2,10 +2,16 @@
 set -eux -o pipefail
 
 # TODO we use v2 for generating manifests, v3 for production - we should always use v3
-KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-3.1.0}
+KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-3.2.1}
 DL=$DOWNLOADS/kustomize-${KUSTOMIZE_VERSION}
 
-[ -e $DL ] || curl -sLf --retry 3 -o $DL https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64
+# Note that kustomize release URIs have changed for v3.2.1. Then again for
+# v3.3.0. When upgrading to versions >= v3.3.0 please change the URI format. And
+# also note that as of version v3.3.0, assets are in .tar.gz form.
+# v3.2.0 = https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_linux_amd64
+# v3.2.1 = https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.2.1/kustomize_kustomize.v3.2.1_linux_amd64
+# v3.3.0 = https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz
+[ -e $DL ] || curl -sLf --retry 3 -o $DL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_kustomize.v${KUSTOMIZE_VERSION}_linux_amd64
 cp $DL $BIN/kustomize
 chmod +x $BIN/kustomize
 kustomize version

--- a/test/manifests_test.go
+++ b/test/manifests_test.go
@@ -16,7 +16,7 @@ func TestBuildManifests(t *testing.T) {
 
 	out, err := argoexec.RunCommand("kustomize", argoexec.CmdOpts{}, "version")
 	assert.NoError(t, err)
-	assert.True(t, Contains(out, "KustomizeVersion:3") || Contains(out, "KustomizeVersion:v3"), "kustomize should be version 3")
+	assert.True(t, Contains(out, "Version:kustomize/v3"), "kustomize should be version 3")
 
 	err = filepath.Walk("../manifests", func(path string, f os.FileInfo, err error) error {
 		if err != nil {

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -186,7 +186,7 @@ func Version() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not get kustomize version: %s", err)
 	}
-	re := regexp.MustCompile(`KustomizeVersion:([a-zA-Z0-9\.]+)`)
+	re := regexp.MustCompile(`Version:kustomize/([a-zA-Z0-9\.]+)`)
 	matches := re.FindStringSubmatch(out)
 	if len(matches) != 2 {
 		return "", errors.New("could not get kustomize version")


### PR DESCRIPTION
Note that kustomize release URIs have changed for v3.2.1. Then again for
v3.3.0. When upgrading to versions >= v3.3.0 please change the URI format. And
also note that as of version v3.3.0, assets are in .tar.gz form.

```
v3.2.0 = https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_linux_amd64
v3.2.1 = https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.2.1/kustomize_kustomize.v3.2.1_linux_amd64
v3.3.0 = https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz
```

Closes #2609 

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
