### PR TITLE
docs: document Traefik 2 ingress requires disabling TLS

### DIFF
--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -158,6 +158,8 @@ Traefik can be used as an edge router and provide [TLS](https://docs.traefik.io/
 
 It currently has an advantage over NGINX in that it can terminate both TCP and HTTP connections _on the same port_ meaning you do not require multiple ingress objects and hosts.
 
+The API server should be run with TLS disabled. Edit the `argocd-server` deployment to add the `--insecure` flag to the argocd-server command.
+
 ```yaml
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute


### PR DESCRIPTION
The nginx ingress setup explains that when nginx takes care of TLS, then the ArgoCD server should be deployed with the `--insecure` flag. Otherwise, Argo receives HTTP requests and tries to upgrade them to HTTPS, resulting in an infinite loop.

The suggested Traefik 2 ingress also handles TLS, as such a similar note about setting the `--insecure` flag is desired.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
