### PR TITLE
fix: Summary legend overflow view (#4187)

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-summary.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-summary.tsx
@@ -60,7 +60,7 @@ export const ApplicationsSummary = ({applications}: {applications: models.Applic
     return (
         <div className='white-box applications-list__summary'>
             <div className='row'>
-                <div className='columns large-4 small-12'>
+                <div className='columns large-3 small-12'>
                     <div className='white-box__details'>
                         <p className='row'>SUMMARY</p>
                         {attributes.map(attr => (
@@ -75,18 +75,22 @@ export const ApplicationsSummary = ({applications}: {applications: models.Applic
                 </div>
                 {charts.map(chart => (
                     <React.Fragment key={chart.title}>
-                        <div className='columns large-3 small-4'>
-                            <h4 style={{textAlign: 'center'}}>{chart.title}</h4>
-                            <PieChart data={chart.data} />
-                        </div>
-                        <div className='columns large-1 small-2'>
-                            <ul>
-                                {Array.from(chart.legend.keys()).map(key => (
-                                    <li style={{color: chart.legend.get(key)}} key={key}>
-                                        {key}
-                                    </li>
-                                ))}
-                            </ul>
+                        <div className='columns large-4 small-12'>
+                            <div className='row'>
+                                <div className='columns large-10 small-6'>
+                                    <h4 style={{textAlign: 'center'}}>{chart.title}</h4>
+                                    <PieChart data={chart.data} />
+                                </div>
+                                <div className='columns large-1 small-1'>
+                                    <ul>
+                                        {Array.from(chart.legend.keys()).map(key => (
+                                            <li style={{color: chart.legend.get(key)}} key={key}>
+                                                {key}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            </div>
                         </div>
                     </React.Fragment>
                 ))}


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

UI change only.  This will fix https://github.com/argoproj/argo-cd/issues/4187 and also relayout the pie charts in one column when the width of the browser is too narrow.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
