### PR TITLE
fix: Sync Window status in argocd CLI is not matched with argocd UI for same sync window (#3831)

### DIFF
--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1062,14 +1062,247 @@ func TestSyncWindows_HasWindows(t *testing.T) {
 }
 
 func TestSyncWindows_Active(t *testing.T) {
-	proj := newTestProjectWithSyncWindows()
-	assert.Equal(t, 1, len(*proj.Spec.SyncWindows.Active()))
+	t.Run("WithTestProject", func(t *testing.T) {
+		proj := newTestProjectWithSyncWindows()
+		assert.Equal(t, 1, len(*proj.Spec.SyncWindows.Active()))
+	})
+
+	syncWindow := func(kind string, schedule string, duration string) *SyncWindow {
+		return &SyncWindow{
+			Kind:         kind,
+			Schedule:     schedule,
+			Duration:     duration,
+			Applications: []string{},
+			Namespaces:   []string{},
+		}
+	}
+
+	timeWithHour := func(hour int, location *time.Location) time.Time {
+		now := time.Now()
+		return time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, location)
+	}
+
+	utcM4Zone := time.FixedZone("UTC-4", -4*60*60)
+
+	tests := []struct {
+		name           string
+		syncWindow     SyncWindows
+		currentTime    time.Time
+		matchingIndex  int
+		expectedLength int
+	}{
+		{
+			name: "MatchFirst",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(11, time.UTC),
+			matchingIndex:  0,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchSecond",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(15, time.UTC),
+			matchingIndex:  1,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchBoth",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "3h"),
+				syncWindow("allow", "* 11 * * *", "3h"),
+			},
+			currentTime:    timeWithHour(12, time.UTC),
+			expectedLength: 2,
+		},
+		{
+			name: "MatchNone",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(17, time.UTC),
+			expectedLength: 0,
+		},
+		{
+			name: "MatchFirst-NonUTC",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(11-4, utcM4Zone), // 11AM UTC is 7AM EDT
+			matchingIndex:  0,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchSecond-NonUTC",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(15-4, utcM4Zone),
+			matchingIndex:  1,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchNone-NonUTC",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(17-4, utcM4Zone),
+			expectedLength: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			result := tt.syncWindow.active(tt.currentTime)
+			if result == nil {
+				result = &SyncWindows{}
+			}
+			assert.Equal(t, tt.expectedLength, len(*result))
+
+			if len(*result) == 1 {
+				assert.Equal(t, tt.syncWindow[tt.matchingIndex], (*result)[0])
+			}
+
+		})
+	}
+
 }
 
 func TestSyncWindows_InactiveAllows(t *testing.T) {
-	proj := newTestProjectWithSyncWindows()
-	proj.Spec.SyncWindows[0].Schedule = "0 0 1 1 1"
-	assert.Equal(t, 1, len(*proj.Spec.SyncWindows.InactiveAllows()))
+	t.Run("WithTestProject", func(t *testing.T) {
+		proj := newTestProjectWithSyncWindows()
+		proj.Spec.SyncWindows[0].Schedule = "0 0 1 1 1"
+		assert.Equal(t, 1, len(*proj.Spec.SyncWindows.InactiveAllows()))
+	})
+
+	syncWindow := func(kind string, schedule string, duration string) *SyncWindow {
+		return &SyncWindow{
+			Kind:         kind,
+			Schedule:     schedule,
+			Duration:     duration,
+			Applications: []string{},
+			Namespaces:   []string{},
+		}
+	}
+
+	timeWithHour := func(hour int, location *time.Location) time.Time {
+		now := time.Now()
+		return time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, location)
+	}
+
+	utcM4Zone := time.FixedZone("UTC-4", -4*60*60)
+
+	tests := []struct {
+		name           string
+		syncWindow     SyncWindows
+		currentTime    time.Time
+		matchingIndex  int
+		expectedLength int
+	}{
+		{
+			name: "MatchFirst",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 5 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(6, time.UTC),
+			matchingIndex:  0,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchSecond",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(11, time.UTC),
+			matchingIndex:  1,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchBoth",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(17, time.UTC),
+			expectedLength: 2,
+		},
+		{
+			name: "MatchNone",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "4h"),
+				syncWindow("allow", "* 11 * * *", "4h"),
+			},
+			currentTime:    timeWithHour(12, time.UTC),
+			expectedLength: 0,
+		},
+		{
+			name: "MatchFirst-NonUTC",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 5 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(6-4, utcM4Zone), // 6AM UTC is 2AM EDT
+			matchingIndex:  0,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchSecond-NonUTC",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(11-4, utcM4Zone),
+			matchingIndex:  1,
+			expectedLength: 1,
+		},
+		{
+			name: "MatchBoth-NonUTC",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2h"),
+				syncWindow("allow", "* 14 * * *", "2h"),
+			},
+			currentTime:    timeWithHour(17-4, utcM4Zone),
+			expectedLength: 2,
+		},
+		{
+			name: "MatchNone",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "4h"),
+				syncWindow("allow", "* 11 * * *", "4h"),
+			},
+			currentTime:    timeWithHour(12-4, utcM4Zone),
+			expectedLength: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			result := tt.syncWindow.inactiveAllows(tt.currentTime)
+			if result == nil {
+				result = &SyncWindows{}
+			}
+			assert.Equal(t, tt.expectedLength, len(*result))
+
+			if len(*result) == 1 {
+				assert.Equal(t, tt.syncWindow[tt.matchingIndex], (*result)[0])
+			}
+
+		})
+	}
+
 }
 
 func TestAppProjectSpec_AddWindow(t *testing.T) {
@@ -1346,6 +1579,89 @@ func TestSyncWindow_Active(t *testing.T) {
 		window.Active()
 		assert.True(t, window.Active())
 	})
