### PR TITLE
feat: improve api-server and controller performance

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -72,6 +72,7 @@
     "errors",
     "exec",
     "rand",
+    "stats",
     "time",
   ]
   pruneopts = ""
@@ -1930,6 +1931,7 @@
     "github.com/TomOnTime/utfutil",
     "github.com/argoproj/pkg/errors",
     "github.com/argoproj/pkg/exec",
+    "github.com/argoproj/pkg/stats",
     "github.com/argoproj/pkg/time",
     "github.com/casbin/casbin",
     "github.com/casbin/casbin/model",

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ test:
 .PHONY: test-e2e
 test-e2e:
 	# NO_PROXY ensures all tests don't go out through a proxy if one is configured on the test system
-	NO_PROXY=* ./hack/test.sh -timeout 15m ./test/e2e
+	NO_PROXY=* ./hack/test.sh -timeout 15m -v ./test/e2e
 
 .PHONY: start-e2e
 start-e2e: cli

--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/argoproj/pkg/stats"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -25,7 +26,6 @@ import (
 	"github.com/argoproj/argo-cd/util/cli"
 	"github.com/argoproj/argo-cd/util/kube"
 	"github.com/argoproj/argo-cd/util/settings"
-	"github.com/argoproj/argo-cd/util/stats"
 )
 
 const (

--- a/cmd/argocd-repo-server/main.go
+++ b/cmd/argocd-repo-server/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/argoproj/pkg/stats"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -16,7 +17,6 @@ import (
 	reposervercache "github.com/argoproj/argo-cd/reposerver/cache"
 	"github.com/argoproj/argo-cd/reposerver/metrics"
 	"github.com/argoproj/argo-cd/util/cli"
-	"github.com/argoproj/argo-cd/util/stats"
 	"github.com/argoproj/argo-cd/util/tls"
 )
 

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/argoproj/pkg/stats"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -15,7 +16,6 @@ import (
 	"github.com/argoproj/argo-cd/server"
 	servercache "github.com/argoproj/argo-cd/server/cache"
 	"github.com/argoproj/argo-cd/util/cli"
