### PR TITLE
docs: fix typo "make lint-ui"

### DIFF
--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -76,7 +76,7 @@ After you have submitted your PR, and whenever you push new commits to that bran
 * Run a Go linter on the code (`make lint`)
 * Run the unit tests (`make test`)
 * Run the End-to-End tests (`make test-e2e`)
-* Build and lint the UI code (`make ui`)
+* Build and lint the UI code (`make lint-ui`)
 * Build the `argocd` CLI (`make cli`)
 
 If any of these tests in the CI pipeline fail, it means that some of your contribution is considered faulty (or a test might be flaky, see below).


### PR DESCRIPTION
There is no target "ui" in the Makefile.   The documentation should read "lint-ui".

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
