### PR TITLE
fix: Hide bindPW in dex config

### DIFF
--- a/cmd/argocd-util/main.go
+++ b/cmd/argocd-util/main.go
@@ -109,7 +109,7 @@ func NewRunDexCommand() *cobra.Command {
 				} else {
 					err = ioutil.WriteFile("/tmp/dex.yaml", dexCfgBytes, 0644)
 					errors.CheckError(err)
-					log.Info(redactor(string(dexCfgBytes)))
+					log.Debug(redactor(string(dexCfgBytes)))
 					cmd = exec.Command("dex", "serve", "/tmp/dex.yaml")
 					cmd.Stdout = os.Stdout
 					cmd.Stderr = os.Stderr
@@ -640,7 +640,7 @@ func redactor(dirtyString string) string {
 	err := yaml.Unmarshal([]byte(dirtyString), &config)
 	errors.CheckError(err)
 	iterateStringFields(config, func(name string, val string) string {
-		if name == "clientSecret" || name == "secret" {
+		if name == "clientSecret" || name == "secret" || name == "bindPW" {
 			return "********"
 		} else {
 			return val

--- a/cmd/argocd-util/main_test.go
+++ b/cmd/argocd-util/main_test.go
@@ -18,6 +18,13 @@ connectors:
   id: github
   name: GitHub
   type: github
+- config:
+    bindDN: uid=serviceaccount,cn=users,dc=example,dc=com
+    bindPW: theSecret
+    host: ldap.example.com:636
+  id: ldap
+  name: LDAP
+  type: ldap
 grpc:
   addr: 0.0.0.0:5557
 issuer: https://argocd.example.com/api/dex
@@ -49,6 +56,13 @@ var expectedRedaction = `connectors:
   id: github
   name: GitHub
   type: github
+- config:
+    bindDN: uid=serviceaccount,cn=users,dc=example,dc=com
+    bindPW: '********'
+    host: ldap.example.com:636
+  id: ldap
+  name: LDAP
+  type: ldap
 grpc:
   addr: 0.0.0.0:5557
 issuer: https://argocd.example.com/api/dex


### PR DESCRIPTION
Like https://github.com/argoproj/argo-cd/issues/2536 , the DEX password for LDAP is being leaked in a command that prints configuration.
This change not only hides the bindPW but also changes the logging level to debug so that by default, the configuration is not leaked to logs.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
