### PR TITLE
fix: Allow multiple hostnames per SSH known hosts entry and also allow IPv6 (#2814)

### DIFF
--- a/cmd/argocd/commands/cert.go
+++ b/cmd/argocd/commands/cert.go
@@ -174,18 +174,20 @@ func NewCertAddSSHCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 			}
 
 			for _, knownHostsEntry := range sshKnownHostsLists {
-				hostname, certSubType, certData, err := certutil.TokenizeSSHKnownHostsEntry(knownHostsEntry)
+				_, certSubType, certData, err := certutil.TokenizeSSHKnownHostsEntry(knownHostsEntry)
 				errors.CheckError(err)
-				_, _, err = certutil.KnownHostsLineToPublicKey(knownHostsEntry)
+				hostnameList, _, err := certutil.KnownHostsLineToPublicKey(knownHostsEntry)
 				errors.CheckError(err)
-				certificate := appsv1.RepositoryCertificate{
-					ServerName:  hostname,
-					CertType:    "ssh",
-					CertSubType: certSubType,
-					CertData:    certData,
+				// Each key could be valid for multiple hostnames
+				for _, hostname := range(hostnameList) {
+					certificate := appsv1.RepositoryCertificate{
+						ServerName:  hostname,
+						CertType:    "ssh",
+						CertSubType: certSubType,
+						CertData:    certData,
+					}
+					certificates = append(certificates, certificate)
 				}
-
-				certificates = append(certificates, certificate)
 			}
 
 			certList := &appsv1.RepositoryCertificateList{Items: certificates}

--- a/cmd/argocd/commands/cert.go
+++ b/cmd/argocd/commands/cert.go
@@ -179,7 +179,7 @@ func NewCertAddSSHCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 				hostnameList, _, err := certutil.KnownHostsLineToPublicKey(knownHostsEntry)
 				errors.CheckError(err)
 				// Each key could be valid for multiple hostnames
-				for _, hostname := range(hostnameList) {
+				for _, hostname := range hostnameList {
 					certificate := appsv1.RepositoryCertificate{
 						ServerName:  hostname,
 						CertType:    "ssh",

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -223,13 +223,19 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                             // the first place.
                             const subType = knownHosts[1].match(/^(ssh\-[a-z0-9]+|ecdsa-[a-z0-9\-]+)$/gi);
                             if (subType != null) {
-                                knownHostEntries = knownHostEntries.concat({
-                                    serverName: knownHosts[0],
-                                    certType: 'ssh',
-                                    certSubType: knownHosts[1],
-                                    certData: btoa(knownHosts[2]),
-                                    certInfo: ''
-                                });
+                                // Key could be valid for multiple hosts
+                                const hostnames = knownHosts[0].split(',')
+                                for (let i = 0; i < hostnames.length; i++) {
+                                    knownHostEntries = knownHostEntries.concat({
+                                        serverName: hostnames[i],
+                                        certType: 'ssh',
+                                        certSubType: knownHosts[1],
+                                        certData: btoa(knownHosts[2]),
+                                        certInfo: ''
+                                    });
+                                }
+                            } else {
+                                throw new Error('Invalid SSH subtype: ' + subType)
                             }
                         }
                     }

--- a/ui/src/app/settings/components/certs-list/certs-list.tsx
+++ b/ui/src/app/settings/components/certs-list/certs-list.tsx
@@ -224,10 +224,10 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                             const subType = knownHosts[1].match(/^(ssh\-[a-z0-9]+|ecdsa-[a-z0-9\-]+)$/gi);
                             if (subType != null) {
                                 // Key could be valid for multiple hosts
-                                const hostnames = knownHosts[0].split(',')
-                                for (let i = 0; i < hostnames.length; i++) {
+                                const hostnames = knownHosts[0].split(',');
+                                for (const hostname of hostnames) {
                                     knownHostEntries = knownHostEntries.concat({
-                                        serverName: hostnames[i],
+                                        serverName: hostname,
                                         certType: 'ssh',
                                         certSubType: knownHosts[1],
                                         certData: btoa(knownHosts[2]),
@@ -235,7 +235,7 @@ export class CertsList extends React.Component<RouteComponentProps<any>> {
                                     });
                                 }
                             } else {
-                                throw new Error('Invalid SSH subtype: ' + subType)
+                                throw new Error('Invalid SSH subtype: ' + subType);
                             }
                         }
                     }

--- a/util/cert/cert.go
+++ b/util/cert/cert.go
@@ -67,6 +67,10 @@ const (
 // Regular expression that matches a valid hostname
 var validHostNameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))*(\.){0,1}$`)
 
+// Regular expression that matches all kind of IPv6 addresses
+// See https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
+var validIPv6Regexp = regexp.MustCompile(`(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))`)
+
 // Regular expression that matches a valid FQDN
 var validFQDNRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))*(\.){1}$`)
 
@@ -74,7 +78,7 @@ var validFQDNRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{
 // If fqdn is true, given string must also be a FQDN representation.
 func IsValidHostname(hostname string, fqdn bool) bool {
 	if !fqdn {
-		return validHostNameRegexp.Match([]byte(hostname))
+		return validHostNameRegexp.Match([]byte(hostname)) || validIPv6Regexp.Match([]byte(hostname))
 	} else {
 		return validFQDNRegexp.Match([]byte(hostname))
 	}


### PR DESCRIPTION
Allow multiple hostnames separated by comma when parsing SSH known_hosts data and also allow to specify IPv6 addresses as hostname.

Fixes #2814 

Checklist:

* [x] this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
