### PR TITLE
docs: Improve docs for Hooks

### DIFF
--- a/docs/user-guide/resource_hooks.md
+++ b/docs/user-guide/resource_hooks.md
@@ -12,7 +12,7 @@ Kubernetes rolling update strategy.
 
 ## Usage
 
-Hooks are simply Kubernetes manifests annotated with `argocd.argoproj.io/hook`, e.g.:
+Hooks are simply Kubernetes manifests inside your Argo CD Application annotated with `argocd.argoproj.io/hook`, e.g.:
 
 ```yaml
 apiVersion: batch/v1


### PR DESCRIPTION
The description was extended by explaining that the Hook has to be inside the Argo CD Application.
