### PR TITLE
chore: Migrate CI checks to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - coverage.out
+            - test-results/coverage.out
   save_node_modules:
     steps:
       - persist_to_workspace:
@@ -149,7 +149,7 @@ jobs:
       - run: make test-local
       - run:
           name: Uploading code coverage
-          command: bash <(curl -s https://codecov.io/bash) -f coverage.out
+          command: bash <(curl -s https://codecov.io/bash) -f test-results/coverage.out
       - run:
           name: Output of test-results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,11 +355,11 @@ workflows:
       - ui:
           requires:
             - build
-      - sonarcloud:
-          context: SonarCloud
-          requires:
-            - test
-            - ui
+      # - sonarcloud:
+      #     context: SonarCloud
+      #     requires:
+      #       - test
+      #       - ui
       - e2e:
           requires:
             - build

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -9,7 +9,6 @@ on:
       - 'master'
 
 env:
-  GO_VERSION: 1.14.1
   TEST_TOOLS_TAG: v0.2.0
   DOCKER_ARGS: null
 

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -145,6 +145,8 @@ jobs:
       working-directory: ${{ env.GOCACHE }}
 
     - name: Run all unit tests
+      env:
+        ARGOCD_TEST_PARALLELISM: 2
       run: |
         export PATH=$PATH:$GITHUB_WORKSPACE/src/github.com/argoproj/argo-cd/hack
         make test

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -125,6 +125,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+        fetch-depth: 0
+        persist-credentials: false
 
     - name: Restore dependency cache
       id: cache-dependencies
@@ -146,7 +148,7 @@ jobs:
 
     - name: Run all unit tests
       env:
-        ARGOCD_TEST_PARALLELISM: 1
+        ARGOCD_TEST_PARALLELISM: 8
       run: |
         export PATH=$PATH:$GITHUB_WORKSPACE/src/github.com/argoproj/argo-cd/hack
         make test

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -128,6 +128,11 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    - name: Fetch complete history for blame information
+      run: |
+        git fetch --prune --no-tags origin +refs/heads/*:refs/remotes/origin/*
+      working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
     - name: Restore dependency cache
       id: cache-dependencies
       uses: actions/cache@v1

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -125,12 +125,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
-        fetch-depth: 0
-        persist-credentials: false
 
     - name: Fetch complete history for blame information
       run: |
-        git fetch --prune --no-tags origin +refs/heads/*:refs/remotes/origin/*
+        git fetch --prune --no-tags --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
 
     - name: Restore dependency cache

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -3,7 +3,7 @@ name: CI checks
 on:
   push:
     branches:
-      - '**' 
+      - 'master' 
   pull_request:
     branches:
       - 'master'

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -160,6 +160,7 @@ jobs:
     name: Run sonarcloud analysis
     needs:
       - test
+      - ui
     runs-on: ubuntu-latest
     env:
       GOPATH: /home/runner/work/argo-cd/argo-cd
@@ -173,7 +174,7 @@ jobs:
 
       - name: Fetch complete history for blame information
         run: |
-          git fetch --prune --depth 1 --no-tags origin +refs/heads/*:refs/remotes/origin/*
+          git fetch --prune --no-tags origin +refs/heads/*:refs/remotes/origin/*
         working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
 
       - name: Create test-results directory

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -125,6 +125,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+        persist-credentials: false
+
+    - name: Switch to temporal branch so we re-attach head
+      run: |
+        git switch -c temporal-pr-branch
+        git status
+      working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
 
     - name: Fetch complete history for blame information
       run: |

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -146,7 +146,7 @@ jobs:
 
     - name: Run all unit tests
       env:
-        ARGOCD_TEST_PARALLELISM: 2
+        ARGOCD_TEST_PARALLELISM: 1
       run: |
         export PATH=$PATH:$GITHUB_WORKSPACE/src/github.com/argoproj/argo-cd/hack
         make test

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -1,0 +1,383 @@
+name: CI checks
+
+on:
+  push:
+    branches:
+      - '**' 
+  pull_request:
+    branches:
+      - 'master'
+
+env:
+  GO_VERSION: 1.14.1
+  TEST_TOOLS_TAG: v0.2.0
+  DOCKER_ARGS: null
+
+jobs:
+  #############################################################################
+  # The build job is responsible for a complete build of all Go units in the
+  # codebase. It also ensures Gopkg.lock is up-to-date with Gopkg.toml and the
+  # dependencies. It sets up the vendor and build caches, so must be run before
+  # all other jobs.
+  #############################################################################
+  build:
+    name: Build codebase
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+      DOCKER_ARGS: null
+    steps:
+      - name: Pull required images
+        run: docker pull argoproj/argocd-test-tools:$TEST_TOOLS_TAG
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - run: mkdir -p $HOME/.cache/go-build
+
+      - name: Restore dependency cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd/vendor
+          key: ${{ runner.os }}-go-dep-v2-${{ hashFiles('**/Gopkg.lock') }}
+
+      - name: Ensure Gopkg.lock is in sync with Gopkg.toml
+        run: make dep-check
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - name: Synchronize vendor dependencies
+        run: make dep 
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - name: Restore any build cache for this PR
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-build-v2-${{ github.ref }}
+
+      - name: Build the codebase
+        run: make build
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+  codegen:
+    name: Run codegen
+    runs-on: ubuntu-latest
+    needs: 
+      - build
+
+    env:
+      GOPATH: /home/runner/work/argo-cd/argo-cd
+      DOCKER_ARGS: null
+
+    steps:
+    - name: Pull required images
+      run: docker pull argoproj/argocd-test-tools:$TEST_TOOLS_TAG
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+    - name: Restore dependency cache
+      id: cache-dependencies
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd/vendor
+        key: ${{ runner.os }}-go-dep-v2-${{ hashFiles('**/Gopkg.lock') }}
+
+    - name: Restore any build cache for this PR
+      id: cache-build-cache
+      uses: actions/cache@v1
+      with:
+        path: /home/runner/.cache/go-build
+        key: ${{ runner.os }}-go-build-v2-${{ github.ref }}
+
+    - name: Run codegen 
+      run: make codegen
+      working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+    - name: Ensure nothing has changed
+      run: |
+        set -xo pipefail
+        # This makes sure you ran `make pre-commit` before you pushed.
+        # We exclude the Swagger resources; CircleCI doesn't generate them correctly.
+        # When this fails, it will, create a patch file you can apply locally to fix it.
+        # To troubleshoot builds: https://argoproj.github.io/argo-cd/developer-guide/ci/
+        git diff --exit-code -- . ':!Gopkg.lock'  ':!assets/swagger.json' | tee codegen.patch
+      working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    needs: 
+      - build
+    env:
+      GOPATH: ${{ github.workspace }}
+      DOCKER_ARGS: null
+      GOCACHE: /home/runner/.cache/go-build
+
+    steps:
+    - name: Pull required images
+      run: docker pull argoproj/argocd-test-tools:$TEST_TOOLS_TAG
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+    - name: Restore dependency cache
+      id: cache-dependencies
+      uses: actions/cache@v1
+      with:
+        path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd/vendor
+        key: ${{ runner.os }}-go-dep-v2-${{ hashFiles('**/Gopkg.lock') }}
+
+    - name: Restore any build cache for this PR
+      id: cache-build-cache
+      uses: actions/cache@v1
+      with:
+        path: ${{ env.GOCACHE }}
+        key: ${{ runner.os }}-go-build-v2-${{ github.ref }}
+    
+    - name: Show cache directory
+      run: ls -la
+      working-directory: ${{ env.GOCACHE }}
+
+    - name: Run all unit tests
+      run: |
+        export PATH=$PATH:$GITHUB_WORKSPACE/src/github.com/argoproj/argo-cd/hack
+        make test
+      working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+    - name: Store coverage information
+      uses: actions/upload-artifact@v1
+      with:
+        name: test-results
+        path: ${{ github.workspace }}/./src/github.com/argoproj/argo-cd/test-results
+
+  sonarcloud:
+    name: Run sonarcloud analysis
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/work/argo-cd/argo-cd
+      DOCKER_ARGS: null
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+          fetch-depth: 0
+
+      - name: Fetch complete history for blame information
+        run: |
+          git fetch --prune --depth 1 --no-tags origin +refs/heads/*:refs/remotes/origin/*
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - name: Create test-results directory
+        run: mkdir -p $GITHUB_WORKSPACE/src/github.com/argoproj/argo-cd/test-results
+
+      - name: Restore node dependency cache
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace}}/src/github.com/argoproj/argo-cd/ui/node_modules
+          key: ${{ runner.os }}-node-dep-v2-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Remove stray node configuration
+        run: |
+          rm -rf ui/node_modules/argo-ui/node_modules
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - name: Restore Code coverage information
+        uses: actions/download-artifact@v1
+        with:
+          name: test-results
+          path: ${{ github.workspace }}/src/github.com/argoproj/argo-cd/test-results
+
+      - name: Run sonar-scanner
+        uses: jannfis/sonarcloud-github-action@master
+        with:
+          projectBaseDir: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          NODE_MODULES: ${{ github.workspace }}/src/github.com/argoproj/argo-cd/ui/node_modules
+
+  lint:
+    needs: 
+      - build
+    name: Lint codebase
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/work/argo-cd/argo-cd
+      DOCKER_ARGS: null
+    steps:
+      - name: Pull required images
+        run: docker pull argoproj/argocd-test-tools:$TEST_TOOLS_TAG
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace}}/src/github.com/argoproj/argo-cd
+
+      - name: Restore dependency cache
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace}}/src/github.com/argoproj/argo-cd/vendor
+          key: ${{ runner.os }}-go-dep-v2-${{ hashFiles('**/Gopkg.lock') }}
+
+      - name: Restore any build cache for this PR
+        id: cache-build-cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-build-v2-${{ github.ref }}
+
+      - name: Run golangci-lint
+        run: make lint ARGOCD_LINT_GOGC=100
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - name: Check that nothing has changed
+        run: |
+          gDiff=$(git diff)
+          if test "$gDiff" != ""; then
+            echo "################################################################################"
+            echo "golangci-lint has detected & fixed changes. Please fix them in your local repo,"
+            echo "commit the changes and push them to re-trigger the check."
+            echo "################################################################################"
+            git diff
+            exit 1
+          fi
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+  test-e2e:
+    name: Run end-to-end tests
+    runs-on: ubuntu-latest
+    needs: 
+      - build
+    env:
+      GOPATH: /home/runner/work/argo-cd/argo-cd
+      DOCKER_ARGS: null
+      ARGOCD_FAKE_IN_CLUSTER: "true"
+      ARGOCD_SSH_DATA_PATH: "/tmp/argo-e2e/app/config/ssh"
+      ARGOCD_TLS_DATA_PATH: "/tmp/argo-e2e/app/config/tls"
+      ARGOCD_E2E_K3S: "true"
+      ARGOCD_IN_CI: "true"
+
+    steps:
+      - name: Pull required images
+        run: docker pull argoproj/argocd-test-tools:$TEST_TOOLS_TAG
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace}}/src/github.com/argoproj/argo-cd
+
+      - name: Restore dependency cache
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace}}/src/github.com/argoproj/argo-cd/vendor
+          key: ${{ runner.os }}-go-dep-v2-${{ hashFiles('**/Gopkg.lock') }}
+
+      - name: Restore any build cache for this PR
+        id: cache-build-cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-build-v2-${{ github.ref }}
+
+      - name: Install K3S
+        env:
+          INSTALL_K3S_VERSION: v1.0.1
+        run: |
+          set -x
+          curl -sfL https://get.k3s.io | sh -
+          sudo chmod -R a+rw /etc/rancher/k3s
+          sudo mkdir -p $HOME/.kube && sudo chown -R runner $HOME/.kube
+          sudo k3s kubectl config view --raw > $HOME/.kube/config
+          sudo chown runner $HOME/.kube/config
+          kubectl version
+
+      - name: Get interface information
+        env:
+          IFACE: eth0
+        run: |
+          set -x
+          ifconfig
+          ipaddr=$(ifconfig $IFACE |grep "inet " | awk '{print $2}')
+          if echo $ipaddr | grep -q 'addr:'; then
+            ipaddr=$(echo $ipaddr | awk -F ':' '{print $2}')
+          fi
+          echo "Using IPAddr '$ipaddr'"
+          test -d $HOME/.kube || mkdir -p $HOME/.kube
+          tempfile=$(mktemp)
+          kubectl config view --raw | sed -e "s/127.0.0.1:6443/${ipaddr}:6443/g" -e "s/localhost:6443/${ipaddr}:6443/g" > $tempfile
+          mv $tempfile $HOME/.kube/config
+          kubectl version
+
+      - name: Run E2E server and wait for it being available
+        timeout-minutes: 30
+        run: |
+          set -x
+          make start-e2e &
+          count=1
+          until curl http://localhost:8080/healthz; do 
+            sleep 10;
+            if test $count -ge 60; then
+              echo "Timeout"
+              exit 1
+            fi
+            count=$((count+1))
+          done
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - name: Run E2E tests
+        timeout-minutes: 30
+        env:
+          ARGOCD_OPTS: "--plaintext"
+          ARGOCD_E2E_K3S: "true"
+          DOCKER_ARGS: -t
+          DOCKER_SRCDIR: ${{ github.workspace }}/src
+        run: |
+          set -x
+          make test-e2e
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+  ui:
+    runs-on: ubuntu-latest
+    name: Build & lint UI code
+    env:
+      DOCKER_SRCDIR: ${{ github.workspace }}/src
+    steps:
+
+      - name: Pull required images
+        run: docker pull argoproj/argocd-test-tools:$TEST_TOOLS_TAG
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace}}/src/github.com/argoproj/argo-cd
+
+      - name: Restore node dependency cache
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace}}/src/github.com/argoproj/argo-cd/ui/node_modules
+          key: ${{ runner.os }}-node-dep-v2-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Update yarn dependencies
+        run: |
+          make dep-ui
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd
+
+      - name: Test, build and lint UI code
+        run: |
+          make build-ui
+        working-directory: ${{ github.workspace }}/src/github.com/argoproj/argo-cd

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,8 @@ sonar.sourceEncoding=UTF-8
 
 sonar.host.url=https://sonarcloud.io
 
