### PR TITLE
feat: make argocd installation manifests Istio compatible #2784

### DIFF
--- a/manifests/base/application-controller/argocd-metrics.yaml
+++ b/manifests/base/application-controller/argocd-metrics.yaml
@@ -8,7 +8,7 @@ metadata:
   name: argocd-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-argocdacmetrics
     protocol: TCP
     port: 8082
     targetPort: 8082

--- a/manifests/base/application-controller/kustomization.yaml
+++ b/manifests/base/application-controller/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
 - argocd-application-controller-rolebinding.yaml
 - argocd-application-controller-deployment.yaml
 - argocd-metrics.yaml
+patchesStrategicMerge:
+- overlays/version_label_patch.yaml
+

--- a/manifests/base/application-controller/overlays/version_label_patch.tmpl
+++ b/manifests/base/application-controller/overlays/version_label_patch.tmpl
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-application-controller
+  labels:
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/base/application-controller/overlays/version_label_patch.yaml
+++ b/manifests/base/application-controller/overlays/version_label_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-application-controller
+  labels:
+    app.kubernetes.io/version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: v1.7.0

--- a/manifests/base/dex/argocd-dex-server-service.yaml
+++ b/manifests/base/dex/argocd-dex-server-service.yaml
@@ -8,15 +8,15 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - name: http-argocddex
     protocol: TCP
     port: 5556
     targetPort: 5556
-  - name: grpc
+  - name: grpc-argocddex
     protocol: TCP
     port: 5557
     targetPort: 5557
-  - name: metrics
+  - name: http-argocddexmetrics
     port: 5558
     protocol: TCP
     targetPort: 5558

--- a/manifests/base/dex/kustomization.yaml
+++ b/manifests/base/dex/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - argocd-dex-server-rolebinding.yaml
 - argocd-dex-server-sa.yaml
 - argocd-dex-server-service.yaml
+patchesStrategicMerge:
+- overlays/version_label_patch.yaml

--- a/manifests/base/dex/overlays/version_label_patch.tmpl
+++ b/manifests/base/dex/overlays/version_label_patch.tmpl
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+  labels:
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/base/dex/overlays/version_label_patch.yaml
+++ b/manifests/base/dex/overlays/version_label_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+  labels:
+    app.kubernetes.io/version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: v1.7.0

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,15 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+
+images:
+- name: argoproj/argocd
+  newName: argoproj/argocd
+  newTag: latest
+resources:
 - ./application-controller
 - ./dex
 - ./repo-server
 - ./server
 - ./config
 - ./redis
-
-images:
-- name: argoproj/argocd
-  newName: argoproj/argocd
-  newTag: latest

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,15 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-
-images:
-- name: argoproj/argocd
-  newName: argoproj/argocd
-  newTag: latest
-resources:
+bases:
 - ./application-controller
 - ./dex
 - ./repo-server
 - ./server
 - ./config
 - ./redis
+
+images:
+- name: argoproj/argocd
+  newName: argoproj/argocd
+  newTag: latest

--- a/manifests/base/redis/kustomization.yaml
+++ b/manifests/base/redis/kustomization.yaml
@@ -13,3 +13,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
+patchesStrategicMerge:
+- overlays/version_label_patch.yaml
+

--- a/manifests/base/redis/overlays/version_label_patch.tmpl
+++ b/manifests/base/redis/overlays/version_label_patch.tmpl
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-redis
+  labels:
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/base/redis/overlays/version_label_patch.yaml
+++ b/manifests/base/redis/overlays/version_label_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-redis
+  labels:
+    app.kubernetes.io/version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: v1.7.0

--- a/manifests/base/repo-server/argocd-repo-server-service.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-service.yaml
@@ -8,11 +8,11 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - name: server
+  - name: https-argocdreposerver
     protocol: TCP
     port: 8081
     targetPort: 8081
-  - name: metrics
+  - name: http-argocdreposervermetrics
     protocol: TCP
     port: 8084
     targetPort: 8084

--- a/manifests/base/repo-server/kustomization.yaml
+++ b/manifests/base/repo-server/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 resources:
 - argocd-repo-server-deployment.yaml
 - argocd-repo-server-service.yaml
+patchesStrategicMerge:
+- overlays/version_label_patch.yaml

--- a/manifests/base/repo-server/overlays/version_label_patch.tmpl
+++ b/manifests/base/repo-server/overlays/version_label_patch.tmpl
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+  labels:
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/base/repo-server/overlays/version_label_patch.yaml
+++ b/manifests/base/repo-server/overlays/version_label_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+  labels:
+    app.kubernetes.io/version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: v1.7.0

--- a/manifests/base/server/argocd-server-metrics.yaml
+++ b/manifests/base/server/argocd-server-metrics.yaml
@@ -8,7 +8,7 @@ metadata:
   name: argocd-server-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-argocdservermetrics
     protocol: TCP
     port: 8083
     targetPort: 8083

--- a/manifests/base/server/argocd-server-service.yaml
+++ b/manifests/base/server/argocd-server-service.yaml
@@ -8,11 +8,11 @@ metadata:
   name: argocd-server
 spec:
   ports:
-  - name: http
+  - name: tcp-argocdserver
     protocol: TCP
     port: 80
     targetPort: 8080
-  - name: https
+  - name: tcp-argocdservertls
     protocol: TCP
     port: 443
     targetPort: 8080

--- a/manifests/base/server/kustomization.yaml
+++ b/manifests/base/server/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
 - argocd-server-sa.yaml
 - argocd-server-service.yaml
 - argocd-server-metrics.yaml
+patchesStrategicMerge:
+- overlays/version_label_patch.yaml
+

--- a/manifests/base/server/overlays/version_label_patch.tmpl
+++ b/manifests/base/server/overlays/version_label_patch.tmpl
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+  labels:
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/base/server/overlays/version_label_patch.yaml
+++ b/manifests/base/server/overlays/version_label_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+  labels:
+    app.kubernetes.io/version: v1.7.0
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: v1.7.0

