### PR TITLE
docs: update upgrading overview doc to include missed versions

### DIFF
--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -37,6 +37,8 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
+* [v1.6 to v1.7](./1.6-1.7.md) 
+* [v1.5 to v1.6](./1.5-1.6.md) 
 * [v1.4 to v1.5](./1.4-1.5.md) 
 * [v1.3 to v1.4](./1.3-1.4.md) 
 * [v1.2 to v1.3](./1.2-1.3.md)


### PR DESCRIPTION
minor docs update to add missing links to 1.5->1.6 and 1.6->1.7 upgrades notes.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
