### PR TITLE
chore: Upgrade golang version from v1.14.0 to v1.14.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,13 @@ commands:
   install_golang:
     steps:
       - run:
-          name: Install Golang v1.14
+          name: Install Golang v1.14.1
           command: |
-            go get golang.org/dl/go1.14
-            [ -e /home/circleci/sdk/go1.14 ] || go1.14 download
+            go get golang.org/dl/go1.14.1
+            [ -e /home/circleci/sdk/go1.14.1 ] || go1.14.1 download
             go env
             echo "export GOPATH=/home/circleci/.go_workspace" | tee -a $BASH_ENV
-            echo "export PATH=/home/circleci/sdk/go1.14/bin:\$PATH" | tee -a $BASH_ENV
+            echo "export PATH=/home/circleci/sdk/go1.14.1/bin:\$PATH" | tee -a $BASH_ENV
   save_go_cache:
     steps:
       - save_cache:
@@ -58,7 +58,7 @@ commands:
           # https://circleci.com/docs/2.0/language-go/
           paths:
             - /home/circleci/.cache/go-build
-            - /home/circleci/sdk/go1.14
+            - /home/circleci/sdk/go1.14.1
   restore_go_cache:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: argoproj/argocd-test-tools:v0.1.0
+      - image: argoproj/argocd-test-tools:v0.2.0
     working_directory: /go/src/github.com/argoproj/argo-cd
     steps:
       - prepare_environment
@@ -102,7 +102,7 @@ jobs:
 
   codegen:
     docker:
-      - image: argoproj/argocd-test-tools:v0.1.0
+      - image: argoproj/argocd-test-tools:v0.2.0
     working_directory: /go/src/github.com/argoproj/argo-cd
     steps:
       - prepare_environment
@@ -125,7 +125,7 @@ jobs:
   test:
     working_directory: /go/src/github.com/argoproj/argo-cd
     docker:
-      - image: argoproj/argocd-test-tools:v0.1.0
+      - image: argoproj/argocd-test-tools:v0.2.0
     steps:
       - prepare_environment
       - checkout

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.14'
+          go-version: '1.14.1'
       - uses: actions/checkout@master
         with:
           path: src/github.com/argoproj/argo-cd

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=debian:10-slim
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM golang:1.14.0 as builder
+FROM golang:1.14.1 as builder
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 
@@ -97,7 +97,7 @@ RUN NODE_ENV='production' yarn build
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
 ####################################################################################################
-FROM golang:1.14.0 as argocd-build
+FROM golang:1.14.1 as argocd-build
 
 COPY --from=builder /usr/local/bin/dep /usr/local/bin/dep
 COPY --from=builder /usr/local/bin/packr /usr/local/bin/packr

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ARGOCD_PROCFILE?=Procfile
 # Configuration for building argocd-test-tools image
 TEST_TOOLS_NAMESPACE?=argoproj
 TEST_TOOLS_IMAGE=argocd-test-tools
-TEST_TOOLS_TAG?=v0.1.0
+TEST_TOOLS_TAG?=v0.2.0
 ifdef TEST_TOOLS_NAMESPACE
 TEST_TOOLS_PREFIX=${TEST_TOOLS_NAMESPACE}/
 endif


### PR DESCRIPTION
I upgraded Go to the latest version.
https://golang.org/doc/devel/release.html#go1.14

Checklist:

* [x] this does not need to be in the release notes
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 