### PR TITLE
fix: JS error on application list page if app has no namespace

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -142,7 +142,7 @@ function filterApps(applications: models.Application[], pref: AppsListPreference
             (pref.reposFilter.length === 0 || pref.reposFilter.includes(app.spec.source.repoURL)) &&
             (pref.syncFilter.length === 0 || pref.syncFilter.includes(app.status.sync.status)) &&
             (pref.healthFilter.length === 0 || pref.healthFilter.includes(app.status.health.status)) &&
-            (pref.namespacesFilter.length === 0 || pref.namespacesFilter.some(ns => minimatch(app.spec.destination.namespace, ns))) &&
+            (pref.namespacesFilter.length === 0 || pref.namespacesFilter.some(ns => app.spec.destination.namespace && minimatch(app.spec.destination.namespace, ns))) &&
             (pref.clustersFilter.length === 0 || pref.clustersFilter.some(server => minimatch(app.spec.destination.server || app.spec.destination.name, server))) &&
             (pref.labelsFilter.length === 0 || pref.labelsFilter.every(selector => LabelSelector.match(selector, app.metadata.labels)))
     );


### PR DESCRIPTION
PR fixes javascript error on applications list page. To reproduce JS error create any application with empty destination namespace. Navigate to applications list page and try to set any namespace filter.