### PR TITLE
fix: enable redis retries; add redis request duration metric

### DIFF
--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-redis/redis"
 	"github.com/spf13/cobra"
 
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -23,12 +24,12 @@ func NewCache(cache *cacheutil.Cache, repoCacheExpiration time.Duration) *Cache 
 	return &Cache{cache, repoCacheExpiration}
 }
 
-func AddCacheFlagsToCmd(cmd *cobra.Command) func() (*Cache, error) {
+func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) func() (*Cache, error) {
 	var repoCacheExpiration time.Duration
 
 	cmd.Flags().DurationVar(&repoCacheExpiration, "repo-cache-expiration", 24*time.Hour, "Cache expiration for repo state, incl. app lists, app details, manifest generation, revision meta-data")
 
-	repoFactory := cacheutil.AddCacheFlagsToCmd(cmd)
+	repoFactory := cacheutil.AddCacheFlagsToCmd(cmd, opts...)
 
 	return func() (*Cache, error) {
 		cache, err := repoFactory()

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"io"
+	"fmt"
 	"time"
 
 	rediscache "github.com/go-redis/cache"
@@ -29,39 +29,46 @@ type redisCache struct {
 	codec      *rediscache.Codec
 }
 
-// if redis server goes down the first client request fails with EOF error
-func doWithRetry(action func() error) error {
-	err := action()
-	if err == io.EOF {
-		return action()
-	}
-	return err
-}
-
 func (r *redisCache) Set(item *Item) error {
 	expiration := item.Expiration
 	if expiration == 0 {
 		expiration = r.expiration
 	}
-	return doWithRetry(func() error {
-		return r.codec.Set(&rediscache.Item{
-			Key:        item.Key,
-			Object:     item.Object,
-			Expiration: expiration,
-		})
+	return r.codec.Set(&rediscache.Item{
+		Key:        item.Key,
+		Object:     item.Object,
+		Expiration: expiration,
 	})
 }
 
 func (r *redisCache) Get(key string, obj interface{}) error {
-	return doWithRetry(func() error {
-		err := r.codec.Get(key, obj)
-		if err == rediscache.ErrCacheMiss {
-			return ErrCacheMiss
-		}
-		return err
-	})
+	err := r.codec.Get(key, obj)
+	if err == rediscache.ErrCacheMiss {
+		return ErrCacheMiss
+	}
+	return err
 }
 
 func (r *redisCache) Delete(key string) error {
 	return r.codec.Delete(key)
+}
+
+type MetricsRegistry interface {
+	IncRedisRequest(failed bool)
+	ObserveRedisRequestDuration(duration time.Duration)
+}
+
+// CollectMetrics add transport wrapper that pushes metrics into the specified metrics registry
+func CollectMetrics(client *redis.Client, registry MetricsRegistry) {
+	client.WrapProcess(func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
+		return func(cmd redis.Cmder) error {
+			startTime := time.Now()
+			err := oldProcess(cmd)
+			registry.IncRedisRequest(err != nil && err != rediscache.ErrCacheMiss)
+			duration := time.Since(startTime)
+			println(fmt.Sprintf("%v", duration.Seconds()))
+			registry.ObserveRedisRequestDuration(duration)
+			return err
+		}
+	})
 }


### PR DESCRIPTION
Partially fixes #3547 

PR enables redis client retries and additionally redis request duration metric