+
+	syncWindow := func(kind string, schedule string, duration string) SyncWindow {
+		return SyncWindow{
+			Kind:         kind,
+			Schedule:     schedule,
+			Duration:     duration,
+			Applications: []string{},
+			Namespaces:   []string{},
+		}
+	}
+
+	timeWithHour := func(hour int, location *time.Location) time.Time {
+		now := time.Now()
+		return time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, location)
+	}
+
+	utcM4Zone := time.FixedZone("UTC-4", -4*60*60) // Eastern Daylight Saving Time (EDT)
+
+	tests := []struct {
+		name           string
+		syncWindow     SyncWindow
+		currentTime    time.Time
+		expectedResult bool
+	}{
+		{
+			name:           "Allow-active",
+			syncWindow:     syncWindow("allow", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(11, time.UTC),
+			expectedResult: true,
+		},
+		{
+			name:           "Allow-inactive",
+			syncWindow:     syncWindow("allow", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(13, time.UTC),
+			expectedResult: false,
+		},
+		{
+			name:           "Deny-active",
+			syncWindow:     syncWindow("deny", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(11, time.UTC),
+			expectedResult: true,
+		},
+		{
+			name:           "Deny-inactive",
+			syncWindow:     syncWindow("deny", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(13, time.UTC),
+			expectedResult: false,
+		},
+		{
+			name:           "Allow-active-NonUTC",
+			syncWindow:     syncWindow("allow", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(11-4, utcM4Zone), // 11AM UTC is 7AM EDT
+			expectedResult: true,
+		},
+		{
+			name:           "Allow-inactive-NonUTC",
+			syncWindow:     syncWindow("allow", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(13-4, utcM4Zone),
+			expectedResult: false,
+		},
+		{
+			name:           "Deny-active-NonUTC",
+			syncWindow:     syncWindow("deny", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(11-4, utcM4Zone),
+			expectedResult: true,
+		},
+		{
+			name:           "Deny-inactive-NonUTC",
+			syncWindow:     syncWindow("deny", "* 10 * * *", "2h"),
+			currentTime:    timeWithHour(13-4, utcM4Zone),
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			result := tt.syncWindow.active(tt.currentTime)
+			assert.Equal(t, result, tt.expectedResult)
+
+		})
+	}
+
 }
 
 func TestSyncWindow_Update(t *testing.T) {


### PR DESCRIPTION
#### Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

#### Description

With this PR I update the shared CLI/API-server code to use UTC only, as this appears as the defacto standard.
I've also added unit tests to the functions that are affected by this change to verify that the behaviour is as expected.

Fixes https://github.com/argoproj/argo-cd/issues/3831

#### The fix can be confirmed from the CLI with the following steps:

```
# Get the hour of the day in UTC timezone
date -u

# Where '15' is the UTC hour from above
argocd proj windows add default --kind "allow" --schedule "0 15 * * *" --duration "1h" --namespaces default

# Confirm the status as active
argocd proj windows list default

argocd proj windows delete default 0

# Where '17' is UTC hour+2, from above
argocd proj windows add default --kind "allow" --schedule "0 17 * * *" --duration "1h" --namespaces default

# Confirm the status as inactive
argocd proj windows list default
```