### PR TITLE
docs: Add missing parentheses to Webhook docs

### DIFF
--- a/docs/operator-manual/webhook.md
+++ b/docs/operator-manual/webhook.md
@@ -16,7 +16,7 @@ arbitrary value in the secret. This value will be used when configuring the webh
 
 ![Add Webhook](../assets/webhook-config.png "Add Webhook")
 
-### 2. Configure Argo CD With The WebHook Secret Optional)
+### 2. Configure Argo CD With The WebHook Secret (Optional)
 
 Configuring a webhook shared secret is optional, since Argo CD will still refresh applications
 related to the Git repository, even with unauthenticated webhook events. This is safe to do since


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Just a simple doc fix, there was amassing parentheses so I added it.