### PR TITLE
feat: CLI: Allow setting Helm values literal (#3601)

### DIFF
--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
+	"net/http"
 	"os"
 	"testing"
 
@@ -118,6 +120,70 @@ func TestHelmValues(t *testing.T) {
 		Then().
 		And(func(app *Application) {
 			assert.Equal(t, []string{"foo.yml"}, app.Spec.Source.Helm.ValueFiles)
+		})
+}
+
+func TestHelmValuesLiteralFileLocal(t *testing.T) {
+	Given(t).
+		Path("helm").
+		When().
+		Create().
+		AppSet("--values-literal-file", "testdata/helm/baz.yaml").
+		Then().
+		And(func(app *Application) {
+			data, err := ioutil.ReadFile("testdata/helm/baz.yaml")
+			if err != nil {
+				panic(err)
+			}
+			assert.Equal(t, string(data), app.Spec.Source.Helm.Values)
+		}).
+		When().
+		AppUnSet("--values-literal").
+		Then().
+		And(func(app *Application) {
+			assert.Nil(t, app.Spec.Source.Helm)
+		})
+}
+
+func TestHelmValuesLiteralFileRemote(t *testing.T) {
+	sentinel := "a: b"
+	serve := func(c chan<- string) {
+		// listen on first available dynamic (unprivileged) port
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			panic(err)
+		}
+
+		// send back the address so that it can be used
+		c <- listener.Addr().String()
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			// return the sentinel text at root URL
+			fmt.Fprint(w, sentinel)
+		})
+
+		panic(http.Serve(listener, nil))
+	}
+	c := make(chan string, 1)
+
+	// run a local webserver to test data retrieval
+	go serve(c)
+	address := <-c
+	t.Logf("Listening at address: %s", address)
+
+	Given(t).
+		Path("helm").
+		When().
+		Create().
+		AppSet("--values-literal-file", "http://"+address).
+		Then().
+		And(func(app *Application) {
+			assert.Equal(t, "a: b", app.Spec.Source.Helm.Values)
+		}).
+		When().
+		AppUnSet("--values-literal").
+		Then().
+		And(func(app *Application) {
+			assert.Nil(t, app.Spec.Source.Helm)
 		})
 }
 


### PR DESCRIPTION
While you could already set values files using the `--values` flag using the CLI with `argocd app create` and `argocd app set`, and you already could set individual parameters from an external source using `--helm-set`, it was not yet possible to manage the literal `.spec.source.helm.values` value in an Application without resorting to a complicated `argocd app patch` escaped parameter or by generating the entire application YAML manifest by yourself.

Therefore, this PR adds a `--values-literal-file` flag to the `argocd app create` and `argocd app set` commands, which accepts a local file name or URL to a values file, which will be read and included as a multiline string in the application manifest. This is different from the `--helm-set-file` flag which expects the file in the chart itself.

The `argocd app unset` command is expanded with a `--values-literal` flag, so we can also unset this field again.

I hope I chose nice enough names for the flags, I wanted to make clear it expects a file name, but also distinguish it enough from the existing `--values` flag which actually points to values files.

Because the current `setHelmOpt()` functionality would not work for unsetting things to an empty value and it was difficult to do these changes independently, this PR also contains the fix for issue #3644. A separate PR has still been created for that one because I think it should end up as a separate issue in the release notes.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
