### PR TITLE
chore: Change log level in updateClusters() from info to debug

### DIFF
--- a/controller/clusterinfoupdater.go
+++ b/controller/clusterinfoupdater.go
@@ -82,7 +82,7 @@ func (c *clusterInfoUpdater) updateClusters() {
 		}
 		return nil
 	})
-	log.Infof("Successfully saved info of %d clusters", len(clustersFiltered))
+	log.Debugf("Successfully saved info of %d clusters", len(clustersFiltered))
 }
 
 func (c *clusterInfoUpdater) updateClusterInfo(cluster appv1.Cluster, info *cache.ClusterInfo) error {


### PR DESCRIPTION
There's a log message with level info in the application controller that gets printed each 10 seconds. IMO it does not add any value at all for day-to-day operations of argo-cd, and therefore I think we should decrease loglevel to debug for this particular message.

Log message is
```
20:16:59  controller | INFO[0800] Successfully saved info of 1 clusters
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
