### PR TITLE
fix: set default login redirect to baseHRef (#3163)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -601,7 +601,7 @@ func (a *ArgoCDServer) registerDexHandlers(mux *http.ServeMux) {
 		tlsConfig := a.settings.TLSConfig()
 		tlsConfig.InsecureSkipVerify = true
 	}
-	a.ssoClientApp, err = oidc.NewClientApp(a.settings, a.Cache, a.DexServerAddr)
+	a.ssoClientApp, err = oidc.NewClientApp(a.settings, a.Cache, a.DexServerAddr, a.BaseHRef)
 	errors.CheckError(err)
 	mux.HandleFunc(common.LoginEndpoint, a.ssoClientApp.HandleLogin)
 	mux.HandleFunc(common.CallbackEndpoint, a.ssoClientApp.HandleCallback)


### PR DESCRIPTION
This PR fixes post-SSO login redirect when no return_url is set.

For example, when visiting https://<cluster>/argo-cd/applications, one is redirected to a SSO flow which finally redirects to https://<cluster>/argo-cd/applications as expected. However, when visiting https://<cluster>/argo-cd/login, one ends up being redirected to https://<cluster>/ instead of https://<cluster>/argo-cd and typically receives a 404.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
