### PR TITLE
fix: Include resource group for events InvolvedObject.APIVersion #3011

### DIFF
--- a/util/argo/audit_logger.go
+++ b/util/argo/audit_logger.go
@@ -72,7 +72,7 @@ func (l *AuditLogger) logEvent(objMeta ObjectRef, gvk schema.GroupVersionKind, i
 			Name:            objMeta.Name,
 			Namespace:       objMeta.Namespace,
 			ResourceVersion: objMeta.ResourceVersion,
-			APIVersion:      gvk.Version,
+			APIVersion:      gvk.GroupVersion().String(),
 			UID:             objMeta.UID,
 		},
 		FirstTimestamp: t,


### PR DESCRIPTION
close #3011
refs: https://github.com/kubernetes/kubernetes/issues/87434

## Details

Group is not included in `involvedObject.apiVersion`.

```shell
kubectl -n argocd get events -o yaml
```

```yaml
apiVersion: v1
items:
- apiVersion: v1
  count: 1
  eventTime: null
  firstTimestamp: "2020-01-25T05:06:35Z"
  involvedObject:
    apiVersion: v1alpha1
    kind: Application
    name: foo
    namespace: argocd
    resourceVersion: "40528515"
    uid: b961e04b-3b7c-11ea-ac0c-0e7ae0cc4212
  kind: Event
  lastTimestamp: "2020-01-25T05:06:35Z"
  message: foo@example.com initiated sync to master (SHA1)
  metadata:
    creationTimestamp: "2020-01-25T05:06:35Z"
    name: foo.15ed08de6fe84a24
    namespace: argocd
    resourceVersion: "40528517"
    selfLink: /api/v1/namespaces/argocd/events/foo.15ed08de6fe84a24
    uid: 75e77984-3f30-11ea-964e-0ac522f51146
  reason: OperationStarted
  reportingComponent: ""
  reportingInstance: ""
  source:
    component: argocd-server
  type: Normal
...
``` 

Use `func (GroupVersion) String` function instead of` gvk.Version`.
https://godoc.org/k8s.io/apimachinery/pkg/runtime/schema#GroupVersion.String
https://github.com/kubernetes/kubernetes/issues/87434#issuecomment-577189967

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
