### PR TITLE
chore: Update Go version from v1.13.8 to v1.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,13 @@ commands:
   install_golang:
     steps:
       - run:
-          name: Install Golang v1.13.8
+          name: Install Golang v1.14
           command: |
-            go get golang.org/dl/go1.13.8
-            [ -e /home/circleci/sdk/go1.13.6 ] || go1.13.8 download
+            go get golang.org/dl/go1.14
+            [ -e /home/circleci/sdk/go1.14 ] || go1.14 download
             go env
             echo "export GOPATH=/home/circleci/.go_workspace" | tee -a $BASH_ENV
-            echo "export PATH=/home/circleci/sdk/go1.13.8/bin:\$PATH" | tee -a $BASH_ENV
+            echo "export PATH=/home/circleci/sdk/go1.14/bin:\$PATH" | tee -a $BASH_ENV
   save_go_cache:
     steps:
       - save_cache:
@@ -39,7 +39,7 @@ commands:
           # https://circleci.com/docs/2.0/language-go/
           paths:
             - /home/circleci/.cache/go-build
-            - /home/circleci/sdk/go1.13.8
+            - /home/circleci/sdk/go1.14
   restore_go_cache:
     steps:
       - restore_cache:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.14'
       - uses: actions/checkout@master
         with:
           path: src/github.com/argoproj/argo-cd

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=debian:10-slim
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM golang:1.13.8 as builder
+FROM golang:1.14.0 as builder
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 
@@ -95,7 +95,7 @@ RUN NODE_ENV='production' yarn build
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
 ####################################################################################################
-FROM golang:1.13.8 as argocd-build
+FROM golang:1.14.0 as argocd-build
 
 COPY --from=builder /usr/local/bin/dep /usr/local/bin/dep
 COPY --from=builder /usr/local/bin/packr /usr/local/bin/packr

--- a/hack/Dockerfile.dev-tools
+++ b/hack/Dockerfile.dev-tools
@@ -1,4 +1,4 @@
-FROM golang:1.13.8 as builder
+FROM golang:1.14.0 as builder
 
 RUN apt-get update && apt-get install -y zip
 


### PR DESCRIPTION
I upgraded Go to the latest version.
https://golang.org/doc/devel/release.html#go1.14

Go v1.14.0 release note
https://golang.org/doc/go1.14

```shell
$ git grep -E "1\.13\.8"
# Not Hits
```

Checklist:

* [x] this does not need to be in the release notes
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
