### PR TITLE
fix: show error message if unable to terminate operation

### DIFF
--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
@@ -44,7 +44,7 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
                         const confirmed = await ctx.apis.popup.confirm('Terminate operation', 'Are you sure you want to terminate operation?');
                         if (confirmed) {
                             try {
-                                services.applications.terminateOperation(application.metadata.name);
+                                await services.applications.terminateOperation(application.metadata.name);
                             } catch (e) {
                                 ctx.apis.notifications.show({
                                     content: <ErrorNotification title='Unable to terminate operation' e={e} />,


### PR DESCRIPTION
PR ensures that error message if API request to terminate operation fails. Fixes https://sonarcloud.io/project/issues?id=argoproj_argo-cd&open=AXFcJMc_aPDFCRVJAbx8&resolved=false&types=BUG