### PR TITLE
chore: Fix intermittently failing CLI build in e2e-tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -329,6 +329,10 @@ jobs:
           docker pull quay.io/dexidp/dex:v2.22.0
           docker pull argoproj/argo-cd-ci-builder:v1.0.0
           docker pull redis:5.0.8-alpine
+      - name: Create target directory for binaries in the build-process
+        run: |
+          mkdir -p dist
+          chown runner dist
       - name: Run E2E server and wait for it being available
         timeout-minutes: 30
         run: |

--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ test-e2e:
 test-e2e-local: cli-local
 	# NO_PROXY ensures all tests don't go out through a proxy if one is configured on the test system
 	export GO111MODULE=off
-	ARGOCD_GPG_ENABLED=true NO_PROXY=* ./hack/test.sh -timeout 15m -v ./test/e2e
+	ARGOCD_GPG_ENABLED=true NO_PROXY=* ./hack/test.sh -timeout 20m -v ./test/e2e
 
 # Spawns a shell in the test server container for debugging purposes
 debug-test-server:

--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,7 @@ cli:
 
 .PHONY: cli-local
 cli-local: clean-debug
-	ls -la ${DIST_DIR}/
-	CGO_ENABLED=0 ${PACKR_CMD} build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
+	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 
 .PHONY: cli-docker
 	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ cli:
 cli-local: clean-debug
 	rm -f ${DIST_DIR}/${CLI_NAME}
 	mkdir -p ${DIST_DIR}
-	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
+	CGO_ENABLED=0 ${PACKR_CMD} build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 
 .PHONY: cli-docker
 	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ cli-local: clean-debug
 	rm -f ${DIST_DIR}/${CLI_NAME}
 	mkdir -p ${DIST_DIR}
 	ls -la ${DIST_DIR}/
-	CGO_ENABLED=1 ${PACKR_CMD} build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
+	CGO_ENABLED=0 ${PACKR_CMD} build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 
 .PHONY: cli-docker
 	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd

--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,6 @@ cli:
 
 .PHONY: cli-local
 cli-local: clean-debug
-	rm -f ${DIST_DIR}/${CLI_NAME}
-	mkdir -p ${DIST_DIR}
 	ls -la ${DIST_DIR}/
 	CGO_ENABLED=0 ${PACKR_CMD} build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,8 @@ cli:
 cli-local: clean-debug
 	rm -f ${DIST_DIR}/${CLI_NAME}
 	mkdir -p ${DIST_DIR}
-	CGO_ENABLED=0 ${PACKR_CMD} build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
+	ls -la ${DIST_DIR}/
+	CGO_ENABLED=1 ${PACKR_CMD} build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 
 .PHONY: cli-docker
 	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd


### PR DESCRIPTION
Also updates timeout from 15m to 20m for running e2e tests, because sometimes GH runners tend to be slowish.

Addresses one of the issues of #3932 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
