### PR TITLE
docs: Use official curl image instead of appropriate/curl

### DIFF
--- a/docs/user-guide/resource_hooks.md
+++ b/docs/user-guide/resource_hooks.md
@@ -95,7 +95,7 @@ spec:
     spec:
       containers:
       - name: slack-notification
-        image: appropriate/curl
+        image: curlimages/curl
         command:
           - "curl"
           - "-X"
@@ -120,7 +120,7 @@ spec:
     spec:
       containers:
       - name: slack-notification
-        image: appropriate/curl
+        image: curlimages/curl
         command: 
           - "curl"
           - "-X"


### PR DESCRIPTION
The appropriate/curl last update is from two years ago:

```
$ docker run -it --entrypoint /bin/ash appropriate/curl:latest
$ curl --version
curl 7.59.0 (x86_64-alpine-linux-musl) libcurl/7.59.0 LibreSSL/2.6.3 zlib/1.2.11 libssh2/1.8.0
Release-Date: 2018-03-14
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IPv6 Largefile NTLM NTLM_WB SSL libz UnixSockets HTTPS-proxy
```

There is already an official curl image at https://hub.docker.com/r/curlimages/curl (The link to the docker hub can be found in the official curl download page: https://curl.haxx.se/download.html)
```
$ docker run -it --entrypoint /bin/ash curlimages/curl:latest
$ curl --version
curl 7.70.0-DEV (x86_64-pc-linux-musl) libcurl/7.70.0-DEV OpenSSL/1.1.1d zlib/1.2.11 libssh2/1.9.0 nghttp2/1.40.0
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL TLS-SRP UnixSockets
```
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
