### PR TITLE
Remove obsolete instructions for GKE

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,12 +17,6 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/st
 
 This will create a new namespace, `argocd`, where Argo CD services and application resources will live.
 
-On GKE, you will need grant your account the ability to create new cluster roles:
-    
-```bash
-kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user="$(gcloud config get-value account)"
-```
-
 !!! note
     If you are not interested in UI, SSO, multi-cluster management and just want to pull changes into the cluster then you can disable
     authentication using `--disable-auth` flag and access Argo CD via CLI using `--port-forward` or `--port-forward-namespace` flags


### PR DESCRIPTION
The oldest K8s version supported by GKE is currently 1.15, but the instructions shown here for GKE haven't been required since 1.11 (https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#iam-rolebinding-bootstrap).