### PR TITLE
fix: Re-create already initialized ARGOCD_GNUPGHOME on startup (#4214)

### DIFF
--- a/util/gpg/gpg_test.go
+++ b/util/gpg/gpg_test.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/test"
@@ -60,10 +62,20 @@ func Test_GPG_InitializeGnuPG(t *testing.T) {
 	assert.Len(t, keys, 1)
 	assert.Equal(t, keys[0].Trust, "ultimate")
 
-	// Second run should return error
+	// During unit-tests, we need to also kill gpg-agent so we can create a new key.
+	// In real world scenario -- i.e. container crash -- gpg-agent is not running yet.
+	cmd := exec.Command("gpgconf", "--kill", "gpg-agent")
+	cmd.Env = []string{fmt.Sprintf("GNUPGHOME=%s", p)}
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	// Second run should not return error
 	err = InitializeGnuPG()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "already initialized")
+	require.NoError(t, err)
+	keys, err = GetInstalledPGPKeys(nil)
+	assert.NoError(t, err)
+	assert.Len(t, keys, 1)
+	assert.Equal(t, keys[0].Trust, "ultimate")
 
 	// GNUPGHOME is a file - we need to error out
 	f, err := ioutil.TempFile("", "gpg-test")


### PR DESCRIPTION
Fixes #4214 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
