### PR TITLE
Fix TestAutoSyncSelfHealEnabled test

### DIFF
--- a/test/e2e/app_autosync_test.go
+++ b/test/e2e/app_autosync_test.go
@@ -8,10 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/argoproj/argo-cd/errors"
-	"github.com/argoproj/argo-cd/test/e2e/fixture"
-	"github.com/argoproj/argo-cd/test/fixture/test"
-
 	. "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/test/e2e/fixture/app"
 )
 
@@ -42,7 +40,6 @@ func TestAutoSyncSelfHealDisabled(t *testing.T) {
 }
 
 func TestAutoSyncSelfHealEnabled(t *testing.T) {
-	test.Flaky(t)
 	Given(t).
 		Path(guestbookPath).
 		When().


### PR DESCRIPTION
Unable to test failure. I want to enable it again and wait until it fails to get logs.