### PR TITLE
fix: application external url falsely uses backend servicePort

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -127,19 +127,12 @@ func populateIngressInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 					}
 				}
 
-				var externalURL string
-				switch stringPort {
-				case "http":
-					externalURL = fmt.Sprintf("http://%s", host)
-				case "https":
-					externalURL = fmt.Sprintf("https://%s", host)
-				}
+				externalURL := fmt.Sprintf("%s://%s", stringPort, host)
 
 				subPath := ""
 				if nestedPath, ok, err := unstructured.NestedString(path, "path"); ok && err == nil {
 					subPath = nestedPath
 				}
-
 				externalURL += subPath
 				urlsSet[externalURL] = true
 			}

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -63,6 +63,9 @@ var (
             serviceName: helm-guestbook
             servicePort: https
           path: /
+    tls:
+    - host: helm-guestbook.com
+    secretName: my-tls-secret
   status:
     loadBalancer:
       ingress:
@@ -143,6 +146,8 @@ func TestGetIngressInfoNoHost(t *testing.T) {
             serviceName: helm-guestbook
             servicePort: 443
           path: /
+    tls:
+    - secretName: my-tls
   status:
     loadBalancer:
       ingress:
@@ -177,6 +182,8 @@ func TestExternalUrlWithSubPath(t *testing.T) {
             serviceName: helm-guestbook
             servicePort: 443
           path: /my/sub/path/
+    tls:
+    - secretName: my-tls
   status:
     loadBalancer:
       ingress:
@@ -211,6 +218,8 @@ func TestExternalUrlWithMultipleSubPaths(t *testing.T) {
         - backend:
             serviceName: helm-guestbook-3
             servicePort: 443
+    tls:
+    - secretName: my-tls
   status:
     loadBalancer:
       ingress:
@@ -239,6 +248,8 @@ func TestExternalUrlWithNoSubPath(t *testing.T) {
         - backend:
             serviceName: helm-guestbook
             servicePort: 443
+    tls:
+    - secretName: my-tls
   status:
     loadBalancer:
       ingress:
@@ -265,6 +276,8 @@ func TestExternalUrlWithNetworkingApi(t *testing.T) {
         - backend:
             serviceName: helm-guestbook
             servicePort: 443
+    tls:
+    - secretName: my-tls
   status:
     loadBalancer:
       ingress:


### PR DESCRIPTION
Use https for `externalURL` if `spec.tls` is specified. Otherwise use http.
Fixes: #2318