### PR TITLE
Fix 'Open application' link when using basehref

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -156,7 +156,7 @@ export class App extends React.Component<{}, {popupProps: PopupProps; error: Err
                     <link rel='icon' type='image/png' href={`${base}assets/favicon/favicon-16x16.png`} sizes='16x16' />
                 </Helmet>
                 <PageContext.Provider value={{title: 'Argo CD'}}>
-                    <Provider value={{history, popup: this.popupManager, notifications: this.notificationsManager, navigation: this.navigationManager}}>
+                    <Provider value={{history, popup: this.popupManager, notifications: this.notificationsManager, navigation: this.navigationManager, baseHref: base}}>
                         {this.state.popupProps && <Popup {...this.state.popupProps} />}
                         <Router history={history}>
                             <Switch>

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import * as models from '../../../shared/models';
 
 import {EmptyState} from '../../../shared/components';
+import {Consumer} from '../../../shared/context';
 import {ApplicationURLs} from '../application-urls';
 import {ResourceIcon} from '../resource-icon';
 import {ComparisonStatusIcon, getAppOverridesCount, HealthStatusIcon, isAppNode, NodeId, nodeKey} from '../utils';
@@ -214,9 +215,13 @@ function renderResourceNode(props: ApplicationResourceTreeProps, id: string, nod
                     {healthState != null && <HealthStatusIcon state={healthState} />}
                     {comparisonStatus != null && <ComparisonStatusIcon status={comparisonStatus} resource={!rootNode && node} />}
                     {appNode && !rootNode && (
-                        <a href={'/applications/' + node.name} title='Open application'>
-                            <i className='fa fa-external-link-alt' />
-                        </a>
+                        <Consumer>
+                            {ctx => (
+                                <a href={ctx.baseHref + 'applications/' + node.name} title='Open application'>
+                                    <i className='fa fa-external-link-alt' />
+                                </a>
+                            )}
+                        </Consumer>
                     )}
                     <ApplicationURLs urls={rootNode ? props.app.status.summary.externalURLs : node.networkingInfo && node.networkingInfo.externalURLs} />
                 </div>

--- a/ui/src/app/shared/context.ts
+++ b/ui/src/app/shared/context.ts
@@ -2,12 +2,13 @@ import {AppContext as ArgoAppContext, NavigationApi, NotificationsApi, PopupApi}
 import {History} from 'history';
 import * as React from 'react';
 
-export type AppContext = ArgoAppContext & {apis: {popup: PopupApi; notifications: NotificationsApi; navigation: NavigationApi}};
+export type AppContext = ArgoAppContext & {apis: {popup: PopupApi; notifications: NotificationsApi; navigation: NavigationApi; baseHref: string}};
 
 export interface ContextApis {
     popup: PopupApi;
     notifications: NotificationsApi;
     navigation: NavigationApi;
+    baseHref: string;
 }
 
 export const {Provider, Consumer} = React.createContext<ContextApis & {history: History}>(null);


### PR DESCRIPTION
The link for accessing applications using an application of
applications didn't take into account when using a basehref
option.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
