### PR TITLE
fix: support project finalizer to ensure proper deletion

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -24,6 +24,7 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -89,6 +90,7 @@ type ApplicationController struct {
 	// queue contains app namespace/name/comparisonType and used to request app refresh with the predefined comparison type
 	appComparisonTypeRefreshQueue workqueue.RateLimitingInterface
 	appOperationQueue             workqueue.RateLimitingInterface
+	projectRefreshQueue           workqueue.RateLimitingInterface
 	appInformer                   cache.SharedIndexInformer
 	appLister                     applisters.ApplicationLister
 	projInformer                  cache.SharedIndexInformer
@@ -135,6 +137,7 @@ func NewApplicationController(
 		repoClientset:                 repoClientset,
 		appRefreshQueue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "app_reconciliation_queue"),
 		appOperationQueue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "app_operation_processing_queue"),
+		projectRefreshQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "project_reconciliation_queue"),
 		appComparisonTypeRefreshQueue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		db:                            db,
 		statusRefreshTimeout:          appResyncPeriod,
@@ -154,6 +157,23 @@ func NewApplicationController(
 	}
 	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
 	projInformer := v1alpha1.NewAppProjectInformer(applicationClientset, namespace, appResyncPeriod, indexers)
+	projInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if key, err := cache.MetaNamespaceKeyFunc(obj); err == nil {
+				ctrl.projectRefreshQueue.Add(key)
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			if key, err := cache.MetaNamespaceKeyFunc(new); err == nil {
+				ctrl.projectRefreshQueue.Add(key)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			if key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err == nil {
+				ctrl.projectRefreshQueue.Add(key)
+			}
+		},
+	})
 	metricsAddr := fmt.Sprintf("0.0.0.0:%d", metricsPort)
 	ctrl.metricsServer = metrics.NewMetricsServer(metricsAddr, appLister, func() error {
 		_, err := kubeClientset.Discovery().ServerVersion()
@@ -420,6 +440,7 @@ func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int
 	defer ctrl.appRefreshQueue.ShutDown()
 	defer ctrl.appComparisonTypeRefreshQueue.ShutDown()
 	defer ctrl.appOperationQueue.ShutDown()
+	defer ctrl.projectRefreshQueue.ShutDown()
 
 	ctrl.metricsServer.RegisterClustersInfoSource(ctx, ctrl.stateCache)
 	ctrl.RegisterClusterSecretUpdater(ctx)
@@ -453,6 +474,11 @@ func (ctrl *ApplicationController) Run(ctx context.Context, statusProcessors int
 
 	go wait.Until(func() {
 		for ctrl.processAppComparisonTypeQueueItem() {
+		}
+	}, time.Second, ctx.Done())
+
+	go wait.Until(func() {
+		for ctrl.processProjectQueueItem() {
 		}
 	}, time.Second, ctx.Done())
 	<-ctx.Done()
@@ -559,6 +585,71 @@ func (ctrl *ApplicationController) processAppComparisonTypeQueueItem() (processN
 	return
 }
 
+func (ctrl *ApplicationController) processProjectQueueItem() (processNext bool) {
+	key, shutdown := ctrl.projectRefreshQueue.Get()
+	processNext = true
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("Recovered from panic: %+v\n%s", r, debug.Stack())
+		}
+		ctrl.projectRefreshQueue.Done(key)
+	}()
+	if shutdown {
+		processNext = false
+		return
+	}
+	obj, exists, err := ctrl.projInformer.GetIndexer().GetByKey(key.(string))
+	if err != nil {
+		log.Errorf("Failed to get project '%s' from informer index: %+v", key, err)
+		return
+	}
+	if !exists {
+		// This happens after appproj was deleted, but the work queue still had an entry for it.
+		return
+	}
+	origProj, ok := obj.(*appv1.AppProject)
+	if !ok {
+		log.Warnf("Key '%s' in index is not an appproject", key)
+		return
+	}
+
+	if origProj.DeletionTimestamp != nil && origProj.HasFinalizer() {
+		if err := ctrl.finalizeProjectDeletion(origProj.DeepCopy()); err != nil {
+			log.Warnf("Failed to finalize project deletion: %v", err)
+		}
+	}
+	return
+}
+
+func (ctrl *ApplicationController) finalizeProjectDeletion(proj *appv1.AppProject) error {
+	apps, err := ctrl.appLister.Applications(ctrl.namespace).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	hasApps := false
+	for i := range apps {
+		if apps[i].Spec.GetProject() == proj.Name {
+			hasApps = true
+			break
+		}
+	}
+	if !hasApps {
+		proj.RemoveFinalizer()
+		var patch []byte
+		patch, _ = json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"finalizers": proj.Finalizers,
+			},
+		})
+		_, err = ctrl.applicationClientset.ArgoprojV1alpha1().AppProjects(ctrl.namespace).Patch(proj.Name, types.MergePatchType, patch)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // shouldBeDeleted returns whether a given resource obj should be deleted on cascade delete of application app
 func (ctrl *ApplicationController) shouldBeDeleted(app *appv1.Application, obj *unstructured.Unstructured) bool {
 	return !kube.IsCRD(obj) && !isSelfReferencedApp(app, kube.GetObjectRef(obj))
@@ -655,6 +746,7 @@ func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Applic
 	}
 
 	logCtx.Infof("Successfully deleted %d resources", len(objs))
