### PR TITLE
feat: add status badge for project

### DIFF
--- a/server/badge/badge.go
+++ b/server/badge/badge.go
@@ -12,6 +12,7 @@ import (
 
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
+	"github.com/argoproj/argo-cd/util/argo"
 	"github.com/argoproj/argo-cd/util/assets"
 	"github.com/argoproj/argo-cd/util/settings"
 )
@@ -85,7 +86,26 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			notFound = true
 		}
 	}
-
+	//Sample url: http://localhost:8080/api/badge?project=default
+	if projects, ok := r.URL.Query()["project"]; ok && enabled {
+		if apps, err := h.appClientset.ArgoprojV1alpha1().Applications(h.namespace).List(context.Background(), v1.ListOptions{}); err == nil {
+			applicationSet := argo.FilterByProjects(apps.Items, projects)
+			for _, a := range applicationSet {
+				if a.Status.Sync.Status != appv1.SyncStatusCodeSynced {
+					status = appv1.SyncStatusCodeOutOfSync
+				}
+				if a.Status.Health.Status != healthutil.HealthStatusHealthy {
+					health = healthutil.HealthStatusDegraded
+				}
+			}
+			if health != healthutil.HealthStatusDegraded && len(applicationSet) > 0 {
+				health = healthutil.HealthStatusHealthy
+			}
+			if status != appv1.SyncStatusCodeOutOfSync && len(applicationSet) > 0 {
+				status = appv1.SyncStatusCodeSynced
+			}
+		}
+	}
 	//Sample url: http://localhost:8080/api/badge?name=123&revision=true
 	if _, ok := r.URL.Query()["revision"]; ok && enabled {
 		revisionEnabled = true

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -2,8 +2,10 @@ package badge
 
 import (
 	"context"
+	"image/color"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -49,6 +51,10 @@ var (
 			},
 		},
 	}
