### PR TITLE
fix: normalize libs jsonnet and broken command in docs

### DIFF
--- a/docs/user-guide/jsonnet.md
+++ b/docs/user-guide/jsonnet.md
@@ -14,7 +14,7 @@ E.g. via the CLI:
 ```bash
 argocd app create APPNAME \
   --jsonnet-ext-str 'app=${ARGOCD_APP_NAME}' \
-  --jsonnet-tla-str 'ns=${ARGOCD_APP_NAMESPACE}'
+  --jsonnet-tla-str 'ns=${ARGOCD_APP_NAMESPACE}' \
   --jsonnet-libs 'vendor'
 ```
 

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -358,7 +358,7 @@ type ApplicationSourceJsonnet struct {
 }
 
 func (j *ApplicationSourceJsonnet) IsZero() bool {
-	return j == nil || len(j.ExtVars) == 0 && len(j.TLAs) == 0
+	return j == nil || len(j.ExtVars) == 0 && len(j.TLAs) == 0 && len(j.Libs) == 0
 }
 
 // ApplicationSourceKsonnet holds ksonnet specific options


### PR DESCRIPTION
Fixes #3991 

This fix the isZero() fonction to take into account the Libs array. Without this change the normalization of apps in argo would remove the entire Directory dictionnary.

I have also fixed a little issue on jsonnet libs in docs.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
