### PR TITLE
chore: Replace deprecated commands for release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,10 +76,10 @@ jobs:
           fi
 
           # Make the variables available in follow-up steps
-          echo "::set-env name=TARGET_VERSION::${TARGET_VERSION}"
-          echo "::set-env name=TARGET_BRANCH::${TARGET_BRANCH}"
-          echo "::set-env name=RELEASE_TAG::${RELEASE_TAG}"
-          echo "::set-env name=PRE_RELEASE::${PRE_RELEASE}"
+          echo "TARGET_VERSION=${TARGET_VERSION}" >> $GITHUB_ENV
+          echo "TARGET_BRANCH=${TARGET_BRANCH}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
+          echo "PRE_RELEASE=${PRE_RELEASE}" >> $GITHUB_ENV
 
       - name: Check if our release tag has a correct annotation
         run: |
@@ -134,7 +134,7 @@ jobs:
 
           # We store path to temporary release notes file for later reading, we
           # need it when creating release.
-          echo "::set-env name=RELEASE_NOTES::$RELEASE_NOTES"
+          echo "RELEASE_NOTES=${RELEASE_NOTES}" >> $GITHUB_ENV
 
       - name: Setup Golang
         uses: actions/setup-go@v1


### PR DESCRIPTION
This replaces deprecated GitHub actions commands (as described in #4589) for our release action.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
