### PR TITLE
feat: add "service-account" flag to "cluster add" command (#3183)

### DIFF
--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -127,7 +127,7 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 	command.PersistentFlags().StringVar(&pathOpts.LoadingRules.ExplicitPath, pathOpts.ExplicitFileFlag, pathOpts.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 	command.Flags().BoolVar(&inCluster, "in-cluster", false, "Indicates Argo CD resides inside this cluster and should connect using the internal k8s hostname (kubernetes.default.svc)")
 	command.Flags().BoolVar(&upsert, "upsert", false, "Override an existing cluster with the same name even if the spec differs")
-	command.Flags().StringVar(&serviceAccount, "service-account", "", "System namespace service account to use for kubernetes resource management. If not set then default \"argocd-manager\" SA will be created")
+	command.Flags().StringVar(&serviceAccount, "service-account", "", fmt.Sprintf("System namespace service account to use for kubernetes resource management. If not set then default \"%s\" SA will be created", clusterauth.ArgoCDManagerServiceAccount))
 	command.Flags().StringVar(&awsClusterName, "aws-cluster-name", "", "AWS Cluster name if set then aws cli eks token command will be used to access cluster")
 	command.Flags().StringVar(&awsRoleArn, "aws-role-arn", "", "Optional AWS role arn. If set then AWS IAM Authenticator assume a role to perform cluster operations instead of the default AWS credential provider chain.")
 	command.Flags().StringVar(&systemNamespace, "system-namespace", common.DefaultSystemNamespace, "Use different system namespace")

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -60,6 +60,7 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 	var (
 		inCluster       bool
 		upsert          bool
+		skipRBACSetup   bool
 		awsRoleArn      string
 		awsClusterName  string
 		systemNamespace string
@@ -101,7 +102,11 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 				// Install RBAC resources for managing the cluster
 				clientset, err := kubernetes.NewForConfig(conf)
 				errors.CheckError(err)
-				managerBearerToken, err = clusterauth.InstallClusterManagerRBAC(clientset, systemNamespace, namespaces)
+				if skipRBACSetup {
+					managerBearerToken, err = clusterauth.GetServiceAccountBearerToken(clientset, systemNamespace)
+				} else {
+					managerBearerToken, err = clusterauth.InstallClusterManagerRBAC(clientset, systemNamespace, namespaces)
+				}
 				errors.CheckError(err)
 			}
 			conn, clusterIf := argocdclient.NewClientOrDie(clientOpts).NewClusterClientOrDie()
@@ -122,6 +127,7 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 	command.PersistentFlags().StringVar(&pathOpts.LoadingRules.ExplicitPath, pathOpts.ExplicitFileFlag, pathOpts.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 	command.Flags().BoolVar(&inCluster, "in-cluster", false, "Indicates Argo CD resides inside this cluster and should connect using the internal k8s hostname (kubernetes.default.svc)")
 	command.Flags().BoolVar(&upsert, "upsert", false, "Override an existing cluster with the same name even if the spec differs")
+	command.Flags().BoolVar(&skipRBACSetup, "skip-rbac-setup", false, "Skip setting up cluster manager RBAC (RoleBindings and Roles for SA)")
 	command.Flags().StringVar(&awsClusterName, "aws-cluster-name", "", "AWS Cluster name if set then aws cli eks token command will be used to access cluster")
 	command.Flags().StringVar(&awsRoleArn, "aws-role-arn", "", "Optional AWS role arn. If set then AWS IAM Authenticator assume a role to perform cluster operations instead of the default AWS credential provider chain.")
 	command.Flags().StringVar(&systemNamespace, "system-namespace", common.DefaultSystemNamespace, "Use different system namespace")

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -60,7 +60,7 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 	var (
 		inCluster       bool
 		upsert          bool
-		skipRBACSetup   bool
+		serviceAccount  string
 		awsRoleArn      string
 		awsClusterName  string
 		systemNamespace string
@@ -102,8 +102,8 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 				// Install RBAC resources for managing the cluster
 				clientset, err := kubernetes.NewForConfig(conf)
 				errors.CheckError(err)
-				if skipRBACSetup {
-					managerBearerToken, err = clusterauth.GetServiceAccountBearerToken(clientset, systemNamespace)
+				if serviceAccount != "" {
+					managerBearerToken, err = clusterauth.GetServiceAccountBearerToken(clientset, systemNamespace, serviceAccount)
 				} else {
 					managerBearerToken, err = clusterauth.InstallClusterManagerRBAC(clientset, systemNamespace, namespaces)
 				}
@@ -127,7 +127,7 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 	command.PersistentFlags().StringVar(&pathOpts.LoadingRules.ExplicitPath, pathOpts.ExplicitFileFlag, pathOpts.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 	command.Flags().BoolVar(&inCluster, "in-cluster", false, "Indicates Argo CD resides inside this cluster and should connect using the internal k8s hostname (kubernetes.default.svc)")
 	command.Flags().BoolVar(&upsert, "upsert", false, "Override an existing cluster with the same name even if the spec differs")
-	command.Flags().BoolVar(&skipRBACSetup, "skip-rbac-setup", false, "Skip setting up cluster manager RBAC (RoleBindings and Roles for SA)")
+	command.Flags().StringVar(&serviceAccount, "service-account", "", "System namespace service account to use for kubernetes resource management. If not set then default \"argocd-manager\" SA will be created")
 	command.Flags().StringVar(&awsClusterName, "aws-cluster-name", "", "AWS Cluster name if set then aws cli eks token command will be used to access cluster")
 	command.Flags().StringVar(&awsRoleArn, "aws-role-arn", "", "Optional AWS role arn. If set then AWS IAM Authenticator assume a role to perform cluster operations instead of the default AWS credential provider chain.")
 	command.Flags().StringVar(&systemNamespace, "system-namespace", common.DefaultSystemNamespace, "Use different system namespace")

--- a/util/clusterauth/clusterauth.go
+++ b/util/clusterauth/clusterauth.go
@@ -211,13 +211,13 @@ func InstallClusterManagerRBAC(clientset kubernetes.Interface, ns string, namesp
 		}
 	}
 
-	return getServiceAccountBearerToken(clientset, ns)
+	return GetServiceAccountBearerToken(clientset, ns)
 }
 
-// getServiceAccountBearerToken will attempt to get the Argo manager service account until it
+// GetServiceAccountBearerToken will attempt to get the Argo manager service account until it
 // exists, iterate the secrets associated with it looking for one of type
 // kubernetes.io/service-account-token, and return it's token if found.
-func getServiceAccountBearerToken(clientset kubernetes.Interface, ns string) (string, error) {
+func GetServiceAccountBearerToken(clientset kubernetes.Interface, ns string) (string, error) {
 	var serviceAccount *corev1.ServiceAccount
 	var secret *corev1.Secret
 	var err error

--- a/util/clusterauth/clusterauth.go
+++ b/util/clusterauth/clusterauth.go
@@ -211,18 +211,18 @@ func InstallClusterManagerRBAC(clientset kubernetes.Interface, ns string, namesp
 		}
 	}
 
-	return GetServiceAccountBearerToken(clientset, ns)
+	return GetServiceAccountBearerToken(clientset, ns, ArgoCDManagerServiceAccount)
 }
 
-// GetServiceAccountBearerToken will attempt to get the Argo manager service account until it
+// GetServiceAccountBearerToken will attempt to get the provided service account until it
 // exists, iterate the secrets associated with it looking for one of type
 // kubernetes.io/service-account-token, and return it's token if found.
-func GetServiceAccountBearerToken(clientset kubernetes.Interface, ns string) (string, error) {
+func GetServiceAccountBearerToken(clientset kubernetes.Interface, ns string, sa string) (string, error) {
 	var serviceAccount *corev1.ServiceAccount
 	var secret *corev1.Secret
 	var err error
 	err = wait.Poll(500*time.Millisecond, 30*time.Second, func() (bool, error) {
-		serviceAccount, err = clientset.CoreV1().ServiceAccounts(ns).Get(ArgoCDManagerServiceAccount, metav1.GetOptions{})
+		serviceAccount, err = clientset.CoreV1().ServiceAccounts(ns).Get(sa, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -124,7 +124,7 @@ func TestGetServiceAccountBearerToken(t *testing.T) {
 	}
 	kubeclientset := fake.NewSimpleClientset(sa, dockercfgSecret, tokenSecret)
 
-	token, err := getServiceAccountBearerToken(kubeclientset, "kube-system")
+	token, err := GetServiceAccountBearerToken(kubeclientset, "kube-system")
 	assert.NoError(t, err)
 	assert.Equal(t, testToken, token)
 }

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -124,7 +124,7 @@ func TestGetServiceAccountBearerToken(t *testing.T) {
 	}
 	kubeclientset := fake.NewSimpleClientset(sa, dockercfgSecret, tokenSecret)
 
-	token, err := GetServiceAccountBearerToken(kubeclientset, "kube-system")
+	token, err := GetServiceAccountBearerToken(kubeclientset, "kube-system", sa.Name)
 	assert.NoError(t, err)
 	assert.Equal(t, testToken, token)
 }


### PR DESCRIPTION
"InstallClusterManagerRBAC" method of the clusterauth package is somewhat opinionated about rolebindings and role definitions for "argocd-manager" SA. Sometimes it is desirable however to manually pre-configure such bindings and/or modify them in order to comply with existing infrastructure requirements.

This commit introduces a new option "--service-account" which allows operator to skip the aforementioned "InstallClusterManagerRBAC" method call and use their own service account for kubernetes resource management.

Checklist:

* [x] I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/3183)
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
