### PR TITLE
Set X-Frame-Options on serving static assets (#2706)

### DIFF
--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -36,6 +36,7 @@ func NewCommand() *cobra.Command {
 		disableAuth              bool
 		tlsConfigCustomizerSrc   func() (tls.ConfigCustomizer, error)
 		cacheSrc                 func() (*servercache.Cache, error)
+		frameOptions             string
 	)
 	var command = &cobra.Command{
 		Use:   cliName,
@@ -76,6 +77,7 @@ func NewCommand() *cobra.Command {
 				DisableAuth:         disableAuth,
 				TLSConfigCustomizer: tlsConfigCustomizer,
 				Cache:               cache,
+				XFrameOptions:       frameOptions,
 			}
 
 			stats.RegisterStackDumper()
@@ -105,6 +107,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().IntVar(&listenPort, "port", common.DefaultPortAPIServer, "Listen on given port")
 	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDAPIServerMetrics, "Start metrics on given port")
 	command.Flags().IntVar(&repoServerTimeoutSeconds, "repo-server-timeout-seconds", 60, "Repo server RPC call timeout seconds.")
+	command.Flags().StringVar(&frameOptions, "x-frame-options", "sameorigin", "Set X-Frame-Options header in HTTP responses to `value`. To disable, set to \"\".")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(command)
 	cacheSrc = servercache.AddCacheFlagsToCmd(command)
 	return command

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -486,6 +486,9 @@ func Test_StaticHeaders(t *testing.T) {
 		err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
 		assert.NoError(t, err)
 
+		// Allow server startup
+		time.Sleep(1 * time.Second)
+
 		client := http.Client{}
 		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", port)
 		req, err := http.NewRequest("GET", url, nil)
@@ -513,6 +516,9 @@ func Test_StaticHeaders(t *testing.T) {
 		err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
 		assert.NoError(t, err)
 
+		// Allow server startup
+		time.Sleep(1 * time.Second)
+
 		client := http.Client{}
 		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", port)
 		req, err := http.NewRequest("GET", url, nil)
@@ -539,6 +545,9 @@ func Test_StaticHeaders(t *testing.T) {
 
 		err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
 		assert.NoError(t, err)
+
+		// Allow server startup
+		time.Sleep(1 * time.Second)
 
 		client := http.Client{}
 		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", port)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -37,11 +38,13 @@ func fakeServer() *ArgoCDServer {
 	appClientSet := apps.NewSimpleClientset()
 
 	argoCDOpts := ArgoCDServerOpts{
-		Namespace:     test.FakeArgoCDNamespace,
-		KubeClientset: kubeclientset,
-		AppClientset:  appClientSet,
-		Insecure:      true,
-		DisableAuth:   true,
+		Namespace:       test.FakeArgoCDNamespace,
+		KubeClientset:   kubeclientset,
+		AppClientset:    appClientSet,
+		Insecure:        true,
+		DisableAuth:     true,
+		StaticAssetsDir: "../test/testdata/static",
+		XFrameOptions:   "sameorigin",
 	}
 	return NewServer(context.Background(), argoCDOpts)
 }
@@ -462,6 +465,88 @@ func TestAuthenticate(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func Test_StaticHeaders(t *testing.T) {
+	// Test default policy "sameorigin"
+	{
+		s := fakeServer()
+		cancelInformer := test.StartInformer(s.projInformer)
+		defer cancelInformer()
+		port, err := test.GetFreePort()
+		assert.NoError(t, err)
+		metricsPort, err := test.GetFreePort()
+		assert.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go s.Run(ctx, port, metricsPort)
+		defer func() { time.Sleep(3 * time.Second) }()
+
+		err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
+		assert.NoError(t, err)
+
+		client := http.Client{}
+		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", port)
+		req, err := http.NewRequest("GET", url, nil)
+		assert.NoError(t, err)
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "sameorigin", resp.Header.Get("X-Frame-Options"))
+	}
+
+	// Test custom policy
+	{
+		s := fakeServer()
+		s.XFrameOptions = "deny"
+		cancelInformer := test.StartInformer(s.projInformer)
+		defer cancelInformer()
+		port, err := test.GetFreePort()
+		assert.NoError(t, err)
+		metricsPort, err := test.GetFreePort()
+		assert.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go s.Run(ctx, port, metricsPort)
+		defer func() { time.Sleep(3 * time.Second) }()
+
+		err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
+		assert.NoError(t, err)
+
+		client := http.Client{}
+		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", port)
+		req, err := http.NewRequest("GET", url, nil)
+		assert.NoError(t, err)
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "deny", resp.Header.Get("X-Frame-Options"))
+	}
+
+	// Test disabled
+	{
+		s := fakeServer()
+		s.XFrameOptions = ""
+		cancelInformer := test.StartInformer(s.projInformer)
+		defer cancelInformer()
+		port, err := test.GetFreePort()
+		assert.NoError(t, err)
+		metricsPort, err := test.GetFreePort()
+		assert.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go s.Run(ctx, port, metricsPort)
+		defer func() { time.Sleep(3 * time.Second) }()
+
+		err = test.WaitForPortListen(fmt.Sprintf("127.0.0.1:%d", port), 10*time.Second)
+		assert.NoError(t, err)
+
+		client := http.Client{}
+		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", port)
+		req, err := http.NewRequest("GET", url, nil)
+		assert.NoError(t, err)
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Empty(t, resp.Header.Get("X-Frame-Options"))
 	}
 }
 

--- a/test/testdata/static/test.html
+++ b/test/testdata/static/test.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Static test asset page</title>
+  </head>
+  <body>
+    <h1>This is a static page.</h1>
+  </body>
+</html>


### PR DESCRIPTION
Checklist:

* [x] This is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

This PR addresses one of the issues described in #2706 and adds a `X-Frame-Options` header to requests serving static assets (such as the web UI). 

The default value for the added header is `samesite`, but this can be controlled by the `--x-frame-options` switch to `argocd-server` command. If `--x-frame-options ""` is given, the header will not be send at all, otherwise the header's content will be the argument to the switch (i.e. `deny` or `allow-url http://foobar`).