### PR TITLE
fix(types.go): adding string match check to prevent short-circuit

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -109,7 +109,12 @@ func (e Env) Environ() []string {
 // see https://linux.die.net/man/1/envsubst
 func (e Env) Envsubst(s string) string {
 	for _, v := range e {
-		s = strings.ReplaceAll(s, fmt.Sprintf("$%s", v.Name), v.Value)
+		if fmt.Sprintf("$%s", v.Name) == s {
+			s = strings.ReplaceAll(s, fmt.Sprintf("$%s", v.Name), v.Value)
+		}
+		if fmt.Sprintf("'$%s'", v.Name) == s {
+			s = strings.ReplaceAll(s, fmt.Sprintf("'$%s'", v.Name), v.Value)
+		}
 		s = strings.ReplaceAll(s, fmt.Sprintf("${%s}", v.Name), v.Value)
 	}
 	return s

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1019,10 +1019,15 @@ func TestEnv_IsZero(t *testing.T) {
 }
 
 func TestEnv_Envsubst(t *testing.T) {
-	env := Env{&EnvEntry{"FOO", "bar"}}
+	env := Env{&EnvEntry{"FOO", "bar"}, &EnvEntry{"ARGOCD_APP_NAMESPACE", "argocd"}, &EnvEntry{"ARGOCD_APP_NAME", "baz"}}
 	assert.Equal(t, "", env.Envsubst(""))
 	assert.Equal(t, "bar", env.Envsubst("$FOO"))
 	assert.Equal(t, "bar", env.Envsubst("${FOO}"))
+	assert.Equal(t, "argocd", env.Envsubst("$ARGOCD_APP_NAMESPACE"))
+	assert.Equal(t, "argocd", env.Envsubst("${ARGOCD_APP_NAMESPACE}"))
+	assert.Equal(t, "baz", env.Envsubst("$ARGOCD_APP_NAME"))
+	assert.Equal(t, "baz", env.Envsubst("${ARGOCD_APP_NAME}"))
+	assert.Equal(t, "baz", env.Envsubst("'$ARGOCD_APP_NAME'"))
 }
 
 func TestEnv_Environ(t *testing.T) {


### PR DESCRIPTION
parameters using the `ARGOCD_APP_NAMESPACE` build env var were being replaced by the value of `ARGOCD_APP_NAME`

_example app spec_
```
project: default
source:
  repoURL: >-
    ssh://git@github/foo/project-bar.git
  path: incubator/foo-bar
  targetRevision: master
  helm:
    valueFiles:
      - values.yaml
    parameters:
      - name: namespace
        value: $ARGOCD_APP_NAMESPACE
destination:
  server: 'https://YOLOABC.gr7.us-west-2.eks.amazonaws.com'
  namespace: kube-system
```

example of the bug:
https://play.golang.org/p/7kuXKreUCfs
