### PR TITLE
 chore: Code coverage offensive 03: util/cache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -66,6 +66,25 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:3cce78d5d0090e3f1162945fba60ba74e72e8422e8e41bb9c701afb67237bb65"
+  name = "github.com/alicebob/gopher-json"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5a6b3ba71ee69b77cf64febf8b5a7526ca5eaef0"
+
+[[projects]]
+  digest = "1:18a07506ddaa87b1612bfd69eef03f510faf122398df3da774d46dcfe751a060"
+  name = "github.com/alicebob/miniredis"
+  packages = [
+    ".",
+    "server",
+  ]
+  pruneopts = ""
+  revision = "3d7aa1333af56ab862d446678d93aaa6803e0938"
+  version = "v2.7.0"
+
+[[projects]]
+  branch = "master"
   digest = "1:fbe4779f247babd0b21e2283d419f848a8dab42c0f6bbdeb88d83f190f52c159"
   name = "github.com/argoproj/pkg"
   packages = [
@@ -468,6 +487,17 @@
   pruneopts = ""
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
+
+[[projects]]
+  digest = "1:dcf8316121302735c0ac84e05f4686e3b34e284444435e9a206da48d8be18cb1"
+  name = "github.com/gomodule/redigo"
+  packages = [
+    "internal",
+    "redis",
+  ]
+  pruneopts = ""
+  revision = "9c11da706d9b7902c6da69c592f75637793fe121"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
@@ -1939,6 +1969,7 @@
     "bou.ke/monkey",
     "github.com/Masterminds/semver",
     "github.com/TomOnTime/utfutil",
+    "github.com/alicebob/miniredis",
     "github.com/argoproj/pkg/errors",
     "github.com/argoproj/pkg/exec",
     "github.com/argoproj/pkg/grpc/http",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -119,3 +119,8 @@ required = [
 [[constraint]]
   name = "github.com/google/uuid"
   version = "1.1.1"
+
+
+[[constraint]]
+  name = "github.com/alicebob/miniredis"
+  version = "2.7.0"

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -13,3 +13,34 @@ func TestAddCacheFlagsToCmd(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 24*time.Hour, cache.client.(*redisCache).expiration)
 }
+
+func TestCacheClient(t *testing.T) {
+	client := NewInMemoryCache(60 * time.Second)
+	cache := NewCache(client)
+	t.Run("SetItem", func(t *testing.T) {
+		err := cache.SetItem("foo", "bar", 60*time.Second, false)
+		assert.NoError(t, err)
+	})
+	t.Run("GetItem", func(t *testing.T) {
+		var val string
+		err := cache.GetItem("foo", &val)
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", val)
+	})
+	t.Run("DeleteItem", func(t *testing.T) {
+		err := cache.SetItem("foo", "bar", 0, true)
+		assert.NoError(t, err)
+		var val string
+		err = cache.GetItem("foo", &val)
+		assert.Error(t, err)
+		assert.Empty(t, val)
+	})
+	t.Run("Check for nil items", func(t *testing.T) {
+		err := cache.SetItem("foo", nil, 0, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot set item")
+		err = cache.GetItem("foo", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot get item")
+	})
+}

--- a/util/cache/redis_test.go
+++ b/util/cache/redis_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisSetCache(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer mr.Close()
+	assert.NotNil(t, mr)
+
+	t.Run("Successfull set", func(t *testing.T) {
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 60*time.Second)
+		err = client.Set(&Item{Key: "foo", Object: "bar"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Successfull get", func(t *testing.T) {
+		var res string
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second)
+		err = client.Get("foo", &res)
+		assert.NoError(t, err)
+		assert.Equal(t, res, "bar")
+	})
+
+	t.Run("Successfull delete", func(t *testing.T) {
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second)
+		err = client.Delete("foo")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Cache miss", func(t *testing.T) {
+		var res string
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second)
+		err = client.Get("foo", &res)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cache: key is missing")
+	})
+}


### PR DESCRIPTION
**Code coverage offensive 03**

This is the third part of an effort to increase our overall code coverage for tests to an acceptable limit.

The PR adds units test for `util/cache` package with a package coverage of 92.1%. Previous package coverage was 50.8%.

It introduces a new dependency, `github.com/alicebob/miniredis`, which provides a Redis server interface for unit testing (https://github.com/alicebob/miniredis), available under the **MIT** license.

Checklist:

* [x]  (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
