### PR TITLE
chore: Use 'latest' as default tag for Docker image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ endif
 ifneq (${GIT_TAG},)
 IMAGE_TAG=${GIT_TAG}
 LDFLAGS += -X ${PACKAGE}.gitTag=${GIT_TAG}
+else
+IMAGE_TAG?=latest
 endif
 
 ifeq (${DOCKER_PUSH},true)


### PR DESCRIPTION
Checklist:

* [x] this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
