### PR TITLE
fix: Automated smoke test that mimics user behavior UI (#4393)

### DIFF
--- a/ui/src/app/applications/components/__snapshots__/utils.test.tsx.snap
+++ b/ui/src/app/applications/components/__snapshots__/utils.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`ComparisonStatusIcon.OutOfSync 1`] = `
 Array [
   <i
     className="fa fa-arrow-alt-circle-up"
+    qe-id="utils-sync-status-title"
     style={
       Object {
         "color": "#f4c030",
@@ -19,6 +20,7 @@ exports[`ComparisonStatusIcon.Synced 1`] = `
 Array [
   <i
     className="fa fa-check-circle"
+    qe-id="utils-sync-status-title"
     style={
       Object {
         "color": "#18BE94",
@@ -34,6 +36,7 @@ exports[`ComparisonStatusIcon.Unknown 1`] = `
 Array [
   <i
     className="fa fa-circle-notch fa-spin"
+    qe-id="utils-sync-status-title"
     style={
       Object {
         "color": "#CCD6DD",
@@ -48,6 +51,7 @@ Array [
 exports[`HealthStatusIcon.Degraded 1`] = `
 <i
   className="fa fa-heart-broken"
+  qe-id="utils-health-status-title"
   style={
     Object {
       "color": "#E96D76",
@@ -60,6 +64,7 @@ exports[`HealthStatusIcon.Degraded 1`] = `
 exports[`HealthStatusIcon.Healthy 1`] = `
 <i
   className="fa fa-heart"
+  qe-id="utils-health-status-title"
   style={
     Object {
       "color": "#18BE94",
@@ -72,6 +77,7 @@ exports[`HealthStatusIcon.Healthy 1`] = `
 exports[`HealthStatusIcon.Missing 1`] = `
 <i
   className="fa fa-question-circle"
+  qe-id="utils-health-status-title"
   style={
     Object {
       "color": "#CCD6DD",
@@ -84,6 +90,7 @@ exports[`HealthStatusIcon.Missing 1`] = `
 exports[`HealthStatusIcon.Progressing 1`] = `
 <i
   className="fa fa fa-circle-notch fa-spin"
+  qe-id="utils-health-status-title"
   style={
     Object {
       "color": "#0DADEA",
@@ -96,6 +103,7 @@ exports[`HealthStatusIcon.Progressing 1`] = `
 exports[`HealthStatusIcon.Suspended 1`] = `
 <i
   className="fa fa-heart"
+  qe-id="utils-health-status-title"
   style={
     Object {
       "color": "#CCD6DD",
@@ -108,6 +116,7 @@ exports[`HealthStatusIcon.Suspended 1`] = `
 exports[`HealthStatusIcon.Unknown 1`] = `
 <i
   className="fa fa-question-circle"
+  qe-id="utils-health-status-title"
   style={
     Object {
       "color": "#CCD6DD",
@@ -121,6 +130,7 @@ exports[`OperationState.Deleting 1`] = `
 Array [
   <i
     className="fa fa-circle-notch fa-spin"
+    qe-id="utils-operations-status-title"
     style={
       Object {
         "color": "#0DADEA",
@@ -137,6 +147,7 @@ exports[`OperationState.Sync OK 1`] = `
 Array [
   <i
     className="fa fa-check-circle"
+    qe-id="utils-operations-status-title"
     style={
       Object {
         "color": "#18BE94",
@@ -153,6 +164,7 @@ exports[`OperationState.Sync error 1`] = `
 Array [
   <i
     className="fa fa-times-circle"
+    qe-id="utils-operations-status-title"
     style={
       Object {
         "color": "#E96D76",
@@ -169,6 +181,7 @@ exports[`OperationState.Sync failed 1`] = `
 Array [
   <i
     className="fa fa-times-circle"
+    qe-id="utils-operations-status-title"
     style={
       Object {
         "color": "#E96D76",
@@ -185,6 +198,7 @@ exports[`OperationState.Syncing 1`] = `
 Array [
   <i
     className="fa fa-circle-notch fa-spin"
+    qe-id="utils-operations-status-title"
     style={
       Object {
         "color": "#0DADEA",
@@ -201,6 +215,7 @@ exports[`OperationState.Unknown 1`] = `
 Array [
   <i
     className="fa fa-circle-notch fa-spin"
+    qe-id="utils-operations-status-title"
     style={
       Object {
         "color": "#0DADEA",

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -180,19 +180,31 @@ export const ApplicationCreatePanel = (props: {
                                                     </button>
                                                 )}
                                                 <div className='argo-form-row'>
-                                                    <FormField formApi={api} label='Application Name' field='metadata.name' component={Text} />
+                                                    <FormField
+                                                        formApi={api}
+                                                        label='Application Name'
+                                                        qeId='application-create-field-app-name'
+                                                        field='metadata.name'
+                                                        component={Text}
+                                                    />
                                                 </div>
                                                 <div className='argo-form-row'>
                                                     <FormField
                                                         formApi={api}
                                                         label='Project'
+                                                        qeId='application-create-field-project'
                                                         field='spec.project'
                                                         component={AutocompleteField}
                                                         componentProps={{items: projects}}
                                                     />
                                                 </div>
                                                 <div className='argo-form-row'>
-                                                    <FormField formApi={api} field='spec.syncPolicy.automated' component={AutoSyncFormField} />
+                                                    <FormField
+                                                        formApi={api}
+                                                        field='spec.syncPolicy.automated'
+                                                        qeId='application-create-field-sync-policy'
+                                                        component={AutoSyncFormField}
+                                                    />
                                                 </div>
                                                 <div className='argo-form-row'>
                                                     <label>Sync Options</label>
@@ -210,6 +222,7 @@ export const ApplicationCreatePanel = (props: {
                                                         <FormField
                                                             formApi={api}
                                                             label='Repository URL'
+                                                            qeId='application-create-field-repository-url'
                                                             field='spec.source.repoURL'
                                                             component={AutocompleteField}
                                                             componentProps={{items: repos}}
@@ -228,6 +241,7 @@ export const ApplicationCreatePanel = (props: {
                                                                             {repoType.toUpperCase()} <i className='fa fa-caret-down' />
                                                                         </p>
                                                                     )}
+                                                                    qeId='application-create-dropdown-source-repository'
                                                                     items={['git', 'helm'].map((type: 'git' | 'helm') => ({
                                                                         title: type.toUpperCase(),
                                                                         action: () => {
@@ -265,6 +279,7 @@ export const ApplicationCreatePanel = (props: {
                                                                     <FormField
                                                                         formApi={api}
                                                                         label='Path'
+                                                                        qeId='application-create-field-path'
                                                                         field='spec.source.path'
                                                                         component={AutocompleteField}
                                                                         componentProps={{
@@ -326,6 +341,7 @@ export const ApplicationCreatePanel = (props: {
                                                             <FormField
                                                                 formApi={api}
                                                                 label='Cluster URL'
+                                                                qeId='application-create-field-cluster-url'
                                                                 field='spec.destination.server'
                                                                 componentProps={{items: clusters.map(cluster => cluster.server)}}
                                                                 component={AutocompleteField}
@@ -336,6 +352,7 @@ export const ApplicationCreatePanel = (props: {
                                                             <FormField
                                                                 formApi={api}
                                                                 label='Cluster Name'
+                                                                qeId='application-create-field-cluster-name'
                                                                 field='spec.destination.name'
                                                                 componentProps={{items: clusters.map(cluster => cluster.name)}}
                                                                 component={AutocompleteField}
@@ -350,6 +367,7 @@ export const ApplicationCreatePanel = (props: {
                                                                         {destFormat} <i className='fa fa-caret-down' />
                                                                     </p>
                                                                 )}
+                                                                qeId='application-create-dropdown-destination'
                                                                 items={['URL', 'NAME'].map((type: 'URL' | 'NAME') => ({
                                                                     title: type,
                                                                     action: () => {
@@ -370,7 +388,13 @@ export const ApplicationCreatePanel = (props: {
                                                     </div>
                                                 </div>
                                                 <div className='argo-form-row'>
-                                                    <FormField formApi={api} label='Namespace' field='spec.destination.namespace' component={Text} />
+                                                    <FormField
+                                                        qeId='application-create-field-namespace'
+                                                        formApi={api}
+                                                        label='Namespace'
+                                                        field='spec.destination.namespace'
+                                                        component={Text}
+                                                    />
                                                 </div>
                                             </div>
                                         );
@@ -430,6 +454,7 @@ export const ApplicationCreatePanel = (props: {
                                                                         {type} <i className='fa fa-caret-down' />
                                                                     </p>
                                                                 )}
+                                                                qeId='application-create-dropdown-source'
                                                                 items={appTypes.map(item => ({
                                                                     title: item.type,
                                                                     action: () => {

--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
@@ -27,7 +27,11 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
                     onClose={() => hide()}
                     header={
                         <div>
-                            <button className='argo-button argo-button--base' disabled={isPending} onClick={() => form.submitForm(null)}>
+                            <button
+                                qe-id='application-sync-panel-button-synchronize'
+                                className='argo-button argo-button--base'
+                                disabled={isPending}
+                                onClick={() => form.submitForm(null)}>
                                 <Spinner show={isPending} style={{marginRight: '5px'}} />
                                 Synchronize
                             </button>{' '}

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -222,6 +222,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                     {
                                         title: 'New App',
                                         iconClassName: 'fa fa-plus',
+                                        qeId: 'applications-list-button-new-app',
                                         action: () => ctx.navigation.goto('.', {new: '{}'})
                                     },
                                     {
@@ -248,7 +249,10 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                 <EmptyState icon='argo-icon-application'>
                                                     <h4>No applications yet</h4>
                                                     <h5>Create new application to start managing resources in your cluster</h5>
-                                                    <button className='argo-button argo-button--base' onClick={() => ctx.navigation.goto('.', {new: JSON.stringify({})})}>
+                                                    <button
+                                                        qe-id='applications-list-button-create-application'
+                                                        className='argo-button argo-button--base'
+                                                        onClick={() => ctx.navigation.goto('.', {new: JSON.stringify({})})}>
                                                         Create application
                                                     </button>
                                                 </EmptyState>
@@ -382,7 +386,11 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                             onClose={() => ctx.navigation.goto('.', {new: null})}
                             header={
                                 <div>
-                                    <button className='argo-button argo-button--base' disabled={isAppCreatePending} onClick={() => createApi && createApi.submitForm(null)}>
+                                    <button
+                                        qe-id='applications-list-button-create'
+                                        className='argo-button argo-button--base'
+                                        disabled={isAppCreatePending}
+                                        onClick={() => createApi && createApi.submitForm(null)}>
                                         <Spinner show={isAppCreatePending} style={{marginRight: '5px'}} />
                                         Create
                                     </button>{' '}

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -75,7 +75,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                         <div className='columns small-3' title='Status:'>
                                             Status:
                                         </div>
-                                        <div className='columns small-9'>
+                                        <div className='columns small-9' qe-id='applications-tiles-health-status'>
                                             <AppUtils.HealthStatusIcon state={app.status.health} /> {app.status.health.status}
                                             &nbsp;
                                             <AppUtils.ComparisonStatusIcon status={app.status.sync.status} /> {app.status.sync.status}
@@ -133,6 +133,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                         <div className='columns applications-list__entry--actions'>
                                             <a
                                                 className='argo-button argo-button--base'
+                                                qe-id='applications-tiles-button-sync'
                                                 onClick={e => {
                                                     e.stopPropagation();
                                                     syncApplication(app.metadata.name);
@@ -142,6 +143,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                             &nbsp;
                                             <a
                                                 className='argo-button argo-button--base'
+                                                qe-id='applications-tiles-button-refresh'
                                                 {...AppUtils.refreshLinkAttrs(app)}
                                                 onClick={e => {
                                                     e.stopPropagation();
@@ -153,6 +155,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                             &nbsp;
                                             <a
                                                 className='argo-button argo-button--base'
+                                                qe-id='applications-tiles-button-delete'
                                                 onClick={e => {
                                                     e.stopPropagation();
                                                     deleteApplication(app.metadata.name);

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -85,7 +85,7 @@ export const OperationPhaseIcon = ({app}: {app: appModels.Application}) => {
             color = COLORS.operation.running;
             break;
     }
-    return <i title={getOperationStateTitle(app)} className={className} style={{color}} />;
+    return <i title={getOperationStateTitle(app)} qe-id='utils-operations-status-title' className={className} style={{color}} />;
 };
 
 export const ComparisonStatusIcon = ({status, resource, label}: {status: appModels.SyncStatusCode; resource?: {requiresPruning?: boolean}; label?: boolean}) => {
@@ -114,7 +114,7 @@ export const ComparisonStatusIcon = ({status, resource, label}: {status: appMode
     }
     return (
         <React.Fragment>
-            <i title={title} className={className} style={{color}} /> {label && title}
+            <i qe-id='utils-sync-status-title' title={title} className={className} style={{color}} /> {label && title}
         </React.Fragment>
     );
 };
@@ -179,7 +179,7 @@ export const HealthStatusIcon = ({state}: {state: appModels.HealthStatus}) => {
     if (state.message) {
         title = `${state.status}: ${state.message};`;
     }
-    return <i title={title} className={'fa ' + icon} style={{color}} />;
+    return <i qe-id='utils-health-status-title' title={title} className={'fa ' + icon} style={{color}} />;
 };
 
 export const ResourceResultIcon = ({resource}: {resource: appModels.ResourceResult}) => {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1824,7 +1824,7 @@ are-we-there-yet@~1.1.2:
 
 "argo-ui@https://github.com/argoproj/argo-ui.git":
   version "1.0.0"
-  resolved "https://github.com/argoproj/argo-ui.git#5371e5ba1645d52679e7a57814c7793c830d0f02"
+  resolved "https://github.com/argoproj/argo-ui.git#3d2740a5531f77e137ea6470314a03a0fdf5f937"
   dependencies:
     "@fortawesome/fontawesome-free" "^5.8.1"
     "@tippy.js/react" "^2.1.2"


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

This is part II of the automated UI tests for https://github.com/argoproj/argo-cd/issues/4393

The PR simply adds the unique identifiers to the relevant UI components, plus some formatting changes so as to not exceed 180 characters per line.  Feel free to suggest a new format of the identifiers, but they should be unique. I used the page/source as the 'prefix' to ensure there are no id clashes with similarly named components in other pages.

For example, if it is the `New App` button shown on the applications list page (application-list.tsx), the identifier is:
`applications-list-button-add-new`

For example, if it is the `Application Name` field shown on the application create sliding panel (application-create-panel.tsx), the identifier is:  `application-create-field-app-name`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
