### PR TITLE
fix: fix possible deadlock in /v1/api/stream/applications and /v1/api/application APIs

### DIFF
--- a/server/application/broadcaster.go
+++ b/server/application/broadcaster.go
@@ -3,29 +3,49 @@ package application
 import (
 	"sync"
 
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/watch"
 
 	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 )
 
+type subscriber struct {
+	ch      chan *appv1.ApplicationWatchEvent
+	filters []func(*appv1.ApplicationWatchEvent) bool
+}
+
+func (s *subscriber) matches(event *appv1.ApplicationWatchEvent) bool {
+	for i := range s.filters {
+		if !s.filters[i](event) {
+			return false
+		}
+	}
+	return true
+}
+
 type broadcasterHandler struct {
 	lock        sync.Mutex
-	subscribers []chan *appv1.ApplicationWatchEvent
+	subscribers []*subscriber
 }
 
 func (b *broadcasterHandler) notify(event *appv1.ApplicationWatchEvent) {
 	subscribers := b.subscribers
-	for i := range subscribers {
-		s := subscribers[i]
-		go func() {
-			s <- event
-		}()
+	for _, s := range subscribers {
+		if s.matches(event) {
+			select {
+			case s.ch <- event:
+			default:
+				// drop event if cannot send right away
+				log.WithField("application", event.Application.Name).Warn("unable to send event notification")
+			}
+		}
 	}
 }
 
-func (b *broadcasterHandler) Subscribe(subscriber chan *appv1.ApplicationWatchEvent) func() {
+func (b *broadcasterHandler) Subscribe(ch chan *appv1.ApplicationWatchEvent, filters ...func(event *appv1.ApplicationWatchEvent) bool) func() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
+	subscriber := &subscriber{ch, filters}
 	b.subscribers = append(b.subscribers, subscriber)
 	return func() {
 		b.lock.Lock()

--- a/server/application/broadcaster_test.go
+++ b/server/application/broadcaster_test.go
@@ -15,7 +15,7 @@ func TestBroadcasterHandler_SubscribeUnsubscribe(t *testing.T) {
 	subscriber := make(chan *appv1.ApplicationWatchEvent)
 	unsubscribe := broadcaster.Subscribe(subscriber)
 
-	assert.ElementsMatch(t, broadcaster.subscribers, []chan *appv1.ApplicationWatchEvent{subscriber})
+	assert.Len(t, broadcaster.subscribers, 1)
 
 	unsubscribe()
 	assert.Empty(t, broadcaster.subscribers)
@@ -24,8 +24,8 @@ func TestBroadcasterHandler_SubscribeUnsubscribe(t *testing.T) {
 func TestBroadcasterHandler_ReceiveEvents(t *testing.T) {
 	broadcaster := broadcasterHandler{}
 
-	subscriber1 := make(chan *appv1.ApplicationWatchEvent)
-	subscriber2 := make(chan *appv1.ApplicationWatchEvent)
+	subscriber1 := make(chan *appv1.ApplicationWatchEvent, 1000)
+	subscriber2 := make(chan *appv1.ApplicationWatchEvent, 1000)
 
 	_ = broadcaster.Subscribe(subscriber1)
 	_ = broadcaster.Subscribe(subscriber2)


### PR DESCRIPTION
The `broadcasterHandler` used in `/v1/api/stream/applications` and `/v1/api/application` might cause deadlock if receives even when no one is ready from channel any more:


https://github.com/argoproj/argo-cd/blob/d60486fb4763a039b3a9938d3d779b071f388c1d/server/application/broadcaster.go#L18-L20


PR changes `broadcasterHandler` to use non-blocking channel write. This ensures that deadlock won't happen. In case when consumed don't want to miss events (`/v1/api/application` APIs) passed channel must have a big enough buffer.