### PR TITLE
fix: Update 4.5.3 redis-ha helm manifest

### DIFF
--- a/manifests/ha/base/redis-ha/chart/requirements.lock
+++ b/manifests/ha/base/redis-ha/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 4.3.4
-digest: sha256:d130faa98f99a99e503bce560bcec26e1dc0a988775a6609e39a8d855ec687d5
-generated: "2020-02-20T10:42:01.98332-08:00"
+  repository: https://dandydeveloper.github.io/charts
+  version: 4.5.3
+digest: sha256:79e2a60f86c34dcd2c81217f111ef6dfb55e949dd71cc43aebf6a679dc27c042
+generated: "2020-04-06T18:11:37.013005+09:00"

--- a/manifests/ha/base/redis-ha/chart/requirements.yaml
+++ b/manifests/ha/base/redis-ha/chart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-ha
-  version: 4.3.4
-  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 4.5.3
+  repository: https://dandydeveloper.github.io/charts

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -581,13 +581,13 @@ spec:
         configMap:
           name: argocd-redis-ha-configmap
       - name: shared-socket
-        emptyDir:
+        emptyDir: 
           {}
-
+          
       - name: data
-        emptyDir:
+        emptyDir: 
           {}
-
+          
 
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -720,7 +720,7 @@ spec:
       - name: data
         emptyDir:
           {}
-
+          
 
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-auth-secret.yaml

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     heritage: Tiller
     release: argocd
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
     app: argocd-redis-ha
 data:
   redis.conf: |
@@ -272,7 +272,7 @@ metadata:
   labels:
     heritage: Tiller
     release: argocd
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
     app: argocd-redis-ha
 
 ---
@@ -286,7 +286,7 @@ metadata:
   labels:
     heritage: Tiller
     release: argocd
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
     app: argocd-redis-ha
 
 ---
@@ -300,7 +300,7 @@ metadata:
   labels:
     heritage: Tiller
     release: argocd
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
     app: argocd-redis-ha
 rules:
 - apiGroups:
@@ -321,7 +321,7 @@ metadata:
   labels:
     heritage: Tiller
     release: argocd
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
     app: argocd-redis-ha
 subjects:
 - kind: ServiceAccount
@@ -344,7 +344,7 @@ metadata:
     app: redis-ha
     heritage: "Tiller"
     release: "argocd"
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -373,7 +373,7 @@ metadata:
     app: redis-ha
     heritage: "Tiller"
     release: "argocd"
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -402,7 +402,7 @@ metadata:
     app: redis-ha
     heritage: "Tiller"
     release: "argocd"
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -433,7 +433,7 @@ metadata:
     app: redis-ha
     heritage: "Tiller"
     release: "argocd"
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
   annotations:
 spec:
   type: ClusterIP
@@ -462,7 +462,7 @@ metadata:
     app: redis-ha
     heritage: "Tiller"
     release: "argocd"
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
     component: argocd-redis-ha-haproxy
   annotations:
 spec:
@@ -488,7 +488,7 @@ metadata:
     app: redis-ha
     heritage: "Tiller"
     release: "argocd"
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
 spec:
   strategy:
     type: RollingUpdate
@@ -581,9 +581,13 @@ spec:
         configMap:
           name: argocd-redis-ha-configmap
       - name: shared-socket
-        emptyDir: {}
+        emptyDir:
+          {}
+
       - name: data
-        emptyDir: {}
+        emptyDir:
+          {}
+
 
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -597,7 +601,7 @@ metadata:
     app: redis-ha
     heritage: "Tiller"
     release: "argocd"
-    chart: redis-ha-4.3.4
+    chart: redis-ha-4.5.3
 spec:
   selector:
     matchLabels:
@@ -676,7 +680,6 @@ spec:
         - redis-server
         args:
         - /data/conf/redis.conf
-        env:
         livenessProbe:
           tcpSocket:
             port: 6379
@@ -715,7 +718,9 @@ spec:
         configMap:
           name: argocd-redis-ha-configmap
       - name: data
-        emptyDir: {}
+        emptyDir:
+          {}
+
 
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-auth-secret.yaml

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3092,7 +3092,6 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        env: null
         image: redis:5.0.6-alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3007,7 +3007,6 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        env: null
         image: redis:5.0.6-alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

## Description
- This env part is not used in the manifest, and it becomes null when kustomize build and an error occurs. See the issue for details.
    - https://github.com/argoproj/argo-cd/issues/3348
- stable/redis-ha chart is deprecated.
    - https://github.com/helm/charts/tree/master/stable/redis-ha#deprecation-warning
    - https://github.com/helm/charts/#deprecation-timeline
## Related issue
- https://github.com/argoproj/argo-cd/issues/3348
- https://github.com/argoproj/argo-cd/pull/3366