### PR TITLE
docs: replace deployment with statefulset

### DIFF
--- a/docs/developer-guide/running-locally.md
+++ b/docs/developer-guide/running-locally.md
@@ -22,7 +22,7 @@ kubectl apply -n argocd --force -f manifests/install.yaml
 Make sure that ArgoCD is not running in your development cluster by scaling down the deployments:
 
 ```shell
-kubectl -n argocd scale deployment/argocd-application-controller --replicas 0
+kubectl -n argocd scale statefulset/argocd-application-controller --replicas 0
 kubectl -n argocd scale deployment/argocd-dex-server --replicas 0
 kubectl -n argocd scale deployment/argocd-repo-server --replicas 0
 kubectl -n argocd scale deployment/argocd-server --replicas 0

--- a/docs/developer-guide/running-locally.md
+++ b/docs/developer-guide/running-locally.md
@@ -56,7 +56,7 @@ export ARGOCD_OPTS="--plaintext --insecure"
 Once you have finished testing your changes locally and want to bring back ArgoCD in your development cluster, simply scale the deployments up again:
 
 ```bash
-kubectl -n argocd scale deployment/argocd-application-controller --replicas 1
+kubectl -n argocd scale statefulset/argocd-application-controller --replicas 1
 kubectl -n argocd scale deployment/argocd-dex-server --replicas 1
 kubectl -n argocd scale deployment/argocd-repo-server --replicas 1
 kubectl -n argocd scale deployment/argocd-server --replicas 1


### PR DESCRIPTION
The step below should be updated.  deployments.apps "argocd-application-controller" does not exist.
```
$ kubectl -n argocd scale deployment/argocd-application-controller --replicas 0
Error from server (NotFound): deployments.apps "argocd-application-controller" not found
```
It should be updated to:
```
$ kubectl -n argocd scale statefulset/argocd-application-controller --replicas 0
statefulset.apps/argocd-application-controller scaled
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
