### PR TITLE
docs: Format issue in documentation site for dependencies.md (#4491)

### DIFF
--- a/docs/developer-guide/dependencies.md
+++ b/docs/developer-guide/dependencies.md
@@ -10,21 +10,23 @@ https://github.com/argoproj/gitops-engine
 
 After your GitOps Engine PR has been merged, ArgoCD needs to be updated to pull in the version of the GitOps engine that contains your change.  Here are the steps:
 
-1. Retrieve the SHA hash for your commit. You will use this in the next step.
-2. From the `argo-cd` folder, run the following command
+* Retrieve the SHA hash for your commit. You will use this in the next step.
+* From the `argo-cd` folder, run the following command
 
-   `go get github.com/argoproj/gitops-engine@<git-commit-sha>`
-   
-   If you get an error message `invalid version: unknown revision` then you got the wrong SHA hash
-3. Run:
+    `go get github.com/argoproj/gitops-engine@<git-commit-sha>`
 
-   `go mod tidy`
-   
-4. The following files are changed:
+    If you get an error message `invalid version: unknown revision` then you got the wrong SHA hash
 
-   - `go.mod`
-   - `go.sum`
-5. Create an ArgoCD PR with a `refactor:` type in its title for the two file changes.
+* Run:
+
+    `go mod tidy`
+
+* The following files are changed:
+
+    - `go.mod`
+    - `go.sum`
+
+* Create an ArgoCD PR with a `refactor:` type in its title for the two file changes.
 
 ### Tips:
 * See https://github.com/argoproj/argo-cd/pull/4434 as an example


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

@jannfis , the formatting in the documentation site is off, although the markdown is rendered properly in GitHub.  Switch to using bullet points.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Follow-on to https://github.com/argoproj/argo-cd/issues/4491
