### PR TITLE
fix: support both <group>/<kind> as well as <kind> as a resource override key

### DIFF
--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -2,7 +2,6 @@ package normalizers
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/util/diff"
@@ -32,12 +31,10 @@ type overrideIgnoreDiff struct {
 // NewIgnoreNormalizer creates diff normalizer which removes ignored fields according to given application spec and resource overrides
 func NewIgnoreNormalizer(ignore []v1alpha1.ResourceIgnoreDifferences, overrides map[string]v1alpha1.ResourceOverride) (diff.Normalizer, error) {
 	for key, override := range overrides {
-		parts := strings.Split(key, "/")
-		if len(parts) < 2 {
-			continue
+		group, kind, err := getGroupKindForOverrideKey(key)
+		if err != nil {
+			log.Warn(err)
 		}
-		group := parts[0]
-		kind := parts[1]
 		if override.IgnoreDifferences != "" {
 			ignoreSettings := overrideIgnoreDiff{}
 			err := yaml.Unmarshal([]byte(override.IgnoreDifferences), &ignoreSettings)

--- a/util/argo/normalizers/knowntypes_normalizer_test.go
+++ b/util/argo/normalizers/knowntypes_normalizer_test.go
@@ -7,16 +7,18 @@ import (
 	"testing"
 
 	"github.com/argoproj/argo-cd/errors"
+	"github.com/argoproj/argo-cd/pkg/apis/application"
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
-	testRolloutYAML = `apiVersion: argoproj.io/v1alpha1
-kind: Rollout
+	someCRDYaml = `apiVersion: some.io/v1alpha1
+kind: TestCRD
 metadata:
   name: canary-demo
 spec:
@@ -26,7 +28,7 @@ spec:
         app: canary-demo
     spec:
       containers:
-      - image: argoproj/rollouts-demo:yellow
+      - image: something:latest
         name: canary-demo
         volumeMounts:
         - name: config-volume
@@ -36,6 +38,7 @@ spec:
           requests:
             cpu: 2000m
             memory: 32Mi`
+	crdGroupKind = "some.io/TestCRD"
 )
 
 func mustUnmarshalYAML(yamlStr string) *unstructured.Unstructured {
@@ -66,7 +69,7 @@ func nestedSliceMap(obj map[string]interface{}, i int, path ...string) (map[stri
 
 func TestNormalize_MapField(t *testing.T) {
 	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{
-		"argoproj.io/Rollout": {
+		crdGroupKind: {
 			KnownTypeFields: []v1alpha1.KnownTypeField{{
 				Type:  "core/v1/PodSpec",
 				Field: "spec.template.spec",
@@ -77,7 +80,7 @@ func TestNormalize_MapField(t *testing.T) {
 		return
 	}
 
-	rollout := mustUnmarshalYAML(testRolloutYAML)
+	rollout := mustUnmarshalYAML(someCRDYaml)
 
 	err = normalizer.Normalize(rollout)
 	if !assert.NoError(t, err) {
@@ -107,9 +110,9 @@ func TestNormalize_MapField(t *testing.T) {
 }
 
 func TestNormalize_FieldInNestedSlice(t *testing.T) {
-	rollout := mustUnmarshalYAML(testRolloutYAML)
+	rollout := mustUnmarshalYAML(someCRDYaml)
 	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{
-		"argoproj.io/Rollout": {
+		crdGroupKind: {
 			KnownTypeFields: []v1alpha1.KnownTypeField{{
 				Type:  "core/v1/Container",
 				Field: "spec.template.spec.containers",
@@ -139,8 +142,8 @@ func TestNormalize_FieldInNestedSlice(t *testing.T) {
 }
 
 func TestNormalize_FieldInDoubleNestedSlice(t *testing.T) {
-	rollout := mustUnmarshalYAML(`apiVersion: argoproj.io/v1alpha1
-kind: Rollout
+	rollout := mustUnmarshalYAML(`apiVersion: some.io/v1alpha1
+kind: TestCRD
 metadata:
   name: canary-demo
 spec:
@@ -161,7 +164,7 @@ spec:
               cpu: 2000m
               memory: 32Mi`)
 	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{
-		"argoproj.io/Rollout": {
+		crdGroupKind: {
 			KnownTypeFields: []v1alpha1.KnownTypeField{{
 				Type:  "core/v1/Container",
 				Field: "spec.templates.spec.containers",
@@ -195,9 +198,9 @@ spec:
 }
 
 func TestFieldDoesNotExist(t *testing.T) {
-	rollout := mustUnmarshalYAML(testRolloutYAML)
+	rollout := mustUnmarshalYAML(someCRDYaml)
 	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{
-		"argoproj.io/Rollout": {
+		crdGroupKind: {
 			KnownTypeFields: []v1alpha1.KnownTypeField{{
 				Type:  "core/v1/PodSpec",
 				Field: "fieldDoesNotExist",
@@ -224,6 +227,31 @@ func TestFieldDoesNotExist(t *testing.T) {
 	}
 
 	assert.Equal(t, "2000m", cpu)
+}
+
+func TestRolloutPreConfigured(t *testing.T) {
+	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{})
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, ok := normalizer.typeFields[schema.GroupKind{Group: application.Group, Kind: "Rollout"}]
+	assert.True(t, ok)
+}
+
+func TestOverrideKeyWithoutGroup(t *testing.T) {
+	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{
+		"ConfigMap": {
+			KnownTypeFields: []v1alpha1.KnownTypeField{{
+				Type:  "core/v1/PodSpec",
+				Field: "data",
+			}},
+		},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, ok := normalizer.typeFields[schema.GroupKind{Group: "", Kind: "ConfigMap"}]
+	assert.True(t, ok)
 }
 
 func TestKnownTypes(t *testing.T) {

--- a/util/argo/normalizers/util.go
+++ b/util/argo/normalizers/util.go
@@ -1,0 +1,21 @@
+package normalizers
+
+import (
+	"fmt"
+	"strings"
+)
+
+func getGroupKindForOverrideKey(key string) (string, string, error) {
+	var group, kind string
+	parts := strings.Split(key, "/")
+
+	if len(parts) == 2 {
+		group = parts[0]
+		kind = parts[1]
+	} else if len(parts) == 1 {
+		kind = parts[0]
+	} else {
+		return "", "", fmt.Errorf("override key must be <group>/<kind> or <kind>, got: '%s' ", key)
+	}
+	return group, kind, nil
+}


### PR DESCRIPTION
Closes #3406

Additionally adds default known type configuration for argoproj.io/Rollout CRD