### PR TITLE
Refine docs: How to explicitly select a tool

### DIFF
--- a/docs/user-guide/tool_detection.md
+++ b/docs/user-guide/tool_detection.md
@@ -4,6 +4,26 @@ The tool used to build an application is detected as follows:
 
 If a specific tool is explicitly configured, then that tool is selected to create your application's manifests.
 
+The tool can be explicitly specified in the Application custom resource like this:
+```
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  ...
+spec:
+  ...
+  source:
+    ...
+    
+    # Tool -> plain directory
+    directory:
+      recurse: true
+...
+```
+
+You also can select the tool in the Application creation wizard in the web user interface. The default is 'Directory'. Press the dropdown button beneath the tool name if you want to choose a different one.
+
+
 If not, then the tool is detected implicitly as follows:
 
 * **Ksonnet** if there are two files, one named `app.yaml` and one named `components/params.libsonnet`.


### PR DESCRIPTION
Its easy to misconfigure the Application if you use the Application creation wizard, because the default is 'Directory'. If you choose that, your kustomize repo won't work.

Documentation should contain more details about how the tools are selected more precisely.

Greetings,

Josef


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
