### PR TITLE
fix: Fix possible panic when generating Dex config from malformed YAML

### DIFF
--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -58,14 +58,23 @@ func GenerateDexConfigYAML(settings *settings.ArgoCDSettings) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	connectors := dexCfg["connectors"].([]interface{})
+	connectors, ok := dexCfg["connectors"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("malformed Dex configuration found")
+	}
 	for i, connectorIf := range connectors {
-		connector := connectorIf.(map[string]interface{})
+		connector, ok := connectorIf.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("malformed Dex configuration found")
+		}
 		connectorType := connector["type"].(string)
 		if !needsRedirectURI(connectorType) {
 			continue
 		}
-		connectorCfg := connector["config"].(map[string]interface{})
+		connectorCfg, ok := connector["config"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("malformed Dex configuration found")
+		}
 		connectorCfg["redirectURI"] = dexRedirectURL
 		connector["config"] = connectorCfg
 		connectors[i] = connector


### PR DESCRIPTION
Issue found during writing unit tests for `util/dex/config.go` - panics can happen when `dex.config` contains unexpected data.

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
