### PR TITLE
fix: Allow no config cluster

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -47,6 +47,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Optoro](https://www.optoro.com/)
 1. [Peloton Interactive](https://www.onepeloton.com/)
 1. [Pipefy](https://www.pipefy.com/)
+1. [Preferred Networks](https://preferred.jp/en/)
 1. [Prudential](https://prudential.com.sg)
 1. [PUBG](https://www.pubg.com)
 1. [QuintoAndar](https://quintoandar.com.br)

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -314,10 +314,13 @@ func clusterToSecret(c *appv1.Cluster, secret *apiv1.Secret) error {
 // secretToCluster converts a secret into a Cluster object
 func secretToCluster(s *apiv1.Secret) *appv1.Cluster {
 	var config appv1.ClusterConfig
-	err := json.Unmarshal(s.Data["config"], &config)
-	if err != nil {
-		panic(err)
+	if len(s.Data["config"]) > 0 {
+		err := json.Unmarshal(s.Data["config"], &config)
+		if err != nil {
+			panic(err)
+		}
 	}
+
 	var namespaces []string
 	for _, ns := range strings.Split(string(s.Data["namespaces"]), ",") {
 		if ns = strings.TrimSpace(ns); ns != "" {

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -25,6 +25,46 @@ func Test_serverToSecretName(t *testing.T) {
 	assert.Equal(t, "cluster-foo-752281925", name)
 }
 
+func Test_secretToCluster(t *testing.T) {
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: fakeNamespace,
+		},
+		Data: map[string][]byte{
+			"name":   []byte("test"),
+			"server": []byte("http://mycluster"),
+			"config": []byte("{\"username\":\"foo\"}"),
+		},
+	}
+	cluster := secretToCluster(secret)
+	assert.Equal(t, *cluster, v1alpha1.Cluster{
+		Name:               "test",
+		Server:             "http://mycluster",
+		Config: v1alpha1.ClusterConfig{
+			Username: "foo",
+		},
+	})
+}
+
+func Test_secretToCluster_NoConfig(t *testing.T) {
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: fakeNamespace,
+		},
+		Data: map[string][]byte{
+			"name":   []byte("test"),
+			"server": []byte("http://mycluster"),
+		},
+	}
+	cluster := secretToCluster(secret)
+	assert.Equal(t, *cluster, v1alpha1.Cluster{
+		Name:               "test",
+		Server:             "http://mycluster",
+	})
+}
+
 func TestUpdateCluster(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(&v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -39,8 +39,8 @@ func Test_secretToCluster(t *testing.T) {
 	}
 	cluster := secretToCluster(secret)
 	assert.Equal(t, *cluster, v1alpha1.Cluster{
-		Name:               "test",
-		Server:             "http://mycluster",
+		Name:   "test",
+		Server: "http://mycluster",
 		Config: v1alpha1.ClusterConfig{
 			Username: "foo",
 		},
@@ -60,8 +60,8 @@ func Test_secretToCluster_NoConfig(t *testing.T) {
 	}
 	cluster := secretToCluster(secret)
 	assert.Equal(t, *cluster, v1alpha1.Cluster{
-		Name:               "test",
-		Server:             "http://mycluster",
+		Name:   "test",
+		Server: "http://mycluster",
 	})
 }
 


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

I found if a cluster config doesn't have `config` field, ArgoCD rais an error and cannot proceed anything even if the config it not required like the in-cluster case.

Here's my argocd version.

```
$ argocd version
argocd: v1.6.2+3d1f37b.dirty
  BuildDate: 2020-08-01T06:59:53Z
  GitCommit: 3d1f37b0c53f4c75864dc7339e2831c6e6a947e0
  GitTreeState: dirty
  GoVersion: go1.14.6
  Compiler: gc
  Platform: darwin/amd64
argocd-server: v1.6.2+3d1f37b
  BuildDate: 2020-07-31T23:45:07Z
  GitCommit: 3d1f37b0c53f4c75864dc7339e2831c6e6a947e0
  GitTreeState: clean
  GoVersion: go1.14.1
  Compiler: gc
  Platform: linux/amd64
  Ksonnet Version: v0.13.1
  Kustomize Version: {Version:kustomize/v3.6.1 GitCommit:c97fa946d576eb6ed559f17f2ac43b3b5a8d5dbd BuildDate:2020-05-27T20:47:35Z GoOs:linux GoArch:amd64}
  Helm Version: version.BuildInfo{Version:"v3.2.0", GitCommit:"e11b7ce3b12db2941e90399e874513fbd24bcb71", GitTreeState:"clean", GoVersion:"go1.13.10"}
  Kubectl Version: v1.14.0
```

And the controller log.

<details><summary>application controller log</summary>

```
$ kubectl logs -n argocd-example argocd-application-controller-54d8d45ccc-r8g4z --tail 200
time="2020-08-26T15:54:11Z" level=info msg="appResyncPeriod=3m0s"
time="2020-08-26T15:54:11Z" level=info msg="Application Controller (version: v1.6.2+3d1f37b, built: 2020-07-31T23:45:21Z) starting (namespace: argocd-example)"
time="2020-08-26T15:54:11Z" level=info msg="Starting configmap/secret informers"
time="2020-08-26T15:54:11Z" level=info msg="Configmap/secret informer synced"
time="2020-08-26T15:54:11Z" level=info msg="Refreshing app status (normal refresh requested), level (2)" application=aaa
time="2020-08-26T15:54:11Z" level=info msg="Refreshing app status (normal refresh requested), level (2)" application=test
time="2020-08-26T15:54:11Z" level=info msg="Reconciliation completed" application=test dest-namespace=argocd-example dest-server="https://kubernetes.default.svc" fields.level=2 time_ms=0
time="2020-08-26T15:54:11Z" level=info msg="Reconciliation completed" application=aaa dest-namespace=argocd-example dest-server="https://kubernetes.default.svc" fields.level=2 time_ms=0
time="2020-08-26T15:54:11Z" level=error msg="Recovered from panic: unexpected end of JSON input\ngoroutine 134 [running]:\nruntime/debug.Stack(0xc000558890, 0x1b62a80, 0xc0006373a0)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).processAppRefreshQueueItem.func1(0xc0005ac280, 0x1afb2c0, 0xc00064a1f0)\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:806 +0x88\npanic(0x1b62a80, 0xc0006373a0)\n\t/usr/local/go/src/runtime/panic.go:973 +0x3e3\ngithub.com/argoproj/argo-cd/util/db.secretToCluster(0xc000669098, 0xc00000ea28)\n\t/go/src/github.com/argoproj/argo-cd/util/db/cluster.go:280 +0x520\ngithub.com/argoproj/argo-cd/util/db.(*db).getClusterSecret(0xc0002b48d0, 0xc000567f20, 0x1e, 0xe, 0x0, 0x1)\n\t/go/src/github.com/argoproj/argo-cd/util/db/cluster.go:182 +0x8c\ngithub.com/argoproj/argo-cd/util/db.(*db).GetCluster(0xc0002b48d0, 0x2161380, 0xc0000ae000, 0xc000567f20, 0x1e, 0xe, 0x0, 0x0)\n\t/go/src/github.com/argoproj/argo-cd/util/db/cluster.go:192 +0x43\ngithub.com/argoproj/argo-cd/util/argo.ValidatePermissions(0x2161380, 0xc0000ae000, 0xc000576f18, 0xc0001d0400, 0x218d720, 0xc0002b48d0, 0x8, 0x1c876c0, 0xce90b2fc5f6a8c01, 0x203000, ...)\n\t/go/src/github.com/argoproj/argo-cd/util/argo/argo.go:302 +0x4ce\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).refreshAppConditions(0xc0005ac280, 0xc000576e00, 0x32b8340, 0xb)\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:994 +0x51a\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).processAppRefreshQueueItem(0xc0005ac280, 0x1)\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:876 +0x47d\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).Run.func3()\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:429 +0x36\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00081dcc0)\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.6/pkg/util/wait/wait.go:152 +0x5f\nk8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00081dcc0, 0x3b9aca00, 0x0, 0x1, 0xc000098a80)\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.6/pkg/util/wait/wait.go:153 +0xf8\nk8s.io/apimachinery/pkg/util/wait.Until(0xc00081dcc0, 0x3b9aca00, 0xc000098a80)\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.6/pkg/util/wait/wait.go:88 +0x4d\ncreated by github.com/argoproj/argo-cd/controller.(*ApplicationController).Run\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:428 +0x3fc\n"
time="2020-08-26T15:54:11Z" level=error msg="Recovered from panic: unexpected end of JSON input\ngoroutine 137 [running]:\nruntime/debug.Stack(0xc00055c890, 0x1b62a80, 0xc00082d8a0)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).processAppRefreshQueueItem.func1(0xc0005ac280, 0x1afb2c0, 0xc00064a230)\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:806 +0x88\npanic(0x1b62a80, 0xc00082d8a0)\n\t/usr/local/go/src/runtime/panic.go:973 +0x3e3\ngithub.com/argoproj/argo-cd/util/db.secretToCluster(0xc000669098, 0xc0000c1d70)\n\t/go/src/github.com/argoproj/argo-cd/util/db/cluster.go:280 +0x520\ngithub.com/argoproj/argo-cd/util/db.(*db).getClusterSecret(0xc0002b48d0, 0xc0008302e0, 0x1e, 0xe, 0x0, 0x1)\n\t/go/src/github.com/argoproj/argo-cd/util/db/cluster.go:182 +0x8c\ngithub.com/argoproj/argo-cd/util/db.(*db).GetCluster(0xc0002b48d0, 0x2161380, 0xc0000ae000, 0xc0008302e0, 0x1e, 0xe, 0x0, 0x0)\n\t/go/src/github.com/argoproj/argo-cd/util/db/cluster.go:192 +0x43\ngithub.com/argoproj/argo-cd/util/argo.ValidatePermissions(0x2161380, 0xc0000ae000, 0xc00082eb98, 0xc0001d0400, 0x218d720, 0xc0002b48d0, 0x8, 0x1c876c0, 0x78acea81ffed101, 0x203000, ...)\n\t/go/src/github.com/argoproj/argo-cd/util/argo/argo.go:302 +0x4ce\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).refreshAppConditions(0xc0005ac280, 0xc00082ea80, 0x32b8340, 0xb)\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:994 +0x51a\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).processAppRefreshQueueItem(0xc0005ac280, 0x1)\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:876 +0x47d\ngithub.com/argoproj/argo-cd/controller.(*ApplicationController).Run.func3()\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:429 +0x36\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00081dcf0)\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.6/pkg/util/wait/wait.go:152 +0x5f\nk8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00081dcf0, 0x3b9aca00, 0x0, 0x1, 0xc000098a80)\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.6/pkg/util/wait/wait.go:153 +0xf8\nk8s.io/apimachinery/pkg/util/wait.Until(0xc00081dcf0, 0x3b9aca00, 0xc000098a80)\n\t/go/pkg/mod/k8s.io/apimachinery@v0.16.6/pkg/util/wait/wait.go:88 +0x4d\ncreated by github.com/argoproj/argo-cd/controller.(*ApplicationController).Run\n\t/go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:428 +0x3fc\n"
time="2020-08-26T15:54:11Z" level=info msg="0xc0007d3f20 subscribed to settings updates"
panic: unexpected end of JSON input

goroutine 120 [running]:
github.com/argoproj/argo-cd/util/db.secretToCluster(0xc000669098, 0xc00000ea68)
        /go/src/github.com/argoproj/argo-cd/util/db/cluster.go:280 +0x520
github.com/argoproj/argo-cd/util/db.(*db).getClusterSecret(0xc0002b48d0, 0x1e35fc7, 0x1e, 0x40cc78, 0x8, 0x1d6bf00)
        /go/src/github.com/argoproj/argo-cd/util/db/cluster.go:182 +0x8c
github.com/argoproj/argo-cd/util/db.(*db).GetCluster(0xc0002b48d0, 0x2161340, 0xc000322580, 0x1e35fc7, 0x1e, 0xc000622a80, 0x26, 0x0)
        /go/src/github.com/argoproj/argo-cd/util/db/cluster.go:192 +0x43
github.com/argoproj/argo-cd/util/db.(*db).WatchClusters(0xc0002b48d0, 0x2161340, 0xc000322580, 0xc00064a4a0, 0x0, 0x0)
        /go/src/github.com/argoproj/argo-cd/util/db/cluster.go:124 +0x339
github.com/argoproj/argo-cd/controller/cache.(*liveStateCache).Run.func1(0xc0000cc000, 0x5)
        /go/src/github.com/argoproj/argo-cd/controller/cache/cache.go:432 +0x9a
github.com/argoproj/gitops-engine/pkg/utils/kube.RetryUntilSucceed(0xc000549f20, 0x1e1a0b9, 0xe, 0x2161340, 0xc000322580, 0x2540be400)
        /go/pkg/mod/github.com/argoproj/gitops-engine@v0.1.3/pkg/utils/kube/kube.go:384 +0x257
github.com/argoproj/argo-cd/controller/cache.(*liveStateCache).Run(0xc000534f00, 0x2161340, 0xc000322580, 0x0, 0x0)
        /go/src/github.com/argoproj/argo-cd/controller/cache/cache.go:409 +0xea
github.com/argoproj/argo-cd/controller.(*ApplicationController).Run.func1(0xc0005ac280, 0x2161340, 0xc000322580)
        /go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:424 +0x52
created by github.com/argoproj/argo-cd/controller.(*ApplicationController).Run
        /go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:424 +0x3a3
```

</details>