### PR TITLE
fix: pass APIVersions value to manifest generation request during app validation and during app manifests loading

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -140,12 +140,6 @@ func (m *appStateManager) getRepoObjs(app *v1alpha1.Application, source v1alpha1
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	var apiVersions []string
-	for _, g := range apiGroups {
-		for _, v := range g.Versions {
-			apiVersions = append(apiVersions, v.GroupVersion)
-		}
-	}
 	ts.AddCheckpoint("version_ms")
 	manifestInfo, err := repoClient.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 		Repo:              repo,
@@ -161,7 +155,7 @@ func (m *appStateManager) getRepoObjs(app *v1alpha1.Application, source v1alpha1
 			BuildOptions: buildOptions,
 		},
 		KubeVersion: serverVersion,
-		ApiVersions: apiVersions,
+		ApiVersions: argo.APIGroupsToVersions(apiGroups),
 	})
 	if err != nil {
 		return nil, nil, nil, err

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -225,7 +225,12 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 	if err != nil {
 		return nil, err
 	}
-	cluster.ServerVersion, err = s.kubectl.GetServerVersion(cluster.RESTConfig())
+	config := cluster.RESTConfig()
+	cluster.ServerVersion, err = s.kubectl.GetServerVersion(config)
+	if err != nil {
+		return nil, err
+	}
+	apiGroups, err := s.kubectl.GetAPIGroups(config)
 	if err != nil {
 		return nil, err
 	}
@@ -240,6 +245,7 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 		Plugins:           plugins,
 		KustomizeOptions:  &kustomizeOptions,
 		KubeVersion:       cluster.ServerVersion,
+		ApiVersions:       argo.APIGroupsToVersions(apiGroups),
 	})
 	if err != nil {
 		return nil, err

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -236,11 +236,17 @@ func ValidateRepo(
 		})
 		return conditions, nil
 	}
-	cluster.ServerVersion, err = kubectl.GetServerVersion(cluster.RESTConfig())
+	config := cluster.RESTConfig()
+	cluster.ServerVersion, err = kubectl.GetServerVersion(config)
 	if err != nil {
 		return nil, err
 	}
-	conditions = append(conditions, verifyGenerateManifests(ctx, repo, helmRepos, app, repoClient, kustomizeOptions, plugins, cluster.ServerVersion)...)
+	apiGroups, err := kubectl.GetAPIGroups(config)
+	if err != nil {
+		return nil, err
+	}
+	conditions = append(conditions, verifyGenerateManifests(
+		ctx, repo, helmRepos, app, repoClient, kustomizeOptions, plugins, cluster.ServerVersion, APIGroupsToVersions(apiGroups))...)
 
 	return conditions, nil
 }
@@ -310,6 +316,17 @@ func ValidatePermissions(ctx context.Context, spec *argoappv1.ApplicationSpec, p
 	return conditions, nil
 }
 
+// APIGroupsToVersions converts list of API Groups into versions string list
+func APIGroupsToVersions(apiGroups []metav1.APIGroup) []string {
+	var apiVersions []string
+	for _, g := range apiGroups {
+		for _, v := range g.Versions {
+			apiVersions = append(apiVersions, v.GroupVersion)
+		}
+	}
+	return apiVersions
+}
+
 // GetAppProject returns a project from an application
 func GetAppProject(spec *argoappv1.ApplicationSpec, projLister applicationsv1.AppProjectLister, ns string) (*argoappv1.AppProject, error) {
 	return projLister.AppProjects(ns).Get(spec.GetProject())
@@ -325,6 +342,7 @@ func verifyGenerateManifests(
 	kustomizeOptions *argoappv1.KustomizeOptions,
 	plugins []*argoappv1.ConfigManagementPlugin,
 	kubeVersion string,
+	apiVersions []string,
 ) []argoappv1.ApplicationCondition {
 	spec := &app.Spec
 	var conditions []argoappv1.ApplicationCondition
@@ -349,6 +367,7 @@ func verifyGenerateManifests(
 		Plugins:           plugins,
 		KustomizeOptions:  kustomizeOptions,
 		KubeVersion:       kubeVersion,
+		ApiVersions:       apiVersions,
 	}
 	req.Repo.CopyCredentialsFromRepo(repoRes)
 	req.Repo.CopySettingsFrom(repoRes)

--- a/util/kube/kubetest/mock.go
+++ b/util/kube/kubetest/mock.go
@@ -25,6 +25,7 @@ type MockKubectlCmd struct {
 	LastValidate  bool
 	Version       string
 	DynamicClient dynamic.Interface
+	APIGroups     []metav1.APIGroup
 }
 
 func (k *MockKubectlCmd) NewDynamicClient(config *rest.Config) (dynamic.Interface, error) {
@@ -70,7 +71,7 @@ func (k *MockKubectlCmd) GetServerVersion(config *rest.Config) (string, error) {
 }
 
 func (k *MockKubectlCmd) GetAPIGroups(config *rest.Config) ([]metav1.APIGroup, error) {
-	return nil, nil
+	return k.APIGroups, nil
 }
 
 func (k *MockKubectlCmd) SetOnKubectlRun(onKubectlRun func(command string) (util.Closer, error)) {


### PR DESCRIPTION
The https://github.com/argoproj/argo-cd/pull/3243 introduced support of `--api-versions` flag during helm chart rendering . The value for `--api-versions` flag is supplied by application controller but does not supply by API server while executing `Create` and `GetManifests` API. This PR fixes that issue.