### PR TITLE
feat: support setting --loglevel through kustomize env patches

### DIFF
--- a/manifests/base/application-controller/argocd-application-controller-deployment.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-deployment.yaml
@@ -24,9 +24,14 @@ spec:
         - "20"
         - --operation-processors
         - "10"
+        - --loglevel
+        - $(ARGOCD_APPLICATION_CONTROLLER_LOG_LEVEL)
         image: argoproj/argocd:latest
         imagePullPolicy: Always
         name: argocd-application-controller
+        env:
+        - name: ARGOCD_APPLICATION_CONTROLLER_LOG_LEVEL
+          value: "info"
         ports:
         - containerPort: 8082
         readinessProbe:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -25,6 +25,11 @@ spec:
         - argocd-repo-server
         - --redis
         - $(ARGOCD_REDIS_SERVICE):6379
+        - --loglevel
+        - $(ARGOCD_REPO_SERVER_LOG_LEVEL)
+        env:
+        - name: ARGOCD_REPO_SERVER_LOG_LEVEL
+          value: "info"
         ports:
         - containerPort: 8081
         - containerPort: 8084

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -20,12 +20,20 @@ spec:
       - name: argocd-server
         image: argoproj/argocd:latest
         imagePullPolicy: Always
-        command: [argocd-server, --staticassets, /shared/app]
+        command:
+        - argocd-server
+        - --staticassets
+        - /shared/app
+        - --loglevel
+        - $(ARGOCD_SERVER_LOG_LEVEL)
         volumeMounts:
         - name: ssh-known-hosts
           mountPath: /app/config/ssh
         - name: tls-certs
           mountPath: /app/config/tls
+        env:
+        - name: ARGOCD_SERVER_LOG_LEVEL
+          value: "info"
         ports:
         - containerPort: 8080
         - containerPort: 8083

--- a/manifests/ha/base/overlays/argocd-application-controller-deployment.yaml
+++ b/manifests/ha/base/overlays/argocd-application-controller-deployment.yaml
@@ -15,3 +15,5 @@ spec:
         - "10"
         - --redis
         - "argocd-redis-ha-haproxy:6379"
+        - --loglevel
+        - $(ARGOCD_APPLICATION_CONTROLLER_LOG_LEVEL)

--- a/manifests/ha/base/overlays/argocd-repo-server-deployment.yaml
+++ b/manifests/ha/base/overlays/argocd-repo-server-deployment.yaml
@@ -27,3 +27,5 @@ spec:
         - argocd-repo-server
         - --redis
         - "argocd-redis-ha-haproxy:6379"
+        - --loglevel
+        - $(ARGOCD_REPO_SERVER_LOG_LEVEL)

--- a/manifests/ha/base/overlays/argocd-server-deployment.yaml
+++ b/manifests/ha/base/overlays/argocd-server-deployment.yaml
@@ -31,3 +31,5 @@ spec:
         - /shared/app
         - --redis
         - "argocd-redis-ha-haproxy:6379"
+        - --loglevel
+        - $(ARGOCD_SERVER_LOG_LEVEL)

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3108,6 +3108,11 @@ spec:
         - "10"
         - --redis
         - argocd-redis-ha-haproxy:6379
+        - --loglevel
+        - $(ARGOCD_APPLICATION_CONTROLLER_LOG_LEVEL)
+        env:
+        - name: ARGOCD_APPLICATION_CONTROLLER_LOG_LEVEL
+          value: "info"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
         livenessProbe:
@@ -3214,6 +3219,11 @@ spec:
         - argocd-repo-server
         - --redis
         - argocd-redis-ha-haproxy:6379
+        - --loglevel
+        - $(ARGOCD_REPO_SERVER_LOG_LEVEL)
+        env:
+        - name: ARGOCD_REPO_SERVER_LOG_LEVEL
+          value: "info"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
         name: argocd-repo-server
@@ -3282,9 +3292,13 @@ spec:
         - /shared/app
         - --redis
         - argocd-redis-ha-haproxy:6379
+        - --loglevel
+        - $(ARGOCD_SERVER_LOG_LEVEL)
         env:
         - name: ARGOCD_API_SERVER_REPLICAS
           value: "2"
+        - name: ARGOCD_SERVER_LOG_LEVEL
+          value: "info"
         image: argoproj/argocd:latest
         imagePullPolicy: Always
         name: argocd-server


### PR DESCRIPTION
This allows setting the appropriate env vars through a kustomize patch. Users
otherwise need to patch the command attributes and on every update check that
they remain correct.

Example patch:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: argocd-application-controller
spec:
  template:
    spec:
      containers:
      - name: argocd-application-controller
        env:
        - name: ARGOCD_APPLICATION_CONTROLLER_LOG_LEVEL
          value: "warn"
```

The info level is the current default in the applications.