### PR TITLE
refactor(makefile): adding kubernetes client version to LDFLAGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ ADD hack/installers installers
 ADD hack/tool-versions.sh .
 
 RUN ./install.sh packr-linux
-RUN ./install.sh kubectl-linux
 RUN ./install.sh ksonnet-linux
 RUN ./install.sh helm2-linux
 RUN ./install.sh helm-linux
@@ -61,7 +60,6 @@ COPY hack/git-verify-wrapper.sh /usr/local/bin/git-verify-wrapper.sh
 COPY --from=builder /usr/local/bin/ks /usr/local/bin/ks
 COPY --from=builder /usr/local/bin/helm2 /usr/local/bin/helm2
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
-COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 # script to add current (possibly arbitrary) user to /etc/passwd at runtime
 # (if it's not already there, to be openshift friendly)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GIT_TAG=$(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-
 GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
 PACKR_CMD=$(shell if [ "`which packr`" ]; then echo "packr"; else echo "go run github.com/gobuffalo/packr/packr"; fi)
 VOLUME_MOUNT=$(shell if test "$(go env GOOS)" = "darwin"; then echo ":delegated"; elif test selinuxenabled; then echo ":delegated"; else echo ""; fi)
+KUBE_CLIENT_VERSION=$(shell cat go.mod | grep kubernetes | awk '{print $$2}')
 
 GOPATH?=$(shell if test -x `which go`; then go env GOPATH; else echo "$(HOME)/go"; fi)
 GOCACHE?=$(HOME)/.cache/go-build
@@ -109,7 +110,8 @@ override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \
   -X ${PACKAGE}.buildDate=${BUILD_DATE} \
   -X ${PACKAGE}.gitCommit=${GIT_COMMIT} \
-  -X ${PACKAGE}.gitTreeState=${GIT_TREE_STATE}
+  -X ${PACKAGE}.gitTreeState=${GIT_TREE_STATE} \
+  -X ${PACKAGE}.kubeClientVersion=${KUBE_CLIENT_VERSION}
 
 ifeq (${STATIC_BUILD}, true)
 override LDFLAGS += -extldflags "-static"

--- a/common/version.go
+++ b/common/version.go
@@ -8,23 +8,25 @@ import (
 // Version information set by link flags during build. We fall back to these sane
 // default values when we build outside the Makefile context (e.g. go run, go build, or go test).
 var (
-	version      = "99.99.99"             // value from VERSION file
-	buildDate    = "1970-01-01T00:00:00Z" // output from `date -u +'%Y-%m-%dT%H:%M:%SZ'`
-	gitCommit    = ""                     // output from `git rev-parse HEAD`
-	gitTag       = ""                     // output from `git describe --exact-match --tags HEAD` (if clean tree state)
-	gitTreeState = ""                     // determined from `git status --porcelain`. either 'clean' or 'dirty'
+	version           = "99.99.99"             // value from VERSION file
+	buildDate         = "1970-01-01T00:00:00Z" // output from `date -u +'%Y-%m-%dT%H:%M:%SZ'`
+	gitCommit         = ""                     // output from `git rev-parse HEAD`
+	gitTag            = ""                     // output from `git describe --exact-match --tags HEAD` (if clean tree state)
+	gitTreeState      = ""                     // determined from `git status --porcelain`. either 'clean' or 'dirty'
+	kubeClientVersion = ""                     // determined from `cat go.mod | grep kubernetes | awk '{print $2}'`
 )
 
 // Version contains Argo version information
 type Version struct {
-	Version      string
-	BuildDate    string
-	GitCommit    string
-	GitTag       string
-	GitTreeState string
-	GoVersion    string
-	Compiler     string
-	Platform     string
+	Version           string
+	BuildDate         string
+	GitCommit         string
+	GitTag            string
+	GitTreeState      string
+	GoVersion         string
+	Compiler          string
+	Platform          string
+	KubeClientVersion string
 }
 
 func (v Version) String() string {
@@ -53,13 +55,14 @@ func GetVersion() Version {
 		}
 	}
 	return Version{
-		Version:      versionStr,
-		BuildDate:    buildDate,
-		GitCommit:    gitCommit,
-		GitTag:       gitTag,
-		GitTreeState: gitTreeState,
-		GoVersion:    runtime.Version(),
-		Compiler:     runtime.Compiler,
-		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Version:           versionStr,
+		BuildDate:         buildDate,
+		GitCommit:         gitCommit,
+		GitTag:            gitTag,
+		GitTreeState:      gitTreeState,
+		GoVersion:         runtime.Version(),
+		Compiler:          runtime.Compiler,
+		KubeClientVersion: kubeClientVersion,
+		Platform:          fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }


### PR DESCRIPTION
adding version of kubernetes go-client library at compile time

#4385

This is a proposal to the changes discussed in https://github.com/argoproj/argo-cd/issues/4385

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
