### PR TITLE
fix: Unhang UI on long app info items by using more sane URL match pattern (#3159)

### DIFF
--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -12,8 +12,9 @@ import {ComparisonStatusIcon, HealthStatusIcon, syncStatusMessage} from '../util
 require('./application-summary.scss');
 
 const urlPattern = new RegExp(
-    '^(https?:\\/\\/)?((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|((\\d{1,3}\\.){3}\\d{1,3}))' + '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*(\\?[;&a-z\\d%_.~+=-]*)?(\\#[-a-z\\d_]*)?$',
-    'i'
+    `^(https?://(?:www\.|(?!www))[a-z0-9][a-z0-9-]+[a-z0-9]\.[^\s]{2,}|www\.[a-z0-9][a-z0-9-]+[a-z0-9]\.` +
+        `[^\s]{2,}|https?://(?:www\.|(?!www))[a-z0-9]+\.[^\s]{2,}|www\.[a-z0-9]+\.[^\s]{2,})$`,
+    'gi'
 );
 
 function swap(array: any[], a: number, b: number) {


### PR DESCRIPTION
Fixes #3159 by using a more sane regexp pattern without capture groups for URL matching.

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
