### PR TITLE
feat: Flag to add kustomize common labels (#3703)

### DIFF
--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -47,6 +47,39 @@ func Test_setHelmOpt(t *testing.T) {
 	})
 }
 
+func Test_setKustomizeOpt(t *testing.T) {
+	t.Run("No kustomize", func(t *testing.T) {
+		src := v1alpha1.ApplicationSource{}
+		setKustomizeOpt(&src, kustomizeOpts{})
+		assert.Nil(t, src.Kustomize)
+	})
+	t.Run("Name prefix", func(t *testing.T) {
+		src := v1alpha1.ApplicationSource{}
+		setKustomizeOpt(&src, kustomizeOpts{namePrefix: "test-"})
+		assert.Equal(t, &v1alpha1.ApplicationSourceKustomize{NamePrefix: "test-"}, src.Kustomize)
+	})
+	t.Run("Name suffix", func(t *testing.T) {
+		src := v1alpha1.ApplicationSource{}
+		setKustomizeOpt(&src, kustomizeOpts{nameSuffix: "-test"})
+		assert.Equal(t, &v1alpha1.ApplicationSourceKustomize{NameSuffix: "-test"}, src.Kustomize)
+	})
+	t.Run("Images", func(t *testing.T) {
+		src := v1alpha1.ApplicationSource{}
+		setKustomizeOpt(&src, kustomizeOpts{images: []string{"org/image:v1", "org/image:v2"}})
+		assert.Equal(t, &v1alpha1.ApplicationSourceKustomize{Images: v1alpha1.KustomizeImages{v1alpha1.KustomizeImage("org/image:v2")}}, src.Kustomize)
+	})
+	t.Run("Version", func(t *testing.T) {
+		src := v1alpha1.ApplicationSource{}
+		setKustomizeOpt(&src, kustomizeOpts{version: "v0.1"})
+		assert.Equal(t, &v1alpha1.ApplicationSourceKustomize{Version: "v0.1"}, src.Kustomize)
+	})
+	t.Run("Common labels", func(t *testing.T) {
+		src := v1alpha1.ApplicationSource{}
+		setKustomizeOpt(&src, kustomizeOpts{commonLabels: map[string]string{"foo1": "bar1", "foo2": "bar2"}})
+		assert.Equal(t, &v1alpha1.ApplicationSourceKustomize{CommonLabels: map[string]string{"foo1": "bar1", "foo2": "bar2"}}, src.Kustomize)
+	})
+}
+
 func Test_setJsonnetOpt(t *testing.T) {
 	t.Run("TlaSets", func(t *testing.T) {
 		src := v1alpha1.ApplicationSource{}


### PR DESCRIPTION
Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

This PR adds a new optional flag `--kustomize-common-label` to the app create command. It can be used to set common labels in kustomize.

Usage:
```
argocd app create APP_NAME  --kustomize-common-label key1=value1 --kustomize-common-label key2=value2 --repo REPO_NAME --path PATH_TO_KUSTOMIZE --dest-server SERVER_NAME --dest-namespace DEST_NAMESPACE 
```
Check the labels added to the kustomize section in the application manifest 

```yaml
  kustomize:
    commonLabels:
      key1: value1
      key2: value2
```



closes: #3703 