### PR TITLE
fix: Allow dash character in output of kubectl version (#3034)

### DIFF
--- a/util/kube/ctl.go
+++ b/util/kube/ctl.go
@@ -429,7 +429,7 @@ func Version() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not get kubectl version: %s", err)
 	}
-	re := regexp.MustCompile(`GitVersion:"([a-zA-Z0-9\.]+)"`)
+	re := regexp.MustCompile(`GitVersion:"([a-zA-Z0-9\.\-]+)"`)
 	matches := re.FindStringSubmatch(out)
 	if len(matches) != 2 {
 		return "", errors.New("could not get kubectl version")


### PR DESCRIPTION
Fixes #3034 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
