### PR TITLE
fix: upgrade gitops-engine dependency to v0.1.2

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -395,11 +395,6 @@ func (ctrl *ApplicationController) managedResources(comparisonResult *comparison
 		} else {
 			item.TargetState = "null"
 		}
-		jsonDiff, err := resDiff.JSONFormat()
-		if err != nil {
-			return nil, err
-		}
-		item.Diff = jsonDiff
 		item.PredictedLiveState = string(resDiff.PredictedLive)
 		item.NormalizedLiveState = string(resDiff.NormalizedLive)
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -15,7 +15,6 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/io"
 	kubeutil "github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
-	"github.com/yudai/gojsondiff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -387,12 +386,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *ap
 		if i < len(diffResults.Diffs) {
 			diffResult = diffResults.Diffs[i]
 		} else {
-			diffResult = diff.DiffResult{
-				Diff:           gojsondiff.New().CompareObjects(map[string]interface{}{}, map[string]interface{}{}),
-				Modified:       false,
-				NormalizedLive: []byte("{}"),
-				PredictedLive:  []byte("{}"),
-			}
+			diffResult = diff.DiffResult{Modified: false, NormalizedLive: []byte("{}"), PredictedLive: []byte("{}")}
 		}
 		if resState.Hook || ignore.Ignore(obj) {
 			// For resource hooks, don't store sync status, and do not affect overall sync status

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/argoproj/gitops-engine v0.0.0-00010101000000-000000000000
+	github.com/argoproj/gitops-engine v0.1.2
 	github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54
 	github.com/bsm/redislock v0.4.3
 	github.com/casbin/casbin v1.9.1
@@ -57,7 +57,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	github.com/vmihailenco/msgpack v3.3.1+incompatible
-	github.com/yudai/gojsondiff v1.0.1-0.20180504020246-0525c875b75c
 	github.com/yuin/gopher-lua v0.0.0-20190115140932-732aa6820ec4
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
@@ -83,7 +82,6 @@ require (
 )
 
 replace (
-	github.com/argoproj/gitops-engine => github.com/argoproj/gitops-engine v0.1.1-0.20200601171118-4bd4f29670ee
 	github.com/golang/protobuf => github.com/golang/protobuf v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.3.1
 	github.com/improbable-eng/grpc-web => github.com/improbable-eng/grpc-web v0.0.0-20181111100011-16092bd1d58a

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/argoproj/gitops-engine v0.1.1-0.20200601171118-4bd4f29670ee h1:oCQxH/zplZhggoIhXpBNJyx4F45CcSL6Hiyz4N2uJQU=
-github.com/argoproj/gitops-engine v0.1.1-0.20200601171118-4bd4f29670ee/go.mod h1:UmBGlQLT/MPNiMmbnouZRWhkk3slPuozMsENdXMkIMs=
+github.com/argoproj/gitops-engine v0.1.2 h1:tUDt0DR3axmHLmEJwgqWnr+cHHSK6cJLJef3YTLkQ+E=
+github.com/argoproj/gitops-engine v0.1.2/go.mod h1:UmBGlQLT/MPNiMmbnouZRWhkk3slPuozMsENdXMkIMs=
 github.com/argoproj/pkg v0.0.0-20200102163130-2dd1f3f6b4de/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=
 github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54 h1:hDn02iEkh5EUl4TJfOo6AI9uSgh0vt/qh66ODuQl/YE=
 github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=


### PR DESCRIPTION
PR upgrades gitops-engine to v0.1.2 and resolves #3241 and #3719 