### PR TITLE
feat(applications-tiles.tsx): adding helm icon to app tiles

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -35,6 +35,9 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                     </div>
                                     <div className='row'>
                                         <div className='columns applications-list__title'>{app.metadata.name}</div>
+                                        <div className='columns small-9'>
+                                            <i className={'icon argo-icon-' + ((app.spec.source.chart != null) ? 'helm' : 'git')} />
+                                        </div>
                                     </div>
                                     <div className='row'>
                                         <div className='columns small-3'>Project:</div>

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -36,7 +36,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                     <div className='row'>
                                         <div className='columns applications-list__title'>{app.metadata.name}</div>
                                         <div className='columns small-9'>
-                                            <i className={'icon argo-icon-' + ((app.spec.source.chart != null) ? 'helm' : 'git')} />
+                                            <i className={'icon argo-icon-' + (app.spec.source.chart != null ? 'helm' : 'git')} />
                                         </div>
                                     </div>
                                     <div className='row'>


### PR DESCRIPTION
conditionally add the helm icon if the application uses a "chart" otherwise default to git

#2961

I looked into added the helm icon into `resource-icon.tsx`, but without a proper svg it looked really bad.

[
![argo-helm](https://user-images.githubusercontent.com/5673097/84564763-1ff29280-ad19-11ea-834f-8b0c094b5daf.JPG)
](url)