### PR TITLE
fix: minor UI fixes in applications create/edit panels

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -6,7 +6,7 @@ import {clusterTitle, RevisionHelpIcon, YamlEditor} from '../../../shared/compon
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {ApplicationParameters} from '../application-parameters/application-parameters';
-import {ApplicationSyncOptionsCreateNamespaceField, ApplicationSyncOptionsField} from '../application-sync-options';
+import {ApplicationSyncOptionsField} from '../application-sync-options';
 
 const jsonMergePatch = require('json-merge-patch');
 
@@ -62,13 +62,13 @@ const AutoSyncFormField = ReactFormField((props: {fieldApi: FieldApi; className:
             {automated && (
                 <div className='application-create-panel__sync-params'>
                     <div className='checkbox-container'>
-                        <Checkbox onChange={val => setValue({...automated, prune: val})} checked={automated.prune} id='policyPrune' />
+                        <Checkbox onChange={val => setValue({...automated, prune: val})} checked={!!automated.prune} id='policyPrune' />
                         <label htmlFor='policyPrune'>Prune Resources</label>
                         <HelpIcon title='If checked, Argo will delete resources if they are no longer defined in Git' />
                     </div>
                     <div className='checkbox-container'>
-                        <Checkbox onChange={val => setValue({...automated, selfHeal: val})} checked={automated.selfHeal} id='policySelfHeal' />
-                        <label htmlFor='selfHeal'>Self Heal</label>
+                        <Checkbox onChange={val => setValue({...automated, selfHeal: val})} checked={!!automated.selfHeal} id='policySelfHeal' />
+                        <label htmlFor='policySelfHeal'>Self Heal</label>
                         <HelpIcon title='If checked, Argo will force the state defined in Git into the cluster when a deviation in the cluster is detected' />
                     </div>
                 </div>
@@ -191,7 +191,6 @@ export const ApplicationCreatePanel = (props: {
                                                 <div className='argo-form-row'>
                                                     <label>Sync Options</label>
                                                     <FormField formApi={api} field='spec.syncPolicy.syncOptions' component={ApplicationSyncOptionsField} />
-                                                    <FormField formApi={api} field='spec.syncPolicy.syncOptions' component={ApplicationSyncOptionsCreateNamespaceField} />
                                                 </div>
                                             </div>
                                         );

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -6,7 +6,7 @@ import {Consumer} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 
-import {ApplicationSyncOptionsCreateNamespaceField, ApplicationSyncOptionsField} from '../application-sync-options';
+import {ApplicationSyncOptionsField} from '../application-sync-options';
 import {ComparisonStatusIcon, HealthStatusIcon, syncStatusMessage} from '../utils';
 
 require('./application-summary.scss');
@@ -128,7 +128,7 @@ export const ApplicationSummary = (props: {app: models.Application; updateApp: (
                                                           items: versions
                                                       }}
                                                   />
-                                                  <RevisionHelpIcon type='helm' />
+                                                  <RevisionHelpIcon type='helm' top='0' />
                                               </div>
                                           )}
                                       </DataLoader>
@@ -145,7 +145,7 @@ export const ApplicationSummary = (props: {app: models.Application; updateApp: (
                       edit: (formApi: FormApi) => (
                           <React.Fragment>
                               <FormField formApi={formApi} field='spec.source.targetRevision' component={Text} componentProps={{placeholder: 'HEAD'}} />
-                              <RevisionHelpIcon type='git' />{' '}
+                              <RevisionHelpIcon type='git' top='0' />{' '}
                           </React.Fragment>
                       )
                   },
@@ -160,17 +160,18 @@ export const ApplicationSummary = (props: {app: models.Application; updateApp: (
             title: 'REVISION HISTORY LIMIT',
             view: app.spec.revisionHistoryLimit,
             edit: (formApi: FormApi) => (
-                <React.Fragment>
+                <div style={{position: 'relative'}}>
                     <FormField formApi={formApi} field='spec.revisionHistoryLimit' component={Text} />
-                    <HelpIcon
-                        title='This limits this number of items kept in the apps revision history.
-This should only be changed in exceptional circumstances.
-Setting to zero will store no history. This will reduce storage used.
-Increasing will increase the space used to store the history, so we do not recommend increasing it.
-Default is 10.
-'
-                    />
-                </React.Fragment>
+                    <div style={{position: 'absolute', right: '0', top: '0'}}>
+                        <HelpIcon
+                            title='This limits this number of items kept in the apps revision history.
+    This should only be changed in exceptional circumstances.
+    Setting to zero will store no history. This will reduce storage used.
+    Increasing will increase the space used to store the history, so we do not recommend increasing it.
+    Default is 10.'
+                        />
+                    </div>
+                </div>
             )
         },
         {
@@ -179,7 +180,6 @@ Default is 10.
             edit: (formApi: FormApi) => (
                 <div>
                     <FormField formApi={formApi} field='spec.syncPolicy.syncOptions' component={ApplicationSyncOptionsField} />
-                    <FormField formApi={formApi} field='spec.syncPolicy.syncOptions' component={ApplicationSyncOptionsCreateNamespaceField} />
                 </div>
             )
         },

--- a/ui/src/app/applications/components/application-sync-options.tsx
+++ b/ui/src/app/applications/components/application-sync-options.tsx
@@ -31,7 +31,14 @@ function booleanOption(name: string, label: string, defaultVal: boolean, props: 
     );
 }
 
-export const ApplicationSyncOptions = (props: ApplicationSyncOptionProps) => <div>{booleanOption('Validate', 'Use a schema to validate resource manifests', true, props)}</div>;
+const optionStyle: React.CSSProperties = {marginTop: '0.5em'};
+
+export const ApplicationSyncOptions = (props: ApplicationSyncOptionProps) => (
+    <React.Fragment>
+        <div style={optionStyle}>{booleanOption('Validate', 'Use a schema to validate resource manifests', true, props)}</div>
+        <div style={optionStyle}>{booleanOption('CreateNamespace', 'Auto-create namespace', false, props)}</div>
+    </React.Fragment>
+);
 
 export const ApplicationSyncOptionsField = ReactForm.FormField((props: {fieldApi: ReactForm.FieldApi}) => {
     const {
@@ -41,26 +48,6 @@ export const ApplicationSyncOptionsField = ReactForm.FormField((props: {fieldApi
     return (
         <div className='argo-field'>
             <ApplicationSyncOptions
-                options={val}
-                onChanged={opts => {
-                    setTouched(true);
-                    setValue(opts);
-                }}
-            />
-        </div>
-    );
-});
-
-export const ApplicationSyncOptionsCreateNamespace = (props: ApplicationSyncOptionProps) => <div>{booleanOption('CreateNamespace', 'Auto-create namespace', false, props)}</div>;
-
-export const ApplicationSyncOptionsCreateNamespaceField = ReactForm.FormField((props: {fieldApi: ReactForm.FieldApi}) => {
-    const {
-        fieldApi: {getValue, setValue, setTouched}
-    } = props;
-    const val = getValue() || [];
-    return (
-        <div className='argo-field'>
-            <ApplicationSyncOptionsCreateNamespace
                 options={val}
                 onChanged={opts => {
                     setTouched(true);

--- a/ui/src/app/shared/components/revision-help-icon.tsx
+++ b/ui/src/app/shared/components/revision-help-icon.tsx
@@ -1,5 +1,8 @@
 import {HelpIcon} from 'argo-ui';
 import * as React from 'react';
 
-export const RevisionHelpIcon = ({type}: {type: string}) =>
-    type === 'helm' ? <HelpIcon title='E.g. 1.2.0, 1.2.*, 1.*, or *' /> : <HelpIcon title='E.g. v1.2.0, v1.2, v1, dev, e2e, master, or HEAD' />;
+export const RevisionHelpIcon = ({type, top}: {type: string; top?: string}) => (
+    <div style={{position: 'absolute', top: top === undefined ? '1em' : top, right: '0.5em'}}>
+        {type === 'helm' ? <HelpIcon title='E.g. 1.2.0, 1.2.*, 1.*, or *' /> : <HelpIcon title='E.g. v1.2.0, v1.2, v1, dev, e2e, master, or HEAD' />}
+    </div>
+);


### PR DESCRIPTION
PR implements several following improvements on application create/edit panels:

* merges sync options into one form field:

from:

![image](https://user-images.githubusercontent.com/426437/88690938-10ed5700-d0b1-11ea-99b6-a78cb114fc9c.png)

to:

![image](https://user-images.githubusercontent.com/426437/88691026-2e222580-d0b1-11ea-9cde-8f80c3753bc6.png)

* moves help icons to the top right corner of input field

from:

![image](https://user-images.githubusercontent.com/426437/88691201-66c1ff00-d0b1-11ea-84a7-28153ff709e6.png)

to:

![image](https://user-images.githubusercontent.com/426437/88691218-6fb2d080-d0b1-11ea-8d58-7721c8dfbfac.png)

