### PR TITLE
fix: handle encoded URL parameter in cluster details page

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -910,6 +910,7 @@ var pathPatters = []*regexp.Regexp{
 	regexp.MustCompile(`/api/v1/repocreds/[^/]+`),
 	regexp.MustCompile(`/api/v1/repositories/[^/]+/apps`),
 	regexp.MustCompile(`/api/v1/repositories/[^/]+/apps/[^/]+`),
+	regexp.MustCompile(`/settings/clusters/[^/]+`),
 }
 
 func (bf *bug21955Workaround) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
PR adds URL encoded part in cluster details page URL