### PR TITLE
fix: Log an error when invalid token exists (#4156)

### DIFF
--- a/util/settings/accounts.go
+++ b/util/settings/accounts.go
@@ -307,7 +307,7 @@ func parseAccounts(secret *v1.Secret, cm *v1.ConfigMap) (map[string]Account, err
 			account.Tokens = make([]Token, 0)
 			if string(tokensStr) != "" {
 				if err := json.Unmarshal(tokensStr, &account.Tokens); err != nil {
-					return nil, err
+					log.Errorf("Account '%s' has invalid token in secret '%s'", name, secret.Name)
 				}
 			}
 		}

--- a/util/settings/accounts_test.go
+++ b/util/settings/accounts_test.go
@@ -70,6 +70,27 @@ func TestGetAccount(t *testing.T) {
 	})
 }
 
+func TestGetAccount_WithInvalidToken(t *testing.T) {
+	_, settingsManager := fixtures(map[string]string{
+		"accounts.user1":       "apiKey",
+		"accounts.invaliduser": "apiKey",
+		"accounts.user2":       "apiKey",
+	},
+		func(secret *v1.Secret) {
+			secret.Data["accounts.user1.tokens"] = []byte(`[{"id":"1","iat":158378932,"exp":1583789194}]`)
+		},
+		func(secret *v1.Secret) {
+			secret.Data["accounts.invaliduser.tokens"] = []byte("Invalid token")
+		},
+		func(secret *v1.Secret) {
+			secret.Data["accounts.user2.tokens"] = []byte(`[{"id":"2","iat":1583789194,"exp":1583784545}]`)
+		},
+	)
+
+	_, err := settingsManager.GetAccounts()
+	assert.NoError(t, err)
+}
+
 func TestGetAdminAccount(t *testing.T) {
 	mTime := time.Now().Format(time.RFC3339)
 	_, settingsManager := fixtures(nil, func(secret *v1.Secret) {


### PR DESCRIPTION
Instead of returning an error for invalid token and thereby breaking API requests for all users, print the error to the logs.

Fixes: #4156

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
