### PR TITLE
fix: set MaxCallSendMsgSize to MaxGRPCMessageSize for the GRPC caller (fixes #3117)

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -400,7 +400,7 @@ func (c *client) newConn() (*grpc.ClientConn, io.Closer, error) {
 	}
 	var dialOpts []grpc.DialOption
 	dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(endpointCredentials))
-	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize)))
+	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize), grpc.MaxCallSendMsgSize(MaxGRPCMessageSize)))
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Set MaxCallSendMsgSize to MaxGRPCMessageSize for the GRPC caller.

fixes #3117 