### PR TITLE
fix: app refresh API should use app resource version

### DIFF
--- a/server/application/broadcaster.go
+++ b/server/application/broadcaster.go
@@ -16,7 +16,10 @@ type broadcasterHandler struct {
 func (b *broadcasterHandler) notify(event *appv1.ApplicationWatchEvent) {
 	subscribers := b.subscribers
 	for i := range subscribers {
-		subscribers[i] <- event
+		s := subscribers[i]
+		go func() {
+			s <- event
+		}()
 	}
 }
 


### PR DESCRIPTION
PR fixes bug introduced by https://github.com/argoproj/argo-cd/pull/4290 . The informer might have stale application data, so we need to use resource version to filter out state data.