### PR TITLE
feat: Add build support for ARM images (#2167)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,10 +109,13 @@ RUN go mod download
 
 # Perform the build
 COPY . .
-RUN make cli server controller repo-server argocd-util && \
-    make CLI_NAME=argocd-darwin-amd64 GOOS=darwin cli && \
-    make CLI_NAME=argocd-windows-amd64.exe GOOS=windows cli
+RUN make cli server controller repo-server argocd-util
 
+ARG BUILD_ALL_CLIS=true
+RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
+    make CLI_NAME=argocd-darwin-amd64 GOOS=darwin cli && \
+    make CLI_NAME=argocd-windows-amd64.exe GOOS=windows cli \
+    ; fi
 
 ####################################################################################################
 # Final image

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,12 @@ image:
 endif
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argocd:$(IMAGE_TAG) ; fi
 
+.PHONY: armimage
+# The "BUILD_ALL_CLIS" argument is to skip building the CLIs for darwin and windows
+# which would take a really long time.
+armimage:
+	docker build -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG)-arm . --build-arg BUILD_ALL_CLIS="false"
+
 .PHONY: builder-image
 builder-image:
 	docker build  -t $(IMAGE_PREFIX)argo-cd-ci-builder:$(IMAGE_TAG) --target builder .

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
-	github.com/google/go-jsonnet v0.15.0
+	github.com/google/go-jsonnet v0.16.0
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.1.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,7 @@ github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -295,6 +296,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-jsonnet v0.15.0 h1:lEUXTDnVsHu+CLLzMeWAdWV4JpCgkJeDqdVNS8RtyuY=
 github.com/google/go-jsonnet v0.15.0/go.mod h1:ex9QcU8vzXQUDeNe4gaN1uhGQbTYpOeZ6AbWdy6JbX4=
+github.com/google/go-jsonnet v0.16.0 h1:Nb4EEOp+rdeGGyB1rQ5eisgSAqrTnhf9ip+X6lzZbY0=
+github.com/google/go-jsonnet v0.16.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -412,11 +415,14 @@ github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwm
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -690,6 +696,8 @@ golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -6,6 +6,17 @@ export BIN=${BIN:-/usr/local/bin}
 
 mkdir -p $DOWNLOADS
 
+ARCHITECTURE=""
+case $(uname -m) in
+    x86_64)                     ARCHITECTURE="amd64" ;;
+    arm|armv7l|armv8l|aarch64)  dpkg --print-architecture | grep -q "arm64" && ARCHITECTURE="arm64" || ARCHITECTURE="arm" ;;
+esac
+
+if [ -z "$ARCHITECTURE" ]; then
+      echo "Could not detect the architecture of the system"
+      exit 1
+fi
+
 for product in $*; do
-  "$(dirname $0)/installers/install-${product}.sh"
+  ARCHITECTURE=$ARCHITECTURE "$(dirname $0)/installers/install-${product}.sh"
 done

--- a/hack/installers/install-dep-linux.sh
+++ b/hack/installers/install-dep-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/dep ] || curl -sLf --retry 3 -o $DOWNLOADS/dep https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64
+[ -e $DOWNLOADS/dep ] || curl -sLf --retry 3 -o $DOWNLOADS/dep https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-$ARCHITECTURE
 cp $DOWNLOADS/dep $BIN/
 chmod +x $BIN/dep
 dep version

