### PR TITLE
fix: Unable to create project JWT token on K8S v1.15

### DIFF
--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -46,6 +46,10 @@ func getCustomResourceDefinitions() map[string]*extensionsobj.CustomResourceDefi
 		// We need to completely remove validation of problematic fields such as creationTimestamp,
 		// which get marshalled to `null`, but are typed as as a `string` during Open API validation
 		removeValidation(un, "metadata.creationTimestamp")
+		// remove status validation for AppProject CRD as workaround for https://github.com/argoproj/argo-cd/issues/4158
+		if un.GetName() == "appprojects.argoproj.io" {
+			removeValidation(un, "status")
+		}
 
 		crd := toCRD(un)
 		crd.Labels = map[string]string{

--- a/manifests/crds/appproject-crd.yaml
+++ b/manifests/crds/appproject-crd.yaml
@@ -218,31 +218,6 @@ spec:
                 type: object
               type: array
           type: object
-        status:
-          description: AppProjectStatus contains information about appproj
-          properties:
-            jwtTokensByRole:
-              additionalProperties:
-                properties:
-                  items:
-                    items:
-                      description: JWTToken holds the issuedAt and expiresAt values of a token
-                      properties:
-                        exp:
-                          format: int64
-                          type: integer
-                        iat:
-                          format: int64
-                          type: integer
-                        id:
-                          type: string
-                      required:
-                      - iat
-                      type: object
-                    type: array
-                type: object
-              type: object
-          type: object
       required:
       - metadata
       - spec

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2133,32 +2133,6 @@ spec:
                 type: object
               type: array
           type: object
-        status:
-          description: AppProjectStatus contains information about appproj
-          properties:
-            jwtTokensByRole:
-              additionalProperties:
-                properties:
-                  items:
-                    items:
-                      description: JWTToken holds the issuedAt and expiresAt values
-                        of a token
-                      properties:
-                        exp:
-                          format: int64
-                          type: integer
-                        iat:
-                          format: int64
-                          type: integer
-                        id:
-                          type: string
-                      required:
-                      - iat
-                      type: object
-                    type: array
-                type: object
-              type: object
-          type: object
       required:
       - metadata
       - spec

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2133,32 +2133,6 @@ spec:
                 type: object
               type: array
           type: object
-        status:
-          description: AppProjectStatus contains information about appproj
-          properties:
-            jwtTokensByRole:
-              additionalProperties:
-                properties:
-                  items:
-                    items:
-                      description: JWTToken holds the issuedAt and expiresAt values
-                        of a token
-                      properties:
-                        exp:
-                          format: int64
-                          type: integer
-                        iat:
-                          format: int64
-                          type: integer
-                        id:
-                          type: string
-                      required:
-                      - iat
-                      type: object
-                    type: array
-                type: object
-              type: object
-          type: object
       required:
       - metadata
       - spec

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2133,32 +2133,6 @@ spec:
                 type: object
               type: array
           type: object
-        status:
-          description: AppProjectStatus contains information about appproj
-          properties:
-            jwtTokensByRole:
-              additionalProperties:
-                properties:
-                  items:
-                    items:
-                      description: JWTToken holds the issuedAt and expiresAt values
-                        of a token
-                      properties:
-                        exp:
-                          format: int64
-                          type: integer
-                        iat:
-                          format: int64
-                          type: integer
-                        id:
-                          type: string
-                      required:
-                      - iat
-                      type: object
-                    type: array
-                type: object
-              type: object
-          type: object
       required:
       - metadata
       - spec

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2133,32 +2133,6 @@ spec:
                 type: object
               type: array
           type: object
-        status:
-          description: AppProjectStatus contains information about appproj
-          properties:
-            jwtTokensByRole:
-              additionalProperties:
-                properties:
-                  items:
-                    items:
-                      description: JWTToken holds the issuedAt and expiresAt values
-                        of a token
-                      properties:
-                        exp:
-                          format: int64
-                          type: integer
-                        iat:
-                          format: int64
-                          type: integer
-                        id:
-                          type: string
-                      required:
-                      - iat
-                      type: object
-                    type: array
-                type: object
-              type: object
-          type: object
       required:
       - metadata
       - spec


### PR DESCRIPTION
Closes #4158

Even though K8S 1.15 is not supported anymore I'm sure a lot of people are still using that version. PR removes AppProject CRD status validation from schema as workaround. I think that is safe since users are not editing status manually anyway.