### PR TITLE
docs: add slack link to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,10 @@ title: ''
 labels: 'bug'
 assignees: ''
 ---
+
+If you are trying to resolve an environment-specific issue or have a one-off question about the edge case that does not require a feature then please consider asking a
+question in argocd slack [channel](https://argoproj.github.io/community/join-slack).
+
 Checklist:
 
 * [ ] I've searched in the docs and FAQ for my answer: http://bit.ly/argocd-faq.


### PR DESCRIPTION
We are clearly unable to handle all issues. A lot of them are questions but it is hard to provide help because more interactive communication is required. Adding slack link directly to the issue template to encourage people to ask in slack instead.