### PR TITLE
fix: api-server unnecessary normalize projects on every start

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2606,7 +2606,7 @@ func jwtTokensCombine(tokens1 []JWTToken, tokens2 []JWTToken) []JWTToken {
 		tokensMap[token.ID] = token
 	}
 
-	tokens := []JWTToken{}
+	var tokens []JWTToken
 	for _, v := range tokensMap {
 		tokens = append(tokens, v)
 	}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1695,6 +1695,11 @@ func TestProjectNormalize(t *testing.T) {
 		assert.Nil(t, p.Spec.Roles)
 		assert.Nil(t, p.Status.JWTTokensByRole)
 	})
+	t.Run("HasRoles_NoTokens", func(t *testing.T) {
+		p := AppProject{Spec: AppProjectSpec{Roles: []ProjectRole{{Name: "test-role"}}}}
+		needNormalize := p.NormalizeJWTTokens()
+		assert.False(t, needNormalize)
+	})
 	t.Run("SpecRolesToken-StatusRolesTokenEmpty", func(t *testing.T) {
 		p := AppProject{Spec: AppProjectSpec{Roles: []ProjectRole{{Name: "test-role", JWTTokens: testTokens}}}}
 		needNormalize := p.NormalizeJWTTokens()

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -412,7 +412,6 @@ func (s *Server) NormalizeProjs() error {
 		return status.Errorf(codes.Internal, "Error retrieving project list: %s", err.Error())
 	}
 	for _, proj := range projList.Items {
-		// if !apierr.IsConflict(err), retry 3 times
 		for i := 0; i < 3; i++ {
 			if proj.NormalizeJWTTokens() {
 				_, err := s.appclientset.ArgoprojV1alpha1().AppProjects(s.ns).Update(context.Background(), &proj, metav1.UpdateOptions{})
@@ -432,6 +431,8 @@ func (s *Server) NormalizeProjs() error {
 				if i == 2 {
 					return status.Errorf(codes.Internal, "Failed normalize project %s", proj.Name)
 				}
+			} else {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
API server unnecessary trying to normalize already normalized project.  Error happens because `syncJWTTokenBetweenStatusAndSpec` comparing `nil` and empty slices: 

https://github.com/argoproj/argo-cd/blob/c14f87d56582962a7549e27e17f00e0a400cf41c/pkg/apis/application/v1alpha1/types.go#L2592
