### PR TITLE
Adds support for the custom health checks for the new cert-manager API. Closes #2667

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -124,6 +124,29 @@ data:
         hs.status = "Progressing"
         hs.message = "Waiting for certificate"
         return hs
+    cert-manager.io/Certificate:
+      # Lua script for customizing the health status assessment
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Ready" and condition.status == "False" then
+                hs.status = "Degraded"
+                hs.message = condition.message
+                return hs
+              end
+              if condition.type == "Ready" and condition.status == "True" then
+                hs.status = "Healthy"
+                hs.message = condition.message
+                return hs
+              end
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for certificate"
+        return hs
     apps/Deployment:
       # List of Lua Scripts to introduce custom actions
       actions: |

--- a/docs/operator-manual/health.md
+++ b/docs/operator-manual/health.md
@@ -30,12 +30,12 @@ There are two ways to configure a custom health check. The next two sections des
 
 ### Way 1. Define a Custom Health Check in `argocd-cm` ConfigMap
 
-Custom health checks can be defined in `resource.customizations` field of `argocd-cm`. Following example demonstrates a health check for `certmanager.k8s.io/Certificate`.
+Custom health checks can be defined in `resource.customizations` field of `argocd-cm`. Following example demonstrates a health check for `cert-manager.io/Certificate`.
 
 ```yaml
 data:
   resource.customizations: |
-    certmanager.k8s.io/Certificate:
+    cert-manager.io/Certificate:
       health.lua: |
         hs = {}
         if obj.status ~= nil then

--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -54,7 +54,7 @@ metadata:
   name: argocd-server-ingress
   namespace: argocd
   annotations:
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"

--- a/resource_customizations/cert-manager.io/Certificate/health.lua
+++ b/resource_customizations/cert-manager.io/Certificate/health.lua
@@ -1,0 +1,21 @@
+hs = {}
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil then
+    for i, condition in ipairs(obj.status.conditions) do
+      if condition.type == "Ready" and condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = condition.message
+        return hs
+      end
+      if condition.type == "Ready" and condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = condition.message
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for certificate"
+return hs

--- a/resource_customizations/cert-manager.io/Certificate/health_test.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/health_test.yaml
@@ -1,0 +1,18 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: Waiting for certificate
+  inputPath: testdata/progressing_noStatus.yaml
+- healthStatus:
+    status: Degraded
+    message: 'Resource validation failed: spec.acme.config: Required value: no ACME
+      solver configuration specified for domain "cd.apps.argoproj.io"'
+  inputPath: testdata/degraded_configError.yaml
+- healthStatus:
+    status: Healthy
+    message: 'Certificate issued successfully'
+  inputPath: testdata/healthy_issued.yaml
+- healthStatus:
+    status: Healthy
+    message: 'Certificate renewed successfully'
+  inputPath: testdata/healthy_renewed.yaml

--- a/resource_customizations/cert-manager.io/Certificate/testdata/degraded_configError.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/testdata/degraded_configError.yaml
@@ -1,0 +1,35 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"cert-manager.io/v1alpha2","kind":"Certificate","metadata":{"annotations":{},"name":"test-cert","namespace":"argocd"},"spec":{"acme":{"config":[{"domains":["cd.apps.argoproj.io"],"http01":{"ingress":"http01"}}]},"commonName":"cd.apps.argoproj.io","dnsNames":["cd.apps.argoproj.io"],"issuerRef":{"kind":"Issuer","name":"argo-cd-issuer"}}}
+  creationTimestamp: "2019-02-15T18:17:06Z"
+  generation: 1
+  name: test-cert
+  namespace: argocd
+  resourceVersion: "68338442"
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/certificates/test-cert
+  uid: e6cfba50-314d-11e9-be3f-42010a800011
+spec:
+  acme:
+    config:
+    - domains:
+      - cd.apps.argoproj.io123
+      http01:
+        ingress: http01
+  commonName: cd.apps.argoproj.io
+  dnsNames:
+  - cd.apps.argoproj.io
+  issuerRef:
+    kind: Issuer
+    name: argo-cd-issuer
+  secretName: test-secret
+status:
+  conditions:
+  - lastTransitionTime: "2019-02-15T18:26:37Z"
+    message: 'Resource validation failed: spec.acme.config: Required value: no ACME
+      solver configuration specified for domain "cd.apps.argoproj.io"'
+    reason: ConfigError
+    status: "False"
+    type: Ready

--- a/resource_customizations/cert-manager.io/Certificate/testdata/healthy_issued.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/testdata/healthy_issued.yaml
@@ -1,0 +1,39 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  creationTimestamp: "2019-02-15T18:17:06Z"
+  generation: 1
+  name: test-cert
+  namespace: argocd
+  resourceVersion: "68337322"
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/certificates/test-cert
+  uid: e6cfba50-314d-11e9-be3f-42010a800011
+spec:
+  acme:
+    config:
+    - domains:
+      - cd.apps.argoproj.io
+      http01:
+        ingress: http01
+  commonName: cd.apps.argoproj.io
+  dnsNames:
+  - cd.apps.argoproj.io
+  issuerRef:
+    kind: Issuer
+    name: argo-cd-issuer
+  secretName: test-secret
+status:
+  acme:
+    order:
+      url: https://acme-v02.api.letsencrypt.org/acme/order/45250083/316944902
+  conditions:
+  - lastTransitionTime: "2019-02-15T18:21:10Z"
+    message: Order validated
+    reason: OrderValidated
+    status: "False"
+    type: ValidateFailed
+  - lastTransitionTime: null
+    message: Certificate issued successfully
+    reason: CertIssued
+    status: "True"
+    type: Ready

--- a/resource_customizations/cert-manager.io/Certificate/testdata/healthy_renewed.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/testdata/healthy_renewed.yaml
@@ -1,0 +1,39 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  creationTimestamp: '2018-11-07T00:06:12Z'
+  generation: 1
+  name: test-cert
+  namespace: argocd
+  resourceVersion: '64763033'
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/certificates/test-cert
+  uid: e6cfba50-314d-11e9-be3f-42010a800011
+spec:
+  acme:
+    config:
+      - domains:
+          - cd.apps.argoproj.io
+        http01:
+          ingress: http01
+  commonName: cd.apps.argoproj.io
+  dnsNames:
+    - cd.apps.argoproj.io
+  issuerRef:
+    kind: Issuer
+    name: argo-cd-issuer
+  secretName: test-secret
+status:
+  acme:
+    order:
+      url: 'https://acme-v02.api.letsencrypt.org/acme/order/45250083/298963150'
+  conditions:
+    - lastTransitionTime: '2019-02-03T09:48:13Z'
+      message: Certificate renewed successfully
+      reason: CertRenewed
+      status: 'True'
+      type: Ready
+    - lastTransitionTime: '2019-02-03T09:48:11Z'
+      message: Order validated
+      reason: OrderValidated
+      status: 'False'
+      type: ValidateFailed

--- a/resource_customizations/cert-manager.io/Certificate/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/testdata/progressing_noStatus.yaml
@@ -1,0 +1,24 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  creationTimestamp: '2018-11-07T00:06:12Z'
+  generation: 1
+  name: test-cert
+  namespace: argocd
+  resourceVersion: '64763033'
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/certificates/test-cert
+  uid: e6cfba50-314d-11e9-be3f-42010a800011
+spec:
+  acme:
+    config:
+      - domains:
+          - cd.apps.argoproj.io
+        http01:
+          ingress: http01
+  commonName: cd.apps.argoproj.io
+  dnsNames:
+    - cd.apps.argoproj.io
+  issuerRef:
+    kind: Issuer
+    name: argo-cd-issuer
+  secretName: test-secret

--- a/resource_customizations/cert-manager.io/Issuer/health.lua
+++ b/resource_customizations/cert-manager.io/Issuer/health.lua
@@ -1,0 +1,21 @@
+hs = {}
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil then
+    for i, condition in ipairs(obj.status.conditions) do
+      if condition.type == "Ready" and condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = condition.message
+        return hs
+      end
+      if condition.type == "Ready" and condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = condition.message
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Initializing issuer"
+return hs

--- a/resource_customizations/cert-manager.io/Issuer/health_test.yaml
+++ b/resource_customizations/cert-manager.io/Issuer/health_test.yaml
@@ -1,0 +1,14 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: Initializing issuer
+  inputPath: testdata/progressing_noStatus.yaml
+- healthStatus:
+    status: Healthy
+    message: The ACME account was registered with the ACME server
+  inputPath: testdata/healthy_registered.yaml
+- healthStatus:
+    status: Degraded
+    message: "Failed to verify ACME account: acme: : 404 page not found\n"
+  inputPath: testdata/degraded_acmeFailed.yaml
+

--- a/resource_customizations/cert-manager.io/Issuer/testdata/degraded_acmeFailed.yaml
+++ b/resource_customizations/cert-manager.io/Issuer/testdata/degraded_acmeFailed.yaml
@@ -1,0 +1,28 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  creationTimestamp: "2019-02-15T19:23:48Z"
+  generation: 1
+  name: test-issuer
+  namespace: argocd
+  resourceVersion: "68352438"
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/issuers/test-issuer
+  uid: 37f408e3-3157-11e9-be3f-42010a800011
+spec:
+  acme:
+    email: myemail@test.com
+    http01: {}
+    privateKeySecretRef:
+      key: ""
+      name: letsencrypt
+    server: https://acme-v02.api.letsencrypt.org/directory124
+status:
+  acme:
+    uri: ""
+  conditions:
+  - lastTransitionTime: "2019-02-15T19:23:53Z"
+    message: |
+      Failed to verify ACME account: acme: : 404 page not found
+    reason: ErrRegisterACMEAccount
+    status: "False"
+    type: Ready

--- a/resource_customizations/cert-manager.io/Issuer/testdata/healthy_registered.yaml
+++ b/resource_customizations/cert-manager.io/Issuer/testdata/healthy_registered.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  creationTimestamp: "2018-11-06T23:14:18Z"
+  generation: 1
+  name: test-issuer
+  namespace: argocd
+  resourceVersion: "48889060"
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/issuers/argo-cd-issuer
+  uid: b0045219-e219-11e8-9f93-42010a80021d
+spec:
+  acme:
+    email: myemail@test.com
+    http01: {}
+    privateKeySecretRef:
+      key: ""
+      name: letsencrypt
+    server: https://acme-v02.api.letsencrypt.org/directory
+status:
+  acme:
+    uri: https://acme-v02.api.letsencrypt.org/acme/acct/45250083
+  conditions:
+  - lastTransitionTime: "2018-12-06T06:42:59Z"
+    message: The ACME account was registered with the ACME server
+    reason: ACMEAccountRegistered
+    status: "True"
+    type: Ready

--- a/resource_customizations/cert-manager.io/Issuer/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/cert-manager.io/Issuer/testdata/progressing_noStatus.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  creationTimestamp: "2018-11-06T23:14:18Z"
+  generation: 1
+  name: test-issuer
+  namespace: argocd
+  resourceVersion: "48889060"
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/issuers/argo-cd-issuer
+  uid: b0045219-e219-11e8-9f93-42010a80021d
+spec:
+  acme:
+    email: myemail@test.com
+    http01: {}
+    privateKeySecretRef:
+      key: ""
+      name: letsencrypt
+    server: https://acme-v02.api.letsencrypt.org/directory

--- a/util/argo/diff_normalizer_test.go
+++ b/util/argo/diff_normalizer_test.go
@@ -79,9 +79,9 @@ const testCRDYAML = `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: certificates.certmanager.k8s.io
+  name: certificates.cert-manager.io
 spec:
