### PR TITLE
Issue #2645 - /api/version should not fail if unable to load tool version

### DIFF
--- a/server/version/version.go
+++ b/server/version/version.go
@@ -25,31 +25,36 @@ func (s *Server) Version(context.Context, *empty.Empty) (*version.VersionMessage
 	vers := common.GetVersion()
 	if s.ksonnetVersion == "" {
 		ksonnetVersion, err := ksutil.Version()
-		if err != nil {
-			return nil, err
+		if err == nil {
+			s.ksonnetVersion = ksonnetVersion
+		} else {
+			s.ksonnetVersion = err.Error()
 		}
-		s.ksonnetVersion = ksonnetVersion
 	}
 	if s.kustomizeVersion == "" {
 		kustomizeVersion, err := kustomize.Version()
-		if err != nil {
-			return nil, err
+		if err == nil {
+			s.kustomizeVersion = kustomizeVersion
+		} else {
+			s.kustomizeVersion = err.Error()
 		}
-		s.kustomizeVersion = kustomizeVersion
+
 	}
 	if s.helmVersion == "" {
 		helmVersion, err := helm.Version()
-		if err != nil {
-			return nil, err
+		if err == nil {
+			s.helmVersion = helmVersion
+		} else {
+			s.helmVersion = err.Error()
 		}
-		s.helmVersion = helmVersion
 	}
 	if s.kubectlVersion == "" {
 		kubectlVersion, err := kube.Version()
-		if err != nil {
-			return nil, err
+		if err == nil {
+			s.kubectlVersion = kubectlVersion
+		} else {
+			s.kubectlVersion = err.Error()
 		}
-		s.kubectlVersion = kubectlVersion
 	}
 	return &version.VersionMessage{
 		Version:          vers.Version,

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -181,21 +180,12 @@ func IsKustomization(path string) bool {
 }
 
 func Version() (string, error) {
-	cmd := exec.Command("kustomize", "version")
+	cmd := exec.Command("kustomize", "version", "--short")
 	out, err := argoexec.RunCommandExt(cmd, config.CmdOpts())
 	if err != nil {
 		return "", fmt.Errorf("could not get kustomize version: %s", err)
 	}
-	re := regexp.MustCompile(`Version:kustomize/([a-zA-Z0-9\.]+)`)
-	matches := re.FindStringSubmatch(out)
-	if len(matches) != 2 {
-		return "", errors.New("could not get kustomize version")
-	}
-	version := matches[1]
-	if version[0] != 'v' {
-		version = "v" + version
-	}
-	return strings.TrimSpace(version), nil
+	return strings.TrimSpace("v" + out), nil
 }
 
 func getImageParameters(objs []*unstructured.Unstructured) []Image {

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/Masterminds/semver"
+
 	"github.com/argoproj/pkg/exec"
 	"github.com/stretchr/testify/assert"
 
@@ -104,7 +106,7 @@ func TestParseKustomizeBuildOptions(t *testing.T) {
 func TestVersion(t *testing.T) {
 	ver, err := Version()
 	assert.NoError(t, err)
-	SemverRegexValidation := `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`
-	re := regexp.MustCompile(SemverRegexValidation)
+
+	re := regexp.MustCompile(semver.SemVerRegex)
 	assert.True(t, re.MatchString(ver))
 }


### PR DESCRIPTION
Closes #2645

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
