### PR TITLE
examples/dashboard.json: added labels to legends

### DIFF
--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -1288,7 +1288,7 @@
           "expr": "sum(increase(argocd_app_reconcile_count{namespace=~\"$namespace\", project=~\"$project\"}[10m])) by (namespace, project)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{namespace}}",
+          "legendFormat": "{{namespace}},{{project}}",
           "refId": "A"
         }
       ],
@@ -1374,7 +1374,7 @@
           "expr": "sum(increase(argocd_app_k8s_request_total{namespace=~\"$namespace\",project=~\"$project\"}[5m])) by (namespace, project)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{namespace}}",
+          "legendFormat": "{{namespace}},{{project}}",
           "refId": "A"
         }
       ],
@@ -1981,7 +1981,7 @@
               "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"application.ApplicationService\",namespace=~\"$namespace\"} > 0",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{grpc_code}},{{grpc_method}}",
+              "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
               "refId": "A"
             }
           ],
@@ -2075,7 +2075,7 @@
               "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"cluster.ClusterService\",namespace=~\"$namespace\"} > 0",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{grpc_code}},{{grpc_method}}",
+              "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
               "refId": "A"
             }
           ],
@@ -2169,7 +2169,7 @@
               "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"project.ProjectService\",namespace=~\"$namespace\"} > 0",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{grpc_code}},{{grpc_method}}",
+              "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
               "refId": "A"
             }
           ],
@@ -2263,7 +2263,7 @@
               "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"repository.RepositoryService\",namespace=~\"$namespace\"} > 0",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{grpc_code}},{{grpc_method}}",
+              "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
               "refId": "A"
             }
           ],
@@ -2357,7 +2357,7 @@
               "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"session.SessionService\",namespace=~\"$namespace\"} > 0",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{grpc_code}},{{grpc_method}}",
+              "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
               "refId": "A"
             }
           ],
@@ -2451,7 +2451,7 @@
               "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"version.VersionService\",namespace=~\"$namespace\"} > 0",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{grpc_code}},{{grpc_method}}",
+              "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
               "refId": "A"
             }
           ],
@@ -2545,7 +2545,7 @@
               "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"account.AccountService\",namespace=~\"$namespace\"} >1",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{grpc_code}},{{grpc_method}}",
+              "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
               "refId": "A"
             }
           ],
@@ -2827,6 +2827,7 @@
           "expr": "sum(increase(argocd_git_request_total{request_type=\"ls-remote\", namespace=~\"$namespace\"}[10m])) by (namespace)",
           "format": "time_series",
           "intervalFactor": 1,
+          "legendFormat": "{{namespace}}",
           "refId": "A"
         }
       ],
@@ -2911,6 +2912,7 @@
           "expr": "sum(increase(argocd_git_request_total{request_type=\"fetch\", namespace=~\"$namespace\"}[10m])) by (namespace)",
           "format": "time_series",
           "intervalFactor": 1,
+          "legendFormat": "{{namespace}}",
           "refId": "A"
         }
       ],
@@ -3060,5 +3062,5 @@
   "timezone": "",
   "title": "ArgoCD",
   "uid": "BjWwX3jik",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
Hi,

while testing the example dashboard I noticed some panels are lacking some information to distinguish the graphs (when using multiple projects in argocd or the HA installation with multiple pods). Therefore I added further labels to the legend of those panels.

Checklist:

* [c] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
