### PR TITLE
feat: add settings troubleshooting commands to the 'argocd-util' binary

### DIFF
--- a/cmd/argocd-util/commands/projects.go
+++ b/cmd/argocd-util/commands/projects.go
@@ -1,4 +1,4 @@
-package main
+package commands
 
 import (
 	"fmt"

--- a/cmd/argocd-util/commands/projects_test.go
+++ b/cmd/argocd-util/commands/projects_test.go
@@ -1,4 +1,4 @@
-package main
+package commands
 
 import (
 	"testing"

--- a/cmd/argocd-util/commands/settings.go
+++ b/cmd/argocd-util/commands/settings.go
@@ -1,0 +1,467 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	syserrors "errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/ghodss/yaml"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/errors"
+	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/util/argo/normalizers"
+	"github.com/argoproj/argo-cd/util/cli"
+	"github.com/argoproj/argo-cd/util/diff"
+	"github.com/argoproj/argo-cd/util/health"
+	"github.com/argoproj/argo-cd/util/lua"
+	"github.com/argoproj/argo-cd/util/settings"
+)
+
+type settingsOpts struct {
+	argocdCMPath        string
+	argocdSecretPath    string
+	loadClusterSettings bool
+	clientConfig        clientcmd.ClientConfig
+}
+
+func collectLogs(callback func()) string {
+	log.SetLevel(log.DebugLevel)
+	out := bytes.Buffer{}
+	log.SetOutput(&out)
+	defer log.SetLevel(log.FatalLevel)
+	callback()
+	return out.String()
+}
+
+func setSettingsMeta(obj v1.Object) {
+	obj.SetNamespace("default")
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["app.kubernetes.io/part-of"] = "argocd"
+	obj.SetLabels(labels)
+}
+
+func (opts *settingsOpts) createSettingsManager() (*settings.SettingsManager, error) {
+	var argocdCM *corev1.ConfigMap
+	if opts.argocdCMPath == "" && !opts.loadClusterSettings {
+		return nil, syserrors.New("either --argocd-cm-path must be provided or --load-cluster-settings must be set to true")
+	} else if opts.argocdCMPath == "" {
+		realClientset, ns, err := opts.getK8sClient()
+		if err != nil {
+			return nil, err
+		}
+
+		argocdCM, err = realClientset.CoreV1().ConfigMaps(ns).Get(common.ArgoCDConfigMapName, v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		data, err := ioutil.ReadFile(opts.argocdCMPath)
+		if err != nil {
+			return nil, err
+		}
+		err = yaml.Unmarshal(data, &argocdCM)
+		if err != nil {
+			return nil, err
+		}
+	}
+	setSettingsMeta(argocdCM)
+
+	var argocdSecret *corev1.Secret
+	if opts.argocdSecretPath != "" {
+		data, err := ioutil.ReadFile(opts.argocdSecretPath)
+		if err != nil {
+			return nil, err
+		}
+		err = yaml.Unmarshal(data, &argocdSecret)
+		if err != nil {
+			return nil, err
+		}
+		setSettingsMeta(argocdSecret)
+	} else if opts.loadClusterSettings {
+		realClientset, ns, err := opts.getK8sClient()
+		if err != nil {
+			return nil, err
+		}
+		argocdSecret, err = realClientset.CoreV1().Secrets(ns).Get(common.ArgoCDSecretName, v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		argocdSecret = &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name: common.ArgoCDSecretName,
+			},
+			Data: map[string][]byte{
+				"admin.password":   []byte("test"),
+				"server.secretkey": []byte("test"),
+			},
+		}
+	}
+	setSettingsMeta(argocdSecret)
+	clientset := fake.NewSimpleClientset(argocdSecret, argocdCM)
+
+	manager := settings.NewSettingsManager(context.Background(), clientset, "default")
+	errors.CheckError(manager.ResyncInformers())
+
+	return manager, nil
+}
+
+func (opts *settingsOpts) getK8sClient() (*kubernetes.Clientset, string, error) {
+	namespace, _, err := opts.clientConfig.Namespace()
+	if err != nil {
+		return nil, "", err
+	}
+
+	restConfig, err := opts.clientConfig.ClientConfig()
+	if err != nil {
+		return nil, "", err
+	}
+
+	realClientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, "", err
+	}
+	return realClientset, namespace, nil
+}
+
+func NewSettingsCommand() *cobra.Command {
+	var (
+		opts settingsOpts
+	)
+
+	var command = &cobra.Command{
+		Use: "settings",
+		Run: func(c *cobra.Command, args []string) {
+			c.HelpFunc()(c, args)
+		},
+	}
+	log.SetLevel(log.FatalLevel)
+
+	command.AddCommand(NewValidateSettingsCommand(&opts))
+	command.AddCommand(NewResourceOverridesCommand(&opts))
+
+	opts.clientConfig = cli.AddKubectlFlagsToCmd(command)
+	command.PersistentFlags().StringVar(&opts.argocdCMPath, "argocd-cm-path", "", "Path to local argocd-cm.yaml file")
+	command.PersistentFlags().StringVar(&opts.argocdSecretPath, "argocd-secret-path", "", "Path to local argocd-secret.yaml file")
+	command.PersistentFlags().BoolVar(&opts.loadClusterSettings, "load-cluster-settings", false,
+		"Indicates that config map and secret should be loaded from cluster unless local file path is provided")
+	return command
+}
+
+type settingValidator func(manager *settings.SettingsManager) (string, error)
+
+func joinValidators(validators ...settingValidator) settingValidator {
+	return func(manager *settings.SettingsManager) (string, error) {
+		var errorStrs []string
+		var summaries []string
+		for i := range validators {
+			summary, err := validators[i](manager)
+			if err != nil {
+				errorStrs = append(errorStrs, err.Error())
+			}
+			if summary != "" {
+				summaries = append(summaries, summary)
+			}
+		}
+		if len(errorStrs) > 0 {
+			return "", fmt.Errorf("%s", strings.Join(errorStrs, "\n"))
+		}
+		return strings.Join(summaries, "\n"), nil
+	}
+}
+
+var validatorsByGroup = map[string]settingValidator{
+	"general": joinValidators(func(manager *settings.SettingsManager) (string, error) {
+		general, err := manager.GetSettings()
+		if err != nil {
+			return "", err
+		}
+		var summary string
+		ssoConfigured := general.IsSSOConfigured()
+		if ssoConfigured && general.URL == "" {
+			summary = "sso configured ('url' field is missing)"
+		} else if ssoConfigured && general.URL != "" {
+			summary = "sso configured"
+		} else {
+			summary = "sso is not configured"
+		}
+		return summary, nil
+	}, func(manager *settings.SettingsManager) (string, error) {
+		_, err := manager.GetAppInstanceLabelKey()
+		return "", err
+	}, func(manager *settings.SettingsManager) (string, error) {
+		_, err := manager.GetHelp()
+		return "", err
+	}, func(manager *settings.SettingsManager) (string, error) {
+		_, err := manager.GetGoogleAnalytics()
+		return "", err
+	}),
+	"plugins": func(manager *settings.SettingsManager) (string, error) {
+		plugins, err := manager.GetConfigManagementPlugins()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%d plugins", len(plugins)), nil
+	},
+	"kustomize": func(manager *settings.SettingsManager) (string, error) {
+		opts, err := manager.GetKustomizeBuildOptions()
+		if opts == "" {
+			opts = "default options"
+		}
+		return opts, err
+	},
+	"repositories": joinValidators(func(manager *settings.SettingsManager) (string, error) {
+		repos, err := manager.GetRepositories()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%d repositories", len(repos)), nil
+	}, func(manager *settings.SettingsManager) (string, error) {
+		creds, err := manager.GetRepositoryCredentials()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%d repository credentials", len(creds)), nil
+	}),
+	"accounts": func(manager *settings.SettingsManager) (string, error) {
+		accounts, err := manager.GetAccounts()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%d accounts", len(accounts)), nil
+	},
+	"resource-overrides": func(manager *settings.SettingsManager) (string, error) {
+		overrides, err := manager.GetResourceOverrides()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%d resource overrides", len(overrides)), nil
+	},
+}
+
+func NewValidateSettingsCommand(opts *settingsOpts) *cobra.Command {
+	var (
+		groups []string
+	)
+
+	var allGroups []string
+	for k := range validatorsByGroup {
+		allGroups = append(allGroups, k)
+	}
+	sort.Slice(allGroups, func(i, j int) bool {
+		return allGroups[i] < allGroups[j]
+	})
+
+	var command = &cobra.Command{
+		Use:  "validate",
+		Long: "Validates settings specified in 'argocd-cm' ConfigMap and 'argocd-secret' Secret",
+		Example: `
+#Validates all settings in the specified YAML file
+argocd-util settings validate --argocd-cm-path ./argocd-cm.yaml
+
+#Validates accounts and plugins settings in Kubernetes cluster of current kubeconfig context
+argocd-util settings validate --group accounts --group plugins --load-cluster-settings`,
+		Run: func(c *cobra.Command, args []string) {
+			settingsManager, err := opts.createSettingsManager()
+			errors.CheckError(err)
+
+			if len(groups) == 0 {
+				groups = allGroups
+			}
+			for i, group := range groups {
+				validator := validatorsByGroup[group]
+
+				logs := collectLogs(func() {
+					summary, err := validator(settingsManager)
+
+					if err != nil {
+						_, _ = fmt.Fprintf(os.Stdout, "❌ %s\n", group)
+						_, _ = fmt.Fprintf(os.Stdout, "%s\n", err.Error())
+					} else {
+						_, _ = fmt.Fprintf(os.Stdout, "✅ %s\n", group)
+						if summary != "" {
+							_, _ = fmt.Fprintf(os.Stdout, "%s\n", summary)
+						}
+					}
+				})
+				if logs != "" {
+					_, _ = fmt.Fprintf(os.Stdout, "%s\n", logs)
+				}
+				if i != len(groups)-1 {
+					_, _ = fmt.Fprintf(os.Stdout, "\n")
+				}
+			}
+		},
+	}
+
+	command.Flags().StringArrayVar(&groups, "group", nil, fmt.Sprintf(
+		"Optional list of setting groups that have to be validated ( one of: %s)", strings.Join(allGroups, ", ")))
+
+	return command
+}
+
+func NewResourceOverridesCommand(opts *settingsOpts) *cobra.Command {
+	var command = &cobra.Command{
+		Use: "resource-overrides",
+		Run: func(c *cobra.Command, args []string) {
+			c.HelpFunc()(c, args)
+		},
+	}
+	command.AddCommand(NewResourceIgnoreDifferencesCommand(opts))
+	command.AddCommand(NewResourceActionCommand(opts))
+	command.AddCommand(NewResourceHealthCommand(opts))
+	return command
+}
+
+func executeResourceOverrideCommand(opts *settingsOpts, args []string, callback func(res unstructured.Unstructured, override v1alpha1.ResourceOverride, overrides map[string]v1alpha1.ResourceOverride)) {
+	data, err := ioutil.ReadFile(args[0])
+	errors.CheckError(err)
+
+	res := unstructured.Unstructured{}
+	errors.CheckError(yaml.Unmarshal(data, &res))
+
+	settingsManager, err := opts.createSettingsManager()
+	errors.CheckError(err)
+
+	overrides, err := settingsManager.GetResourceOverrides()
+	errors.CheckError(err)
+	gvk := res.GroupVersionKind()
+	override, hasOverride := overrides[fmt.Sprintf("%s/%s", gvk.Group, gvk.Kind)]
+	if !hasOverride {
+		_, _ = fmt.Printf("No overrides configured for '%s/%s'\n", gvk.Group, gvk.Kind)
+		return
+	}
+	callback(res, override, overrides)
+}
+
+func NewResourceIgnoreDifferencesCommand(opts *settingsOpts) *cobra.Command {
+	var command = &cobra.Command{
+		Use:  "ignore-differences RESOURCE_YAML_PATH",
+		Long: "Renders ignored fields using the 'ignoreDifferences' setting specified in the 'resource.customizations' field of 'argocd-cm' ConfigMap",
+		Example: `
+argocd-util settings resource-overrides ignore-differences ./deploy.yaml --argocd-cm-path ./argocd-cm.yaml`,
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) < 1 {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
+			}
+
+			executeResourceOverrideCommand(opts, args, func(res unstructured.Unstructured, override v1alpha1.ResourceOverride, overrides map[string]v1alpha1.ResourceOverride) {
+				gvk := res.GroupVersionKind()
+				if override.IgnoreDifferences == "" {
+					_, _ = fmt.Printf("Ignore differences are not configured for '%s/%s'\n", gvk.Group, gvk.Kind)
+					return
+				}
+
+				normalizer, err := normalizers.NewIgnoreNormalizer(nil, overrides)
+				errors.CheckError(err)
+
+				normalizedRes := res.DeepCopy()
+				logs := collectLogs(func() {
+					errors.CheckError(normalizer.Normalize(normalizedRes))
+				})
+				if logs != "" {
+					_, _ = fmt.Println(logs)
+				}
+
+				if reflect.DeepEqual(&res, normalizedRes) {
+					_, _ = fmt.Printf("No fields are ignored by ignoreDifferences settings: \n%s\n", override.IgnoreDifferences)
+					return
+				}
+
+				_, _ = fmt.Printf("Following fields are ignored:\n\n")
+				_ = diff.PrintDiff(res.GetName(), &res, normalizedRes)
+			})
+		},
+	}
+	return command
+}
+
+func NewResourceHealthCommand(opts *settingsOpts) *cobra.Command {
+	var command = &cobra.Command{
+		Use:  "health RESOURCE_YAML_PATH",
+		Long: "Assess resource health using the lua script configured in the 'resource.customizations' field of 'argocd-cm' ConfigMap",
+		Example: `
+argocd-util settings resource-overrides health ./deploy.yaml --argocd-cm-path ./argocd-cm.yaml`,
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) < 1 {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
+			}
+
+			executeResourceOverrideCommand(opts, args, func(res unstructured.Unstructured, override v1alpha1.ResourceOverride, overrides map[string]v1alpha1.ResourceOverride) {
+				gvk := res.GroupVersionKind()
+				if override.HealthLua == "" {
+					_, _ = fmt.Printf("Health script is not configured for '%s/%s'\n", gvk.Group, gvk.Kind)
+					return
+				}
+
+				resHealth, err := health.GetResourceHealth(&res, overrides)
+				errors.CheckError(err)
+
+				_, _ = fmt.Printf("STATUS: %s\n", resHealth.Status)
+				_, _ = fmt.Printf("MESSAGE: %s\n", resHealth.Message)
+			})
+		},
+	}
+	return command
+}
+
+func NewResourceActionCommand(opts *settingsOpts) *cobra.Command {
+	var command = &cobra.Command{
+		Use:  "action RESOURCE_YAML_PATH ACTION",
+		Long: "Executes resource action using the lua script configured in the 'resource.customizations' field of 'argocd-cm' ConfigMap and outputs updated fields",
+		Example: `
+argocd-util settings resource-overrides action /tmp/deploy.yaml restart --argocd-cm-path ./argocd-cm.yaml`,
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) < 2 {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
+			}
+			action := args[1]
+
+			executeResourceOverrideCommand(opts, args, func(res unstructured.Unstructured, override v1alpha1.ResourceOverride, overrides map[string]v1alpha1.ResourceOverride) {
+				gvk := res.GroupVersionKind()
+				if override.Actions == "" {
+					_, _ = fmt.Printf("Actions are not configured for '%s/%s'\n", gvk.Group, gvk.Kind)
+					return
+				}
+
+				luaVM := lua.VM{ResourceOverrides: overrides}
+				action, err := luaVM.GetResourceAction(&res, action)
+				errors.CheckError(err)
+
+				modifiedRes, err := luaVM.ExecuteResourceAction(&res, action.ActionLua)
+				errors.CheckError(err)
+
+				if reflect.DeepEqual(&res, modifiedRes) {
+					_, _ = fmt.Printf("No fields had been changed by action: \n%s\n", action.Name)
+					return
+				}
+
+				_, _ = fmt.Printf("Following fields have been changed:\n\n")
+				_ = diff.PrintDiff(res.GetName(), &res, modifiedRes)
+			})
+		},
+	}
+	return command
+}

