### PR TITLE
feat: Include cluster name in application filter (#4135)

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -7,6 +7,7 @@ import * as models from '../../../shared/models';
 import {AppsListPreferences, services} from '../../../shared/services';
 
 export interface ApplicationsFilterProps {
+    clusters: models.Cluster[];
     applications: models.Application[];
     pref: AppsListPreferences;
     onChange: (pref: AppsListPreferences) => any;
@@ -167,10 +168,10 @@ export class ApplicationsFilter extends React.Component<ApplicationsFilterProps,
                             <ul>
                                 <li>
                                     <TagsInput
-                                        placeholder='https://kubernetes.default.svc'
-                                        autocomplete={Array.from(
-                                            new Set(applications.map(app => app.spec.destination.server || app.spec.destination.name).filter(item => !!item))
-                                        ).filter(ns => pref.clustersFilter.indexOf(ns) === -1)}
+                                        placeholder='in-cluster (https://kubernetes.default.svc)'
+                                        autocomplete={Array.from(new Set(applications.map(app => this.getClusterDetail(app.spec.destination)).filter(item => !!item))).filter(
+                                            ns => pref.clustersFilter.indexOf(ns) === -1
+                                        )}
                                         tags={pref.clustersFilter}
                                         onChange={selected => onChange({...pref, clustersFilter: selected})}
                                     />
@@ -194,5 +195,13 @@ export class ApplicationsFilter extends React.Component<ApplicationsFilterProps,
                 </div>
             </div>
         );
+    }
+
+    private getClusterDetail(dest: models.ApplicationDestination): string {
+        const cluster = this.props.clusters.find(target => target.name === dest.name || target.server === dest.server);
+        if (cluster.name === cluster.server) {
+            return cluster.name;
+        }
+        return `${cluster.name} (${cluster.server})`;
     }
 }

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {Consumer} from '../../../shared/context';
 import * as models from '../../../shared/models';
 
+import {Cluster} from '../../../shared/components';
 import {ApplicationURLs} from '../application-urls';
 import * as AppUtils from '../utils';
 import {OperationState} from '../utils';
@@ -16,13 +17,6 @@ export interface ApplicationTilesProps {
     syncApplication: (appName: string) => any;
     refreshApplication: (appName: string) => any;
     deleteApplication: (appName: string) => any;
-}
-
-function getDestination(dest: models.ApplicationDestination) {
-    if (dest.server === undefined) {
-        return dest.name;
-    }
-    return dest.server;
 }
 
 export const ApplicationTiles = ({applications, syncApplication, refreshApplication, deleteApplication}: ApplicationTilesProps) => (
@@ -125,7 +119,9 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                         <div className='columns small-3' title='Destination:'>
                                             Destination:
                                         </div>
-                                        <div className='columns small-9'>{getDestination(app.spec.destination)}</div>
+                                        <div className='columns small-9'>
+                                            <Cluster server={app.spec.destination.server} name={app.spec.destination.name} />
+                                        </div>
                                     </div>
                                     <div className='row'>
                                         <div className='columns small-3' title='Namespace:'>


### PR DESCRIPTION
Including cluster-name is beneficial since names are more human-readable. Followed the same convention used in the app details page for consistency

_Cases handled:_
1. Application tiles will only display cluster-name
2. Filter will display both name and URL
3. If cluster-name is absent (the name will default to URL)

Fixes: #4135

![Screenshot from 2020-10-19 10-47-46](https://user-images.githubusercontent.com/21128732/96404915-b704b500-11f9-11eb-981b-c50c87ec9812.jpg)


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
