### PR TITLE
fix: Log output stops if message is too long (#3258)

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	goio "io"
 	"reflect"
 	"sort"
 	"strconv"
@@ -1031,9 +1032,15 @@ func (s *Server) PodLogs(q *application.ApplicationPodLogsQuery, ws application.
 	done := make(chan bool)
 	gracefulExit := false
 	go func() {
-		scanner := bufio.NewScanner(stream)
-		for scanner.Scan() {
-			line := scanner.Text()
+		bufReader := bufio.NewReader(stream)
+
+		for {
+			line, err := bufReader.ReadString('\n')
+			if err != nil {
+				// Error or io.EOF
+				break
+			}
+			line = strings.TrimSpace(line) // Remove trailing line ending
 			parts := strings.Split(line, " ")
 			logTime, err := time.Parse(time.RFC3339, parts[0])
 			metaLogTime := metav1.NewTime(logTime)
@@ -1053,11 +1060,11 @@ func (s *Server) PodLogs(q *application.ApplicationPodLogsQuery, ws application.
 			}
 		}
 		if gracefulExit {
-			logCtx.Info("k8s pod logs scanner completed due to closed grpc context")
-		} else if err := scanner.Err(); err != nil {
-			logCtx.Warnf("k8s pod logs scanner failed with error: %v", err)
+			logCtx.Info("k8s pod logs reader completed due to closed grpc context")
+		} else if err != nil && err != goio.EOF {
+			logCtx.Warnf("k8s pod logs reader failed with error: %v", err)
 		} else {
-			logCtx.Info("k8s pod logs scanner completed with EOF")
+			logCtx.Info("k8s pod logs reader completed with EOF")
 		}
 		close(done)
 	}()


### PR DESCRIPTION
As seen on the parent issue, `bufio.Scanner` will return an error if the token (line, in this case) is larger than `MaxScanTokenSize`. This PR replaces the use of `Scanner` with `bufio.NewReader(..).ReadString('\n')` as recommended by [bufio godoc](https://golang.org/pkg/bufio/#Scanner).

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Fixes #3258