### PR TITLE
Allow '@'-character in SSH usernames when connecting a repository

### DIFF
--- a/util/git/git.go
+++ b/util/git/git.go
@@ -24,7 +24,7 @@ func removeSuffix(s, suffix string) string {
 
 var (
 	commitSHARegex = regexp.MustCompile("^[0-9A-Fa-f]{40}$")
-	sshURLRegex    = regexp.MustCompile("^(ssh://)?([^/@:]*?)@.*")
+	sshURLRegex    = regexp.MustCompile("^(ssh://)?([^/:]*?)@[^@]+$")
 	httpsURLRegex  = regexp.MustCompile("^(https://).*")
 )
 

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -82,6 +82,23 @@ func TestIsSSHURLUserName(t *testing.T) {
 	isSSH, user = IsSSHURL("john@john-server.org:29418/project")
 	assert.True(t, isSSH)
 	assert.Equal(t, "john", user)
+
+	isSSH, user = IsSSHURL("john@doe.org@john-server.org:29418/project")
+	assert.True(t, isSSH)
+	assert.Equal(t, "john@doe.org", user)
+
+	isSSH, user = IsSSHURL("ssh://john@doe.org@john-server.org:29418/project")
+	assert.True(t, isSSH)
+	assert.Equal(t, "john@doe.org", user)
+
+	isSSH, user = IsSSHURL("john@doe.org@john-server.org:project")
+	assert.True(t, isSSH)
+	assert.Equal(t, "john@doe.org", user)
+
+	isSSH, user = IsSSHURL("john@doe.org@john-server.org:29418/project")
+	assert.True(t, isSSH)
+	assert.Equal(t, "john@doe.org", user)
+
 }
 
 func TestSameURL(t *testing.T) {


### PR DESCRIPTION
Checklist:

* [x] this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

This PR allows for `@` sign in usernames when connecting SSH repositories. Fixes #2611