### PR TITLE
improvement: examples/dashboard.json: removing filling, add increase to grpc metrics

### DIFF
--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -1072,7 +1072,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 5,
         "w": 24,
@@ -1164,7 +1164,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 5,
         "w": 24,
@@ -1253,7 +1253,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -1339,7 +1339,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -1489,7 +1489,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -1575,7 +1575,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -1673,7 +1673,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 8,
             "w": 24,
@@ -1759,7 +1759,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 24,
@@ -1845,7 +1845,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 24,
@@ -1946,7 +1946,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -1978,7 +1978,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"application.ApplicationService\",namespace=~\"$namespace\"} > 0",
+              "expr": "increase(grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"application.ApplicationService\",namespace=~\"$namespace\"}[10m]) > 0 or on() vector (0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
@@ -2040,7 +2040,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -2072,7 +2072,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"cluster.ClusterService\",namespace=~\"$namespace\"} > 0",
+              "expr": "increase(grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"cluster.ClusterService\",namespace=~\"$namespace\"}[10m]) > 0 or on() vector (0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
@@ -2134,7 +2134,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -2166,7 +2166,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"project.ProjectService\",namespace=~\"$namespace\"} > 0",
+              "expr": "increase(grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"project.ProjectService\",namespace=~\"$namespace\"}[10m]) > 0 or on() vector (0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
@@ -2228,7 +2228,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -2260,7 +2260,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"repository.RepositoryService\",namespace=~\"$namespace\"} > 0",
+              "expr": "increase(grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"repository.RepositoryService\",namespace=~\"$namespace\"}[10m]) > 0 or on() vector (0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
@@ -2322,7 +2322,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -2354,7 +2354,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"session.SessionService\",namespace=~\"$namespace\"} > 0",
+              "expr": "increase(grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"session.SessionService\",namespace=~\"$namespace\"}[10m]) > 0 or on() vector (0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
@@ -2416,7 +2416,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -2448,7 +2448,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"version.VersionService\",namespace=~\"$namespace\"} > 0",
+              "expr": "increase(grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"version.VersionService\",namespace=~\"$namespace\"}[10m]) > 0 or on() vector (0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
@@ -2510,7 +2510,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$Source",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
@@ -2542,7 +2542,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"account.AccountService\",namespace=~\"$namespace\"} >1",
+              "expr": "increase(grpc_server_handled_total{job=\"argocd-server-metrics\",grpc_service=\"account.AccountService\",namespace=~\"$namespace\"}[10m]) > 1 or on() vector (0)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{grpc_code}},{{grpc_method}},{{pod}}",
@@ -2621,7 +2621,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -2707,7 +2707,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
@@ -2793,7 +2793,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -2878,7 +2878,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$Source",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -3062,5 +3062,5 @@
   "timezone": "",
   "title": "ArgoCD",
   "uid": "BjWwX3jik",
-  "version": 6
+  "version": 7
 }


### PR DESCRIPTION
Hi,

this is a follow up to #3140. As discussed there, I built a version which:
- removed the filling from each panel
- added "increase(...[10m]) to the panels just using *_totals
- added "OR on () vector (0)" to some panels using conditions e.g. > 0 to make sure they always show a graph.

Checklist:

* [x] (c) Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
