### PR TITLE
chore: Migrate CI toolchain to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,22 +302,22 @@ orbs:
 workflows:
   version: 2
   workflow:
-    jobs:
-      - build
-      - test:
-          requires:
-            - build
-      - codegen:
-          requires:
-            - build
-      - ui:
-          requires:
-            - build
-      - sonarcloud:
-          context: SonarCloud
-          requires:
-            - test
-            - ui
-      - e2e:
-          requires:
-            - build
+    jobs: []
+      # - build
+      # - test:
+      #     requires:
+      #       - build
+      # - codegen:
+      #     requires:
+      #       - build
+      # - ui:
+      #     requires:
+      #       - build
+      # - sonarcloud:
+      #     context: SonarCloud
+      #     requires:
+      #       - test
+      #       - ui
+      # - e2e:
+      #     requires:
+      #       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+jobs:
+  dummy:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - run:
+          name: Dummy step
+          command: |
+            echo "This is a dummy step to satisfy CircleCI"
+
+workflows:
+  version: 2
+  workflow:
+    jobs: 
+      - dummy

--- a/.circleci/config.yml.off
+++ b/.circleci/config.yml.off
@@ -1,3 +1,4 @@
+# CircleCI currently disabled in favor of GH actions
 version: 2.1
 commands:
   prepare_environment:
@@ -302,22 +303,22 @@ orbs:
 workflows:
   version: 2
   workflow:
-    jobs: []
-      # - build
-      # - test:
-      #     requires:
-      #       - build
-      # - codegen:
-      #     requires:
-      #       - build
-      # - ui:
-      #     requires:
-      #       - build
-      # - sonarcloud:
-      #     context: SonarCloud
-      #     requires:
-      #       - test
-      #       - ui
-      # - e2e:
-      #     requires:
-      #       - build
+    jobs: 
+      - build
+      - test:
+          requires:
+            - build
+      - codegen:
+          requires:
+            - build
+      - ui:
+          requires:
+            - build
+      - sonarcloud:
+          context: SonarCloud
+          requires:
+            - test
+            - ui
+      - e2e:
+          requires:
+            - build

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -192,7 +192,7 @@ jobs:
         working-directory: ui/
 
   analyze:
-    name: Perform static code analysis 
+    name: Process & analyze test artifacts
     runs-on: ubuntu-latest
     needs:
       - test-go
@@ -225,13 +225,11 @@ jobs:
         with:
           name: test-results
           path: test-results
-      - name: Display working directory
-        run: ls -la
       - name: Upload code coverage information to codecov.io
         uses: codecov/codecov-action@v1
         with:
           file: coverage.out
