### PR TITLE
fix: Microsoft SSO docs RBAC ConfigMap ref

### DIFF
--- a/docs/operator-manual/user-management/microsoft.md
+++ b/docs/operator-manual/user-management/microsoft.md
@@ -59,7 +59,7 @@
 
     [RBAC Configurations](../rbac.md)
 
-        ConfigMap -> argocd-cm
+        ConfigMap -> argocd-rbac-cm
 
         policy.default: role:readonly
         policy.csv: |


### PR DESCRIPTION
Ensure the ConfigMap name in the code block matches the line above:

> Edit `argocd-rbac-cm` ...