### PR TITLE
fix: correcting regex for matching SHAs

### DIFF
--- a/ui/src/app/shared/components/__snapshots__/revision.test.tsx.snap
+++ b/ui/src/app/shared/components/__snapshots__/revision.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Revision.Branch.Children 1`] = `
 <a
-  href="http://github.com/my-org/my-repo/commit/long-branch-name"
+  href="http://github.com/my-org/my-repo/tree/long-branch-name"
 >
   foo
 </a>
@@ -10,7 +10,7 @@ exports[`Revision.Branch.Children 1`] = `
 
 exports[`Revision.Branch.NoChildren 1`] = `
 <a
-  href="http://github.com/my-org/my-repo/commit/long-branch-name"
+  href="http://github.com/my-org/my-repo/tree/long-branch-name"
 >
   long-branch-name
 </a>

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -10,5 +10,5 @@ export const Revision = ({repoUrl, revision, children}: {repoUrl: string; revisi
 
 export const isSHA = (revision: string) => {
     // https://stackoverflow.com/questions/468370/a-regex-to-match-a-sha1
-    return revision.match(/[0-9a-f]{5,40}/) !== null;
+    return revision.match(/^[a-f0-9]{5,40}$/) !== null;
 };

--- a/ui/src/app/shared/components/urls.ts
+++ b/ui/src/app/shared/components/urls.ts
@@ -1,4 +1,5 @@
 import {GitUrl} from 'git-url-parse';
+import {isSHA} from './revision';
 
 const GitUrlParse = require('git-url-parse');
 
@@ -22,10 +23,15 @@ export function repoUrl(url: string): string {
 
 export function revisionUrl(url: string, revision: string): string {
     const parsed = GitUrlParse(url);
+    let urlSubPath = isSHA(revision) ? 'commit' : 'tree';
+
+    if (url.indexOf('bitbucket') >= 0) {
+        urlSubPath = isSHA(revision) ? 'commits' : 'branch';
+    }
 
     if (!supportedSource(parsed)) {
         return null;
     }
 
-    return `${protocol(parsed.protocol)}://${parsed.resource}/${parsed.owner}/${parsed.name}/${url.indexOf('bitbucket') >= 0 ? 'commits' : 'commit'}/${revision || 'HEAD'}`;
+    return `${protocol(parsed.protocol)}://${parsed.resource}/${parsed.owner}/${parsed.name}/${urlSubPath}/${revision || 'HEAD'}`;
 }


### PR DESCRIPTION
caused some targetRevisions to be treated like commits instead of branches, also fixed URLs for github repos

3801

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
![Annotation 2020-06-20 201207](https://user-images.githubusercontent.com/5673097/85215810-55f3d000-b332-11ea-8e83-08de4a017bd5.png)