### PR TITLE
Adds code coverage reporting on CLI code, increasing coverage by 7%

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,9 +194,10 @@ jobs:
           name: Kill services
           command: |
             set -eux
-            pkill argocd-application-controller
-            pkill argocd-server
-            pkill argocd-repo-server
+            ps
+            killall argocd-application-controller
+            killall argocd-server
+            killall argocd-repo-server
           when: always
       - upload_codecov
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,7 @@ jobs:
           name: Kill services
           command: |
             set -eux
-            ps -aef
-            pkill -u circleci argocd-application-controller
+            ps -aef | grep argocd-application-controller | grep -v grep | awk '{print #2}' | xargs kill
             pkill -u circleci argocd-server
             pkill -u circleci argocd-repo-server
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,10 @@ jobs:
       - restore_vendor
       - run: dep ensure
       - configure_git
-      - run: make e2e-clis
+      - run:
+          command: |
+            make e2e-clis
+            echo "export PATH=$(pwd)/dist:\$PATH"| tee -a $BASH_ENV
       - run:
           name: Create namespace
           command: |
@@ -164,11 +167,11 @@ jobs:
           background: true
       - run:
           name: Start repo server
-          command: ./dist/argocd-repo-server --loglevel debug --redis localhost:6379
+          command: argocd-repo-server --loglevel debug --redis localhost:6379
           background: true
       - run:
           name: Start API server
-          command: ./dist/argocd-server --loglevel debug --redis localhost:6379 --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ../argo-cd-ui/dist/app
+          command: argocd-server --loglevel debug --redis localhost:6379 --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ../argo-cd-ui/dist/app
           background: true
       - run:
           name: Start Test Git
@@ -177,10 +180,10 @@ jobs:
       - run: until curl -v http://localhost:8080/healthz; do sleep 10; done
       - run:
           name: Start controller
-          command: ./dist/argocd-application-controller --loglevel debug --redis localhost:6379 --repo-server localhost:8081 --kubeconfig ~/.kube/config
+          command: argocd-application-controller --loglevel debug --redis localhost:6379 --repo-server localhost:8081 --kubeconfig ~/.kube/config
           background: true
       - run:
-          command: PATH=$(pwd)/dist:$PATH make test-e2e
+          command: make test-e2e
           environment:
             ARGOCD_OPTS: "--server localhost:8080 --plaintext"
             ARGOCD_E2E_EXPECT_TIMEOUT: "30"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,11 +194,10 @@ jobs:
           name: Kill services
           command: |
             set -eux
-            ps -aef | grep argocd-application-controller | grep -v grep | awk '{print $2}' | xargs kill
-            pkill -u circleci argocd-server
-            pkill -u circleci argocd-repo-server
+            ps -aef | grep argocd-application-controller | grep -v grep | awk '{print $2}'
           when: always
       - run: ls
+          when: always
       - upload_codecov
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ jobs:
       ARGOCD_SSH_DATA_PATH: "/tmp/argo-e2e/app/config/ssh"
       ARGOCD_TLS_DATA_PATH: "/tmp/argo-e2e/app/config/tls"
     steps:
-      - run: pkill --helpgit
       - run:
           name: Install and start K3S v0.5.0
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,10 +194,14 @@ jobs:
           name: Kill services
           command: |
             set -eux
-            ps -aef | grep argocd-application-controller | grep -v grep | awk '{print $2}'
+            ps -aef | grep argocd-application-controller\|argocd-server\|argocd-repo-server | grep -v grep
+             # | awk '{print $2}' | xargs kill
           when: always
       - run:
