### PR TITLE
feat: Introduce sync-option SkipDryRunOnMissingResource=true (#2873)

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -478,9 +478,11 @@ func (sc *syncContext) getSyncTasks() (_ syncTasks, successful bool) {
 		serverRes, err := kube.ServerResourceForGroupVersionKind(sc.disco, task.groupVersionKind())
 		if err != nil {
 			// Special case for custom resources: if CRD is not yet known by the K8s API server,
-			// skip verification during `kubectl apply --dry-run` since we expect the CRD
+			// and the CRD is part of this sync or the resource is annotated with SkipDryRunOnMissingResource=true,
+			// then skip verification during `kubectl apply --dry-run` since we expect the CRD
 			// to be created during app synchronization.
-			if apierr.IsNotFound(err) && sc.hasCRDOfGroupKind(task.group(), task.kind()) {
+			skipDryRunOnMissingResource := resource.HasAnnotationOption(task.targetObj, common.AnnotationSyncOptions, "SkipDryRunOnMissingResource=true")
+			if apierr.IsNotFound(err) && (skipDryRunOnMissingResource || sc.hasCRDOfGroupKind(task.group(), task.kind())) {
 				sc.log.WithFields(log.Fields{"task": task}).Debug("skip dry-run for custom resource")
 				task.skipDryRun = true
 			} else {

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -458,6 +458,101 @@ func TestObjectsGetANamespace(t *testing.T) {
 	assert.Equal(t, "", pod.GetNamespace())
 }
 
+func TestSyncCustomResources(t *testing.T) {
+	type fields struct {
+		skipDryRunAnnotationPresent bool
+		crdAlreadyPresent           bool
+		crdInSameSync               bool
+	}
+
+	tests := []struct {
+		name       string
+		fields     fields
+		wantDryRun bool
+		wantSuccess bool
+	}{
+
+		{"unknown crd", fields{
+			skipDryRunAnnotationPresent: false, crdAlreadyPresent: false, crdInSameSync: false,
+		}, true, false},
+		{"crd present in same sync", fields{
+			skipDryRunAnnotationPresent: false, crdAlreadyPresent: false, crdInSameSync: true,
+		}, false, true},
+		{"crd is already present in cluster", fields{
+			skipDryRunAnnotationPresent: false, crdAlreadyPresent: true, crdInSameSync: false,
+		}, true, true},
+		{"crd is already present in cluster, skip dry run annotated", fields{
+			skipDryRunAnnotationPresent: true, crdAlreadyPresent: true, crdInSameSync: false,
+		}, true, true},
+		{"unknown crd, skip dry run annotated", fields{
+			skipDryRunAnnotationPresent: true, crdAlreadyPresent: false, crdInSameSync: false,
+		}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			knownCustomResourceTypes := []v1.APIResource{}
+			if tt.fields.crdAlreadyPresent {
+				knownCustomResourceTypes = append(knownCustomResourceTypes, v1.APIResource{Kind: "TestCrd", Group: "argoproj.io", Version: "v1", Namespaced: true})
+			}
+
+			syncCtx := newTestSyncCtx(
+				&v1.APIResourceList{
+					GroupVersion: "argoproj.io/v1",
+					APIResources: knownCustomResourceTypes,
+				},
+				&v1.APIResourceList{
+					GroupVersion: "apiextensions.k8s.io/v1beta1",
+					APIResources: []v1.APIResource{
+						{Kind: "CustomResourceDefinition", Group: "apiextensions.k8s.io", Version: "v1beta1", Namespaced: true},
+					},
+				},
+			)
+
+			cr := test.Unstructured(`
+{
+  "apiVersion": "argoproj.io/v1",
+  "kind": "TestCrd",
+  "metadata": {
+    "name": "my-resource"
+  }
+}
+`)
+
+			if tt.fields.skipDryRunAnnotationPresent {
+				cr.SetAnnotations(map[string]string{common.AnnotationSyncOptions: "SkipDryRunOnMissingResource=true"})
+			}
+
+			resources := []managedResource{{Target: cr}}
+			if tt.fields.crdInSameSync {
+				resources = append(resources, managedResource{Target: test.NewCRD()})
+			}
+
+			syncCtx.compareResult = &comparisonResult{managedResources: resources}
+
+			tasks, successful := syncCtx.getSyncTasks()
+
+			if successful != tt.wantSuccess {
+				t.Errorf("successful = %v, want: %v", successful, tt.wantSuccess)
+				return
+			}
+
+			skipDryRun := false
+			for _, task := range tasks {
+				if task.targetObj.GetKind() == cr.GetKind() {
+					skipDryRun = task.skipDryRun
+					break
+				}
+			}
+
+			if tt.wantDryRun != !skipDryRun {
+				t.Errorf("dryRun = %v, want: %v", !skipDryRun, tt.wantDryRun)
+			}
+		})
+	}
+
+}
+
 func TestPersistRevisionHistory(t *testing.T) {
 	app := newFakeApp()
 	app.Status.OperationState = nil

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -466,9 +466,9 @@ func TestSyncCustomResources(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		fields     fields
-		wantDryRun bool
+		name        string
+		fields      fields
+		wantDryRun  bool
 		wantSuccess bool
 	}{
 

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -38,3 +38,22 @@ metadata:
 
 If you want to exclude a whole class of objects globally, consider setting `resource.customizations` in [system level configuation](../user-guide/diffing.md#system-level-configuration). 
     
+## Skip Dry Run for new custom resources types
+
+>v1.5
+
+When syncing a custom resource which is not yet known to the cluster, there are generally two options:
+
+1) The CRD manifest is part of the same sync. Then ArgoCD will automatically skip the dry run, the CRD will be applied and the resource can be created.
+2) In some cases the CRD is not part of the sync, but it could be created in another way, e.g. by a controller in the cluster. An example is [gatekeeper](https://github.com/open-policy-agent/gatekeeper),
+which creates CRDs in response to user defined `ConstraintTemplates`. ArgoCD cannot find the CRD in the sync and will fail with the error `the server could not find the requested resource`.
+
+To skip the dry run for missing resource types, use the following annotation:
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+```
+
+The dry run will still be executed if the CRD is already present in the cluster.

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -40,7 +40,7 @@ If you want to exclude a whole class of objects globally, consider setting `reso
     
 ## Skip Dry Run for new custom resources types
 
->v1.5
+>v1.6
 
 When syncing a custom resource which is not yet known to the cluster, there are generally two options:
 


### PR DESCRIPTION
* Annotation `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` can be set on any resource
* When set, then the dry run for this resource will be skipped when syncing, but only if the Group and Kind are currently not present in the cluster.
* This is analogous to the current handling of missing CRDs, but when the CRD is part of the same sync.
* Supports the use case where a CRD is created by a kubernetes controller inside the cluster in response to another CRD in the same sync.
* Closes #2873

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
