### PR TITLE
refactor: Migrate JSON marshaler from gitops-engine to argo-cd

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/errors"
 	"github.com/argoproj/gitops-engine/pkg/utils/io"
-	jsonutil "github.com/argoproj/gitops-engine/pkg/utils/json"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/go-redis/redis"
@@ -616,7 +615,7 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 	// golang/protobuf. Which does not support types such as time.Time. gogo/protobuf does support
 	// time.Time, but does not support custom UnmarshalJSON() and MarshalJSON() methods. Therefore
 	// we use our own Marshaler
-	gwMuxOpts := runtime.WithMarshalerOption(runtime.MIMEWildcard, new(jsonutil.JSONMarshaler))
+	gwMuxOpts := runtime.WithMarshalerOption(runtime.MIMEWildcard, new(grpc_util.JSONMarshaler))
 	gwCookieOpts := runtime.WithForwardResponseOption(a.translateGrpcCookieHeader)
 	gwmux := runtime.NewServeMux(gwMuxOpts, gwCookieOpts)
 	mux.Handle("/api/", gwmux)

--- a/util/grpc/json.go
+++ b/util/grpc/json.go
@@ -34,4 +34,3 @@ func (j *JSONMarshaler) NewEncoder(w io.Writer) gwruntime.Encoder {
 func (j *JSONMarshaler) Unmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
-

--- a/util/grpc/json.go
+++ b/util/grpc/json.go
@@ -1,0 +1,37 @@
+package grpc
+
+import (
+	"encoding/json"
+	"io"
+
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// JSONMarshaler is a type which satisfies the grpc-gateway Marshaler interface
+type JSONMarshaler struct{}
+
+// ContentType implements gwruntime.Marshaler.
+func (j *JSONMarshaler) ContentType() string {
+	return "application/json"
+}
+
+// Marshal implements gwruntime.Marshaler.
+func (j *JSONMarshaler) Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// NewDecoder implements gwruntime.Marshaler.
+func (j *JSONMarshaler) NewDecoder(r io.Reader) gwruntime.Decoder {
+	return json.NewDecoder(r)
+}
+
+// NewEncoder implements gwruntime.Marshaler.
+func (j *JSONMarshaler) NewEncoder(w io.Writer) gwruntime.Encoder {
+	return json.NewEncoder(w)
+}
+
+// Unmarshal implements gwruntime.Marshaler.
+func (j *JSONMarshaler) Unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}
+


### PR DESCRIPTION
To fix building against latest gitops-engine changes introduced with https://github.com/argoproj/gitops-engine/pull/63

Checklist:

* [x]  (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
