### PR TITLE
fix: dex proxy should forward request to dex preserving the basehref

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -596,7 +596,7 @@ func (a *ArgoCDServer) registerDexHandlers(mux *http.ServeMux) {
 	}
 	// Run dex OpenID Connect Identity Provider behind a reverse proxy (served at /api/dex)
 	var err error
-	mux.HandleFunc(common.DexAPIEndpoint+"/", dexutil.NewDexHTTPReverseProxy(a.DexServerAddr))
+	mux.HandleFunc(common.DexAPIEndpoint+"/", dexutil.NewDexHTTPReverseProxy(a.DexServerAddr, a.BaseHRef))
 	if a.useTLS() {
 		tlsConfig := a.settings.TLSConfig()
 		tlsConfig.InsecureSkipVerify = true


### PR DESCRIPTION
Closes #3163

It appears that dex uses  `issuer` URL path from the generated dex config to setup handlers: https://github.com/dexidp/dex/blob/b7cf7010326ac13d36ffb33fb573e561f53fe697/server/server.go#L273


So if issuer url is http://myargocd.test.com/api/dex then Dex server setups handler for `api/dex`, if issuer url is http://myargocd.test.com/api/dex then handler is `argocd/api/dex`. So if baseref is set then argocd should forward dex query to `<basehref>/api/dex` instead of assuming that url path is always `/api/dex`