### PR TITLE
fix: application controller should not modify cached applications

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/argoproj/argo-cd/controller/metrics"
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/util/argo"
 	"github.com/argoproj/argo-cd/util/db"
 	"github.com/argoproj/argo-cd/util/lua"
 	"github.com/argoproj/argo-cd/util/settings"
@@ -351,9 +352,17 @@ func (c *liveStateCache) GetVersionsInfo(serverURL string) (string, []metav1.API
 	return clusterInfo.GetServerVersion(), clusterInfo.GetAPIGroups(), nil
 }
 
-func isClusterHasApps(apps []interface{}, cluster *appv1.Cluster) bool {
+func (c *liveStateCache) isClusterHasApps(apps []interface{}, cluster *appv1.Cluster) bool {
 	for _, obj := range apps {
-		if app, ok := obj.(*appv1.Application); ok && app.Spec.Destination.Server == cluster.Server {
+		app, ok := obj.(*appv1.Application)
+		if !ok {
+			continue
+		}
+		err := argo.ValidateDestination(context.Background(), &app.Spec.Destination, c.db)
+		if err != nil {
+			continue
+		}
+		if app.Spec.Destination.Server == cluster.Server {
 			return true
 		}
 	}
@@ -420,7 +429,7 @@ func (c *liveStateCache) handleAddEvent(cluster *appv1.Cluster) {
 	_, ok := c.clusters[cluster.Server]
 	c.lock.Unlock()
 	if !ok {
-		if isClusterHasApps(c.appInformer.GetStore().List(), cluster) {
+		if c.isClusterHasApps(c.appInformer.GetStore().List(), cluster) {
 			go func() {
 				// warm up cache for cluster with apps
 				_, _ = c.getSyncedCluster(cluster.Server)

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -689,8 +689,8 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 		return err
 	}
 
-	if cond := argo.ValidateDestination(ctx, &app.Spec.Destination, s.db); cond != nil {
-		return status.Errorf(codes.InvalidArgument, "application destination spec is invalid: %s", argo.FormatAppConditions([]appv1.ApplicationCondition{*cond}))
+	if err := argo.ValidateDestination(ctx, &app.Spec.Destination, s.db); err != nil {
+		return status.Errorf(codes.InvalidArgument, "application destination spec is invalid: %s", err.Error())
 	}
 
 	conditions, err := argo.ValidateRepo(ctx, app, s.repoClientset, s.db, kustomizeOptions, plugins, s.kubectl)
@@ -714,8 +714,8 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 }
 
 func (s *Server) getApplicationClusterConfig(ctx context.Context, a *appv1.Application) (*rest.Config, error) {
-	if condition := argo.ValidateDestination(ctx, &a.Spec.Destination, s.db); condition != nil {
-		return nil, errors.New(condition.Message)
+	if err := argo.ValidateDestination(ctx, &a.Spec.Destination, s.db); err != nil {
+		return nil, err
 	}
 	clst, err := s.db.GetCluster(ctx, a.Spec.Destination.Server)
 	if err != nil {

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -623,9 +623,8 @@ func TestValidateDestination(t *testing.T) {
 			Namespace: "default",
 		}
 
-		appCond := ValidateDestination(context.Background(), &dest, nil)
-		assert.Equal(t, argoappv1.ApplicationConditionInvalidSpecError, appCond.Type)
-		assert.Equal(t, "application destination can't have both name and server defined: minikube https://127.0.0.1:6443", appCond.Message)
+		err := ValidateDestination(context.Background(), &dest, nil)
+		assert.Equal(t, "application destination can't have both name and server defined: minikube https://127.0.0.1:6443", err.Error())
 		assert.False(t, dest.IsServerInferred())
 	})
 
@@ -637,9 +636,8 @@ func TestValidateDestination(t *testing.T) {
 		db := &dbmocks.ArgoDB{}
 		db.On("ListClusters", context.Background()).Return(nil, fmt.Errorf("an error occured"))
 
-		appCond := ValidateDestination(context.Background(), &dest, db)
-		assert.Equal(t, argoappv1.ApplicationConditionInvalidSpecError, appCond.Type)
-		assert.Equal(t, "unable to find destination server: an error occured", appCond.Message)
+		err := ValidateDestination(context.Background(), &dest, db)
+		assert.Equal(t, "unable to find destination server: an error occured", err.Error())
 		assert.False(t, dest.IsServerInferred())
 	})
 
@@ -658,9 +656,8 @@ func TestValidateDestination(t *testing.T) {
 			},
 		}, nil)
 
-		appCond := ValidateDestination(context.Background(), &dest, db)
-		assert.Equal(t, argoappv1.ApplicationConditionInvalidSpecError, appCond.Type)
-		assert.Equal(t, "unable to find destination server: there are no clusters with this name: minikube", appCond.Message)
+		err := ValidateDestination(context.Background(), &dest, db)
+		assert.Equal(t, "unable to find destination server: there are no clusters with this name: minikube", err.Error())
 		assert.False(t, dest.IsServerInferred())
 	})
 
@@ -683,9 +680,8 @@ func TestValidateDestination(t *testing.T) {
 			},
 		}, nil)
 
-		appCond := ValidateDestination(context.Background(), &dest, db)
-		assert.Equal(t, argoappv1.ApplicationConditionInvalidSpecError, appCond.Type)
-		assert.Equal(t, "unable to find destination server: there are 2 clusters with the same name: [https://127.0.0.1:2443 https://127.0.0.1:8443]", appCond.Message)
+		err := ValidateDestination(context.Background(), &dest, db)
+		assert.Equal(t, "unable to find destination server: there are 2 clusters with the same name: [https://127.0.0.1:2443 https://127.0.0.1:8443]", err.Error())
 		assert.False(t, dest.IsServerInferred())
 	})
 


### PR DESCRIPTION
PR fixes few minor issues in app controller:

* controller should now modify application objects stored in informer cache
* controller should call `argo.ValidateDestination` to correctly find clusters with the applications
