### PR TITLE
feat: Add external link annotation support. #3487

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -123,6 +123,16 @@ const (
 	AnnotationValueManagedByArgoCD = "argocd.argoproj.io"
 	// ResourcesFinalizerName the finalizer value which we inject to finalize deletion of an application
 	ResourcesFinalizerName = "resources-finalizer.argocd.argoproj.io"
+
+	// AnnotationKeyLinkPrefix tells the UI to add an external link icon to the application node
+	// that links to the value given in the annotation.
+	// The annotation key must be followed by a unique identifier. Ex: link.argocd.argoproj.io/dashboard
+	// It's valid to have multiple annotions that match the prefix.
+	// Values can simply be a url or they can have
+	// an optional link title separated by a "|"
+	// Ex: "http://grafana.example.com/d/yu5UH4MMz/deployments"
+	// Ex: "Go to Dashboard|http://grafana.example.com/d/yu5UH4MMz/deployments"
+	AnnotationKeyLinkPrefix = "link.argocd.argoproj.io/"
 )
 
 // Environment variables for tuning and debugging Argo CD

--- a/ui/src/app/applications/components/application-urls.tsx
+++ b/ui/src/app/applications/components/application-urls.tsx
@@ -1,23 +1,56 @@
 import {DropDownMenu} from 'argo-ui';
 import * as React from 'react';
 
+class ExternalLink {
+    public title: string;
+    public ref: string;
+
+    constructor(url: string) {
+        const parts = url.split('|');
+        if (parts.length === 2) {
+            this.title = parts[0];
+            this.ref = parts[1];
+        } else {
+            this.title = url;
+            this.ref = url;
+        }
+    }
+}
+
 export const ApplicationURLs = ({urls}: {urls: string[]}) => {
-    (urls || []).sort();
+    const externalLinks: ExternalLink[] = [];
+    for (const url of urls || []) {
+        externalLinks.push(new ExternalLink(url));
+    }
+
+    // sorted alphabetically & links with titles first
+    externalLinks.sort((a, b) => {
+        if (a.title !== '' && b.title !== '') {
+            return a.title > b.title ? 1 : -1;
+        } else if (a.title === '') {
+            return 1;
+        } else if (b.title === '') {
+            return -1;
+        }
+        return a.ref > b.ref ? 1 : -1;
+    });
+
     return (
-        ((urls || []).length > 0 && (
+        ((externalLinks || []).length > 0 && (
             <span>
                 <a
+                    title={externalLinks[0].title}
                     onClick={e => {
                         e.stopPropagation();
-                        window.open(urls[0]);
+                        window.open(externalLinks[0].ref);
                     }}>
                     <i className='fa fa-external-link-alt' />{' '}
-                    {urls.length > 1 && (
+                    {externalLinks.length > 1 && (
                         <DropDownMenu
                             anchor={() => <i className='fa fa-caret-down' />}
-                            items={urls.map(item => ({
-                                title: item,
-                                action: () => window.open(item)
+                            items={externalLinks.map(item => ({
+                                title: item.title,
+                                action: () => window.open(item.ref)
                             }))}
                         />
                     )}


### PR DESCRIPTION
Example implementation of https://github.com/argoproj/argo-cd/issues/3487

Using the current `node.Info` list is a bit clunky but requires minimal code change for the feature. I'm open to other ideas, maybe a second info list that is not automatically attached to nodes. That would allow the ui to get bits of metadata that it can use more selectively.

It's a simple interface for the end-user. Just add the annotation to any resource:

![image](https://user-images.githubusercontent.com/2973513/93690108-ebb60d00-fa91-11ea-9f6b-d6358b4bf280.png)

And then get a link in the interface. This was typically only done for ingress resources or other Argo links. But it can now be done on any resource. Providing a handy way to make Argo-CD the jumping-off point for any application. I think this could be extended even further with a CRD as defined in the issue. But this is a good start and would be enough for most users.

![image](https://user-images.githubusercontent.com/2973513/93690126-0ee0bc80-fa92-11ea-8002-3fd09d2d7cfb.png)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
