### PR TITLE
Clarify the need for namespace during export

### DIFF
--- a/docs/operator-manual/disaster_recovery.md
+++ b/docs/operator-manual/disaster_recovery.md
@@ -23,3 +23,6 @@ Import from a backup:
 ```bash
 docker run -v ~/.kube:/home/argocd/.kube --rm argoproj/argocd:$VERSION argocd-util import - < backup.yaml
 ```
+
+!!! note
+    If you are running Argo CD on a namespace different than default remember to pass the namespace parameter (-n <namespace>). 'argocd-util export' will not fail if you run it in the wrong namespace.


### PR DESCRIPTION
Clarify the need for a namespace if you are not using default, running 'argocd-util export' against the wrong namespace will still return a result, but won't be a valid backup

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
