### PR TITLE
refactor: load only project names in UI

### DIFF
--- a/pkg/apiclient/project/forwarder_overwrite.go
+++ b/pkg/apiclient/project/forwarder_overwrite.go
@@ -1,0 +1,9 @@
+package project
+
+import (
+	"github.com/argoproj/pkg/grpc/http"
+)
+
+func init() {
+	forward_ProjectService_List_0 = http.UnaryForwarder
+}

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -120,7 +120,7 @@ export const ApplicationCreatePanel = (props: {
                 key='creation-deps'
                 load={() =>
                     Promise.all([
-                        services.projects.list().then(projects => projects.map(proj => proj.metadata.name).sort()),
+                        services.projects.list('items.metadata.name').then(projects => projects.map(proj => proj.metadata.name).sort()),
                         services.clusters.list().then(clusters => clusters.sort()),
                         services.repos.list()
                     ]).then(([projects, clusters, reposInfo]) => ({projects, clusters, reposInfo}))

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -35,7 +35,7 @@ export const ApplicationSummary = (props: {app: models.Application; updateApp: (
             title: 'PROJECT',
             view: <a href={'/settings/projects/' + app.spec.project}>{app.spec.project}</a>,
             edit: (formApi: FormApi) => (
-                <DataLoader load={() => services.projects.list().then(projs => projs.map(item => item.metadata.name))}>
+                <DataLoader load={() => services.projects.list('items.metadata.name').then(projs => projs.map(item => item.metadata.name))}>
                     {projects => <FormField formApi={formApi} field='spec.project' component={FormSelect} componentProps={{options: projects}} />}
                 </DataLoader>
             )

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -146,7 +146,7 @@ export class ApplicationsFilter extends React.Component<ApplicationsFilterProps,
                             <p>Projects</p>
                             <ul>
                                 <li>
-                                    <DataLoader load={() => services.projects.list()}>
+                                    <DataLoader load={() => services.projects.list('items.metadata.name')}>
                                         {projects => {
                                             const projAppCount = new Map<string, number>();
                                             projects.forEach(proj => projAppCount.set(proj.metadata.name, 0));

--- a/ui/src/app/shared/services/projects-service.ts
+++ b/ui/src/app/shared/services/projects-service.ts
@@ -90,9 +90,10 @@ function paramsToProj(params: ProjectParams) {
 }
 
 export class ProjectsService {
-    public list(): Promise<models.Project[]> {
+    public list(...fields: string[]): Promise<models.Project[]> {
         return requests
             .get('/projects')
+            .query({fields: fields.join(',')})
             .then(res => res.body as models.ProjectList)
             .then(list => list.items || []);
     }


### PR DESCRIPTION
One Argo CD might have hundreds of projects. In this case UI unnecessary loads ~1mb of JSON. PR changes UI so it loads only projects name. 

Closes https://github.com/argoproj/argo-cd/issues/4224