### PR TITLE
fix: Even if define multiple configManagementPlugin, you can only get one plugin (#3058)

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1272,8 +1272,9 @@ func (s *Server) plugins() ([]*v1alpha1.ConfigManagementPlugin, error) {
 		return nil, err
 	}
 	tools := make([]*v1alpha1.ConfigManagementPlugin, len(plugins))
-	for i, plugin := range plugins {
-		tools[i] = &plugin
+	for i, p := range plugins {
+		p := p
+		tools[i] = &p
 	}
 	return tools, nil
 }


### PR DESCRIPTION
close: #3058

You can only get one plugin even if there are multiple plugins because they refer to the same pointer.
I have prepared a simple code to reproduce the same situation.

```go
package main

import (
	"fmt"
)

func main() {
	var str = []string{"foo", "bar", "baz"}
	results := make([]*string, len(str))
	for i, s := range str {
		results[i] = &s
	}
	for i, v := range results {
		fmt.Printf("%d %s:%v\n", i, *v, v)
	}
}
```

```shell
# results
0 baz:0x40c138
1 baz:0x40c138
2 baz:0x40c138
```

This bug fix is easy.
Create a variable in the scope of a for.

```diff
  func main() {
      var str = []string{"foo", "bar", "baz"}
      results := make([]*string, len(str))
      for i, s := range str {
+         s := s
          results[i] = &s
      }
      for i, v := range results {
          fmt.Printf("%d %s:%v\n", i, *v, v)
      }
  }
```

<details>

```go
package main

import (
	"fmt"
)

func main() {
	var str = []string{"foo", "bar", "baz"}
	results := make([]*string, len(str))
	for i, s := range str {
		s := s
		results[i] = &s
	}
	for i, v := range results {
		fmt.Printf("%d %s:%v\n", i, *v, v)
	}
}
```

</details>

```shell
# results
0 foo:0x40c138
1 bar:0x40c140
2 baz:0x40c148
```

Checklist:

* [x] this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
