### PR TITLE
chore: fix codegen-local

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export GO111MODULE=off
+
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
With golang v1.13 we need to explicitly disable go modules during codegen. Otherwise codegen might fail.