### PR TITLE
fix: fix broken docker build of argocd-test-tools image

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=redis /usr/local/bin/* /usr/local/bin/
 # Copy node binaries
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node /usr/local/bin/node /usr/local/bin
-COPY --from=node /opt/yarn-v1.15.2 /opt/yarn-v1.15.2
+COPY --from=node /opt/yarn-v1.22.4 /opt/yarn-v1.22.4
 
 # Entrypoint is required for container's user management
 COPY ./test/container/uid_entrypoint.sh /usr/local/bin
@@ -95,7 +95,7 @@ RUN useradd -l -u ${UID} -d /home/user -s /bin/bash user && \
     ln -s /usr/local/bin/node /usr/local/bin/nodejs && \
     ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
-    ln -s /opt/yarn-v1.15.2/bin/yarn /usr/local/bin/yarn && \
-    ln -s /opt/yarn-v1.15.2/bin/yarnpkg /usr/local/bin/yarnpkg
+    ln -s /opt/yarn-v1.22.4/bin/yarn /usr/local/bin/yarn && \
+    ln -s /opt/yarn-v1.22.4/bin/yarnpkg /usr/local/bin/yarnpkg
 
 ENTRYPOINT ["/usr/local/bin/uid_entrypoint.sh"]


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

Building the `argocd-test-tools` docker image used by the virtual toolchain was broken by PR https://github.com/argoproj/argo-cd/pull/4461

The error is

```
Step 21/25 : COPY --from=node /opt/yarn-v1.15.2 /opt/yarn-v1.15.2
COPY failed: stat /var/lib/docker/overlay2/ac0bf6cbf1acfd18d636ad733752da83227bf9e4ee3eb641923559931c159369/merged/opt/yarn-v1.15.2: no such file or directory
make: *** [test-tools-image] Error 1
```

This is because the new node:12.18.4 docker image has updated the version of the included yarn to v1.22.4

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