--- a/hack/installers/install-helm-linux.sh
+++ b/hack/installers/install-helm-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/helm.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm.tar.gz https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz
+[ -e $DOWNLOADS/helm.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm.tar.gz https://get.helm.sh/helm-v3.2.0-linux-$ARCHITECTURE.tar.gz
 mkdir -p /tmp/helm && tar -C /tmp/helm -xf $DOWNLOADS/helm.tar.gz
-cp /tmp/helm/linux-amd64/helm $BIN/helm
+cp /tmp/helm/linux-$ARCHITECTURE/helm $BIN/helm
 helm version --client

--- a/hack/installers/install-helm2-linux.sh
+++ b/hack/installers/install-helm2-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/helm2.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm2.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.15.2-linux-amd64.tar.gz
+[ -e $DOWNLOADS/helm2.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm2.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.15.2-linux-$ARCHITECTURE.tar.gz
 mkdir -p /tmp/helm2 && tar -C /tmp/helm2 -xf $DOWNLOADS/helm2.tar.gz
-cp /tmp/helm2/linux-amd64/helm $BIN/helm2
+cp /tmp/helm2/linux-$ARCHITECTURE/helm $BIN/helm2
 helm2 version --client

--- a/hack/installers/install-ksonnet-linux.sh
+++ b/hack/installers/install-ksonnet-linux.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/ks.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/ks.tar.gz https://github.com/ksonnet/ksonnet/releases/download/v0.13.1/ks_0.13.1_linux_amd64.tar.gz
-tar -C /tmp -xf $DOWNLOADS/ks.tar.gz
-cp /tmp/ks_0.13.1_linux_amd64/ks $BIN/ks
+KSONNET_VERSION=0.13.1
+case $ARCHITECTURE in
+  arm|arm64)
+    set +o pipefail
+    go get -u github.com/ksonnet/ksonnet || true
+    set -o pipefail
+    cd $GOPATH/src/github.com/ksonnet/ksonnet && git checkout tags/v$KSONNET_VERSION
+    cd $GOPATH/src/github.com/ksonnet/ksonnet && make install
+    mv $GOPATH/bin/ks $BIN/ks
+    ;;
+  *)
+    [ -e $DOWNLOADS/ks.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/ks.tar.gz https://github.com/ksonnet/ksonnet/releases/download/v${KSONNET_VERSION}/ks_${KSONNET_VERSION}_linux_${ARCHITECTURE}.tar.gz
+    tar -C /tmp -xf $DOWNLOADS/ks.tar.gz
+    cp /tmp/ks_${KSONNET_VERSION}_linux_${ARCHITECTURE}/ks $BIN/ks
+    ;;
+esac
+
 chmod +x $BIN/ks
 ks version

--- a/hack/installers/install-kubectl-linux.sh
+++ b/hack/installers/install-kubectl-linux.sh
@@ -2,6 +2,6 @@
 set -eux -o pipefail
 
 # NOTE: keep the version synced with https://storage.googleapis.com/kubernetes-release/release/stable.txt
-[ -e $DOWNLOADS/kubectl ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+[ -e $DOWNLOADS/kubectl ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/$ARCHITECTURE/kubectl
 cp $DOWNLOADS/kubectl $BIN/
 chmod +x $BIN/kubectl

--- a/hack/installers/install-kustomize-linux.sh
+++ b/hack/installers/install-kustomize-linux.sh
@@ -9,25 +9,38 @@ KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-3.5.5}
 # v3.2.0 = https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_linux_amd64
 # v3.2.1 = https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.2.1/kustomize_kustomize.v3.2.1_linux_amd64
 # v3.3.0 = https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz
-case $KUSTOMIZE_VERSION in
-  2.*)
-    DL=$DOWNLOADS/kustomize-${KUSTOMIZE_VERSION}
-    URL=https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64
-    BINNAME=kustomize2
-    [ -e $DL ] || curl -sLf --retry 3 -o $DL $URL
-    mv $DL $BIN/$BINNAME
+case $ARCHITECTURE in
+  arm|arm64)
+    # Note that installing kustomize via Go is broken in version v3.5.5
+    # This is fixed in v3.6.1, more details in the github issue:
+    # https://github.com/kubernetes-sigs/kustomize/issues/2462
+    # TODO: Remove this once kustomize gets updated to v3.6.1 for linux
+    KUSTOMIZE_VERSION="3.6.1"
+    BINNAME=kustomize
+    GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3@v${KUSTOMIZE_VERSION}
+    mv $GOPATH/bin/kustomize $BIN/$BINNAME
     ;;
   *)
