### PR TITLE
docs: Instructions on `make verify-kube-connect` step when using k3d

### DIFF
--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -156,9 +156,9 @@ make: *** [Makefile:386: verify-kube-connect] Error 1
 
 you should edit your `~/.kube/config` and modify the `server` option to point to your correct K8s API (as described above).
 
-### If using k3d to spin-up your Kubernetes cluster
+### Using k3d
 
-Because it's running in a docker container, you're dealing with docker's internal networking rules when using k3d. This is the cost of a fully self-contained, disposable k8s cluster. The following steps should help with a successful `make verify-kube-connect` execution.
+k3d is a lightweight wrapper to run [k3s](https://github.com/rancher/k3s), a minimal Kubernetes distribution, in docker. Because it's running in a docker container, you're dealing with docker's internal networking rules when using k3d. A typical Kubernetes cluster running on your local machine is part of the same network that you're on so you can access it using **kubectl**. However, a Kubernetes cluster running within a docker container (in this case, the one launched by make) cannot access 0.0.0.0 from inside the container itself, when 0.0.0.0 is a network resource outside the container itself (and/or the container's network). This is the cost of a fully self-contained, disposable Kubernetes cluster. The following steps should help with a successful `make verify-kube-connect` execution.
 
 1. Find the actual external IP of your host. You can do so by executing `ifconfig` on Mac/Linux and `ipconfig` on Windows. For most users, the following command works to find the IP address.
 

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -156,7 +156,7 @@ make: *** [Makefile:386: verify-kube-connect] Error 1
 
 you should edit your `~/.kube/config` and modify the `server` option to point to your correct K8s API (as described above).
 
-## If using k3d to spin-up your Kubernetes cluster
+### If using k3d to spin-up your Kubernetes cluster
 
 Because it's running in a docker container, you're dealing with docker's internal networking rules when using k3d. This is the cost of a fully self-contained, disposable k8s cluster. The following steps should help with a successful `make verify-kube-connect` execution.
 

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -156,6 +156,29 @@ make: *** [Makefile:386: verify-kube-connect] Error 1
 
 you should edit your `~/.kube/config` and modify the `server` option to point to your correct K8s API (as described above).
 
+## If using k3d to spin-up your Kubernetes cluster
+
+Because it's running in a docker container, you're dealing with docker's internal networking rules when using k3d. This is the cost of a fully self-contained, disposable k8s cluster. The following steps should help with a successful `make verify-kube-connect` execution.
+
+1. Find the actual external IP of your host. You can do so by executing `ifconfig` on Mac/Linux and `ipconfig` on Windows. For most users, the following command works to find the IP address.
+
+```
+IP=`ifconfig en0 | grep inet | grep -v inet6 | awk '{print $2}'`
+echo $IP
+```
+
+2. Edit your ~/.kube/config and replace 0.0.0.0 with the above IP address.
+
+3. Execute a `kubectl version` to make sure you can still connect to the Kubernetes API server via this new IP. If not, go back to step 1.
+
+4. Run `make verify-kube-connect` and check if it works.
+
+5. Finally, so that you don't have to keep updating your kube-config whenever you spin up a new k3d cluster, add `--api-port $IP:6550` to your **k3d cluster create** command, where $IP is the value from step 1. An example command is provided here.
+
+```
+k3d cluster create my-cluster --wait --k3s-server-arg '--disable=traefik' --api-port $IP:6550 -p 443:443@loadbalancer
+```
+
 ## The development cycle
 
 When you have developed and possibly manually tested the code you want to contribute, you should ensure that everything will build correctly. Commit your changes to the local copy of your Git branch and perform the following steps:

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -160,20 +160,27 @@ you should edit your `~/.kube/config` and modify the `server` option to point to
 
 k3d is a lightweight wrapper to run [k3s](https://github.com/rancher/k3s), a minimal Kubernetes distribution, in docker. Because it's running in a docker container, you're dealing with docker's internal networking rules when using k3d. A typical Kubernetes cluster running on your local machine is part of the same network that you're on so you can access it using **kubectl**. However, a Kubernetes cluster running within a docker container (in this case, the one launched by make) cannot access 0.0.0.0 from inside the container itself, when 0.0.0.0 is a network resource outside the container itself (and/or the container's network). This is the cost of a fully self-contained, disposable Kubernetes cluster. The following steps should help with a successful `make verify-kube-connect` execution.
 
-1. Find the actual external IP of your host. You can do so by executing `ifconfig` on Mac/Linux and `ipconfig` on Windows. For most users, the following command works to find the IP address.
+1. Find your host IP by executing `ifconfig` on Mac/Linux and `ipconfig` on Windows. For most users, the following command works to find the IP address.
 
+For Mac:
 ```
 IP=`ifconfig en0 | grep inet | grep -v inet6 | awk '{print $2}'`
 echo $IP
 ```
 
+For Linux:
+```
+IP=`ifconfig eth0 | grep inet | grep -v inet6 | awk '{print $2}'`
+echo $IP
+```
+
+Keep in mind that this IP is dynamically assigned by the router so if your router restarts for any reason, your IP might change.
+
 2. Edit your ~/.kube/config and replace 0.0.0.0 with the above IP address.
 
-3. Execute a `kubectl version` to make sure you can still connect to the Kubernetes API server via this new IP. If not, go back to step 1.
+3. Execute a `kubectl version` to make sure you can still connect to the Kubernetes API server via this new IP. Run `make verify-kube-connect` and check if it works.
 
-4. Run `make verify-kube-connect` and check if it works.
-
-5. Finally, so that you don't have to keep updating your kube-config whenever you spin up a new k3d cluster, add `--api-port $IP:6550` to your **k3d cluster create** command, where $IP is the value from step 1. An example command is provided here.
+4. Finally, so that you don't have to keep updating your kube-config whenever you spin up a new k3d cluster, add `--api-port $IP:6550` to your **k3d cluster create** command, where $IP is the value from step 1. An example command is provided here.
 
 ```
 k3d cluster create my-cluster --wait --k3s-server-arg '--disable=traefik' --api-port $IP:6550 -p 443:443@loadbalancer

--- a/docs/developer-guide/faq.md
+++ b/docs/developer-guide/faq.md
@@ -20,7 +20,7 @@ To be on the safe side, make sure that you have created an Enhancement Proposal 
 See [Failing CI Checks](ci.md#troubleshooting-ci-checks).
 
 ### What checked-in code is generated, and how is it generated?
-The following files under this repository are generated, and must be kept up-to-date. Also see [Why does the codegen step fail?](ci#why-does-the-codegen-step-fail).
+The following files under this repository are generated, and must be kept up-to-date. Also see [Why does the codegen step fail?](ci.md#why-does-the-codegen-step-fail).
 
 See the Makefile for targets that can also run these scripts, and the `codegen` target which runs them all.
 


### PR DESCRIPTION
When setting up my local development environment following the [developer guide](https://argoproj.github.io/argo-cd/developer-guide/contributing), I got stuck at testing the connection from build container to my Kubernetes cluster which is a k3s cluster using k3d. After posting the question on argocd slack, I was pointed to [this discussion](https://argoproj.slack.com/archives/CEWCP8TV5/p1601489188022400) where someone else faced the same challenge. Being the second person to get stuck on this issue, I would not want a third person to get stuck and hence proposing this doc update. This PR will provide step-by-step guidance to someone using k3d to execute a successful `make verify-kube-connect`.

Checklist:

* [x] This is a doc update.
* [x] The title of the PR states what changed but it doesn't have an associated issue number (used for the release note).
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
