### PR TITLE
fix: don't re-pull fonts on each webpack build

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -8,6 +8,7 @@ const webpack = require('webpack');
 const path = require('path');
 
 const isProd = process.env.NODE_ENV === 'production';
+console.log(`Bundling in ${isProd ? 'production' : 'development'} mode...`);
 
 const proxyConf = {
     'target': process.env.ARGOCD_API_URL || 'http://localhost:8080',
@@ -81,7 +82,9 @@ const config = {
             // This works by downloading the fonts at bundle time and adding those font-faces to 'fonts.css'.
             name: 'fonts',
             filename: 'fonts.css',
-            local: true,
+            // local: false in dev prevents pulling fonts on each code change
+            // https://github.com/gabiseabra/google-fonts-webpack-plugin/issues/2
+            local: isProd,
             path: 'assets/fonts/google-fonts'
 		})
     ],


### PR DESCRIPTION
Signed-off-by: Tim Etchells <tetchell@redhat.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
