### PR TITLE
fix: remove TestSyncOptionDryRun test

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -853,25 +853,6 @@ func TestSyncOptionPruneFalse(t *testing.T) {
 		Expect(ResourceSyncStatusIs("Pod", "pod-1", SyncStatusCodeOutOfSync))
 }
 
-// make sure that if we sync with dry run, app does not go OutOfSync
-func TestSyncOptionDryRun(t *testing.T) {
-	Given(t).
-		Path("two-nice-pods").
-		When().
-		Create().
-		Sync().
-		Then().
-		Expect(OperationPhaseIs(OperationSucceeded)).
-		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		When().
-		PatchFile("pod-1.yaml", `[{"op": "replace", "path": "/spec/containers/0/image", "value": "nginx:1.19.0"}]`).
-		Sync("--dry-run").
-		Then().
-		Expect(OperationPhaseIs(OperationSucceeded)).
-		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(ResourceSyncStatusIs("Pod", "pod-1", SyncStatusCodeSynced))
-}
-
 // make sure that if we have an invalid manifest, we can add it if we disable validation, we get a server error rather than a client error
 func TestSyncOptionValidateFalse(t *testing.T) {
 


### PR DESCRIPTION
PR removes TestSyncOptionDryRun. The test is supposed to verify that app is not refreshed immediately if sync is executed with `--dry-run` flag, but this is almost impossible to do in e2e test. The controller refresh app periodically and app still might be refreshed immediately right after syncing. I think we need to add unit test instead.
