### PR TITLE
Remove references to argocd-ui image during manifests generation

### DIFF
--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -25,8 +25,8 @@ if [ "$IMAGE_TAG" = "" ]; then
   IMAGE_TAG=latest
 fi
 
-cd ${SRCROOT}/manifests/base && kustomize edit set image argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG} argoproj/argocd-ui=${IMAGE_NAMESPACE}/argocd-ui:${IMAGE_TAG}
-cd ${SRCROOT}/manifests/ha/base && kustomize edit set image argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG} argoproj/argocd-ui=${IMAGE_NAMESPACE}/argocd-ui:${IMAGE_TAG}
+cd ${SRCROOT}/manifests/base && kustomize edit set image argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
+cd ${SRCROOT}/manifests/ha/base && kustomize edit set image argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
 
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install.yaml"
 kustomize build "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifests/install.yaml"

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -6,9 +6,6 @@ images:
 - name: argoproj/argocd
   newName: argoproj/argocd
   newTag: latest
-- name: argoproj/argocd-ui
-  newName: argoproj/argocd-ui
-  newTag: latest
 resources:
 - ./application-controller
 - ./dex

--- a/manifests/ha/base/kustomization.yaml
+++ b/manifests/ha/base/kustomization.yaml
@@ -12,9 +12,6 @@ images:
 - name: argoproj/argocd
   newName: argoproj/argocd
   newTag: latest
-- name: argoproj/argocd-ui
-  newName: argoproj/argocd-ui
-  newTag: latest
 resources:
 - ../../base/application-controller
 - ../../base/dex


### PR DESCRIPTION
Docker image argocd-ui is no longer used and is not present in YAML manifests; however, there was still references to it in the manifest generation workflow.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
