### PR TITLE
fix: Read cert data from kubeconfig during cluster addition and use if present (#3655)

### DIFF
--- a/cmd/argocd/commands/cluster_test.go
+++ b/cmd/argocd/commands/cluster_test.go
@@ -1,9 +1,12 @@
 package commands
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 )
@@ -29,3 +32,54 @@ func Test_printClusterTable(t *testing.T) {
 		},
 	})
 }
+
+func Test_newCluster(t *testing.T) {
+	clusterWithData := newCluster("test-cluster", []string{"test-namespace"},&rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: false,
+			ServerName: "test-endpoint.example.com",
+			CAData: []byte("test-ca-data"),
+			CertData: []byte("test-cert-data"),
+			KeyData: []byte("test-key-data"),
+		},
+		Host: "test-endpoint.example.com",
+	},
+	"test-bearer-token",
+	&v1alpha1.AWSAuthConfig{})
+
+	assert.Equal(t, "test-cert-data", string(clusterWithData.Config.CertData))
+	assert.Equal(t, "test-key-data", string(clusterWithData.Config.KeyData))
+	assert.Equal(t, "", clusterWithData.Config.BearerToken)
+
+	clusterWithFiles := newCluster("test-cluster", []string{"test-namespace"},&rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: false,
+			ServerName: "test-endpoint.example.com",
+			CAData: []byte("test-ca-data"),
+			CertFile: "./testdata/test.cert.pem",
+			KeyFile: "./testdata/test.key.pem",
+		},
+		Host: "test-endpoint.example.com",
+	},
+		"test-bearer-token",
+		&v1alpha1.AWSAuthConfig{})
+
+	assert.True(t, strings.Contains(string(clusterWithFiles.Config.CertData), "test-cert-data"))
+	assert.True(t, strings.Contains(string(clusterWithFiles.Config.KeyData), "test-key-data"))
+	assert.Equal(t, "", clusterWithFiles.Config.BearerToken)
+
+	clusterWithBearerToken := newCluster("test-cluster", []string{"test-namespace"},&rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: false,
+			ServerName: "test-endpoint.example.com",
+			CAData: []byte("test-ca-data"),
+		},
+		Host: "test-endpoint.example.com",
+	},
+		"test-bearer-token",
+		&v1alpha1.AWSAuthConfig{})
+
+	assert.Equal(t, "test-bearer-token", clusterWithBearerToken.Config.BearerToken)
+}
+
+

--- a/cmd/argocd/commands/cluster_test.go
+++ b/cmd/argocd/commands/cluster_test.go
@@ -34,30 +34,30 @@ func Test_printClusterTable(t *testing.T) {
 }
 
 func Test_newCluster(t *testing.T) {
-	clusterWithData := newCluster("test-cluster", []string{"test-namespace"},&rest.Config{
+	clusterWithData := newCluster("test-cluster", []string{"test-namespace"}, &rest.Config{
 		TLSClientConfig: rest.TLSClientConfig{
-			Insecure: false,
+			Insecure:   false,
 			ServerName: "test-endpoint.example.com",
-			CAData: []byte("test-ca-data"),
-			CertData: []byte("test-cert-data"),
-			KeyData: []byte("test-key-data"),
+			CAData:     []byte("test-ca-data"),
+			CertData:   []byte("test-cert-data"),
+			KeyData:    []byte("test-key-data"),
 		},
 		Host: "test-endpoint.example.com",
 	},
-	"test-bearer-token",
-	&v1alpha1.AWSAuthConfig{})
+		"test-bearer-token",
+		&v1alpha1.AWSAuthConfig{})
 
 	assert.Equal(t, "test-cert-data", string(clusterWithData.Config.CertData))
 	assert.Equal(t, "test-key-data", string(clusterWithData.Config.KeyData))
 	assert.Equal(t, "", clusterWithData.Config.BearerToken)
 
-	clusterWithFiles := newCluster("test-cluster", []string{"test-namespace"},&rest.Config{
+	clusterWithFiles := newCluster("test-cluster", []string{"test-namespace"}, &rest.Config{
 		TLSClientConfig: rest.TLSClientConfig{
-			Insecure: false,
+			Insecure:   false,
 			ServerName: "test-endpoint.example.com",
-			CAData: []byte("test-ca-data"),
-			CertFile: "./testdata/test.cert.pem",
-			KeyFile: "./testdata/test.key.pem",
+			CAData:     []byte("test-ca-data"),
+			CertFile:   "./testdata/test.cert.pem",
+			KeyFile:    "./testdata/test.key.pem",
 		},
 		Host: "test-endpoint.example.com",
 	},
@@ -68,11 +68,11 @@ func Test_newCluster(t *testing.T) {
 	assert.True(t, strings.Contains(string(clusterWithFiles.Config.KeyData), "test-key-data"))
 	assert.Equal(t, "", clusterWithFiles.Config.BearerToken)
 
-	clusterWithBearerToken := newCluster("test-cluster", []string{"test-namespace"},&rest.Config{
+	clusterWithBearerToken := newCluster("test-cluster", []string{"test-namespace"}, &rest.Config{
 		TLSClientConfig: rest.TLSClientConfig{
-			Insecure: false,
+			Insecure:   false,
 			ServerName: "test-endpoint.example.com",
-			CAData: []byte("test-ca-data"),
+			CAData:     []byte("test-ca-data"),
 		},
 		Host: "test-endpoint.example.com",
 	},
@@ -81,5 +81,3 @@ func Test_newCluster(t *testing.T) {
 
 	assert.Equal(t, "test-bearer-token", clusterWithBearerToken.Config.BearerToken)
 }
-
-

--- a/cmd/argocd/commands/testdata/test.cert.pem
+++ b/cmd/argocd/commands/testdata/test.cert.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+test-cert-data
+-----END CERTIFICATE-----

--- a/cmd/argocd/commands/testdata/test.key.pem
+++ b/cmd/argocd/commands/testdata/test.key.pem
@@ -1,0 +1,3 @@
+-----BEGIN RSA PRIVATE KEY-----
+test-key-data
+-----END RSA PRIVATE KEY-----


### PR DESCRIPTION
Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

 Closes https://github.com/argoproj/argo-cd/issues/3655