### PR TITLE
fix: application list page consumes too much CPU

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1746,11 +1746,11 @@ func waitOnApplicationStatus(acdClient apiclient.Client, appName string, timeout
 	_, _ = fmt.Fprintf(w, waitFormatString, "TIMESTAMP", "GROUP", "KIND", "NAMESPACE", "NAME", "STATUS", "HEALTH", "HOOK", "MESSAGE")
 
 	prevStates := make(map[string]*resourceState)
-	appEventCh := acdClient.WatchApplicationWithRetry(ctx, appName)
 	conn, appClient := acdClient.NewApplicationClientOrDie()
 	defer argoio.Close(conn)
 	app, err := appClient.Get(ctx, &applicationpkg.ApplicationQuery{Name: &appName})
 	errors.CheckError(err)
+	appEventCh := acdClient.WatchApplicationWithRetry(ctx, appName, app.ResourceVersion)
 
 	for appEvent := range appEventCh {
 		app = &appEvent.Application

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/argoproj/gitops-engine v0.1.3-0.20200624184852-ce9616ad10da
-	github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54
+	github.com/argoproj/pkg v0.0.0-20200624215116-23e74cb168fe
 	github.com/bsm/redislock v0.4.3
 	github.com/casbin/casbin v1.9.1
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/argoproj/gitops-engine v0.1.3-0.20200624184852-ce9616ad10da h1:dPzchrZaO8C4yhnosaX9ZltOCAwqAZUzfovIqbrrprI=
 github.com/argoproj/gitops-engine v0.1.3-0.20200624184852-ce9616ad10da/go.mod h1:Wz/VrkZzWx4Hdsyl/i1woG1wrsiiLqlDHfqgl4FPais=
 github.com/argoproj/pkg v0.0.0-20200102163130-2dd1f3f6b4de/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=
-github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54 h1:hDn02iEkh5EUl4TJfOo6AI9uSgh0vt/qh66ODuQl/YE=
-github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=
+github.com/argoproj/pkg v0.0.0-20200624215116-23e74cb168fe h1:HjTM7H8Z+J1xt340LNpH9q4jc8pXeqzkC8QKIjQphp4=
+github.com/argoproj/pkg v0.0.0-20200624215116-23e74cb168fe/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -83,7 +83,7 @@ type Client interface {
 	NewProjectClientOrDie() (io.Closer, projectpkg.ProjectServiceClient)
 	NewAccountClient() (io.Closer, accountpkg.AccountServiceClient, error)
 	NewAccountClientOrDie() (io.Closer, accountpkg.AccountServiceClient)
-	WatchApplicationWithRetry(ctx context.Context, appName string) chan *argoappv1.ApplicationWatchEvent
+	WatchApplicationWithRetry(ctx context.Context, appName string, revision string) chan *argoappv1.ApplicationWatchEvent
 }
 
 // ClientOptions hold address, security, and other settings for the API client.
@@ -683,7 +683,7 @@ func (c *client) NewAccountClientOrDie() (io.Closer, accountpkg.AccountServiceCl
 
 // WatchApplicationWithRetry returns a channel of watch events for an application, retrying the
 // watch upon errors. Closes the returned channel when the context is cancelled.
-func (c *client) WatchApplicationWithRetry(ctx context.Context, appName string) chan *argoappv1.ApplicationWatchEvent {
+func (c *client) WatchApplicationWithRetry(ctx context.Context, appName string, revision string) chan *argoappv1.ApplicationWatchEvent {
 	appEventsCh := make(chan *argoappv1.ApplicationWatchEvent)
 	cancelled := false
 	go func() {

--- a/pkg/apiclient/application/forwarder_overwrite.go
+++ b/pkg/apiclient/application/forwarder_overwrite.go
@@ -1,12 +1,23 @@
 package application
 
 import (
+	"errors"
+
 	"github.com/argoproj/pkg/grpc/http"
+	"github.com/golang/protobuf/proto"
+
+	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 )
 
 func init() {
 	forward_ApplicationService_PodLogs_0 = http.StreamForwarder
-	forward_ApplicationService_Watch_0 = http.StreamForwarder
+	forward_ApplicationService_Watch_0 = http.NewStreamForwarder(func(message proto.Message) (string, error) {
+		event, ok := message.(*v1alpha1.ApplicationWatchEvent)
+		if !ok {
+			return "", errors.New("unexpected message type")
+		}
+		return event.Application.Name, nil
+	})
 	forward_ApplicationService_List_0 = http.UnaryForwarder
 	forward_ApplicationService_ManagedResources_0 = http.UnaryForwarder
 }

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -167,6 +167,7 @@ func newTestAppServer(objects ...runtime.Object) *Server {
 		kubeclientset,
 		fakeAppsClientset,
 		factory.Argoproj().V1alpha1().Applications().Lister().Applications(testNamespace),
+		appInformer,
 		mockRepoClient,
 		nil,
 		&kubetest.MockKubectlCmd{},

--- a/server/application/broadcaster.go
+++ b/server/application/broadcaster.go
@@ -1,0 +1,55 @@
+package application
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+
+	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+)
+
+type broadcasterHandler struct {
+	lock        sync.Mutex
+	subscribers []chan *appv1.ApplicationWatchEvent
+}
+
+func (b *broadcasterHandler) notify(event *appv1.ApplicationWatchEvent) {
+	subscribers := b.subscribers
+	for i := range subscribers {
+		subscribers[i] <- event
+	}
+}
+
+func (b *broadcasterHandler) Subscribe(subscriber chan *appv1.ApplicationWatchEvent) func() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	b.subscribers = append(b.subscribers, subscriber)
+	return func() {
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		for i := range b.subscribers {
+			if b.subscribers[i] == subscriber {
+				b.subscribers = append(b.subscribers[:i], b.subscribers[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+func (b *broadcasterHandler) OnAdd(obj interface{}) {
+	if app, ok := obj.(*appv1.Application); ok {
+		b.notify(&appv1.ApplicationWatchEvent{Application: *app, Type: watch.Added})
+	}
+}
+
+func (b *broadcasterHandler) OnUpdate(_, newObj interface{}) {
+	if app, ok := newObj.(*appv1.Application); ok {
+		b.notify(&appv1.ApplicationWatchEvent{Application: *app, Type: watch.Modified})
+	}
+}
+
+func (b *broadcasterHandler) OnDelete(obj interface{}) {
+	if app, ok := obj.(*appv1.Application); ok {
+		b.notify(&appv1.ApplicationWatchEvent{Application: *app, Type: watch.Deleted})
+	}
+}

--- a/server/application/broadcaster_test.go
+++ b/server/application/broadcaster_test.go
@@ -1,0 +1,53 @@
+package application
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+)
+
+func TestBroadcasterHandler_SubscribeUnsubscribe(t *testing.T) {
+	broadcaster := broadcasterHandler{}
+
+	subscriber := make(chan *appv1.ApplicationWatchEvent)
+	unsubscribe := broadcaster.Subscribe(subscriber)
+
+	assert.ElementsMatch(t, broadcaster.subscribers, []chan *appv1.ApplicationWatchEvent{subscriber})
+
+	unsubscribe()
+	assert.Empty(t, broadcaster.subscribers)
+}
+
+func TestBroadcasterHandler_ReceiveEvents(t *testing.T) {
+	broadcaster := broadcasterHandler{}
+
+	subscriber1 := make(chan *appv1.ApplicationWatchEvent)
+	subscriber2 := make(chan *appv1.ApplicationWatchEvent)
+
+	_ = broadcaster.Subscribe(subscriber1)
+	_ = broadcaster.Subscribe(subscriber2)
+
+	firstReceived := false
+	secondReceived := false
+
+	go broadcaster.notify(&appv1.ApplicationWatchEvent{})
+
+	for {
+		select {
+		case <-time.After(1 * time.Second):
+			t.Error("timeout expired")
+			return
+		case <-subscriber1:
+			firstReceived = true
+		case <-subscriber2:
+			secondReceived = true
+		}
+		if firstReceived && secondReceived {
+			return
+		}
+	}
+
+}

--- a/server/server.go
+++ b/server/server.go
@@ -510,7 +510,7 @@ func (a *ArgoCDServer) newGRPCServer() *grpc.Server {
 	}
 	sessionService := session.NewServer(a.sessionMgr, a, a.policyEnforcer, loginRateLimiter)
 	projectLock := util.NewKeyLock()
-	applicationService := application.NewServer(a.Namespace, a.KubeClientset, a.AppClientset, a.appLister, a.RepoClientset, a.Cache, kubectl, db, a.enf, projectLock, a.settingsMgr)
+	applicationService := application.NewServer(a.Namespace, a.KubeClientset, a.AppClientset, a.appLister, a.appInformer, a.RepoClientset, a.Cache, kubectl, db, a.enf, projectLock, a.settingsMgr)
 	projectService := project.NewServer(a.Namespace, a.KubeClientset, a.AppClientset, a.enf, projectLock, a.sessionMgr, a.policyEnforcer)
 	settingsService := settings.NewServer(a.settingsMgr, a, a.DisableAuth)
 	accountService := account.NewServer(a.sessionMgr, a.settingsMgr, a.enf)

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -927,7 +927,7 @@ func TestSelfManagedApps(t *testing.T) {
 
 			reconciledCount := 0
 			var lastReconciledAt *metav1.Time
-			for event := range ArgoCDClientset.WatchApplicationWithRetry(ctx, a.Name) {
+			for event := range ArgoCDClientset.WatchApplicationWithRetry(ctx, a.Name, a.ResourceVersion) {
 				reconciledAt := event.Application.Status.ReconciledAt
 				if reconciledAt == nil {
 					reconciledAt = &metav1.Time{}

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -25,7 +25,6 @@ const APP_FIELDS = [
     'metadata.name',
     'metadata.annotations',
     'metadata.labels',
-    'metadata.resourceVersion',
     'metadata.creationTimestamp',
     'metadata.deletionTimestamp',
     'spec',
@@ -47,9 +46,6 @@ function loadApplications(): Observable<models.Application[]> {
                 .watch(null, {fields: APP_WATCH_FIELDS})
                 .map(appChange => {
                     const index = applications.findIndex(item => item.metadata.name === appChange.application.metadata.name);
-                    if (index > -1 && appChange.application.metadata.resourceVersion === applications[index].metadata.resourceVersion) {
-                        return {applications, updated: false};
-                    }
                     switch (appChange.type) {
                         case 'DELETED':
                             if (index > -1) {


### PR DESCRIPTION
PR implements following changes to improve UI performance. 

* leverages `http.NewStreamForwarder` with the key function instead of `http.StreamForwarder`. The new forwarder sends message only if any of requested fields have changed. This significantly reduce number of messages sent by application/stream API on application list page.
* changes `Watch` API to use informer which restarts watch API. Without informer UI has to re-execute watch API everytime when watch closes - this is happening very frequently if number of applications is large.

Closes #3730