### PR TITLE
feat: make argocd installation manifests Istio compatible #2784

### DIFF
--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -13,13 +13,14 @@ cd ${SRCROOT}/manifests/ha/base/redis-ha && ./generate.sh
 
 IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-argoproj}"
 IMAGE_TAG="${IMAGE_TAG:-}"
+ARGOCD_VERSION_LABEL=v$(cat $SRCROOT/VERSION)
 
 # if the tag has not been declared, and we are on a release branch, use the VERSION file.
 if [ "$IMAGE_TAG" = "" ]; then
   branch=$(git rev-parse --abbrev-ref HEAD)
   if [[ $branch = release-* ]]; then
     pwd
-    IMAGE_TAG=v$(cat $SRCROOT/VERSION)
+    IMAGE_TAG=${ARGOCD_VERSION_LABEL}
   fi
 fi
 # otherwise, use latest
@@ -27,7 +28,7 @@ if [ "$IMAGE_TAG" = "" ]; then
   IMAGE_TAG=latest
 fi
 
-cd ${SRCROOT}/manifests/base && $KUSTOMIZE edit set image argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
+cd ${SRCROOT}/manifests/base && $KUSTOMIZE edit set image argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG} && sed "s/ARGOCD_VERSION_TO_BE_REPLACED/${ARGOCD_VERSION_LABEL}/g" version_label_patches.tmpl > version_label_patches.yaml
 cd ${SRCROOT}/manifests/ha/base && $KUSTOMIZE edit set image argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
 
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install.yaml"

--- a/manifests/base/application-controller/argocd-application-controller-deployment.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: application-controller
+    app: argocd-application-controller
   name: argocd-application-controller
 spec:
   strategy:
@@ -16,6 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-application-controller
+        app: argocd-application-controller
     spec:
       containers:
       - command:

--- a/manifests/base/application-controller/argocd-metrics.yaml
+++ b/manifests/base/application-controller/argocd-metrics.yaml
@@ -8,7 +8,7 @@ metadata:
   name: argocd-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-argocdacmetrics
     protocol: TCP
     port: 8082
     targetPort: 8082

--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: dex-server
+    app: argocd-dex-server
+    version: v2.22.0
   name: argocd-dex-server
 spec:
   selector:
@@ -14,6 +16,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-dex-server
+        app: argocd-dex-server
+        version: v2.22.0
     spec:
       serviceAccountName: argocd-dex-server
       initContainers:

--- a/manifests/base/dex/argocd-dex-server-service.yaml
+++ b/manifests/base/dex/argocd-dex-server-service.yaml
@@ -8,15 +8,15 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - name: http-argocddex
     protocol: TCP
     port: 5556
     targetPort: 5556
-  - name: grpc
+  - name: grpc-argocddex
     protocol: TCP
     port: 5557
     targetPort: 5557
-  - name: metrics
+  - name: http-argocddexmetrics
     port: 5558
     protocol: TCP
     targetPort: 5558

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -13,3 +13,7 @@ images:
 - name: argoproj/argocd
   newName: argoproj/argocd
   newTag: latest
+
+patchesStrategicMerge:
+- version_label_patches.yaml
+

--- a/manifests/base/redis/argocd-redis-deployment.yaml
+++ b/manifests/base/redis/argocd-redis-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: redis
+    app: argocd-redis
+    version: v5.0.8
   name: argocd-redis
 spec:
   selector:
@@ -14,6 +16,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-redis
+        app: argocd-redis
+        version: v5.0.8
     spec:
       containers:
       - name: redis

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: repo-server
+    app: argocd-repo-server
   name: argocd-repo-server
 spec:
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-repo-server
+        app: argocd-repo-server
     spec:
       automountServiceAccountToken: false
       containers:

--- a/manifests/base/repo-server/argocd-repo-server-service.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-service.yaml
@@ -8,11 +8,11 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - name: server
+  - name: https-argocdreposerver
     protocol: TCP
     port: 8081
     targetPort: 8081
-  - name: metrics
+  - name: http-argocdreposervermetrics
     protocol: TCP
     port: 8084
     targetPort: 8084

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: server
+    app: argocd-server
   name: argocd-server
 spec:
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-server
+        app: argocd-server
     spec:
       serviceAccountName: argocd-server
       containers:

--- a/manifests/base/server/argocd-server-metrics.yaml
+++ b/manifests/base/server/argocd-server-metrics.yaml
@@ -8,7 +8,7 @@ metadata:
   name: argocd-server-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-argocdservermetrics
     protocol: TCP
     port: 8083
     targetPort: 8083

--- a/manifests/base/server/argocd-server-service.yaml
+++ b/manifests/base/server/argocd-server-service.yaml
@@ -8,11 +8,11 @@ metadata:
   name: argocd-server
 spec:
   ports:
-  - name: http
+  - name: tcp-argocdserver
     protocol: TCP
     port: 80
     targetPort: 8080
-  - name: https
+  - name: tcp-argocdservertls
     protocol: TCP
     port: 443
     targetPort: 8080

--- a/manifests/base/version_label_patches.tmpl
+++ b/manifests/base/version_label_patches.tmpl
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+  labels:
+    version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        version: ARGOCD_VERSION_TO_BE_REPLACED
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+  labels:
+    version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        version: ARGOCD_VERSION_TO_BE_REPLACED
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-application-controller
+  labels:
+    version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/base/version_label_patches.yaml
+++ b/manifests/base/version_label_patches.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+  labels:
+    version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        version: v1.7.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+  labels:
+    version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        version: v1.7.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-application-controller
+  labels:
+    version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        version: v1.7.0


### PR DESCRIPTION
Checklist:

* [ X ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ X ] The title of the PR states what changed and the related issues number (used for the release note).
* [ X ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ Partially ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

I've signed the CLA no test build was done as I did not touch code.

This PR makes argocd installation manifests compatible with Istio. It implements this request: https://github.com/argoproj/argo-cd/issues/2784

In case this is accepted I will make a PR to have 2 examples with Istio ingress:
* TLS termination at Istio Ingress gateway
* TLS termination at ArgoCD server (Istio ingress gateway is configured to TLS PASSTHROUGH)