### PR TITLE
fix: Don't parse empty strings as maps in settings.

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -470,7 +470,7 @@ func (mgr *SettingsManager) GetResourceOverrides() (map[string]v1alpha1.Resource
 		return nil, err
 	}
 	resourceOverrides := map[string]v1alpha1.ResourceOverride{}
-	if value, ok := argoCDCM.Data[resourceCustomizationsKey]; ok {
+	if value, ok := argoCDCM.Data[resourceCustomizationsKey]; ok && value != "" {
 		err := yaml.Unmarshal([]byte(value), &resourceOverrides)
 		if err != nil {
 			return nil, err

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -112,6 +112,7 @@ func TestGetResourceFilter(t *testing.T) {
 		ResourceInclusions: []FilteredResource{{APIGroups: []string{"group2"}, Kinds: []string{"kind2"}, Clusters: []string{"cluster2"}}},
 	}, filter)
 }
+
 func TestGetConfigManagementPlugins(t *testing.T) {
 	data := map[string]string{
 		"configManagementPlugins": `
@@ -219,6 +220,17 @@ func TestGetResourceOverrides(t *testing.T) {
 	overrides, err = settingsManager.GetResourceOverrides()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(overrides))
+
+}
+
+func TestSettingsManager_GetResourceOverrides_with_empty_string(t *testing.T) {
+	_, settingsManager := fixtures(map[string]string{
+		resourceCustomizationsKey: "",
+	})
+	overrides, err := settingsManager.GetResourceOverrides()
+	assert.NoError(t, err)
+
+	assert.Len(t, overrides, 1)
 }
 
 func TestGetResourceCompareOptions(t *testing.T) {


### PR DESCRIPTION
There's a bug in the resource inclusions parsing, if the string is "" then it's
parsed as a map, which returns nil, and so it fails when adding elements later.

This fixes: #4555 

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 