-    DL=$DOWNLOADS/kustomize-${KUSTOMIZE_VERSION}.tar.gz
-    URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
-    BINNAME=kustomize
+    case $KUSTOMIZE_VERSION in
+      2.*)
+        DL=$DOWNLOADS/kustomize-${KUSTOMIZE_VERSION}
+        URL=https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_$ARCHITECTURE
+        BINNAME=kustomize2
+        [ -e $DL ] || curl -sLf --retry 3 -o $DL $URL
+        mv $DL $BIN/$BINNAME
+        ;;
+      *)
+        DL=$DOWNLOADS/kustomize-${KUSTOMIZE_VERSION}.tar.gz
+        URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_$ARCHITECTURE.tar.gz
+        BINNAME=kustomize
 
-    [ -e $DL ] || curl -sLf --retry 3 -o $DL $URL
-    tar -C /tmp -xf $DL
-    mv /tmp/kustomize $BIN/$BINNAME
+        [ -e $DL ] || curl -sLf --retry 3 -o $DL $URL
+        tar -C /tmp -xf $DL
+        mv /tmp/kustomize $BIN/$BINNAME
+        ;;
+    esac
     ;;
 esac
-
 
 chmod +x $BIN/$BINNAME
 $BINNAME version

--- a/hack/installers/install-packr-linux.sh
+++ b/hack/installers/install-packr-linux.sh
@@ -2,8 +2,21 @@
 set -eux -o pipefail
 
 PACKR_VERSION=1.21.9
-[ -e $DOWNLOADS/parkr.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/parkr.tar.gz https://github.com/gobuffalo/packr/releases/download/v${PACKR_VERSION}/packr_${PACKR_VERSION}_linux_amd64.tar.gz
-tar -vxf $DOWNLOADS/parkr.tar.gz -C /tmp/
-cp /tmp/packr $BIN/
+case $ARCHITECTURE in
+  arm|arm64)
+    set +o pipefail
+    go get -u github.com/gobuffalo/packr
+    set -o pipefail
+    cd $GOPATH/src/github.com/gobuffalo/packr && git checkout tags/v$PACKR_VERSION
+    cd $GOPATH/src/github.com/gobuffalo/packr && make install
+    mv $GOPATH/bin/packr $BIN/packr
+    ;;
+  *)
+    [ -e $DOWNLOADS/parkr.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/parkr.tar.gz https://github.com/gobuffalo/packr/releases/download/v${PACKR_VERSION}/packr_${PACKR_VERSION}_linux_$ARCHITECTURE.tar.gz
+    tar -vxf $DOWNLOADS/parkr.tar.gz -C /tmp/
+    cp /tmp/packr $BIN/
+    ;;
+esac
+
 chmod +x $BIN/packr
 packr version

--- a/hack/installers/install-swagger-linux.sh
+++ b/hack/installers/install-swagger-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/swagger ] || curl -sLf --retry 3 -o $DOWNLOADS/swagger https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64
+[ -e $DOWNLOADS/swagger ] || curl -sLf --retry 3 -o $DOWNLOADS/swagger https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_$ARCHITECTURE
 cp $DOWNLOADS/swagger $BIN/swagger
 chmod +x $BIN/swagger
 swagger version


### PR DESCRIPTION
Since ArgoCD is written in Go, the code can be compiled on other architectures as well.

Unfortunately, I haven't found an option for CircleCI to run the build on the ARM architecture, so there are no automated builds for the ARM images.

For the convenience, I have created a Drone pipeline which supports both arm and arm64 to show the build status for the ARM images for this PR: https://cloud.drone.io/alinbalutoiu/argo-cd/13

Images are being pushed automatically to https://hub.docker.com/r/alinbalutoiu/argocd/tags

To build the ARM images, you need to run `make armimage` from an arm device (such as a raspberry pi for example).

It is currently running on my home Raspberry Pi 4 without any issues.

Closes #2167
Closes #3120 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 