### PR TITLE
refactor: upgrade gitops-engine version ( #4354, #1787 )

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/argoproj/gitops-engine v0.1.3-0.20201013235340-a1dc4c598b93
+	github.com/argoproj/gitops-engine v0.1.3-0.20201014183719-4eb3ca3feefb
 	github.com/argoproj/pkg v0.2.0
 	github.com/casbin/casbin v1.9.1
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
-github.com/argoproj/gitops-engine v0.1.3-0.20201013235340-a1dc4c598b93 h1:4cObITfq2HV1+rtBpqmsRlynU0KN4IMyUe98WRHyVqY=
-github.com/argoproj/gitops-engine v0.1.3-0.20201013235340-a1dc4c598b93/go.mod h1:q1l0iuCyihknkeO3ne6cvOuagsp2NR+7ijRovlDz254=
+github.com/argoproj/gitops-engine v0.1.3-0.20201014183719-4eb3ca3feefb h1:lf5CH6YyPqBJhg7DEI7h75A/Bu4Sfv9OjPePr0mlDl0=
+github.com/argoproj/gitops-engine v0.1.3-0.20201014183719-4eb3ca3feefb/go.mod h1:q1l0iuCyihknkeO3ne6cvOuagsp2NR+7ijRovlDz254=
 github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=
 github.com/argoproj/pkg v0.2.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
PR upgrades gitops engine.

Pulls in changes that are required for #4354 and #1787