### PR TITLE
fix: redis timeout should be more than client timeout

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -135,8 +135,8 @@ data:
     defaults REDIS
       mode tcp
       timeout connect 4s
-      timeout server 30s
-      timeout client 30s
+      timeout server 6m
+      timeout client 6m
       timeout check 2s
 
     listen health_check_http_url

--- a/manifests/ha/base/redis-ha/generate.sh
+++ b/manifests/ha/base/redis-ha/generate.sh
@@ -19,3 +19,5 @@ helm2 template ./chart \
   >> ./chart/upstream_orig.yaml
 
 sed -e 's/check inter 1s/check inter 3s/' ./chart/upstream_orig.yaml >> ./chart/upstream.yaml && rm ./chart/upstream_orig.yaml
+sed -i 's/timeout server 30s/timeout server 6m/' ./chart/upstream.yaml
+sed -i 's/timeout client 30s/timeout client 6m/' ./chart/upstream.yaml

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2231,8 +2231,8 @@ data:
     defaults REDIS
       mode tcp
       timeout connect 4s
-      timeout server 30s
-      timeout client 30s
+      timeout server 6m
+      timeout client 6m
       timeout check 2s
 
     listen health_check_http_url

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2146,8 +2146,8 @@ data:
     defaults REDIS
       mode tcp
       timeout connect 4s
-      timeout server 30s
-      timeout client 30s
+      timeout server 6m
+      timeout client 6m
       timeout check 2s
 
     listen health_check_http_url


### PR DESCRIPTION
After upgrading to HA proxy redis requests intermittently fails with EOF error. I run into this issue after trying to find a solution: https://github.com/goharbor/harbor/issues/7871 . Argo CD uses redis client with default 5 mins timeout that must be less than server timeout. After increasing HA timeout to 6 mins ( > 5 mins) EOF errors disappear.