--- a/manifests/ha/base/kustomization.yaml
+++ b/manifests/ha/base/kustomization.yaml
@@ -7,15 +7,15 @@ patchesStrategicMerge:
 - overlays/argocd-server-deployment.yaml
 - overlays/argocd-application-controller-deployment.yaml
 
-
-images:
-- name: argoproj/argocd
-  newName: argoproj/argocd
-  newTag: latest
-resources:
+bases:
 - ../../base/application-controller
 - ../../base/dex
 - ../../base/repo-server
 - ../../base/server
 - ../../base/config
 - ./redis-ha
+
+images:
+- name: argoproj/argocd
+  newName: argoproj/argocd
+  newTag: latest

--- a/manifests/ha/base/kustomization.yaml
+++ b/manifests/ha/base/kustomization.yaml
@@ -7,15 +7,15 @@ patchesStrategicMerge:
 - overlays/argocd-server-deployment.yaml
 - overlays/argocd-application-controller-deployment.yaml
 
-bases:
+
+images:
+- name: argoproj/argocd
+  newName: argoproj/argocd
+  newTag: latest
+resources:
 - ../../base/application-controller
 - ../../base/dex
 - ../../base/repo-server
 - ../../base/server
 - ../../base/config
 - ./redis-ha
-
-images:
-- name: argoproj/argocd
-  newName: argoproj/argocd
-  newTag: latest

--- a/manifests/ha/base/redis-ha/kustomization.yaml
+++ b/manifests/ha/base/redis-ha/kustomization.yaml
@@ -176,3 +176,31 @@ patchesJson6902:
     kind: StatefulSet
     name: argocd-redis-ha-server
   path: overlays/remove-namespace.yaml
+
+# update port names for istio
+- target:
+    version: v1
+    kind: Service
+    name: argocd-redis-ha-announce-0
+  path: overlays/modify-portname.yaml
+- target:
+    version: v1
+    kind: Service
+    name: argocd-redis-ha-announce-1
+  path: overlays/modify-portname.yaml
+- target:
+    version: v1
+    kind: Service
+    name: argocd-redis-ha-announce-2
+  path: overlays/modify-portname.yaml
+- target:
+    version: v1
+    kind: Service
+    name: argocd-redis-ha
+  path: overlays/modify-portname.yaml
+- target:
+    version: v1
+    kind: Service
+    name: argocd-redis-ha-haproxy
+  path: overlays/modify-portname-haproxy.yaml
+

--- a/manifests/ha/base/redis-ha/overlays/deployment-labels.tmpl
+++ b/manifests/ha/base/redis-ha/overlays/deployment-labels.tmpl
@@ -6,7 +6,7 @@
   path: /spec/template/metadata/labels
   value:
     app.kubernetes.io/name: argocd-redis-ha-haproxy
-    app.kubernetes.io/version: v1.7.0
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED
 - op: replace
   path: /spec/template/spec/affinity/podAntiAffinity/preferredDuringSchedulingIgnoredDuringExecution/0/podAffinityTerm/labelSelector/matchLabels
   value:

--- a/manifests/ha/base/redis-ha/overlays/haproxy-modify-labels.tmpl
+++ b/manifests/ha/base/redis-ha/overlays/haproxy-modify-labels.tmpl
@@ -1,7 +1,7 @@
 - op: replace
   path: /metadata/labels
   value:
-    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/component: redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/ha/base/redis-ha/overlays/haproxy-modify-labels.yaml
+++ b/manifests/ha/base/redis-ha/overlays/haproxy-modify-labels.yaml
@@ -4,3 +4,4 @@
     app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/component: redis
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0

--- a/manifests/ha/base/redis-ha/overlays/modify-labels.tmpl
+++ b/manifests/ha/base/redis-ha/overlays/modify-labels.tmpl
@@ -4,4 +4,4 @@
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/component: redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED

--- a/manifests/ha/base/redis-ha/overlays/modify-portname-haproxy.yaml
+++ b/manifests/ha/base/redis-ha/overlays/modify-portname-haproxy.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/ports/0/name
+  value: tcp-haproxy

--- a/manifests/ha/base/redis-ha/overlays/modify-portname.yaml
+++ b/manifests/ha/base/redis-ha/overlays/modify-portname.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/ports/0/name
+  value: tcp-server
+- op: replace
+  path: /spec/ports/1/name
+  value: tcp-sentinel

--- a/manifests/ha/base/redis-ha/overlays/statefulset-labels.tmpl
+++ b/manifests/ha/base/redis-ha/overlays/statefulset-labels.tmpl
@@ -1,17 +1,17 @@
 - op: replace
   path: /spec/selector/matchLabels
   value:
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/name: argocd-redis-ha
 - op: replace
   path: /spec/template/metadata/labels
   value:
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
-    app.kubernetes.io/version: v1.7.0
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/version: ARGOCD_VERSION_TO_BE_REPLACED
 - op: replace
   path: /spec/template/spec/affinity/podAntiAffinity/preferredDuringSchedulingIgnoredDuringExecution/0/podAffinityTerm/labelSelector/matchLabels
   value:
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/name: argocd-redis-ha
 - op: replace
   path: /spec/template/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution/0/labelSelector/matchLabels
   value:
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/name: argocd-redis-ha

--- a/manifests/ha/base/redis-ha/overlays/statefulset-labels.yaml
+++ b/manifests/ha/base/redis-ha/overlays/statefulset-labels.yaml
@@ -6,6 +6,7 @@
   path: /spec/template/metadata/labels
   value:
     app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/version: v1.7.0
 - op: replace
   path: /spec/template/spec/affinity/podAntiAffinity/preferredDuringSchedulingIgnoredDuringExecution/0/podAffinityTerm/labelSelector/matchLabels
   value:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2007,6 +2007,26 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha-haproxy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2025,30 +2045,27 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha-haproxy
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2107,23 +2124,6 @@ rules:
   - get
   - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2223,6 +2223,23 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-redis-ha
+subjects:
+- kind: ServiceAccount
+  name: argocd-redis-ha
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2255,23 +2272,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-redis-ha
-subjects:
-- kind: ServiceAccount
-  name: argocd-redis-ha
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -2317,30 +2317,6 @@ subjects:
 - kind: ServiceAccount
   name: argocd-server
   namespace: argocd
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-gpg-keys-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-gpg-keys-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-rbac-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-rbac-cm
 ---
 apiVersion: v1
 data:
