### PR TITLE
feat: support overriding default cluster re-sync duration

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -146,6 +146,8 @@ const (
 	EnvK8sClientQPS = "ARGOCD_K8S_CLIENT_QPS"
 	// EnvK8sClientBurst is the burst value used for the kubernetes client (default: twice the client QPS)
 	EnvK8sClientBurst = "ARGOCD_K8S_CLIENT_BURST"
+	// EnvClusterCacheResyncDuration is the env variable that holds cluster cache re-sync duration
+	EnvClusterCacheResyncDuration = "ARGOCD_CLUSTER_CACHE_RESYNC_DURATION"
 	// EnvK8sClientMaxIdleConnections is the number of max idle connections in K8s REST client HTTP transport (default: 500)
 	EnvK8sClientMaxIdleConnections = "ARGOCD_K8S_CLIENT_MAX_IDLE_CONNECTIONS"
 	// EnvGnuPGHome is the path to ArgoCD's GnuPG keyring for signature verification
@@ -178,6 +180,8 @@ var (
 	K8sClientConfigBurst int = 100
 	// K8sMaxIdleConnections controls the number of max idle connections in K8s REST client HTTP transport
 	K8sMaxIdleConnections = 500
+	// K8sMaxIdleConnections controls the duration of cluster cache refresh
+	K8SClusterResyncDuration = 12 * time.Hour
 )
 
 func init() {
@@ -197,6 +201,11 @@ func init() {
 	if envMaxConn := os.Getenv(EnvK8sClientMaxIdleConnections); envMaxConn != "" {
 		if maxConn, err := strconv.Atoi(envMaxConn); err != nil {
 			K8sMaxIdleConnections = maxConn
+		}
+	}
+	if clusterResyncDurationStr := os.Getenv(EnvClusterCacheResyncDuration); clusterResyncDurationStr != "" {
+		if duration, err := time.ParseDuration(clusterResyncDurationStr); err == nil {
+			K8SClusterResyncDuration = duration
 		}
 	}
 }

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/controller/metrics"
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/util/argo"
@@ -231,6 +232,7 @@ func (c *liveStateCache) getCluster(server string) (clustercache.ClusterCache, e
 	}
 
 	clusterCache = clustercache.NewClusterCache(cluster.RESTConfig(),
+		clustercache.SetResyncTimeout(common.K8SClusterResyncDuration),
 		clustercache.SetSettings(cacheSettings.clusterSettings),
 		clustercache.SetNamespaces(cluster.Namespaces),
 		clustercache.SetPopulateResourceInfoHandler(func(un *unstructured.Unstructured, isRoot bool) (interface{}, bool) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/argoproj/gitops-engine v0.1.3-0.20200727173650-dcb86f7d6b64
+	github.com/argoproj/gitops-engine v0.1.3-0.20200727214732-11d47a621575
 	github.com/argoproj/pkg v0.0.0-20200624215116-23e74cb168fe
 	github.com/bsm/redislock v0.4.3
 	github.com/casbin/casbin v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+Dx
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/argoproj/gitops-engine v0.1.3-0.20200727173650-dcb86f7d6b64 h1:3BGkjx4qBuEzKixkNAJG/PZi5Du1TnJB1HaFqLsPuUA=
-github.com/argoproj/gitops-engine v0.1.3-0.20200727173650-dcb86f7d6b64/go.mod h1:JkoSXhq63nmmf/3pKe8fFGrZC0/cyEasF7aFXCB8B24=
+github.com/argoproj/gitops-engine v0.1.3-0.20200727214732-11d47a621575 h1:/B/3cWRuv2jfcEbwyNguUM6sfY6kgXzf3ctBBg4zQ1Q=
+github.com/argoproj/gitops-engine v0.1.3-0.20200727214732-11d47a621575/go.mod h1:JkoSXhq63nmmf/3pKe8fFGrZC0/cyEasF7aFXCB8B24=
 github.com/argoproj/pkg v0.0.0-20200102163130-2dd1f3f6b4de/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=
 github.com/argoproj/pkg v0.0.0-20200624215116-23e74cb168fe h1:HjTM7H8Z+J1xt340LNpH9q4jc8pXeqzkC8QKIjQphp4=
 github.com/argoproj/pkg v0.0.0-20200624215116-23e74cb168fe/go.mod h1:2EZ44RG/CcgtPTwrRR0apOc7oU6UIw8GjCUJWZ8X3bM=


### PR DESCRIPTION
PR supports changing the default cluster cache resync duration. 