### PR TITLE
fix: terminated sync operation should not auto-retry

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -797,6 +797,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 			ctrl.setOperationState(app, state)
 		}
 	}()
+	terminating := false
 	if isOperationInProgress(app) {
 		// If we get here, we are about process an operation but we notice it is already in progress.
 		// We need to detect if the app object we pulled off the informer is stale and doesn't
@@ -813,8 +814,9 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		}
 		app = freshApp
 		state = app.Status.OperationState.DeepCopy()
+		terminating = state.Phase == synccommon.OperationTerminating
 		// Failed  operation with retry strategy might have be in-progress and has completion time
-		if state.FinishedAt != nil && state.Phase != synccommon.OperationTerminating {
+		if state.FinishedAt != nil && !terminating {
 			retryAt, err := app.Status.OperationState.Operation.Retry.NextRetryAt(state.FinishedAt.Time, state.RetryCount)
 			if err != nil {
 				state.Phase = synccommon.OperationFailed
@@ -860,7 +862,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 			}
 		}
 	} else if state.Phase == synccommon.OperationFailed || state.Phase == synccommon.OperationError {
-		if state.RetryCount < state.Operation.Retry.Limit || state.Operation.Retry.Limit < 0 {
+		if !terminating && (state.RetryCount < state.Operation.Retry.Limit || state.Operation.Retry.Limit < 0) {
 			now := metav1.Now()
 			state.FinishedAt = &now
 			if retryAt, err := state.Operation.Retry.NextRetryAt(now.Time, state.RetryCount); err != nil {


### PR DESCRIPTION
PR fixes incorrect sync auto-retry implementation: terminated sync operation should not auto-retry.