### PR TITLE
chore: Fix flaky unit test TestWatchCacheUpdated (race condition)

### DIFF
--- a/controller/cache/cluster_test.go
+++ b/controller/cache/cluster_test.go
@@ -504,6 +504,7 @@ func TestWatchCacheUpdated(t *testing.T) {
 
 	podGroupKind := testPod.GroupVersionKind().GroupKind()
 
+	cluster.lock.Lock()
 	cluster.replaceResourceCache(podGroupKind, "updated-list-version", []unstructured.Unstructured{*updated, *added}, "")
 
 	_, ok := cluster.nodes[kube.GetResourceKey(removed)]
@@ -515,6 +516,7 @@ func TestWatchCacheUpdated(t *testing.T) {
 
 	_, ok = cluster.nodes[kube.GetResourceKey(added)]
 	assert.True(t, ok)
+	cluster.lock.Unlock()
 }
 
 func TestNamespaceModeReplace(t *testing.T) {


### PR DESCRIPTION
Fix a race condition in the unit test for `TestWatchCacheUpdated`, this should stabilize our CI.

Checklist:

* [x] (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
