### PR TITLE
docs: json pointer in docs

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -100,7 +100,7 @@ data:
       # List of json pointers in the object to ignore differences
       ignoreDifferences: |
         jsonPointers:
-        - webhooks/0/clientConfig/caBundle
+        - /webhooks/0/clientConfig/caBundle
     certmanager.k8s.io/Certificate:
       # Lua script for customizing the health status assessment
       health.lua: |


### PR DESCRIPTION
We just copy/pasted this json pointer because we deployed a
`MutatingWebhookConfiguration` and realized it wasn't fixing the out of sync.

Checklist:

* [ x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ x] The title of the PR states what changed and the related issues number (used for the release note).
* [x ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
