### PR TITLE
docs: Fixed description of non-cascade command in App Deletion (#3173)

### DIFF
--- a/docs/user-guide/app_deletion.md
+++ b/docs/user-guide/app_deletion.md
@@ -7,13 +7,19 @@ Apps can be deleted with or without a cascade option. A **cascade delete**, dele
 To perform a non-cascade delete:
 
 ```bash
-argocd app delete APPNAME
+argocd app delete APPNAME --cascade=false
 ```
 
 To perform a cascade delete:
 
 ```bash
 argocd app delete APPNAME --cascade
+```
+
+or
+
+```bash
+argocd app delete APPNAME
 ```
 
 # Deletion Using `kubectl`


### PR DESCRIPTION
The document of non-cascade command in App Deletion has been updated as follows
https://github.com/argoproj/argo-cd/issues/3173

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
