### PR TITLE
feat: Add support for TLS client authentication in the CLI (Fixes #3778)

### DIFF
--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -61,6 +61,8 @@ func NewCommand() *cobra.Command {
 	command.PersistentFlags().BoolVar(&clientOpts.PlainText, "plaintext", config.GetBoolFlag("plaintext"), "Disable TLS")
 	command.PersistentFlags().BoolVar(&clientOpts.Insecure, "insecure", config.GetBoolFlag("insecure"), "Skip server certificate and domain verification")
 	command.PersistentFlags().StringVar(&clientOpts.CertFile, "server-crt", config.GetFlag("server-crt", ""), "Server certificate file")
+	command.PersistentFlags().StringVar(&clientOpts.ClientCertFile, "client-crt", config.GetFlag("client-crt", ""), "Client certificate file")
+	command.PersistentFlags().StringVar(&clientOpts.ClientCertKeyFile, "client-crt-key", config.GetFlag("client-crt-key", ""), "Client certificate key file")
 	command.PersistentFlags().StringVar(&clientOpts.AuthToken, "auth-token", config.GetFlag("auth-token", ""), "Authentication token")
 	command.PersistentFlags().BoolVar(&clientOpts.GRPCWeb, "grpc-web", config.GetBoolFlag("grpc-web"), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.")
 	command.PersistentFlags().StringVar(&clientOpts.GRPCWebRootPath, "grpc-web-root-path", config.GetFlag("grpc-web-root-path", ""), "Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.")

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -46,6 +46,10 @@ type Server struct {
 	// CACertificateAuthorityData is the base64 string of a PEM encoded certificate
 	// TODO: not yet implemented
 	CACertificateAuthorityData string `json:"certificate-authority-data,omitempty"`
+	// ClientCertificateData is the base64 string of a PEM encoded certificate used to authenticate the client
+	ClientCertificateData string `json:"client-certificate-data,omitempty"`
+	// ClientCertificateKeyData is the base64 string of a PEM encoded private key of the client certificate
+	ClientCertificateKeyData string `json:"client-certificate-key-data,omitempty"`
 	// PlainText indicates to connect with TLS disabled
 	PlainText bool `json:"plain-text,omitempty"`
 }


### PR DESCRIPTION
This commit adds support for TLS client authentication in the CLI.
It adds the necessary fields to the config and CLI parameters, modeled
on the existing server-crt functionality.

It also fixes 2 bugs in the grpcproxy:
1. The grpcproxy would ignore the server-crt when making a call to the
upstream server.
2. The grpcproxy would falsely assume that the HTTP status code returned
by the upstream server is always 200. It would then try to parse the
body as if it was a grpc response. At best this led to weird errors
being shown, at worst I have seen it cause the runtime to run out of
memory.

Checklist:

* [ x ] (a) Enhancement issue: https://github.com/argoproj/argo-cd/issues/3778
         (b) Bug fixes: I had to fix 2 bugs to get the new functionality to work. I can create additional issues for these if necessary
* [ x ] The title of the PR states what changed and the related issues number (used for the release note).
* [ x ] I've updated both the CLI and UI to expose my feature.
