### PR TITLE
feat: support generating manifests for the same commit in parallel

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -158,9 +158,6 @@ func (a *ApplicationSource) AllowsConcurrentProcessing() bool {
 	// Kustomize with parameters requires changing params.libsonnet file
 	case a.Ksonnet != nil:
 		return a.Ksonnet.AllowsConcurrentProcessing()
-	// Plugin might change anything so unsafe to process concurrently
-	case a.Plugin != nil:
-		return false
 	}
 	return true
 }

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2099,3 +2099,27 @@ func TestRetryStrategy_NextRetryAtCustomBackoff(t *testing.T) {
 		assert.Equal(t, expected.Format(time.RFC850), retryAt.Format(time.RFC850))
 	}
 }
+
+func TestSourceAllowsConcurrentProcessing_KsonnetNoParams(t *testing.T) {
+	src := ApplicationSource{Path: "."}
+
+	assert.True(t, src.AllowsConcurrentProcessing())
+}
+
+func TestSourceAllowsConcurrentProcessing_KsonnetParams(t *testing.T) {
+	src := ApplicationSource{Path: ".", Ksonnet: &ApplicationSourceKsonnet{
+		Parameters: []KsonnetParameter{{
+			Name: "test", Component: "test", Value: "1",
+		}},
+	}}
+
+	assert.False(t, src.AllowsConcurrentProcessing())
+}
+
+func TestSourceAllowsConcurrentProcessing_KustomizeParams(t *testing.T) {
+	src := ApplicationSource{Path: ".", Kustomize: &ApplicationSourceKustomize{
+		NameSuffix: "test",
+	}}
+
+	assert.False(t, src.AllowsConcurrentProcessing())
+}

--- a/reposerver/repository/lock.go
+++ b/reposerver/repository/lock.go
@@ -17,7 +17,7 @@ type repositoryLock struct {
 }
 
 // Lock acquires lock unless lock is already acquired with the same commit and allowConcurrent is set to true