-      - name: Run SonarCloud scanner
+      - name: Perform static code analysis using SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,0 +1,337 @@
+name: Integration tests
+on: 
+  push:
+    branches:
+      - 'master' 
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  check-go:
+    name: Ensure Go modules synchronicity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14.2'
+      - name: Download all Go modules
+        run: |
+          go mod download
+      - name: Check for tidyness of go.mod and go.sum
+        run: |
+          go mod tidy
+          git diff --exit-code -- .
+
+  build-go:
+    name: Build & cache Go code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14.2'
+      - name: Restore go build cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
+      - name: Download all Go modules
+        run: |
+          go mod download
+      - name: Compile all packages
+        run: make build-local
+
+  lint-go:
+    name: Lint Go code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.26
+          args: --timeout 5m
+
+  test-go:
+    name: Run unit tests for Go packages
+    runs-on: ubuntu-latest
+    needs:
+      - build-go
+    steps:
+      - name: Create checkout directory
+        run: mkdir -p ~/go/src/github.com/argoproj
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create symlink in GOPATH
+        run: ln -s $(pwd) ~/go/src/github.com/argoproj/argo-cd
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14.2'
+      - name: Install required packages
+        run: |
+          sudo apt-get install git -y
+      - name: Switch to temporal branch so we re-attach head
+        run: |
+          git switch -c temporal-pr-branch
+          git status
+      - name: Fetch complete history for blame information
+        run: |
+          git fetch --prune --no-tags --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+      - name: Add ~/go/bin to PATH
+        run: echo "::add-path::/home/runner/go/bin"
+      - name: Add /usr/local/bin to PATH
+        run: echo "::add-path::/usr/local/bin"
+      - name: Restore go build cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
+      - name: Install all tools required for building & testing
+        run: |
+          make install-test-tools-local
+      - name: Setup git username and email
+        run: |
+          git config --global user.name "John Doe"
+          git config --global user.email "john.doe@example.com"
+      - name: Download and vendor all required packages
+        run: |
+          go mod download
+      - name: Run all unit tests
+        run: make test-local
+      - name: Generate code coverage artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage
+          path: coverage.out
+      - name: Generate test results artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: test-results/
+
+  codegen:
+    name: Check changes to generated code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14.2'
+      - name: Create symlink in GOPATH
+        run: |
+          mkdir -p ~/go/src/github.com/argoproj
+          cp -a ../argo-cd ~/go/src/github.com/argoproj
+      - name: Add /usr/local/bin to PATH
+        run: echo "::add-path::/usr/local/bin"
+      - name: Add ~/go/bin to PATH
+        run: echo "::add-path::/home/runner/go/bin"
+      - name: Download & vendor dependencies
+        run: |
+          # We need to vendor go modules for codegen yet
+          go mod download
+          go mod vendor -v
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
+      - name: Install toolchain for codegen
+        run: |
+          make install-codegen-tools-local
+          make install-go-tools-local
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
+      - name: Initialize local Helm
+        run: |
+          helm2 init --client-only
+      - name: Run codegen
+        run: |
+          set -x
+          export GOPATH=$(go env GOPATH)
+          make codegen-local
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
+      - name: Check nothing has changed
+        run: |
+          set -xo pipefail
+          git diff --exit-code -- . ':!go.sum' ':!go.mod' ':!assets/swagger.json' | tee codegen.patch
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
+
+  build-ui:
+    name: Build, test & lint UI code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: '11.15.0'
+      - name: Restore node dependency cache
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ui/node_modules
+          key: ${{ runner.os }}-node-dep-v2-${{ hashFiles('**/yarn.lock') }}
+      - name: Install node dependencies
+        run: |
+          cd ui && yarn install --frozen-lockfile --ignore-optional --non-interactive
+      - name: Build UI code
+        run: |
+          yarn test
+          yarn build
+        env:
+          NODE_ENV: production
+        working-directory: ui/
+      - name: Run ESLint
+        run: yarn lint
+        working-directory: ui/
+
+  analyze:
+    name: Perform static code analysis 
+    runs-on: ubuntu-latest
+    needs:
+      - test-go
+      - build-ui
+    env:
+      sonar_secret: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Restore node dependency cache
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ui/node_modules
+          key: ${{ runner.os }}-node-dep-v2-${{ hashFiles('**/yarn.lock') }}
+      - name: Remove other node_modules directory
+        run: |
+          rm -rf ui/node_modules/argo-ui/node_modules
+      - name: Create test-results directory
+        run: |
+          mkdir -p test-results
+      - name: Get code coverage artifiact
+        uses: actions/download-artifact@v2
+        with:
+          name: code-coverage
+      - name: Get test result artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: test-results
+          path: test-results
+      - name: Display working directory
+        run: ls -la
+      - name: Run SonarCloud scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SCANNER_VERSION: 4.2.0.1873
+          SCANNER_PATH: /tmp/cache/scanner
+          OS: linux
+        run: |
+            # We do not use the provided action, because it does contain an old
+            # version of the scanner, and also takes time to build.
+            set -e
+            mkdir -p ${SCANNER_PATH}
+            export SONAR_USER_HOME=${SCANNER_PATH}/.sonar
+            if [[ ! -x "${SCANNER_PATH}/sonar-scanner-${SCANNER_VERSION}-${OS}/bin/sonar-scanner" ]]; then
+              curl -Ol https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SCANNER_VERSION}-${OS}.zip
+              unzip -qq -o sonar-scanner-cli-${SCANNER_VERSION}-${OS}.zip -d ${SCANNER_PATH}
+            fi
+
+            chmod +x ${SCANNER_PATH}/sonar-scanner-${SCANNER_VERSION}-${OS}/bin/sonar-scanner
+            chmod +x ${SCANNER_PATH}/sonar-scanner-${SCANNER_VERSION}-${OS}/jre/bin/java
+
+            # Explicitly set NODE_MODULES
+            export NODE_MODULES=${PWD}/ui/node_modules
+            export NODE_PATH=${PWD}/ui/node_modules
+
+            ${SCANNER_PATH}/sonar-scanner-${SCANNER_VERSION}-${OS}/bin/sonar-scanner
+        if: env.sonar_secret != ''
+
+  test-e2e:
+    name: Run end-to-end tests
+    runs-on: ubuntu-latest
+    needs: 
+      - build-go
+    env:
+      GOPATH: /home/runner/go
+      ARGOCD_FAKE_IN_CLUSTER: "true"
+      ARGOCD_SSH_DATA_PATH: "/tmp/argo-e2e/app/config/ssh"
+      ARGOCD_TLS_DATA_PATH: "/tmp/argo-e2e/app/config/tls"
+      ARGOCD_E2E_SSH_KNOWN_HOSTS: "../fixture/certs/ssh_known_hosts"
+      ARGOCD_E2E_K3S: "true"
+      ARGOCD_IN_CI: "true"
+      ARGOCD_E2E_APISERVER_PORT: "8088"
+      ARGOCD_SERVER: "127.0.0.1:8088"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14.2'
+      - name: Install K3S
+        env:
+          INSTALL_K3S_VERSION: v0.5.0
+        run: |
+          set -x
+          curl -sfL https://get.k3s.io | sh -
+          sudo chmod -R a+rw /etc/rancher/k3s
+          sudo mkdir -p $HOME/.kube && sudo chown -R runner $HOME/.kube
+          sudo k3s kubectl config view --raw > $HOME/.kube/config
+          sudo chown runner $HOME/.kube/config
+          kubectl version
+      - name: Restore go build cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
+      - name: Add /usr/local/bin to PATH
+        run: echo "::add-path::/usr/local/bin"
+      - name: Add ~/go/bin to PATH
+        run: echo "::add-path::/home/runner/go/bin"
+      - name: Download Go dependencies
+        run: |
+          go mod download
+          go get github.com/mattn/goreman
+      - name: Install all tools required for building & testing
+        run: |
+          make install-test-tools-local
+      - name: Setup git username and email
+        run: |
+          git config --global user.name "John Doe"
+          git config --global user.email "john.doe@example.com"
+      - name: Pull Docker image required for tests
+        run: |
+          docker pull quay.io/dexidp/dex:v2.22.0
+          docker pull argoproj/argo-cd-ci-builder:v1.0.0
+          docker pull redis:5.0.3-alpine
+      - name: Run E2E server and wait for it being available
+        timeout-minutes: 30
+        run: |
+          set -x
+          # Something is weird in GH runners -- there's a phantom listener for
+          # port 8080 which is not visible in netstat -tulpen, but still there
+          # with a HTTP listener. We have API server listening on port 8088
+          # instead.
+          make start-e2e-local &
+          count=1
+          until curl -f http://127.0.0.1:8088/healthz; do
+            sleep 10;
+            if test $count -ge 60; then
+              echo "Timeout"
+              exit 1
+            fi
+            count=$((count+1))
+          done
+      - name: Run E2E testsuite
+        run: |
+          set -x
+          make test-e2e-local

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -227,6 +227,10 @@ jobs:
           path: test-results
       - name: Display working directory
         run: ls -la
