### PR TITLE
docs: Switch to argocd namespace before starting local services

### DIFF
--- a/docs/developer-guide/debugging-remote-environment.md
+++ b/docs/developer-guide/debugging-remote-environment.md
@@ -14,7 +14,7 @@ To read more about it, refer to the official documentation at [telepresence.io](
 First of all, install ArgoCD on your cluster
 ```shell
 kubectl create ns argocd
-curl -sSfL https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml | k apply -n argocd -f -
+curl -sSfL https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml | kubectl apply -n argocd -f -
 ```
 
 ## Connect

--- a/docs/developer-guide/running-locally.md
+++ b/docs/developer-guide/running-locally.md
@@ -31,7 +31,7 @@ kubectl -n argocd scale deployment/argocd-redis --replicas 0
 
 ### Start local services
 
-When you use the virtualized toolchain, starting local services is as simple as running
+Before starting local services, make sure you are present in `argocd` namespace. When you use the virtualized toolchain, starting local services is as simple as running
 
 ```bash
 make start


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

While setting up ArgoCD locally, I was running `make start` while being in a different namespace. This was causing issues since it expects the user to be in `argocd` namespace. I solved this issue after getting help from the channel. It would be really helpful for newcomers if it's mentioned in the docs.

cc @jannfis 