### PR TITLE
docs: Add clarification on the initial password to Getting Started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -86,6 +86,10 @@ Change the password using the command:
 argocd account update-password
 ```
 
+!!! note
+    The initial password is set in a kubernetes secret, named `argocd-secret`, during ArgoCD's initial start up. This means if you edit
+    the deployment in any way which causes a new pod to be deployed, such as disabling TLS on the Argo CD API server. Take note of the initial
+    pod name when you first install Argo CD, or reset the password by following [these instructions](https://argoproj.github.io/argo-cd/faq/#i-forgot-the-admin-password-how-do-i-reset-it)
 
 ## 5. Register A Cluster To Deploy Apps To (Optional)
 


### PR DESCRIPTION
I have recently been experimenting with ArgoCD and I ran into some trouble logging in after getting everything set up. I eventually found #3187 which showed me what I had done wrong. I had edited the deployment and therefore deployed a new api server pod, so when I finally tried to log in to Argo, I had the wrong pod name and password.


I thought clarifying this in the docs would be a good idea and the Getting Started guide seems like the right spot for it.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x ] Does this PR require documentation updates?
* [x ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
