### PR TITLE
docs: fix typo in docs/operator-manual/user-management/index.md

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -5,7 +5,7 @@ for initial configuration and then switch to local users or configure SSO integr
 
 ## Local users/accounts (v1.5)
 
-The local users/accounts feature serving to main use-cases:
+The local users/accounts feature serves two main use-cases:
 
 * Auth tokens for Argo CD management automation. It is possible to configure an API account with limited permissions and generate an authentication token.
 Such token can be used to automatically create applications, projects etc.


### PR DESCRIPTION
Just a quick typo fix in the user-management main page (sorry for this stupidly small pull request :wink: )

Checklist:

* [x] (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've signed the CLA
