### PR TITLE
fix: Add aliases for "rm" and "delete" commands in argocd cli

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1042,8 +1042,9 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 		cascade bool
 	)
 	var command = &cobra.Command{
-		Use:   "delete APPNAME",
-		Short: "Delete an application",
+		Use:     "delete APPNAME",
+		Short:   "Delete an application",
+		Aliases: []string{"rm", "del"},
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {
 				c.HelpFunc()(c, args)

--- a/cmd/argocd/commands/cert.go
+++ b/cmd/argocd/commands/cert.go
@@ -211,8 +211,9 @@ func NewCertRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 		certQuery   certificatepkg.RepositoryCertificateQuery
 	)
 	var command = &cobra.Command{
-		Use:   "rm REPOSERVER",
-		Short: "Remove certificate of TYPE for REPOSERVER",
+		Use:     "rm REPOSERVER",
+		Short:   "Remove certificate of TYPE for REPOSERVER",
+		Aliases: []string{"delete", "del"},
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) < 1 {
 				c.HelpFunc()(c, args)

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -269,6 +269,7 @@ func NewClusterRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 	var command = &cobra.Command{
 		Use:     "rm SERVER",
 		Short:   "Remove cluster credentials",
+		Aliases: []string{"del", "delete"},
 		Example: `argocd cluster rm https://12.34.567.89`,
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -479,8 +479,9 @@ func NewProjectRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *cobr
 // NewProjectDeleteCommand returns a new instance of an `argocd proj delete` command
 func NewProjectDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "delete PROJECT",
-		Short: "Delete project",
+		Use:     "delete PROJECT",
+		Aliases: []string{"del", "rm"},
+		Short:   "Delete project",
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {
 				c.HelpFunc()(c, args)

--- a/cmd/argocd/commands/repo.go
+++ b/cmd/argocd/commands/repo.go
@@ -184,8 +184,9 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 // NewRepoRemoveCommand returns a new instance of an `argocd repo list` command
 func NewRepoRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "rm REPO",
-		Short: "Remove repository credentials",
+		Use:     "rm REPO",
+		Short:   "Remove repository credentials",
+		Aliases: []string{"del", "delete"},
 		Run: func(c *cobra.Command, args []string) {
 			if len(args) == 0 {
 				c.HelpFunc()(c, args)


### PR DESCRIPTION
details
----------
- allows using "rm"/"delete"/"del" interchangeably for removing/deleting things in argocd-cli
- applies to app,cert,cluster,project and repo

Issue: #2921
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
