### PR TITLE
feat: Add Strimzi KafkaConnect CRD custom health checks

### DIFF
--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/health.lua
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/health.lua
@@ -1,0 +1,21 @@
+hs = {}
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil then
+    for i, condition in ipairs(obj.status.conditions) do
+      if condition.type == "Ready" and condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = ""
+        return hs
+      end
+      if condition.type == "Ready" and condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = ""
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for Kafka Connect"
+return hs

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/health.lua
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/health.lua
@@ -2,9 +2,9 @@ hs = {}
 if obj.status ~= nil then
   if obj.status.conditions ~= nil then
     for i, condition in ipairs(obj.status.conditions) do
-      if condition.type == "Ready" and condition.status == "False" then
+      if condition.type == "NotReady" and condition.status == "True" then
         hs.status = "Degraded"
-        hs.message = ""
+        hs.message = condition.message
         return hs
       end
       if condition.type == "Ready" and condition.status == "True" then

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/health_test.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/health_test.yaml
@@ -5,6 +5,7 @@ tests:
   inputPath: testdata/progressing_noStatus.yaml
 - healthStatus:
     status: Degraded
+    message: "Error"
   inputPath: testdata/degraded.yaml
 - healthStatus:
     status: Healthy

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/health_test.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/health_test.yaml
@@ -1,0 +1,11 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "Waiting for Kafka Connect"
+  inputPath: testdata/progressing_noStatus.yaml
+- healthStatus:
+    status: Degraded
+  inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Healthy
+  inputPath: testdata/healthy.yaml

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/degraded.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/degraded.yaml
@@ -8,7 +8,7 @@ metadata:
   - foregroundDeletion
   generation: 25
   labels:
-    app.kubernetes.io/instance: dev-teal-kafka-connect
+    app.kubernetes.io/instance: kafka-connect
   name: kafka
   namespace: strimzi
   resourceVersion: "43088521"