@@ -2599,6 +2575,30 @@ metadata:
   name: argocd-redis-ha-configmap
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-gpg-keys-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-gpg-keys-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+---
+apiVersion: v1
 data:
   ssh_known_hosts: |
     bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
@@ -2632,73 +2632,6 @@ metadata:
     app.kubernetes.io/part-of: argocd
   name: argocd-secret
 type: Opaque
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-spec:
-  ports:
-  - name: http-argocddex
-    port: 5556
-    protocol: TCP
-    targetPort: 5556
-  - name: grpc-argocddex
-    port: 5557
-    protocol: TCP
-    targetPort: 5557
-  - name: http-argocddexmetrics
-    port: 5558
-    protocol: TCP
-    targetPort: 5558
-  selector:
-    app.kubernetes.io/name: argocd-dex-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/name: argocd-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-metrics
-spec:
-  ports:
-  - name: http-argocdacmetrics
-    port: 8082
-    protocol: TCP
-    targetPort: 8082
-  selector:
-    app.kubernetes.io/name: argocd-application-controller
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations: null
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha
-spec:
-  clusterIP: None
-  ports:
-  - name: tcp-server
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: tcp-sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: sentinel
-  selector:
-    app.kubernetes.io/name: argocd-redis-ha
-  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -2804,6 +2737,73 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp-server
+    port: 6379
+    protocol: TCP
+    targetPort: redis
+  - name: tcp-sentinel
+    port: 26379
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    app.kubernetes.io/name: argocd-redis-ha
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
+spec:
+  ports:
+  - name: http-argocddex
+    port: 5556
+    protocol: TCP
+    targetPort: 5556
+  - name: grpc-argocddex
+    port: 5557
+    protocol: TCP
+    targetPort: 5557
+  - name: http-argocddexmetrics
+    port: 5558
+    protocol: TCP
+    targetPort: 5558
+  selector:
+    app.kubernetes.io/name: argocd-dex-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: argocd-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-metrics
+spec:
+  ports:
+  - name: http-argocdacmetrics
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
+  selector:
+    app.kubernetes.io/name: argocd-application-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
@@ -2827,6 +2827,23 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: http-argocdservermetrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2843,22 +2860,95 @@ spec:
   selector:
     app.kubernetes.io/name: argocd-server
 ---
-apiVersion: v1
-kind: Service
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha-haproxy
 spec:
-  ports:
-  - name: http-argocdservermetrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
+  replicas: 3
+  revisionHistoryLimit: 1
   selector:
-    app.kubernetes.io/name: argocd-server
+    matchLabels:
+      app.kubernetes.io/name: argocd-redis-ha-haproxy
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 790be9eae7c7e468c497c0256949ab96cb3f14b935c6702424647c3c60fba91c
+      labels:
+        app.kubernetes.io/name: argocd-redis-ha-haproxy
+        app.kubernetes.io/version: v1.7.0
+      name: argocd-redis-ha-haproxy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-redis-ha-haproxy
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-redis-ha-haproxy
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: haproxy:2.0.4
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8888
+          initialDelaySeconds: 5
+          periodSeconds: 3
+        name: haproxy
+        ports:
+        - containerPort: 6379
+          name: redis
+        resources: {}
+        volumeMounts:
+        - mountPath: /usr/local/etc/haproxy
+          name: data
+        - mountPath: /run/haproxy
+          name: shared-socket
+      initContainers:
+      - args:
+        - /readonly/haproxy_init.sh
+        command:
+        - sh
+        image: haproxy:2.0.4
+        imagePullPolicy: IfNotPresent
+        name: config-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /readonly
+          name: config-volume
+          readOnly: true
+        - mountPath: /data
+          name: data
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: argocd-redis-ha-haproxy
+      tolerations: null
+      volumes:
+      - configMap:
+          name: argocd-redis-ha-configmap
+        name: config-volume
+      - emptyDir: {}
+        name: shared-socket
+      - emptyDir: {}
+        name: data
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -2958,96 +3048,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: static-files
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha-haproxy
-spec:
-  replicas: 3
-  revisionHistoryLimit: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-redis-ha-haproxy
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        checksum/config: 790be9eae7c7e468c497c0256949ab96cb3f14b935c6702424647c3c60fba91c
-      labels:
-        app.kubernetes.io/name: argocd-redis-ha-haproxy
-        app.kubernetes.io/version: v1.7.0
-      name: argocd-redis-ha-haproxy
-    spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: argocd-redis-ha-haproxy
-              topologyKey: failure-domain.beta.kubernetes.io/zone
-            weight: 100
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: argocd-redis-ha-haproxy
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - image: haproxy:2.0.4
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8888
-          initialDelaySeconds: 5
-          periodSeconds: 3
-        name: haproxy
-        ports:
-        - containerPort: 6379
-          name: redis
-        resources: {}
-        volumeMounts:
-        - mountPath: /usr/local/etc/haproxy
-          name: data
-        - mountPath: /run/haproxy
-          name: shared-socket
-      initContainers:
-      - args:
-        - /readonly/haproxy_init.sh
-        command:
-        - sh
-        image: haproxy:2.0.4
-        imagePullPolicy: IfNotPresent
-        name: config-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /readonly
-          name: config-volume
-          readOnly: true
-        - mountPath: /data
-          name: data
-      nodeSelector: {}
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
-      serviceAccountName: argocd-redis-ha-haproxy
-      tolerations: null
-      volumes:
-      - configMap:
-          name: argocd-redis-ha-configmap
-        name: config-volume
-      - emptyDir: {}
-        name: shared-socket
-      - emptyDir: {}
-        name: data
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2007,24 +2007,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha-haproxy
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2043,26 +2025,30 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha-haproxy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2121,6 +2107,23 @@ rules:
   - get
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2220,22 +2223,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-redis-ha
-subjects:
-- kind: ServiceAccount
-  name: argocd-redis-ha
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2268,6 +2255,23 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-redis-ha
+subjects:
+- kind: ServiceAccount
+  name: argocd-redis-ha
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -2313,6 +2317,30 @@ subjects:
 - kind: ServiceAccount
   name: argocd-server
   namespace: argocd
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-gpg-keys-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-gpg-keys-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
 ---
 apiVersion: v1
 data:
