### PR TITLE
fix: Test for nil to prevent nil pointer dereference in state.go

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -166,7 +166,7 @@ func unmarshalManifests(manifests []string) ([]*unstructured.Unstructured, []*un
 		if err != nil {
 			return nil, nil, err
 		}
-		if ignore.Ignore(obj) {
+		if obj == nil || ignore.Ignore(obj) {
 			continue
 		}
 		if hookutil.IsHook(obj) {


### PR DESCRIPTION
While developing unit tests for a new feature, I noticed that certain tests can lead to nil pointer dereference when syncing local manifests, when giving empty local manifests (i.e. as `[]string{""}`). 
`v1alpha1.UnmarshalToUnstructured` will return nil but without error when unmarshaling the empty string. I'm not sure whether those can happen in real-world scenarios, as I could not reproduce the issue outside of unit tests.

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
