### PR TITLE
fix: settings manager should invalidate cache after updating repositories/repository credentials

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -342,8 +342,13 @@ func (mgr *SettingsManager) updateConfigMap(callback func(*apiv1.ConfigMap) erro
 		_, err = mgr.clientset.CoreV1().ConfigMaps(mgr.namespace).Update(argoCDCM)
 	}
 
+	if err != nil {
+		return err
+	}
+
 	mgr.invalidateCache()
-	return err
+
+	return mgr.ResyncInformers()
 }
 
 func (mgr *SettingsManager) getConfigMap() (*apiv1.ConfigMap, error) {


### PR DESCRIPTION
The TestAddHelmRepoInsecureSkipVerify is flaky (https://github.com/argoproj/argo-cd/issues/3635) because of a real bug. The config maps/secrets cached in informers must be invalidated after updating repositories/repository credentials 