### PR TITLE
fix(UI): SSO condition when several SSO connectors has been configured

### DIFF
--- a/ui/src/app/login/components/login.tsx
+++ b/ui/src/app/login/components/login.tsx
@@ -62,7 +62,7 @@ export class Login extends React.Component<RouteComponentProps<{}>, State> {
                             <a href={`auth/login?return_url=${encodeURIComponent(this.state.returnUrl)}`}>
                                 <button className='argo-button argo-button--base argo-button--full-width argo-button--xlg'>
                                     {(authSettings.oidcConfig && <span>Login via {authSettings.oidcConfig.name}</span>) ||
-                                        (authSettings.dexConfig.connectors.length > 0 && <span>Login via {authSettings.dexConfig.connectors[0].name}</span>) || (
+                                        (authSettings.dexConfig.connectors.length === 1 && <span>Login via {authSettings.dexConfig.connectors[0].name}</span>) || (
                                             <span>SSO Login</span>
                                         )}
                                 </button>


### PR DESCRIPTION
Hello,

I opened this pull request to fix this issue on `argocd` ui with SSO login button [#3009](https://github.com/argoproj/argo-cd/issues/3009)

Before this pull request, when we configured at least 2 SSO connector into `argocd-cm` and go to UI render only one button with the first connector found which can be confusing.

So, on this pull request, I just make changes to fix button name when we have more than 1 SSO provider configured. 

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 