### PR TITLE
feat: display k8s objects in local time insted of UTC (#4347)

### DIFF
--- a/ui/src/app/applications/components/application-node-info/application-node-info.tsx
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.tsx
@@ -1,4 +1,5 @@
 import {DataLoader, Tab, Tabs} from 'argo-ui';
+import * as moment from 'moment';
 import * as React from 'react';
 
 import {YamlEditor} from '../../../shared/components';
@@ -23,7 +24,7 @@ export const ApplicationNodeInfo = (props: {
     if (props.node.createdAt) {
         attributes.push({
             title: 'CREATED_AT',
-            value: props.node.createdAt
+            value: moment.utc(props.node.createdAt).local().format('MM/DD/YYYY HH:mm:ss')
         });
     }
     if ((props.node.images || []).length) {


### PR DESCRIPTION
Inspired by #4347 

UI now display the k8s object's CREATED_AT attribute in local time instead of UTC before.
<img width="1347" alt="WX20200920-143247@2x" src="https://user-images.githubusercontent.com/22801725/93722790-2f6e4c80-fb4e-11ea-9980-d11a4520d767.png">


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
