### PR TITLE
fix: automatically stop watch API requests when page is hidden

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -491,24 +491,28 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                     Observable.merge(
                         Observable.from([app]),
                         this.appChanged.filter(item => !!item),
-                        services.applications
-                            .watch({name})
-                            .map(watchEvent => {
-                                if (watchEvent.type === 'DELETED') {
-                                    this.onAppDeleted();
-                                }
-                                return watchEvent.application;
-                            })
-                            .repeat()
-                            .retryWhen(errors => errors.delay(500))
+                        AppUtils.handlePageVisibility(() =>
+                            services.applications
+                                .watch({name})
+                                .map(watchEvent => {
+                                    if (watchEvent.type === 'DELETED') {
+                                        this.onAppDeleted();
+                                    }
+                                    return watchEvent.application;
+                                })
+                                .repeat()
+                                .retryWhen(errors => errors.delay(500))
+                        )
                     ),
                     Observable.merge(
                         Observable.from([fallbackTree]),
                         services.applications.resourceTree(name).catch(() => fallbackTree),
-                        services.applications
-                            .watchResourceTree(name)
-                            .repeat()
-                            .retryWhen(errors => errors.delay(500))
+                        AppUtils.handlePageVisibility(() =>
+                            services.applications
+                                .watchResourceTree(name)
+                                .repeat()
+                                .retryWhen(errors => errors.delay(500))
+                        )
                     )
                 );
             })

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -234,7 +234,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                 {pref => (
                                     <DataLoader
                                         ref={loaderRef}
-                                        load={() => loadApplications()}
+                                        load={() => AppUtils.handlePageVisibility(() => loadApplications())}
                                         loadingRenderer={() => (
                                             <div className='argo-container'>
                                                 <MockupList height={100} marginTop={30} />


### PR DESCRIPTION
After changes implemented in v1.7 release the /api/v1/stream/applications API is very stable and does not close often. The side effect is that every open Applications List and Application Details page keeps one open connection. Browser allows up to 6 open connections so user cannot opens more than 6 tabs. 

PR changes UI so that it automatically closes and restarts stream APIs when page visibility changes.