### PR TITLE
fix: #3933 - Use a non root Redis Image

### DIFF
--- a/manifests/base/redis/argocd-redis-deployment.yaml
+++ b/manifests/base/redis/argocd-redis-deployment.yaml
@@ -16,9 +16,10 @@ spec:
         app.kubernetes.io/name: argocd-redis
     spec:
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         runAsNonRoot: true
-        runAsUser: 1000
       containers:
       - name: redis
         image: redis:5.0.8

--- a/manifests/base/redis/argocd-redis-deployment.yaml
+++ b/manifests/base/redis/argocd-redis-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-redis
     spec:
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: redis
         image: redis:5.0.8

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2591,6 +2591,10 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-redis
     spec:
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - args:
         - --save

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2592,9 +2592,10 @@ spec:
         app.kubernetes.io/name: argocd-redis
     spec:
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         runAsNonRoot: true
-        runAsUser: 1000
       containers:
       - args:
         - --save

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2591,11 +2591,6 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-redis
     spec:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        runAsNonRoot: true
       containers:
       - args:
         - --save
@@ -2607,6 +2602,11 @@ spec:
         name: redis
         ports:
         - containerPort: 6379
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2506,6 +2506,10 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-redis
     spec:
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - args:
         - --save

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2507,9 +2507,10 @@ spec:
         app.kubernetes.io/name: argocd-redis
     spec:
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         runAsNonRoot: true
-        runAsUser: 1000
       containers:
       - args:
         - --save

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2506,11 +2506,6 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-redis
     spec:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        runAsNonRoot: true
       containers:
       - args:
         - --save
@@ -2522,6 +2517,11 @@ spec:
         name: redis
         ports:
         - containerPort: 6379
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
We should use an image for the Redis image that doesn't
require the process to be started as root.

Checklist:

* [x ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x ] The title of the PR states what changed and the related issues number (used for the release note).
* [x ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
