### PR TITLE
fix: bump cache version to avoid nil pointer error

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -183,7 +183,7 @@ const (
 	MinClientVersion = "1.4.0"
 	// CacheVersion is a objects version cached using util/cache/cache.go.
 	// Number should be bumped in case of backward incompatible change to make sure cache is invalidated after upgrade.
-	CacheVersion = "1.8.0"
+	CacheVersion = "1.8.1"
 )
 
 // GetGnuPGHomePath retrieves the path to use for GnuPG home directory, which is either taken from GNUPGHOME environment or a default value


### PR DESCRIPTION
Increases cache version number that is required due to cached structure changes implemented in https://github.com/argoproj/argo-cd/commit/d479d22de7e33dd5583bd51e4eb76163baf6318c