### PR TITLE
feat: Allow --local with automatic sync for --dry-run

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1483,8 +1483,8 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				if local != "" {
 					app, err := appIf.Get(context.Background(), &applicationpkg.ApplicationQuery{Name: &appName})
 					errors.CheckError(err)
-					if app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.Automated != nil {
-						log.Fatal("Cannot use local sync when Automatic Sync Policy is enabled")
+					if app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.Automated != nil && !dryRun {
+						log.Fatal("Cannot use local sync when Automatic Sync Policy is enabled except with --dry-run")
 					}
 
 					errors.CheckError(err)

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1055,8 +1055,8 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 		if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacpolicy.ActionOverride, appRBACName(*a)); err != nil {
 			return nil, err
 		}
-		if a.Spec.SyncPolicy != nil && a.Spec.SyncPolicy.Automated != nil {
-			return nil, status.Error(codes.FailedPrecondition, "Cannot use local sync when Automatic Sync Policy is enabled")
+		if a.Spec.SyncPolicy != nil && a.Spec.SyncPolicy.Automated != nil && !syncReq.DryRun {
+			return nil, status.Error(codes.FailedPrecondition, "Cannot use local sync when Automatic Sync Policy is enabled unless for dry run")
 		}
 	}
 	if a.DeletionTimestamp != nil {

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -684,6 +685,26 @@ func TestNoLocalSyncWithAutosyncEnabled(t *testing.T) {
 
 			_, err = RunCli("app", "sync", app.Name, "--local", guestbookPathLocal)
 			assert.Error(t, err)
+		})
+}
+
+func TestLocalSyncDryRunWithAutosyncEnabled(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		Create().
+		Sync().
+		Then().
+		And(func(app *Application) {
+			_, err := RunCli("app", "set", app.Name, "--sync-policy", "automated")
+			assert.NoError(t, err)
+
+			appBefore := app.DeepCopy()
+			_, err = RunCli("app", "sync", app.Name, "--dry-run", "--local", guestbookPathLocal)
+			assert.NoError(t, err)
+
+			appAfter := app.DeepCopy()
+			assert.True(t, reflect.DeepEqual(appBefore, appAfter))
 		})
 }
 


### PR DESCRIPTION
Signed-off-by: darshanime <deathbullet@gmail.com>

Allow `argocd app sync <app name> --dry-run --local .` when automatic sync policy is enabled.
Closes https://github.com/argoproj/argo-cd/issues/3614