### PR TITLE
fix: ssh repo url match failed when webhook gitlab http custom port

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -165,7 +165,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload interface{}) {
 			log.Warnf("Failed to parse repoURL '%s'", webURL)
 			continue
 		}
-		regexpStr := `(?i)(http://|https://|\w+@|ssh://(\w+@)?)` + urlObj.Host + "(:[0-9]+|)[:/]" + urlObj.Path[1:] + "(\\.git)?"
+		regexpStr := `(?i)(http://|https://|\w+@|ssh://(\w+@)?)` + urlObj.Hostname() + "(:[0-9]+|)[:/]" + urlObj.Path[1:] + "(\\.git)?"
 		repoRegexp, err := regexp.Compile(regexpStr)
 		if err != nil {
 			log.Warnf("Failed to compile regexp for repoURL '%s'", webURL)


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

When the gitlab http address has a defined port number, such as http://example.com:8080, the webhook ssh repo will fail to match. This fixed it for me and should not affect anyone who already had it working.
