### PR TITLE
make the copyutil init container in the dex server deployment resilient to restarts (#3070)

### DIFF
--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - name: copyutil
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        command: [cp, /usr/local/bin/argocd-util, /shared]
+        command: [cp, -n, /usr/local/bin/argocd-util, /shared]
         volumeMounts:
         - mountPath: /shared
           name: static-files

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2591,6 +2591,7 @@ spec:
       initContainers:
       - command:
         - cp
+        - -n
         - /usr/local/bin/argocd-util
         - /shared
         image: argoproj/argocd:latest

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2506,6 +2506,7 @@ spec:
       initContainers:
       - command:
         - cp
+        - -n
         - /usr/local/bin/argocd-util
         - /shared
         image: argoproj/argocd:latest

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2355,6 +2355,7 @@ spec:
       initContainers:
       - command:
         - cp
+        - -n
         - /usr/local/bin/argocd-util
         - /shared
         image: argoproj/argocd:latest

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2270,6 +2270,7 @@ spec:
       initContainers:
       - command:
         - cp
+        - -n
         - /usr/local/bin/argocd-util
         - /shared
         image: argoproj/argocd:latest


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
