### PR TITLE
docs: Fix broken 'Dex Connectors' link in user-mgmt docs

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -127,7 +127,7 @@ Argo CD embeds and bundles [Dex](https://github.com/coreos/dex) as part of its i
 purpose of delegating authentication to an external identity provider. Multiple types of identity
 providers are supported (OIDC, SAML, LDAP, GitHub, etc...). SSO configuration of Argo CD requires
 editing the `argocd-cm` ConfigMap with
-[Dex connector](https://github.com/coreos/dex/tree/master/Documentation/connectors) settings.
+[Dex connector](https://dexidp.io/docs/connectors/) settings.
 
 This document describes how to configure Argo CD SSO using GitHub (OAuth2) as an example, but the
 steps should be similar for other identity providers.


### PR DESCRIPTION
The documentation of Dex was materialized to https://dexidp.io/docs/ in the meantime.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
