### PR TITLE
docs: Correct the value for application.instanceLabelKey in comment

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -196,5 +196,5 @@ data:
 
   # The metadata.label key name where Argo CD injects the app name as a tracking label (optional).
   # Tracking labels are used to determine which resources need to be deleted when pruning.
-  # If omitted, Argo CD injects the app name into the label: 'app.kubernetes.io/instance'
+  # If omitted, Argo CD injects the app name into the label: 'argocd.argoproj.io/instance'
   application.instanceLabelKey: mycompany.com/appname


### PR DESCRIPTION
argocd actually uses `argocd.argoproj.io/instance` and not `app.kubernetes.io/instance` for `application.instanceLabelKey`

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
