### PR TITLE
docs: Add `namespace` field to cluster secret documentation

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -3960,7 +3960,7 @@
           "title": "Name of the cluster. If omitted, will use the server address"
         },
         "namespaces": {
-          "description": "Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list if not empty.",
+          "description": "Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.",
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -431,6 +431,7 @@ The secret data must include following fields:
 
 * `name` - cluster name
 * `server` - cluster api server url
+* `namespaces` - optional list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list if not empty. 
 * `config` - JSON representation of following data structure:
 
 ```yaml

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -431,7 +431,7 @@ The secret data must include following fields:
 
 * `name` - cluster name
 * `server` - cluster api server url
-* `namespaces` - optional list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list if not empty. 
+* `namespaces` - optional list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
 * `config` - JSON representation of following data structure:
 
 ```yaml

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -335,7 +335,7 @@ message Cluster {
   // The server version
   optional string serverVersion = 5;
 
-  // Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list if not empty.
+  // Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
   repeated string namespaces = 6;
 
   // RefreshRequestedAt holds time when cluster cache refresh has been requested

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -1217,7 +1217,7 @@ func schema_pkg_apis_application_v1alpha1_Cluster(ref common.ReferenceCallback) 
 					},
 					"namespaces": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list if not empty.",
+							Description: "Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -967,7 +967,7 @@ type Cluster struct {
 	// DEPRECATED: use Info.ServerVersion field instead.
 	// The server version
 	ServerVersion string `json:"serverVersion,omitempty" protobuf:"bytes,5,opt,name=serverVersion"`
-	// Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list if not empty.
+	// Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
 	Namespaces []string `json:"namespaces,omitempty" protobuf:"bytes,6,opt,name=namespaces"`
 	// RefreshRequestedAt holds time when cluster cache refresh has been requested
 	RefreshRequestedAt *metav1.Time `json:"refreshRequestedAt,omitempty" protobuf:"bytes,7,opt,name=refreshRequestedAt"`


### PR DESCRIPTION
This feature for connecting with clusters where you only are (or can) watch a set of namespaces. Also useful when connecting argo with several clusters to avoid having the controller watching every single kind from every single api group from every single cluster.

Feature added in #2839

> Checklist:
> 
> * [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
> * [x] The title of the PR states what changed and the related issues number (used for the release note).
> * [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
> * [x] Optional. My organization is added to USERS.md.
> * [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
