### PR TITLE
fix: allow duplicates when using generateName

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -205,6 +205,9 @@ func DeduplicateTargetObjects(
 			obj.SetNamespace(namespace)
 		}
 		key := kubeutil.GetResourceKey(obj)
+		if key.Name == "" && obj.GetGenerateName() != "" {
+			key.Name = fmt.Sprintf("%s%d", obj.GetGenerateName(), i)
+		}
 		targetByKey[key] = append(targetByKey[key], obj)
 	}
 	conditions := make([]v1alpha1.ApplicationCondition, 0)

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -188,11 +188,17 @@ func TestCompareAppStateDuplicatedNamespacedResources(t *testing.T) {
 	obj2 := NewPod()
 	obj3 := NewPod()
 	obj3.SetNamespace("kube-system")
+	obj4 := NewPod()
+	obj4.SetGenerateName("my-pod")
+	obj4.SetName("")
+	obj5 := NewPod()
+	obj5.SetName("")
+	obj5.SetGenerateName("my-pod")
 
 	app := newFakeApp()
 	data := fakeData{
 		manifestResponse: &apiclient.ManifestResponse{
-			Manifests: []string{toJSON(t, obj1), toJSON(t, obj2), toJSON(t, obj3)},
+			Manifests: []string{toJSON(t, obj1), toJSON(t, obj2), toJSON(t, obj3), toJSON(t, obj4), toJSON(t, obj5)},
 			Namespace: test.FakeDestNamespace,
 			Server:    test.FakeClusterURL,
 			Revision:  "abc123",
@@ -210,7 +216,7 @@ func TestCompareAppStateDuplicatedNamespacedResources(t *testing.T) {
 	assert.NotNil(t, app.Status.Conditions[0].LastTransitionTime)
 	assert.Equal(t, argoappv1.ApplicationConditionRepeatedResourceWarning, app.Status.Conditions[0].Type)
 	assert.Equal(t, "Resource /Pod/fake-dest-ns/my-pod appeared 2 times among application resources.", app.Status.Conditions[0].Message)
-	assert.Equal(t, 2, len(compRes.resources))
+	assert.Equal(t, 4, len(compRes.resources))
 }
 
 var defaultProj = argoappv1.AppProject{


### PR DESCRIPTION
* Generate Name field generates names when created so should not cause a duplication warning
* Updating existing test case to check no additional conditions are added

(bug report: #3858 )

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
