### PR TITLE
Assume git as default repository type (fixes #2622)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -21,9 +21,10 @@ const (
 	ArgoCDTLSCertsConfigMapName = "argocd-tls-certs-cm"
 )
 
-// Default system namespace
+// Some default configurables
 const (
 	DefaultSystemNamespace = "kube-system"
+	DefaultRepoType        = "git"
 )
 
 // Default listener ports for ArgoCD components

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/argoproj/argo-cd/common"
 	repositorypkg "github.com/argoproj/argo-cd/pkg/apiclient/repository"
 	appsv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
@@ -93,10 +94,15 @@ func (s *Server) ListRepositories(ctx context.Context, q *repositorypkg.RepoQuer
 	items := appsv1.Repositories{}
 	for _, repo := range repos {
 		if s.enf.Enforce(ctx.Value("claims"), rbacpolicy.ResourceRepositories, rbacpolicy.ActionGet, repo.Repo) {
+			// For backwards compatibility, if we have no repo type set assume a default
+			rType := repo.Type
+			if rType == "" {
+				rType = common.DefaultRepoType
+			}
 			// remove secrets
 			items = append(items, &appsv1.Repository{
 				Repo:      repo.Repo,
-				Type:      repo.Type,
+				Type:      rType,
 				Name:      repo.Name,
 				Username:  repo.Username,
 				Insecure:  repo.IsInsecure(),

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -90,7 +90,7 @@ func TestDeclarativeHelmInvalidValuesFile(t *testing.T) {
 func TestHelmRepo(t *testing.T) {
 	Given(t).
 		CustomCACertAdded().
-		HelmRepoAdded("").
+		HelmRepoAdded("custom-repo").
 		RepoURLType(RepoURLTypeHelm).
 		Chart("helm").
 		Revision("1.0.0").


### PR DESCRIPTION
Checklist:

* [x] this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

This PR makes the ArgoCD CLI assume `git` to be the default repository type for `argocd repo add` CLI command. It also makes the `--name` switch mandatory if repository type is `helm`, and sets a default value of `git` for repositories returned in `RepositoryService.ListRepositories()` API for legacy repositories which do not have the `type` attribute in their definition.

Fixes #2622 