### PR TITLE
doc: fix the ci_automation's kustomize source code.

### DIFF
--- a/docs/user-guide/ci_automation.md
+++ b/docs/user-guide/ci_automation.md
@@ -27,7 +27,7 @@ git clone https://github.com/mycompany/guestbook-config.git
 cd guestbook-config
 
 # kustomize
-kustomize edit set imagetag mycompany/guestbook:v2.0
+kustomize edit set image mycompany/guestbook:v2.0
 
 # ksonnet
 ks param set guestbook image mycompany/guestbook:v2.0


### PR DESCRIPTION
Fix the ci_automation's kustomize source code in the example.

`kustomize edit set imagetag` was deleted by the [PR: Support changing of image registries in addition to image tags](https://github.com/kubernetes-sigs/kustomize/issues/402).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
