### PR TITLE
feat: Add support for ssh-with-port repo url (#2866)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1649,6 +1649,7 @@
     "tools/clientcmd/api/v1",
     "tools/metrics",
     "tools/pager",
+    "tools/portforward",
     "tools/reference",
     "tools/remotecommand",
     "tools/watch",
@@ -1853,6 +1854,7 @@
     "pkg/util/node",
     "pkg/util/parsers",
     "pkg/util/slice",
+    "pkg/util/workqueue/prometheus",
   ]
   pruneopts = ""
   revision = "bfafae8f1c2fdf3c3cfef04674db028531a7c098"
@@ -2020,6 +2022,7 @@
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
+    "k8s.io/api/networking/v1beta1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
@@ -2034,6 +2037,8 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/selection",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/jsonmergepatch",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/strategicpatch",
     "k8s.io/apimachinery/pkg/util/wait",
@@ -2056,6 +2061,8 @@
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/portforward",
+    "k8s.io/client-go/transport/spdy",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/go-to-protobuf",
@@ -2090,6 +2097,7 @@
     "k8s.io/kubernetes/pkg/kubectl/cmd/auth",
     "k8s.io/kubernetes/pkg/util/node",
     "k8s.io/kubernetes/pkg/util/slice",
+    "k8s.io/kubernetes/pkg/util/workqueue/prometheus",
     "k8s.io/utils/pointer",
     "layeh.com/gopher-json",
   ]

--- a/util/webhook/gitlab-event.json
+++ b/util/webhook/gitlab-event.json
@@ -1,0 +1,65 @@
+{
+  "object_kind": "push",
+  "event_name": "push",
+  "before": "e5ba5f6c13b64670048daa88e4c053d60b0e115a",
+  "after": "bb0748feaa336d841c251017e4e374c22d0c8a98",
+  "ref": "refs/heads/master",
+  "checkout_sha": "bb0748feaa336d841c251017e4e374c22d0c8a98",
+  "message": null,
+  "user_id": 1,
+  "user_name": "name",
+  "user_username": "username",
+  "user_email": "",
+  "user_avatar": "",
+  "project_id": 1,
+  "project": {
+    "id": 1,
+    "name": "project",
+    "description": "",
+    "web_url": "https://gitlab/group/name",
+    "avatar_url": null,
+    "git_ssh_url": "ssh://git@gitlab:2222/group/name.git",
+    "git_http_url": "https://gitlab/group/name.git",
+    "namespace": "group",
+    "visibility_level": 1,
+    "path_with_namespace": "group/name",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab/group/name",
+    "url": "ssh://git@gitlab:2222/group/name.git",
+    "ssh_url": "ssh://git@gitlab:2222/group/name.git",
+    "http_url": "https://gitlab/group/name.git"
+  },
+  "commits": [
+    {
+      "id": "bb0748feaa336d841c251017e4e374c22d0c8a98",
+      "message": "Test commit message\n",
+      "timestamp": "2020-01-06T03:47:55Z",
+      "url": "https://gitlab/group/name/commit/bb0748feaa336d841c251017e4e374c22d0c8a98",
+      "author": {
+        "name": "User",
+        "email": "user@example.com"
+      },
+      "added": [
+        "file.yaml"
+      ],
+      "modified": [
+      ],
+      "removed": [
+
+      ]
+    }
+  ],
+  "total_commits_count": 1,
+  "push_options": {
+  },
+  "repository": {
+    "name": "name",
+    "url": "ssh://git@gitlab:2222/group/name.git",
+    "description": "",
+    "homepage": "https://gitlab/group/name",
+    "git_http_url": "https://gitlab/group/name.git",
+    "git_ssh_url": "ssh://git@gitlab:2222/group/name.git",
+    "visibility_level": 10
+  }
+}

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -87,7 +87,6 @@ func affectedRevisionInfo(payloadIf interface{}) (string, string, bool) {
 		touchedHead = bool(payload.Repository.DefaultBranch == revision)
 	case gitlab.PushEventPayload:
 		// See: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
-		// NOTE: this is untested
 		webURL = payload.Project.WebURL
 		revision = parseRef(payload.Ref)
 		touchedHead = bool(payload.Project.DefaultBranch == revision)

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -158,7 +158,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload interface{}) {
 		log.Warnf("Failed to parse repoURL '%s'", webURL)
 		return
 	}
-	regexpStr := "(?i)(http://|https://|git@)" + urlObj.Host + "[:/]" + urlObj.Path[1:] + "(\\.git)?"
+	regexpStr := "(?i)(http://|https://|git@|ssh://git@)" + urlObj.Host + "(:[0-9]+|)[:/]" + urlObj.Path[1:] + "(\\.git)?"
 	repoRegexp, err := regexp.Compile(regexpStr)
 	if err != nil {
 		log.Warn("Failed to compile repoURL regexp")

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -81,3 +81,19 @@ func TestGogsPushEvent(t *testing.T) {
 	assert.Equal(t, expectedLogResult, hook.LastEntry().Message)
 	hook.Reset()
 }
+
+func TestGitLabPushEvent(t *testing.T) {
+	hook := test.NewGlobal()
+	h := NewMockHandler()
+	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req.Header.Set("X-Gitlab-Event", "Push Hook")
+	eventJSON, err := ioutil.ReadFile("gitlab-event.json")
+	assert.NoError(t, err)
+	req.Body = ioutil.NopCloser(bytes.NewReader(eventJSON))
+	w := httptest.NewRecorder()
+	h.Handler(w, req)
+	assert.Equal(t, w.Code, http.StatusOK)
+	expectedLogResult := "Received push event repo: https://gitlab/group/name, revision: master, touchedHead: true"
+	assert.Equal(t, expectedLogResult, hook.LastEntry().Message)
+	hook.Reset()
+}


### PR DESCRIPTION
Fixes #2866 . I also have added test file for Gitlab webhook format

Tested with Gitlab:

```
time="2020-01-07T02:22:49Z" level=info msg="Received push event repo: https://gitlab/namespace/project, revision: master, touchedHead: true"
time="2020-01-07T02:22:50Z" level=info msg="Requested app 'a' refresh"
time="2020-01-07T02:22:50Z" level=info msg="Requested app 'b' refresh"
time="2020-01-07T02:22:50Z" level=info msg="Requested app 'root' refresh"
```

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. - N/A
* [ ] Optional. My organization is added to the README. - We're in stage of testing out ArgoCD :)
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