-func (r *repositoryLock) Lock(path string, revision string, allowConcurrent func(root string) bool, init func() error) (io.Closer, error) {
+func (r *repositoryLock) Lock(path string, revision string, allowConcurrent bool, init func() error) (io.Closer, error) {
 	r.lock.Lock()
 	state, ok := r.stateByKey[path]
 	if !ok {
@@ -52,10 +52,10 @@ func (r *repositoryLock) Lock(path string, revision string, allowConcurrent func
 
 			state.revision = revision
 			state.processCount = 1
-			state.allowConcurrent = allowConcurrent(path)
+			state.allowConcurrent = allowConcurrent
 			state.cond.L.Unlock()
 			return closer, nil
-		} else if state.revision == revision && state.allowConcurrent && allowConcurrent(path) {
+		} else if state.revision == revision && state.allowConcurrent && allowConcurrent {
 			// same revision already processing and concurrent processing allowed. Increment process count and go ahead.
 			state.processCount++
 			state.cond.L.Unlock()

--- a/reposerver/repository/lock.go
+++ b/reposerver/repository/lock.go
@@ -1,0 +1,76 @@
+package repository
+
+import (
+	"io"
+	"sync"
+
+	ioutil "github.com/argoproj/gitops-engine/pkg/utils/io"
+)
+
+func NewRepositoryLock() *repositoryLock {
+	return &repositoryLock{stateByKey: map[string]*repositoryState{}}
+}
+
+type repositoryLock struct {
+	lock       sync.Mutex
+	stateByKey map[string]*repositoryState
+}
+
+// Lock acquires lock unless lock is already acquired with the same commit and allowConcurrent is set to true
+func (r *repositoryLock) Lock(path string, revision string, allowConcurrent func(root string) bool, init func() error) (io.Closer, error) {
+	r.lock.Lock()
+	state, ok := r.stateByKey[path]
+	if !ok {
+		state = &repositoryState{cond: &sync.Cond{L: &sync.Mutex{}}}
+		r.stateByKey[path] = state
+	}
+	r.lock.Unlock()
+
+	closer := ioutil.NewCloser(func() error {
+		state.cond.L.Lock()
+		notify := false
+		state.processCount--
+		if state.processCount == 0 {
+			notify = true
+			state.revision = ""
+		}
+		state.cond.L.Unlock()
+		if notify {
+			state.cond.Broadcast()
+		}
+		return nil
+	})
+
+	for {
+		state.cond.L.Lock()
+		if state.revision == "" {
+			// no in progress operation for that repo. Go ahead.
+			if err := init(); err != nil {
+				state.cond.L.Unlock()
+				return nil, err
+			}
+
+			state.revision = revision
+			state.processCount = 1
+			state.allowConcurrent = allowConcurrent(path)
+			state.cond.L.Unlock()
+			return closer, nil
+		} else if state.revision == revision && state.allowConcurrent && allowConcurrent(path) {
+			// same revision already processing and concurrent processing allowed. Increment process count and go ahead.
+			state.processCount++
+			state.cond.L.Unlock()
+			return closer, nil
+		} else {
+			state.cond.Wait()
+			// wait when all in-flight processes of this revision complete and try again
+			state.cond.L.Unlock()
+		}
+	}
+}
+
+type repositoryState struct {
+	cond            *sync.Cond
+	revision        string
+	processCount    int
+	allowConcurrent bool
+}

--- a/reposerver/repository/lock_test.go
+++ b/reposerver/repository/lock_test.go
@@ -38,7 +38,7 @@ func TestLock_SameRevision(t *testing.T) {
 	initializedTimes := 0
 	init := numberOfInits(&initializedTimes)
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(true), init)
+		return lock.Lock("myRepo", "1", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -46,7 +46,7 @@ func TestLock_SameRevision(t *testing.T) {
 	}
 
 	closer2, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(true), init)
+		return lock.Lock("myRepo", "1", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -66,7 +66,7 @@ func TestLock_DifferentRevisions(t *testing.T) {
 	init := numberOfInits(&initializedTimes)
 
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(true), init)
+		return lock.Lock("myRepo", "1", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -74,7 +74,7 @@ func TestLock_DifferentRevisions(t *testing.T) {
 	}
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "2", allow(true), init)
+		return lock.Lock("myRepo", "2", true, init)
 	})
 
 	if !assert.False(t, done) {
@@ -84,7 +84,7 @@ func TestLock_DifferentRevisions(t *testing.T) {
 	util.Close(closer1)
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "2", allow(true), init)
+		return lock.Lock("myRepo", "2", true, init)
 	})
 
 	if !assert.True(t, done) {
@@ -98,7 +98,7 @@ func TestLock_NoConcurrentWithSameRevision(t *testing.T) {
 	init := numberOfInits(&initializedTimes)
 
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(false), init)
+		return lock.Lock("myRepo", "1", false, init)
 	})
 
 	if !assert.True(t, done) {
@@ -106,7 +106,7 @@ func TestLock_NoConcurrentWithSameRevision(t *testing.T) {
 	}
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(false), init)
+		return lock.Lock("myRepo", "1", false, init)
 	})
 
 	if !assert.False(t, done) {
@@ -120,7 +120,7 @@ func TestLock_FailedInitialization(t *testing.T) {
 	lock := NewRepositoryLock()
 
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(true), func() error {
+		return lock.Lock("myRepo", "1", true, func() error {
 			return errors.New("failed")
 		})
 	})
@@ -132,7 +132,7 @@ func TestLock_FailedInitialization(t *testing.T) {
 	assert.Nil(t, closer1)
 
 	closer2, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(true), func() error {
+		return lock.Lock("myRepo", "1", true, func() error {
 			return nil
 		})
 	})
@@ -149,7 +149,7 @@ func TestLock_SameRevisionFirstNotConcurrent(t *testing.T) {
 	initializedTimes := 0
 	init := numberOfInits(&initializedTimes)
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(false), init)
+		return lock.Lock("myRepo", "1", false, init)
 	})
 
 	if !assert.True(t, done) {
@@ -157,7 +157,7 @@ func TestLock_SameRevisionFirstNotConcurrent(t *testing.T) {
 	}
 
 	_, done = lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", allow(true), init)
+		return lock.Lock("myRepo", "1", true, init)
 	})
 
 	if !assert.False(t, done) {

--- a/reposerver/repository/lock_test.go
+++ b/reposerver/repository/lock_test.go
@@ -1,0 +1,170 @@
+package repository
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	util "github.com/argoproj/gitops-engine/pkg/utils/io"
+)
+
+// execute given action and return false if action have not completed within 1 second
+func lockQuickly(action func() (io.Closer, error)) (io.Closer, bool) {
+	done := make(chan io.Closer)
+	go func() {
+		closer, _ := action()
+		done <- closer
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		return nil, false
+	case closer := <-done:
+		return closer, true
+	}
+}
+
+func numberOfInits(initializedTimes *int) func() error {
+	return func() error {
+		*initializedTimes++
+		return nil
+	}
+}
+
+func TestLock_SameRevision(t *testing.T) {
+	lock := NewRepositoryLock()
+	initializedTimes := 0
+	init := numberOfInits(&initializedTimes)
+	closer1, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(true), init)
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+
+	closer2, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(true), init)
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+
+	assert.Equal(t, 1, initializedTimes)
+
+	util.Close(closer1)
+
+	util.Close(closer2)
+}
+
+func TestLock_DifferentRevisions(t *testing.T) {
+	lock := NewRepositoryLock()
+	initializedTimes := 0
+	init := numberOfInits(&initializedTimes)
+
+	closer1, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(true), init)
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+
+	_, done = lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "2", allow(true), init)
+	})
+
+	if !assert.False(t, done) {
+		return
+	}
+
+	util.Close(closer1)
+
+	_, done = lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "2", allow(true), init)
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+}
+
+func TestLock_NoConcurrentWithSameRevision(t *testing.T) {
+	lock := NewRepositoryLock()
+	initializedTimes := 0
+	init := numberOfInits(&initializedTimes)
+
+	closer1, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(false), init)
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+
+	_, done = lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(false), init)
+	})
+
+	if !assert.False(t, done) {
+		return
+	}
+
+	util.Close(closer1)
+}
+
+func TestLock_FailedInitialization(t *testing.T) {
+	lock := NewRepositoryLock()
+
+	closer1, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(true), func() error {
+			return errors.New("failed")
+		})
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+
+	assert.Nil(t, closer1)
+
+	closer2, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(true), func() error {
+			return nil
+		})
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+
+	util.Close(closer2)
+}
+
+func TestLock_SameRevisionFirstNotConcurrent(t *testing.T) {
+	lock := NewRepositoryLock()
+	initializedTimes := 0
+	init := numberOfInits(&initializedTimes)
+	closer1, done := lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(false), init)
+	})
+
+	if !assert.True(t, done) {
+		return
+	}
+
+	_, done = lockQuickly(func() (io.Closer, error) {
+		return lock.Lock("myRepo", "1", allow(true), init)
+	})
+
+	if !assert.False(t, done) {
+		return
+	}
+
+	assert.Equal(t, 1, initializedTimes)
+
+	util.Close(closer1)
+}

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -411,9 +411,16 @@ func getHelmRepos(repositories []*v1alpha1.Repository) []helm.HelmRepository {
 
 var helmBuildLock = sync.NewKeyLock()
 
+// runHelmBuild executes `helm dependency build` in a given path and ensures that it is executed only once
+// if multiple threads are trying to run it.
+// Multiple goroutines might process same helm app in one repo concurrently when repo server process multiple
+// manifest generation requests of the same commit.
 func runHelmBuild(appPath string, h helm.Helm) error {
 	helmBuildLock.Lock(appPath)
 	defer helmBuildLock.Unlock(appPath)
+	// the `helm dependency build` is potentially time consuming 1~2 seconds
+	// marker file is used to check if command already run to avoid running it again unnecessary
+	// file is removed when repository re-initialized (e.g. when another commit is processed)
 	markerFile := path.Join(appPath, ".argocd-helm-build")
 	_, err := os.Stat(markerFile)
 	if err == nil {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1174,27 +1174,3 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 	}
 
 }
-
-func TestAllowConcurrent_KsonnetNoParams(t *testing.T) {
-	res := allowConcurrent(&argoappv1.ApplicationSource{Path: "."})
-
-	assert.True(t, res)
-}
-
-func TestAllowConcurrent_KsonnetParams(t *testing.T) {
-	res := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Ksonnet: &argoappv1.ApplicationSourceKsonnet{
-		Parameters: []argoappv1.KsonnetParameter{{
-			Name: "test", Component: "test", Value: "1",
-		}},
-	}})
-
-	assert.False(t, res)
-}
-
-func TestAllowConcurrent_KustomizeParams(t *testing.T) {
-	res := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Kustomize: &argoappv1.ApplicationSourceKustomize{
-		NameSuffix: "test",
-	}})
-
-	assert.False(t, res)
-}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1174,3 +1174,33 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 	}
 
 }