@@ -2567,31 +2595,8 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-configmap
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-gpg-keys-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-gpg-keys-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-rbac-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-rbac-cm
 ---
 apiVersion: v1
 data:
@@ -2631,20 +2636,88 @@ type: Opaque
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
+spec:
+  ports:
+  - name: http-argocddex
+    port: 5556
+    protocol: TCP
+    targetPort: 5556
+  - name: grpc-argocddex
+    port: 5557
+    protocol: TCP
+    targetPort: 5557
+  - name: http-argocddexmetrics
+    port: 5558
+    protocol: TCP
+    targetPort: 5558
+  selector:
+    app.kubernetes.io/name: argocd-dex-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: argocd-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-metrics
+spec:
+  ports:
+  - name: http-argocdacmetrics
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
+  selector:
+    app.kubernetes.io/name: argocd-application-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp-server
+    port: 6379
+    protocol: TCP
+    targetPort: redis
+  - name: tcp-sentinel
+    port: 26379
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    app.kubernetes.io/name: argocd-redis-ha
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-announce-0
 spec:
   ports:
-  - name: server
+  - name: tcp-server
     port: 6379
     protocol: TCP
     targetPort: redis
-  - name: sentinel
+  - name: tcp-sentinel
     port: 26379
     protocol: TCP
     targetPort: sentinel
@@ -2663,14 +2736,15 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-announce-1
 spec:
   ports:
-  - name: server
+  - name: tcp-server
     port: 6379
     protocol: TCP
     targetPort: redis
-  - name: sentinel
+  - name: tcp-sentinel
     port: 26379
     protocol: TCP
     targetPort: sentinel
@@ -2689,14 +2763,15 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-announce-2
 spec:
   ports:
-  - name: server
+  - name: tcp-server
     port: 6379
     protocol: TCP
     targetPort: redis
-  - name: sentinel
+  - name: tcp-sentinel
     port: 26379
     protocol: TCP
     targetPort: sentinel
@@ -2714,82 +2789,17 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-haproxy
 spec:
   ports:
-  - name: haproxy
+  - name: tcp-haproxy
     port: 6379
     protocol: TCP
     targetPort: redis
   selector:
     app.kubernetes.io/name: argocd-redis-ha-haproxy
   type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations: null
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
-spec:
-  clusterIP: None
-  ports:
-  - name: server
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: sentinel
-  selector:
-    app.kubernetes.io/name: argocd-redis-ha
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-spec:
-  ports:
-  - name: http
-    port: 5556
-    protocol: TCP
-    targetPort: 5556
-  - name: grpc
-    port: 5557
-    protocol: TCP
-    targetPort: 5557
-  - name: metrics
-    port: 5558
-    protocol: TCP
-    targetPort: 5558
-  selector:
-    app.kubernetes.io/name: argocd-dex-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/name: argocd-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-metrics
-spec:
-  ports:
-  - name: metrics
-    port: 8082
-    protocol: TCP
-    targetPort: 8082
-  selector:
-    app.kubernetes.io/name: argocd-application-controller
 ---
 apiVersion: v1
 kind: Service
@@ -2801,11 +2811,11 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - name: server
+  - name: https-argocdreposerver
     port: 8081
     protocol: TCP
     targetPort: 8081
-  - name: metrics
+  - name: http-argocdreposervermetrics
     port: 8084
     protocol: TCP
     targetPort: 8084
@@ -2817,15 +2827,19 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
+  name: argocd-server
 spec:
   ports:
-  - name: metrics
-    port: 8083
+  - name: tcp-argocdserver
+    port: 80
     protocol: TCP
-    targetPort: 8083
+    targetPort: 8080
+  - name: tcp-argocdservertls
+    port: 443
+    protocol: TCP
+    targetPort: 8080
   selector:
     app.kubernetes.io/name: argocd-server
 ---
@@ -2834,21 +2848,116 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/name: argocd-server-metrics
     app.kubernetes.io/part-of: argocd
-  name: argocd-server
+  name: argocd-server-metrics
 spec:
   ports:
-  - name: http
-    port: 80
+  - name: http-argocdservermetrics
+    port: 8083
     protocol: TCP
-    targetPort: 8080
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: 8080
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-application-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-application-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-application-controller
+        app.kubernetes.io/version: v1.7.0
+    spec:
+      containers:
+      - command:
+        - argocd-application-controller
+        - --status-processors
+        - "20"
+        - --operation-processors
+        - "10"
+        - --redis
+        - argocd-redis-ha-haproxy:6379
+        image: argoproj/argocd:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        name: argocd-application-controller
+        ports:
+        - containerPort: 8082
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      serviceAccountName: argocd-application-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-dex-server
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-dex-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-dex-server
+        app.kubernetes.io/version: v1.7.0
+    spec:
+      containers:
+      - command:
+        - /shared/argocd-util
+        - rundex
+        image: quay.io/dexidp/dex:v2.22.0
+        imagePullPolicy: Always
+        name: dex
+        ports:
+        - containerPort: 5556
+        - containerPort: 5557
+        - containerPort: 5558
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      initContainers:
+      - command:
+        - cp
+        - -n
+        - /usr/local/bin/argocd-util
+        - /shared
+        image: argoproj/argocd:latest
+        imagePullPolicy: Always
+        name: copyutil
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      serviceAccountName: argocd-dex-server
+      volumes:
+      - emptyDir: {}
+        name: static-files
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -2857,6 +2966,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-haproxy
 spec:
   replicas: 3
@@ -2872,6 +2982,7 @@ spec:
         checksum/config: 790be9eae7c7e468c497c0256949ab96cb3f14b935c6702424647c3c60fba91c
       labels:
         app.kubernetes.io/name: argocd-redis-ha-haproxy
