### PR TITLE
fix: sort output of 'argocd-util resource-overrides action list' command

### DIFF
--- a/cmd/argocd-util/commands/settings.go
+++ b/cmd/argocd-util/commands/settings.go
@@ -487,6 +487,9 @@ argocd-util settings resource-overrides action list /tmp/deploy.yaml --argocd-cm
 
 				availableActions, err := luaVM.ExecuteResourceActionDiscovery(&res, discoveryScript)
 				errors.CheckError(err)
+				sort.Slice(availableActions, func(i, j int) bool {
+					return availableActions[i].Name < availableActions[j].Name
+				})
 
 				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 				_, _ = fmt.Fprintf(w, "NAME\tENABLED\n")


### PR DESCRIPTION
PR makes sure that `argocd-util resource-overrides action list` command prints actions sorted alphabetically. This fixes flaky test `TestResourceOverrideAction/ActionConfigured` 
