### PR TITLE
feat: Add argocd cmd for Windows #2121

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,8 @@ RUN cd ${GOPATH}/src/dummy && \
 WORKDIR /go/src/github.com/argoproj/argo-cd
 COPY . .
 RUN make cli server controller repo-server argocd-util && \
-    make CLI_NAME=argocd-darwin-amd64 GOOS=darwin cli
+    make CLI_NAME=argocd-darwin-amd64 GOOS=darwin cli && \
+    make CLI_NAME=argocd-windows-amd64.exe GOOS=windows cli
 
 
 ####################################################################################################

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ release-cli: clean-debug image
 	docker create --name tmp-argocd-linux $(IMAGE_PREFIX)argocd:$(IMAGE_TAG)
 	docker cp tmp-argocd-linux:/usr/local/bin/argocd ${DIST_DIR}/argocd-linux-amd64
 	docker cp tmp-argocd-linux:/usr/local/bin/argocd-darwin-amd64 ${DIST_DIR}/argocd-darwin-amd64
+	docker cp tmp-argocd-linux:/usr/local/bin/argocd-windows-amd64.exe ${DIST_DIR}/argocd-windows-amd64.exe
 	docker rm tmp-argocd-linux
 
 .PHONY: argocd-util
@@ -134,6 +135,7 @@ image: packr
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 dist/packr build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-util ./cmd/argocd-util
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 dist/packr build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd ./cmd/argocd
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 dist/packr build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-darwin-amd64 ./cmd/argocd
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 dist/packr build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-windows-amd64.exe ./cmd/argocd
 	cp Dockerfile.dev dist
 	docker build -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG) -f dist/Dockerfile.dev dist
 else

--- a/cmd/argocd/commands/account.go
+++ b/cmd/argocd/commands/account.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
@@ -54,7 +53,7 @@ func NewAccountUpdatePasswordCommand(clientOpts *argocdclient.ClientOptions) *co
 
 			if currentPassword == "" {
 				fmt.Print("*** Enter current password: ")
-				password, err := terminal.ReadPassword(syscall.Stdin)
+				password, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 				errors.CheckError(err)
 				currentPassword = string(password)
 				fmt.Print("\n")

--- a/server/server.go
+++ b/server/server.go
@@ -640,6 +640,14 @@ func registerDownloadHandlers(mux *http.ServeMux, base string) {
 			http.ServeFile(w, r, darwinPath)
 		})
 	}
+	windowsPath, err := exec.LookPath("argocd-windows-amd64.exe")
+	if err != nil {
+		log.Warnf("argocd-windows-amd64 not in PATH")
+	} else {
+		mux.HandleFunc(base+"/argocd-windows-amd64.exe", func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, windowsPath)
+		})
+	}
 }
 
 func indexFilePath(srcPath string, baseHRef string) (string, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -642,7 +642,7 @@ func registerDownloadHandlers(mux *http.ServeMux, base string) {
 	}
 	windowsPath, err := exec.LookPath("argocd-windows-amd64.exe")
 	if err != nil {
-		log.Warnf("argocd-windows-amd64 not in PATH")
+		log.Warnf("argocd-windows-amd64.exe not in PATH")
 	} else {
 		mux.HandleFunc(base+"/argocd-windows-amd64.exe", func(w http.ResponseWriter, r *http.Request) {
 			http.ServeFile(w, r, windowsPath)

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -27,6 +27,10 @@ export const Help = () => (
                             <a href={`download/argocd-darwin-amd64`} className='argo-button argo-button--base'>
                                 <i className='fab fa-apple' /> macOS
                             </a>
+                            &nbsp;
+                            <a href={`download/argocd-windows-amd64.exe`} className='argo-button argo-button--base'>
+                                <i className='fab fa-windows' /> Windows
+                            </a>
                         </div>
                     </div>
                     <div className='columns large-4 small-6'>

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -91,7 +90,7 @@ func PromptMessage(message, value string) string {
 func PromptPassword(password string) string {
 	for password == "" {
 		fmt.Print("Password: ")
-		passwordRaw, err := terminal.ReadPassword(syscall.Stdin)
+		passwordRaw, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		errors.CheckError(err)
 		password = string(passwordRaw)
 		fmt.Print("\n")
@@ -120,13 +119,13 @@ func AskToProceed(message string) bool {
 func ReadAndConfirmPassword() (string, error) {
 	for {
 		fmt.Print("*** Enter new password: ")
-		password, err := terminal.ReadPassword(syscall.Stdin)
+		password, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", err
 		}
 		fmt.Print("\n")
 		fmt.Print("*** Confirm new password: ")
-		confirmPassword, err := terminal.ReadPassword(syscall.Stdin)
+		confirmPassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
ref: Need Windows argocd cmd #2121

I added the `argocd` command for Windows discussed in the above issue.
Could you review it when you have time?

I confirmed:
- This PR can be built on Ubuntu 18.04.
- The windows binary works on Windows 10 (64 bit).
- The windows binary can be downloaded from the `argocd-server`'s help page.
![help-download](https://user-images.githubusercontent.com/47380942/72879697-c1fce880-3d40-11ea-9124-5c3f2cc57ca1.png)

```
> .\argocd-windows-amd64.exe version
argocd: v1.4.0+be43ebe.dirty
  BuildDate: 2020-01-22T08:32:13Z
  GitCommit: be43ebe7554cee3c8dc0b7022e980c8711c4253c
  GitTreeState: dirty
  GoVersion: go1.12.6
  Compiler: gc
  Platform: windows/amd64
argocd-server: v1.4.0+be43ebe.dirty
  BuildDate: 2020-01-22T08:31:22Z
  GitCommit: be43ebe7554cee3c8dc0b7022e980c8711c4253c
  GitTreeState: dirty
  GoVersion: go1.12.6
  Compiler: gc
  Platform: linux/amd64
  Ksonnet Version: v0.13.1
  Kustomize Version: Version: {Version:kustomize/v3.2.1 GitCommit:d89b448c745937f0cf1936162f26a5aac688f840 BuildDate:2019-09-27T00:10:52Z GoOs:linux GoArch:amd64}
  Helm Version: v2.15.2
  Kubectl Version: v1.14.0
```

Checklist:

* [ ] (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community
  => Other user have created the enhancement proposal (#2121). And some users hope it.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