-          command: ls
+          command: |
+            ls
+            cat *.out > coverage.out
+
           when: always
       - upload_codecov
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
           command: bash <(curl -s https://codecov.io/bash) -f *.out -F {{ .Environment.CIRCLE_JOB }}
           when: always
 jobs:
-  cfodegen:
+  codegen:
     docker:
       - image: circleci/golang:1.12
     working_directory: /go/src/github.com/argoproj/argo-cd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
           command: bash <(curl -s https://codecov.io/bash) -f *.out -F {{ .Environment.CIRCLE_JOB }}
           when: always
 jobs:
-  codegen:
+  cfodegen:
     docker:
       - image: circleci/golang:1.12
     working_directory: /go/src/github.com/argoproj/argo-cd
@@ -187,9 +187,10 @@ jobs:
             ARGOCD_E2E_K3S: "true"
       - save_vendor
       - save_go_cache
-      - run: pkill argocd-repo-server
-      - run: pkill argocd-server
-      - run: pkill argocd-application-controller
+      - run:
+          name: Kill services
+          command: pkill argocd-repo-server argocd-server argocd-application-controller
+          when: always
       - upload_codecov
       - store_test_results:
           path: test-results
@@ -211,7 +212,10 @@ jobs:
           key: yarn-packages-v4-{{ checksum "yarn.lock" }}
           paths: [~/.cache/yarn, node_modules]
       - run: yarn test
-      - run: ./node_modules/.bin/codecov -p .. -F {{ .Environment.CIRCLE_JOB }}
+      - run:
+          name: Upload code coverage
+          command: ./node_modules/.bin/codecov -p .. -F {{ .Environment.CIRCLE_JOB }}
+          when: always
       - run: yarn build
       - run: yarn lint
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ commands:
     steps:
       - run:
           name: Uploading code coverage
-          command: bash <(curl -s https://codecov.io/bash) -f coverage.out
+          command: bash <(curl -s https://codecov.io/bash) -f *.out -F {{ .Environment.CIRCLE_JOB }}
+          when: always
 jobs:
   codegen:
     docker:
@@ -210,7 +211,7 @@ jobs:
           key: yarn-packages-v4-{{ checksum "yarn.lock" }}
           paths: [~/.cache/yarn, node_modules]
       - run: yarn test
-      - run: ./node_modules/.bin/codecov -p ..
+      - run: ./node_modules/.bin/codecov -p .. -F {{ .Environment.CIRCLE_JOB }}
       - run: yarn build
       - run: yarn lint
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,11 @@ jobs:
       - save_go_cache
       - run:
           name: Kill services
-          command: pkill argocd-repo-server argocd-server argocd-application-controller
+          command: |
+            set -eux
+            pkill argocd-application-controller
+            pkill argocd-server
+            pkill argocd-repo-server
           when: always
       - upload_codecov
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,11 @@ commands:
           keys:
             - go-v1-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
             - go-v1-master-{{ .Environment.CIRCLE_JOB }}
+  upload_codecov:
+    steps:
+      - run:
+          name: Uploading code coverage
+          command: bash <(curl -s https://codecov.io/bash) -f coverage.out
 jobs:
   codegen:
     docker:
@@ -96,9 +101,7 @@ jobs:
       - run: make test
       - save_vendor
       - save_go_cache
-      - run:
-          name: Uploading code coverage
-          command: bash <(curl -s https://codecov.io/bash) -f coverage.out
+      - upload_codecov
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -136,7 +139,7 @@ jobs:
       - restore_vendor
       - run: dep ensure
       - configure_git
-      - run: make cli
+      - run: make e2e-clis
       - run:
           name: Create namespace
           command: |
@@ -158,21 +161,20 @@ jobs:
           background: true
       - run:
           name: Start repo server
-          command: go run ./cmd/argocd-repo-server/main.go --loglevel debug --redis localhost:6379
+          command: ./dist/argocd-repo-server --loglevel debug --redis localhost:6379
           background: true
       - run:
           name: Start API server
-          command: go run ./cmd/argocd-server/main.go --loglevel debug --redis localhost:6379 --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ../argo-cd-ui/dist/app
+          command: ./dist/argocd-server --loglevel debug --redis localhost:6379 --insecure --dex-server http://localhost:5556 --repo-server localhost:8081 --staticassets ../argo-cd-ui/dist/app
           background: true
       - run:
           name: Start Test Git
-          command: |
-            test/fixture/testrepos/start-git.sh
+          command: test/fixture/testrepos/start-git.sh
           background: true
       - run: until curl -v http://localhost:8080/healthz; do sleep 10; done
       - run:
           name: Start controller
-          command: go run ./cmd/argocd-application-controller/main.go --loglevel debug --redis localhost:6379 --repo-server localhost:8081 --kubeconfig ~/.kube/config
+          command: ./dist/argocd-application-controller --loglevel debug --redis localhost:6379 --repo-server localhost:8081 --kubeconfig ~/.kube/config
           background: true
       - run:
           command: PATH=dist:$PATH make test-e2e
@@ -182,6 +184,7 @@ jobs:
             ARGOCD_E2E_K3S: "true"
       - save_vendor
       - save_go_cache
+      - upload_codecov
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,7 @@ jobs:
             killall argocd-server
             killall argocd-repo-server
           when: always
+      - run: ls
       - upload_codecov
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,8 @@ jobs:
             set -eux
             ps -aef | grep argocd-application-controller | grep -v grep | awk '{print $2}'
           when: always
-      - run: ls
+      - run:
+          command: ls
           when: always
       - upload_codecov
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           name: Kill services
           command: |
             set -eux
-            ps -aef | grep argocd-application-controller\|argocd-server\|argocd-repo-server | grep -v grep
+            ps -aef | grep 'argocd-application-controller\|argocd-server\|argocd-repo-server' | grep -v grep
              # | awk '{print $2}' | xargs kill
           when: always
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
     steps:
       - run:
           name: Uploading code coverage
-          command: bash <(curl -s https://codecov.io/bash) -f *.out -F {{ .Environment.CIRCLE_JOB }}
+          command: bash <(curl -s https://codecov.io/bash) -f *.out
           when: always
 jobs:
   codegen:
@@ -223,7 +223,7 @@ jobs:
       - run: yarn test
       - run:
           name: Upload code coverage
-          command: ./node_modules/.bin/codecov -p .. -F {{ .Environment.CIRCLE_JOB }}
+          command: ./node_modules/.bin/codecov -p ..
           when: always
       - run: NODE_ENV='production' yarn build
       - run: yarn lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,17 +191,14 @@ jobs:
       - save_vendor
       - save_go_cache
       - run:
-          name: Kill services
-          command: |
-            set -eux
-            ps -aef | grep 'argocd-application-controller\|argocd-server\|argocd-repo-server' | grep -v grep
-             # | awk '{print $2}' | xargs kill
+          name: Kill the services
+          # ...so they dump coverage files
+          command: ps -aef | grep 'argocd-application-controller\|argocd-server\|argocd-repo-server' | grep -v grep | awk '{print $2}' | xargs kill
           when: always
       - run:
-          command: |
-            ls
-            cat *.out > coverage.out
-
+          name: Create a combined coverage file
+          #  ...named such that is first in the directory listing, as that is the only file codecov will process
+          command: cat *.out > coverage.0.out
           when: always
       - upload_codecov
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           name: Kill services
           command: |
             set -eux
-            ps
+            ps -aef
             killall argocd-application-controller
             killall argocd-server
             killall argocd-repo-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           name: Kill services
           command: |
             set -eux
-            ps -aef | grep argocd-application-controller | grep -v grep | awk '{print #2}' | xargs kill
+            ps -aef | grep argocd-application-controller | grep -v grep | awk '{print $2}' | xargs kill
             pkill -u circleci argocd-server
             pkill -u circleci argocd-repo-server
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,9 +195,9 @@ jobs:
           command: |
             set -eux
             ps -aef
-            killall argocd-application-controller
-            killall argocd-server
-            killall argocd-repo-server
+            pkill -u circleci argocd-application-controller
+            pkill -u circleci argocd-server
+            pkill -u circleci argocd-repo-server
           when: always
       - run: ls
       - upload_codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
       ARGOCD_SSH_DATA_PATH: "/tmp/argo-e2e/app/config/ssh"
       ARGOCD_TLS_DATA_PATH: "/tmp/argo-e2e/app/config/tls"
     steps:
+      - run: pkill --helpgit
       - run:
           name: Install and start K3S v0.5.0
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
   save_go_cache:
     steps:
       - save_cache:
-          key: go-v1-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: go-v2-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           # https://circleci.com/docs/2.0/language-go/
           paths:
             - /home/circleci/.cache/go-build
@@ -44,6 +44,8 @@ commands:
     steps:
       - restore_cache:
           keys:
+            - go-v2-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+            - go-v2-master-{{ .Environment.CIRCLE_JOB }}
             - go-v1-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
             - go-v1-master-{{ .Environment.CIRCLE_JOB }}
   upload_codecov:
@@ -177,13 +179,16 @@ jobs:
           command: ./dist/argocd-application-controller --loglevel debug --redis localhost:6379 --repo-server localhost:8081 --kubeconfig ~/.kube/config
           background: true
       - run:
-          command: PATH=dist:$PATH make test-e2e
+          command: PATH=$(pwd)/dist:$PATH make test-e2e
           environment:
             ARGOCD_OPTS: "--server localhost:8080 --plaintext"
             ARGOCD_E2E_EXPECT_TIMEOUT: "30"
             ARGOCD_E2E_K3S: "true"
       - save_vendor
       - save_go_cache
+      - run: pkill argocd-repo-server
+      - run: pkill argocd-server
+      - run: pkill argocd-application-controller
       - upload_codecov
       - store_test_results:
           path: test-results

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,9 +15,3 @@ coverage:
       default:
         # allow test coverage to drop by 2%, assume that it's typically due to CI problems
         threshold: 2
-      e2e:
-        flags: e2e
-      test:
-        flags: test
-      ui:
-        flags: ui

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,3 +15,9 @@ coverage:
       default:
         # allow test coverage to drop by 2%, assume that it's typically due to CI problems
         threshold: 2
+      e2e:
+        flags: e2e
+      test:
+        flags: test
+      ui:
+        flags: ui

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ site/
 # delve debug binaries
 cmd/**/debug
 debug.test
-coverage.out
+/coverage*.out
 test-results

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ e2e-ns:
 	kubectl config set-context --current --namespace=argocd-e2e
 	kustomize build test/manifests/base | kubectl apply -f -
 
-.PHONY e2e-clis
+.PHONY: e2e-clis
 e2e-clis: e2e-cli e2e-server e2e-repo-server e2e-controller
 
 .PHONY: start-e2e

--- a/Procfile.e2e
+++ b/Procfile.e2e
@@ -1,0 +1,7 @@
+controller: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true ./dist/argocd-application-controller --loglevel debug --redis localhost:${ARGOCD_E2E_REDIS_PORT:-6379} --repo-server localhost:${ARGOCD_E2E_REPOSERVER_PORT:-8081}"
+api-server: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true ./dist/argocd-server --loglevel debug --redis localhost:${ARGOCD_E2E_REDIS_PORT:-6379} --disable-auth=${ARGOCD_E2E_DISABLE_AUTH:-'true'} --insecure --dex-server http://localhost:${ARGOCD_E2E_DEX_PORT:-5556} --repo-server localhost:${ARGOCD_E2E_REPOSERVER_PORT:-8081} --port ${ARGOCD_E2E_APISERVER_PORT:-8080} --staticassets ui/dist/app"
+dex: sh -c "go run ./cmd/argocd-util/main.go gendexcfg -o `pwd`/dist/dex.yaml && docker run --rm -p ${ARGOCD_E2E_DEX_PORT:-5556}:${ARGOCD_E2E_DEX_PORT:-5556} -v `pwd`/dist/dex.yaml:/dex.yaml quay.io/dexidp/dex:v2.14.0 serve /dex.yaml"
+redis: docker run --rm --name argocd-redis -i -p ${ARGOCD_E2E_REDIS_PORT:-6379}:${ARGOCD_E2E_REDIS_PORT:-6379} redis:5.0.3-alpine --save "" --appendonly no --port ${ARGOCD_E2E_REDIS_PORT:-6379}
+repo-server: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true ./dist/argocd-repo-server --loglevel debug --port ${ARGOCD_E2E_REPOSERVER_PORT:-8081} --redis localhost:${ARGOCD_E2E_REDIS_PORT:-6379}"
+ui: sh -c 'cd ui && ${ARGOCD_E2E_YARN_CMD:-yarn} start'
+git-server: test/fixture/testrepos/start-git.sh

--- a/cmd/argocd-application-controller/commands/root.go
+++ b/cmd/argocd-application-controller/commands/root.go
@@ -1,0 +1,119 @@
+package commands
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// load the gcp plugin (required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// load the oidc plugin (required to authenticate with OpenID Connect).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+
+	"github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/controller"
+	"github.com/argoproj/argo-cd/errors"
+	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
+	"github.com/argoproj/argo-cd/reposerver/apiclient"
+	appstatecache "github.com/argoproj/argo-cd/util/cache/appstate"
+	"github.com/argoproj/argo-cd/util/cli"
+	"github.com/argoproj/argo-cd/util/kube"
+	"github.com/argoproj/argo-cd/util/settings"
+	"github.com/argoproj/argo-cd/util/stats"
+)
+
+const (
+	// CLIName is the name of the CLI
+	cliName = "argocd-application-controller"
+	// Default time in seconds for application resync period
+	defaultAppResyncPeriod = 180
+)
+
+func NewCommand() *cobra.Command {
+	var (
+		clientConfig             clientcmd.ClientConfig
+		appResyncPeriod          int64
+		repoServerAddress        string
+		repoServerTimeoutSeconds int
+		selfHealTimeoutSeconds   int
+		statusProcessors         int
+		operationProcessors      int
+		logLevel                 string
+		glogLevel                int
+		metricsPort              int
+		kubectlParallelismLimit  int64
+		cacheSrc                 func() (*appstatecache.Cache, error)
+	)
+	var command = cobra.Command{
+		Use:   cliName,
+		Short: "application-controller is a controller to operate on applications CRD",
+		RunE: func(c *cobra.Command, args []string) error {
+			cli.SetLogLevel(logLevel)
+			cli.SetGLogLevel(glogLevel)
+
+			config, err := clientConfig.ClientConfig()
+			errors.CheckError(err)
+			config.QPS = common.K8sClientConfigQPS
+			config.Burst = common.K8sClientConfigBurst
+
+			kubeClient := kubernetes.NewForConfigOrDie(config)
+			appClient := appclientset.NewForConfigOrDie(config)
+
+			namespace, _, err := clientConfig.Namespace()
+			errors.CheckError(err)
+
+			resyncDuration := time.Duration(appResyncPeriod) * time.Second
+			repoClientset := apiclient.NewRepoServerClientset(repoServerAddress, repoServerTimeoutSeconds)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cache, err := cacheSrc()
+			errors.CheckError(err)
+
+			settingsMgr := settings.NewSettingsManager(ctx, kubeClient, namespace)
+			kubectl := kube.KubectlCmd{}
+			appController, err := controller.NewApplicationController(
+				namespace,
+				settingsMgr,
+				kubeClient,
+				appClient,
+				repoClientset,
+				cache,
+				kubectl,
+				resyncDuration,
+				time.Duration(selfHealTimeoutSeconds)*time.Second,
+				metricsPort,
+				kubectlParallelismLimit)
+			errors.CheckError(err)
+
+			log.Infof("Application Controller (version: %s) starting (namespace: %s)", common.GetVersion(), namespace)
+			stats.RegisterStackDumper()
+			stats.StartStatsTicker(10 * time.Minute)
+			stats.RegisterHeapDumper("memprofile")
+
+			go appController.Run(ctx, statusProcessors, operationProcessors)
+
+			// Wait forever
+			select {}
+		},
+	}
+
+	clientConfig = cli.AddKubectlFlagsToCmd(&command)
+	command.Flags().Int64Var(&appResyncPeriod, "app-resync", defaultAppResyncPeriod, "Time period in seconds for application resync.")
+	command.Flags().StringVar(&repoServerAddress, "repo-server", common.DefaultRepoServerAddr, "Repo server address.")
+	command.Flags().IntVar(&repoServerTimeoutSeconds, "repo-server-timeout-seconds", 60, "Repo server RPC call timeout seconds.")
+	command.Flags().IntVar(&statusProcessors, "status-processors", 1, "Number of application status processors")
+	command.Flags().IntVar(&operationProcessors, "operation-processors", 1, "Number of application operation processors")
+	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
+	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
+	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDMetrics, "Start metrics server on given port")
+	command.Flags().IntVar(&selfHealTimeoutSeconds, "self-heal-timeout-seconds", 5, "Specifies timeout between application self heal attempts")
+	command.Flags().Int64Var(&kubectlParallelismLimit, "kubectl-parallelism-limit", 20, "Number of allowed concurrent kubectl fork/execs. Any value less the 1 means no limit.")
+
+	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
+	return &command
+}

--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+
 	// load the gcp plugin (required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// load the oidc plugin (required to authenticate with OpenID Connect).

--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -1,127 +1,18 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"time"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-
 	// load the gcp plugin (required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// load the oidc plugin (required to authenticate with OpenID Connect).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	"github.com/argoproj/argo-cd/common"
-	"github.com/argoproj/argo-cd/controller"
-	"github.com/argoproj/argo-cd/errors"
-	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
-	"github.com/argoproj/argo-cd/reposerver/apiclient"
-	appstatecache "github.com/argoproj/argo-cd/util/cache/appstate"
-	"github.com/argoproj/argo-cd/util/cli"
-	"github.com/argoproj/argo-cd/util/kube"
-	"github.com/argoproj/argo-cd/util/settings"
-	"github.com/argoproj/argo-cd/util/stats"
+	"github.com/argoproj/argo-cd/cmd/argocd-application-controller/commands"
 )
-
-const (
-	// CLIName is the name of the CLI
-	cliName = "argocd-application-controller"
-	// Default time in seconds for application resync period
-	defaultAppResyncPeriod = 180
-)
-
-func newCommand() *cobra.Command {
-	var (
-		clientConfig             clientcmd.ClientConfig
-		appResyncPeriod          int64
-		repoServerAddress        string
-		repoServerTimeoutSeconds int
-		selfHealTimeoutSeconds   int
-		statusProcessors         int
-		operationProcessors      int
-		logLevel                 string
-		glogLevel                int
-		metricsPort              int
-		kubectlParallelismLimit  int64
-		cacheSrc                 func() (*appstatecache.Cache, error)
-	)
-	var command = cobra.Command{
-		Use:   cliName,
-		Short: "application-controller is a controller to operate on applications CRD",
-		RunE: func(c *cobra.Command, args []string) error {
-			cli.SetLogLevel(logLevel)
-			cli.SetGLogLevel(glogLevel)
-
-			config, err := clientConfig.ClientConfig()
-			errors.CheckError(err)
-			config.QPS = common.K8sClientConfigQPS
-			config.Burst = common.K8sClientConfigBurst
-
-			kubeClient := kubernetes.NewForConfigOrDie(config)
-			appClient := appclientset.NewForConfigOrDie(config)
-
-			namespace, _, err := clientConfig.Namespace()
-			errors.CheckError(err)
-
-			resyncDuration := time.Duration(appResyncPeriod) * time.Second
-			repoClientset := apiclient.NewRepoServerClientset(repoServerAddress, repoServerTimeoutSeconds)
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			cache, err := cacheSrc()
-			errors.CheckError(err)
-
-			settingsMgr := settings.NewSettingsManager(ctx, kubeClient, namespace)
-			kubectl := kube.KubectlCmd{}
-			appController, err := controller.NewApplicationController(
-				namespace,
-				settingsMgr,
-				kubeClient,
-				appClient,
-				repoClientset,
-				cache,
-				kubectl,
-				resyncDuration,
-				time.Duration(selfHealTimeoutSeconds)*time.Second,
-				metricsPort,
-				kubectlParallelismLimit)
-			errors.CheckError(err)
-
-			log.Infof("Application Controller (version: %s) starting (namespace: %s)", common.GetVersion(), namespace)
-			stats.RegisterStackDumper()
-			stats.StartStatsTicker(10 * time.Minute)
-			stats.RegisterHeapDumper("memprofile")
-
-			go appController.Run(ctx, statusProcessors, operationProcessors)
-
-			// Wait forever
-			select {}
-		},
-	}
-
-	clientConfig = cli.AddKubectlFlagsToCmd(&command)
-	command.Flags().Int64Var(&appResyncPeriod, "app-resync", defaultAppResyncPeriod, "Time period in seconds for application resync.")
-	command.Flags().StringVar(&repoServerAddress, "repo-server", common.DefaultRepoServerAddr, "Repo server address.")
-	command.Flags().IntVar(&repoServerTimeoutSeconds, "repo-server-timeout-seconds", 60, "Repo server RPC call timeout seconds.")
-	command.Flags().IntVar(&statusProcessors, "status-processors", 1, "Number of application status processors")
-	command.Flags().IntVar(&operationProcessors, "operation-processors", 1, "Number of application operation processors")
-	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
-	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
-	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDMetrics, "Start metrics server on given port")
-	command.Flags().IntVar(&selfHealTimeoutSeconds, "self-heal-timeout-seconds", 5, "Specifies timeout between application self heal attempts")
-	command.Flags().Int64Var(&kubectlParallelismLimit, "kubectl-parallelism-limit", 20, "Number of allowed concurrent kubectl fork/execs. Any value less the 1 means no limit.")
-
-	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
-	return &command
-}
 
 func main() {
-	if err := newCommand().Execute(); err != nil {
+	if err := commands.NewCommand().Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/argocd-repo-server/commands/root.go
+++ b/cmd/argocd-repo-server/commands/root.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/errors"
+	"github.com/argoproj/argo-cd/reposerver"
+	reposervercache "github.com/argoproj/argo-cd/reposerver/cache"
+	"github.com/argoproj/argo-cd/reposerver/metrics"
+	"github.com/argoproj/argo-cd/util/cli"
+	"github.com/argoproj/argo-cd/util/stats"
+	"github.com/argoproj/argo-cd/util/tls"
+)
+
+const (
+	// CLIName is the name of the CLI
+	cliName = "argocd-repo-server"
+)
+
+func NewCommand() *cobra.Command {
+	var (
+		logLevel               string
+		parallelismLimit       int64
+		listenPort             int
+		metricsPort            int
+		cacheSrc               func() (*reposervercache.Cache, error)
+		tlsConfigCustomizerSrc func() (tls.ConfigCustomizer, error)
+	)
+	var command = cobra.Command{
+		Use:   cliName,
+		Short: "Run argocd-repo-server",
+		RunE: func(c *cobra.Command, args []string) error {
+			cli.SetLogLevel(logLevel)
+
+			tlsConfigCustomizer, err := tlsConfigCustomizerSrc()
+			errors.CheckError(err)
+
+			cache, err := cacheSrc()
+			errors.CheckError(err)
+
+			metricsServer := metrics.NewMetricsServer()
+			server, err := reposerver.NewServer(metricsServer, cache, tlsConfigCustomizer, parallelismLimit)
+			errors.CheckError(err)
+
+			grpc := server.CreateGRPC()
+			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", listenPort))
+			errors.CheckError(err)
+
+			http.Handle("/metrics", metricsServer.GetHandler())
+			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)) }()
+
+			log.Infof("argocd-repo-server %s serving on %s", common.GetVersion(), listener.Addr())
+			stats.RegisterStackDumper()
+			stats.StartStatsTicker(10 * time.Minute)
+			stats.RegisterHeapDumper("memprofile")
+			err = grpc.Serve(listener)
+			errors.CheckError(err)
+			return nil
+		},
+	}
+
+	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
+	command.Flags().Int64Var(&parallelismLimit, "parallelismlimit", 0, "Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit.")
+	command.Flags().IntVar(&listenPort, "port", common.DefaultPortRepoServer, "Listen on given port for incoming connections")
+	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortRepoServerMetrics, "Start metrics server on given port")
+	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
+	cacheSrc = reposervercache.AddCacheFlagsToCmd(&command)
+	return &command
+}

--- a/cmd/argocd-repo-server/main.go
+++ b/cmd/argocd-repo-server/main.go
@@ -2,82 +2,13 @@ package main
 
 import (
 	"fmt"
-	"net"
-	"net/http"
 	"os"
-	"time"
 
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
-	"github.com/argoproj/argo-cd/common"
-	"github.com/argoproj/argo-cd/errors"
-	"github.com/argoproj/argo-cd/reposerver"
-	reposervercache "github.com/argoproj/argo-cd/reposerver/cache"
-	"github.com/argoproj/argo-cd/reposerver/metrics"
-	"github.com/argoproj/argo-cd/util/cli"
-	"github.com/argoproj/argo-cd/util/stats"
-	"github.com/argoproj/argo-cd/util/tls"
+	"github.com/argoproj/argo-cd/cmd/argocd-repo-server/commands"
 )
-
-const (
-	// CLIName is the name of the CLI
-	cliName = "argocd-repo-server"
-)
-
-func newCommand() *cobra.Command {
-	var (
-		logLevel               string
-		parallelismLimit       int64
-		listenPort             int
-		metricsPort            int
-		cacheSrc               func() (*reposervercache.Cache, error)
-		tlsConfigCustomizerSrc func() (tls.ConfigCustomizer, error)
-	)
-	var command = cobra.Command{
-		Use:   cliName,
-		Short: "Run argocd-repo-server",
-		RunE: func(c *cobra.Command, args []string) error {
-			cli.SetLogLevel(logLevel)
-
-			tlsConfigCustomizer, err := tlsConfigCustomizerSrc()
-			errors.CheckError(err)
-
-			cache, err := cacheSrc()
-			errors.CheckError(err)
-
-			metricsServer := metrics.NewMetricsServer()
-			server, err := reposerver.NewServer(metricsServer, cache, tlsConfigCustomizer, parallelismLimit)
-			errors.CheckError(err)
-
-			grpc := server.CreateGRPC()
-			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", listenPort))
-			errors.CheckError(err)
-
-			http.Handle("/metrics", metricsServer.GetHandler())
-			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)) }()
-
-			log.Infof("argocd-repo-server %s serving on %s", common.GetVersion(), listener.Addr())
-			stats.RegisterStackDumper()
-			stats.StartStatsTicker(10 * time.Minute)
-			stats.RegisterHeapDumper("memprofile")
-			err = grpc.Serve(listener)
-			errors.CheckError(err)
-			return nil
-		},
-	}
-
-	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
-	command.Flags().Int64Var(&parallelismLimit, "parallelismlimit", 0, "Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit.")
-	command.Flags().IntVar(&listenPort, "port", common.DefaultPortRepoServer, "Listen on given port for incoming connections")
-	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortRepoServerMetrics, "Start metrics server on given port")
-	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
-	cacheSrc = reposervercache.AddCacheFlagsToCmd(&command)
-	return &command
-}
 
 func main() {
-	if err := newCommand().Execute(); err != nil {
+	if err := commands.NewCommand().Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/test/e2e/cmd/argocd-application-controller/main.go
+++ b/test/e2e/cmd/argocd-application-controller/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/argoproj/argo-cd/test/e2e/cmd"
+
+func main() {
+	cmd.Invoke("./dist/argocd-application-controller.test", "-test.coverprofile=coverage.argocd-controller.out")
+}

--- a/test/e2e/cmd/argocd-application-controller/root_test.go
+++ b/test/e2e/cmd/argocd-application-controller/root_test.go
@@ -1,0 +1,17 @@
+// +build e2efixtures
+
+package main
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/cmd/argocd-application-controller/commands"
+
+	"github.com/argoproj/argo-cd/test/e2e/cmd"
+)
+
+func TestArgoCDServer(t *testing.T) {
+	cmd.Wrap(func() error {
+		return commands.NewCommand().Execute()
+	})
+}

--- a/test/e2e/cmd/argocd-repo-server/main.go
+++ b/test/e2e/cmd/argocd-repo-server/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/argoproj/argo-cd/test/e2e/cmd"
+
+func main() {
+	cmd.Invoke("./dist/argocd-repo-server.test", "-test.coverprofile=coverage.argocd-repo-server.out")
+}

--- a/test/e2e/cmd/argocd-repo-server/root_test.go
+++ b/test/e2e/cmd/argocd-repo-server/root_test.go
@@ -1,0 +1,16 @@
+// +build e2efixtures
+
+package main
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/cmd/argocd-repo-server/commands"
+	"github.com/argoproj/argo-cd/test/e2e/cmd"
+)
+
+func TestArgoCDRepoServer(t *testing.T) {
+	cmd.Wrap(func() error {
+		return commands.NewCommand().Execute()
+	})
+}

