### PR TITLE
fix: Revert "feat: metrics, argocd_app_info adding syncpolicy info, argocd_cluster_info adding clustername"

### DIFF
--- a/controller/metrics/clustercollector.go
+++ b/controller/metrics/clustercollector.go
@@ -43,7 +43,6 @@ var (
 
 type ClusterInfo struct {
 	Server            string
-	Clustername       string
 	K8SVersion        string
 	ResourcesCount    int
 	APIsCount         int
@@ -88,7 +87,7 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 	now := time.Now()
 	for _, c := range c.info {
 		defaultValues := []string{c.Server}
-		ch <- prometheus.MustNewConstMetric(descClusterInfo, prometheus.GaugeValue, 1, append(defaultValues, c.K8SVersion, c.Clustername)...)
+		ch <- prometheus.MustNewConstMetric(descClusterInfo, prometheus.GaugeValue, 1, append(defaultValues, c.K8SVersion)...)
 		ch <- prometheus.MustNewConstMetric(descClusterCacheResources, prometheus.GaugeValue, float64(c.ResourcesCount), defaultValues...)
 		ch <- prometheus.MustNewConstMetric(descClusterAPIs, prometheus.GaugeValue, float64(c.APIsCount), defaultValues...)
 		cacheAgeSeconds := -1
@@ -98,4 +97,3 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(descClusterCacheAgeSeconds, prometheus.GaugeValue, float64(cacheAgeSeconds), defaultValues...)
 	}
 }
-

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -36,10 +36,6 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
 status:
   sync:
     status: Synced
@@ -61,8 +57,6 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
-  syncPolicy:
-    automated: {}
 status:
   sync:
     status: Synced
@@ -110,10 +104,6 @@ spec:
   source:
     path: some/path
     repoURL: https://github.com/argoproj/argocd-example-apps.git
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
 status:
   sync:
     status: Synced
@@ -178,9 +168,9 @@ func TestMetrics(t *testing.T) {
 			expectedResponse: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="false",sync_prune="false",sync_selfheal="false",sync_status="OutOfSync"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="true",sync_prune="true",sync_selfheal="true",sync_status="Synced"} 1
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="true",sync_prune="false",sync_selfheal="false",sync_status="Synced"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Degraded",name="my-app-3",namespace="argocd",operation="delete",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="OutOfSync"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app-2",namespace="argocd",operation="sync",project="important-project",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
 `,
 		},
 		{
@@ -188,7 +178,7 @@ argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:
 			expectedResponse: `
 # HELP argocd_app_info Information about application.
 # TYPE argocd_app_info gauge
-argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_automated="true",sync_prune="true",sync_selfheal="true",sync_status="Synced"} 1
+argocd_app_info{dest_namespace="dummy-namespace",dest_server="https://localhost:6443",health_status="Healthy",name="my-app",namespace="argocd",operation="",project="default",repo="https://github.com/argoproj/argocd-example-apps",sync_status="Synced"} 1
 `,
 		},
 	}
@@ -293,4 +283,3 @@ argocd_app_reconcile_count{dest_server="https://localhost:6443",namespace="argoc
 	log.Println(body)
 	assertMetricsPrinted(t, appReconcileMetrics, body)
 }
-


### PR DESCRIPTION
Reverts argoproj/argo-cd#3411 - crashes application controller on metrics collection according to reports.