### PR TITLE
fix: remove unnecessary liveness probe from argocd components

### DIFF
--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -33,11 +33,6 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
         volumeMounts:
         - name: ssh-known-hosts
           mountPath: /app/config/ssh

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -35,12 +35,6 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 30
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 30
       volumes:
       - emptyDir: {}
         name: static-files

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3216,11 +3216,6 @@ spec:
         - argocd-redis-ha-haproxy:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 8081
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -3292,12 +3287,6 @@ spec:
           value: "2"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 30
         name: argocd-server
         ports:
         - containerPort: 8080

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3131,11 +3131,6 @@ spec:
         - argocd-redis-ha-haproxy:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 8081
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -3207,12 +3202,6 @@ spec:
           value: "2"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 30
         name: argocd-server
         ports:
         - containerPort: 8080

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2735,11 +2735,6 @@ spec:
         - argocd-redis:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 8081
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -2791,12 +2786,6 @@ spec:
         - /shared/app
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 30
         name: argocd-server
         ports:
         - containerPort: 8080

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2650,11 +2650,6 @@ spec:
         - argocd-redis:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 8081
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -2706,12 +2701,6 @@ spec:
         - /shared/app
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 30
         name: argocd-server
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Liveness probes were added to repo server and api server primarily as a workaround for an issue caused by leaked go routine. 
The issue is fixed in api-server by ( by moving to informers instead of using k8s watch directly ). 


Same Readiness & liveness probe causes more harm than good. For example, In 1.7 we've introduced automated AppProject CRD data migration that might delay api-server start time by few seconds. This might cause liveness probe to fail and K8S unnecessary restart container. 