-  group: certmanager.k8s.io
+  group: cert-manager.io
   names:
     kind: Certificate
     listKind: CertificateList

--- a/util/health/testdata/apiservice-v1-false.yaml
+++ b/util/health/testdata/apiservice-v1-false.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.admission.certmanager.k8s.io
+  name: v1beta1.admission.cert-manager.io
   labels:
     app: webhook
     app.kubernetes.io/instance: external-dns
 spec:
-  group: admission.certmanager.k8s.io
+  group: admission.cert-manager.io
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/util/health/testdata/apiservice-v1-true.yaml
+++ b/util/health/testdata/apiservice-v1-true.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.admission.certmanager.k8s.io
+  name: v1beta1.admission.cert-manager.io
   labels:
     app: webhook
     app.kubernetes.io/instance: external-dns
 spec:
-  group: admission.certmanager.k8s.io
+  group: admission.cert-manager.io
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/util/health/testdata/apiservice-v1beta1-false.yaml
+++ b/util/health/testdata/apiservice-v1beta1-false.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1beta1.admission.certmanager.k8s.io
+  name: v1beta1.admission.cert-manager.io
   labels:
     app: webhook
     app.kubernetes.io/instance: external-dns
 spec:
-  group: admission.certmanager.k8s.io
+  group: admission.cert-manager.io
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/util/health/testdata/apiservice-v1beta1-true.yaml
+++ b/util/health/testdata/apiservice-v1beta1-true.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1beta1.admission.certmanager.k8s.io
+  name: v1beta1.admission.cert-manager.io
   labels:
     app: webhook
     app.kubernetes.io/instance: external-dns
 spec:
-  group: admission.certmanager.k8s.io
+  group: admission.cert-manager.io
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:


### PR DESCRIPTION
For #2667 , this pull request made the following changes:
- add custom health checks for the new cert-manager API
- replace old API with new API in documents and tests

Please review if you have time.

Checklist:
* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Closes #2667