### PR TITLE
chore: Run "dep check" in CircleCI pipeline to detect for changes in Gopkg.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,10 @@ jobs:
     steps:
       - prepare_environment
       - checkout
+      - restore_vendor
       - run:
           name: Ensuring Gopkg.lock is up-to-date
           command: make dep-check-local
-      - restore_vendor
       - run:
           name: Syncing vendor dependencies
           command: dep ensure -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,13 @@ jobs:
     steps:
       - prepare_environment
       - checkout
+      - run:
+          name: Ensuring Gopkg.lock is up-to-date
+          command: make dep-check-local
       - restore_vendor
-      - run: dep ensure -v
+      - run:
+          name: Syncing vendor dependencies
+          command: dep ensure -v
       - run: make build-local
       - run: chmod -R 777 vendor
       - run: chmod -R 777 ${GOCACHE}

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2076,6 +2076,7 @@
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/pager",
     "k8s.io/client-go/tools/portforward",
     "k8s.io/client-go/transport/spdy",
     "k8s.io/client-go/util/flowcontrol",

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ dep-check:
 # Runs dep check locally to ensure Gopkg.lock is up-to-date with dependencies
 .PHONY: dep-check-local
 dep-check-local:
-	if ! dep check; then echo "Please make sure Gopkg.lock is up-to-date - see https://argoproj.github.io/argo-cd/developer-guide/faq/#why-does-the-build-step-fail"; exit 1; fi
+	if ! dep check -skip-vendor; then echo "Please make sure Gopkg.lock is up-to-date - see https://argoproj.github.io/argo-cd/developer-guide/faq/#why-does-the-build-step-fail"; exit 1; fi
 
 # Deprecated - replace by install-local-tools
 .PHONY: install-lint-tools

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,16 @@ dep-ensure:
 dep-ensure-local:
 	dep ensure -no-vendor
 
+# Runs dep check in a container to ensure Gopkg.lock is up-to-date with dependencies
+.PHONY: dep-check
+dep-check:
+	$(call run-in-test-client,make dep-check-local)
+
+# Runs dep check locally to ensure Gopkg.lock is up-to-date with dependencies
+.PHONY: dep-check-local
+dep-check-local:
+	if ! dep check; then echo "Please make sure Gopkg.lock is up-to-date - see https://argoproj.github.io/argo-cd/developer-guide/faq/#why-does-the-build-step-fail"; exit 1; fi
+
 # Deprecated - replace by install-local-tools
 .PHONY: install-lint-tools
 install-lint-tools:

--- a/docs/developer-guide/faq.md
+++ b/docs/developer-guide/faq.md
@@ -37,7 +37,11 @@ git push origin <yourbranch>
 
 ### Why does the build step fail?
 
-Sometimes, CircleCI kills the build step due to excessive memory usage. This happens rarely, but it has happened in the past. If you see a message like "killed" in the log output of CircleCI, you should retrigger the pipeline as described above. If the issue persists, please let us know.
+Chances are that it fails for two of the following reasons in the CI while running fine on your machine:
+
+* Sometimes, CircleCI kills the build step due to excessive memory usage. This happens rarely, but it has happened in the past. If you see a message like "killed" in the log output of CircleCI, you should retrigger the pipeline as described above. If the issue persists, please let us know.
+
+* If the build is failing at the `Ensuring Gopkg.lock is up-to-date` step, you need to update the dependencies before you push your commits. Run `make dep-ensure` and `make dep` and commit the changes to `Gopkg.lock` to your branch.
 
 ### Why does the codegen step fail?
 


### PR DESCRIPTION
Sometimes packages are not contained in `Gopkg.lock` triggering a long run of `dep ensure`. This runs `dep check` in the initial build step and fails if `Gopkg.lock` needs to be updated. If Gopkg.lock is out of sync, `dep` will go bonkers, circumvent our vendor cache and take a long time to sync dependencies.

Checklist:

* [x] this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
