### PR TITLE
chore: Code coverage offensive 05: util/clusterauth

### DIFF
--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -176,6 +176,14 @@ func TestInstallClusterManagerRBAC(t *testing.T) {
 
 }
 
+func TestUninstallClusterManagerRBAC(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		cs := fake.NewSimpleClientset(newServiceAccountSecret())
+		err := UninstallClusterManagerRBAC(cs)
+		assert.NoError(t, err)
+	})
+}
+
 func TestGenerateNewClusterManagerSecret(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(newServiceAccountSecret())
 	kubeclientset.ReactionChain = nil

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -55,6 +55,127 @@ func TestParseServiceAccountToken(t *testing.T) {
 	assert.Equal(t, testClaims, *claims)
 }
 
+func TestCreateServiceAccount(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-system",
+		},
+	}
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-manager",
+			Namespace: "kube-system",
+		},
+	}
+
+	t.Run("New SA", func(t *testing.T) {
+		cs := fake.NewSimpleClientset(ns)
+		err := CreateServiceAccount(cs, "argocd-manager", "kube-system")
+		assert.NoError(t, err)
+		rsa, err := cs.CoreV1().ServiceAccounts("kube-system").Get("argocd-manager", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, rsa)
+	})
+
+	t.Run("SA exists already", func(t *testing.T) {
+		cs := fake.NewSimpleClientset(ns, sa)
+		err := CreateServiceAccount(cs, "argocd-manager", "kube-system")
+		assert.NoError(t, err)
+		rsa, err := cs.CoreV1().ServiceAccounts("kube-system").Get("argocd-manager", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, rsa)
+	})
+
+	t.Run("Invalid name", func(t *testing.T) {
+		cs := fake.NewSimpleClientset(ns)
+		err := CreateServiceAccount(cs, "", "kube-system")
+		assert.NoError(t, err)
+		rsa, err := cs.CoreV1().ServiceAccounts("kube-system").Get("argocd-manager", metav1.GetOptions{})
+		assert.Error(t, err)
+		assert.Nil(t, rsa)
+	})
+
+	t.Run("Invalid namespace", func(t *testing.T) {
+		cs := fake.NewSimpleClientset()
+		err := CreateServiceAccount(cs, "argocd-manager", "invalid")
+		assert.NoError(t, err)
+		rsa, err := cs.CoreV1().ServiceAccounts("invalid").Get("argocd-manager", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, rsa)
+	})
+}
+
+func TestInstallClusterManagerRBAC(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sa-secret",
+			Namespace: "test",
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+		Data: map[string][]byte{
+			"token": []byte("foobar"),
+		},
+	}
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ArgoCDManagerServiceAccount,
+			Namespace: "test",
+		},
+		Secrets: []corev1.ObjectReference{
+			corev1.ObjectReference{
+				Kind:            secret.GetObjectKind().GroupVersionKind().Kind,
+				APIVersion:      secret.APIVersion,
+				Name:            secret.GetName(),
+				Namespace:       secret.GetNamespace(),
+				UID:             secret.GetUID(),
+				ResourceVersion: secret.GetResourceVersion(),
+			},
+		},
+	}
+
+	t.Run("Cluster Scope - Success", func(t *testing.T) {
+		cs := fake.NewSimpleClientset(ns, secret, sa)
+		token, err := InstallClusterManagerRBAC(cs, "test", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "foobar", token)
+	})
+
+	t.Run("Cluster Scope - Missing data in secret", func(t *testing.T) {
+		nsecret := secret.DeepCopy()
+		nsecret.Data = make(map[string][]byte)
+		cs := fake.NewSimpleClientset(ns, nsecret, sa)
+		token, err := InstallClusterManagerRBAC(cs, "test", nil)
+		assert.Error(t, err)
+		assert.Empty(t, token)
+	})
+
+	t.Run("Namespace Scope - Success", func(t *testing.T) {
+		cs := fake.NewSimpleClientset(ns, secret, sa)
+		token, err := InstallClusterManagerRBAC(cs, "test", []string{"nsa"})
+		assert.NoError(t, err)
+		assert.Equal(t, "foobar", token)
+	})
+
+	t.Run("Namespace Scope - Missing data in secret", func(t *testing.T) {
+		nsecret := secret.DeepCopy()
+		nsecret.Data = make(map[string][]byte)
+		cs := fake.NewSimpleClientset(ns, nsecret, sa)
+		token, err := InstallClusterManagerRBAC(cs, "test", []string{"nsa"})
+		assert.Error(t, err)
+		assert.Empty(t, token)
+	})
+
+}
+
 func TestGenerateNewClusterManagerSecret(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(newServiceAccountSecret())
 	kubeclientset.ReactionChain = nil


### PR DESCRIPTION
**Code coverage offensive 05**

This is the fifth part of an effort to increase our overall code coverage for tests to an acceptable limit.

The PR adds units test for `util/clusterauth` package with a package coverage of 73.1%. Previous package coverage was 39.3%.

**Notes:** The fake K8s clientset makes it impossible(?) to test for certain cases, i.e. creating a resource in a non-existing namespace always succeeds. That's why some error cases are not covered by the unit tests.

Checklist:

* [x]  (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
