### PR TITLE
chore: make make cli use virtualized toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,8 +120,8 @@ RUN make cli server controller repo-server argocd-util
 
 ARG BUILD_ALL_CLIS=true
 RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
-    make CLI_NAME=argocd-darwin-amd64 GOOS=darwin cli && \
-    make CLI_NAME=argocd-windows-amd64.exe GOOS=windows cli \
+    make CLI_NAME=argocd-darwin-amd64 GOOS=darwin cli-local && \
+    make CLI_NAME=argocd-windows-amd64.exe GOOS=windows cli-local \
     ; fi
 
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ RUN go mod download
 
 # Perform the build
 COPY . .
-RUN make cli server controller repo-server argocd-util
+RUN make cli-local server controller repo-server argocd-util
 
 ARG BUILD_ALL_CLIS=true
 RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \


### PR DESCRIPTION
Signed-off-by: darshanime <deathbullet@gmail.com>

`make cli` now uses the virtualized toolchain, dumping the binaries in `./dist/argocd`. To use local option, use `make cli-local`.
This makes `cli` consistent with other make targets.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
