### PR TITLE
Issue #2721 - cache parsed repositories, repo credentials to avoid unnecessary yaml parsing

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -111,6 +111,7 @@ func newFakeController(data *fakeData) *ApplicationController {
 	ctrl.stateCache = &mockStateCache
 	mockStateCache.On("IsNamespaced", mock.Anything, mock.Anything).Return(true, nil)
 	mockStateCache.On("GetManagedLiveObjs", mock.Anything, mock.Anything).Return(data.managedLiveObjs, nil)
+	mockStateCache.On("GetServerVersion", mock.Anything).Return("v1.2.3", nil)
 	response := make(map[kube.ResourceKey]argoappv1.ResourceNode)
 	for k, v := range data.namespacedResources {
 		response[k] = v.ResourceNode

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -28,7 +28,7 @@ type cacheSettings struct {
 
 type LiveStateCache interface {
 	// Returns k8s server version
-	GetServerVersion(server string) (string, error)
+	GetServerVersion(serverURL string) (string, error)
 	// Returns true of given group kind is a namespaced resource
 	IsNamespaced(server string, gk schema.GroupKind) (bool, error)
 	// Executes give callback against resource specified by the key and all its children
@@ -190,8 +190,8 @@ func (c *liveStateCache) GetManagedLiveObjs(a *appv1.Application, targetObjs []*
 	}
 	return clusterInfo.getManagedLiveObjs(a, targetObjs, c.metricsServer)
 }
-func (c *liveStateCache) GetServerVersion(server string) (string, error) {
-	clusterInfo, err := c.getSyncedCluster(server)
+func (c *liveStateCache) GetServerVersion(serverURL string) (string, error) {
+	clusterInfo, err := c.getSyncedCluster(serverURL)
 	if err != nil {
 		return "", err
 	}

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -27,6 +27,9 @@ type cacheSettings struct {
 }
 
 type LiveStateCache interface {
+	// Returns k8s server version
+	GetServerVersion(server string) (string, error)
+	// Returns true of given group kind is a namespaced resource
 	IsNamespaced(server string, gk schema.GroupKind) (bool, error)
 	// Executes give callback against resource specified by the key and all its children
 	IterateHierarchy(server string, key kube.ResourceKey, action func(child appv1.ResourceNode, appName string)) error
@@ -186,6 +189,13 @@ func (c *liveStateCache) GetManagedLiveObjs(a *appv1.Application, targetObjs []*
 		return nil, err
 	}
 	return clusterInfo.getManagedLiveObjs(a, targetObjs, c.metricsServer)
+}
+func (c *liveStateCache) GetServerVersion(server string) (string, error) {
+	clusterInfo, err := c.getSyncedCluster(server)
+	if err != nil {
+		return "", err
+	}
+	return clusterInfo.serverVersion, nil
 }
 
 func isClusterHasApps(apps []interface{}, cluster *appv1.Cluster) bool {

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetServerVersion(t *testing.T) {
+	now := time.Now()
+	cache := &liveStateCache{
+		lock: &sync.Mutex{},
+		clusters: map[string]*clusterInfo{
+			"http://localhost": {
+				syncTime:      &now,
+				syncLock:      &sync.Mutex{},
+				lock:          &sync.Mutex{},
+				serverVersion: "123",
+			},
+		}}
+
+	version, err := cache.GetServerVersion("http://localhost")
+	assert.NoError(t, err)
+	assert.Equal(t, "123", version)
+}

--- a/controller/cache/mocks/LiveStateCache.go
+++ b/controller/cache/mocks/LiveStateCache.go
@@ -5,9 +5,8 @@ package mocks
 import (
 	context "context"
 
-	mock "github.com/stretchr/testify/mock"
-
 	kube "github.com/argoproj/argo-cd/util/kube"
+	mock "github.com/stretchr/testify/mock"
 
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -60,6 +59,27 @@ func (_m *LiveStateCache) GetNamespaceTopLevelResources(server string, namespace
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, string) error); ok {
 		r1 = rf(server, namespace)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetServerVersion provides a mock function with given fields: server
+func (_m *LiveStateCache) GetServerVersion(server string) (string, error) {
+	ret := _m.Called(server)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(server)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(server)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/controller/state.go
+++ b/controller/state.go
@@ -128,11 +128,7 @@ func (m *appStateManager) getRepoObjs(app *v1alpha1.Application, source v1alpha1
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	cluster, err := m.db.GetCluster(context.Background(), app.Spec.Destination.Server)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	cluster.ServerVersion, err = m.kubectl.GetServerVersion(cluster.RESTConfig())
+	serverVersion, err := m.liveStateCache.GetServerVersion(app.Spec.Destination.Server)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -149,7 +145,7 @@ func (m *appStateManager) getRepoObjs(app *v1alpha1.Application, source v1alpha1
 		KustomizeOptions: &appv1.KustomizeOptions{
 			BuildOptions: buildOptions,
 		},
-		KubeVersion: cluster.ServerVersion,
+		KubeVersion: serverVersion,
 	})
 	if err != nil {
 		return nil, nil, nil, err

--- a/util/db/mocks/ArgoDB.go
+++ b/util/db/mocks/ArgoDB.go
@@ -5,9 +5,8 @@ package mocks
 import (
 	context "context"
 
-	mock "github.com/stretchr/testify/mock"
-
 	db "github.com/argoproj/argo-cd/util/db"
+	mock "github.com/stretchr/testify/mock"
 
 	v1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 )
@@ -40,6 +39,29 @@ func (_m *ArgoDB) CreateCluster(ctx context.Context, c *v1alpha1.Cluster) (*v1al
 	return r0, r1
 }
 
+// CreateRepoCertificate provides a mock function with given fields: ctx, certificate, upsert
+func (_m *ArgoDB) CreateRepoCertificate(ctx context.Context, certificate *v1alpha1.RepositoryCertificateList, upsert bool) (*v1alpha1.RepositoryCertificateList, error) {
+	ret := _m.Called(ctx, certificate, upsert)
+
+	var r0 *v1alpha1.RepositoryCertificateList
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.RepositoryCertificateList, bool) *v1alpha1.RepositoryCertificateList); ok {
+		r0 = rf(ctx, certificate, upsert)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.RepositoryCertificateList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *v1alpha1.RepositoryCertificateList, bool) error); ok {
+		r1 = rf(ctx, certificate, upsert)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateRepository provides a mock function with given fields: ctx, r
 func (_m *ArgoDB) CreateRepository(ctx context.Context, r *v1alpha1.Repository) (*v1alpha1.Repository, error) {
 	ret := _m.Called(ctx, r)
@@ -63,13 +85,36 @@ func (_m *ArgoDB) CreateRepository(ctx context.Context, r *v1alpha1.Repository) 
 	return r0, r1
 }
 
-// DeleteCluster provides a mock function with given fields: ctx, name
-func (_m *ArgoDB) DeleteCluster(ctx context.Context, name string) error {
-	ret := _m.Called(ctx, name)
+// CreateRepositoryCredentials provides a mock function with given fields: ctx, r
+func (_m *ArgoDB) CreateRepositoryCredentials(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error) {
+	ret := _m.Called(ctx, r)
+
+	var r0 *v1alpha1.RepoCreds
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.RepoCreds) *v1alpha1.RepoCreds); ok {
+		r0 = rf(ctx, r)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.RepoCreds)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *v1alpha1.RepoCreds) error); ok {
+		r1 = rf(ctx, r)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteCluster provides a mock function with given fields: ctx, server
+func (_m *ArgoDB) DeleteCluster(ctx context.Context, server string) error {
+	ret := _m.Called(ctx, server)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, name)
+		r0 = rf(ctx, server)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -91,13 +136,27 @@ func (_m *ArgoDB) DeleteRepository(ctx context.Context, name string) error {
 	return r0
 }
 
-// GetCluster provides a mock function with given fields: ctx, name
-func (_m *ArgoDB) GetCluster(ctx context.Context, name string) (*v1alpha1.Cluster, error) {
+// DeleteRepositoryCredentials provides a mock function with given fields: ctx, name
+func (_m *ArgoDB) DeleteRepositoryCredentials(ctx context.Context, name string) error {
 	ret := _m.Called(ctx, name)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GetCluster provides a mock function with given fields: ctx, server
+func (_m *ArgoDB) GetCluster(ctx context.Context, server string) (*v1alpha1.Cluster, error) {
+	ret := _m.Called(ctx, server)
 
 	var r0 *v1alpha1.Cluster
 	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.Cluster); ok {
-		r0 = rf(ctx, name)
+		r0 = rf(ctx, server)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1alpha1.Cluster)
@@ -106,7 +165,7 @@ func (_m *ArgoDB) GetCluster(ctx context.Context, name string) (*v1alpha1.Cluste
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
+		r1 = rf(ctx, server)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -114,16 +173,39 @@ func (_m *ArgoDB) GetCluster(ctx context.Context, name string) (*v1alpha1.Cluste
 	return r0, r1
 }
 
-// GetRepository provides a mock function with given fields: ctx, name
-func (_m *ArgoDB) GetRepository(ctx context.Context, name string) (*v1alpha1.Repository, error) {
-	ret := _m.Called(ctx, name)
+// GetRepository provides a mock function with given fields: ctx, url
+func (_m *ArgoDB) GetRepository(ctx context.Context, url string) (*v1alpha1.Repository, error) {
+	ret := _m.Called(ctx, url)
 
 	var r0 *v1alpha1.Repository
 	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.Repository); ok {
-		r0 = rf(ctx, name)
+		r0 = rf(ctx, url)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1alpha1.Repository)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, url)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetRepositoryCredentials provides a mock function with given fields: ctx, name
+func (_m *ArgoDB) GetRepositoryCredentials(ctx context.Context, name string) (*v1alpha1.RepoCreds, error) {
+	ret := _m.Called(ctx, name)
+
+	var r0 *v1alpha1.RepoCreds
+	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.RepoCreds); ok {
+		r0 = rf(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.RepoCreds)
 		}
 	}
 
@@ -160,6 +242,52 @@ func (_m *ArgoDB) ListClusters(ctx context.Context) (*v1alpha1.ClusterList, erro
 	return r0, r1
 }
 
+// ListHelmRepositories provides a mock function with given fields: ctx
+func (_m *ArgoDB) ListHelmRepositories(ctx context.Context) ([]*v1alpha1.Repository, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []*v1alpha1.Repository
+	if rf, ok := ret.Get(0).(func(context.Context) []*v1alpha1.Repository); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*v1alpha1.Repository)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListRepoCertificates provides a mock function with given fields: ctx, selector
+func (_m *ArgoDB) ListRepoCertificates(ctx context.Context, selector *db.CertificateListSelector) (*v1alpha1.RepositoryCertificateList, error) {
+	ret := _m.Called(ctx, selector)
+
+	var r0 *v1alpha1.RepositoryCertificateList
+	if rf, ok := ret.Get(0).(func(context.Context, *db.CertificateListSelector) *v1alpha1.RepositoryCertificateList); ok {
+		r0 = rf(ctx, selector)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.RepositoryCertificateList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *db.CertificateListSelector) error); ok {
+		r1 = rf(ctx, selector)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListRepositories provides a mock function with given fields: ctx
 func (_m *ArgoDB) ListRepositories(ctx context.Context) ([]*v1alpha1.Repository, error) {
 	ret := _m.Called(ctx)
@@ -176,6 +304,52 @@ func (_m *ArgoDB) ListRepositories(ctx context.Context) ([]*v1alpha1.Repository,
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
 		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListRepositoryCredentials provides a mock function with given fields: ctx
+func (_m *ArgoDB) ListRepositoryCredentials(ctx context.Context) ([]string, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RemoveRepoCertificates provides a mock function with given fields: ctx, selector
+func (_m *ArgoDB) RemoveRepoCertificates(ctx context.Context, selector *db.CertificateListSelector) (*v1alpha1.RepositoryCertificateList, error) {
+	ret := _m.Called(ctx, selector)
+
+	var r0 *v1alpha1.RepositoryCertificateList
+	if rf, ok := ret.Get(0).(func(context.Context, *db.CertificateListSelector) *v1alpha1.RepositoryCertificateList); ok {
+		r0 = rf(ctx, selector)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.RepositoryCertificateList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *db.CertificateListSelector) error); ok {
+		r1 = rf(ctx, selector)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -221,6 +395,29 @@ func (_m *ArgoDB) UpdateRepository(ctx context.Context, r *v1alpha1.Repository) 
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *v1alpha1.Repository) error); ok {
+		r1 = rf(ctx, r)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateRepositoryCredentials provides a mock function with given fields: ctx, r
+func (_m *ArgoDB) UpdateRepositoryCredentials(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error) {
+	ret := _m.Called(ctx, r)
+
+	var r0 *v1alpha1.RepoCreds
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.RepoCreds) *v1alpha1.RepoCreds); ok {
+		r0 = rf(ctx, r)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.RepoCreds)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *v1alpha1.RepoCreds) error); ok {
 		r1 = rf(ctx, r)
 	} else {
 		r1 = ret.Error(1)

--- a/util/kube/kubetest/mock.go
+++ b/util/kube/kubetest/mock.go
@@ -21,6 +21,7 @@ type MockKubectlCmd struct {
 	Commands     map[string]KubectlOutput
 	Events       chan watch.Event
 	LastValidate bool
+	Version      string
 }
 
 func (k *MockKubectlCmd) GetAPIResources(config *rest.Config, resourceFilter kube.ResourceFilter) ([]kube.APIResourceInfo, error) {
@@ -58,7 +59,7 @@ func (k *MockKubectlCmd) ConvertToVersion(obj *unstructured.Unstructured, group,
 }
 
 func (k *MockKubectlCmd) GetServerVersion(config *rest.Config) (string, error) {
-	return "", nil
+	return k.Version, nil
 }
 
 func (k *MockKubectlCmd) SetOnKubectlRun(onKubectlRun func(command string) (util.Closer, error)) {

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -51,6 +51,17 @@ func TestSaveRepositories(t *testing.T) {
 	assert.ElementsMatch(t, repos, []Repository{{URL: "http://foo"}})
 }
 
+func TestSaveRepositoresNoConfigMap(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
+
+	err := settingsManager.SaveRepositories([]Repository{{URL: "http://foo"}})
+	assert.NoError(t, err)
+	cm, err := kubeClient.CoreV1().ConfigMaps("default").Get(common.ArgoCDConfigMapName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, cm.Data["repositories"], "- url: http://foo\n")
+}
+
 func TestSaveRepositoryCredentials(t *testing.T) {
 	kubeClient, settingsManager := fixtures(nil)
 	err := settingsManager.SaveRepositoryCredentials([]RepositoryCredentials{{URL: "http://foo"}})

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -45,6 +45,23 @@ func TestSaveRepositories(t *testing.T) {
 	cm, err := kubeClient.CoreV1().ConfigMaps("default").Get(common.ArgoCDConfigMapName, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, cm.Data["repositories"], "- url: http://foo\n")
+
+	repos, err := settingsManager.GetRepositories()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, repos, []Repository{{URL: "http://foo"}})
+}
+
+func TestSaveRepositoryCredentials(t *testing.T) {
+	kubeClient, settingsManager := fixtures(nil)
+	err := settingsManager.SaveRepositoryCredentials([]RepositoryCredentials{{URL: "http://foo"}})
+	assert.NoError(t, err)
+	cm, err := kubeClient.CoreV1().ConfigMaps("default").Get(common.ArgoCDConfigMapName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, cm.Data["repository.credentials"], "- url: http://foo\n")
+
+	creds, err := settingsManager.GetRepositoryCredentials()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, creds, []RepositoryCredentials{{URL: "http://foo"}})
 }
 
 func TestGetRepositoryCredentials(t *testing.T) {


### PR DESCRIPTION
Closes #2721


Once PR is merged the SettingManager is going to cache parsed repositories and repository credentials. In real live Argo CD might has hundreds of  connected repositories and YAML parsing consumes a lot of CPU