### PR TITLE
fix: reduce number of v1/applications/<appName>/syncwindows requests from app details page

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -100,11 +100,11 @@ export const ApplicationStatusPanel = ({application, showOperation, showConditio
             )}
             <DataLoader
                 noLoaderOnInputChange={true}
-                input={application}
-                load={async () => {
-                    return await services.applications.getApplicationSyncWindowState(application.metadata.name);
+                input={application.metadata.name}
+                load={async name => {
+                    return await services.applications.getApplicationSyncWindowState(name);
                 }}>
-                {data => (
+                {(data: models.ApplicationSyncWindowState) => (
                     <React.Fragment>
                         <div className='application-status-panel__item columns small-2' style={{position: 'relative'}}>
                             <div className='application-status-panel__item-value'>


### PR DESCRIPTION
The app details page unnecessary loads sync windows data multiple times ( every time when app changes ). PR reduces ensures that app details page sends only one v1/applications/<appName>/syncwindows request when page is loaded. 