### PR TITLE
fix: fix flaky TestTrackAppStateAndSyncApp e2e test

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -249,8 +249,6 @@ func TestTrackAppStateAndSyncApp(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
-		Expect(Success(fmt.Sprintf("apps  Deployment  %s          guestbook-ui  OutOfSync  Missing", DeploymentNamespace()))).
-		Expect(Success(fmt.Sprintf("Service  %s          guestbook-ui  OutOfSync  Missing", DeploymentNamespace()))).
 		Expect(Success(fmt.Sprintf("Service     %s  guestbook-ui  Synced ", DeploymentNamespace()))).
 		Expect(Success(fmt.Sprintf("apps   Deployment  %s  guestbook-ui  Synced", DeploymentNamespace()))).
 		Expect(Event(EventReasonResourceUpdated, "sync")).


### PR DESCRIPTION
The TestTrackAppStateAndSyncApp e2e test verifies that `app sync` command first prints each resource with `Missing` state and then `Synced` after sync is completed.

The test fails frequently because sometimes sync is executed too quickly and first message already prints that all app resources are synced. This is totally fine from user perspective, so removing `Missing` status check to avoid false test failures.
