### PR TITLE
docs: (and chore) Add UI lint instructions and accompanying targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,14 @@ lint-local:
 	# See https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
 	GOGC=100 golangci-lint run --fix --verbose
 
+.PHONY: lint-ui
+lint-ui:
+	$(call run-in-test-client,make lint-ui-local)
+
+.PHONY: lint-ui-local
+lint-ui-local:
+	cd ui && yarn lint
+
 # Build all Go code
 .PHONY: build
 build:

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -198,6 +198,11 @@ The Linter might make some automatic changes to your code, such as indentation f
 * Finally, after the Linter reports no errors anymore, run `git status` or `git diff` to check for any changes made automatically by Lint
 * If there were automatic changes, commit them to your local branch
 
+If you touched UI code, you should also run the Yarn linter on it:
+
+* Run `make lint-ui`
+* Fix any of the errors reported by it
+
 ## Setting up a local toolchain
 
 For development, you can either use the fully virtualized toolchain provided as Docker images, or you can set up the toolchain on your local development machine. Due to the dynamic nature of requirements, you might want to stay with the virtualized environment.


### PR DESCRIPTION
Mention to run lint on UI in case UI code was touched. Also adds the proper targets in the Makefile (`lint-ui` and `lint-ui-local`).

Checklist:

* [x] (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
