### PR TITLE
fix: Fix possible nil pointer deref on resource deduplication

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -194,6 +194,9 @@ func DeduplicateTargetObjects(
 	targetByKey := make(map[kubeutil.ResourceKey][]*unstructured.Unstructured)
 	for i := range objs {
 		obj := objs[i]
+		if obj == nil {
+			continue
+		}
 		isNamespaced := kubeutil.IsNamespacedOrUnknown(infoProvider, obj.GroupVersionKind().GroupKind())
 		if !isNamespaced {
 			obj.SetNamespace("")


### PR DESCRIPTION
When supplying local manifest with the empty string (i.e. `[]string{""}`), `targetObjs` list can contain `obj` that is nil and gets dereferenced in `DeduplicateTargetObjects` method of controller. 

Noticed during unit testing new code.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
