### PR TITLE
chore: Integrate sonarqube with our CI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ commands:
             echo "export GOCACHE=/tmp/go-build-cache" | tee -a $BASH_ENV
             echo "export ARGOCD_TEST_VERBOSE=true" | tee -a $BASH_ENV
             echo "export ARGOCD_TEST_PARALLELISM=8" | tee -a $BASH_ENV
+            echo "export ARGOCD_SONAR_VERSION=4.2.0.1873" | tee -a $BASH_ENV
   configure_git:
     steps:
       - run:
@@ -37,6 +38,12 @@ commands:
           root: .
           paths:
             - vendor
+  save_coverage_info:
+    steps:
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage.out
   attach_vendor:
     steps:
       - attach_workspace:
@@ -142,11 +149,55 @@ jobs:
           command: |
             ls -l test-results || true
             cat test-results/junit.xml || true
+      - save_coverage_info
       - store_test_results:
           path: test-results
       - store_artifacts:
           path: test-results
           destination: .
+  
+  sonarcloud:
+    working_directory: /go/src/github.com/argoproj/argo-cd
+    docker:
+      - image: argoproj/argocd-test-tools:v0.2.0
+    environment:
+      NODE_MODULES: /go/src/github.com/argoproj/argo-cd/ui/node_modules
+    steps:
+      - prepare_environment
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          command: mkdir -p /tmp/cache/scanner
+          name: Create cache directory if it doesn't exist
+      - restore_cache:
+          keys:
+            - v1-sonarcloud-scanner-4.2.0.1873
+      - run:
+          command: |
+            set -e
+            VERSION=4.2.0.1873
+            SONAR_TOKEN=$SONAR_TOKEN
+            SCANNER_DIRECTORY=/tmp/cache/scanner
+            export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
+            OS="linux"
+            echo $SONAR_USER_HOME
+
+            if [[ ! -x "$SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner" ]]; then
+              curl -Ol https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$VERSION-$OS.zip
+              unzip -qq -o sonar-scanner-cli-$VERSION-$OS.zip -d $SCANNER_DIRECTORY
+            fi
+
+            chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
+            chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
+
+            $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
+          name: SonarCloud
+      - save_cache:
+          key: v1-sonarcloud-scanner-4.2.0.1873
+          paths:
+            - /tmp/cache/scanner
+    
   e2e:
     working_directory: /home/circleci/.go_workspace/src/github.com/argoproj/argo-cd
     machine:
@@ -240,6 +291,10 @@ jobs:
       - run: ./node_modules/.bin/codecov -p ..
       - run: NODE_ENV='production' yarn build
       - run: yarn lint
+
+orbs:
+  sonarcloud: sonarsource/sonarcloud@1.0.1
+
 workflows:
   version: 2
   workflow:
@@ -253,7 +308,11 @@ workflows:
             - build
       - ui:
           requires:
-            - codegen
+            - build
+      - sonarcloud:
+          context: SonarCloud
+          requires:
+            - test
       - e2e:
           requires:
             - build

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ cmd/**/debug
 debug.test
 coverage.out
 test-results
+.scannerwork
+.scratch

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,23 @@
+sonar.projectKey=argoproj_argo-cd
+sonar.organization=argoproj
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=argo-cd
+sonar.projectVersion=1.0
+ 
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=.
+ 
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.host.url=https://sonarcloud.io
+
+# Exclude following set of patterns from coverage analysis
+sonar.coverage.exclusions=**/*.pb.go,**/*.pb.gw.go,**/mocks/**,**/*.ts*,**/vendor/**,**/openapi_generated.go,**/*_test.go,**/*_generated*,test/**,pkg/client/**,pkg/apiclient/**
+
+# Exlcude following set of patterns from code analysis
+sonar.go.exclusions=**/vendor/**,*/*.pb.go,**/*_test.go,**/*.pb.gw.go,**/mocks/**,**/openapi_generated.go,**/*_generated*.go
+
+# Exclude following set of patterns from duplication detection
+sonar.cpd.exclusions=**/*.pg.go,**/*.g.cs,**/*.gw.go,**/mocks/*


### PR DESCRIPTION
This integrates SonarQube scanner to our CI checks, using sonarcloud.io as backend.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
