### PR TITLE
fix: fix nil pointer error in Argo CD repo server

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -211,14 +211,14 @@ func (s *Service) runRepoOperation(
 		})
 
 		if err != nil {
-			return err, nil
+			return nil, err
 		}
 
 		defer io.Close(closer)
 
 		commitSHA, err := gitClient.CommitSHA()
 		if err != nil {
-			return err, nil
+			return nil, err
 		}
 
 		// double-check locking


### PR DESCRIPTION
Fixes bug that causes nil pointer error in Argo CD repo server
