### PR TITLE
fix: Cluster remove should return an error for unknown cluster name ( #3476 )

### DIFF
--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -247,11 +247,7 @@ func (db *db) UpdateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Clust
 func (db *db) DeleteCluster(ctx context.Context, server string) error {
 	secret, err := db.getClusterSecret(server)
 	if err != nil {
-		if errorStatus, ok := status.FromError(err); ok && errorStatus.Code() == codes.NotFound {
-			return nil
-		} else {
-			return err
-		}
+		return err
 	}
 
 	canDelete := secret.Annotations != nil && secret.Annotations[common.AnnotationKeyManagedBy] == common.AnnotationValueManagedByArgoCD


### PR DESCRIPTION
Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

The argocd cluster remove command should return an error if an unknown cluster name is passed as an argument

Example:
```shell
$ argocd cluster rm unknown

FATA[0000] rpc error: code = NotFound desc = cluster "unknown" not found
```

Fixes: #3476
