### PR TITLE
fix: Ensure SSH private key is written out with a final newline character (#2890)

### DIFF
--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -157,7 +157,7 @@ func (c SSHCreds) Environ() (io.Closer, []string, error) {
 	}
 	defer file.Close()
 
-	_, err = file.WriteString(c.sshPrivateKey)
+	_, err = file.WriteString(c.sshPrivateKey + "\n")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This fixes at least one of the issues in #2890 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
