### PR TITLE
fix: argocd fails to connect clusters with IAM authentication configuration

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2187,8 +2187,7 @@ func SetK8SConfigDefaults(config *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	// set default tls config since we use it in a custom transport
-	config.TLSClientConfig = rest.TLSClientConfig{}
+
 	dial := (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
@@ -2207,6 +2206,12 @@ func SetK8SConfigDefaults(config *rest.Config) error {
 	if err != nil {
 		return err
 	}
+
+	// set default tls config and remove auth/exec provides since we use it in a custom transport
+	config.TLSClientConfig = rest.TLSClientConfig{}
+	config.AuthProvider = nil
+	config.ExecProvider = nil
+
 	config.Transport = tr
 	return nil
 }


### PR DESCRIPTION
PR fixes the bug introduced by https://github.com/argoproj/argo-cd/commit/7fd7999e49be09dde59e48cdd318a98e12c69317