@@ -97,7 +97,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2020-05-28T13:43:05.813Z"
-    status: "False"
-    type: Ready
+    status: "True"
+    type: NotReady
+    message: "Error"
   observedGeneration: 25
   url: http://kafka-connect-api.strimzi.svc:8083

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/degraded.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/degraded.yaml
@@ -1,0 +1,103 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaConnect
+metadata:
+  creationTimestamp: "2020-02-13T14:03:15Z"
+  deletionGracePeriodSeconds: 0
+  deletionTimestamp: "2020-05-28T10:29:44Z"
+  finalizers:
+  - foregroundDeletion
+  generation: 25
+  labels:
+    app.kubernetes.io/instance: dev-teal-kafka-connect
+  name: kafka
+  namespace: strimzi
+  resourceVersion: "43088521"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/strimzi/kafkaconnects/kafka
+  uid: 941ae21d-4e69-11ea-a53d-06e66a171f98
+spec:
+  bootstrapServers: PLAINTEXT://b-1.kafka.eu-west-1.amazonaws.com:9092,
+    PLAINTEXT://b-2.kafka.eu-west-1.amazonaws.com:9092, PLAINTEXT://b-3.kafka.eu-west-1.amazonaws.com:9092
+  config:
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+    config.storage.topic: connect-configs
+    connector.client.config.override.policy: All
+    group.id: connect-cluster
+    internal.key.converter: org.apache.kafka.connect.json.JsonConverter
+    internal.key.converter.schemas.enable: "false"
+    internal.value.converter: org.apache.kafka.connect.json.JsonConverter
+    internal.value.converter.schemas.enable: "false"
+    key.converter: org.apache.kafka.connect.storage.StringConverter
+    key.converter.schemas.enable: "false"
+    offset.storage.topic: connect-offsets
+    schema.registry.url: http://kafka-schema-registry:8081
+    status.storage.topic: connect-statuses
+    task.shutdown.graceful.timeout.ms: 30000
+    value.converter: io.confluent.connect.avro.AvroConverter
+    value.converter.schema.registry.url: http://kafka-schema-registry:8081
+    value.converter.schemas.enable: "true"
+  externalConfiguration:
+    volumes:
+    - name: kafka-connect-credentials
+      secret:
+        secretName: kafka-connect-credentials
+  image: strimzi/kafka-connect:strimzi_0.17.0_kafka_2.3.1-2
+  jvmOptions:
+    -Xms: 8000m
+    -Xmx: 8000m
+    gcLoggingEnabled: false
+  logging:
+    type: inline
+  replicas: 5
+  resources:
+    limits:
+      cpu: "1"
+      memory: 7Gi
+    requests:
+      cpu: "1"
+      memory: 5Gi
+  template:
+    connectContainer:
+      env:
+      - name: JMX_PORT
+        value: "9999"
+    pod:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - kafka-connect
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - kafka-connect
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+      metadata:
+        annotations:
+          prometheus.io/path: /
+          prometheus.io/port: "9404"
+          prometheus.io/scrape: true
+      priorityClassName: kafka-connect
+      tolerations:
+      - effect: NoSchedule
+        key: dynamic-node
+        operator: Equal
+        value: "true"
+status:
+  conditions:
+  - lastTransitionTime: "2020-05-28T13:43:05.813Z"
+    status: "False"
+    type: Ready
+  observedGeneration: 25
+  url: http://kafka-connect-api.strimzi.svc:8083

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/healthy.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/healthy.yaml
@@ -1,0 +1,103 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaConnect
+metadata:
+  creationTimestamp: "2020-02-13T14:03:15Z"
+  deletionGracePeriodSeconds: 0
+  deletionTimestamp: "2020-05-28T10:29:44Z"
+  finalizers:
+  - foregroundDeletion
+  generation: 25
+  labels:
+    app.kubernetes.io/instance: dev-teal-kafka-connect
+  name: kafka
+  namespace: strimzi
+  resourceVersion: "43088521"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/strimzi/kafkaconnects/kafka
+  uid: 941ae21d-4e69-11ea-a53d-06e66a171f98
+spec:
+  bootstrapServers: PLAINTEXT://b-1.kafka.eu-west-1.amazonaws.com:9092,
+    PLAINTEXT://b-2.kafka.eu-west-1.amazonaws.com:9092, PLAINTEXT://b-3.kafka.eu-west-1.amazonaws.com:9092
+  config:
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+    config.storage.topic: connect-configs
+    connector.client.config.override.policy: All
+    group.id: connect-cluster
+    internal.key.converter: org.apache.kafka.connect.json.JsonConverter
+    internal.key.converter.schemas.enable: "false"
+    internal.value.converter: org.apache.kafka.connect.json.JsonConverter
+    internal.value.converter.schemas.enable: "false"
+    key.converter: org.apache.kafka.connect.storage.StringConverter
+    key.converter.schemas.enable: "false"
+    offset.storage.topic: connect-offsets
+    schema.registry.url: http://kafka-schema-registry:8081
+    status.storage.topic: connect-statuses
+    task.shutdown.graceful.timeout.ms: 30000
+    value.converter: io.confluent.connect.avro.AvroConverter
+    value.converter.schema.registry.url: http://kafka-schema-registry:8081
+    value.converter.schemas.enable: "true"
+  externalConfiguration:
+    volumes:
+    - name: kafka-connect-credentials
+      secret:
+        secretName: kafka-connect-credentials
+  image: strimzi/kafka-connect:strimzi_0.17.0_kafka_2.3.1-2
+  jvmOptions:
+    -Xms: 8000m
+    -Xmx: 8000m
+    gcLoggingEnabled: false
+  logging:
+    type: inline
+  replicas: 5
+  resources:
+    limits:
+      cpu: "1"
+      memory: 7Gi
+    requests:
+      cpu: "1"
+      memory: 5Gi
+  template:
+    connectContainer:
+      env:
+      - name: JMX_PORT
+        value: "9999"
+    pod:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - kafka-connect
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - kafka-connect
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+      metadata:
+        annotations:
+          prometheus.io/path: /
+          prometheus.io/port: "9404"
+          prometheus.io/scrape: true
+      priorityClassName: kafka-connect
+      tolerations:
+      - effect: NoSchedule
+        key: dynamic-node
+        operator: Equal
+        value: "true"
+status:
+  conditions:
+  - lastTransitionTime: "2020-05-28T13:43:05.813Z"
+    status: "True"
+    type: Ready
+  observedGeneration: 25
+  url: http://kafka-connect-api.strimzi.svc:8083

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/healthy.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/healthy.yaml
@@ -8,7 +8,7 @@ metadata:
   - foregroundDeletion
   generation: 25
   labels:
-    app.kubernetes.io/instance: dev-teal-kafka-connect
+    app.kubernetes.io/instance: kafka-connect
   name: kafka
   namespace: strimzi
   resourceVersion: "43088521"

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/progressing_noStatus.yaml
@@ -8,7 +8,7 @@ metadata:
   - foregroundDeletion
   generation: 25
   labels:
-    app.kubernetes.io/instance: dev-teal-kafka-connect
+    app.kubernetes.io/instance: kafka-connect
   name: kafka
   namespace: strimzi
   resourceVersion: "43088521"

--- a/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaConnect/testdata/progressing_noStatus.yaml
@@ -1,0 +1,96 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaConnect
+metadata:
+  creationTimestamp: "2020-02-13T14:03:15Z"
+  deletionGracePeriodSeconds: 0
+  deletionTimestamp: "2020-05-28T10:29:44Z"
+  finalizers:
+  - foregroundDeletion
+  generation: 25
+  labels:
+    app.kubernetes.io/instance: dev-teal-kafka-connect
+  name: kafka
+  namespace: strimzi
+  resourceVersion: "43088521"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/strimzi/kafkaconnects/kafka
+  uid: 941ae21d-4e69-11ea-a53d-06e66a171f98
+spec:
+  bootstrapServers: PLAINTEXT://b-1.kafka.eu-west-1.amazonaws.com:9092,
+    PLAINTEXT://b-2.kafka.eu-west-1.amazonaws.com:9092, PLAINTEXT://b-3.kafka.eu-west-1.amazonaws.com:9092
+  config:
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+    config.storage.topic: connect-configs
+    connector.client.config.override.policy: All
+    group.id: connect-cluster
+    internal.key.converter: org.apache.kafka.connect.json.JsonConverter
+    internal.key.converter.schemas.enable: "false"
+    internal.value.converter: org.apache.kafka.connect.json.JsonConverter
+    internal.value.converter.schemas.enable: "false"
+    key.converter: org.apache.kafka.connect.storage.StringConverter
+    key.converter.schemas.enable: "false"
+    offset.storage.topic: connect-offsets
+    schema.registry.url: http://kafka-schema-registry:8081
+    status.storage.topic: connect-statuses
+    task.shutdown.graceful.timeout.ms: 30000
+    value.converter: io.confluent.connect.avro.AvroConverter
+    value.converter.schema.registry.url: http://kafka-schema-registry:8081
+    value.converter.schemas.enable: "true"
+  externalConfiguration:
+    volumes:
+    - name: kafka-connect-credentials
+      secret:
+        secretName: kafka-connect-credentials
+  image: strimzi/kafka-connect:strimzi_0.17.0_kafka_2.3.1-2
+  jvmOptions:
+    -Xms: 8000m
+    -Xmx: 8000m
+    gcLoggingEnabled: false
+  logging:
+    type: inline
+  replicas: 5
+  resources:
+    limits:
+      cpu: "1"
+      memory: 7Gi
+    requests:
+      cpu: "1"
+      memory: 5Gi
+  template:
+    connectContainer:
+      env:
+      - name: JMX_PORT
+        value: "9999"
+    pod:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - kafka-connect
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                  - kafka-connect
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+      metadata:
+        annotations:
+          prometheus.io/path: /
+          prometheus.io/port: "9404"
+          prometheus.io/scrape: true
+      priorityClassName: kafka-connect
+      tolerations:
+      - effect: NoSchedule
+        key: dynamic-node
+        operator: Equal
+        value: "true"


### PR DESCRIPTION
This is a PR to contribute a custom health check to ArgoCD for Strimzi's KafkaConnect CRD. My team had an issue where the `KafkaConnect` resource would be forever stuck in a `Progressing` state, so we created this health check.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
