### PR TITLE
fix: Fixes username matching for SSH repositories for webhooks (fixes #2988)

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -158,7 +158,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload interface{}) {
 		log.Warnf("Failed to parse repoURL '%s'", webURL)
 		return
 	}
-	regexpStr := "(?i)(http://|https://|\w+@|ssh://(\w+@)?)" + urlObj.Host + "(:[0-9]+|)[:/]" + urlObj.Path[1:] + "(\\.git)?"
+	regexpStr := `(?i)(http://|https://|\w+@|ssh://(\w+@)?)` + urlObj.Host + "(:[0-9]+|)[:/]" + urlObj.Path[1:] + "(\\.git)?"
 	repoRegexp, err := regexp.Compile(regexpStr)
 	if err != nil {
 		log.Warn("Failed to compile repoURL regexp")

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -158,7 +158,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload interface{}) {
 		log.Warnf("Failed to parse repoURL '%s'", webURL)
 		return
 	}
-	regexpStr := "(?i)(http://|https://|git@|ssh://git@)" + urlObj.Host + "(:[0-9]+|)[:/]" + urlObj.Path[1:] + "(\\.git)?"
+	regexpStr := "(?i)(http://|https://|\w+@|ssh://(\w+@)?)" + urlObj.Host + "(:[0-9]+|)[:/]" + urlObj.Path[1:] + "(\\.git)?"
 	repoRegexp, err := regexp.Compile(regexpStr)
 	if err != nil {
 		log.Warn("Failed to compile repoURL regexp")


### PR DESCRIPTION
Checklist:

* [x] this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

This PR fixes the issue #2988 by changing the regex which is use while matching the repourls with the received webhook-url. With this change, it's possible to use a username other than git for ssh-repositories. It's also possible to use no username at all.


