### PR TITLE
fix: Update dependencies built from source for ARM (#3908)

### DIFF
--- a/hack/installers/install-ksonnet-linux.sh
+++ b/hack/installers/install-ksonnet-linux.sh
@@ -7,10 +7,11 @@ KSONNET_VERSION=${ksonnet_version}
 case $ARCHITECTURE in
   arm|arm64)
     set +o pipefail
+    # Clone the repository in $GOPATH/src/github.com/ksonnet/ksonnet
     go get -u github.com/ksonnet/ksonnet || true
     set -o pipefail
     cd $GOPATH/src/github.com/ksonnet/ksonnet && git checkout tags/v$KSONNET_VERSION
-    cd $GOPATH/src/github.com/ksonnet/ksonnet && make install
+    cd $GOPATH/src/github.com/ksonnet/ksonnet && CGO_ENABLED=0 GO_LDFLAGS="-s" make install
     mv $GOPATH/bin/ks $BIN/ks
     ;;
   *)

--- a/hack/installers/install-kustomize-linux.sh
+++ b/hack/installers/install-kustomize-linux.sh
@@ -14,7 +14,7 @@ KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-$kustomize3_version}
 case $ARCHITECTURE in
   arm|arm64)
     BINNAME=kustomize
-    GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3@v${KUSTOMIZE_VERSION}
+    CGO_ENABLED=0 GO111MODULE=on go get -ldflags="-s" sigs.k8s.io/kustomize/kustomize/v3@v${KUSTOMIZE_VERSION}
     mv $GOPATH/bin/kustomize $BIN/$BINNAME
     ;;
   *)

--- a/hack/installers/install-packr-linux.sh
+++ b/hack/installers/install-packr-linux.sh
@@ -6,11 +6,10 @@ set -eux -o pipefail
 PACKR_VERSION=${packr_version}
 case $ARCHITECTURE in
   arm|arm64)
-    set +o pipefail
+    # Clone the repository in $GOPATH/src/github.com/gobuffalo/packr
     go get -u github.com/gobuffalo/packr
-    set -o pipefail
     cd $GOPATH/src/github.com/gobuffalo/packr && git checkout tags/v$PACKR_VERSION
-    cd $GOPATH/src/github.com/gobuffalo/packr && make install
+    cd $GOPATH/src/github.com/gobuffalo/packr && CGO_ENABLED=0 make install
     mv $GOPATH/bin/packr $BIN/packr
     ;;
   *)


### PR DESCRIPTION
Signed-off-by: Alin Balutoiu <alinbalutoiu@gmail.com>

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Having a deeper look at the `kustomize` and `ks` binaries built from source, I found that the binaries are dynamically compiled.

While this has worked fine previously, it has changed in the latest `debian:10-slim` image. To be more precise, this tag is now pointing to `debian:10.4-slim` image released last month, which seems to be breaking those binaries as they are working fine in `debian:10.3-slim`.

The build process for the `kustomize` binary has been updated to use the same flags from the official repository https://github.com/kubernetes-sigs/kustomize/blob/master/releasing/cloudbuild.sh

Old binary for `kustomize`:
```
/usr/local/bin/kustomize: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, Go BuildID=dOs7THZrlBIVw7YnTl7f/qDzAE3AQOoE1eIVSiMx5/04xu5tgiS952bcUWEnmy/fFKeXz6aHif5jsjXCzBo, BuildID[sha1]=e9d7027695531cb5d63c12bfa7436dbb4f6bcfb9, not stripped
```

New binary for `kustomize`:
```
/usr/local/bin/kustomize: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=Pfx_jdoNOpy9etJzDfJm/zuGkLnueeSm8zRDJXTtc/QZDnHVBiDjCV0Zh2TCdq/grLgQv0G7_qtInFLVDLV, stripped
```

Same happens for `ksonnet`.

For your convenience, here are the build logs for both ARM and ARM64 systems:
- `master` branch https://cloud.drone.io/alinbalutoiu/argo-cd/32
- `v1.6.1` release https://cloud.drone.io/alinbalutoiu/argo-cd/34

Those images are pushed to https://hub.docker.com/repository/docker/alinbalutoiu/argocd (`alinbalutoiu/argocd:master` and `alinbalutoiu/argocd:v1.6.1`, note that it support docker multiple architectures which means that the right image will be pulled for your ARM device without having to change the tag).

Closes #3908 
