### PR TITLE
fix: sort application summary images and urls to avoid unnecessary updates

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -845,10 +845,16 @@ func (t *ApplicationTree) GetSummary() ApplicationSummary {
 	for url := range urlsSet {
 		urls = append(urls, url)
 	}
+	sort.Slice(urls, func(i, j int) bool {
+		return urls[i] < urls[j]
+	})
 	images := make([]string, 0)
 	for image := range imagesSet {
 		images = append(images, image)
 	}
+	sort.Slice(images, func(i, j int) bool {
+		return images[i] < images[j]
+	})
 	return ApplicationSummary{ExternalURLs: urls, Images: images}
 }
 


### PR DESCRIPTION
PR ensures that application summary URLs and Images are sorted. This allows avoiding updating application CR if images/url order is the only change.
