### PR TITLE
feat: Implement Crossplane CRD health checks

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -54,6 +54,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Universidad Mesoamericana](https://www.umes.edu.gt/)
 1. [Viaduct](https://www.viaduct.ai/)
 1. [Volvo Cars](https://www.volvocars.com/)
+1. [VSHN - The DevOps Company](https://vshn.ch/)
 1. [Walkbase](https://www.walkbase.com/)
 1. [Whitehat Berlin](https://whitehat.berlin) by Guido Maria Serra +Fenaroli
 1. [Yieldlab](https://www.yieldlab.de/)

--- a/resource_customizations/stacks.crossplane.io/ClusterStackInstall/health.lua
+++ b/resource_customizations/stacks.crossplane.io/ClusterStackInstall/health.lua
@@ -1,0 +1,20 @@
+hs = {
+  status = "Progressing",
+  message = "Waiting for stack to be installed"
+}
+if obj.status ~= nil then
+  if obj.status.conditionedStatus ~= nil then
+    if obj.status.conditionedStatus.conditions ~= nil then
+      for i, condition in ipairs(obj.status.conditionedStatus.conditions) do
+        if condition.type == "Ready" then
+          hs.message = condition.reason
+          if condition.status == "True" then
+            hs.status = "Healthy"
+            return hs
+          end
+        end
+      end
+    end
+  end
+end
+return hs

--- a/resource_customizations/stacks.crossplane.io/ClusterStackInstall/health_test.yaml
+++ b/resource_customizations/stacks.crossplane.io/ClusterStackInstall/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: Waiting for stack to be installed
+  inputPath: testdata/wait_stack.yaml
+- healthStatus:
+    status: Progressing
+    message: 'Resource is being created'
+  inputPath: testdata/being_created_stack.yaml
+- healthStatus:
+    status: Healthy
+    message: 'Resource is available for use'
+  inputPath: testdata/installed_stack.yaml

--- a/resource_customizations/stacks.crossplane.io/ClusterStackInstall/testdata/being_created_stack.yaml
+++ b/resource_customizations/stacks.crossplane.io/ClusterStackInstall/testdata/being_created_stack.yaml
@@ -1,0 +1,34 @@
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: ClusterStackInstall
+metadata:
+  creationTimestamp: "2020-05-13T09:35:26Z"
+  finalizers:
+  - finalizer.stackinstall.crossplane.io
+  generation: 1
+  labels:
+    argocd.argoproj.io/instance: crossplane-cloudscale
+    name: stack-cloudscale
+  name: stack-cloudscale
+  namespace: syn-crossplane
+  resourceVersion: "20004"
+  selfLink: /apis/stacks.crossplane.io/v1alpha1/namespaces/syn-crossplane/clusterstackinstalls/stack-cloudscale
+  uid: cce4dfb5-185f-421d-be97-338408e0c712
+spec:
+  package: docker.io/vshn/stack-cloudscale:v0.0.2@sha256:8a9a94c3ef557da951d5c7f5bb0286a2f36c79f7ece499f61a8807383caed59b
+status:
+  conditionedStatus:
+    conditions:
+    - lastTransitionTime: "2020-05-13T09:35:26Z"
+      reason: Resource is being created
+      status: "False"
+      type: Ready
+    - lastTransitionTime: "2020-05-13T09:35:26Z"
+      reason: Successfully reconciled resource
+      status: "True"
+      type: Synced
+  installJob:
+    apiVersion: batch/v1
+    kind: Job
+    name: stack-cloudscale
+    namespace: syn-crossplane
+    uid: e9c2d5d5-41b1-4b11-8193-e5029c37cc52

--- a/resource_customizations/stacks.crossplane.io/ClusterStackInstall/testdata/installed_stack.yaml
+++ b/resource_customizations/stacks.crossplane.io/ClusterStackInstall/testdata/installed_stack.yaml
@@ -1,0 +1,40 @@
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: ClusterStackInstall
+metadata:
+  creationTimestamp: "2020-05-13T09:35:26Z"
+  finalizers:
+  - finalizer.stackinstall.crossplane.io
+  generation: 1
+  labels:
+    argocd.argoproj.io/instance: crossplane-cloudscale
+    name: stack-cloudscale
+  name: stack-cloudscale
+  namespace: syn-crossplane
+  resourceVersion: "20136"
+  selfLink: /apis/stacks.crossplane.io/v1alpha1/namespaces/syn-crossplane/clusterstackinstalls/stack-cloudscale
+  uid: cce4dfb5-185f-421d-be97-338408e0c712
+spec:
+  package: docker.io/vshn/stack-cloudscale:v0.0.2@sha256:8a9a94c3ef557da951d5c7f5bb0286a2f36c79f7ece499f61a8807383caed59b
+status:
+  conditionedStatus:
+    conditions:
+    - lastTransitionTime: "2020-05-13T09:35:48Z"
+      reason: Resource is available for use
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2020-05-13T09:35:26Z"
+      reason: Successfully reconciled resource
+      status: "True"
+      type: Synced
+  installJob:
+    apiVersion: batch/v1
+    kind: Job
+    name: stack-cloudscale
+    namespace: syn-crossplane
+    uid: e9c2d5d5-41b1-4b11-8193-e5029c37cc52
+  stackRecord:
+    apiVersion: stacks.crossplane.io/v1alpha1
+    kind: Stack
+    name: stack-cloudscale
+    namespace: syn-crossplane
+    uid: abccf273-2ec1-45a1-9738-af7b6aa39b76

--- a/resource_customizations/stacks.crossplane.io/ClusterStackInstall/testdata/wait_stack.yaml
+++ b/resource_customizations/stacks.crossplane.io/ClusterStackInstall/testdata/wait_stack.yaml
@@ -1,0 +1,17 @@
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: ClusterStackInstall
+metadata:
+  creationTimestamp: "2020-05-13T09:35:26Z"
+  finalizers:
+  - finalizer.stackinstall.crossplane.io
+  generation: 1
+  labels:
+    argocd.argoproj.io/instance: crossplane-cloudscale
+    name: stack-cloudscale
+  name: stack-cloudscale
+  namespace: syn-crossplane
+  resourceVersion: "19999"
+  selfLink: /apis/stacks.crossplane.io/v1alpha1/namespaces/syn-crossplane/clusterstackinstalls/stack-cloudscale
+  uid: cce4dfb5-185f-421d-be97-338408e0c712
+spec:
+  package: docker.io/vshn/stack-cloudscale:v0.0.2@sha256:8a9a94c3ef557da951d5c7f5bb0286a2f36c79f7ece499f61a8807383caed59b


### PR DESCRIPTION
A health check for the ClusterStackInstall CRD to help Argo CD to wait
for a successful install.

This enables having a ClusterStackInstall and the corresponding CRs introduced with this stack in the same Argo app. By using a earlier sync wave for the ClusterStackInstall, the CRDs will be ready for the later waves.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