--- a/test/e2e/cmd/argocd-server/main.go
+++ b/test/e2e/cmd/argocd-server/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/argoproj/argo-cd/test/e2e/cmd"
+
+func main() {
+	cmd.Invoke("./dist/argocd-server.test", "-test.coverprofile=coverage.argocd-server.out")
+}

--- a/test/e2e/cmd/argocd-server/root_test.go
+++ b/test/e2e/cmd/argocd-server/root_test.go
@@ -1,0 +1,16 @@
+// +build e2efixtures
+
+package main
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/cmd/argocd-server/commands"
+	"github.com/argoproj/argo-cd/test/e2e/cmd"
+)
+
+func TestArgoCDServer(t *testing.T) {
+	cmd.Wrap(func() error {
+		return commands.NewCommand().Execute()
+	})
+}

--- a/test/e2e/cmd/argocd/main.go
+++ b/test/e2e/cmd/argocd/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/argoproj/argo-cd/test/e2e/cmd"
+)
+
+func main() {
+	cmd.Invoke("argocd.test", fmt.Sprintf("-test.coverprofile=../../coverage.argocd.%v.out", os.Getpid()))
+}

--- a/test/e2e/cmd/argocd/main.go
+++ b/test/e2e/cmd/argocd/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"time"
 
 	"github.com/argoproj/argo-cd/test/e2e/cmd"
 )
 
 func main() {
-	cmd.Invoke("argocd.test", fmt.Sprintf("-test.coverprofile=../../coverage.argocd.%v.out", os.Getpid()))
+	cmd.Invoke("argocd.test", fmt.Sprintf("-test.coverprofile=../../coverage.argocd.%v.out", time.Now().Second()))
 }

