### PR TITLE
fix: argocd app wait/sync might stuck

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -711,9 +711,6 @@ func (c *client) WatchApplicationWithRetry(ctx context.Context, appName string, 
 				if isCanceledContextErr(err) {
 					cancelled = true
 				} else {
-					if err != io.EOF {
-						log.Warnf("watch err: %v", err)
-					}
 					time.Sleep(1 * time.Second)
 				}
 			}

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -670,8 +670,11 @@ func (s *Server) Watch(q *application.ApplicationQuery, ws application.Applicati
 	}
 
 	events := make(chan *appv1.ApplicationWatchEvent)
-	if q.ResourceVersion == "" {
-		// mimic watch API behavior: send ADDED events if no resource version provided
+	// Mimic watch API behavior: send ADDED events if no resource version provided
+	// If watch API is executed for one application when emit event even if resource version is provided
+	// This is required since single app watch API is used for during operations like app syncing and it is
+	// critical to never miss events.
+	if q.ResourceVersion == "" || q.GetName() != "" {
 		apps, err := s.appLister.List(selector)
 		if err != nil {
 			return err


### PR DESCRIPTION
After switching API server to informers the `argocd app sync` might fail because the `/api/v1/stream/applications` no longer return events from the "past" even if resourceVersion is provided. It only returns events that are older than the provided resource version. As a result CLI might start watching app events after sync is completed and CLI completion will be delayed. 


The compromise is to return 'ADDED' event if watch is requested for one application.


Number of successfully test runs so far: 4