### PR TITLE
Issue #2668 - Delete a specified context

### DIFF
--- a/cmd/argocd/commands/context.go
+++ b/cmd/argocd/commands/context.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/spf13/pflag"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -30,22 +28,21 @@ func NewContextCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			localCfg, err := localconfig.ReadLocalConfig(clientOpts.ConfigPath)
 			errors.CheckError(err)
 
-			deletePresentContext := false
-			c.Flags().Visit(func(f *pflag.Flag) {
-				if f.Name == "delete" {
-					deletePresentContext = true
+			if delete {
+				var ctxName string
+				if len(args) == 0 {
+					ctxName = localCfg.CurrentContext
+				} else {
+					ctxName = args[0]
 				}
-			})
+				err := deleteContext(ctxName, clientOpts.ConfigPath)
+				errors.CheckError(err)
+				return
+			}
 
 			if len(args) == 0 {
-				if deletePresentContext {
-					err := deleteContext(localCfg.CurrentContext, clientOpts.ConfigPath)
-					errors.CheckError(err)
-					return
-				} else {
-					printArgoCDContexts(clientOpts.ConfigPath)
-					return
-				}
+				printArgoCDContexts(clientOpts.ConfigPath)
+				return
 			}
 
 			ctxName := args[0]

--- a/cmd/argocd/commands/context.go
+++ b/cmd/argocd/commands/context.go
@@ -20,7 +20,7 @@ import (
 func NewContextCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var delete bool
 	var command = &cobra.Command{
-		Use:     "context",
+		Use:     "context [CONTEXT]",
 		Aliases: []string{"ctx"},
 		Short:   "Switch between contexts",
 		Run: func(c *cobra.Command, args []string) {
@@ -30,8 +30,8 @@ func NewContextCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 
 			if delete {
 				if len(args) == 0 {
-					fmt.Printf("Specify a context\n")
-					return
+					c.HelpFunc()(c, args)
+					os.Exit(1)
 				}
 				err := deleteContext(args[0], clientOpts.ConfigPath)
 				errors.CheckError(err)

--- a/cmd/argocd/commands/context.go
+++ b/cmd/argocd/commands/context.go
@@ -29,13 +29,11 @@ func NewContextCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			errors.CheckError(err)
 
 			if delete {
-				var ctxName string
 				if len(args) == 0 {
-					ctxName = localCfg.CurrentContext
-				} else {
-					ctxName = args[0]
+					fmt.Printf("Specify a context\n")
+					return
 				}
-				err := deleteContext(ctxName, clientOpts.ConfigPath)
+				err := deleteContext(args[0], clientOpts.ConfigPath)
 				errors.CheckError(err)
 				return
 			}
@@ -97,7 +95,7 @@ func deleteContext(context, configPath string) error {
 		errors.CheckError(err)
 	} else {
 		if localCfg.CurrentContext == context {
-			localCfg.CurrentContext = localCfg.Contexts[0].Name
+			localCfg.CurrentContext = ""
 		}
 		err = localconfig.ValidateLocalConfig(*localCfg)
 		if err != nil {

--- a/cmd/argocd/commands/context_test.go
+++ b/cmd/argocd/commands/context_test.go
@@ -11,20 +11,27 @@ import (
 )
 
 const testConfig = `contexts:
-- name: argocd.example.com:443
-  server: argocd.example.com:443
-  user: argocd.example.com:443
+- name: argocd1.example.com:443
+  server: argocd1.example.com:443
+  user: argocd1.example.com:443
+- name: argocd2.example.com:443
+  server: argocd2.example.com:443
+  user: argocd2.example.com:443
 - name: localhost:8080
   server: localhost:8080
   user: localhost:8080
 current-context: localhost:8080
 servers:
-- server: argocd.example.com:443
+- server: argocd1.example.com:443
+- server: argocd2.example.com:443
 - plain-text: true
   server: localhost:8080
 users:
 - auth-token: vErrYS3c3tReFRe$hToken
-  name: argocd.example.com:443
+  name: argocd1.example.com:443
+  refresh-token: vErrYS3c3tReFRe$hToken
+- auth-token: vErrYS3c3tReFRe$hToken
+  name: argocd2.example.com:443
   refresh-token: vErrYS3c3tReFRe$hToken
 - auth-token: vErrYS3c3tReFRe$hToken
   name: localhost:8080`
@@ -42,16 +49,30 @@ func TestContextDelete(t *testing.T) {
 	assert.Equal(t, localConfig.CurrentContext, "localhost:8080")
 	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "localhost:8080", Server: "localhost:8080", User: "localhost:8080"})
 
+	// Delete a non-current context
+	err = deleteContext("argocd1.example.com:443", testConfigFilePath)
+	assert.NoError(t, err)
+
+	localConfig, err = localconfig.ReadLocalConfig(testConfigFilePath)
+	assert.NoError(t, err)
+	assert.Equal(t, localConfig.CurrentContext, "localhost:8080")
+	assert.NotContains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd1.example.com:443", Server: "argocd1.example.com:443", User: "argocd1.example.com:443"})
+	assert.NotContains(t, localConfig.Servers, localconfig.Server{Server: "argocd1.example.com:443"})
+	assert.NotContains(t, localConfig.Users, localconfig.User{AuthToken: "vErrYS3c3tReFRe$hToken", Name: "argocd1.example.com:443"})
+	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd2.example.com:443", Server: "argocd2.example.com:443", User: "argocd2.example.com:443"})
+	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "localhost:8080", Server: "localhost:8080", User: "localhost:8080"})
+
+	// Delete the current context
 	err = deleteContext("localhost:8080", testConfigFilePath)
 	assert.NoError(t, err)
 
 	localConfig, err = localconfig.ReadLocalConfig(testConfigFilePath)
 	assert.NoError(t, err)
-	assert.Equal(t, localConfig.CurrentContext, "argocd.example.com:443")
+	assert.Equal(t, localConfig.CurrentContext, "")
 	assert.NotContains(t, localConfig.Contexts, localconfig.ContextRef{Name: "localhost:8080", Server: "localhost:8080", User: "localhost:8080"})
 	assert.NotContains(t, localConfig.Servers, localconfig.Server{PlainText: true, Server: "localhost:8080"})
 	assert.NotContains(t, localConfig.Users, localconfig.User{AuthToken: "vErrYS3c3tReFRe$hToken", Name: "localhost:8080"})
-	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd.example.com:443", Server: "argocd.example.com:443", User: "argocd.example.com:443"})
+	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd2.example.com:443", Server: "argocd2.example.com:443", User: "argocd2.example.com:443"})
 
 	// Write the file again so that no conflicts are made in git
 	err = ioutil.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)

--- a/cmd/argocd/commands/logout_test.go
+++ b/cmd/argocd/commands/logout_test.go
@@ -30,7 +30,9 @@ func TestLogout(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, localConfig.CurrentContext, "localhost:8080")
 	assert.NotContains(t, localConfig.Users, localconfig.User{AuthToken: "vErrYS3c3tReFRe$hToken", Name: "localhost:8080"})
-	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd.example.com:443", Server: "argocd.example.com:443", User: "argocd.example.com:443"})
+	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd1.example.com:443", Server: "argocd1.example.com:443", User: "argocd1.example.com:443"})
+	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd2.example.com:443", Server: "argocd2.example.com:443", User: "argocd2.example.com:443"})
+	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "localhost:8080", Server: "localhost:8080", User: "localhost:8080"})
 
 	// Write the file again so that no conflicts are made in git
 	err = ioutil.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)

