### PR TITLE
fix: application details page crash when app is deleted

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -505,6 +505,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                     )
                 );
             })
+            .filter(([application, tree]) => !!application && !!tree)
             .map(([application, tree]) => ({application, tree}));
     }
 


### PR DESCRIPTION
PR fixes the Javascript error that happens on app details page when application is deleted: 
```
TypeError: Cannot read property 'nodes' of undefined
    at Object.children (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:33:258902)
    at t.render (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:33:86283)
    at Oi (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:63228)
    at Ai (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:63023)
    at Yi (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:66858)
    at Ka (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:90782)
    at Xa (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:91166)
    at Ps (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:98191)
    at Ns (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:97571)
    at Ds (https://cd.apps.argoproj.io/main.660998bad9b1de23d41f.js:354:96592)
```