### PR TITLE
fix: Better handling of K8s secrets for repository credentials & templates (#3016 #3028)

### DIFF
--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -55,7 +55,6 @@ var (
 	KubeClientset       kubernetes.Interface
 	AppClientset        appclientset.Interface
 	ArgoCDClientset     argocdclient.Client
-	settingsManager     *settings.SettingsManager
 	apiServerAddress    string
 	token               string
 	plainText           bool
@@ -123,7 +122,6 @@ func init() {
 	})
 	CheckError(err)
 
-	settingsManager = settings.NewSettingsManager(context.Background(), KubeClientset, "argocd-e2e")
 	token = sessionResponse.Token
 	plainText = !tlsTestResult.TLS
 

--- a/util/db/db_test.go
+++ b/util/db/db_test.go
@@ -60,7 +60,7 @@ func TestCreateRepository(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "https://github.com/argoproj/argocd-example-apps", repo.Repo)
 
-	secret, err := clientset.CoreV1().Secrets(testNamespace).Get(repoURLToSecretName(repo.Repo), metav1.GetOptions{})
+	secret, err := clientset.CoreV1().Secrets(testNamespace).Get(repoURLToSecretName(repoSecretPrefix, repo.Repo), metav1.GetOptions{})
 	assert.Nil(t, err)
 
 	assert.Equal(t, common.AnnotationValueManagedByArgoCD, secret.Annotations[common.AnnotationKeyManagedBy])
@@ -81,7 +81,7 @@ func TestCreateRepoCredentials(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "https://github.com/argoproj/", creds.URL)
 
-	secret, err := clientset.CoreV1().Secrets(testNamespace).Get(repoURLToSecretName(creds.URL), metav1.GetOptions{})
+	secret, err := clientset.CoreV1().Secrets(testNamespace).Get(repoURLToSecretName(credSecretPrefix, creds.URL), metav1.GetOptions{})
 	assert.Nil(t, err)
 
 	assert.Equal(t, common.AnnotationValueManagedByArgoCD, secret.Annotations[common.AnnotationKeyManagedBy])

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -496,19 +496,5 @@ func getRepositoryCredentialIndex(repoCredentials []settings.RepositoryCredentia
 func repoURLToSecretName(prefix string, repo string) string {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(repo))
-	// Part of the original repo name is incorporated into the secret name for debugging purposes
-	// If we do not have a repo name (i.e. when URL ends on '/', as can happen with templates)
-	// we use the complete URL as identifier.
-	parts := strings.Split(strings.TrimSuffix(repo, ".git"), "/")
-	shortName := ""
-	if parts[len(parts)-1] == "" {
-		shortName = strings.TrimSuffix(strings.ToLower(repo), "/")
-	} else {
-		shortName = strings.ToLower(parts[len(parts)-1])
-	}
-	shortName = strings.Replace(shortName, "_", "-", -1)
-	shortName = strings.Replace(shortName, "@", "-", -1)
-	shortName = strings.Replace(shortName, ":", "-", -1)
-
-	return fmt.Sprintf("%s-%s-%v", prefix, shortName, h.Sum32())
+	return fmt.Sprintf("%s-%v", prefix, h.Sum32())
 }

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -21,6 +21,10 @@ import (
 )
 
 const (
+	// Prefix to use for naming repository secrets
+	repoSecretPrefix = "repo"
+	// Prefix to use for naming credential template secrets
+	credSecretPrefix = "creds"
 	// The name of the key storing the username in the secret
 	username = "username"
 	// The name of the key storing the password in the secret
@@ -349,56 +353,13 @@ func (db *db) updateCredentialsSecret(credsInfo *settings.RepositoryCredentials,
 		TLSClientCertData: c.TLSClientCertData,
 		TLSClientCertKey:  c.TLSClientCertKey,
 	}
-	var repoInfo settings.Repository
-
-	err := db.updateRepositorySecrets(&repoInfo, r)
-	if err != nil {
-		return err
-	}
-
-	credsInfo.UsernameSecret = repoInfo.UsernameSecret
-	credsInfo.PasswordSecret = repoInfo.PasswordSecret
-	credsInfo.SSHPrivateKeySecret = repoInfo.SSHPrivateKeySecret
-	credsInfo.TLSClientCertDataSecret = repoInfo.TLSClientCertDataSecret
-	credsInfo.TLSClientCertKeySecret = repoInfo.TLSClientCertKeySecret
-
-	return nil
-}
-
-func (db *db) updateRepositorySecrets(repoInfo *settings.Repository, r *appsv1.Repository) error {
 	secretsData := make(map[string]map[string][]byte)
 
-	setSecretData := func(secretKey *apiv1.SecretKeySelector, value string, defaultKeyName string) *apiv1.SecretKeySelector {
-		if secretKey == nil && value != "" {
-			secretKey = &apiv1.SecretKeySelector{
-				LocalObjectReference: apiv1.LocalObjectReference{Name: repoURLToSecretName(r.Repo)},
-				Key:                  defaultKeyName,
-			}
-		}
-
-		if secretKey != nil {
-			data, ok := secretsData[secretKey.Name]
-			if !ok {
-				data = map[string][]byte{}
-			}
-			if value != "" {
-				data[secretKey.Key] = []byte(value)
-			}
-			secretsData[secretKey.Name] = data
-		}
-
-		if value == "" {
-			secretKey = nil
-		}
-
-		return secretKey
-	}
-
-	repoInfo.UsernameSecret = setSecretData(repoInfo.UsernameSecret, r.Username, username)
-	repoInfo.PasswordSecret = setSecretData(repoInfo.PasswordSecret, r.Password, password)
-	repoInfo.SSHPrivateKeySecret = setSecretData(repoInfo.SSHPrivateKeySecret, r.SSHPrivateKey, sshPrivateKey)
-	repoInfo.TLSClientCertDataSecret = setSecretData(repoInfo.TLSClientCertDataSecret, r.TLSClientCertData, tlsClientCertData)
-	repoInfo.TLSClientCertKeySecret = setSecretData(repoInfo.TLSClientCertKeySecret, r.TLSClientCertKey, tlsClientCertKey)
+	credsInfo.UsernameSecret = setSecretData(credSecretPrefix, r.Repo, secretsData, credsInfo.UsernameSecret, r.Username, username)
+	credsInfo.PasswordSecret = setSecretData(credSecretPrefix, r.Repo, secretsData, credsInfo.PasswordSecret, r.Password, password)
+	credsInfo.SSHPrivateKeySecret = setSecretData(credSecretPrefix, r.Repo, secretsData, credsInfo.SSHPrivateKeySecret, r.SSHPrivateKey, sshPrivateKey)
+	credsInfo.TLSClientCertDataSecret = setSecretData(credSecretPrefix, r.Repo, secretsData, credsInfo.TLSClientCertDataSecret, r.TLSClientCertData, tlsClientCertData)
+	credsInfo.TLSClientCertKeySecret = setSecretData(credSecretPrefix, r.Repo, secretsData, credsInfo.TLSClientCertKeySecret, r.TLSClientCertKey, tlsClientCertKey)
 	for k, v := range secretsData {
 		err := db.upsertSecret(k, v)
 		if err != nil {
@@ -406,6 +367,52 @@ func (db *db) updateRepositorySecrets(repoInfo *settings.Repository, r *appsv1.R
 		}
 	}
 	return nil
+}
+
+func (db *db) updateRepositorySecrets(repoInfo *settings.Repository, r *appsv1.Repository) error {
+	secretsData := make(map[string]map[string][]byte)
+
+	repoInfo.UsernameSecret = setSecretData(repoSecretPrefix, r.Repo, secretsData, repoInfo.UsernameSecret, r.Username, username)
+	repoInfo.PasswordSecret = setSecretData(repoSecretPrefix, r.Repo, secretsData, repoInfo.PasswordSecret, r.Password, password)
+	repoInfo.SSHPrivateKeySecret = setSecretData(repoSecretPrefix, r.Repo, secretsData, repoInfo.SSHPrivateKeySecret, r.SSHPrivateKey, sshPrivateKey)
+	repoInfo.TLSClientCertDataSecret = setSecretData(repoSecretPrefix, r.Repo, secretsData, repoInfo.TLSClientCertDataSecret, r.TLSClientCertData, tlsClientCertData)
+	repoInfo.TLSClientCertKeySecret = setSecretData(repoSecretPrefix, r.Repo, secretsData, repoInfo.TLSClientCertKeySecret, r.TLSClientCertKey, tlsClientCertKey)
+	for k, v := range secretsData {
+		err := db.upsertSecret(k, v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set data to be stored in a given secret used for repository credentials and templates.
+// The name of the secret is a combination of the prefix given, and a calculated value
+// from the repository or template URL.
+func setSecretData(prefix string, url string, secretsData map[string]map[string][]byte, secretKey *apiv1.SecretKeySelector, value string, defaultKeyName string) *apiv1.SecretKeySelector {
+	if secretKey == nil && value != "" {
+		secretKey = &apiv1.SecretKeySelector{
+			LocalObjectReference: apiv1.LocalObjectReference{Name: repoURLToSecretName(prefix, url)},
+			Key:                  defaultKeyName,
+		}
+	}
+
+	if secretKey != nil {
+		data, ok := secretsData[secretKey.Name]
+		if !ok {
+			data = map[string][]byte{}
+		}
+		if value != "" {
+			data[secretKey.Key] = []byte(value)
+		}
+		secretsData[secretKey.Name] = data
+	}
+
+	if value == "" {
+		secretKey = nil
+	}
+
+	return secretKey
 }
 
 func (db *db) upsertSecret(name string, data map[string][]byte) error {
@@ -486,11 +493,22 @@ func getRepositoryCredentialIndex(repoCredentials []settings.RepositoryCredentia
 // repositories are _imperatively_ created and need its credentials to be stored in a secret.
 // NOTE: this formula should not be considered stable and may change in future releases.
 // Do NOT rely on this formula as a means of secret lookup, only secret creation.
-func repoURLToSecretName(repo string) string {
+func repoURLToSecretName(prefix string, repo string) string {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(repo))
 	// Part of the original repo name is incorporated into the secret name for debugging purposes
+	// If we do not have a repo name (i.e. can happen when setting up credentials instead of repo)
+	// we use a fix pseudo string as identifier.
 	parts := strings.Split(strings.TrimSuffix(repo, ".git"), "/")
-	shortName := strings.ToLower(strings.Replace(parts[len(parts)-1], "_", "-", -1))
-	return fmt.Sprintf("repo-%s-%v", shortName, h.Sum32())
+	shortName := ""
+	if parts[len(parts)-1] == "" {
+		shortName = strings.TrimSuffix(strings.ToLower(repo), "/")
+	} else {
+		shortName = strings.ToLower(parts[len(parts)-1])
+	}
+	shortName = strings.Replace(shortName, "_", "-", -1)
+	shortName = strings.Replace(shortName, "@", "-", -1)
+	shortName = strings.Replace(shortName, ":", "-", -1)
+
+	return fmt.Sprintf("%s-%s-%v", prefix, shortName, h.Sum32())
 }

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -497,8 +497,8 @@ func repoURLToSecretName(prefix string, repo string) string {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(repo))
 	// Part of the original repo name is incorporated into the secret name for debugging purposes
-	// If we do not have a repo name (i.e. can happen when setting up credentials instead of repo)
-	// we use a fix pseudo string as identifier.
+	// If we do not have a repo name (i.e. when URL ends on '/', as can happen with templates)
+	// we use the complete URL as identifier.
 	parts := strings.Split(strings.TrimSuffix(repo, ".git"), "/")
 	shortName := ""
 	if parts[len(parts)-1] == "" {

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -8,16 +8,31 @@ import (
 
 func TestRepoURLToSecretName(t *testing.T) {
 	tables := map[string]string{
-		"git://git@github.com:argoproj/ARGO-cd.git": "repo-argo-cd-83273445",
-		"https://github.com/argoproj/ARGO-cd":       "repo-argo-cd-1890113693",
-		"https://github.com/argoproj/argo-cd":       "repo-argo-cd-42374749",
-		"https://github.com/argoproj/argo-cd.git":   "repo-argo-cd-821842295",
-		"https://github.com/argoproj/argo_cd.git":   "repo-argo-cd-1049844989",
-		"ssh://git@github.com/argoproj/argo-cd.git": "repo-argo-cd-3569564120",
+		"git://git@github.com:argoproj/ARGO-cd.git": "repo-83273445",
+		"https://github.com/argoproj/ARGO-cd":       "repo-1890113693",
+		"https://github.com/argoproj/argo-cd":       "repo-42374749",
+		"https://github.com/argoproj/argo-cd.git":   "repo-821842295",
+		"https://github.com/argoproj/argo_cd.git":   "repo-1049844989",
+		"ssh://git@github.com/argoproj/argo-cd.git": "repo-3569564120",
 	}
 
 	for k, v := range tables {
 		if sn := repoURLToSecretName(repoSecretPrefix, k); sn != v {
+			t.Errorf("Expected secret name %q for repo %q; instead, got %q", v, k, sn)
+		}
+	}
+}
+
+func Test_CredsURLToSecretName(t *testing.T) {
+	tables := map[string]string{
+		"git://git@github.com:argoproj": "creds-2483499391",
+		"git://git@github.com:argoproj/": "creds-1465032944",
+		"git@github.com:argoproj": "creds-2666065091",
+		"git@github.com:argoproj/": "creds-346879876",
+	}
+
+	for k, v := range tables {
+		if sn := repoURLToSecretName(credSecretPrefix, k); sn != v {
 			t.Errorf("Expected secret name %q for repo %q; instead, got %q", v, k, sn)
 		}
 	}

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -17,7 +17,7 @@ func TestRepoURLToSecretName(t *testing.T) {
 	}
 
 	for k, v := range tables {
-		if sn := repoURLToSecretName(k); sn != v {
+		if sn := repoURLToSecretName(repoSecretPrefix, k); sn != v {
 			t.Errorf("Expected secret name %q for repo %q; instead, got %q", v, k, sn)
 		}
 	}

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -25,10 +25,10 @@ func TestRepoURLToSecretName(t *testing.T) {
 
 func Test_CredsURLToSecretName(t *testing.T) {
 	tables := map[string]string{
-		"git://git@github.com:argoproj": "creds-2483499391",
+		"git://git@github.com:argoproj":  "creds-2483499391",
 		"git://git@github.com:argoproj/": "creds-1465032944",
-		"git@github.com:argoproj": "creds-2666065091",
-		"git@github.com:argoproj/": "creds-346879876",
+		"git@github.com:argoproj":        "creds-2666065091",
+		"git@github.com:argoproj/":       "creds-346879876",
 	}
 
 	for k, v := range tables {


### PR DESCRIPTION
This PR fixes correct deletion of credential templates secrets when the corresponding template is deleted from ArgoCD (fixes #3028) and also handle secret generation in a much more stable way (fixes #3016).

It changes the name of newly generated secrets in that it will not encode part of the repo or template URL into the name anymore, and just uses the FNV hash as identifier (i.e. `repo-XYZ`, where `XYZ` is the hash represented as number). Also, to better differentiate between actual repository credential secrets and credential template secrets, the latter will be prefixed with `creds-` instead of `repo-`. This change is not breaking and fully backward compatible, as existing secrets will not be touched.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
