### PR TITLE
fix(applications-table.tsx): adding "name" to Cluster

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-table.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-table.tsx
@@ -52,7 +52,7 @@ export const ApplicationsTable = (props: {
                                 <div className='row'>
                                     <div className='show-for-xxlarge columns small-2'>Destination:</div>
                                     <div className='columns small-12 xxlarge-10'>
-                                        <Cluster server={app.spec.destination.server} />/{app.spec.destination.namespace}
+                                        <Cluster server={app.spec.destination.server} name={app.spec.destination.name} />/{app.spec.destination.namespace}
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
this corrects the "destination" of the table view of applications if they use
app.spec.destination.name instead of app.spec.destination.server

#4291

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
![issue](https://user-images.githubusercontent.com/5673097/93011677-085fbb80-f54d-11ea-80d8-53d3aa5d3136.JPG)
