### PR TITLE
fix: Revert "fix webpack-dev-server proxy hostname"

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -10,7 +10,7 @@ const path = require('path');
 const isProd = process.env.NODE_ENV === 'production';
 
 const proxyConf = {
-    'target': process.env.ARGOCD_API_URL || 'http://[::1]:8080',
+    'target': process.env.ARGOCD_API_URL || 'http://localhost:8080',
     'secure': false,
 };
 


### PR DESCRIPTION
Reverts argoproj/argo-cd#4515

due to https://github.com/argoproj/argo-cd/issues/4528

@alexmt @jgwest