### PR TITLE
feat: add redis metrics to application controller and api server

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -167,6 +167,10 @@ func NewApplicationController(
 	return &ctrl, nil
 }
 
+func (ctrl *ApplicationController) GetMetricsServer() *metrics.MetricsServer {
+	return ctrl.metricsServer
+}
+
 func (ctrl *ApplicationController) onKubectlRun(command string) (util.Closer, error) {
 	ctrl.metricsServer.IncKubectlExec(command)
 	if ctrl.kubectlSemaphore != nil {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type MetricsServer struct {
+	*http.Server
+	redisRequestCounter *prometheus.CounterVec
+}
+
+var (
+	redisRequestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "argocd_redis_request_total",
+			Help: "Number of kubernetes requests executed during application reconciliation.",
+		},
+		[]string{"initiator", "failed"},
+	)
+)
+
+// NewMetricsServer returns a new prometheus server which collects api server metrics
+func NewMetricsServer(port int) *MetricsServer {
+	mux := http.NewServeMux()
+	registry := prometheus.NewRegistry()
+	mux.Handle("/metrics", promhttp.HandlerFor(prometheus.Gatherers{
+		registry,
+		prometheus.DefaultGatherer,
+	}, promhttp.HandlerOpts{}))
+
+	registry.MustRegister(redisRequestCounter)
+
+	return &MetricsServer{
+		Server: &http.Server{
+			Addr:    fmt.Sprintf("0.0.0.0:%d", port),
+			Handler: mux,
+		},
+		redisRequestCounter: redisRequestCounter,
+	}
+}
+
+func (m *MetricsServer) IncRedisRequest(failed bool) {
+	m.redisRequestCounter.WithLabelValues("argocd-server", strconv.FormatBool(failed)).Inc()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -249,13 +249,15 @@ func (a *ArgoCDServer) Run(ctx context.Context, port int, metricsPort int) {
 	}
 
 	metricsServ := metrics.NewMetricsServer(metricsPort)
-	a.RedisClient.WrapProcess(func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
-		return func(cmd redis.Cmder) error {
-			err := oldProcess(cmd)
-			metricsServ.IncRedisRequest(err != nil && err != rediscache.ErrCacheMiss)
-			return err
-		}
-	})
+	if a.RedisClient != nil {
+		a.RedisClient.WrapProcess(func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
+			return func(cmd redis.Cmder) error {
+				err := oldProcess(cmd)
+				metricsServ.IncRedisRequest(err != nil && err != rediscache.ErrCacheMiss)
+				return err
+			}
+		})
+	}
 
 	// Start listener
 	var conn net.Listener

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	rediscache "github.com/go-redis/cache"
 	"github.com/go-redis/redis"
 	golang_proto "github.com/golang/protobuf/proto"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -25,7 +26,6 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 	netCtx "golang.org/x/net/context"
@@ -67,6 +67,7 @@ import (
 	servercache "github.com/argoproj/argo-cd/server/cache"
 	"github.com/argoproj/argo-cd/server/certificate"
 	"github.com/argoproj/argo-cd/server/cluster"
+	"github.com/argoproj/argo-cd/server/metrics"
 	"github.com/argoproj/argo-cd/server/project"
 	"github.com/argoproj/argo-cd/server/rbacpolicy"
 	"github.com/argoproj/argo-cd/server/repocreds"
@@ -246,7 +247,15 @@ func (a *ArgoCDServer) Run(ctx context.Context, port int, metricsPort int) {
 			httpsS.Handler = withRootPath(httpsS.Handler, a.RootPath)
 		}
 	}
-	metricsServ := newAPIServerMetricsServer(metricsPort)
+
+	metricsServ := metrics.NewMetricsServer(metricsPort)
+	a.RedisClient.WrapProcess(func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
+		return func(cmd redis.Cmder) error {
+			err := oldProcess(cmd)
+			metricsServ.IncRedisRequest(err != nil && err != rediscache.ErrCacheMiss)
+			return err
+		}
+	})
 
 	// Start listener
 	var conn net.Listener
@@ -721,16 +730,6 @@ func indexFilePath(srcPath string, baseHRef string) (string, error) {
 	}
 
 	return filePath, nil
-}
-
-// newAPIServerMetricsServer returns HTTP server which serves prometheus metrics on gRPC requests
-func newAPIServerMetricsServer(port int) *http.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	return &http.Server{
-		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
-		Handler: mux,
-	}
 }
 
 func fileExists(filename string) bool {


### PR DESCRIPTION
PR adds `argocd_redis_request_total` counter that represents redis requests. Counter has two labels:

* `initiator` - either `argocd-application-controller` or `argocd-server`

* `failed` - indicates if the request failed or succeeded. Redis uses TCP based protocol, so no HTTP status code. I could not find any other reliable error indicator so had to fallback to just `true`/`false`.