### PR TITLE
fix: wait/sync command should send app resource version to avoid receiving stale data

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -694,7 +694,7 @@ func (c *client) WatchApplicationWithRetry(ctx context.Context, appName string, 
 			conn, appIf, err := c.NewApplicationClient()
 			if err == nil {
 				var wc applicationpkg.ApplicationService_WatchClient
-				wc, err = appIf.Watch(ctx, &applicationpkg.ApplicationQuery{Name: &appName})
+				wc, err = appIf.Watch(ctx, &applicationpkg.ApplicationQuery{Name: &appName, ResourceVersion: revision})
 				if err == nil {
 					for {
 						var appEvent *v1alpha1.ApplicationWatchEvent
@@ -702,6 +702,7 @@ func (c *client) WatchApplicationWithRetry(ctx context.Context, appName string, 
 						if err != nil {
 							break
 						}
+						revision = appEvent.Application.ResourceVersion
 						appEventsCh <- appEvent
 					}
 				}


### PR DESCRIPTION
Hopefully fixes CLI nil pointer exception reported in https://github.com/argoproj/argo-cd/issues/3932.


Rerunning tests multiple times to ensure issue is actually fixed. So far 5 successful runs