### PR TITLE
fix: uid instead of named user (fixes #2746)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir -p /app/config/tls
 # workaround ksonnet issue https://github.com/ksonnet/ksonnet/issues/298
 ENV USER=argocd
 
-USER argocd
+USER 999
 WORKDIR /home/argocd
 
 ####################################################################################################


### PR DESCRIPTION
When specifying:
```yaml
containerSecurityContext:
  runAsNonRoot: true
  capabilities:
    drop:
      - all
```

You keep getting the error:
```yaml
    state:
      waiting:
        message: container has runAsNonRoot and image has non-numeric user (argocd),
          cannot verify user is non-root
        reason: CreateContainerConfigError
```

And since we are creating user 999 inside the container, it is better to use this user by UID than by username.

issue: #2746 

Checklist:

* [x] this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