-	"github.com/argoproj/argo-cd/util/stats"
 	"github.com/argoproj/argo-cd/util/tls"
 )
 

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -11,11 +11,11 @@ import (
 func TestGetServerVersion(t *testing.T) {
 	now := time.Now()
 	cache := &liveStateCache{
-		lock: &sync.Mutex{},
+		lock: &sync.RWMutex{},
 		clusters: map[string]*clusterInfo{
 			"http://localhost": {
 				syncTime:      &now,
-				lock:          &sync.Mutex{},
+				lock:          &sync.RWMutex{},
 				serverVersion: "123",
 			},
 		}}

--- a/controller/cache/cluster_test.go
+++ b/controller/cache/cluster_test.go
@@ -153,7 +153,7 @@ func newCluster(objs ...*unstructured.Unstructured) *clusterInfo {
 
 func newClusterExt(kubectl kube.Kubectl) *clusterInfo {
 	return &clusterInfo{
-		lock:            &sync.Mutex{},
+		lock:            &sync.RWMutex{},
 		nodes:           make(map[kube.ResourceKey]*node),
 		onObjectUpdated: func(managedByApp map[string]bool, reference corev1.ObjectReference) {},
 		kubectl:         kubectl,

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -119,7 +119,7 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, health
 	clusterEventsCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "argocd_cluster_events_total",
 		Help: "Number of processes k8s resource events.",
-	}, descClusterDefaultLabels)
+	}, append(descClusterDefaultLabels, "group", "kind"))
 	registry.MustRegister(clusterEventsCounter)
 
 	return &MetricsServer{
@@ -164,8 +164,8 @@ func (m *MetricsServer) DecKubectlExecPending(command string) {
 }
 
 // IncClusterEventsCount increments the number of cluster events
-func (m *MetricsServer) IncClusterEventsCount(server string) {
-	m.clusterEventsCounter.WithLabelValues(server).Inc()
+func (m *MetricsServer) IncClusterEventsCount(server, group, kind string) {
+	m.clusterEventsCounter.WithLabelValues(server, group, kind).Inc()
 }
 
 // IncKubernetesRequest increments the kubernetes requests counter for an application

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -20,4 +20,4 @@ report() {
 
 trap 'report' EXIT
 
-go test -v $* 2>&1 | tee $TEST_RESULTS/test.out
+go test -failfast $* 2>&1 | tee $TEST_RESULTS/test.out

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -30,6 +32,7 @@ import (
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
+	applisters "github.com/argoproj/argo-cd/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
 	servercache "github.com/argoproj/argo-cd/server/cache"
 	"github.com/argoproj/argo-cd/server/rbacpolicy"
@@ -52,6 +55,7 @@ type Server struct {
 	ns            string
 	kubeclientset kubernetes.Interface
 	appclientset  appclientset.Interface
+	appLister     applisters.ApplicationNamespaceLister
 	repoClientset apiclient.Clientset
 	kubectl       kube.Kubectl
 	db            db.ArgoDB
@@ -67,6 +71,7 @@ func NewServer(
 	namespace string,
 	kubeclientset kubernetes.Interface,
 	appclientset appclientset.Interface,
+	appLister applisters.ApplicationNamespaceLister,
 	repoClientset apiclient.Clientset,
 	cache *servercache.Cache,
 	kubectl kube.Kubectl,
@@ -79,6 +84,7 @@ func NewServer(
 	return &Server{
 		ns:            namespace,
 		appclientset:  appclientset,
+		appLister:     appLister,
 		kubeclientset: kubeclientset,
 		cache:         cache,
 		db:            db,
@@ -98,23 +104,25 @@ func appRBACName(app appv1.Application) string {
 
 // List returns list of applications
 func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*appv1.ApplicationList, error) {
-	appList, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).List(metav1.ListOptions{LabelSelector: q.Selector})
+	labelsMap, err := labels.ConvertSelectorToLabelsMap(q.Selector)
+	if err != nil {
+		return nil, err
+	}
+	apps, err := s.appLister.List(labelsMap.AsSelector())
 	if err != nil {
 		return nil, err
 	}
 	newItems := make([]appv1.Application, 0)
-	for _, a := range appList.Items {
-		if s.enf.Enforce(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacpolicy.ActionGet, appRBACName(a)) {
-			newItems = append(newItems, a)
+	for _, a := range apps {
+		if s.enf.Enforce(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacpolicy.ActionGet, appRBACName(*a)) {
+			newItems = append(newItems, *a)
 		}
 	}
 	newItems = argoutil.FilterByProjects(newItems, q.Projects)
-	for i := range newItems {
-		app := newItems[i]
-		newItems[i] = app
+	appList := appv1.ApplicationList{
+		Items: newItems,
 	}
-	appList.Items = newItems
-	return appList, nil
+	return &appList, nil
 }
 
 // Create creates an application
@@ -131,39 +139,44 @@ func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateReq
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Create(&a)
-	if apierr.IsAlreadyExists(err) {
-		// act idempotent if existing spec matches new spec
-		existing, getErr := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(a.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return nil, status.Errorf(codes.Internal, "unable to check existing application details: %v", getErr)
-		}
-		if q.Upsert != nil && *q.Upsert {
-			if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacpolicy.ActionUpdate, appRBACName(a)); err != nil {
-				return nil, err
-			}
-			out, err = s.updateApp(existing, &a, ctx, true)
-		} else {
-			if !reflect.DeepEqual(existing.Spec, a.Spec) ||
-				!reflect.DeepEqual(existing.Labels, a.Labels) ||
-				!reflect.DeepEqual(existing.Annotations, a.Annotations) ||
-				!reflect.DeepEqual(existing.Finalizers, a.Finalizers) {
-
-				return nil, status.Errorf(codes.InvalidArgument, "existing application spec is different, use upsert flag to force update")
-			}
-			return existing, nil
-		}
-	}
-
+	created, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Create(&a)
 	if err == nil {
-		s.logAppEvent(out, ctx, argo.EventReasonResourceCreated, "created application")
+		s.logAppEvent(created, ctx, argo.EventReasonResourceCreated, "created application")
+		s.waitSync(created)
+		return created, nil
 	}
-	return out, err
+	if !apierr.IsAlreadyExists(err) {
+		return nil, err
+	}
+	// act idempotent if existing spec matches new spec
+	existing, err := s.appLister.Get(a.Name)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to check existing application details: %v", err)
+	}
+	equalSpecs := reflect.DeepEqual(existing.Spec, a.Spec) &&
+		reflect.DeepEqual(existing.Labels, a.Labels) &&
+		reflect.DeepEqual(existing.Annotations, a.Annotations) &&
+		reflect.DeepEqual(existing.Finalizers, a.Finalizers)
+
+	if !equalSpecs {
+		return existing, nil
+	}
+	if q.Upsert == nil || !*q.Upsert {
+		return nil, status.Errorf(codes.InvalidArgument, "existing application spec is different, use upsert flag to force update")
+	}
+	if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacpolicy.ActionUpdate, appRBACName(a)); err != nil {
+		return nil, err
+	}
+	updated, err := s.updateApp(existing, &a, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
 }
 
 // GetManifests returns application manifests
 func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationManifestQuery) (*apiclient.ManifestResponse, error) {
-	a, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(*q.Name, metav1.GetOptions{})
+	a, err := s.appLister.Get(*q.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -251,8 +264,7 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 
 // Get returns an application by name
 func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*appv1.Application, error) {
-	appIf := s.appclientset.ArgoprojV1alpha1().Applications(s.ns)
-	a, err := appIf.Get(*q.Name, metav1.GetOptions{})
+	a, err := s.appLister.Get(*q.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -264,6 +276,7 @@ func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*app
 		if *q.Refresh == string(appv1.RefreshTypeHard) {
 			refreshType = appv1.RefreshTypeHard
 		}
+		appIf := s.appclientset.ArgoprojV1alpha1().Applications(s.ns)
 		_, err = argoutil.RefreshApp(appIf, *q.Name, refreshType)
 		if err != nil {
 			return nil, err
@@ -278,7 +291,7 @@ func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*app
 
 // ListResourceEvents returns a list of event resources
 func (s *Server) ListResourceEvents(ctx context.Context, q *application.ApplicationResourceEventsQuery) (*v1.EventList, error) {
-	a, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(*q.Name, metav1.GetOptions{})
+	a, err := s.appLister.Get(*q.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -354,6 +367,37 @@ func mergeStringMaps(items ...map[string]string) map[string]string {
 	return res
 }
 
+// waitSync is a helper to wait until the application informer cache is synced after create/update.
+// It waits until the app in the informer, has a resource version greater than the version in the
+// supplied app, or after 2 seconds, whichever comes first. Returns true if synced.
+// We use an informer cache for read operations (Get, List). Since the cache is only
+// eventually consistent, it is possible that it doesn't reflect an application change immediately
+// after a mutating API call (create/update). This function should be called after a creates &
+// update to give a probable (but not guaranteed) chance of being up-to-date after the create/update.
+func (s *Server) waitSync(app *appv1.Application) {
+	logCtx := log.WithField("application", app.Name)
+	deadline := time.Now().Add(2 * time.Second)
+	minVersion, err := strconv.Atoi(app.ResourceVersion)
+	if err != nil {
+		logCtx.Warnf("waitSync failed: could not parse resource version %s", app.ResourceVersion)
+		time.Sleep(50 * time.Millisecond) // sleep anyways
+		return
+	}
+	for {
+		if currApp, err := s.appLister.Get(app.Name); err == nil {
+			currVersion, err := strconv.Atoi(currApp.ResourceVersion)
+			if err == nil && currVersion >= minVersion {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	logCtx.Warnf("waitSync failed: timed out")
+}
+
 func (s *Server) updateApp(app *appv1.Application, newApp *appv1.Application, ctx context.Context, merge bool) (*appv1.Application, error) {
 	for i := 0; i < 10; i++ {
 		app.Spec = newApp.Spec
@@ -370,6 +414,7 @@ func (s *Server) updateApp(app *appv1.Application, newApp *appv1.Application, ct
 		res, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Update(app)
 		if err == nil {
 			s.logAppEvent(app, ctx, argo.EventReasonResourceUpdated, "updated application spec")
+			s.waitSync(res)
 			return res, nil
 		}
 		if !apierr.IsConflict(err) {
@@ -688,7 +733,7 @@ func (s *Server) getAppResources(ctx context.Context, a *appv1.Application) (*ap
 }
 
 func (s *Server) getAppResource(ctx context.Context, action string, q *application.ApplicationResourceRequest) (*appv1.ResourceNode, *rest.Config, *appv1.Application, error) {
-	a, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(*q.Name, metav1.GetOptions{})
+	a, err := s.appLister.Get(*q.Name)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -810,7 +855,7 @@ func (s *Server) DeleteResource(ctx context.Context, q *application.ApplicationR
 }
 
 func (s *Server) ResourceTree(ctx context.Context, q *application.ResourcesQuery) (*appv1.ApplicationTree, error) {
-	a, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(*q.ApplicationName, metav1.GetOptions{})
+	a, err := s.appLister.Get(*q.ApplicationName)
 	if err != nil {
 		return nil, err
 	}
@@ -821,7 +866,7 @@ func (s *Server) ResourceTree(ctx context.Context, q *application.ResourcesQuery
 }
 
 func (s *Server) RevisionMetadata(ctx context.Context, q *application.RevisionMetadataQuery) (*v1alpha1.RevisionMetadata, error) {
-	a, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(q.GetName(), metav1.GetOptions{})
+	a, err := s.appLister.Get(q.GetName())
 	if err != nil {
 		return nil, err
 	}
@@ -848,7 +893,7 @@ func isMatchingResource(q *application.ResourcesQuery, key kube.ResourceKey) boo
 }
 
 func (s *Server) ManagedResources(ctx context.Context, q *application.ResourcesQuery) (*application.ManagedResourcesResponse, error) {
-	a, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(*q.ApplicationName, metav1.GetOptions{})
+	a, err := s.appLister.Get(*q.ApplicationName)
 	if err != nil {
 		return nil, err
 	}
@@ -1156,8 +1201,9 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 			return nil, status.Errorf(codes.InvalidArgument, "Unable to terminate operation. No operation is in progress")
 		}
 		a.Status.OperationState.Phase = appv1.OperationTerminating
-		_, err = s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Update(a)
+		updated, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Update(a)
 		if err == nil {
+			s.waitSync(updated)
 			return &application.OperationTerminateResponse{}, nil
 		}
 		if !apierr.IsConflict(err) {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -264,7 +264,10 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 
 // Get returns an application by name
 func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*appv1.Application, error) {
-	a, err := s.appLister.Get(*q.Name)
+	// We must use a client Get instead of an informer Get, because it's common to call Get immediately
+	// following a Watch (which is not yet powered by an informer), and the Get must reflect what was
+	// previously seen by the client.
+	a, err := s.appclientset.ArgoprojV1alpha1().Applications(s.ns).Get(*q.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
+	k8scache "k8s.io/client-go/tools/cache"
 
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/errors"
@@ -92,8 +93,8 @@ func newTestAppServer(objects ...runtime.Object) *Server {
 			"server.secretkey": []byte("test"),
 		},
 	})
-	db := db.NewDB(testNamespace, settings.NewSettingsManager(context.Background(), kubeclientset, testNamespace), kubeclientset)
 	ctx := context.Background()
+	db := db.NewDB(testNamespace, settings.NewSettingsManager(ctx, kubeclientset, testNamespace), kubeclientset)
 	_, err := db.CreateRepository(ctx, fakeRepo())
 	errors.CheckError(err)
 	_, err = db.CreateCluster(ctx, fakeCluster())
@@ -148,12 +149,22 @@ func newTestAppServer(objects ...runtime.Object) *Server {
 	enforcer.SetDefaultRole("role:admin")
 	enforcer.SetClaimsEnforcerFunc(rbacpolicy.NewRBACPolicyEnforcer(enforcer, fakeProjLister).EnforceClaims)
 
-	settingsMgr := settings.NewSettingsManager(context.Background(), kubeclientset, testNamespace)
+	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, testNamespace)
+
+	// populate the app informer with the fake objects
+	appInformer := factory.Argoproj().V1alpha1().Applications().Informer()
+	// TODO(jessesuen): probably should return cancel function so tests can stop background informer
+	//ctx, cancel := context.WithCancel(context.Background())
+	go appInformer.Run(ctx.Done())
+	if !k8scache.WaitForCacheSync(ctx.Done(), appInformer.HasSynced) {
+		panic("Timed out waiting forfff caches to sync")
+	}
 
 	server := NewServer(
 		testNamespace,
 		kubeclientset,
 		fakeAppsClientset,
+		factory.Argoproj().V1alpha1().Applications().Lister().Applications(testNamespace),
 		mockRepoClient,
 		nil,
 		&kubetest.MockKubectlCmd{},

--- a/util/settings/resources_filter.go
+++ b/util/settings/resources_filter.go
@@ -7,6 +7,7 @@ package settings
 var coreExcludedResources = []FilteredResource{
 	{APIGroups: []string{"events.k8s.io", "metrics.k8s.io"}},
 	{APIGroups: []string{""}, Kinds: []string{"Event", "Node"}},
+	{APIGroups: []string{"coordination.k8s.io"}, Kinds: []string{"Lease"}},
 }
 
 type ResourcesFilter struct {

--- a/util/settings/resources_filter.go
+++ b/util/settings/resources_filter.go
@@ -1,5 +1,14 @@
 package settings
 
+// The core exclusion list are K8s resources that we assume will never be managed by operators,
+// and are never child objects of managed resources that need to be presented in the resource tree.
+// This list contains high volume and  high churn metadata objects which we exclude for performance
+// reasons, reducing connections and load to the K8s API servers of managed clusters.
+var coreExcludedResources = []FilteredResource{
+	{APIGroups: []string{"events.k8s.io", "metrics.k8s.io"}},
+	{APIGroups: []string{""}, Kinds: []string{"Event", "Node"}},
+}
+
 type ResourcesFilter struct {
 	// ResourceExclusions holds the api groups, kinds per cluster to exclude from Argo CD's watch
 	ResourceExclusions []FilteredResource
@@ -8,10 +17,6 @@ type ResourcesFilter struct {
 }
 
 func (rf *ResourcesFilter) getExcludedResources() []FilteredResource {
-	coreExcludedResources := []FilteredResource{
-		{APIGroups: []string{"events.k8s.io", "metrics.k8s.io"}},
-		{APIGroups: []string{""}, Kinds: []string{"Event"}},
-	}
 	return append(coreExcludedResources, rf.ResourceExclusions...)
 }
 

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -1,0 +1,31 @@
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimingStats(t *testing.T) {
+	start := time.Now()
+	now = func() time.Time {
+		return start
+	}
+	defer func() {
+		now = time.Now
+	}()
+	ts := NewTimingStats()
+	now = func() time.Time {
+		return start.Add(100 * time.Millisecond)
+	}
+	ts.AddCheckpoint("checkpoint-1")
+	now = func() time.Time {
+		return start.Add(300 * time.Millisecond)
+	}
+	ts.AddCheckpoint("checkpoint-2")
+	timings := ts.Timings()
+	assert.Len(t, timings, 2)
+	assert.Equal(t, 100*time.Millisecond, timings["checkpoint-1"])
+	assert.Equal(t, 200*time.Millisecond, timings["checkpoint-2"])
+}


### PR DESCRIPTION
This enhances performance of the API server and controller with the following improvements:
* API server uses an Application informer for some read-only requests. However, it does not make any improvements to the Watch API
* Controller switches from Mutex to RWMutex to reduce contention of read-only operations
* Controller caches values of IsNamespaced() so that there is no lock contention
* Removals of unnecessary lock acquisition and reduction in locking duration
* The "Reconcilation completed" log message also logs timing stats of each phase of comparison, so that it can be graphed/analyzed.
* The coordination.k8s.io/Lease resource is now excluded from watch 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
