### PR TITLE
feat: Allow selecting TLS ciphers on server (#3510)

### DIFF
--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -23,7 +23,7 @@ The Docker version must be fairly recent, and support multi-stage builds. You sh
 
 * Obviously, you will need a `git` client for pulling source code and pushing back your changes.
 
-* Last but not least, you will need a Go SDK and related tools (such as GNU `make`) installed and working on your development environment.
+* Last but not least, you will need a Go SDK and related tools (such as GNU `make`) installed and working on your development environment. The minimum required Go version for building ArgoCD is **v1.14.0**.
 
 * We will assume that your Go workspace is at `~/go`
 

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -14,13 +14,22 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 const (
 	DefaultRSABits = 2048
+	// The default TLS cipher suites to provide to clients - see https://cipherlist.eu for updates
+	// Note that for TLS v1.3, cipher suites are not configurable and will be chosen automatically.
+	DefaultTLSCipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_256_GCM_SHA384"
+	// The default minimum TLS version to provide to clients
+	DefaultTLSMinVersion = "1.2"
+	// The default maximum TLS version to provide to clients
+	DefaultTLSMaxVersion = "1.3"
 )
 
 var (
@@ -28,6 +37,7 @@ var (
 		"1.0": tls.VersionTLS10,
 		"1.1": tls.VersionTLS11,
 		"1.2": tls.VersionTLS12,
+		"1.3": tls.VersionTLS13,
 	}
 )
 
@@ -69,25 +79,103 @@ func getTLSVersionByString(version string) (uint16, error) {
 	return 0, fmt.Errorf("%s is not valid TLS version", version)
 }
 
+// Parse colon seperated string representation of TLS cipher suites into array of values usable by crypto/tls
+func getTLSCipherSuitesByString(cipherSuites string) ([]uint16, error) {
+	suiteMap := make(map[string]uint16)
+	for _, s := range tls.CipherSuites() {
+		suiteMap[s.Name] = s.ID
+	}
+	allowedSuites := make([]uint16, 0)
+	for _, s := range strings.Split(cipherSuites, ":") {
+		id, ok := suiteMap[strings.TrimSpace(s)]
+		if ok {
+			allowedSuites = append(allowedSuites, id)
+		} else {
+			return nil, fmt.Errorf("invalid cipher suite specified: %s", s)
+		}
+	}
+	return allowedSuites, nil
+}
+
+// Return array of strings representing TLS versions
+func tlsVersionsToStr(versions []uint16) []string {
+	ret := make([]string, 0)
+	for _, v := range versions {
+		switch v {
+		case tls.VersionTLS10:
+			ret = append(ret, "1.0")
+		case tls.VersionTLS11:
+			ret = append(ret, "1.1")
+		case tls.VersionTLS12:
+			ret = append(ret, "1.2")
+		case tls.VersionTLS13:
+			ret = append(ret, "1.3")
+		default:
+			ret = append(ret, "unknown")
+		}
+	}
+	return ret
+}
+
+func getTLSConfigCustomizer(minVersionStr, maxVersionStr, tlsCiphersStr string) (ConfigCustomizer, error) {
+	minVersion, err := getTLSVersionByString(minVersionStr)
+	if err != nil {
+		return nil, err
+	}
+	maxVersion, err := getTLSVersionByString(maxVersionStr)
+	if err != nil {
+		return nil, err
+	}
+	if minVersion > maxVersion {
+		return nil, fmt.Errorf("Minimum TLS version %s must not be higher than maximum TLS version %s", minVersionStr, maxVersionStr)
+	}
+
+	// Cipher suites for TLSv1.3 are not configurable
+	if minVersion == tls.VersionTLS13 {
+		if tlsCiphersStr != DefaultTLSCipherSuite {
+			log.Warnf("TLSv1.3 cipher suites are not configurable, ignoring value of --tlsciphers")
+		}
+		tlsCiphersStr = ""
+	}
+
+	if tlsCiphersStr == "list" {
+		fmt.Printf("Supported TLS ciphers:\n")
+		for _, s := range tls.CipherSuites() {
+			fmt.Printf("* %s (TLS versions: %s)\n", tls.CipherSuiteName(s.ID), strings.Join(tlsVersionsToStr(s.SupportedVersions), ", "))
+		}
+		os.Exit(0)
+	}
+
+	var cipherSuites []uint16
+	if tlsCiphersStr != "" {
+		cipherSuites, err = getTLSCipherSuitesByString(tlsCiphersStr)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		cipherSuites = make([]uint16, 0)
+	}
+
+	return func(config *tls.Config) {
+		config.MinVersion = minVersion
+		config.MaxVersion = maxVersion
+		config.CipherSuites = cipherSuites
+	}, nil
+
+}
+
+// Adds TLS server related command line options to a command and returns a TLS
+// config customizer object, set up to the options specified
 func AddTLSFlagsToCmd(cmd *cobra.Command) func() (ConfigCustomizer, error) {
 	minVersionStr := ""
 	maxVersionStr := ""
-	cmd.Flags().StringVar(&minVersionStr, "tlsminversion", "", "The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2)")
-	cmd.Flags().StringVar(&maxVersionStr, "tlsmaxversion", "", "The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2)")
+	tlsCiphersStr := ""
+	cmd.Flags().StringVar(&minVersionStr, "tlsminversion", DefaultTLSMinVersion, "The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3)")
+	cmd.Flags().StringVar(&maxVersionStr, "tlsmaxversion", DefaultTLSMaxVersion, "The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3)")
+	cmd.Flags().StringVar(&tlsCiphersStr, "tlsciphers", DefaultTLSCipherSuite, "The list of acceptable ciphers to be used when establishing TLS connections. Use 'list' to list available ciphers.")
 
 	return func() (ConfigCustomizer, error) {
-		minVersion, err := getTLSVersionByString(minVersionStr)
-		if err != nil {
-			return nil, err
-		}
-		maxVersion, err := getTLSVersionByString(maxVersionStr)
-		if err != nil {
-			return nil, err
-		}
-		return func(config *tls.Config) {
-			config.MinVersion = minVersion
-			config.MaxVersion = maxVersion
-		}, nil
+		return getTLSConfigCustomizer(minVersionStr, maxVersionStr, tlsCiphersStr)
 	}
 }
 

--- a/util/tls/tls_test.go
+++ b/util/tls/tls_test.go
@@ -1,13 +1,15 @@
-package tls_test
+package tls
 
 import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
-	argocdtls "github.com/argoproj/argo-cd/util/tls"
+	"github.com/stretchr/testify/assert"
 )
 
 var chain = `-----BEGIN CERTIFICATE-----
@@ -109,10 +111,233 @@ func decodePem(certInput string) tls.Certificate {
 
 func TestEncodeX509KeyPairString(t *testing.T) {
 	certChain := decodePem(chain)
-	cert, _ := argocdtls.EncodeX509KeyPairString(certChain)
+	cert, _ := EncodeX509KeyPairString(certChain)
 
 	if strings.TrimSpace(chain) != strings.TrimSpace(cert) {
 		t.Errorf("Incorrect, got: %s, want: %s", cert, chain)
 	}
 
+}
+
+func TestGetTLSVersionByString(t *testing.T) {
+	t.Run("Valid versions", func(t *testing.T) {
+		for k, v := range tlsVersionByString {
+			r, err := getTLSVersionByString(k)
+			assert.NoError(t, err)
+			assert.Equal(t, v, r)
+		}
+	})
+
+	t.Run("Invalid versions", func(t *testing.T) {
+		_, err := getTLSVersionByString("1.4")
+		assert.Error(t, err)
+	})
+
+	t.Run("Empty versions", func(t *testing.T) {
+		r, err := getTLSVersionByString("")
+		assert.NoError(t, err)
+		assert.Equal(t, r, uint16(0))
+	})
+}
+
+func TestGetTLSCipherSuitesByString(t *testing.T) {
+	suites := make([]string, 0)
+	for _, s := range tls.CipherSuites() {
+		t.Run(fmt.Sprintf("Test for valid suite %s", s.Name), func(t *testing.T) {
+			ids, err := getTLSCipherSuitesByString(s.Name)
+			assert.NoError(t, err)
+			assert.Len(t, ids, 1)
+			assert.Equal(t, s.ID, ids[0])
+			suites = append(suites, s.Name)
+		})
+	}
+
+	t.Run("Test colon separated list", func(t *testing.T) {
+		ids, err := getTLSCipherSuitesByString(strings.Join(suites, ":"))
+		assert.NoError(t, err)
+		assert.Len(t, ids, len(suites))
+	})
+
+	suites = append([]string{"invalid"}, suites...)
+	t.Run("Test invalid values", func(t *testing.T) {
+		_, err := getTLSCipherSuitesByString(strings.Join(suites, ":"))
+		assert.Error(t, err)
+	})
+
+}
+
+func TestTLSVersionToString(t *testing.T) {
+	t.Run("Test known versions", func(t *testing.T) {
+		versions := make([]uint16, 0)
+		for _, v := range tlsVersionByString {
+			versions = append(versions, v)
+		}
+		s := tlsVersionsToStr(versions)
+		assert.Len(t, s, len(versions))
+	})
+	t.Run("Test unknown version", func(t *testing.T) {
+		s := tlsVersionsToStr([]uint16{999})
+		assert.Len(t, s, 1)
+		assert.Equal(t, "unknown", s[0])
+	})
+}
+
+func TestGenerate(t *testing.T) {
+	t.Run("Invalid: No hosts specified", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{}, Organization: "Acme", ValidFrom: time.Now(), ValidFor: 10 * time.Hour}
+		_, _, err := generate(opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "hosts not supplied")
+	})
+
+	t.Run("Invalid: No organization specified", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{"localhost"}, Organization: "", ValidFrom: time.Now(), ValidFor: 10 * time.Hour}
+		_, _, err := generate(opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "organization not supplied")
+	})
+
+	t.Run("Invalid: Unsupported curve specified", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{"localhost"}, Organization: "Acme", ECDSACurve: "Curve?", ValidFrom: time.Now(), ValidFor: 10 * time.Hour}
+		_, _, err := generate(opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Unrecognized elliptic curve")
+	})
+
+	for _, curve := range []string{"P224", "P256", "P384", "P521"} {
+		t.Run(fmt.Sprintf("Create certificate with curve %s", curve), func(t *testing.T) {
+			opts := CertOptions{Hosts: []string{"localhost"}, Organization: "Acme", ECDSACurve: curve}
+			_, _, err := generate(opts)
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("Create certificate with default options", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{"localhost"}, Organization: "Acme"}
+		certBytes, privKey, err := generate(opts)
+		assert.NoError(t, err)
+		assert.NotNil(t, privKey)
+		cert, err := x509.ParseCertificate(certBytes)
+		assert.NoError(t, err)
+		assert.NotNil(t, cert)
+		assert.Len(t, cert.DNSNames, 1)
+		assert.Equal(t, "localhost", cert.DNSNames[0])
+		assert.Empty(t, cert.IPAddresses)
+		assert.LessOrEqual(t, int64(time.Since(cert.NotBefore)), int64(10*time.Second))
+	})
+
+	t.Run("Create certificate with IP ", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{"localhost", "127.0.0.1"}, Organization: "Acme"}
+		certBytes, privKey, err := generate(opts)
+		assert.NoError(t, err)
+		assert.NotNil(t, privKey)
+		cert, err := x509.ParseCertificate(certBytes)
+		assert.NoError(t, err)
+		assert.NotNil(t, cert)
+		assert.Len(t, cert.DNSNames, 1)
+		assert.Equal(t, "localhost", cert.DNSNames[0])
+		assert.Equal(t, "Acme", cert.Subject.Organization[0])
+		assert.Len(t, cert.IPAddresses, 1)
+		assert.Equal(t, "127.0.0.1", cert.IPAddresses[0].String())
+	})
+
+	t.Run("Create certificate with specific validity timeframe", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{"localhost"}, Organization: "Acme", ValidFrom: time.Now().Add(1 * time.Hour)}
+		certBytes, privKey, err := generate(opts)
+		assert.NoError(t, err)
+		assert.NotNil(t, privKey)
+		cert, err := x509.ParseCertificate(certBytes)
+		assert.NoError(t, err)
+		assert.NotNil(t, cert)
+		assert.GreaterOrEqual(t, (time.Now().Unix())+int64(1*time.Hour), cert.NotBefore.Unix())
+	})
+}
+
+func TestGeneratePEM(t *testing.T) {
+	t.Run("Invalid - PEM creation failure", func(t *testing.T) {
+		opts := CertOptions{Hosts: nil, Organization: "Acme"}
+		cert, key, err := generatePEM(opts)
+		assert.Error(t, err)
+		assert.Nil(t, cert)
+		assert.Nil(t, key)
+	})
+
+	t.Run("Create PEM from certficate options", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{"localhost"}, Organization: "Acme"}
+		cert, key, err := generatePEM(opts)
+		assert.NoError(t, err)
+		assert.NotNil(t, cert)
+		assert.NotNil(t, key)
+	})
+
+	t.Run("Create X509KeyPair", func(t *testing.T) {
+		opts := CertOptions{Hosts: []string{"localhost"}, Organization: "Acme"}
+		cert, err := GenerateX509KeyPair(opts)
+		assert.NoError(t, err)
+		assert.NotNil(t, cert)
+	})
+}
+
+func TestGetTLSConfigCustomizer(t *testing.T) {
+	t.Run("Valid TLS customization", func(t *testing.T) {
+		cfunc, err := getTLSConfigCustomizer(DefaultTLSMinVersion, DefaultTLSMaxVersion, DefaultTLSCipherSuite)
+		assert.NoError(t, err)
+		assert.NotNil(t, cfunc)
+		config := tls.Config{}
+		cfunc(&config)
+		assert.Equal(t, config.MinVersion, uint16(tls.VersionTLS12))
+		assert.Equal(t, config.MaxVersion, uint16(tls.VersionTLS13))
+	})
+
+	t.Run("Valid TLS customization - No cipher customization for TLSv1.3 only with default ciphers", func(t *testing.T) {
+		cfunc, err := getTLSConfigCustomizer("1.3", "1.3", DefaultTLSCipherSuite)
+		assert.NoError(t, err)
+		assert.NotNil(t, cfunc)
+		config := tls.Config{}
+		cfunc(&config)
+		assert.Equal(t, config.MinVersion, uint16(tls.VersionTLS13))
+		assert.Equal(t, config.MaxVersion, uint16(tls.VersionTLS13))
+		assert.Len(t, config.CipherSuites, 0)
+	})
+
+	t.Run("Valid TLS customization - No cipher customization for TLSv1.3 only with custom ciphers", func(t *testing.T) {
+		cfunc, err := getTLSConfigCustomizer("1.3", "1.3", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+		assert.NoError(t, err)
+		assert.NotNil(t, cfunc)
+		config := tls.Config{}
+		cfunc(&config)
+		assert.Equal(t, config.MinVersion, uint16(tls.VersionTLS13))
+		assert.Equal(t, config.MaxVersion, uint16(tls.VersionTLS13))
+		assert.Len(t, config.CipherSuites, 0)
+	})
+
+	t.Run("Invalid TLS customization - Min version higher than max version", func(t *testing.T) {
+		cfunc, err := getTLSConfigCustomizer("1.3", "1.2", DefaultTLSCipherSuite)
+		assert.Error(t, err)
+		assert.Nil(t, cfunc)
+	})
+
+	t.Run("Invalid TLS customization - Invalid min version given", func(t *testing.T) {
+		cfunc, err := getTLSConfigCustomizer("2.0", "1.2", DefaultTLSCipherSuite)
+		assert.Error(t, err)
+		assert.Nil(t, cfunc)
+	})
+
+	t.Run("Invalid TLS customization - Invalid max version given", func(t *testing.T) {
+		cfunc, err := getTLSConfigCustomizer("1.2", "2.0", DefaultTLSCipherSuite)
+		assert.Error(t, err)
+		assert.Nil(t, cfunc)
+	})
+
+	t.Run("Invalid TLS customization - Unknown cipher suite given", func(t *testing.T) {
+		cfunc, err := getTLSConfigCustomizer("1.3", "1.2", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:invalid")
+		assert.Error(t, err)
+		assert.Nil(t, cfunc)
+	})
+
+}
+
+func TestBestEffortSystemCertPool(t *testing.T) {
+	pool := BestEffortSystemCertPool()
+	assert.NotNil(t, pool)
 }


### PR DESCRIPTION
Fixes #3510

New command line parameter `--tlsciphers` for `argocd-server`, `argocd-repo-server` and `argocd-controller` to specify the TLS cipher suites that will be allowed to use for negotiating TLS handshakes.

Parameter accepts a colon-separated list of cipher suites to allow. The default is `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_256_GCM_SHA384`, in accordance to best practices (see https://cipherlist.eu). To get a list of available cipher suites, one can use `--tlsciphers list` which will print all available ciphers to stdout and then exit.

This change also:

* enables the use of TLS v1.3 with all ArgoCD components
* sets the default minimum version for TLS to v1.2 (can still be overridden using `--tlsminversion`)

Since the code uses rather new methods of `crypto/tls` Go package, the minimum required Go version to build ArgoCD is therefore bumped to **v1.14.0** (documented in the contribution guide).

As a bonus, I've written unit tests for most methods in the `util/tls` package, bumping coverage from previously `9.3%` to now `78.8%` :)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