+        app.kubernetes.io/version: v1.7.0
       name: argocd-redis-ha-haproxy
     spec:
       affinity:
@@ -2942,104 +3053,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argocd-application-controller
-    app.kubernetes.io/part-of: argocd
-  name: argocd-application-controller
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-application-controller
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: argocd-application-controller
-    spec:
-      containers:
-      - command:
-        - argocd-application-controller
-        - --status-processors
-        - "20"
-        - --operation-processors
-        - "10"
-        - --redis
-        - argocd-redis-ha-haproxy:6379
-        image: argoproj/argocd:latest
-        imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        name: argocd-application-controller
-        ports:
-        - containerPort: 8082
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-      serviceAccountName: argocd-application-controller
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-dex-server
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: argocd-dex-server
-    spec:
-      containers:
-      - command:
-        - /shared/argocd-util
-        - rundex
-        image: quay.io/dexidp/dex:v2.22.0
-        imagePullPolicy: Always
-        name: dex
-        ports:
-        - containerPort: 5556
-        - containerPort: 5557
-        - containerPort: 5558
-        volumeMounts:
-        - mountPath: /shared
-          name: static-files
-      initContainers:
-      - command:
-        - cp
-        - -n
-        - /usr/local/bin/argocd-util
-        - /shared
-        image: argoproj/argocd:latest
-        imagePullPolicy: Always
-        name: copyutil
-        volumeMounts:
-        - mountPath: /shared
-          name: static-files
-      serviceAccountName: argocd-dex-server
-      volumes:
-      - emptyDir: {}
-        name: static-files
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-repo-server
 spec:
   replicas: 2
@@ -3050,6 +3067,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-repo-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       affinity:
         podAntiAffinity:
@@ -3113,6 +3131,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-server
 spec:
   replicas: 2
@@ -3123,6 +3142,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       affinity:
         podAntiAffinity:
@@ -3186,6 +3206,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-server
 spec:
   podManagementPolicy: OrderedReady
@@ -3200,6 +3221,7 @@ spec:
         checksum/init-config: 552ee3bec8fe5d9d865e371f7b615c6d472253649eb65d53ed4ae874f782647c
       labels:
         app.kubernetes.io/name: argocd-redis-ha
+        app.kubernetes.io/version: v1.7.0
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2007,24 +2007,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha-haproxy
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2043,6 +2025,26 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha-haproxy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -2052,9 +2054,68 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - appprojects
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha
 rules:
 - apiGroups:
@@ -2068,64 +2129,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argocd-application-controller
-    app.kubernetes.io/part-of: argocd
-  name: argocd-application-controller
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - argoproj.io
-  resources:
-  - applications
-  - appprojects
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -2164,6 +2167,38 @@ rules:
   verbs:
   - create
   - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-application-controller
+subjects:
+- kind: ServiceAccount
+  name: argocd-application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-dex-server
+subjects:
+- kind: ServiceAccount
+  name: argocd-dex-server
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -2172,6 +2207,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2180,38 +2216,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argocd-application-controller
-    app.kubernetes.io/part-of: argocd
-  name: argocd-application-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-application-controller
-subjects:
-- kind: ServiceAccount
-  name: argocd-application-controller
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-dex-server
-subjects:
-- kind: ServiceAccount
-  name: argocd-dex-server
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -2228,6 +2232,30 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-server
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-gpg-keys-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-gpg-keys-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
 ---
 apiVersion: v1
 data:
@@ -2482,31 +2510,8 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-configmap
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-gpg-keys-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-gpg-keys-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-rbac-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-rbac-cm
 ---
 apiVersion: v1
 data:
@@ -2546,20 +2551,88 @@ type: Opaque
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
+spec:
+  ports:
+  - name: http-argocddex
+    port: 5556
+    protocol: TCP
+    targetPort: 5556
+  - name: grpc-argocddex
+    port: 5557
+    protocol: TCP
+    targetPort: 5557
+  - name: http-argocddexmetrics
+    port: 5558
+    protocol: TCP
+    targetPort: 5558
+  selector:
+    app.kubernetes.io/name: argocd-dex-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: argocd-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-metrics
+spec:
+  ports:
+  - name: http-argocdacmetrics
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
+  selector:
+    app.kubernetes.io/name: argocd-application-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp-server
+    port: 6379
+    protocol: TCP
+    targetPort: redis
+  - name: tcp-sentinel
+    port: 26379
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    app.kubernetes.io/name: argocd-redis-ha
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-announce-0
 spec:
   ports:
-  - name: server
+  - name: tcp-server
     port: 6379
     protocol: TCP
     targetPort: redis
-  - name: sentinel
+  - name: tcp-sentinel
     port: 26379
     protocol: TCP
     targetPort: sentinel
@@ -2578,14 +2651,15 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-announce-1
 spec:
   ports:
-  - name: server
+  - name: tcp-server
     port: 6379
     protocol: TCP
     targetPort: redis
-  - name: sentinel
+  - name: tcp-sentinel
     port: 26379
     protocol: TCP
     targetPort: sentinel
@@ -2604,14 +2678,15 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-announce-2
 spec:
   ports:
-  - name: server
+  - name: tcp-server
     port: 6379
     protocol: TCP
     targetPort: redis
-  - name: sentinel
+  - name: tcp-sentinel
     port: 26379
     protocol: TCP
     targetPort: sentinel
@@ -2629,82 +2704,17 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-haproxy
 spec:
   ports:
-  - name: haproxy
+  - name: tcp-haproxy
     port: 6379
     protocol: TCP
     targetPort: redis
   selector:
     app.kubernetes.io/name: argocd-redis-ha-haproxy
   type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations: null
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-ha
-spec:
-  clusterIP: None
-  ports:
-  - name: server
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: sentinel
-  selector:
-    app.kubernetes.io/name: argocd-redis-ha
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-spec:
-  ports:
-  - name: http
-    port: 5556
-    protocol: TCP
-    targetPort: 5556
-  - name: grpc
-    port: 5557
-    protocol: TCP
-    targetPort: 5557
-  - name: metrics
-    port: 5558
-    protocol: TCP
-    targetPort: 5558
-  selector:
-    app.kubernetes.io/name: argocd-dex-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/name: argocd-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-metrics
-spec:
-  ports:
-  - name: metrics
-    port: 8082
-    protocol: TCP
-    targetPort: 8082
-  selector:
-    app.kubernetes.io/name: argocd-application-controller
 ---
 apiVersion: v1
 kind: Service
