### PR TITLE
fix: webpack-dev-server proxy hostname

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -10,7 +10,7 @@ const path = require('path');
 const isProd = process.env.NODE_ENV === 'production';
 
 const proxyConf = {
-    'target': process.env.ARGOCD_API_URL || 'http://localhost:8080',
+    'target': process.env.ARGOCD_API_URL || 'http://[::1]:8080',
     'secure': false,
 };
 


### PR DESCRIPTION
Switching the hostname from 'localhost' to the ipv6 '[::1]' fixes the dev server proxy

https://github.com/webpack/webpack-dev-server/issues/793#issuecomment-316650146

Signed-off-by: Tim Etchells <tetchell@redhat.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

### Background
Since I started working on argocd I have been using `make start` instead of `start-local`. `local` starts much faster for me and does not have the overhead/complexity of the docker container. 

But the webpack-dev-server was not working for me outside of the container, meaning API requests were not forwarded from `localhost:4000` to `localhost:8080` as they should have been, making all API requests return 404s.

The issue may be mac-specific, based on the WDS issue linked above. This fixed it for me and should not affect anyone who already had it working.