### PR TITLE
docs: Fix getting started 404, add useful links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,8 @@ kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
-Follow our [getting started guide](getting_started.md). Further [documentation](docs/)
-is provided for additional features.
+Follow our [getting started guide](getting_started.md). Further user oriented [documentation](user_guide/)
+is provided for additional features. Developer oriented [documentation](developer-guide/) is available for people interested in building third-party integrations.
 
 ## How it works
 


### PR DESCRIPTION
This is a documentation fix, I've updated the checklist to reflect what I did.

Checklist:

* [x] this does not need to be in the release notes.
* [x] The title of the PR states what changed.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