@@ -2716,11 +2726,11 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - name: server
+  - name: https-argocdreposerver
     port: 8081
     protocol: TCP
     targetPort: 8081
-  - name: metrics
+  - name: http-argocdreposervermetrics
     port: 8084
     protocol: TCP
     targetPort: 8084
@@ -2732,15 +2742,19 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
+  name: argocd-server
 spec:
   ports:
-  - name: metrics
-    port: 8083
+  - name: tcp-argocdserver
+    port: 80
     protocol: TCP
-    targetPort: 8083
+    targetPort: 8080
+  - name: tcp-argocdservertls
+    port: 443
+    protocol: TCP
+    targetPort: 8080
   selector:
     app.kubernetes.io/name: argocd-server
 ---
@@ -2749,21 +2763,116 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/name: argocd-server-metrics
     app.kubernetes.io/part-of: argocd
-  name: argocd-server
+  name: argocd-server-metrics
 spec:
   ports:
-  - name: http
-    port: 80
+  - name: http-argocdservermetrics
+    port: 8083
     protocol: TCP
-    targetPort: 8080
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: 8080
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-application-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-application-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-application-controller
+        app.kubernetes.io/version: v1.7.0
+    spec:
+      containers:
+      - command:
+        - argocd-application-controller
+        - --status-processors
+        - "20"
+        - --operation-processors
+        - "10"
+        - --redis
+        - argocd-redis-ha-haproxy:6379
+        image: argoproj/argocd:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        name: argocd-application-controller
+        ports:
+        - containerPort: 8082
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      serviceAccountName: argocd-application-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-dex-server
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-dex-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-dex-server
+        app.kubernetes.io/version: v1.7.0
+    spec:
+      containers:
+      - command:
+        - /shared/argocd-util
+        - rundex
+        image: quay.io/dexidp/dex:v2.22.0
+        imagePullPolicy: Always
+        name: dex
+        ports:
+        - containerPort: 5556
+        - containerPort: 5557
+        - containerPort: 5558
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      initContainers:
+      - command:
+        - cp
+        - -n
+        - /usr/local/bin/argocd-util
+        - /shared
+        image: argoproj/argocd:latest
+        imagePullPolicy: Always
+        name: copyutil
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      serviceAccountName: argocd-dex-server
+      volumes:
+      - emptyDir: {}
+        name: static-files
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -2772,6 +2881,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-haproxy
 spec:
   replicas: 3
@@ -2787,6 +2897,7 @@ spec:
         checksum/config: 790be9eae7c7e468c497c0256949ab96cb3f14b935c6702424647c3c60fba91c
       labels:
         app.kubernetes.io/name: argocd-redis-ha-haproxy
+        app.kubernetes.io/version: v1.7.0
       name: argocd-redis-ha-haproxy
     spec:
       affinity:
@@ -2857,104 +2968,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argocd-application-controller
-    app.kubernetes.io/part-of: argocd
-  name: argocd-application-controller
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-application-controller
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: argocd-application-controller
-    spec:
-      containers:
-      - command:
-        - argocd-application-controller
-        - --status-processors
-        - "20"
-        - --operation-processors
-        - "10"
-        - --redis
-        - argocd-redis-ha-haproxy:6379
-        image: argoproj/argocd:latest
-        imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        name: argocd-application-controller
-        ports:
-        - containerPort: 8082
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-      serviceAccountName: argocd-application-controller
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-dex-server
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: argocd-dex-server
-    spec:
-      containers:
-      - command:
-        - /shared/argocd-util
-        - rundex
-        image: quay.io/dexidp/dex:v2.22.0
-        imagePullPolicy: Always
-        name: dex
-        ports:
-        - containerPort: 5556
-        - containerPort: 5557
-        - containerPort: 5558
-        volumeMounts:
-        - mountPath: /shared
-          name: static-files
-      initContainers:
-      - command:
-        - cp
-        - -n
-        - /usr/local/bin/argocd-util
-        - /shared
-        image: argoproj/argocd:latest
-        imagePullPolicy: Always
-        name: copyutil
-        volumeMounts:
-        - mountPath: /shared
-          name: static-files
-      serviceAccountName: argocd-dex-server
-      volumes:
-      - emptyDir: {}
-        name: static-files
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-repo-server
 spec:
   replicas: 2
@@ -2965,6 +2982,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-repo-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       affinity:
         podAntiAffinity:
@@ -3028,6 +3046,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-server
 spec:
   replicas: 2
@@ -3038,6 +3057,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       affinity:
         podAntiAffinity:
@@ -3101,6 +3121,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis-ha
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis-ha-server
 spec:
   podManagementPolicy: OrderedReady
@@ -3115,6 +3136,7 @@ spec:
         checksum/init-config: 552ee3bec8fe5d9d865e371f7b615c6d472253649eb65d53ed4ae874f782647c
       labels:
         app.kubernetes.io/name: argocd-redis-ha
+        app.kubernetes.io/version: v1.7.0
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2007,19 +2007,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
-  name: argocd-application-controller
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha-haproxy
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -2035,11 +2027,19 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha-haproxy
+  name: argocd-application-controller
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -2049,64 +2049,6 @@ metadata:
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argocd-application-controller
-    app.kubernetes.io/part-of: argocd
-  name: argocd-application-controller
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - argoproj.io
-  resources:
-  - applications
-  - appprojects
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2129,6 +2071,64 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - appprojects
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -2172,6 +2172,23 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-redis-ha
+subjects:
+- kind: ServiceAccount
+  name: argocd-redis-ha
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2204,23 +2221,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-redis-ha
-subjects:
-- kind: ServiceAccount
-  name: argocd-redis-ha
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -2232,30 +2232,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-server
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-gpg-keys-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-gpg-keys-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-rbac-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-rbac-cm
 ---
 apiVersion: v1
 data:
