### PR TITLE
fix: rename redis histogram metric name

### DIFF
--- a/reposerver/metrics/metrics.go
+++ b/reposerver/metrics/metrics.go
@@ -59,8 +59,8 @@ func NewMetricsServer() *MetricsServer {
 
 	redisRequestHistogram := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "argocd_redis_request_duration",
-			Help:    "Redis requests duration.",
+			Name:    "argocd_redis_request_duration_seconds",
+			Help:    "Redis requests duration seconds.",
 			Buckets: []float64{0.1, 0.25, .5, 1, 2},
 		},
 		[]string{"initiator"},


### PR DESCRIPTION
Change histogram metric name to follow https://prometheus.io/docs/practices/naming/#metric-names

This is sort of a breaking change

Ref: https://github.com/argoproj/argo-cd/issues/3777