+      - name: Upload code coverage information to codecov.io
+        uses: codecov/codecov-action@v1
+        with:
+          file: coverage.out
       - name: Run SonarCloud scanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,6 @@ install-codegen-tools-local:
 .PHONY: install-go-tools-local
 install-go-tools-local:
 	./hack/install.sh codegen-go-tools
-	./hack/install.sh lint-tools
 
 .PHONY: dep-ui
 dep-ui:

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ clientgen:
 
 .PHONY: codegen-local
 codegen-local: mod-vendor-local gogen protogen clientgen openapigen manifests-local
+	rm -rf vendor/
 
 .PHONY: codegen
 codegen:
@@ -292,9 +293,8 @@ build:
 
 # Build all Go code (local version)
 .PHONY: build-local
-build-local: mod-vendor-local
-	export GO111MODULE=off
-	go build -p 1 -v `go list ./... | grep -v 'resource_customizations\|test/e2e'`
+build-local: 
+	go build -v `go list ./... | grep -v 'resource_customizations\|test/e2e'`
 
 # Run all unit tests
 #
@@ -307,8 +307,7 @@ test:
 
 # Run all unit tests (local version)
 .PHONY: test-local
-test-local: mod-vendor-local
-	export GO111MODULE=off
+test-local:
 	if test "$(TEST_MODULE)" = ""; then \
 		./hack/test.sh -coverprofile=coverage.out `go list ./... | grep -v 'test/e2e'`; \
 	else \
@@ -345,8 +344,7 @@ start-e2e:
 
 # Starts e2e server locally (or within a container)
 .PHONY: start-e2e-local
-start-e2e-local: mod-vendor-local
-	export GO111MODULE=off
+start-e2e-local: 
 	kubectl create ns argocd-e2e || true
 	kubectl config set-context --current --namespace=argocd-e2e
 	kustomize build test/manifests/base | kubectl apply -f -
@@ -433,14 +431,26 @@ show-go-version:
 
 # Installs all tools required to build and test ArgoCD locally
 .PHONY: install-tools-local
-install-tools-local:
-	./hack/install.sh dep-linux
-	./hack/install.sh packr-linux
-	./hack/install.sh kubectl-linux
-	./hack/install.sh ksonnet-linux
-	./hack/install.sh helm2-linux
-	./hack/install.sh helm-linux
-	./hack/install.sh codegen-tools
+install-tools-local: install-test-tools-local install-codegen-tools-local install-go-tools-local
+
+# Installs all tools required for running unit & end-to-end tests (Linux packages)
+.PHONY: install-test-tools-local
+install-test-tools-local:
+	sudo ./hack/install.sh packr-linux
+	sudo ./hack/install.sh kubectl-linux
+	sudo ./hack/install.sh kustomize-linux
+	sudo ./hack/install.sh ksonnet-linux
+	sudo ./hack/install.sh helm2-linux
+	sudo ./hack/install.sh helm-linux
+
+# Installs all tools required for running codegen (Linux packages)
+.PHONY: install-codegen-tools-local
+install-codegen-tools-local:
+	sudo ./hack/install.sh codegen-tools
+
+# Installs all tools required for running codegen (Go packages)
+.PHONY: install-go-tools-local
+install-go-tools-local:
 	./hack/install.sh codegen-go-tools
 	./hack/install.sh lint-tools
 

--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -187,7 +187,7 @@
           "ApplicationService"
         ],
         "summary": "List returns list of applications",
