### PR TITLE
[doc] Add KSOPS to Secret Management List

### DIFF
--- a/docs/operator-manual/secret-management.md
+++ b/docs/operator-manual/secret-management.md
@@ -8,7 +8,7 @@ Argo CD is un-opinionated about how secrets are managed. There's many ways to do
 * [Helm Secrets](https://github.com/futuresimple/helm-secrets)
 * [Kustomize secret generator plugins](https://github.com/kubernetes-sigs/kustomize/blob/fd7a353df6cece4629b8e8ad56b71e30636f38fc/examples/kvSourceGoPlugin.md#secret-values-from-anywhere)
 * [aws-secret-operator](https://github.com/mumoshu/aws-secret-operator)
-* [KSOPS](https://github.com/viaduct-ai/kustomize-sops)
+* [KSOPS](https://github.com/viaduct-ai/kustomize-sops#argo-cd-integration)
 
 
 For discussion, see [#1364](https://github.com/argoproj/argo-cd/issues/1364)

--- a/docs/operator-manual/secret-management.md
+++ b/docs/operator-manual/secret-management.md
@@ -8,5 +8,7 @@ Argo CD is un-opinionated about how secrets are managed. There's many ways to do
 * [Helm Secrets](https://github.com/futuresimple/helm-secrets)
 * [Kustomize secret generator plugins](https://github.com/kubernetes-sigs/kustomize/blob/fd7a353df6cece4629b8e8ad56b71e30636f38fc/examples/kvSourceGoPlugin.md#secret-values-from-anywhere)
 * [aws-secret-operator](https://github.com/mumoshu/aws-secret-operator)
+* [KSOPS](https://github.com/viaduct-ai/kustomize-sops)
+
 
 For discussion, see [#1364](https://github.com/argoproj/argo-cd/issues/1364)


### PR DESCRIPTION
Other than the link to the `kustomize` secret generator docs, there is no example of an implemented `kustomize` secret plugin used with Argo CD. I thought [Viaduct's KSOPS plugin](https://github.com/viaduct-ai/kustomize-sops) could be helpful for future readers. 

Checklist:

* [x] (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
