### PR TITLE
fix: Normalize Helm chart path when chart name contains a slash

### DIFF
--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -244,6 +244,11 @@ func newTLSConfig(creds Creds) (*tls.Config, error) {
 // Normalize a chart name for file system use, that is, if chart name is foo/bar/baz, returns the last component as chart name.
 func normalizeChartName(chart string) string {
 	_, nc := path.Split(chart)
+	// We do not want to return the empty string or something else related to filesystem access
+	// Instead, return original string
+	if nc == "" || nc == "." || nc == ".." {
+		return chart
+	}
 	return nc
 }
 

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -153,7 +153,7 @@ func (c *nativeHelmChart) ExtractChart(chart string, version *semver.Version) (s
 		_ = os.RemoveAll(tempDir)
 		return "", nil, err
 	}
-	return path.Join(tempDir, chart), io.NewCloser(func() error {
+	return path.Join(tempDir, normalizeChartName(chart)), io.NewCloser(func() error {
 		return os.RemoveAll(tempDir)
 	}), nil
 }
@@ -241,6 +241,12 @@ func newTLSConfig(creds Creds) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// Normalize a chart name for file system use, that is, if chart name is foo/bar/baz, returns the last component as chart name.
+func normalizeChartName(chart string) string {
+	_, nc := path.Split(chart)
+	return nc
+}
+
 func (c *nativeHelmChart) getChartPath(chart string, version *semver.Version) string {
-	return path.Join(c.repoPath, fmt.Sprintf("%s-%v.tgz", chart, version))
+	return path.Join(c.repoPath, fmt.Sprintf("%s-%v.tgz", normalizeChartName(chart), version))
 }

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -41,3 +41,34 @@ func Test_nativeHelmChart_ExtractChart(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, info.IsDir())
 }
+
+func Test_normalizeChartName(t *testing.T) {
+	t.Run("Test non-slashed name", func(t *testing.T) {
+		n := normalizeChartName("mychart")
+		assert.Equal(t, n, "mychart")
+	})
+	t.Run("Test single-slashed name", func(t *testing.T) {
+		n := normalizeChartName("myorg/mychart")
+		assert.Equal(t, n, "mychart")
+	})
+	t.Run("Test chart name with suborg", func(t *testing.T) {
+		n := normalizeChartName("myorg/mysuborg/mychart")
+		assert.Equal(t, n, "mychart")
+	})
+	t.Run("Test double-slashed name", func(t *testing.T) {
+		n := normalizeChartName("myorg//mychart")
+		assert.Equal(t, n, "mychart")
+	})
+	t.Run("Test invalid chart name - ends with slash", func(t *testing.T) {
+		n := normalizeChartName("myorg/")
+		assert.Equal(t, n, "myorg/")
+	})
+	t.Run("Test invalid chart name - is dot", func(t *testing.T) {
+		n := normalizeChartName("myorg/.")
+		assert.Equal(t, n, "myorg/.")
+	})
+	t.Run("Test invalid chart name - is two dots", func(t *testing.T) {
+		n := normalizeChartName("myorg/..")
+		assert.Equal(t, n, "myorg/..")
+	})
+}


### PR DESCRIPTION
Fixes #3981 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