-        "operationId": "ListMixin8",
+        "operationId": "List",
         "parameters": [
           {
             "type": "string",
@@ -237,7 +237,7 @@
           "ApplicationService"
         ],
         "summary": "Create creates an application",
-        "operationId": "CreateMixin8",
+        "operationId": "Create",
         "parameters": [
           {
             "name": "body",
@@ -264,7 +264,7 @@
           "ApplicationService"
         ],
         "summary": "Update updates an application",
-        "operationId": "UpdateMixin8",
+        "operationId": "Update",
         "parameters": [
           {
             "type": "string",
@@ -395,7 +395,7 @@
           "ApplicationService"
         ],
         "summary": "Get returns an application by name",
-        "operationId": "GetMixin8",
+        "operationId": "GetMixin1",
         "parameters": [
           {
             "type": "string",
@@ -445,7 +445,7 @@
           "ApplicationService"
         ],
         "summary": "Delete deletes an application",
-        "operationId": "DeleteMixin8",
+        "operationId": "Delete",
         "parameters": [
           {
             "type": "string",
@@ -1084,7 +1084,7 @@
           "ClusterService"
         ],
         "summary": "List returns list of clusters",
-        "operationId": "List",
+        "operationId": "ListMixin4",
         "parameters": [
           {
             "type": "string",
@@ -1106,7 +1106,7 @@
           "ClusterService"
         ],
         "summary": "Create creates a cluster",
-        "operationId": "Create",
+        "operationId": "CreateMixin4",
         "parameters": [
           {
             "name": "body",
@@ -1133,7 +1133,7 @@
           "ClusterService"
         ],
         "summary": "Update updates a cluster",
-        "operationId": "Update",
+        "operationId": "UpdateMixin4",
         "parameters": [
           {
             "type": "string",
@@ -1166,7 +1166,7 @@
           "ClusterService"
         ],
         "summary": "Get returns a cluster by server address",
-        "operationId": "GetMixin2",
+        "operationId": "GetMixin4",
         "parameters": [
           {
             "type": "string",
@@ -1189,7 +1189,7 @@
           "ClusterService"
         ],
         "summary": "Delete deletes a cluster",
-        "operationId": "Delete",
+        "operationId": "DeleteMixin4",
         "parameters": [
           {
             "type": "string",
@@ -1239,7 +1239,7 @@
           "ProjectService"
         ],
         "summary": "List returns list of projects",
-        "operationId": "ListMixin6",
+        "operationId": "ListMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1261,7 +1261,7 @@
           "ProjectService"
         ],
         "summary": "Create a new project.",
-        "operationId": "CreateMixin6",
+        "operationId": "CreateMixin5",
         "parameters": [
           {
             "name": "body",
@@ -1288,7 +1288,7 @@
           "ProjectService"
         ],
         "summary": "Get returns a project by name",
-        "operationId": "GetMixin6",
+        "operationId": "GetMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1311,7 +1311,7 @@
           "ProjectService"
         ],
         "summary": "Delete deletes a project",
-        "operationId": "DeleteMixin6",
+        "operationId": "DeleteMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1386,7 +1386,7 @@
           "ProjectService"
         ],
         "summary": "Update updates a project",
-        "operationId": "UpdateMixin6",
+        "operationId": "UpdateMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1694,7 +1694,7 @@
           "RepositoryService"
         ],
         "summary": "Get returns a repository or its credentials",
-        "operationId": "GetMixin3",
+        "operationId": "Get",
         "parameters": [
           {
             "type": "string",
@@ -1935,7 +1935,7 @@
           "SettingsService"
         ],
         "summary": "Get returns Argo CD settings",
-        "operationId": "Get",
+        "operationId": "GetMixin7",
         "responses": {
           "200": {
             "description": "(empty)",

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/argoproj/gitops-engine v0.1.1-0.20200529001831-99bd42d9a3ee
+	github.com/argoproj/gitops-engine v0.0.0-00010101000000-000000000000
 	github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54
 	github.com/bsm/redislock v0.4.3
 	github.com/casbin/casbin v1.9.1
@@ -39,11 +39,12 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v0.0.0-20190222133341-cfaf5686ec79
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/grpc-ecosystem/grpc-gateway v1.3.1
+	github.com/grpc-ecosystem/grpc-gateway v1.9.2
 	github.com/improbable-eng/grpc-web v0.0.0-20181111100011-16092bd1d58a
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/malexdev/utfutil v0.0.0-20180510171754-00c8d4a8e7a8 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -79,12 +80,13 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/kubectl v0.16.6
-	k8s.io/kubernetes v1.17.0-alpha.0.0.20191207011953-bfafae8f1c2f
+	k8s.io/kubernetes v1.16.6
 	k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6
 	layeh.com/gopher-json v0.0.0-20190114024228-97fed8db8427
 )
 
 replace (
+	github.com/argoproj/gitops-engine => github.com/argoproj/gitops-engine v0.1.1-0.20200529001831-99bd42d9a3ee
 	github.com/golang/protobuf => github.com/golang/protobuf v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.3.1
 	github.com/improbable-eng/grpc-web => github.com/improbable-eng/grpc-web v0.0.0-20181111100011-16092bd1d58a

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/malexdev/utfutil v0.0.0-20180510171754-00c8d4a8e7a8 // indirect
-	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/Azure/go-autorest/autorest/to v0.2.0/go.mod h1:GunWKJp1AEqgMaGLV+iocm
 github.com/Azure/go-autorest/autorest/validation v0.1.0/go.mod h1:Ha3z/SqBeaalWQvokg3NZAlQTalVMtOIAs1aGK7G6u8=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
-github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
@@ -51,8 +50,6 @@ github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/argoproj/gitops-engine v0.1.1-0.20200520172719-a70208905739 h1:u7o1TSi6ouoTg5ONt68d0jybixSxYGfk/uzVd3H2vVs=
-github.com/argoproj/gitops-engine v0.1.1-0.20200520172719-a70208905739/go.mod h1:/4AoMuf5SCQoxZuCk2y6FsDWvU8xItbbqvdDfikZ8gg=
 github.com/argoproj/gitops-engine v0.1.1-0.20200529001831-99bd42d9a3ee h1:OcGmfEW5/OHaGH6aoepDlzbcnf+CwjLkshtWkOqiHnY=
 github.com/argoproj/gitops-engine v0.1.1-0.20200529001831-99bd42d9a3ee/go.mod h1:QWwQdqfctsHHameV7uEgW37divnMGjIAD7Xw5C1QtZ4=
 github.com/argoproj/pkg v0.0.0-20200102163130-2dd1f3f6b4de/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=
@@ -67,10 +64,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/bazelbuild/bazel-gazelle v0.0.0-20181012220611-c728ce9f663e/go.mod h1:uHBSeeATKpVazAACZBDPL/Nk/UhQDDsJWDlqYJo8/Us=
 github.com/bazelbuild/bazel-gazelle v0.18.2/go.mod h1:D0ehMSbS+vesFsLGiD6JXu3mVEzOlfUl8wNnq+x/9p0=
 github.com/bazelbuild/bazel-gazelle v0.19.1-0.20191105222053-70208cbdc798/go.mod h1:rPwzNHUqEzngx1iVBfO/2X2npKaT3tqPqqHW6rVsn/A=
-github.com/bazelbuild/buildtools v0.0.0-20180226164855-80c7f0d45d7e/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/buildtools v0.0.0-20190731111112-f720930ceb60/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/buildtools v0.0.0-20190917191645-69366ca98f89/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/rules_go v0.0.0-20190719190356-6dae44dc5cab/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
@@ -111,7 +106,6 @@ github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1hF1U=
@@ -155,6 +149,7 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
@@ -335,11 +330,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/heketi/heketi v9.0.0+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
-github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413/go.mod h1:BeS3M108VzVlmAue3lv2WcGuPAX94/KN63MUURzbYSI=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
-github.com/heketi/utils v0.0.0-20170317161834-435bc5bdfa64/go.mod h1:RYlF4ghFZPPmk2TC5REt5OFwvfb6lzxFWrTWB+qs28s=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
@@ -412,9 +404,12 @@ github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwm
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -475,7 +470,6 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
-github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
@@ -650,7 +644,6 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -670,7 +663,6 @@ golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20171026204733-164713f0dfce/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20181004145325-8469e314837c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190122071731-054c452bb702/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -699,7 +691,6 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20170915040203-e531a2a1c15f/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -817,7 +808,6 @@ k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-aggregator v0.16.6 h1:bNwY/t432BgxoL73jEMD5EdZQCUkqw5kwhQxFmxdNss=
@@ -831,12 +821,10 @@ k8s.io/kube-scheduler v0.16.6/go.mod h1:ohT2kmuQnNex0cDUYvXBAdMKHlneruoD4KOacEDp
 k8s.io/kubectl v0.16.6 h1:u7bQl9F78+7wYcvBSX7JfnIotLIQfAVpN1E11m2s+3w=
 k8s.io/kubectl v0.16.6/go.mod h1:ybKdxxoYuQLRqsmBFylvgyFPeVmmRYUbxk134JCiNoM=
 k8s.io/kubelet v0.16.6/go.mod h1:NAuB1uZwiOgUnJSgAnJIkWlueXFYkzxwv7xWEA/P35Y=
+k8s.io/kubernetes v1.16.6 h1:ZWSNwxZ1w/IPV7pYH9gohR7AhKmn1VoJ9fEKxmkkeh8=
 k8s.io/kubernetes v1.16.6/go.mod h1:rO6tSgbJjbo6lLkrq4jryUaXqZ2PdDJjzWXKZQmLfnQ=
-k8s.io/kubernetes v1.17.0-alpha.0.0.20191207011953-bfafae8f1c2f h1:JaOJwcEb3V6OoQ1Ttnm7vadJawpBiBkXP7XBVjXpybU=
-k8s.io/kubernetes v1.17.0-alpha.0.0.20191207011953-bfafae8f1c2f/go.mod h1:OdJXH1Q9L+NDVj158Zo8f6R3NSaOx1ewLUcaJv8hSRE=
 k8s.io/legacy-cloud-providers v0.16.6/go.mod h1:trzyJ8vT+vD+FEP4NHDbJvOXYtksUbpD7PfR6Iwnhxk=
 k8s.io/metrics v0.16.6/go.mod h1:de0nJbsn2wX/fapLW0Yi7k+GwXvEv4/g54agaDjzmQY=
-k8s.io/repo-infra v0.0.0-20181204233714-00fe14e3d1a3/go.mod h1:+G1xBfZDfVFsm1Tj/HNCvg4QqWx8rJ2Fxpqr1rqp/gQ=
 k8s.io/repo-infra v0.0.1-alpha.1/go.mod h1:wO1t9WaB99V80ljbeENTnayuEEwNZt7gECYh/CEyOJ8=
 k8s.io/sample-apiserver v0.16.6/go.mod h1:fyN8DaZXgtcQKCtb/x2mr4TDTUkaAdgWNU7BaLnlSqg=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,6 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
@@ -289,8 +287,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-jsonnet v0.15.0 h1:lEUXTDnVsHu+CLLzMeWAdWV4JpCgkJeDqdVNS8RtyuY=
-github.com/google/go-jsonnet v0.15.0/go.mod h1:ex9QcU8vzXQUDeNe4gaN1uhGQbTYpOeZ6AbWdy6JbX4=
 github.com/google/go-jsonnet v0.16.0 h1:Nb4EEOp+rdeGGyB1rQ5eisgSAqrTnhf9ip+X6lzZbY0=
 github.com/google/go-jsonnet v0.16.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -405,15 +401,13 @@ github.com/malexdev/utfutil v0.0.0-20180510171754-00c8d4a8e7a8 h1:A6SLdFpRzUUF5v
 github.com/malexdev/utfutil v0.0.0-20180510171754-00c8d4a8e7a8/go.mod h1:UtpLyb/EupVKXF/N0b4NRe1DNg+QYJsnsHQ038romhM=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
-github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
@@ -680,7 +674,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=

--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -52,7 +52,9 @@ func getCustomResourceDefinitions() map[string]*extensionsobj.CustomResourceDefi
 			"app.kubernetes.io/name":    crd.Name,
 			"app.kubernetes.io/part-of": "argocd",
 		}
+		delete(crd.Annotations, "controller-gen.kubebuilder.io/version")
 		crd.Spec.Scope = "Namespaced"
+		crd.Spec.PreserveUnknownFields = nil
 		crds[crd.Name] = crd
 	}
 	return crds

--- a/hack/generate-proto.sh
+++ b/hack/generate-proto.sh
@@ -21,6 +21,8 @@ MOD_ROOT=${GOPATH}/pkg/mod
 
 . ${PROJECT_ROOT}/hack/versions.sh
 
+export GO111MODULE=off
+
 # protobuf tooling required to build .proto files from go annotations from k8s-like api types
 go build -i -o dist/go-to-protobuf ./vendor/k8s.io/code-generator/cmd/go-to-protobuf
 go build -i -o dist/protoc-gen-gogo ./vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo

--- a/hack/installers/install-codegen-go-tools.sh
+++ b/hack/installers/install-codegen-go-tools.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 set -eux -o pipefail
 
-mkdir -p $DOWNLOADS/codegen-tools
-cd $DOWNLOADS/codegen-tools
-
 GO111MODULE=on go get github.com/gogo/protobuf/gogoproto@v1.3.1
-GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.1
+GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.3
 GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v1.3.1
 GO111MODULE=on go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.9.2
 GO111MODULE=on go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.9.2

--- a/hack/installers/install-helm-linux.sh
+++ b/hack/installers/install-helm-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/helm.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm.tar.gz https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/helm.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm.tar.gz https://get.helm.sh/helm-v${helm3_version}-linux-amd64.tar.gz
 mkdir -p /tmp/helm && tar -C /tmp/helm -xf $DOWNLOADS/helm.tar.gz
 cp /tmp/helm/linux-amd64/helm $BIN/helm
 helm version --client

--- a/hack/installers/install-helm-linux.sh
+++ b/hack/installers/install-helm-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/helm.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm.tar.gz https://get.helm.sh/helm-v3.2.0-linux-$ARCHITECTURE.tar.gz
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/helm.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm.tar.gz https://get.helm.sh/helm-v${helm3_version}-linux-$ARCHITECTURE.tar.gz
 mkdir -p /tmp/helm && tar -C /tmp/helm -xf $DOWNLOADS/helm.tar.gz
 cp /tmp/helm/linux-$ARCHITECTURE/helm $BIN/helm
 helm version --client

--- a/hack/installers/install-helm2-linux.sh
+++ b/hack/installers/install-helm2-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/helm2.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm2.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.15.2-linux-$ARCHITECTURE.tar.gz
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/helm2.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm2.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v${helm2_version}-linux-$ARCHITECTURE.tar.gz
 mkdir -p /tmp/helm2 && tar -C /tmp/helm2 -xf $DOWNLOADS/helm2.tar.gz
 cp /tmp/helm2/linux-$ARCHITECTURE/helm $BIN/helm2
 helm2 version --client

--- a/hack/installers/install-helm2-linux.sh
+++ b/hack/installers/install-helm2-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/helm2.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm2.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.15.2-linux-amd64.tar.gz
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/helm2.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/helm2.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v${helm2_version}-linux-amd64.tar.gz
 mkdir -p /tmp/helm2 && tar -C /tmp/helm2 -xf $DOWNLOADS/helm2.tar.gz
 cp /tmp/helm2/linux-amd64/helm $BIN/helm2
 helm2 version --client

--- a/hack/installers/install-jq-linux.sh
+++ b/hack/installers/install-jq-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/jq ] || curl -sLf --retry 3 -o $DOWNLOADS/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/jq ] || curl -sLf --retry 3 -o $DOWNLOADS/jq https://github.com/stedolan/jq/releases/download/jq-${jq_version}/jq-linux64
 cp $DOWNLOADS/jq $BIN/jq
 chmod +x $BIN/jq
 jq --version

--- a/hack/installers/install-ksonnet-linux.sh
+++ b/hack/installers/install-ksonnet-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/ks.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/ks.tar.gz https://github.com/ksonnet/ksonnet/releases/download/v0.13.1/ks_0.13.1_linux_amd64.tar.gz
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/ks.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/ks.tar.gz https://github.com/ksonnet/ksonnet/releases/download/v${ksonnet_version}/ks_${ksonnet_version}_linux_amd64.tar.gz
 tar -C /tmp -xf $DOWNLOADS/ks.tar.gz
 cp /tmp/ks_0.13.1_linux_amd64/ks $BIN/ks
 chmod +x $BIN/ks

--- a/hack/installers/install-ksonnet-linux.sh
+++ b/hack/installers/install-ksonnet-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-KSONNET_VERSION=0.13.1
+. $(dirname $0)/../tool-versions.sh
+
+KSONNET_VERSION=${ksonnet_version}
 case $ARCHITECTURE in
   arm|arm64)
     set +o pipefail

--- a/hack/installers/install-kubectl-linux.sh
+++ b/hack/installers/install-kubectl-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
+. $(dirname $0)/../tool-versions.sh
+
 # NOTE: keep the version synced with https://storage.googleapis.com/kubernetes-release/release/stable.txt
-[ -e $DOWNLOADS/kubectl ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+[ -e $DOWNLOADS/kubectl ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectl https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl
 cp $DOWNLOADS/kubectl $BIN/
 chmod +x $BIN/kubectl

--- a/hack/installers/install-kubectl-linux.sh
+++ b/hack/installers/install-kubectl-linux.sh
@@ -4,6 +4,6 @@ set -eux -o pipefail
 . $(dirname $0)/../tool-versions.sh
 
 # NOTE: keep the version synced with https://storage.googleapis.com/kubernetes-release/release/stable.txt
-[ -e $DOWNLOADS/kubectl ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/$ARCHITECTURE/kubectl
+[ -e $DOWNLOADS/kubectl ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectl https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/$ARCHITECTURE/kubectl
 cp $DOWNLOADS/kubectl $BIN/
 chmod +x $BIN/kubectl

--- a/hack/installers/install-kubectx-linux.sh
+++ b/hack/installers/install-kubectx-linux.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/kubectx.zip ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectx.zip https://github.com/ahmetb/kubectx/archive/v0.6.3.zip
-unzip $DOWNLOADS/kubectx.zip kubectx-0.6.3/kubectx -d $DOWNLOADS
-unzip $DOWNLOADS/kubectx.zip kubectx-0.6.3/kubens -d $DOWNLOADS
-mv $DOWNLOADS/kubectx-0.6.3/kubectx $BIN/
-mv $DOWNLOADS/kubectx-0.6.3/kubens $BIN/
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/kubectx.zip ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectx.zip https://github.com/ahmetb/kubectx/archive/v${kubectx_version}.zip
+unzip $DOWNLOADS/kubectx.zip kubectx-${kubectx_version}/kubectx -d $DOWNLOADS
+unzip $DOWNLOADS/kubectx.zip kubectx-${kubectx_version}/kubens -d $DOWNLOADS
+mv $DOWNLOADS/kubectx-${kubectx_version}/kubectx $BIN/
+mv $DOWNLOADS/kubectx-${kubectx_version}/kubens $BIN/
 chmod +x $BIN/kubectx
 chmod +x $BIN/kubens

--- a/hack/installers/install-kustomize-linux.sh
+++ b/hack/installers/install-kustomize-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-3.5.5}
+. $(dirname $0)/../tool-versions.sh
+
+KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-$kustomize3_version}
 
 # Note that kustomize release URIs have changed for v3.2.1. Then again for
 # v3.3.0. When upgrading to versions >= v3.3.0 please change the URI format. And

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-mkdir -p $DOWNLOADS/codegen-tools
-cd $DOWNLOADS/codegen-tools
-
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.26.0

--- a/hack/installers/install-packr-linux.sh
+++ b/hack/installers/install-packr-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-PACKR_VERSION=1.21.9
+. $(dirname $0)/../tool-versions.sh
+
+PACKR_VERSION=${packr_version}
 [ -e $DOWNLOADS/parkr.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/parkr.tar.gz https://github.com/gobuffalo/packr/releases/download/v${PACKR_VERSION}/packr_${PACKR_VERSION}_linux_amd64.tar.gz
 tar -vxf $DOWNLOADS/parkr.tar.gz -C /tmp/
 cp /tmp/packr $BIN/

--- a/hack/installers/install-packr-linux.sh
+++ b/hack/installers/install-packr-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-PACKR_VERSION=1.21.9
+. $(dirname $0)/../tool-versions.sh
+
+PACKR_VERSION=${packr_version}
 case $ARCHITECTURE in
   arm|arm64)
     set +o pipefail

--- a/hack/installers/install-protoc-linux.sh
+++ b/hack/installers/install-protoc-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/protoc.zip ] || curl -sLf --retry 3 -o $DOWNLOADS/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/protoc.zip ] || curl -sLf --retry 3 -o $DOWNLOADS/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip
 unzip $DOWNLOADS/protoc.zip bin/protoc -d /usr/local/
 chmod +x /usr/local/bin/protoc
 unzip $DOWNLOADS/protoc.zip include/* -d /usr/local/

--- a/hack/installers/install-swagger-linux.sh
+++ b/hack/installers/install-swagger-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/swagger ] || curl -sLf --retry 3 -o $DOWNLOADS/swagger https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/swagger ] || curl -sLf --retry 3 -o $DOWNLOADS/swagger https://github.com/go-swagger/go-swagger/releases/download/v${swagger_version}/swagger_linux_amd64
 cp $DOWNLOADS/swagger $BIN/swagger
 chmod +x $BIN/swagger
 swagger version

--- a/hack/installers/install-swagger-linux.sh
+++ b/hack/installers/install-swagger-linux.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eux -o pipefail
 
-[ -e $DOWNLOADS/swagger ] || curl -sLf --retry 3 -o $DOWNLOADS/swagger https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_$ARCHITECTURE
+. $(dirname $0)/../tool-versions.sh
+
+[ -e $DOWNLOADS/swagger ] || curl -sLf --retry 3 -o $DOWNLOADS/swagger https://github.com/go-swagger/go-swagger/releases/download/v${swagger_version}/swagger_linux_$ARCHITECTURE
 cp $DOWNLOADS/swagger $BIN/swagger
 chmod +x $BIN/swagger
 swagger version

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -eux -o pipefail
 
-export GO111MODULE=off
-
 # make sure apiclient does not depend on packr
 which godepgraph || go get github.com/kisielk/godepgraph
 which go-junit-report || go get github.com/jstemmer/go-junit-report
+
+export GO111MODULE=off
 if godepgraph -s github.com/argoproj/argo-cd/pkg/apiclient | grep packr; then
   echo apiclient package should not depend on packr
   exit 1
 fi
+unset GO111MODULE
 
 TEST_RESULTS=${TEST_RESULTS:-test-results}
 TEST_FLAGS=

--- a/hack/tool-versions.sh
+++ b/hack/tool-versions.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# The checksum of this file is used as cache key in our integratoin toolchain
+# 
+helm2_version=2.15.2
+helm3_version=3.2.0
+jq_version=1.6
+ksonnet_version=0.13.1
+kubectl_version=1.14.0
+kubectx_version=0.6.3
+kustomize3_version=3.5.5
+packr_version=1.21.9
+protoc_version=3.7.1
+swagger_version=0.19.0

--- a/hack/update-openapi.sh
+++ b/hack/update-openapi.sh
@@ -9,7 +9,9 @@ PROJECT_ROOT=$(cd $(dirname "$0")/.. ; pwd)
 CODEGEN_PKG=${PROJECT_ROOT}/vendor/k8s.io/kube-openapi
 VERSION="v1alpha1"
 
+export GO111MODULE=off
 go build -o dist/openapi-gen ${CODEGEN_PKG}/cmd/openapi-gen
+
 ./dist/openapi-gen \
   --go-header-file ${PROJECT_ROOT}/hack/custom-boilerplate.go.txt \
   --input-dirs github.com/argoproj/argo-cd/pkg/apis/application/${VERSION} \

--- a/manifests/ha/base/redis-ha/generate.sh
+++ b/manifests/ha/base/redis-ha/generate.sh
@@ -14,6 +14,7 @@ echo "${AUTOGENMSG}" > ./chart/upstream.yaml
 
 helm2 template ./chart \
   --name argocd \
+  --namespace default \
   --values ./chart/values.yaml \
   ${helm_execute} \
   >> ./chart/upstream_orig.yaml

--- a/test/e2e/fixture/certs/certs.go
+++ b/test/e2e/fixture/certs/certs.go
@@ -2,6 +2,7 @@ package certs
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/errors"
@@ -28,7 +29,11 @@ func AddCustomCACert() {
 }
 
 func AddCustomSSHKnownHostsKeys() {
-	knownHostsPath, err := filepath.Abs("../fixture/testrepos/ssh_known_hosts")
+	source := os.Getenv("ARGOCD_E2E_SSH_KNOWN_HOSTS")
+	if source == "" {
+		source = "../fixture/testrepos/ssh_known_hosts"
+	}
+	knownHostsPath, err := filepath.Abs(source)
 	errors.CheckError(err)
 	args := []string{"cert", "add-ssh", "--batch", "--from", knownHostsPath}
 	errors.FailOnErr(fixture.RunCli(args...))


### PR DESCRIPTION
Second attempt.

* This also re-introduces our beloved lint check.
* SonarCloud analysis is now skipped on PRs if secret is not available in source repository
* Checks for tidyness of `go.mod` and `go.sum`
* Gets rid of `argocd-test-tools` image for CI

It is slightly faster than CircleCI, on average it finishes in about 15 minutes on GH actions while it takes an average of 19 minutes on CircleCI.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