@@ -2514,6 +2490,30 @@ metadata:
   name: argocd-redis-ha-configmap
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-gpg-keys-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-gpg-keys-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+---
+apiVersion: v1
 data:
   ssh_known_hosts: |
     bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
@@ -2547,73 +2547,6 @@ metadata:
     app.kubernetes.io/part-of: argocd
   name: argocd-secret
 type: Opaque
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: dex-server
-    app.kubernetes.io/name: argocd-dex-server
-    app.kubernetes.io/part-of: argocd
-  name: argocd-dex-server
-spec:
-  ports:
-  - name: http-argocddex
-    port: 5556
-    protocol: TCP
-    targetPort: 5556
-  - name: grpc-argocddex
-    port: 5557
-    protocol: TCP
-    targetPort: 5557
-  - name: http-argocddexmetrics
-    port: 5558
-    protocol: TCP
-    targetPort: 5558
-  selector:
-    app.kubernetes.io/name: argocd-dex-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/name: argocd-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-metrics
-spec:
-  ports:
-  - name: http-argocdacmetrics
-    port: 8082
-    protocol: TCP
-    targetPort: 8082
-  selector:
-    app.kubernetes.io/name: argocd-application-controller
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations: null
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha
-spec:
-  clusterIP: None
-  ports:
-  - name: tcp-server
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: tcp-sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: sentinel
-  selector:
-    app.kubernetes.io/name: argocd-redis-ha
-  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -2719,6 +2652,73 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp-server
+    port: 6379
+    protocol: TCP
+    targetPort: redis
+  - name: tcp-sentinel
+    port: 26379
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    app.kubernetes.io/name: argocd-redis-ha
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
+  name: argocd-dex-server
+spec:
+  ports:
+  - name: http-argocddex
+    port: 5556
+    protocol: TCP
+    targetPort: 5556
+  - name: grpc-argocddex
+    port: 5557
+    protocol: TCP
+    targetPort: 5557
+  - name: http-argocddexmetrics
+    port: 5558
+    protocol: TCP
+    targetPort: 5558
+  selector:
+    app.kubernetes.io/name: argocd-dex-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: argocd-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-metrics
+spec:
+  ports:
+  - name: http-argocdacmetrics
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
+  selector:
+    app.kubernetes.io/name: argocd-application-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
@@ -2742,6 +2742,23 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: http-argocdservermetrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2758,22 +2775,95 @@ spec:
   selector:
     app.kubernetes.io/name: argocd-server
 ---
-apiVersion: v1
-kind: Service
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
+    app.kubernetes.io/version: v1.7.0
+  name: argocd-redis-ha-haproxy
 spec:
-  ports:
-  - name: http-argocdservermetrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
+  replicas: 3
+  revisionHistoryLimit: 1
   selector:
-    app.kubernetes.io/name: argocd-server
+    matchLabels:
+      app.kubernetes.io/name: argocd-redis-ha-haproxy
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 790be9eae7c7e468c497c0256949ab96cb3f14b935c6702424647c3c60fba91c
+      labels:
+        app.kubernetes.io/name: argocd-redis-ha-haproxy
+        app.kubernetes.io/version: v1.7.0
+      name: argocd-redis-ha-haproxy
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-redis-ha-haproxy
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-redis-ha-haproxy
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: haproxy:2.0.4
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8888
+          initialDelaySeconds: 5
+          periodSeconds: 3
+        name: haproxy
+        ports:
+        - containerPort: 6379
+          name: redis
+        resources: {}
+        volumeMounts:
+        - mountPath: /usr/local/etc/haproxy
+          name: data
+        - mountPath: /run/haproxy
+          name: shared-socket
+      initContainers:
+      - args:
+        - /readonly/haproxy_init.sh
+        command:
+        - sh
+        image: haproxy:2.0.4
+        imagePullPolicy: IfNotPresent
+        name: config-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /readonly
+          name: config-volume
+          readOnly: true
+        - mountPath: /data
+          name: data
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: argocd-redis-ha-haproxy
+      tolerations: null
+      volumes:
+      - configMap:
+          name: argocd-redis-ha-configmap
+        name: config-volume
+      - emptyDir: {}
+        name: shared-socket
+      - emptyDir: {}
+        name: data
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -2873,96 +2963,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: static-files
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-ha-haproxy
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v1.7.0
-  name: argocd-redis-ha-haproxy
-spec:
-  replicas: 3
-  revisionHistoryLimit: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-redis-ha-haproxy
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        checksum/config: 790be9eae7c7e468c497c0256949ab96cb3f14b935c6702424647c3c60fba91c
-      labels:
-        app.kubernetes.io/name: argocd-redis-ha-haproxy
-        app.kubernetes.io/version: v1.7.0
-      name: argocd-redis-ha-haproxy
-    spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: argocd-redis-ha-haproxy
-              topologyKey: failure-domain.beta.kubernetes.io/zone
-            weight: 100
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: argocd-redis-ha-haproxy
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - image: haproxy:2.0.4
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8888
-          initialDelaySeconds: 5
-          periodSeconds: 3
-        name: haproxy
-        ports:
-        - containerPort: 6379
-          name: redis
-        resources: {}
-        volumeMounts:
-        - mountPath: /usr/local/etc/haproxy
-          name: data
-        - mountPath: /run/haproxy
-          name: shared-socket
-      initContainers:
-      - args:
-        - /readonly/haproxy_init.sh
-        command:
-        - sh
-        image: haproxy:2.0.4
-        imagePullPolicy: IfNotPresent
-        name: config-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /readonly
-          name: config-volume
-          readOnly: true
-        - mountPath: /data
-          name: data
-      nodeSelector: {}
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
-      serviceAccountName: argocd-redis-ha-haproxy
-      tolerations: null
-      volumes:
-      - configMap:
-          name: argocd-redis-ha-configmap
-        name: config-volume
-      - emptyDir: {}
-        name: shared-socket
-      - emptyDir: {}
-        name: data
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2333,15 +2333,15 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - name: http-argocddex
     port: 5556
     protocol: TCP
     targetPort: 5556
