### PR TITLE
feat: metrics, argocd_app_info adding syncpolicy info, argocd_cluster_info adding clustername

### DIFF
--- a/controller/metrics/clustercollector.go
+++ b/controller/metrics/clustercollector.go
@@ -88,7 +88,7 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 	now := time.Now()
 	for _, c := range c.info {
 		defaultValues := []string{c.Server}
-		ch <- prometheus.MustNewConstMetric(descClusterInfo, prometheus.GaugeValue, 1, append(defaultValues, c.K8SVersion,c.Clustername)...)
+		ch <- prometheus.MustNewConstMetric(descClusterInfo, prometheus.GaugeValue, 1, append(defaultValues, c.K8SVersion, c.Clustername)...)
 		ch <- prometheus.MustNewConstMetric(descClusterCacheResources, prometheus.GaugeValue, float64(c.ResourcesCount), defaultValues...)
 		ch <- prometheus.MustNewConstMetric(descClusterAPIs, prometheus.GaugeValue, float64(c.APIsCount), defaultValues...)
 		cacheAgeSeconds := -1

--- a/controller/metrics/clustercollector.go
+++ b/controller/metrics/clustercollector.go
@@ -43,6 +43,7 @@ var (
 
 type ClusterInfo struct {
 	Server            string
+	Clustername       string
 	K8SVersion        string
 	ResourcesCount    int
 	APIsCount         int
@@ -87,7 +88,7 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 	now := time.Now()
 	for _, c := range c.info {
 		defaultValues := []string{c.Server}
-		ch <- prometheus.MustNewConstMetric(descClusterInfo, prometheus.GaugeValue, 1, append(defaultValues, c.K8SVersion)...)
+		ch <- prometheus.MustNewConstMetric(descClusterInfo, prometheus.GaugeValue, 1, append(defaultValues, c.K8SVersion,c.Clustername)...)
 		ch <- prometheus.MustNewConstMetric(descClusterCacheResources, prometheus.GaugeValue, float64(c.ResourcesCount), defaultValues...)
 		ch <- prometheus.MustNewConstMetric(descClusterAPIs, prometheus.GaugeValue, float64(c.APIsCount), defaultValues...)
 		cacheAgeSeconds := -1
@@ -97,3 +98,4 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(descClusterCacheAgeSeconds, prometheus.GaugeValue, float64(cacheAgeSeconds), defaultValues...)
 	}
 }
+

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -43,7 +43,7 @@ var (
 	descAppInfo = prometheus.NewDesc(
 		"argocd_app_info",
 		"Information about application.",
-		append(descAppDefaultLabels, "repo", "dest_server", "dest_namespace", "sync_status", "health_status", "operation"),
+		append(descAppDefaultLabels, "repo", "dest_server", "dest_namespace", "sync_status", "health_status", "operation","sync_automated","sync_prune","sync_selfheal"),
 		nil,
 	)
 	// DEPRECATED
@@ -238,6 +238,28 @@ func boolFloat64(b bool) float64 {
 	return 0
 }
 
+func getsync(app *argoappv1.Application) (automated string, prune string, selfheal string) {
+	automated = "false"
+	prune = "false"
+	selfheal = "false"
+
+	if app.Spec.SyncPolicy == nil || app.Spec.SyncPolicy.Automated == nil {
+		return
+	} else {
+		automated = "true"
+	}
+
+	if app.Spec.SyncPolicy.Automated.Prune {
+		prune = "true"
+	}
+
+	if app.Spec.SyncPolicy.Automated.SelfHeal {
+		selfheal = "true"
+	}
+
+	return
+}
+
 func collectApps(ch chan<- prometheus.Metric, app *argoappv1.Application) {
 	addConstMetric := func(desc *prometheus.Desc, t prometheus.ValueType, v float64, lv ...string) {
 		project := app.Spec.GetProject()
@@ -248,6 +270,7 @@ func collectApps(ch chan<- prometheus.Metric, app *argoappv1.Application) {
 		addConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
 
+	var sync_automated, sync_prune, sync_selfheal = getsync(app)
 	var operation string
 	if app.DeletionTimestamp != nil {
 		operation = "delete"
@@ -263,7 +286,7 @@ func collectApps(ch chan<- prometheus.Metric, app *argoappv1.Application) {
 		healthStatus = argoappv1.HealthStatusUnknown
 	}
 
-	addGauge(descAppInfo, 1, git.NormalizeGitURL(app.Spec.Source.RepoURL), app.Spec.Destination.Server, app.Spec.Destination.Namespace, string(syncStatus), healthStatus, operation)
+	addGauge(descAppInfo, 1, git.NormalizeGitURL(app.Spec.Source.RepoURL), app.Spec.Destination.Server, app.Spec.Destination.Namespace, string(syncStatus), healthStatus, operation, sync_automated, sync_prune, sync_selfheal)
 
 	// Deprecated controller metrics
 	if os.Getenv(EnvVarLegacyControllerMetrics) == "true" {
@@ -281,3 +304,4 @@ func collectApps(ch chan<- prometheus.Metric, app *argoappv1.Application) {
 		addGauge(descAppHealthStatus, boolFloat64(healthStatus == argoappv1.HealthStatusMissing), argoappv1.HealthStatusMissing)
 	}
 }
+

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -43,7 +43,7 @@ var (
 	descAppInfo = prometheus.NewDesc(
 		"argocd_app_info",
 		"Information about application.",
-		append(descAppDefaultLabels, "repo", "dest_server", "dest_namespace", "sync_status", "health_status", "operation","sync_automated","sync_prune","sync_selfheal"),
+		append(descAppDefaultLabels, "repo", "dest_server", "dest_namespace", "sync_status", "health_status", "operation", "sync_automated", "sync_prune", "sync_selfheal"),
 		nil,
 	)
 	// DEPRECATED

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -62,7 +62,7 @@ spec:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
   syncPolicy:
-    automated: true
+    automated: {}
 status:
   sync:
     status: Synced
@@ -110,6 +110,10 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
 status:
   sync:
     status: Synced
@@ -174,9 +178,9 @@ func TestMetrics(t *testing.T) {
 			expectedResponse: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync",sync_automated="false",sync_prune="false",sync_selfheal="false"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="true",sync_selfheal="true"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="false",sync_selfheal="false"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="false",sync_prune="false",sync_selfheal="false",sync_status="OutOfSync"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="true",sync_prune="true",sync_selfheal="true",sync_status="Synced"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="true",sync_prune="false",sync_selfheal="false",sync_status="Synced"} 1
 `,
 		},
 		{
@@ -184,7 +188,7 @@ argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:
 			expectedResponse: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="true",sync_selfheal="true"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="true",sync_prune="true",sync_selfheal="true",sync_status="Synced"} 1
 `,
 		},
 	}

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -36,10 +36,10 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
-syncPolicy:
-  automated:
-    prune: true
-    selfHeal: true
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
 status:
   sync:
     status: Synced
@@ -61,8 +61,8 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
-syncPolicy:
-  automated: true
+  syncPolicy:
+    automated: true
 status:
   sync:
     status: Synced
@@ -174,9 +174,9 @@ func TestMetrics(t *testing.T) {
 			expectedResponse: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync",sync_automated="true",sync_prune="true",sync_selfheal="true"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="false",sync_selfheal="false"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="false",sync_prune="false",sync_selfheal="false"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync",sync_automated="false",sync_prune="false",sync_selfheal="false"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="true",sync_selfheal="true"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="false",sync_selfheal="false"} 1
 `,
 		},
 		{

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -36,6 +36,10 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
+syncPolicy:
+  automated:
+    prune: true
+    selfHeal: true
 status:
   sync:
     status: Synced
@@ -57,6 +61,8 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
+syncPolicy:
+  automated: true
 status:
   sync:
     status: Synced
@@ -168,9 +174,9 @@ func TestMetrics(t *testing.T) {
 			expectedResponse: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync",sync_automated="true",sync_prune="true",sync_selfheal="true"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="false",sync_selfheal="false"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="false",sync_prune="false",sync_selfheal="false"} 1
 `,
 		},
 		{
@@ -178,7 +184,7 @@ argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:
 			expectedResponse: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced",sync_automated="true",sync_prune="true",sync_selfheal="true"} 1
 `,
 		},
 	}
@@ -283,3 +289,4 @@ argocd_app_reconcile_count{dest_server="https://localhost:6443",namespace="argoc
 	log.Println(body)
 	assertMetricsPrinted(t, appReconcileMetrics, body)
 }
+


### PR DESCRIPTION
Checklist:

* [x] (c) Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Hi, 
this PR adds some new labels to the following metrics:
argocd_app_info: adding sync_automated, sync_prune, sync_selfheal label
argocd_cluster_info: adding clustername label

This allows the users more flexibility while creating dashboards etc. Now you can panels e.g. current sync states of applications with sync automated enabled.
Furthermore the clustername label should allow the users to use the given name for the clusters instead of the destination server URL. 
