### PR TITLE
fix: Child apps should not affect parent app's health by default (#3781)

### DIFF
--- a/util/health/health.go
+++ b/util/health/health.go
@@ -48,10 +48,11 @@ func ignoreLiveObjectHealth(liveObj *unstructured.Unstructured, resHealth appv1.
 			return true
 		}
 		gvk := liveObj.GroupVersionKind()
-		if gvk.Group == "argoproj.io" && gvk.Kind == "Application" && (resHealth.Status == health.HealthStatusMissing || resHealth.Status == health.HealthStatusUnknown) {
+		if gvk.Group == "argoproj.io" && gvk.Kind == "Application" && (resHealth.Status == health.HealthStatusMissing || resHealth.Status == health.HealthStatusUnknown || resHealth.Status == health.HealthStatusDegraded) {
 			// Covers the app-of-apps corner case where child app is deployed but that app itself
 			// has a status of 'Missing', which we don't want to cause the parent's health status
-			// to also be Missing
+			// to also be Missing. Default changed so that if a child app has a degraded health status,
+			// it will not affect the parent's health status.
 			return true
 		}
 	}

--- a/util/health/health_test.go
+++ b/util/health/health_test.go
@@ -105,13 +105,13 @@ func TestAppOfAppsHealth(t *testing.T) {
 		assert.Equal(t, health.HealthStatusHealthy, healthStatus.Status)
 	}
 
-	// verify degraded does affect
+	// verify degraded does not affect app health
 	{
 		degradedAndHealthyStatuses := []*appv1.ResourceStatus{degradedStatus, healthyStatus}
 		degradedAndHealthyLiveObjects := []*unstructured.Unstructured{degradedApp, healthyApp}
 		healthStatus, err := SetApplicationHealth(degradedAndHealthyStatuses, degradedAndHealthyLiveObjects, nil, noFilter)
 		assert.NoError(t, err)
-		assert.Equal(t, health.HealthStatusDegraded, healthStatus.Status)
+		assert.Equal(t, health.HealthStatusHealthy, healthStatus.Status)
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Fix is for https://github.com/argoproj/argo-cd/issues/3781
For checklist item 3 above, from what I could tell, no UI or CLI changes are necessary.

See screenshots in the issue that show the before and after behaviour.