-  - name: grpc
+  - name: grpc-argocddex
     port: 5557
     protocol: TCP
     targetPort: 5557
-  - name: metrics
+  - name: http-argocddexmetrics
     port: 5558
     protocol: TCP
     targetPort: 5558
@@ -2358,7 +2358,7 @@ metadata:
   name: argocd-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-argocdacmetrics
     port: 8082
     protocol: TCP
     targetPort: 8082
@@ -2391,11 +2391,11 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - name: server
+  - name: https-argocdreposerver
     port: 8081
     protocol: TCP
     targetPort: 8081
-  - name: metrics
+  - name: http-argocdreposervermetrics
     port: 8084
     protocol: TCP
     targetPort: 8084
@@ -2407,15 +2407,19 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
+  name: argocd-server
 spec:
   ports:
-  - name: metrics
-    port: 8083
+  - name: tcp-argocdserver
+    port: 80
     protocol: TCP
-    targetPort: 8083
+    targetPort: 8080
+  - name: tcp-argocdservertls
+    port: 443
+    protocol: TCP
+    targetPort: 8080
   selector:
     app.kubernetes.io/name: argocd-server
 ---
@@ -2424,19 +2428,15 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/name: argocd-server-metrics
     app.kubernetes.io/part-of: argocd
-  name: argocd-server
+  name: argocd-server-metrics
 spec:
   ports:
-  - name: http
-    port: 80
+  - name: http-argocdservermetrics
+    port: 8083
     protocol: TCP
-    targetPort: 8080
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: 8080
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---
@@ -2447,6 +2447,7 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-application-controller
 spec:
   selector:
@@ -2458,6 +2459,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-application-controller
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - command:
@@ -2492,6 +2494,7 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-dex-server
 spec:
   selector:
@@ -2501,6 +2504,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-dex-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - command:
@@ -2540,6 +2544,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis
 spec:
   selector:
@@ -2549,6 +2554,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-redis
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - args:
@@ -2569,6 +2575,7 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-repo-server
 spec:
   selector:
@@ -2578,6 +2585,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-repo-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       automountServiceAccountToken: false
       containers:
@@ -2627,6 +2635,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-server
 spec:
   selector:
@@ -2636,6 +2645,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - command:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2407,6 +2407,23 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: http-argocdservermetrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2420,23 +2437,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8080
-  selector:
-    app.kubernetes.io/name: argocd-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
-spec:
-  ports:
-  - name: http-argocdservermetrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2322,6 +2322,23 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-metrics
+spec:
+  ports:
+  - name: http-argocdservermetrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  selector:
+    app.kubernetes.io/name: argocd-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -2335,23 +2352,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8080
-  selector:
-    app.kubernetes.io/name: argocd-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
-spec:
-  ports:
-  - name: http-argocdservermetrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2248,15 +2248,15 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - name: http-argocddex
     port: 5556
     protocol: TCP
     targetPort: 5556
-  - name: grpc
+  - name: grpc-argocddex
     port: 5557
     protocol: TCP
     targetPort: 5557
-  - name: metrics
+  - name: http-argocddexmetrics
     port: 5558
     protocol: TCP
     targetPort: 5558
@@ -2273,7 +2273,7 @@ metadata:
   name: argocd-metrics
 spec:
   ports:
-  - name: metrics
+  - name: http-argocdacmetrics
     port: 8082
     protocol: TCP
     targetPort: 8082
@@ -2306,11 +2306,11 @@ metadata:
   name: argocd-repo-server
 spec:
   ports:
-  - name: server
+  - name: https-argocdreposerver
     port: 8081
     protocol: TCP
     targetPort: 8081
-  - name: metrics
+  - name: http-argocdreposervermetrics
     port: 8084
     protocol: TCP
     targetPort: 8084
@@ -2322,15 +2322,19 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
+    app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
+  name: argocd-server
 spec:
   ports:
-  - name: metrics
-    port: 8083
+  - name: tcp-argocdserver
+    port: 80
     protocol: TCP
-    targetPort: 8083
+    targetPort: 8080
+  - name: tcp-argocdservertls
+    port: 443
+    protocol: TCP
+    targetPort: 8080
   selector:
     app.kubernetes.io/name: argocd-server
 ---
@@ -2339,19 +2343,15 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/name: argocd-server-metrics
     app.kubernetes.io/part-of: argocd
-  name: argocd-server
+  name: argocd-server-metrics
 spec:
   ports:
-  - name: http
-    port: 80
+  - name: http-argocdservermetrics
+    port: 8083
     protocol: TCP
-    targetPort: 8080
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: 8080
+    targetPort: 8083
   selector:
     app.kubernetes.io/name: argocd-server
 ---
@@ -2362,6 +2362,7 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-application-controller
 spec:
   selector:
@@ -2373,6 +2374,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-application-controller
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - command:
@@ -2407,6 +2409,7 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-dex-server
 spec:
   selector:
@@ -2416,6 +2419,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-dex-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - command:
@@ -2455,6 +2459,7 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-redis
 spec:
   selector:
@@ -2464,6 +2469,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-redis
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - args:
@@ -2484,6 +2490,7 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-repo-server
 spec:
   selector:
@@ -2493,6 +2500,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-repo-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       automountServiceAccountToken: false
       containers:
@@ -2542,6 +2550,7 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: v1.7.0
   name: argocd-server
 spec:
   selector:
@@ -2551,6 +2560,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-server
+        app.kubernetes.io/version: v1.7.0
     spec:
       containers:
       - command:


### PR DESCRIPTION


Checklist:

* [ X ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ X ] The title of the PR states what changed and the related issues number (used for the release note).
* [ X ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ Partly ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

I've signed the CLA but apart from making some simple tests, did not run the tests locally.

This PR makes argocd installation manifests compatible with Istio. It implements this request: [#2784](https://github.com/argoproj/argo-cd/issues/2784)

In case this is accepted I will make a PR to have 2 examples with Istio ingress:

    TLS termination at Istio Ingress gateway
    TLS termination at ArgoCD server (Istio ingress gateway is configured to TLS PASSTHROUGH)