### PR TITLE
fix: more space for application title

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -9,6 +9,7 @@
         color: $argo-color-gray-6;
         padding-top: 0.25em;
         padding-bottom: 0.5em;
+        margin-left: 1em;
     }
 
     &__info {

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -34,10 +34,10 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                         <ApplicationURLs urls={app.status.summary.externalURLs} />
                                     </div>
                                     <div className='row'>
-                                        <div className='columns small-3'>
+                                        <div className='columns small-12'>
                                             <i className={'icon argo-icon-' + (app.spec.source.chart != null ? 'helm' : 'git')} />
+                                            <span className='applications-list__title'>{app.metadata.name}</span>
                                         </div>
-                                        <div className='columns applications-list__title'>{app.metadata.name}</div>
                                     </div>
                                     <div className='row'>
                                         <div className='columns small-3'>Project:</div>


### PR DESCRIPTION
PR updated application list page and provides a little more space for application title:

before:

![image](https://user-images.githubusercontent.com/426437/86154787-689ba100-bab8-11ea-9935-6508346e4b4c.png)

after:

![image](https://user-images.githubusercontent.com/426437/86155102-cc25ce80-bab8-11ea-89de-4751e44acd9a.png)
