### PR TITLE
fix: Data race in SettingsManager.GetRepositoryCredentials() (#4561)

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -638,24 +638,32 @@ func (mgr *SettingsManager) SaveRepositoryCredentials(creds []RepositoryCredenti
 }
 
 func (mgr *SettingsManager) GetRepositoryCredentials() ([]RepositoryCredentials, error) {
-	if mgr.repoCredsCache == nil {
-		argoCDCM, err := mgr.getConfigMap()
+
+	mgr.mutex.Lock()
+	repoCredsCache := mgr.repoCredsCache
+	mgr.mutex.Unlock()
+	if repoCredsCache != nil {
+		return repoCredsCache, nil
+	}
+
+	// Get the config map outside of the lock
+	argoCDCM, err := mgr.getConfigMap()
+	if err != nil {
+		return nil, err
+	}
+
+	mgr.mutex.Lock()
+	defer mgr.mutex.Unlock()
+	creds := make([]RepositoryCredentials, 0)
+	credsStr := argoCDCM.Data[repositoryCredentialsKey]
+	if credsStr != "" {
+		err := yaml.Unmarshal([]byte(credsStr), &creds)
 		if err != nil {
 			return nil, err
 		}
-
-		mgr.mutex.Lock()
-		defer mgr.mutex.Unlock()
-		creds := make([]RepositoryCredentials, 0)
-		credsStr := argoCDCM.Data[repositoryCredentialsKey]
-		if credsStr != "" {
-			err := yaml.Unmarshal([]byte(credsStr), &creds)
-			if err != nil {
-				return nil, err
-			}
-		}
-		mgr.repoCredsCache = creds
 	}
+	mgr.repoCredsCache = creds
+
 	return mgr.repoCredsCache, nil
 }
 


### PR DESCRIPTION
This fix for this is essentially the same as #4550, as the two methods are almost carbon copies of each other. To fix we check if the `repoCredsCache` field is nil while holding the lock, then drop the lock so that we don't hold the lock during k8s cluster I/O.

Fixes https://github.com/argoproj/argo-cd/issues/4561

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