+	ctrl.projectRefreshQueue.Add(fmt.Sprintf("%s/%s", app.Namespace, app.Spec.GetProject()))
 	return objs, nil
 }
 

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -84,7 +84,7 @@ kind: AppProject
 metadata:
   name: my-project
   namespace: argocd
-  # Finalizer that ensures that project is not deleted until it is referenced by any application
+  # Finalizer that ensures that project is not deleted until it is not referenced by any application
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -84,6 +84,9 @@ kind: AppProject
 metadata:
   name: my-project
   namespace: argocd
+  # Finalizer that ensures that project is not deleted until it is referenced by any application
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   description: Example Project
   # Allow manifests to deploy from any Git repos

--- a/docs/operator-manual/project.yaml
+++ b/docs/operator-manual/project.yaml
@@ -3,6 +3,9 @@ kind: AppProject
 metadata:
   name: my-project
   namespace: argocd
+  # Finalizer that ensures that project is not deleted until it is not referenced by any application
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   # Project description
   description: Example Project

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2078,18 +2078,9 @@ func (proj *AppProject) ProjectPoliciesString() string {
 	return strings.Join(policies, "\n")
 }
 
-func (app *Application) getFinalizerIndex(name string) int {
-	for i, finalizer := range app.Finalizers {
-		if finalizer == name {
-			return i
-		}
-	}
-	return -1
-}
-
 // CascadedDeletion indicates if resources finalizer is set and controller should delete app resources before deleting app
 func (app *Application) CascadedDeletion() bool {
-	return app.getFinalizerIndex(common.ResourcesFinalizerName) > -1
+	return getFinalizerIndex(app.ObjectMeta, common.ResourcesFinalizerName) > -1
 }
 
 func (app *Application) IsRefreshRequested() (RefreshType, bool) {
@@ -2113,15 +2104,7 @@ func (app *Application) IsRefreshRequested() (RefreshType, bool) {
 
 // SetCascadedDeletion sets or remove resources finalizer
 func (app *Application) SetCascadedDeletion(prune bool) {
-	index := app.getFinalizerIndex(common.ResourcesFinalizerName)
-	if prune != (index > -1) {
-		if index > -1 {
-			app.Finalizers[index] = app.Finalizers[len(app.Finalizers)-1]
-			app.Finalizers = app.Finalizers[:len(app.Finalizers)-1]
-		} else {
-			app.Finalizers = append(app.Finalizers, common.ResourcesFinalizerName)
-		}
-	}
+	setFinalizer(&app.ObjectMeta, common.ResourcesFinalizerName, prune)
 }
 
 // SetConditions updates the application status conditions for a subset of evaluated types.
@@ -2278,6 +2261,37 @@ func (proj AppProject) IsLiveResourcePermitted(un *unstructured.Unstructured, se
 		return proj.IsDestinationPermitted(ApplicationDestination{Server: server, Namespace: un.GetNamespace()})
 	}
 	return true
+}
+
+// getFinalizerIndex returns finalizer index in the list of object finalizers or -1 if finalizer does not exist
+func getFinalizerIndex(meta metav1.ObjectMeta, name string) int {
+	for i, finalizer := range meta.Finalizers {
+		if finalizer == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// setFinalizer adds or removes finalizer with the specified name
+func setFinalizer(meta *metav1.ObjectMeta, name string, exist bool) {
+	index := getFinalizerIndex(*meta, name)
+	if exist != (index > -1) {
+		if index > -1 {
+			meta.Finalizers[index] = meta.Finalizers[len(meta.Finalizers)-1]
+			meta.Finalizers = meta.Finalizers[:len(meta.Finalizers)-1]
+		} else {
+			meta.Finalizers = append(meta.Finalizers, name)
+		}
+	}
+}
+
+func (proj AppProject) HasFinalizer() bool {
+	return getFinalizerIndex(proj.ObjectMeta, common.ResourcesFinalizerName) > -1
+}
+
+func (proj *AppProject) RemoveFinalizer() {
+	setFinalizer(&proj.ObjectMeta, common.ResourcesFinalizerName, false)
 }
 
 func globMatch(pattern string, val string) bool {


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/1329
Closes https://github.com/argoproj/argo-cd/issues/3175

PR adds deletion finalizer to the appproj resource which ensures that declaratively managed projects are deleted only after all applications are deleted.