### PR TITLE
docs: Add clarification when working with Github webhook

### DIFF
--- a/docs/operator-manual/webhook.md
+++ b/docs/operator-manual/webhook.md
@@ -16,6 +16,9 @@ arbitrary value in the secret. This value will be used when configuring the webh
 
 ![Add Webhook](../assets/webhook-config.png "Add Webhook")
 
+!!! note
+    When creating the webhook in Github, the "Content type" needs to be set to "application/json". The default value "application/x-www-form-urlencoded" is not supported by the library used to handle the hooks
+
 ### 2. Configure Argo CD With The WebHook Secret (Optional)
 
 Configuring a webhook shared secret is optional, since Argo CD will still refresh applications


### PR DESCRIPTION
When creating the webhook in Github (enterprise, not sure if it happens in Github.com), The default "Content type" is "application/x-www-form-urlencoded". After some time debugging it I found the library used to handle the hooks (https://github.com/go-playground/webhooks) only supports 'application/json'.

I just noticed that the screenshot has the 'application/json' selected, but since the default is "application/x-www-form-urlencoded" it  can be easily overlooked and create some frustration when the hooks doesn't work as expected. 

Someone else from my team tried to activate the hooks a while ago an assumed they weren't working, and probably this was the reason :S

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
