### PR TITLE
fix: increase max connections count to support clusters with very large number of CRDs

### DIFF
--- a/cmd/argocd-application-controller/main.go
+++ b/cmd/argocd-application-controller/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/controller"
 	"github.com/argoproj/argo-cd/errors"
+	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
 	appstatecache "github.com/argoproj/argo-cd/util/cache/appstate"
@@ -59,8 +60,7 @@ func newCommand() *cobra.Command {
 
 			config, err := clientConfig.ClientConfig()
 			errors.CheckError(err)
-			config.QPS = common.K8sClientConfigQPS
-			config.Burst = common.K8sClientConfigBurst
+			errors.CheckError(v1alpha1.SetK8SConfigDefaults(config))
 
 			kubeClient := kubernetes.NewForConfigOrDie(config)
 			appClient := appclientset.NewForConfigOrDie(config)

--- a/cmd/argocd-server/commands/root.go
+++ b/cmd/argocd-server/commands/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/errors"
+	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/server"
@@ -48,8 +49,7 @@ func NewCommand() *cobra.Command {
 
 			config, err := clientConfig.ClientConfig()
 			errors.CheckError(err)
-			config.QPS = common.K8sClientConfigQPS
-			config.Burst = common.K8sClientConfigBurst
+			errors.CheckError(v1alpha1.SetK8SConfigDefaults(config))
 
 			namespace, _, err := clientConfig.Namespace()
 			errors.CheckError(err)

--- a/common/common.go
+++ b/common/common.go
@@ -141,6 +141,8 @@ const (
 	EnvK8sClientQPS = "ARGOCD_K8S_CLIENT_QPS"
 	// EnvK8sClientBurst is the burst value used for the kubernetes client (default: twice the client QPS)
 	EnvK8sClientBurst = "ARGOCD_K8S_CLIENT_BURST"
+	// EnvK8sClientMaxIdleConnections is the number of max idle connections in K8s REST client HTTP transport (default: 500)
+	EnvK8sClientMaxIdleConnections = "ARGOCD_K8S_CLIENT_MAX_IDLE_CONNECTIONS"
 )
 
 const (
@@ -158,6 +160,8 @@ var (
 	K8sClientConfigQPS float32 = 50
 	// K8sClientConfigBurst controls the burst to be used in K8s REST client configs
 	K8sClientConfigBurst int = 100
+	// K8sMaxIdleConnections controls the number of max idle connections in K8s REST client HTTP transport
+	K8sMaxIdleConnections = 500
 )
 
 func init() {
@@ -172,5 +176,11 @@ func init() {
 		}
 	} else {
 		K8sClientConfigBurst = 2 * int(K8sClientConfigQPS)
+	}
+
+	if envMaxConn := os.Getenv(EnvK8sClientMaxIdleConnections); envMaxConn != "" {
+		if maxConn, err := strconv.Atoi(envMaxConn); err != nil {
+			K8sMaxIdleConnections = maxConn
+		}
 	}
 }

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -47,6 +47,7 @@ type syncContext struct {
 	proj                *v1alpha1.AppProject
 	compareResult       *comparisonResult
 	config              *rest.Config
+	rawConfig           *rest.Config
 	dynamicIf           dynamic.Interface
 	disco               discovery.DiscoveryInterface
 	extensionsclientset *clientset.Clientset
@@ -173,6 +174,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		proj:                proj,
 		compareResult:       compareResult,
 		config:              restConfig,
+		rawConfig:           clst.RawRestConfig(),
 		dynamicIf:           dynamicIf,
 		disco:               disco,
 		extensionsclientset: extensionsclientset,
@@ -549,7 +551,7 @@ func (sc *syncContext) ensureCRDReady(name string) {
 
 // applyObject performs a `kubectl apply` of a single resource
 func (sc *syncContext) applyObject(targetObj *unstructured.Unstructured, dryRun, force, validate bool) (v1alpha1.ResultCode, string) {
-	message, err := sc.kubectl.ApplyResource(sc.config, targetObj, targetObj.GetNamespace(), dryRun, force, validate)
+	message, err := sc.kubectl.ApplyResource(sc.rawConfig, targetObj, targetObj.GetNamespace(), dryRun, force, validate)
 	if err != nil {
 		return v1alpha1.ResultCodeSyncFailed, err.Error()
 	}

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -44,6 +44,7 @@ func newTestSyncCtx(resources ...*v1.APIResourceList) *syncContext {
 		})
 	sc := syncContext{
 		config:    &rest.Config{},
+		rawConfig: &rest.Config{},
 		namespace: test.FakeArgoCDNamespace,
 		server:    test.FakeClusterURL,
 		syncRes: &v1alpha1.SyncOperationResult{

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -3,6 +3,8 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -22,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -2172,8 +2175,40 @@ func (proj AppProject) IsDestinationPermitted(dst ApplicationDestination) bool {
 	return false
 }
 
-// RESTConfig returns a go-client REST config from cluster
-func (c *Cluster) RESTConfig() *rest.Config {
+// SetK8SConfigDefaults sets Kubernetes REST config default settings
+func SetK8SConfigDefaults(config *rest.Config) error {
+	config.QPS = common.K8sClientConfigQPS
+	config.Burst = common.K8sClientConfigBurst
+	tlsConfig, err := rest.TLSConfigFor(config)
+	if err != nil {
+		return err
+	}
+	// set default tls config since we use it in a custom transport
+	config.TLSClientConfig = rest.TLSClientConfig{}
+	dial := (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	transport := utilnet.SetTransportDefaults(&http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+		MaxIdleConns:        common.K8sMaxIdleConnections,
+		MaxIdleConnsPerHost: common.K8sMaxIdleConnections,
+		MaxConnsPerHost:     common.K8sMaxIdleConnections,
+		DialContext:         dial,
+		DisableCompression:  config.DisableCompression,
+	})
+	tr, err := rest.HTTPWrappersForConfig(config, transport)
+	if err != nil {
+		return err
+	}
+	config.Transport = tr
+	return nil
+}
+
+// RawRestConfig returns a go-client REST config from cluster that might be serialized into the file using kube.WriteKubeConfig method.
+func (c *Cluster) RawRestConfig() *rest.Config {
 	var config *rest.Config
 	var err error
 	if c.Server == common.KubernetesInternalAPIServerAddr && os.Getenv(common.EnvVarFakeInClusterConfig) == "true" {
@@ -2220,8 +2255,16 @@ func (c *Cluster) RESTConfig() *rest.Config {
 	if err != nil {
 		panic(fmt.Sprintf("Unable to create K8s REST config: %v", err))
 	}
-	config.QPS = common.K8sClientConfigQPS
-	config.Burst = common.K8sClientConfigBurst
+	return config
+}
+
+// RESTConfig returns a go-client REST config from cluster with tuned throttling and HTTP client settings.
+func (c *Cluster) RESTConfig() *rest.Config {
+	config := c.RawRestConfig()
+	err := SetK8SConfigDefaults(config)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to apply K8s REST config defaults: %v", err))
+	}
 	return config
 }
 


### PR DESCRIPTION
PR increases the number of connections per host in HTTP transport used by K8S rest config.