--- a/test/e2e/cmd/argocd/root_test.go
+++ b/test/e2e/cmd/argocd/root_test.go
@@ -1,0 +1,16 @@
+// +build e2efixtures
+
+package main
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/cmd/argocd/commands"
+	"github.com/argoproj/argo-cd/test/e2e/cmd"
+)
+
+func TestArgoCD(t *testing.T) {
+	cmd.Wrap(func() error {
+		return commands.NewCommand().Execute()
+	})
+}

--- a/test/e2e/cmd/invoker.go
+++ b/test/e2e/cmd/invoker.go
@@ -32,7 +32,7 @@ func Wrap(block func() error) {
 	done := make(chan bool, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		_ = <-sigs
+		<-sigs
 		done <- true
 	}()
 	// fmt.Printf("%v", os.Args)

--- a/test/e2e/cmd/invoker.go
+++ b/test/e2e/cmd/invoker.go
@@ -30,7 +30,7 @@ func Invoke(name string, args ...string) {
 
 	for in.Scan() {
 		line := in.Text()
-		if !strings.HasPrefix(line, "coverage: ") {
+		if !strings.HasPrefix(line, "coverage: ") && line != "PASS" {
 			fmt.Println(line)
 		}
 	}

--- a/test/e2e/cmd/invoker.go
+++ b/test/e2e/cmd/invoker.go
@@ -16,6 +16,7 @@ const delimiter = "★"
 func Invoke(name string, args ...string) {
 	cmd := exec.Command(name, args...)
 	cmd.Env = append(os.Environ(), key+"="+strings.Join(os.Args[1:], delimiter))
+	cmd.Stdin = os.Stdin
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		panic(err)

--- a/test/e2e/cmd/invoker.go
+++ b/test/e2e/cmd/invoker.go
@@ -21,13 +21,10 @@ func Invoke(name string, args ...string) {
 		panic(err)
 	}
 	cmd.Stderr = os.Stderr
-
 	if err := cmd.Start(); err != nil {
 		panic(err)
 	}
-
 	in := bufio.NewScanner(stdout)
-
 	for in.Scan() {
 		line := in.Text()
 		if !strings.HasPrefix(line, "coverage: ") && line != "PASS" {
@@ -35,6 +32,10 @@ func Invoke(name string, args ...string) {
 		}
 	}
 	err = in.Err()
+	if err != nil {
+		panic(err)
+	}
+	err = cmd.Wait()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			os.Exit(ee.ExitCode())

--- a/test/e2e/cmd/invoker.go
+++ b/test/e2e/cmd/invoker.go
@@ -55,14 +55,12 @@ func Wrap(block func() error) {
 		<-sigs
 		done <- true
 	}()
-	// fmt.Printf("%v", os.Args)
 	args := os.Getenv(key)
 	if len(args) > 0 {
 		os.Args = append(os.Args[0:1], strings.Split(args, delimiter)...)
 	} else {
 		os.Args = os.Args[0:1]
 	}
-	// fmt.Printf("%v", os.Args)
 	go func() {
 		err := block()
 		if err != nil {


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

### Goal

Improve our ability to assess the quality of CLI code changes (both the `argocd` binary, and the `argocd-*` binaries.

### Implementation

This is clever stuff if I do say so myself and worthy of a blog post maybe.

For each binary we want to collect coverage on (e.g. `dist/argocd-server` we 

* We build new binary that take the CLI args, put them into and environment variable called `ARGS`, and then invoke a parallel command. E.g. `test/e2e/cmd/argocd/main.go`. This also redirects stdout/err, traps exit codes, and removes some output (e.g. "coverage: 25%" for the delegate command.
* We build a second set of binaries take different args to the original command (i.e. `go test` args). These are just standard Go test binaries, but we have a shim that reads the proper arguments for `$ARGS`. E.g. `test/e2e/cmd/argocd/root_test.go`. 

A test binary can only write a coverage file on SIGINT/EXIT, so that's why we have additional trap code for that. 