### PR TITLE
fix: revert "fix: Text overflow when the application status panel item was  too big (#3460)"

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -17,7 +17,6 @@
         font-size: .8em;
         line-height: 1.2;
         color: $argo-color-gray-5;
-        overflow: hidden;
 
         &:not(:first-child) {
             border-left: 1px solid $argo-color-gray-3;


### PR DESCRIPTION
This reverts commit ffc99354d28da75b6403430d17ac7a00b21736ef.
 
UI fix require a little more changes. In addition to hidden overflow we need to increase toolbar height, overwise even single line commits don't fit. Reverting commit to unblock release.