### PR TITLE
fix: Fix login with port forwarding

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -42,35 +42,44 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 		Short: "Log in to Argo CD",
 		Long:  "Log in to Argo CD",
 		Run: func(c *cobra.Command, args []string) {
-			if len(args) == 0 {
+			var server string
+
+			if len(args) != 1 && !globalClientOpts.PortForward {
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
-			server := args[0]
-			tlsTestResult, err := grpc_util.TestTLS(server)
-			errors.CheckError(err)
-			if !tlsTestResult.TLS {
-				if !globalClientOpts.PlainText {
-					if !cli.AskToProceed("WARNING: server is not configured with TLS. Proceed (y/n)? ") {
-						os.Exit(1)
+
+			if globalClientOpts.PortForward {
+				server = "port-forward"
+			} else {
+				server = args[0]
+				tlsTestResult, err := grpc_util.TestTLS(server)
+				errors.CheckError(err)
+				if !tlsTestResult.TLS {
+					if !globalClientOpts.PlainText {
+						if !cli.AskToProceed("WARNING: server is not configured with TLS. Proceed (y/n)? ") {
+							os.Exit(1)
+						}
+						globalClientOpts.PlainText = true
 					}
-					globalClientOpts.PlainText = true
-				}
-			} else if tlsTestResult.InsecureErr != nil {
-				if !globalClientOpts.Insecure {
-					if !cli.AskToProceed(fmt.Sprintf("WARNING: server certificate had error: %s. Proceed insecurely (y/n)? ", tlsTestResult.InsecureErr)) {
-						os.Exit(1)
+				} else if tlsTestResult.InsecureErr != nil {
+					if !globalClientOpts.Insecure {
+						if !cli.AskToProceed(fmt.Sprintf("WARNING: server certificate had error: %s. Proceed insecurely (y/n)? ", tlsTestResult.InsecureErr)) {
+							os.Exit(1)
+						}
+						globalClientOpts.Insecure = true
 					}
-					globalClientOpts.Insecure = true
 				}
 			}
 			clientOpts := argocdclient.ClientOptions{
-				ConfigPath:      "",
-				ServerAddr:      server,
-				Insecure:        globalClientOpts.Insecure,
-				PlainText:       globalClientOpts.PlainText,
-				GRPCWeb:         globalClientOpts.GRPCWeb,
-				GRPCWebRootPath: globalClientOpts.GRPCWebRootPath,
+				ConfigPath:           "",
+				ServerAddr:           server,
+				Insecure:             globalClientOpts.Insecure,
+				PlainText:            globalClientOpts.PlainText,
+				GRPCWeb:              globalClientOpts.GRPCWeb,
+				GRPCWebRootPath:      globalClientOpts.GRPCWebRootPath,
+				PortForward:          globalClientOpts.PortForward,
+				PortForwardNamespace: globalClientOpts.PortForwardNamespace,
 			}
 			acdClient := argocdclient.NewClientOrDie(&clientOpts)
 			setConn, setIf := acdClient.NewSettingsClientOrDie()
@@ -105,7 +114,7 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 				SkipClaimsValidation: true,
 			}
 			claims := jwt.MapClaims{}
-			_, _, err = parser.ParseUnverified(tokenString, &claims)
+			_, _, err := parser.ParseUnverified(tokenString, &claims)
 			errors.CheckError(err)
 
 			fmt.Printf("'%s' logged in successfully\n", userDisplayName(claims))


### PR DESCRIPTION
The argocd command line supports using the --port-forward options
to allow you to connect to an argocd without an ingress rule.  This
is especially useful for command line automation of new environments.

But login doesn't respect port-forward - making it impossible to login
to argocd to be able to later create apps.  App creation works fine
with port-forwarding after being able to login.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
