### PR TITLE
fix: failed syncs are not retried soon enough

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -500,8 +500,10 @@ func (ctrl *ApplicationController) requestAppRefresh(appName string, compareWith
 		}
 		if after != nil {
 			ctrl.appRefreshQueue.AddAfter(key, *after)
+			ctrl.appOperationQueue.AddAfter(key, *after)
 		} else {
 			ctrl.appRefreshQueue.Add(key)
+			ctrl.appOperationQueue.Add(key)
 		}
 	}
 }


### PR DESCRIPTION
The failed syncs are not retried soon enough. The reason is that `requestAppRefresh` updates only `appRefreshQueue` but should update `appOperationQueue` as well.