### PR TITLE
fix: 'argocd app sync' should not wait for app refresh if '--dry-run' flag is set

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1402,7 +1402,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				}
 			}
 			for _, appName := range appNames {
-				_, err := waitOnApplicationStatus(acdClient, appName, timeout, watchSync, watchHealth, watchOperations, watchSuspended, selectedResources, false)
+				_, err := waitOnApplicationStatus(acdClient, appName, timeout, watchSync, watchHealth, watchOperations, watchSuspended, selectedResources)
 				errors.CheckError(err)
 			}
 		},
@@ -1579,7 +1579,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				errors.CheckError(err)
 
 				if !async {
-					app, err := waitOnApplicationStatus(acdClient, appName, timeout, false, false, true, false, selectedResources, dryRun)
+					app, err := waitOnApplicationStatus(acdClient, appName, timeout, false, false, true, false, selectedResources)
 					errors.CheckError(err)
 
 					if !dryRun {
@@ -1743,7 +1743,7 @@ func checkResourceStatus(watchSync bool, watchHealth bool, watchOperation bool, 
 
 const waitFormatString = "%s\t%5s\t%10s\t%10s\t%20s\t%8s\t%7s\t%10s\t%s\n"
 
-func waitOnApplicationStatus(acdClient apiclient.Client, appName string, timeout uint, watchSync bool, watchHealth bool, watchOperation bool, watchSuspended bool, selectedResources []argoappv1.SyncOperationResource, dryRun bool) (*argoappv1.Application, error) {
+func waitOnApplicationStatus(acdClient apiclient.Client, appName string, timeout uint, watchSync bool, watchHealth bool, watchOperation bool, watchSuspended bool, selectedResources []argoappv1.SyncOperationResource) (*argoappv1.Application, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1793,7 +1793,6 @@ func waitOnApplicationStatus(acdClient apiclient.Client, appName string, timeout
 	app, err := appClient.Get(ctx, &applicationpkg.ApplicationQuery{Name: &appName})
 	errors.CheckError(err)
 	appEventCh := acdClient.WatchApplicationWithRetry(ctx, appName, app.ResourceVersion)
-
 	for appEvent := range appEventCh {
 		app = &appEvent.Application
 
@@ -1802,14 +1801,14 @@ func waitOnApplicationStatus(acdClient apiclient.Client, appName string, timeout
 		if app.Operation != nil {
 			// if it just got requested
 			operationInProgress = true
-			if !dryRun {
+			if !app.Operation.DryRun() {
 				refresh = true
 			}
 		} else if app.Status.OperationState != nil {
 			if app.Status.OperationState.FinishedAt == nil {
 				// if it is not finished yet
 				operationInProgress = true
-			} else if app.Status.ReconciledAt == nil || app.Status.ReconciledAt.Before(app.Status.OperationState.FinishedAt) {
+			} else if !app.Status.OperationState.Operation.DryRun() && (app.Status.ReconciledAt == nil || app.Status.ReconciledAt.Before(app.Status.OperationState.FinishedAt)) {
 				// if it is just finished and we need to wait for controller to reconcile app once after syncing
 				operationInProgress = true
 			}
@@ -2022,7 +2021,7 @@ func NewApplicationRollbackCommand(clientOpts *argocdclient.ClientOptions) *cobr
 			})
 			errors.CheckError(err)
 
-			_, err = waitOnApplicationStatus(acdClient, appName, timeout, false, false, true, false, nil, false)
+			_, err = waitOnApplicationStatus(acdClient, appName, timeout, false, false, true, false, nil)
 			errors.CheckError(err)
 		},
 	}

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -455,6 +455,13 @@ type Operation struct {
 	Retry RetryStrategy `json:"retry,omitempty" protobuf:"bytes,4,opt,name=retry"`
 }
 
+func (o *Operation) DryRun() bool {
+	if o.Sync != nil {
+		return o.Sync.DryRun
+	}
+	return false
+}
+
 // SyncOperationResource contains resources to sync.
 type SyncOperationResource struct {
 	Group     string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`


### PR DESCRIPTION
The `argocd app sync --dry-run` unnecessary wait for `app.Status.ReconciledAt` field update. Controller does not force refresh application after dry-run operation completion. 