--- a/cmd/argocd/commands/testdata/config
+++ b/cmd/argocd/commands/testdata/config
@@ -1,18 +1,25 @@
 contexts:
-- name: argocd.example.com:443
-  server: argocd.example.com:443
-  user: argocd.example.com:443
+- name: argocd1.example.com:443
+  server: argocd1.example.com:443
+  user: argocd1.example.com:443
+- name: argocd2.example.com:443
+  server: argocd2.example.com:443
+  user: argocd2.example.com:443
 - name: localhost:8080
   server: localhost:8080
   user: localhost:8080
 current-context: localhost:8080
 servers:
-- server: argocd.example.com:443
+- server: argocd1.example.com:443
+- server: argocd2.example.com:443
 - plain-text: true
   server: localhost:8080
 users:
 - auth-token: vErrYS3c3tReFRe$hToken
-  name: argocd.example.com:443
+  name: argocd1.example.com:443
+  refresh-token: vErrYS3c3tReFRe$hToken
+- auth-token: vErrYS3c3tReFRe$hToken
+  name: argocd2.example.com:443
   refresh-token: vErrYS3c3tReFRe$hToken
 - auth-token: vErrYS3c3tReFRe$hToken
   name: localhost:8080

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -85,7 +85,7 @@ func ReadLocalConfig(path string) (*LocalConfig, error) {
 
 func ValidateLocalConfig(config LocalConfig) error {
 	if config.CurrentContext == "" {
-		return fmt.Errorf("Local config invalid: current-context unset")
+		return nil
 	}
 	if _, err := config.ResolveContext(config.CurrentContext); err != nil {
 		return fmt.Errorf("Local config invalid: %s", err)
@@ -113,6 +113,9 @@ func DeleteLocalConfig(configPath string) error {
 // ResolveContext resolves the specified context. If unspecified, resolves the current context
 func (l *LocalConfig) ResolveContext(name string) (*Context, error) {
 	if name == "" {
+		if l.CurrentContext == "" {
+			return nil, fmt.Errorf("Local config: current-context unset")
+		}
 		name = l.CurrentContext
 	}
 	for _, ctx := range l.Contexts {


### PR DESCRIPTION
Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
---

Fix for #2668. Please review.

This code behaves as follows:
```shell
# 3 contexts exists.
$ argocd context
CURRENT  NAME                     SERVER
         argocd.hoge.example.com  argocd.hoge.example.com
*        argocd.piyo.example.com  argocd.piyo.example.com
         argocd.fuga.example.com  argocd.fuga.example.com

# Delete a non-current context.
$ argocd context --delete argocd.hoge.example.com
Context 'argocd.hoge.example.com' deleted
$ argocdq context
CURRENT  NAME                     SERVER
*        argocd.piyo.example.com  argocd.piyo.example.com
         argocd.fuga.example.com  argocd.fuga.example.com

# If a context name is not specified, delete the current context.
$ argocd context --delete
Context 'argocd.piyo.example.com' deleted
$ argocd context
CURRENT  NAME                     SERVER
*        argocd.fuga.example.com  argocd.fuga.example.com

# Even if the current context is specified, it is of course deleted.
$ argocd context --delete argocd.fuga.example.com
Context 'argocd.fuga.example.com' deleted
$ argocd context
FATA[0000] No contexts defined in /home/masa213f/.argocd/config
```