### PR TITLE
fix: Support external vendoring of assets using go toolchain

### DIFF
--- a/assets/tools.go
+++ b/assets/tools.go
@@ -1,0 +1,4 @@
+// +build tools
+
+// This existence of this package allows vendoring of the assets in this directory by go 1.13+.
+package tools


### PR DESCRIPTION
Checklist:

* [x] this is a bug fix #2907 
* [x] The title of the PR states what changed and the related issues number (used for the release note)
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Add a build tag gated "tools" package to allow a dependent to vendor the assets (specially builtin-policy.csv) using the standard go toolchain (`go mod`).

A dependent module can vendor argo-cd assets with the following code - 

```
// +build tools

package tools

import (
	_ "github.com/argoproj/argo-cd/assets"
)
```