### PR TITLE
docs: add list format to the cluster `namespaces` field

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -431,7 +431,7 @@ The secret data must include following fields:
 
 * `name` - cluster name
 * `server` - cluster api server url
-* `namespaces` - optional list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
+* `namespaces` - optional comma-separated list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
 * `config` - JSON representation of following data structure:
 
 ```yaml


### PR DESCRIPTION
As spotted by @Unb9rn in https://github.com/argoproj/argo-cd/issues/3838, the documentation is missing the namespaces field list format. This PR updates the documentation to indicate that the field expects a comma-separated list of namespaces.