### PR TITLE
feat: add button loading status for time-consuming operations

### DIFF
--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
@@ -2,6 +2,7 @@ import {ErrorNotification, FormField, NotificationType, SlidingPanel} from 'argo
 import * as React from 'react';
 import {Checkbox, Form, FormApi, Text} from 'react-form';
 
+import {Spinner} from '../../../shared/components';
 import {Consumer} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
@@ -15,6 +16,7 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
         .filter(item => !item.hook);
     const syncResIndex = appResources.findIndex(item => nodeKey(item) === selectedResource);
     const syncStrategy = {} as models.SyncStrategy;
+    const [isPending, setPending] = React.useState(false);
 
     return (
         <Consumer>
@@ -25,7 +27,8 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
                     onClose={() => hide()}
                     header={
                         <div>
-                            <button className='argo-button argo-button--base' onClick={() => form.submitForm(null)}>
+                            <button className='argo-button argo-button--base' disabled={isPending} onClick={() => form.submitForm(null)}>
+                                <Spinner show={isPending} style={{marginRight: '5px'}} />
                                 Synchronize
                             </button>{' '}
                             <button onClick={() => hide()} className='argo-button argo-button--base-o'>
@@ -43,6 +46,7 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
                                 resources: values.resources.every((item: boolean) => !item) && 'Select at least one resource'
                             })}
                             onSubmit={async (params: any) => {
+                                setPending(true);
                                 let resources = appResources.filter((_, i) => params.resources[i]);
                                 if (resources.length === appResources.length) {
                                     resources = null;
@@ -60,6 +64,8 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
                                         content: <ErrorNotification title='Unable to deploy revision' e={e} />,
                                         type: NotificationType.Error
                                     });
+                                } finally {
+                                    setPending(false);
                                 }
                             }}
                             getApi={setForm}>

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import {RouteComponentProps} from 'react-router';
 import {Observable} from 'rxjs';
 
-import {ClusterCtx, DataLoader, EmptyState, ObservableQuery, Page, Paginate, Query} from '../../../shared/components';
+import {ClusterCtx, DataLoader, EmptyState, ObservableQuery, Page, Paginate, Query, Spinner} from '../../../shared/components';
 import {Consumer} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import {AppsListPreferences, AppsListViewType, services} from '../../../shared/services';
@@ -157,6 +157,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
     const syncAppsInput = tryJsonParse(query.get('syncApps'));
     const [createApi, setCreateApi] = React.useState(null);
     const clusters = React.useMemo(() => services.clusters.list(), []);
+    const [isAppCreatePending, setAppCreatePending] = React.useState(false);
 
     return (
         <ClusterCtx.Provider value={clusters}>
@@ -350,7 +351,8 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                             onClose={() => ctx.navigation.goto('.', {new: null})}
                             header={
                                 <div>
-                                    <button className='argo-button argo-button--base' onClick={() => createApi && createApi.submitForm(null)}>
+                                    <button className='argo-button argo-button--base' disabled={isAppCreatePending} onClick={() => createApi && createApi.submitForm(null)}>
+                                        <Spinner show={isAppCreatePending} style={{marginRight: '5px'}} />
                                         Create
                                     </button>{' '}
                                     <button onClick={() => ctx.navigation.goto('.', {new: null})} className='argo-button argo-button--base-o'>
@@ -364,6 +366,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                         setCreateApi(api);
                                     }}
                                     createApp={async app => {
+                                        setAppCreatePending(true);
                                         try {
                                             await services.applications.create(app);
                                             ctx.navigation.goto('.', {new: null});
@@ -372,6 +375,8 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                 content: <ErrorNotification title='Unable to create application' e={e} />,
                                                 type: NotificationType.Error
                                             });
+                                        } finally {
+                                            setAppCreatePending(false);
                                         }
                                     }}
                                     app={appInput}

--- a/ui/src/app/shared/components/index.ts
+++ b/ui/src/app/shared/components/index.ts
@@ -21,3 +21,4 @@ export * from './progress/progress-popup';
 export * from './repo';
 export * from './revision';
 export * from './timestamp';
+export * from './spinner';

--- a/ui/src/app/shared/components/spinner.tsx
+++ b/ui/src/app/shared/components/spinner.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import {COLORS} from './colors';
+
+export const Spinner = ({show, style = {}}: {show: boolean; style?: React.CSSProperties}) =>
+    show ? (
+        <span style={style}>
+            <i className='fa fa-circle-notch fa-spin' style={{color: COLORS.operation.running}} />
+        </span>
+    ) : null;


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

### Why:
For some time-consuming operations in ui, for example, creating an application, there is no loading status for the operation button. When user click the button, it looks like UI is not responding.

### What does this PR do:
- add a Spinner component
- add button loading status for the following operations:
  1. create applications
  2. sync application

### UI change:
before:

![before](https://user-images.githubusercontent.com/11833341/81371028-4ffeb280-9129-11ea-9d72-aff72535367e.gif)

after:

![app-loading](https://user-images.githubusercontent.com/11833341/81371044-5a20b100-9129-11ea-8d86-c8c02c815ff5.gif)

