### PR TITLE
Fix: Text overflow when the application status panel item was too big. #3459

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -17,6 +17,7 @@
         font-size: .8em;
         line-height: 1.2;
         color: $argo-color-gray-5;
+        overflow: hidden;
 
         &:not(:first-child) {
             border-left: 1px solid $argo-color-gray-3;


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, **(b) this is a bug fix**, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 


**Screenshot:**

Before:
<img width="340" alt="Screen Shot 2020-04-21 at 22 35 55" src="https://user-images.githubusercontent.com/50113670/79931127-98775a00-8420-11ea-8570-e93b483e1b4f.png">

After:
<img width="351" alt="Screen Shot 2020-04-21 at 22 35 29" src="https://user-images.githubusercontent.com/50113670/79931134-9dd4a480-8420-11ea-86ae-c3ccf3bb84d2.png">
