### PR TITLE
chore: Update testify to v1.5.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -950,15 +950,15 @@
   version = "v0.1"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
+  digest = "1:cc4eb6813da8d08694e557fcafae8fcc24f47f61a0717f952da130ca9a486dfc"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "mock",
   ]
   pruneopts = ""
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9"
+  version = "v1.5.1"
 
 [[projects]]
   digest = "1:51cf0fca93f4866709ceaf01b750e51d997c299a7bd2edf7ccd79e3b428754ae"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -86,7 +86,7 @@ required = [
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.2"
+  version = "1.5.1"
 
 [[constraint]]
   name = "github.com/gobuffalo/packr"


### PR DESCRIPTION
Update testify framework to latest version. This includes a fix for panics during unit tests we've seen (refer to https://github.com/stretchr/testify/issues/677#issuecomment-426468505)

Checklist:

* [x] this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to the README.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
