### PR TITLE
fix: add no log init flag to useradd test tools Dockerfile (#4381)

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -74,7 +74,7 @@ COPY ./test/container/uid_entrypoint.sh /usr/local/bin
 ARG UID
 
 # Prepare user configuration & build environments
-RUN useradd -u ${UID} -d /home/user -s /bin/bash user && \
+RUN useradd -l -u ${UID} -d /home/user -s /bin/bash user && \
     echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user && \
     HELM_HOME=/home/user/.helm helm2 init --client-only && \
     HOME=/home/user git config --global user.name "ArgoCD Test User" && \


### PR DESCRIPTION
This commit fixes an error where the underlaying disk would get
filled up when running make test-tools-image and the user running
it are running with a big UID.

Adding --no-log-init or -l will prevent useradd from trying to make
sure that there are is room for the user in lastlog and faillog.

The error output looks like this:

```bash
Not installing Tiller due to 'client-only' flag having been set
Error processing tar file(exit status 1): write /var/log/lastlog: no space left on device
make: *** [test-tools-image] Error 1
```

Solves #4381 .

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
