### PR TITLE
Simplify using Argo CD without users/SSO/UI (agent mode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ manifests-local:
 	./hack/update-manifests.sh
 
 .PHONY: manifests
-manifests:
+manifests: dev-tools-image
 	$(call run-in-dev-tool,make manifests-local IMAGE_TAG='${IMAGE_TAG}')
 
 

--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -61,5 +61,7 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", config.GetFlag("loglevel", "info"), "Set the logging level. One of: debug|info|warn|error")
 	command.PersistentFlags().StringSliceVarP(&clientOpts.Headers, "header", "H", []string{}, "Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)")
+	command.PersistentFlags().BoolVar(&clientOpts.PortForward, "port-forward", config.GetBoolFlag("port-forward"), "Connect to a random argocd-server port using port forwarding")
+	command.PersistentFlags().StringVar(&clientOpts.PortForwardNamespace, "port-forward-namespace", config.GetFlag("port-forward-namespace", ""), "Namespace name which should be used for port forwarding")
 	return command
 }

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -23,6 +23,13 @@ On GKE, you will need grant your account the ability to create new cluster roles
 kubectl create clusterrolebinding YOURNAME-cluster-admin-binding --clusterrole=cluster-admin --user=YOUREMAIL@gmail.com
 ```
 
+!!! note
+    If you are not interested in UI, SSO, multi-cluster management and just want to pull changes into the cluster then you can disable
+    authentication using `--disable-auth` flag and access Argo CD via CLI using `--port-forward` or `--port-forward-namespace` flags
+    and proceed to step [#6](#6-create-an-application-from-a-git-repository):
+    
+    `kubectl patch deploy argocd-server -n argocd -p '[{"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--disable-auth"}]' --type json`
+
 ## 2. Download Argo CD CLI
 
 Download the latest Argo CD version from [https://github.com/argoproj/argo-cd/releases/latest](https://github.com/argoproj/argo-cd/releases/latest). More detailed installation instructions can be found via the [CLI installation documentation](cli_installation.md).
@@ -113,13 +120,10 @@ An example repository containing a guestbook application is available at
 
 ### Creating Apps Via CLI
 
-~~~bash
-argocd app create guestbook \
-  --repo https://github.com/argoproj/argocd-example-apps.git \
-  --path guestbook \
-  --dest-server https://kubernetes.default.svc \
-  --dest-namespace default
-~~~
+!!! note
+    You can access Argo CD using port forwarding: add `--port-forward-namespace argocd` flag to every CLI command or set `ARGOCD_OPTS` environment variable: `export ARGOCD_OPTS='--port-forward-namespace argocd'`:
+
+    `argocd app create guestbook --repo https://github.com/argoproj/argocd-example-apps.git --path guestbook --dest-server https://kubernetes.default.svc --dest-namespace default`
 
 ### Creating Apps Via UI
 

--- a/pkg/apiclient/portforwarder.go
+++ b/pkg/apiclient/portforwarder.go
@@ -1,0 +1,95 @@
+package apiclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/argoproj/argo-cd/util"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+func portForward(podSelector string, namespace string) (int, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	overrides := clientcmd.ConfigOverrides{}
+	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return -1, err
+	}
+
+	if namespace == "" {
+		namespace, _, err = clientConfig.Namespace()
+		if err != nil {
+			return -1, err
+		}
+	}
+
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return -1, err
+	}
+
+	pods, err := clientSet.CoreV1().Pods(namespace).List(v1.ListOptions{
+		LabelSelector: podSelector,
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	if len(pods.Items) == 0 {
+		return -1, fmt.Errorf("cannot find argocd-server pod")
+	}
+
+	url := clientSet.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(pods.Items[0].Namespace).
+		Name(pods.Items[0].Name).
+		SubResource("portforward").URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return -1, errors.Wrap(err, "Could not create round tripper")
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
+
+	readyChan := make(chan struct{}, 1)
+	out := new(bytes.Buffer)
+	errOut := new(bytes.Buffer)
+
+	ln, err := net.Listen("tcp", "[::]:0")
+	if err != nil {
+		return -1, err
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	util.Close(ln)
+
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("%d:8080", port)}, context.Background().Done(), readyChan, out, errOut)
+	if err != nil {
+		return -1, err
+	}
+
+	go func() {
+		err = forwarder.ForwardPorts()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+	for range readyChan {
+	}
+	if len(errOut.String()) != 0 {
+		return -1, fmt.Errorf(errOut.String())
+	}
+	return port, nil
+}


### PR DESCRIPTION
PR simplifies the deployment of Argo CD in the agent mode. Following changes are implemented:

- added instructions to install argocd with authentication
- cli can access argocd using port forwarding:
```
argocd app list --port-forward
```