### PR TITLE
chore: Code coverage offensive #1: util/dex

### DIFF
--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -58,14 +58,23 @@ func GenerateDexConfigYAML(settings *settings.ArgoCDSettings) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	connectors := dexCfg["connectors"].([]interface{})
+	connectors, ok := dexCfg["connectors"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("malformed Dex configuration found")
+	}
 	for i, connectorIf := range connectors {
-		connector := connectorIf.(map[string]interface{})
+		connector, ok := connectorIf.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("malformed Dex configuration found")
+		}
 		connectorType := connector["type"].(string)
 		if !needsRedirectURI(connectorType) {
 			continue
 		}
-		connectorCfg := connector["config"].(map[string]interface{})
+		connectorCfg, ok := connector["config"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("malformed Dex configuration found")
+		}
 		connectorCfg["redirectURI"] = dexRedirectURL
 		connector["config"] = connectorCfg
 		connectors[i] = connector

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -1,0 +1,108 @@
+package dex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	// "github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/util/settings"
+)
+
+var malformedDexConfig = `
+valid:
+  yaml: valid	
+yaml: 
+  valid
+`
+
+var goodDexConfig = `
+connectors:
+# GitHub example
+- type: github
+  id: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: $dex.github.clientSecret
+    orgs:
+    - name: your-github-org
+
+# GitHub enterprise example
+- type: github
+  id: acme-github
+  name: Acme GitHub
+  config:
+    hostName: github.acme.com
+    clientID: abcdefghijklmnopqrst
+    clientSecret: $dex.acme.clientSecret
+    orgs:
+    - name: your-github-org
+`
+
+var goodSecrets = map[string]string{
+	"dex.github.clientSecret": "foobar",
+	"dex.acme.clientSecret":   "barfoo",
+}
+
+func Test_GenerateDexConfig(t *testing.T) {
+
+	t.Run("Empty settings", func(t *testing.T) {
+		s := settings.ArgoCDSettings{}
+		config, err := GenerateDexConfigYAML(&s)
+		assert.NoError(t, err)
+		assert.Nil(t, config)
+	})
+
+	t.Run("Invalid URL", func(t *testing.T) {
+		s := settings.ArgoCDSettings{
+			URL:       ":://localhost/foo/bar",
+			DexConfig: goodDexConfig,
+		}
+		config, err := GenerateDexConfigYAML(&s)
+		assert.Error(t, err)
+		assert.Nil(t, config)
+	})
+
+	t.Run("No URL set", func(t *testing.T) {
+		s := settings.ArgoCDSettings{
+			URL:       "",
+			DexConfig: "invalidyaml",
+		}
+		config, err := GenerateDexConfigYAML(&s)
+		assert.NoError(t, err)
+		assert.Nil(t, config)
+	})
+
+	t.Run("Invalid YAML", func(t *testing.T) {
+		s := settings.ArgoCDSettings{
+			URL:       "http://localhost",
+			DexConfig: "invalidyaml",
+		}
+		config, err := GenerateDexConfigYAML(&s)
+		assert.NoError(t, err)
+		assert.Nil(t, config)
+	})
+
+	t.Run("Valid YAML but incorrect Dex config", func(t *testing.T) {
+		s := settings.ArgoCDSettings{
+			URL:       "http://localhost",
+			DexConfig: malformedDexConfig,
+		}
+		config, err := GenerateDexConfigYAML(&s)
+		assert.Error(t, err)
+		assert.Nil(t, config)
+	})
+
+	t.Run("Valid YAML and correct Dex config", func(t *testing.T) {
+		s := settings.ArgoCDSettings{
+			URL:       "http://localhost",
+			DexConfig: goodDexConfig,
+			Secrets:   goodSecrets,
+		}
+		config, err := GenerateDexConfigYAML(&s)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+	})
+
+}

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -188,6 +188,7 @@ func Test_DexReverseProxy(t *testing.T) {
 		resp, err := http.Get(server.URL)
 		assert.NotNil(t, resp)
 		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		fmt.Printf("%s\n", resp.Status)
 	})
 
@@ -207,7 +208,7 @@ func Test_DexReverseProxy(t *testing.T) {
 		resp, err := client.Get(server.URL)
 		assert.NotNil(t, resp)
 		assert.NoError(t, err)
-		assert.Equal(t, 303, resp.StatusCode)
+		assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
 		location, _ := resp.Location()
 		fmt.Printf("%s %s\n", resp.Status, location.RequestURI())
 		assert.True(t, strings.HasPrefix(location.RequestURI(), "/login?sso_error"))


### PR DESCRIPTION
**Code coverage offensive**

This is the first part of an effort to increase our overall code coverage for tests to an acceptable limit.

The PR adds units test for `util/dex` package with a package coverage of 88.5%. Previous package coverage was 0% (not a single test).

Checklist:

* [x] (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
