### PR TITLE
fix: application stream API should not return 'ADDED' events if resource version is provided

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -641,12 +641,15 @@ func (s *Server) Watch(q *application.ApplicationQuery, ws application.Applicati
 	}
 
 	events := make(chan *appv1.ApplicationWatchEvent)
-	apps, err := s.appLister.List(selector)
-	if err != nil {
-		return err
-	}
-	for i := range apps {
-		sendIfPermitted(*apps[i], watch.Added)
+	if q.ResourceVersion == "" {
+		// mimic watch API behavior: send ADDED events if no resource version provided
+		apps, err := s.appLister.List(selector)
+		if err != nil {
+			return err
+		}
+		for i := range apps {
+			sendIfPermitted(*apps[i], watch.Added)
+		}
 	}
 	unsubscribe := s.appBroadcaster.Subscribe(events)
 	defer unsubscribe()

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -172,12 +172,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
             const applications = loaderRef.current.getData() as models.Application[];
             const app = applications.find(item => item.metadata.name === appName);
             if (app) {
-                if (!app.metadata.annotations) {
-                    app.metadata.annotations = {};
-                }
-                if (!app.metadata.annotations[models.AnnotationRefreshKey]) {
-                    app.metadata.annotations[models.AnnotationRefreshKey] = 'refreshing';
-                }
+                AppUtils.setAppRefreshing(app);
                 loaderRef.current.setData(applications);
             }
         }

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -413,6 +413,15 @@ export function isAppRefreshing(app: appModels.Application) {
     return !!(app.metadata.annotations && app.metadata.annotations[appModels.AnnotationRefreshKey]);
 }
 
+export function setAppRefreshing(app: appModels.Application) {
+    if (!app.metadata.annotations) {
+        app.metadata.annotations = {};
+    }
+    if (!app.metadata.annotations[appModels.AnnotationRefreshKey]) {
+        app.metadata.annotations[appModels.AnnotationRefreshKey] = 'refreshing';
+    }
+}
+
 export function refreshLinkAttrs(app: appModels.Application) {
     return {disabled: isAppRefreshing(app)};
 }

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -101,7 +101,7 @@ export class ApplicationsService {
         return requests
             .put(`/applications/${app.metadata.name}`)
             .send(app)
-            .then(res => res.body as models.Application);
+            .then(res => this.parseAppFields(res.body));
     }
 
     public create(app: models.Application): Promise<models.Application> {


### PR DESCRIPTION
PR is required to improve application list performance:

The UI first loads the list of applications and then subscribe to application updates using resource version returns by list call. Same as K8S watch the applications API should return only new changes. That help UI since it won't receive ADDED event for each existing application and reduce CPU usage.