+
+func TestAllowConcurrent_KsonnetNoParams(t *testing.T) {
+	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: "."})
+
+	assert.True(t, fn("../../test/e2e/testdata/ksonnet"))
+}
+
+func TestAllowConcurrent_KsonnetParams(t *testing.T) {
+	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Ksonnet: &argoappv1.ApplicationSourceKsonnet{
+		Parameters: []argoappv1.KsonnetParameter{{
+			Name: "test", Component: "test", Value: "1",
+		}},
+	}})
+
+	assert.False(t, fn("../../test/e2e/testdata/ksonnet"))
+}
+
+func TestAllowConcurrent_KustomizeParams(t *testing.T) {
+	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Kustomize: &argoappv1.ApplicationSourceKustomize{
+		NameSuffix: "test",
+	}})
+
+	assert.False(t, fn("../../test/e2e/testdata/kustomize"))
+}
+
+func TestAllowConcurrent_HelmWithDeps(t *testing.T) {
+	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: "."})
+
+	assert.False(t, fn("../../test/e2e/testdata/helm-with-dependencies"))
+}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1176,31 +1176,25 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 }
 
 func TestAllowConcurrent_KsonnetNoParams(t *testing.T) {
-	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: "."})
+	res := allowConcurrent(&argoappv1.ApplicationSource{Path: "."})
 
