### PR TITLE
fix: Data race between processAppRefreshQueueItem and processAppOperationQueueItem, in appcontroller.go (#4643)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -547,11 +547,13 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 		// This happens after app was deleted, but the work queue still had an entry for it.
 		return
 	}
-	app, ok := obj.(*appv1.Application)
+	origApp, ok := obj.(*appv1.Application)
 	if !ok {
 		log.Warnf("Key '%s' in index is not an application", appKey)
 		return
 	}
+	app := origApp.DeepCopy()
+
 	if app.Operation != nil {
 		ctrl.processRequestedAppOperation(app)
 	} else if app.DeletionTimestamp != nil && app.CascadedDeletion() {


### PR DESCRIPTION
See [parent issue](https://github.com/argoproj/argo-cd/issues/4643) for full description of fix, but:
- In `processAppOperationQueueItem`  adds `DeepCopy()` on the value returned by the indexer, to prevent methods called from `processAppOperationQueueItem` from unintentionally writing values directly to the cache store
- Fixes a couple unit test data races in the same area of the code while I'm at it

Parent Issue: https://github.com/argoproj/argo-cd/issues/4643

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
