### PR TITLE
fix: stop caching helm index

### DIFF
--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -45,7 +45,7 @@ func (c Cmd) run(args ...string) (string, error) {
 	cmd.Dir = c.WorkDir
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("XDG_CACHE_HOME=%s", c.helmHome),
+		fmt.Sprintf("XDG_CACHE_HOME=%s/cache", c.helmHome),
 		fmt.Sprintf("XDG_CONFIG_HOME=%s/config", c.helmHome),
 		fmt.Sprintf("XDG_DATA_HOME=%s/data", c.helmHome),
 		fmt.Sprintf("HELM_HOME=%s", c.helmHome))

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -44,7 +44,11 @@ func (c Cmd) run(args ...string) (string, error) {
 	cmd := exec.Command(c.binaryName, args...)
 	cmd.Dir = c.WorkDir
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("HELM_HOME=%s", c.helmHome))
+	cmd.Env = append(cmd.Env,
+		fmt.Sprintf("XDG_CACHE_HOME=%s", c.helmHome),
+		fmt.Sprintf("XDG_CONFIG_HOME=%s/config", c.helmHome),
+		fmt.Sprintf("XDG_DATA_HOME=%s/data", c.helmHome),
+		fmt.Sprintf("HELM_HOME=%s", c.helmHome))
 	return executil.RunWithRedactor(cmd, redactor)
 }
 

--- a/util/helm/index.go
+++ b/util/helm/index.go
@@ -5,11 +5,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/patrickmn/go-cache"
-)
-
-var (
-	indexCache = cache.New(5*time.Minute, 5*time.Minute)
 )
 
 type Entry struct {


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Closes: #3107

Argo CD controller caches resolve chart revision in the application CRD. So index is not loaded on every app reconciliation and it is ok not to cache it at all.
