### PR TITLE
fix(logging.go): changing marshaler for JSON logging to use gogo

### DIFF
--- a/util/grpc/logging.go
+++ b/util/grpc/logging.go
@@ -1,13 +1,11 @@
 package grpc
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
-	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	ctx_logrus "github.com/grpc-ecosystem/go-grpc-middleware/tags/logrus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -31,11 +29,11 @@ type jsonpbMarshalleble struct {
 }
 
 func (j *jsonpbMarshalleble) MarshalJSON() ([]byte, error) {
-	b := &bytes.Buffer{}
-	if err := grpc_logrus.JsonPbMarshaller.Marshal(b, j.Message); err != nil {
+	b, err := proto.Marshal(j.Message)
+	if err != nil {
 		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
 	}
-	return b.Bytes(), nil
+	return b, nil
 }
 
 type loggingServerStream struct {


### PR DESCRIPTION
grpc-gateway json marshaler breaks with gogo protos

#4117

This issue is related to https://github.com/gogo/protobuf/issues/212#issuecomment-378745985

_argocd cli_
```
$ argocd proj create foo
EE: 0/[]
```

_argocd server corrected output_
```
{"grpc.code":"OK","grpc.method":"Create","grpc.service":"project.ProjectService","grpc.start_time":"2020-09-13T19:41:03-07:00","grpc.time_ms":15.292,"level":"info","msg":"finished unary call with code OK","span.kind":"server","system":"grpc","time":"2020-09-13T19:41:03-07:00"}
```
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
