### PR TITLE
fix: oidc should set samesite cookie

### DIFF
--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -253,7 +253,7 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("invalid session token: %v", err), http.StatusInternalServerError)
 		return
 	}
-	flags := []string{"path=/"}
+	flags := []string{"path=/", "SameSite=lax", "httpOnly"}
 	if a.secureCookie {
 		flags = append(flags, "Secure")
 	}

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	gooidc "github.com/coreos/go-oidc"
@@ -253,7 +254,12 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("invalid session token: %v", err), http.StatusInternalServerError)
 		return
 	}
-	flags := []string{"path=/", "SameSite=lax", "httpOnly"}
+	path := "/"
+	if a.baseHRef != "" {
+	    path = strings.TrimRight(strings.TrimLeft(a.baseHRef, "/"), "/")
+	}
+	cookiePath := fmt.Sprintf("path=/%s", path)
+	flags := []string{cookiePath, "SameSite=lax", "httpOnly"}
 	if a.secureCookie {
 		flags = append(flags, "Secure")
 	}


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/blob/76bacfdea4d9bbce774887f18a62e3ebc27d486c/util/oidc/oidc.go#L252-L261

oidc callback handler should set samesite cookie as same as the server.go does for security issue.

https://github.com/argoproj/argo-cd/blob/fe8d47e0eae9fe5bd9dbcf52ca898fe4b4ba9ce1/server/server.go#L535-L542

---

Checklist:

* [x] (b) this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
