### PR TITLE
fix: Redis securityContext

### DIFF
--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2506,6 +2506,11 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-redis
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        fsGroup: 1000
       containers:
       - args:
         - --save


### PR DESCRIPTION
When running redis with restricted pod security policy you need to set the securitycontext.
This is to prevent the following error: error: failed switching to "redis": operation not permitted

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
