### PR TITLE
fix: upgrade awscli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN groupadd -g 999 argocd && \
     apt-get update && \
     apt-get install -y git git-lfs python3-pip tini && \
     apt-get clean && \
-    pip3 install awscli==1.17.7 && \
+    pip3 install awscli==1.18.80 && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY hack/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh


### PR DESCRIPTION
PR upgrades `awscli` and closes #3748:


https://security-tracker.debian.org/tracker/CVE-2020-1747
```
 pip3 list
Package         Version
--------------- -------
asn1crypto      0.24.0
awscli          1.18.80
botocore        1.17.3
colorama        0.4.3
cryptography    2.6.1
docutils        0.15.2
entrypoints     0.3
jmespath        0.10.0
keyring         17.1.1
keyrings.alt    3.1.1
pip             18.1
pyasn1          0.4.8
pycrypto        2.6.1
PyGObject       3.30.4
python-dateutil 2.8.1
pyxdg           0.25
PyYAML          5.3.1 <- 5.3.1 includes the fix
rsa             3.4.2
s3transfer      0.3.3
SecretStorage   2.3.1
setuptools      40.8.0
six             1.12.0
urllib3         1.25.9
wheel           0.32.3
```

https://security-tracker.debian.org/tracker/CVE-2020-10711

```
dpkg --list linux-libc-dev:amd64
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                 Version            Architecture Description
+++-====================-==================-============-===============================================
ii  linux-libc-dev:amd64 4.19.118-2+deb10u1 amd64        Linux support headers for userspace development
root@4dce0e93c56a:/#
```