+sonar.go.coverage.reportPaths=test-results/coverage.out
+
 # Exclude following set of patterns from coverage analysis
 sonar.coverage.exclusions=**/*.pb.go,**/*.pb.gw.go,**/mocks/**,**/*.ts*,**/vendor/**,**/openapi_generated.go,**/*_test.go,**/*_generated*,test/**,pkg/client/**,pkg/apiclient/**
 

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -495,6 +495,11 @@ func TestConfigMap(t *testing.T) {
 
 func TestFailedConversion(t *testing.T) {
 
+	// k3s does not validate at all, so this test does not work
+	if os.Getenv("ARGOCD_E2E_K3S") == "true" {
+		t.SkipNow()
+	}
+
 	defer func() {
 		FailOnErr(Run("", "kubectl", "delete", "apiservice", "v1beta1.metrics.k8s.io"))
 	}()

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -22,7 +22,7 @@ func (c *Consequences) Expect(e Expectation) *Consequences {
 	c.context.t.Helper()
 	var message string
 	var state state
-	timeout := time.Duration(15) * time.Second
+	timeout := time.Duration(30) * time.Second
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(3 * time.Second) {
 		state, message = e(c)
 		switch state {

--- a/test/e2e/fixture/app/context.go
+++ b/test/e2e/fixture/app/context.go
@@ -39,7 +39,7 @@ type Context struct {
 
 func Given(t *testing.T) *Context {
 	fixture.EnsureCleanState(t)
-	return &Context{t: t, destServer: KubernetesInternalAPIServerAddr, repoURLType: fixture.RepoURLTypeFile, name: fixture.Name(), timeout: 10, project: "default", prune: true}
+	return &Context{t: t, destServer: KubernetesInternalAPIServerAddr, repoURLType: fixture.RepoURLTypeFile, name: fixture.Name(), timeout: 15, project: "default", prune: true}
 }
 
 func (c *Context) CustomCACertAdded() *Context {

--- a/test/e2e/fixture/app/context.go
+++ b/test/e2e/fixture/app/context.go
@@ -39,7 +39,7 @@ type Context struct {
 
 func Given(t *testing.T) *Context {
 	fixture.EnsureCleanState(t)
-	return &Context{t: t, destServer: KubernetesInternalAPIServerAddr, repoURLType: fixture.RepoURLTypeFile, name: fixture.Name(), timeout: 15, project: "default", prune: true}
+	return &Context{t: t, destServer: KubernetesInternalAPIServerAddr, repoURLType: fixture.RepoURLTypeFile, name: fixture.Name(), timeout: 30, project: "default", prune: true}
 }
 
 func (c *Context) CustomCACertAdded() *Context {


### PR DESCRIPTION
**Contents**
* Migrates all CI checks to GH actions
* Disables Sonarcloud scanner on CircleCI to prevent duplicate scanning
* Tweaks some timeouts in E2E checks, because GH actions infrastructure seems a little slower than CircleCI

**Notes**
* CircleCI still runs in parallel so we can check which one is better/more reliable/faster
* ~GH actions runs on all branches and PRs - this is something to discuss~

Checklist:

* [x] (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
