### PR TITLE
 fix: Make gpg watcher re-creation more robust

### DIFF
--- a/reposerver/gpgwatcher.go
+++ b/reposerver/gpgwatcher.go
@@ -48,6 +48,7 @@ func StartGPGWatcher(sourcePath string) error {
 									continue
 								} else {
 									log.Errorf("Maximum retries exceeded.")
+									close(done)
 									return
 								}
 							}

--- a/reposerver/gpgwatcher.go
+++ b/reposerver/gpgwatcher.go
@@ -48,6 +48,7 @@ func StartGPGWatcher(sourcePath string) error {
 									continue
 								} else {
 									log.Errorf("Maximum retries exceeded.")
+									return
 								}
 							}
 							break

--- a/reposerver/gpgwatcher.go
+++ b/reposerver/gpgwatcher.go
@@ -11,6 +11,8 @@ import (
 	"github.com/argoproj/argo-cd/util/gpg"
 )
 
+const maxRecreateRetries = 5
+
 // StartGPGWatcher watches a given directory for creation and deletion of files and syncs the GPG keyring
 func StartGPGWatcher(sourcePath string) error {
 	log.Infof("Starting GPG sync watcher on directory '%s'", sourcePath)
@@ -31,13 +33,24 @@ func StartGPGWatcher(sourcePath string) error {
 				}
 				if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Remove == fsnotify.Remove {
 					// In case our watched path is re-created (i.e. during e2e tests), we need to watch again
+					// For more robustness, we retry re-creating the watcher up to maxRecreateRetries
 					if event.Name == sourcePath && event.Op&fsnotify.Remove == fsnotify.Remove {
 						log.Warnf("Re-creating watcher on %s", sourcePath)
-						time.Sleep(1 * time.Second)
-						err = watcher.Add(sourcePath)
-						if err != nil {
-							log.Errorf("Error re-creating watcher on %s: %v", sourcePath, err)
-							return
+						attempt := 0
+						for {
+							err = watcher.Add(sourcePath)
+							if err != nil {
+								log.Errorf("Error re-creating watcher on %s: %v", sourcePath, err)
+								if attempt < maxRecreateRetries {
+									attempt += 1
+									log.Infof("Retrying to re-create watcher, attempt %d of %d", attempt, maxRecreateRetries)
+									time.Sleep(1 * time.Second)
+									continue
+								} else {
+									log.Errorf("Maximum retries exceeded.")
+								}
+							}
+							break
 						}
 						// Force sync because we probably missed an event
 						forceSync = true


### PR DESCRIPTION
This change will fix the flaky gpg e2e tests.

Root cause was, that the E2E test context setups removes and re-creates the directory where source GnuPG keys are stored. Sometimes the re-creation does not happen quick enough, and the gpg watcher will choke. This change adds a retry mechanism, which should never be triggered in scenarios except e2e testing.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
