### PR TITLE
docs: correct typo in diffing section on HPAs

### DIFF
--- a/docs/user-guide/diffing.md
+++ b/docs/user-guide/diffing.md
@@ -11,7 +11,7 @@ submitted to Kubernetes in a manner which contradicts Git.
 which generates different data every time `helm template` is invoked.
 * For Horizontal Pod Autoscaling (HPA) objects, the HPA controller is known to reorder `spec.metrics`
   in a specific order. See [kubernetes issue #74099](https://github.com/kubernetes/kubernetes/issues/74099).
-  To work around this, you can order `spec.replicas` in Git in the same order that the controller
+  To work around this, you can order `spec.metrics` in Git in the same order that the controller
   prefers.
 
 In case it is impossible to fix the upstream issue, Argo CD allows you to optionally ignore differences of problematic resources.


### PR DESCRIPTION
Reordering `spec.metrics` will fix an OutOfSync state due to the HPA
controller reordering this array. The previously referenced
`spec.replicas` field doesn't exist within any known version of the
`HorizontalPodAutoscaler` (autoscaling/v1, autoscaling/v2beta1, or
autoscaling/v2beta2)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
