### PR TITLE
docs: Minor format correction on Auth0 documentation

### DIFF
--- a/docs/operator-manual/user-management/auth0.md
+++ b/docs/operator-manual/user-management/auth0.md
@@ -8,6 +8,7 @@ User-definitions in Auth0 is out of scope for this guide. Add them directly in A
 ## Registering the app with Auth0
 
 Follow the [register app](https://auth0.com/docs/dashboard/guides/applications/register-app-spa) instructions to create the argocd app in Auth0. In the app definition:
+
 * Take note of the _clientId_ and _clientSecret_ values.
 * Register login url as https://your.argoingress.address/login
 * Set allowed callback url to https://your.argoingress.address/auth/callback


### PR DESCRIPTION
Correct bullet format, which looked fine on GitHub but wasn't rendered correctly on https://argoproj.github.io/argo-cd/operator-manual/user-management/auth0/

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
