### PR TITLE
fix: Removed unused env section in redis-ha manifests.

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -675,7 +675,6 @@ spec:
         - redis-server
         args:
         - /data/conf/redis.conf
-        env:
         livenessProbe:
           tcpSocket:
             port: 6379


### PR DESCRIPTION
Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

## Description
- This env part is not used in the manifest, and it becomes null when kusttomize build and an error occurs. See issue for details.

## Related issue
- https://github.com/argoproj/argo-cd/issues/3348