### PR TITLE
fix: Make GnuPG keyring independent of user ID within container

### DIFF
--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -40,6 +40,8 @@ spec:
           mountPath: /app/config/tls
         - name: gpg-keys
           mountPath: /app/config/gpg/source
+        - name: gpg-keyring
+          mountPath: /app/config/gpg/keys
       volumes:
         - name: ssh-known-hosts
           configMap:
@@ -50,3 +52,5 @@ spec:
         - name: gpg-keys
           configMap:
             name: argocd-gpg-keys-cm
+        - name: gpg-keyring
+          emptyDir: {}

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3232,6 +3232,8 @@ spec:
           name: tls-certs
         - mountPath: /app/config/gpg/source
           name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm
@@ -3242,6 +3244,8 @@ spec:
       - configMap:
           name: argocd-gpg-keys-cm
         name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3147,6 +3147,8 @@ spec:
           name: tls-certs
         - mountPath: /app/config/gpg/source
           name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm
@@ -3157,6 +3159,8 @@ spec:
       - configMap:
           name: argocd-gpg-keys-cm
         name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2751,6 +2751,8 @@ spec:
           name: tls-certs
         - mountPath: /app/config/gpg/source
           name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm
@@ -2761,6 +2763,8 @@ spec:
       - configMap:
           name: argocd-gpg-keys-cm
         name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2666,6 +2666,8 @@ spec:
           name: tls-certs
         - mountPath: /app/config/gpg/source
           name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm
@@ -2676,6 +2678,8 @@ spec:
       - configMap:
           name: argocd-gpg-keys-cm
         name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/util/gpg/gpg_test.go
+++ b/util/gpg/gpg_test.go
@@ -96,6 +96,8 @@ func Test_GPG_InitializeGnuPG(t *testing.T) {
 	}
 
 	// GNUPGHOME with too wide permissions
+	// We do not expect an error here, because of openshift's random UIDs that
+	// forced us to use an emptyDir mount (#4127)
 	p = initTempDir()
 	defer os.RemoveAll(p)
 	err = os.Chmod(p, 0777)
@@ -104,8 +106,7 @@ func Test_GPG_InitializeGnuPG(t *testing.T) {
 	}
 	os.Setenv(common.EnvGnuPGHome, p)
 	err = InitializeGnuPG()
-	assert.Error(t, err)
-
+	assert.NoError(t, err)
 }
 
 func Test_GPG_KeyManagement(t *testing.T) {


### PR DESCRIPTION
Fixes #4127 

- Uses `emptyDir` mount for the keyring in repository server
- Suppresses permissions warnings from gpg

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
