### PR TITLE
chore: Fix unparam errors from linter

### DIFF
--- a/controller/cache/cluster.go
+++ b/controller/cache/cluster.go
@@ -73,7 +73,7 @@ func (c *clusterInfo) replaceResourceCache(gk schema.GroupKind, resourceVersion 
 			obj := &objs[i]
 			key := kube.GetResourceKey(&objs[i])
 			existingNode, exists := c.nodes[key]
-			c.onNodeUpdated(exists, existingNode, obj, key)
+			c.onNodeUpdated(exists, existingNode, obj)
 		}
 
 		// remove existing nodes that a no longer exist
@@ -566,11 +566,11 @@ func (c *clusterInfo) processEvent(event watch.EventType, un *unstructured.Unstr
 			c.onNodeRemoved(key, existingNode)
 		}
 	} else if event != watch.Deleted {
-		c.onNodeUpdated(exists, existingNode, un, key)
+		c.onNodeUpdated(exists, existingNode, un)
 	}
 }
 
-func (c *clusterInfo) onNodeUpdated(exists bool, existingNode *node, un *unstructured.Unstructured, key kube.ResourceKey) {
+func (c *clusterInfo) onNodeUpdated(exists bool, existingNode *node, un *unstructured.Unstructured) {
 	nodes := make([]*node, 0)
 	if exists {
 		nodes = append(nodes, existingNode)


### PR DESCRIPTION
While running a full `make lint` on our source tree, the linter complained (correctly) about the following:

```
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 13 linters: [deadcode errcheck goimports gosimple govet ineffassign staticcheck structcheck typecheck unconvert unparam unused varcheck] 
INFO [lintersdb] Active 13 linters: [deadcode errcheck goimports gosimple govet ineffassign staticcheck structcheck typecheck unconvert unparam unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|files|types_sizes|compiled_files|exports_file|imports|name) took 32.516073916s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 277.964281ms 
INFO [runner/goanalysis_metalinter/goanalysis] analyzers took 1m18.241717724s with top 10 stages: buildssa: 49.004235618s, goimports: 6.794532034s, unconvert: 6.530
14813s, unparam: 2.524233439s, vrp: 1.789371739s, ineffassign: 1.39629306s, inspect: 615.476319ms, fact_deprecated: 568.052976ms, deadcode: 497.489762ms, errcheck: 
477.142691ms 
INFO [runner/unused/goanalysis] analyzers took 27.752204788s with top 10 stages: buildssa: 26.121181921s, U1000: 1.631022867s 
INFO [runner/skip dirs] Skipped 2 issues from dir pkg/client/clientset/versioned by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 7 issues from dir pkg/client/clientset/versioned/fake by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 4 issues from dir pkg/client/informers/externalversions by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 2 issues from dir pkg/client/informers/externalversions/internalinterfaces by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 4 issues from dir pkg/client/informers/externalversions/application/v1alpha1 by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 2 issues from dir pkg/client/clientset/versioned/scheme by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 4 issues from dir pkg/client/listers/application/v1alpha1 by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 6 issues from dir pkg/client/clientset/versioned/typed/application/v1alpha1 by pattern pkg/client/ 
INFO [runner/skip dirs] Skipped 6 issues from dir pkg/client/clientset/versioned/typed/application/v1alpha1/fake by pattern pkg/client/ 
INFO [runner] Issues before processing: 252, after processing: 1 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 13/139, nolint: 1/1, diff: 1/1, max_per_file_from_linter: 1/1, filename_unadjuster: 252/252
, skip_files: 176/252, uniq_by_line: 1/1, max_same_issues: 1/1, source_code: 1/1, path_shortener: 1/1, path_prettifier: 252/252, identifier_marker: 13/13, cgo: 252/
252, exclude-rules: 1/1, max_from_linter: 1/1, skip_dirs: 139/176, exclude: 1/13 
INFO [runner] processing took 10.95355ms with stages: skip_dirs: 4.624363ms, path_prettifier: 2.084385ms, nolint: 1.959299ms, skip_files: 825.889µs, exclude: 602.41
7µs, identifier_marker: 312.874µs, autogenerated_exclude: 295.222µs, cgo: 155.305µs, source_code: 62.765µs, filename_unadjuster: 18.15µs, max_same_issues: 4.141µs, 
uniq_by_line: 3.728µs, max_per_file_from_linter: 1.597µs, path_shortener: 1.293µs, max_from_linter: 1.233µs, diff: 538ns, exclude-rules: 351ns 
INFO [runner] linters took 41.366140374s with stages: goanalysis_metalinter: 24.517572023s, unused: 16.83618522s 
INFO fixer took 0s with no stages                 
controller/cache/cluster.go:573:101: `(*clusterInfo).onNodeUpdated` - `key` is unused (unparam)
func (c *clusterInfo) onNodeUpdated(exists bool, existingNode *node, un *unstructured.Unstructured, key kube.ResourceKey) {
                                                                                                    ^
INFO File cache stats: 1 entries of total size 17.7KiB 
INFO Memory: 585 samples, avg is 332.1MB, max is 3511.8MB 
INFO Execution took 1m14.190764242s               
```
Checklist:

* [x] this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
