### PR TITLE
fix: remove unnecessary padding on summary page

### DIFF
--- a/ui/src/app/applications/components/application-summary/application-summary.scss
+++ b/ui/src/app/applications/components/application-summary/application-summary.scss
@@ -52,18 +52,10 @@
         padding-right: 1em;
     }
 
-    .white-box__details-row .columns {
-        padding-top: 1.5em;
-        padding-bottom: 1.5em;
-
-        & > div {
-           line-height: 1.6em;
-        }
-    }
-
     .white-box__details-row .row .columns:last-child {
         padding-left: 1em;
     }
+
     .select {
         padding-bottom: 0;
     }


### PR DESCRIPTION
@jsoref looks like I did not notice summary page style changes in this PR: https://github.com/argoproj/argo-cd/commit/10dc3ac12a42e255ee72190a83321a7dece58a42#diff-def2d41ee7278a4b5953072047112c44R55

I think after adding padding the summary page looks strange.

with padding:
![image](https://user-images.githubusercontent.com/426437/92199942-5f6adf80-ee2d-11ea-9b5c-32a6d0afb527.png)

without padding:
![image](https://user-images.githubusercontent.com/426437/92199986-7ad5ea80-ee2d-11ea-99c4-072c8fa89aac.png)

Are you ok to remove it? Let me know please if I'm missing something

