### PR TITLE
docs: Add comment for helm valueFiles path reference

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -27,9 +27,11 @@ spec:
       # Release name override (defaults to application name)
       releaseName: guestbook
 
+      # Helm values files for overriding values in the helm chart
+      # The path is relative to the spec.source.path directory defined above
       valueFiles:
       - values-prod.yaml
-      
+
       # Values file as block file
       values: |
         ingress:


### PR DESCRIPTION
This file seems to serve as the only real reference as to what parameters are available for the Application CRD. It took me a bit of trial and error to figure out that these are in the git repo referenced and relative to the path of the helm chart set previously. Hopefully this helps a future user save some time and adds some context while reading the example resource file.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or **(c) this does not need to be in the release notes.**
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. **N/A**
* [ ] Optional. My organization is added to the README.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
