### PR TITLE
fix: SyncOperationResult namespace field should be optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_COMMIT=$(shell git rev-parse HEAD)
 GIT_TAG=$(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-match --tags HEAD 2>/dev/null; fi)
 GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
 PACKR_CMD=$(shell if [ "`which packr`" ]; then echo "packr"; else echo "go run github.com/gobuffalo/packr/packr"; fi)
-VOLUME_MOUNT=$(shell if test "$(go env GOOS)" = "darwin"; then echo ":delegated"; elif test selinuxenabled; then echo ":Z"; else echo ""; fi)
+VOLUME_MOUNT=$(shell if test "$(go env GOOS)" = "darwin"; then echo ":delegated"; elif test selinuxenabled; then echo ":delegated"; else echo ""; fi)
 
 GOPATH?=$(shell if test -x `which go`; then go env GOPATH; else echo "$(HOME)/go"; fi)
 GOCACHE?=$(HOME)/.cache/go-build

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -80,7 +80,6 @@ spec:
                     required:
                     - kind
                     - name
-                    - namespace
                     type: object
                   type: array
                 revision:
@@ -896,7 +895,6 @@ spec:
                             required:
                             - kind
                             - name
-                            - namespace
                             type: object
                           type: array
                         revision:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -81,7 +81,6 @@ spec:
                     required:
                     - kind
                     - name
-                    - namespace
                     type: object
                   type: array
                 revision:
@@ -897,7 +896,6 @@ spec:
                             required:
                             - kind
                             - name
-                            - namespace
                             type: object
                           type: array
                         revision:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -81,7 +81,6 @@ spec:
                     required:
                     - kind
                     - name
-                    - namespace
                     type: object
                   type: array
                 revision:
@@ -897,7 +896,6 @@ spec:
                             required:
                             - kind
                             - name
-                            - namespace
                             type: object
                           type: array
                         revision:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -81,7 +81,6 @@ spec:
                     required:
                     - kind
                     - name
-                    - namespace
                     type: object
                   type: array
                 revision:
@@ -897,7 +896,6 @@ spec:
                             required:
                             - kind
                             - name
-                            - namespace
                             type: object
                           type: array
                         revision:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -81,7 +81,6 @@ spec:
                     required:
                     - kind
                     - name
-                    - namespace
                     type: object
                   type: array
                 revision:
@@ -897,7 +896,6 @@ spec:
                             required:
                             - kind
                             - name
-                            - namespace
                             type: object
                           type: array
                         revision:

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -3120,7 +3120,7 @@ func schema_pkg_apis_application_v1alpha1_SyncOperationResource(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"kind", "name", "namespace"},
+				Required: []string{"kind", "name"},
 			},
 		},
 	}

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -439,7 +439,7 @@ type SyncOperationResource struct {
 	Group     string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	Kind      string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	Name      string `json:"name" protobuf:"bytes,3,opt,name=name"`
-	Namespace string `json:"namespace" protobuf:"bytes,4,opt,name=namespace"`
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
 }
 
 // RevisionHistories is a array of history, oldest first and newest last


### PR DESCRIPTION
The recently introduced namespace field of SyncOperationResource data structure must be optional. Otherwise controller unable to update existing applications.