### PR TITLE
fix: Display link between OLM ClusterServiceVersion and it's OperatorGroup. (issue #2999)

### DIFF
--- a/controller/cache/cluster.go
+++ b/controller/cache/cluster.go
@@ -131,6 +131,17 @@ func (c *clusterInfo) createObjInfo(un *unstructured.Unstructured, appInstanceLa
 		})
 	}
 
+	// Special case for Operator Lifecycle Manager ClusterServiceVersion:
+	if un.GroupVersionKind().Group == "operators.coreos.com" && un.GetKind() == "ClusterServiceVersion" {
+		if un.GetAnnotations()["olm.operatorGroup"] != "" {
+			ownerRefs = append(ownerRefs, metav1.OwnerReference{
+				Name:       un.GetAnnotations()["olm.operatorGroup"],
+				Kind:       "OperatorGroup",
+				APIVersion: "operators.coreos.com/v1",
+			})
+		}
+	}
+
 	// edge case. Consider auto-created service account tokens as a child of service account objects
 	if yes, ref := isServiceAccountTokenSecret(un); yes {
 		ownerRefs = append(ownerRefs, ref)


### PR DESCRIPTION
For anyone installing an Operator Lifecycle Manager operator, the ArgoCD
UI would show your OperatorGroup and Subscription, but would not detect
the resulting ClusterServiceVersion, and subsequent pods etc, limiting
the value of the UI in viewing overall status of your operator.

The CSV should not technically have an owner reference, so we add a fake
one in similar fashion to the pre-existing code above for endpoints. The
CSV then is linked to it's OperatorGroup via the olm.operatorGroup
annotation. The CSV has no link to it's Subscription or InstallPlan that
I can see. Adding an annotation to this might be something we could
pursue with OLM folks.

Fixes #2999.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