--- a/cmd/argocd-util/commands/settings_test.go
+++ b/cmd/argocd-util/commands/settings_test.go
@@ -1,0 +1,364 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/util"
+	"github.com/argoproj/argo-cd/util/settings"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func captureStdout(callback func()) (string, error) {
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	callback()
+	util.Close(w)
+
+	data, err := ioutil.ReadAll(r)
+
+	if err != nil {
+		return "", err
+	}
+	return string(data), err
+}
+
+func newSettingsManager(data map[string]string) *settings.SettingsManager {
+	clientset := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      common.ArgoCDConfigMapName,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: data,
+	}, &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      common.ArgoCDSecretName,
+		},
+		Data: map[string][]byte{
+			"admin.password":   []byte("test"),
+			"server.secretkey": []byte("test"),
+		},
+	})
+	return settings.NewSettingsManager(context.Background(), clientset, "default")
+}
+
+type fakeCmdContext struct {
+	mgr *settings.SettingsManager
+	out bytes.Buffer
+}
+
+func newCmdContext(data map[string]string) *fakeCmdContext {
+	return &fakeCmdContext{mgr: newSettingsManager(data)}
+}
+
+func (ctx *fakeCmdContext) createSettingsManager() (*settings.SettingsManager, error) {
+	return ctx.mgr, nil
+}
+
+type validatorTestCase struct {
+	validator       string
+	data            map[string]string
+	containsSummary string
+	containsError   string
+}
+
+func TestCreateSettingsManager(t *testing.T) {
+	f, closer, err := tempFile(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  url: https://myargocd.com`)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer util.Close(closer)
+
+	opts := settingsOpts{argocdCMPath: f}
+	settingsManager, err := opts.createSettingsManager()
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	argoCDSettings, err := settingsManager.GetSettings()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "https://myargocd.com", argoCDSettings.URL)
+}
+
+func TestValidator(t *testing.T) {
+	testCases := map[string]validatorTestCase{
+		"General_SSOIsNotConfigured": {
+			validator: "general", containsSummary: "SSO is not configured",
+		},
+		"General_DexInvalidConfig": {
+			validator:     "general",
+			data:          map[string]string{"dex.config": "abcdefg"},
+			containsError: "invalid dex.config",
+		},
+		"General_OIDCConfigured": {
+			validator: "general",
+			data: map[string]string{
+				"url": "https://myargocd.com",
+				"oidc.config": `
+name: Okta
+issuer: https://dev-123456.oktapreview.com
+clientID: aaaabbbbccccddddeee
+clientSecret: aaaabbbbccccddddeee`,
+			},
+			containsSummary: "OIDC is configured",
+		},
+		"General_DexConfiguredMissingURL": {
+			validator: "general",
+			data: map[string]string{
+				"dex.config": `connectors:
+- type: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: aabbccddeeff00112233`,
+			},
+			containsSummary: "Dex is configured ('url' field is missing)",
+		},
+		"Plugins_ValidConfig": {
+			validator: "plugins",
+			data: map[string]string{
+				"configManagementPlugins": `[{"name": "test1"}, {"name": "test2"}]`,
+			},
+			containsSummary: "2 plugins",
+		},
+		"Kustomize_ModifiedOptions": {
+			validator:       "kustomize",
+			containsSummary: "default options",
+		},
+		"Kustomize_DefaultOptions": {
+			validator: "kustomize",
+			data: map[string]string{
+				"kustomize.buildOptions": "updated-options",
+			},
+			containsSummary: "updated-options",
+		},
+		"Repositories": {
+			validator: "repositories",
+			data: map[string]string{
+				"repositories": `
+- url: https://github.com/argoproj/my-private-repository1
+- url: https://github.com/argoproj/my-private-repository2`,
+			},
+			containsSummary: "2 repositories",
+		},
+		"Accounts": {
+			validator: "accounts",
+			data: map[string]string{
+				"accounts.user1": "apiKey, login",
+				"accounts.user2": "login",
+				"accounts.user3": "apiKey",
+			},
+			containsSummary: "4 accounts",
+		},
+		"ResourceOverrides": {
+			validator: "resource-overrides",
+			data: map[string]string{
+				"resource.customizations": `
+admissionregistration.k8s.io/MutatingWebhookConfiguration:
+  ignoreDifferences: |
+  jsonPointers:
+  - /webhooks/0/clientConfig/caBundle`,
+			},
+			containsSummary: "1 resource overrides",
+		},
+	}
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			validator, ok := validatorsByGroup[tc.validator]
+			if !assert.True(t, ok) {
+				return
+			}
+			summary, err := validator(newSettingsManager(tc.data))
+			if tc.containsSummary != "" {
+				assert.NoError(t, err)
+				assert.Contains(t, summary, tc.containsSummary)
+			} else if tc.containsError != "" {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tc.containsError)
+				}
+			}
+		})
+	}
+}
+
+const (
+	testDeploymentYAML = `apiVersion: v1
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 0`
+)
+
+func tempFile(content string) (string, io.Closer, error) {
+	f, err := ioutil.TempFile("", "*.yaml")
+	if err != nil {
+		return "", nil, err
+	}
+	_, err = f.Write([]byte(content))
+	if err != nil {
+		_ = os.Remove(f.Name())
+		return "", nil, err
+	}
+	return f.Name(), util.NewCloser(func() error {
+		return os.Remove(f.Name())
+	}), nil
+}
+
+func TestValidateSettingsCommand_NoErrors(t *testing.T) {
+	cmd := NewValidateSettingsCommand(newCmdContext(map[string]string{}))
+	out, err := captureStdout(func() {
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	assert.NoError(t, err)
+	for k := range validatorsByGroup {
+		assert.Contains(t, out, fmt.Sprintf("✅ %s", k))
+	}
+}
+
+func TestResourceOverrideIgnoreDifferences(t *testing.T) {
+	f, closer, err := tempFile(testDeploymentYAML)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer util.Close(closer)
+
+	t.Run("NoOverridesConfigured", func(t *testing.T) {
+		cmd := NewResourceOverridesCommand(newCmdContext(map[string]string{}))
+		out, err := captureStdout(func() {
+			cmd.SetArgs([]string{"ignore-differences", f})
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, out, "No overrides configured")
+	})
+
+	t.Run("DataIgnored", func(t *testing.T) {
+		cmd := NewResourceOverridesCommand(newCmdContext(map[string]string{
+			"resource.customizations": `apps/Deployment:
+  ignoreDifferences: |
+    jsonPointers:
+    - /spec`}))
+		out, err := captureStdout(func() {
+			cmd.SetArgs([]string{"ignore-differences", f})
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, out, "< spec:")
+	})
+}
+
+func TestResourceOverrideHealth(t *testing.T) {
+	f, closer, err := tempFile(testDeploymentYAML)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer util.Close(closer)
+
+	t.Run("NoHealthAssessment", func(t *testing.T) {
+		cmd := NewResourceOverridesCommand(newCmdContext(map[string]string{
+			"resource.customizations": `apps/Deployment: {}`}))
+		out, err := captureStdout(func() {
+			cmd.SetArgs([]string{"health", f})
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Health script is not configured")
+	})
+
+	t.Run("HealthAssessmentConfigured", func(t *testing.T) {
+		cmd := NewResourceOverridesCommand(newCmdContext(map[string]string{
+			"resource.customizations": `apps/Deployment:
+  health.lua: |
+    return { status = "Progressing" }
+`}))
+		out, err := captureStdout(func() {
+			cmd.SetArgs([]string{"health", f})
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Progressing")
+	})
+}
+
+func TestResourceOverrideAction(t *testing.T) {
+	f, closer, err := tempFile(testDeploymentYAML)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer util.Close(closer)
+
+	t.Run("NoActions", func(t *testing.T) {
+		cmd := NewResourceOverridesCommand(newCmdContext(map[string]string{
+			"resource.customizations": `apps/Deployment: {}`}))
+		out, err := captureStdout(func() {
+			cmd.SetArgs([]string{"action", f, "test"})
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, out, "Actions are not configured")
+	})
+
+	t.Run("HealthAssessmentConfigured", func(t *testing.T) {
+		cmd := NewResourceOverridesCommand(newCmdContext(map[string]string{
+			"resource.customizations": `apps/Deployment:
+  actions: |
+    definitions:
+    - name: test
+      action.lua: |
+        obj.metadata.labels["test"] = 'updated'
+        return obj
+`}))
+		out, err := captureStdout(func() {
+			cmd.SetArgs([]string{"action", f, "test"})
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		})
+		assert.NoError(t, err)
+		assert.Contains(t, out, "test: updated")
+	})
+}

--- a/cmd/argocd-util/main.go
+++ b/cmd/argocd-util/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/argoproj/argo-cd/cmd/argocd-util/commands"
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/errors"
 	"github.com/argoproj/argo-cd/util/cli"
@@ -72,7 +73,8 @@ func NewCommand() *cobra.Command {
 	command.AddCommand(NewImportCommand())
 	command.AddCommand(NewExportCommand())
 	command.AddCommand(NewClusterConfig())
-	command.AddCommand(NewProjectsCommand())
+	command.AddCommand(commands.NewProjectsCommand())
+	command.AddCommand(commands.NewSettingsCommand())
 
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	return command

--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -1,0 +1,55 @@
+# Troubleshooting Tools
+
+The document describes how to use `argocd-tool` binary to simplify Argo CD settings customizations and troubleshot
+connectivity issues.
+
+## Settings
+
+Argo CD provides multiple ways to customize system behavior and has a lot of settings. It might be dangerous to modify
+settings on Argo CD used in production by multiple users. Before applying settings you can use `argocd-util` binary to
+make sure that settings are valid and Argo CD is working as expected. The `argocd-util` binary is available in `argocd`
+mage and might be used using docker. Example:
+
+```bash
+docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
+  argocd-util settings validate --argocd-cm-path ./argocd-cm.yaml
+```
+
+The `argocd argocd-util settings validate` command performs basic settings validation and print short summary
+of each settings group.
+
+**Diffing Customization**
+
+[Diffing customization](../user-guide/diffing.md) allows excluding some resource fields from diffing process.
+The diffing customizations are configured in `resource.customizations` field of `argocd-cm` ConfigMap.
+
+The following `argocd-util` command prints information about fields excluded from diffing in the specified ConfigMap.
+
+```bash
+docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
+  argocd-util settings resource-overrides ignore-differences ./deploy.yaml --argocd-cm-path ./argocd-cm.yaml
+```
+
+* Health Assessment
+
+[Health assessment](../user-guide/diffing.md) allows excluding some resource fields from diffing process.
+The diffing customizations are configured in `resource.customizations` field of `argocd-cm` ConfigMap. 
+
+The following `argocd-util` command assess resource health using Lua script configured in the specified ConfigMap.
+
+```bash
+docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
+  argocd-util settings resource-overrides health ./deploy.yaml --argocd-cm-path ./argocd-cm.yaml
+```
+
+* Resource Actions
+
+Resource actions allows configuring named Lua script which performs resource modification.
+
+The following `argocd-util` command executes action using Lua script configured in the specified ConfigMap and prints
+applied modifications.
+
+```bash
+docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
+  argocd-util settings resource-overrides action /tmp/deploy.yaml restart --argocd-cm-path /private/tmp/argocd-cm.yaml 
+```

--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -8,14 +8,20 @@ connectivity issues.
 Argo CD provides multiple ways to customize system behavior and has a lot of settings. It might be dangerous to modify
 settings on Argo CD used in production by multiple users. Before applying settings you can use `argocd-util` binary to
 make sure that settings are valid and Argo CD is working as expected. The `argocd-util` binary is available in `argocd`
-mage and might be used using docker. Example:
+image and might be used using docker. Example:
 
 ```bash
 docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
   argocd-util settings validate --argocd-cm-path ./argocd-cm.yaml
 ```
 
-The `argocd argocd-util settings validate` command performs basic settings validation and print short summary
+If you are using Linux you can extract `argocd-util` binary from docker image:
+
+```bash
+docker run --rm -it -w /src -v $(pwd):/src argocd cp /usr/local/bin/argocd-util ./argocd-util
+``` 
+
+The `argocd-util settings validate` command performs basic settings validation and print short summary
 of each settings group.
 
 **Diffing Customization**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - operator-manual/custom_tools.md
     - operator-manual/metrics.md
     - operator-manual/notifications.md
+    - operator-manual/troubleshooting.md
   - User Guide:
     - user-guide/index.md
     - user-guide/application_sources.md

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -850,8 +850,7 @@ func (a *ArgoCDSettings) IsDexConfigured() bool {
 	if a.URL == "" {
 		return false
 	}
-	var dexCfg map[string]interface{}
-	err := yaml.Unmarshal([]byte(a.DexConfig), &dexCfg)
+	dexCfg, err := UnmarshalDexConfig(a.DexConfig)
 	if err != nil {
 		log.Warn("invalid dex yaml config")
 		return false
@@ -859,18 +858,29 @@ func (a *ArgoCDSettings) IsDexConfigured() bool {
 	return len(dexCfg) > 0
 }
 
+func UnmarshalDexConfig(config string) (map[string]interface{}, error) {
+	var dexCfg map[string]interface{}
+	err := yaml.Unmarshal([]byte(config), &dexCfg)
+	return dexCfg, err
+}
+
 func (a *ArgoCDSettings) OIDCConfig() *OIDCConfig {
 	if a.OIDCConfigRAW == "" {
 		return nil
 	}
-	var oidcConfig OIDCConfig
-	err := yaml.Unmarshal([]byte(a.OIDCConfigRAW), &oidcConfig)
+	oidcConfig, err := UnmarshalOIDCConfig(a.OIDCConfigRAW)
 	if err != nil {
 		log.Warnf("invalid oidc config: %v", err)
 		return nil
 	}
 	oidcConfig.ClientSecret = ReplaceStringSecret(oidcConfig.ClientSecret, a.Secrets)
 	return &oidcConfig
+}
+
+func UnmarshalOIDCConfig(config string) (OIDCConfig, error) {
+	var oidcConfig OIDCConfig
+	err := yaml.Unmarshal([]byte(config), &oidcConfig)
+	return oidcConfig, err
 }
 
 // TLSConfig returns a tls.Config with the configured certificates


### PR DESCRIPTION
PR partially resolved #1447 . 
Implemented changes adds set of commands to `argocd-util` binary which help adjusting argocd settings. More details in https://github.com/alexmt/argo-cd/blob/1447-settings-utils/docs/operator-manual/troubleshooting.md

The main motivation is to reduce the effort needed to support community users. 