+	testProject = v1alpha1.AppProject{
+		ObjectMeta: v1.ObjectMeta{Name: "testProject", Namespace: "default"},
+		Spec:       v1alpha1.AppProjectSpec{},
+	}
 )
 
 func TestHandlerFeatureIsEnabled(t *testing.T) {
@@ -70,6 +76,101 @@ func TestHandlerFeatureIsEnabled(t *testing.T) {
 	assert.NotContains(t, response, "(aa29b85)")
 }
 
+func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
+	projectTests := []struct {
+		testApp     []*v1alpha1.Application
+		apiEndPoint string
+		namespace   string
+		health      string
+		status      string
+		healthColor color.RGBA
+		statusColor color.RGBA
+	}{
+		{createApplications([]string{"Healthy:Synced", "Healthy:Synced"}, []string{"default", "default"}, "test"),
+			"/api/badge?project=default", "test", "Healthy", "Synced", Green, Green},
+		{createApplications([]string{"Healthy:Synced", "Healthy:OutOfSync"}, []string{"testProject", "testProject"}, "default"),
+			"/api/badge?project=testProject", "default", "Healthy", "OutOfSync", Green, Orange},
+		{createApplications([]string{"Healthy:Synced", "Degraded:Synced"}, []string{"default", "default"}, "test"),
+			"/api/badge?project=default", "test", "Degraded", "Synced", Red, Green},
+		{createApplications([]string{"Healthy:Synced", "Degraded:OutOfSync"}, []string{"testProject", "testProject"}, "default"),
+			"/api/badge?project=testProject", "default", "Degraded", "OutOfSync", Red, Orange},
+		{createApplications([]string{"Healthy:Synced", "Healthy:Synced"}, []string{"testProject", "default"}, "test"),
+			"/api/badge?project=default&project=testProject", "test", "Healthy", "Synced", Green, Green},
+		{createApplications([]string{"Healthy:OutOfSync", "Healthy:Synced"}, []string{"testProject", "default"}, "default"),
+			"/api/badge?project=default&project=testProject", "default", "Healthy", "OutOfSync", Green, Orange},
+		{createApplications([]string{"Degraded:Synced", "Healthy:Synced"}, []string{"testProject", "default"}, "test"),
+			"/api/badge?project=default&project=testProject", "test", "Degraded", "Synced", Red, Green},
+		{createApplications([]string{"Degraded:OutOfSync", "Healthy:OutOfSync"}, []string{"testProject", "default"}, "default"),
+			"/api/badge?project=default&project=testProject", "default", "Degraded", "OutOfSync", Red, Orange},
+		{createApplications([]string{"Unknown:Unknown", "Unknown:Unknown"}, []string{"testProject", "default"}, "default"),
+			"/api/badge?project=", "default", "Unknown", "Unknown", Purple, Purple},
+	}
+	for _, tt := range projectTests {
+		argoCDCm.ObjectMeta.Namespace = tt.namespace
+		argoCDSecret.ObjectMeta.Namespace = tt.namespace
+		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), tt.namespace)
+		handler := NewHandler(appclientset.NewSimpleClientset(&testProject, tt.testApp[0], tt.testApp[1]), settingsMgr, tt.namespace)
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", tt.apiEndPoint, nil)
+		assert.NoError(t, err)
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
+		response := rr.Body.String()
+		assert.Equal(t, toRGBString(tt.healthColor), leftRectColorPattern.FindStringSubmatch(response)[1])
+		assert.Equal(t, toRGBString(tt.statusColor), rightRectColorPattern.FindStringSubmatch(response)[1])
+		assert.Equal(t, tt.health, leftTextPattern.FindStringSubmatch(response)[1])
+		assert.Equal(t, tt.status, rightTextPattern.FindStringSubmatch(response)[1])
+
+	}
+}
+
+func createApplicationFeatureProjectIsEnabled(healthStatus health.HealthStatusCode, syncStatus v1alpha1.SyncStatusCode, appName, projectName, namespace string) *v1alpha1.Application {
+	return &v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: appName, Namespace: namespace},
+		Status: v1alpha1.ApplicationStatus{
+			Sync:   v1alpha1.SyncStatus{Status: syncStatus},
+			Health: v1alpha1.HealthStatus{Status: healthStatus},
+			OperationState: &v1alpha1.OperationState{
+				SyncResult: &v1alpha1.SyncOperationResult{},
+			},
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Project: projectName,
+		},
+	}
+}
+
+func createApplications(appCombo, projectName []string, namespace string) []*v1alpha1.Application {
+	apps := make([]*v1alpha1.Application, len(appCombo))
+	healthStatus := func(healthType string) health.HealthStatusCode {
+		switch healthType {
+		case "Healthy":
+			return health.HealthStatusHealthy
+		case "Degraded":
+			return health.HealthStatusDegraded
+		default:
+			return health.HealthStatusUnknown
+		}
+	}
+	syncStatus := func(syncType string) v1alpha1.SyncStatusCode {
+		switch syncType {
+		case "Synced":
+			return v1alpha1.SyncStatusCodeSynced
+		case "OutOfSync":
+			return v1alpha1.SyncStatusCodeOutOfSync
+		default:
+			return v1alpha1.SyncStatusCodeUnknown
+		}
+	}
+	for k, v := range appCombo {
+		a := strings.Split(v, ":")
+		healthApp := healthStatus(a[0])
+		syncApp := syncStatus(a[1])
+		appName := "App" + string(k)
+		apps[k] = createApplicationFeatureProjectIsEnabled(healthApp, syncApp, appName, projectName[k], namespace)
+	}
+	return apps
+}
 func TestHandlerFeatureIsEnabledRevisionIsEnabled(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(&testApp), settingsMgr, "default")


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

The current implementation only determines the status and health of the application. However, it was recommended that we add a similar flag for the project containing numerous applications.

The API endpoint : Sample URL: http://localhost:8080/api/badge?project=default

| Badge |Application health |Application status|
| :---: | :---: | :---: |
| Synced/Healthy| All applications healthy |All applications Synced |
| OutOfSync/Healthy| All applications healthy |Not all applications synced |
| Synced/Degraded| Not all applications healthy |All applications Synced |
| OutOfSync/Unhealthy| Not all applications healthy |Not all applications Synced |



Example badge:

<img width="544" alt="Screen Shot 2020-09-08 at 10 45 15 AM" src="https://user-images.githubusercontent.com/48808456/92491701-85430c00-f1c0-11ea-9160-bd3be9eee058.png">

Extra Notes:
Issue link :https://github.com/argoproj/argo-cd/issues/4001