-	assert.True(t, fn("../../test/e2e/testdata/ksonnet"))
+	assert.True(t, res)
 }
 
 func TestAllowConcurrent_KsonnetParams(t *testing.T) {
-	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Ksonnet: &argoappv1.ApplicationSourceKsonnet{
+	res := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Ksonnet: &argoappv1.ApplicationSourceKsonnet{
 		Parameters: []argoappv1.KsonnetParameter{{
 			Name: "test", Component: "test", Value: "1",
 		}},
 	}})
 
-	assert.False(t, fn("../../test/e2e/testdata/ksonnet"))
+	assert.False(t, res)
 }
 
 func TestAllowConcurrent_KustomizeParams(t *testing.T) {
-	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Kustomize: &argoappv1.ApplicationSourceKustomize{
+	res := allowConcurrent(&argoappv1.ApplicationSource{Path: ".", Kustomize: &argoappv1.ApplicationSourceKustomize{
 		NameSuffix: "test",
 	}})
 
-	assert.False(t, fn("../../test/e2e/testdata/kustomize"))
-}
-
-func TestAllowConcurrent_HelmWithDeps(t *testing.T) {
-	fn := allowConcurrent(&argoappv1.ApplicationSource{Path: "."})
-
-	assert.False(t, fn("../../test/e2e/testdata/helm-with-dependencies"))
+	assert.False(t, res)
 }

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1173,4 +1174,28 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 		})
 	}
 
+}
+
+func TestHelmDependencyWithConcurrency(t *testing.T) {
+	cleanup := func() {
+		_ = os.Remove(filepath.Join("../../util/helm/testdata/helm2-dependency", helmDepUpMarkerFile))
+		_ = os.RemoveAll(filepath.Join("../../util/helm/testdata/helm2-dependency", "charts"))
+	}
+	cleanup()
+	defer cleanup()
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			res, err := helmTemplate("../../util/helm/testdata/helm2-dependency", "../..", nil, &apiclient.ManifestRequest{
+				ApplicationSource: &argoappv1.ApplicationSource{},
+			}, false)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Implements first part of https://github.com/argoproj/argo-cd/issues/4583

PR changes repository server so that it executes multiple operations that require the same repository and same commit SHA ( if the operation does not change files in the repository). This in theory should significantly improve manifest generation for mono repo with many argocd apps in it.

