### PR TITLE
chore: trigger-release should not fail if commentChar not configured

### DIFF
--- a/hack/trigger-release.sh
+++ b/hack/trigger-release.sh
@@ -92,7 +92,7 @@ fi
 
 # We need different git comment char than '#', because markdown makes extensive
 # use of '#' - we chose ';' for our operation.
-origToken=$(git config core.commentChar)
+origToken=$(git config core.commentChar || echo '#')
 echo ">> Saving original Git comment char '${origToken}' and setting it to ';' for this run"
 if ! git config core.commentChar ';'; then
 	echo "!! Could not set git config commentChar ';'" >&2


### PR DESCRIPTION
Minor fix in trigger-release.sh script. Script should not fail if `core.commentChar ` is not configured.