### PR TITLE
fix: return 401 error code if username does not exist

### DIFF
--- a/server/session/session.go
+++ b/server/session/session.go
@@ -27,7 +27,7 @@ func NewServer(mgr *sessionmgr.SessionManager, authenticator Authenticator) *Ser
 
 // Create generates a JWT token signed by Argo CD intended for web/CLI logins of the admin user
 // using username/password
-func (s *Server) Create(ctx context.Context, q *session.SessionCreateRequest) (*session.SessionResponse, error) {
+func (s *Server) Create(_ context.Context, q *session.SessionCreateRequest) (*session.SessionResponse, error) {
 	if q.Token != "" {
 		return nil, status.Errorf(codes.Unauthenticated, "token-based session creation no longer supported. please upgrade argocd cli to v0.7+")
 	}

--- a/test/e2e/accounts_test.go
+++ b/test/e2e/accounts_test.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"testing"
 
-	"github.com/argoproj/argo-cd/pkg/apiclient/session"
-	"github.com/argoproj/argo-cd/util"
-
-	argocdclient "github.com/argoproj/argo-cd/pkg/apiclient"
-
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/argoproj/argo-cd/errors"
+	argocdclient "github.com/argoproj/argo-cd/pkg/apiclient"
+	"github.com/argoproj/argo-cd/pkg/apiclient/session"
 	. "github.com/argoproj/argo-cd/test/e2e/fixture"
+	"github.com/argoproj/argo-cd/util"
 )
 
 func TestCreateAndUseAccount(t *testing.T) {
@@ -49,4 +49,30 @@ test   true     login, apiKey`, output)
 	assert.NoError(t, err)
 
 	assert.Equal(t, info.Username, "test")
+}
+
+func TestLoginBadCredentials(t *testing.T) {
+	EnsureCleanState(t)
+
+	closer, sessionClient := ArgoCDClientset.NewSessionClientOrDie()
+	defer util.Close(closer)
+
+	requests := []session.SessionCreateRequest{{
+		Username: "user-does-not-exist", Password: "some-password",
+	}, {
+		Username: "admin", Password: "bad-password",
+	}}
+
+	for _, r := range requests {
+		_, err := sessionClient.Create(context.Background(), &r)
+		if !assert.Error(t, err) {
+			return
+		}
+		errStatus, ok := status.FromError(err)
+		if !assert.True(t, ok) {
+			return
+		}
+		assert.Equal(t, codes.Unauthenticated, errStatus.Code())
+		assert.Equal(t, "Invalid username or password", errStatus.Message())
+	}
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -156,6 +156,9 @@ func (mgr *SessionManager) Parse(tokenString string) (jwt.Claims, error) {
 func (mgr *SessionManager) VerifyUsernamePassword(username string, password string) error {
 	account, err := mgr.settingsMgr.GetAccount(username)
 	if err != nil {
+		if errStatus, ok := status.FromError(err); ok && errStatus.Code() == codes.NotFound {
+			err = status.Errorf(codes.Unauthenticated, invalidLoginError)
+		}
 		return err
 	}
 	if !account.Enabled {


### PR DESCRIPTION
The session API response code should be the same if either username or password is invalid. Otherwise, it is possible to determine if accounts with a given name do or do not exist.
