### PR TITLE
feat: Allow $secretKey syntax for clientID in dex.config of argocd-cm (#3131)

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -968,6 +968,7 @@ func (a *ArgoCDSettings) OIDCConfig() *OIDCConfig {
 		return nil
 	}
 	oidcConfig.ClientSecret = ReplaceStringSecret(oidcConfig.ClientSecret, a.Secrets)
+	oidcConfig.ClientID = ReplaceStringSecret(oidcConfig.ClientID, a.Secrets)
 	return &oidcConfig
 }
 


### PR DESCRIPTION
Allow $secretKey syntax for clientID in dex.config of argocd-cm, pass the clientID around the same function as the client secret.

Issue Reference: #3131 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
