### PR TITLE
fix: return default scopes if custom scopes are not configured

### DIFF
--- a/server/rbacpolicy/rbacpolicy.go
+++ b/server/rbacpolicy/rbacpolicy.go
@@ -73,7 +73,11 @@ func (p *RBACPolicyEnforcer) SetScopes(scopes []string) {
 }
 
 func (p *RBACPolicyEnforcer) GetScopes() []string {
-	return p.scopes
+	scopes := p.scopes
+	if scopes == nil {
+		scopes = defaultScopes
+	}
+	return scopes
 }
 
 func IsProjectSubject(subject string) bool {

--- a/server/rbacpolicy/rbacpolicy_test.go
+++ b/server/rbacpolicy/rbacpolicy_test.go
@@ -108,3 +108,19 @@ p, cam, applications, %s/argoproj.io/Rollout/resume, my-proj/*, allow
 	claims = jwt.MapClaims{"sub": "eve"}
 	assert.False(t, enf.Enforce(claims, "applications", ActionAction+"/argoproj.io/Rollout/resume", "my-proj/my-app"))
 }
+
+func TestGetScopes_DefaultScopes(t *testing.T) {
+	rbacEnforcer := NewRBACPolicyEnforcer(nil, nil)
+
+	scopes := rbacEnforcer.GetScopes()
+	assert.Equal(t, scopes, defaultScopes)
+}
+
+func TestGetScopes_CustomScopes(t *testing.T) {
+	rbacEnforcer := NewRBACPolicyEnforcer(nil, nil)
+	customScopes := []string{"custom"}
+	rbacEnforcer.SetScopes(customScopes)
+
+	scopes := rbacEnforcer.GetScopes()
+	assert.Equal(t, scopes, customScopes)
+}


### PR DESCRIPTION
Closes #3804 
