### PR TITLE
improvement: Surface failure reasons for Rollouts/AnalysisRuns

### DIFF
--- a/resource_customizations/argoproj.io/AnalysisRun/health.lua
+++ b/resource_customizations/argoproj.io/AnalysisRun/health.lua
@@ -14,15 +14,27 @@ if obj.status ~= nil then
     end
     if obj.status.phase == "Failed" then
         hs.status = "Degraded"
-        hs.message = "Analysis run failed"
+        if obj.status.message ~= nil then
+            hs.message = obj.status.message
+        else
+            hs.message = "Analysis run failed"
+        end
     end
     if obj.status.phase == "Error" then
         hs.status = "Degraded"
-        hs.message = "Analysis run had an error"
+        if obj.status.message ~= nil then
+            hs.message = obj.status.message
+        else
+            hs.message = "Analysis run had an error"
+        end
     end
     if obj.status.phase == "Inconclusive" then
         hs.status = "Unknown"
-        hs.message = "Analysis run was inconclusive"
+        if obj.status.message ~= nil then
+            hs.message = obj.status.message
+        else
+            hs.message = "Analysis run was inconclusive"
+        end
     end
     return hs
 end

--- a/resource_customizations/argoproj.io/AnalysisRun/health_test.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/health_test.yaml
@@ -21,9 +21,21 @@ tests:
   inputPath: testdata/failedAnalysisRun.yaml
 - healthStatus:
     status: Degraded
+    message: "Status Message: Assessed as Failed"
+  inputPath: testdata/failedAnalysisRunWithStatusMessage.yaml
+- healthStatus:
+    status: Degraded
     message: "Analysis run had an error"
   inputPath: testdata/errorAnalysisRun.yaml
+- healthStatus:
+    status: Degraded
+    message: "Status Message: Assessed as Error"
+  inputPath: testdata/errorAnalysisRunWithStatusMessage.yaml
 - healthStatus:
     status: Unknown
     message: "Analysis run was inconclusive"
   inputPath: testdata/inconclusiveAnalysisRun.yaml
+- healthStatus:
+    status: Unknown
+    message: "Status Message: Assessed as Inconclusive"
+  inputPath: testdata/inconclusiveAnalysisRunWithStatusMessage.yaml

--- a/resource_customizations/argoproj.io/AnalysisRun/testdata/errorAnalysisRunWithStatusMessage.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/testdata/errorAnalysisRunWithStatusMessage.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  name: canary-demo-analysis-template-6c6bb7cf6f-btpgc
+  namespace: default
+spec:
+  analysisSpec:
+    metrics:
+      - failureCondition: result < 92
+        interval: 10
+        name: memory-usage
+        provider:
+          prometheus:
+            address: 'http://prometheus-operator-prometheus.prometheus-operator:9090'
+            query: >
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview",status!~"[4-5].*"}[2m]))
+              /
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview"}[2m]))
+        successCondition: result > 95
+status:
+  message: "Status Message: Assessed as Error"
+  metricResults:
+    - consecutiveError: 5
+      error: 5
+      measurements:
+        - finishedAt: '2019-10-28T18:13:01Z'
+          startedAt: '2019-10-28T18:13:01Z'
+          phase: Error
+          value: '[0.9832775919732442]'
+        - finishedAt: '2019-10-28T18:13:11Z'
+          startedAt: '2019-10-28T18:13:11Z'
+          phase: Error
+          value: '[0.9832775919732442]'
+        - finishedAt: '2019-10-28T18:13:21Z'
+          startedAt: '2019-10-28T18:13:21Z'
+          phase: Error
+          value: '[0.9722530521642618]'
+        - finishedAt: '2019-10-28T18:13:31Z'
+          startedAt: '2019-10-28T18:13:31Z'
+          phase: Error
+          value: '[0.9722530521642618]'
+        - finishedAt: '2019-10-28T18:13:41Z'
+          startedAt: '2019-10-28T18:13:41Z'
+          phase: Error
+          value: '[0.9722530521642618]'
+      name: memory-usage
+      phase: Error
+  phase: Error

--- a/resource_customizations/argoproj.io/AnalysisRun/testdata/failedAnalysisRunWithStatusMessage.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/testdata/failedAnalysisRunWithStatusMessage.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  name: canary-demo-analysis-template-6c6bb7cf6f-9k5rj
+  namespace: default
+spec:
+  analysisSpec:
+    metrics:
+      - failureCondition: len(result) > 0
+        interval: 10
+        name: memory-usage
+        provider:
+          prometheus:
+            address: 'http://prometheus-operator-prometheus.prometheus-operator:9090'
+            query: >
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview",status!~"[4-5].*"}[2m]))
+              /
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview"}[2m]))
+        successCondition: len(result) > 0
+status:
+  message: "Status Message: Assessed as Failed"
+  metricResults:
+    - count: 1
+      failed: 1
+      measurements:
+        - finishedAt: '2019-10-28T18:23:23Z'
+          startedAt: '2019-10-28T18:23:23Z'
+          phase: Failed
+          value: '[0.9768211920529802]'
+      name: memory-usage
+      phase: Failed
+  phase: Failed

--- a/resource_customizations/argoproj.io/AnalysisRun/testdata/inconclusiveAnalysisRunWithStatusMessage.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/testdata/inconclusiveAnalysisRunWithStatusMessage.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  name: canary-demo-analysis-template-6c6bb7cf6f-ddvn8
+  namespace: default
+spec:
+  analysisSpec:
+    metrics:
+      - failureCondition: len(result) == 0
+        interval: 10
+        name: memory-usage
+        provider:
+          prometheus:
+            address: 'http://prometheus-operator-prometheus.prometheus-operator:9090'
+            query: >
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview",status!~"[4-5].*"}[2m]))
+              /
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview"}[2m]))
+        successCondition: len(result) == 0
+status:
+  message: "Status Message: Assessed as Inconclusive"
+  metricResults:
+    - count: 1
+      inconclusive: 1
+      measurements:
+        - finishedAt: '2019-10-28T18:24:31Z'
+          startedAt: '2019-10-28T18:24:31Z'
+          phase: Inconclusive
+          value: '[0.9744444444444443]'
+      name: memory-usage
+      phase: Inconclusive
+  phase: Inconclusive


### PR DESCRIPTION
When an AnalysisRun fails, ArgoCD health check sets health message as the AnalysisRun status message.

Health message is set to a hard-coded value if AnalysisRun status doesn't contain a message