### PR TITLE
fix: prevent possible null pointer dereference error in TestAddHelmRepoInsecureSkipVerify test

### DIFF
--- a/test/e2e/repo_management_test.go
+++ b/test/e2e/repo_management_test.go
@@ -121,15 +121,24 @@ func TestAddHelmRepoInsecureSkipVerify(t *testing.T) {
 			"--insecure-skip-server-verification",
 			"--tls-client-cert-path", repos.CertPath,
 			"--tls-client-cert-key-path", repos.CertKeyPath)
-		assert.NoError(t, err)
+
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		conn, repoClient, err := fixture.ArgoCDClientset.NewRepoClient()
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
+
 		defer argoio.Close(conn)
 
 		repo, err := repoClient.List(context.Background(), &repositorypkg.RepoQuery{})
 
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
+
 		exists := false
 		for i := range repo.Items {
 			if repo.Items[i].Repo == fixture.RepoURL(fixture.RepoURLTypeHelm) {


### PR DESCRIPTION
The TestAddHelmRepoInsecureSkipVerify test is flaky. We cannot see the real error due to NPE error. PR prevents NPE error so we can the real error that makes test flaky.