### PR TITLE
docs: add 1.5 - 1.6 upgrade instructions

### DIFF
--- a/docs/operator-manual/upgrading/1.4-1.5.md
+++ b/docs/operator-manual/upgrading/1.4-1.5.md
@@ -20,4 +20,8 @@ observed during the upgrade:
 (see [argo-cd#3547](https://github.com/argoproj/argo-cd/issues/3547), [DandyDeveloper/charts#26](https://github.com/DandyDeveloper/charts/issues/26)).
 As workaround "restart" `argocd-redis-ha-haproxy` Deployment and `argocd-redis-ha-server` StatefulSet.   
 
+## Upgraded Kustomize Version
+
+Note that bundled Kustomize has been upgraded to v3.6.1.
+
 From here on you can follow the [regular upgrade process](./overview.md).

--- a/docs/operator-manual/upgrading/1.5-1.6.md
+++ b/docs/operator-manual/upgrading/1.5-1.6.md
@@ -1,0 +1,8 @@
+# v1.5 to 1.6
+
+## Removed Deprecated Field of /managed-resources API
+
+The deprecated `diff` field had been removed from `/api/v1/applications/<app-name>/managed-resources` API. The field is not used
+by Argo CD CLI or UI, so it might affect you only if you programmatically use the `managed-resources` API.
+
+From here on you can follow the [regular upgrade process](./overview.md).

--- a/docs/security_considerations.md
+++ b/docs/security_considerations.md
@@ -13,7 +13,8 @@ no fix yet.
 
 |Date|CVE|Title|Risk|Affected version(s)|Fix version|
 |----|---|-----|----|-------------------|-----------|
-|2020-04-14|[CVE-2020-5260](https://nvd.nist.gov/vuln/detail/CVE-2020-5260)|Possible Git credential leak|Critical|all|v1.4.3,v1.5.2|
+|2020-06-16|[CVE-2020-1747](https://nvd.nist.gov/vuln/detail/CVE-2020-1747)|PyYAML library susceptible to arbitrary code execution|High|all|v1.5.8|
+|2020-04-14|[CVE-2020-5260](https://nvd.nist.gov/vuln/detail/CVE-2020-5260)|Possible Git credential leak|High|all|v1.4.3,v1.5.2|
 |2020-04-08|[CVE-2020-11576](https://nvd.nist.gov/vuln/detail/CVE-2020-11576)|User Enumeration|Medium|v1.5.0|v1.5.1|
 |2020-04-08|[CVE-2020-8826](https://nvd.nist.gov/vuln/detail/CVE-2020-8826)|Session-fixation|High|all|n/a|
 |2020-04-08|[CVE-2020-8827](https://nvd.nist.gov/vuln/detail/CVE-2020-8827)|Insufficient anti-automation/anti-brute force|High|all <= 1.5.3|v1.5.3|
@@ -25,6 +26,20 @@ no fix yet.
 A recent security audit (thanks a lot to [Matt Hamilton](https://github.com/Eriner) of [https://soluble.ai](https://soluble.ai) )
 has revealed several limitations in Argo CD which could compromise security.
 Most of the issues are related to the built-in user management implementation.
+
+### CVE-2020-1747 - PyYAML library susceptible to arbitrary code execution
+
+**Summary:**
+
+|Risk|Reported by|Fix version|Workaround|
+|----|-----------|-----------|----------|
+|High|[infa-kparida](https://github.com/infa-kparida)|v1.5.8|No|
+
+**Details:**
+
+PyYAML library susceptible to arbitrary code execution when it processes untrusted YAML files.
+We do not believe ArgoCD is affected by this vulnerability, because the impact of CVE-2020-1747 is limited to usage of awscli.
+The `awscli` only used for AWS IAM authentication, and the endpoint is the AWS API.
 
 ### CVE-2020-5260 - Possible Git credential leak
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - operator-manual/troubleshooting.md
     - Upgrading:
         - operator-manual/upgrading/overview.md
+        - operator-manual/upgrading/1.5-1.6.md
         - operator-manual/upgrading/1.4-1.5.md
         - operator-manual/upgrading/1.3-1.4.md
         - operator-manual/upgrading/1.2-1.3.md


### PR DESCRIPTION
PR documents 1.5 - 1.6 upgrade steps.
Additionally, it adds vulnerability to the security considerations doc.