### PR TITLE
fix: Repo-server has silent unmarshalling errors leading to empty applications (#4423)

### DIFF
--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -129,7 +129,7 @@ func TestCachedManifestResponse_HashBehavior(t *testing.T) {
 
 	inMemCache := cacheutil.NewInMemoryCache(1 * time.Hour)
 
-	thing := NewCache(
+	repoCache := NewCache(
 		cacheutil.NewCache(inMemCache),
 		1*time.Minute,
 	)
@@ -151,7 +151,10 @@ func TestCachedManifestResponse_HashBehavior(t *testing.T) {
 		NumberOfCachedResponsesReturned: 0,
 		NumberOfConsecutiveFailures:     0,
 	}
-	thing.SetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, store)
+	err := repoCache.SetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, store)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Get the cache entry of the set value directly from the in memory cache, and check the values
 	var cacheKey string
@@ -179,7 +182,7 @@ func TestCachedManifestResponse_HashBehavior(t *testing.T) {
 
 	// Retrieve the value using 'GetManifests' and confirm it works
 	retrievedVal := &CachedManifestResponse{}
-	err := thing.GetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, retrievedVal)
+	err = repoCache.GetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, retrievedVal)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +205,7 @@ func TestCachedManifestResponse_HashBehavior(t *testing.T) {
 
 	// Retrieve the value using GetManifests and confirm it returns a cache miss
 	retrievedVal = &CachedManifestResponse{}
-	err = thing.GetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, retrievedVal)
+	err = repoCache.GetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, retrievedVal)
 
 	assert.True(t, err == cacheutil.ErrCacheMiss)
 

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -1,6 +1,9 @@
 package cache
 
 import (
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
 	cacheutil "github.com/argoproj/argo-cd/util/cache"
 )
@@ -119,4 +123,172 @@ func TestAddCacheFlagsToCmd(t *testing.T) {
 	cache, err := AddCacheFlagsToCmd(&cobra.Command{})()
 	assert.NoError(t, err)
 	assert.Equal(t, 24*time.Hour, cache.repoCacheExpiration)
+}
+
+func TestCachedManifestResponse_HashBehavior(t *testing.T) {
+
+	inMemCache := cacheutil.NewInMemoryCache(1 * time.Hour)
+
+	thing := NewCache(
+		cacheutil.NewCache(inMemCache),
+		1*time.Minute,
+	)
+
+	response := apiclient.ManifestResponse{
+		Namespace: "default",
+		Revision:  "revision",
+		Manifests: []string{"sample-text"},
+	}
+	appSrc := &appv1.ApplicationSource{}
+	appKey := "key"
+	appValue := "value"
+
+	// Set the value in the cache
+	store := &CachedManifestResponse{
+		FirstFailureTimestamp:           0,
+		ManifestResponse:                &response,
+		MostRecentError:                 "",
+		NumberOfCachedResponsesReturned: 0,
+		NumberOfConsecutiveFailures:     0,
+	}
+	thing.SetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, store)
+
+	// Get the cache entry of the set value directly from the in memory cache, and check the values
+	var cacheKey string
+	var cmr *CachedManifestResponse
+	{
+
+		items := getInMemoryCacheContents(t, inMemCache)
+
+		assert.Equal(t, len(items), 1)
+
+		for key, val := range items {
+			cmr = val
+			cacheKey = key
+		}
+		assert.NotEmpty(t, cmr.CacheEntryHash)
+		assert.NotNil(t, cmr.ManifestResponse)
+		assert.Equal(t, cmr.ManifestResponse, store.ManifestResponse)
+
+		regeneratedHash, err := cmr.generateCacheEntryHash()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, cmr.CacheEntryHash, regeneratedHash)
+	}
+
+	// Retrieve the value using 'GetManifests' and confirm it works
+	retrievedVal := &CachedManifestResponse{}
+	err := thing.GetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, retrievedVal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, retrievedVal, store)
+
+	// Corrupt the hash so that it doesn't match
+	{
+		newCmr := cmr.shallowCopy()
+		newCmr.CacheEntryHash = "!bad-hash!"
+
+		err := inMemCache.Set(&cacheutil.Item{
+			Key:    cacheKey,
+			Object: &newCmr,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+	}
+
+	// Retrieve the value using GetManifests and confirm it returns a cache miss
+	retrievedVal = &CachedManifestResponse{}
+	err = thing.GetManifests(response.Revision, appSrc, response.Namespace, appKey, appValue, retrievedVal)
+
+	assert.True(t, err == cacheutil.ErrCacheMiss)
+
+	// Verify that the hash mismatch item has been deleted
+	items := getInMemoryCacheContents(t, inMemCache)
+	assert.Equal(t, len(items), 0)
+
+}
+
+func getInMemoryCacheContents(t *testing.T, inMemCache *cacheutil.InMemoryCache) map[string]*CachedManifestResponse {
+	items, err := inMemCache.Items(func() interface{} { return &CachedManifestResponse{} })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := map[string]*CachedManifestResponse{}
+	for key, val := range items {
+		obj, ok := val.(*CachedManifestResponse)
+		if !ok {
+			t.Fatal(errors.New("Unexpected type in cache"))
+		}
+
+		result[key] = obj
+	}
+
+	return result
+}
+
+func TestCachedManifestResponse_ShallowCopy(t *testing.T) {
+
+	pre := &CachedManifestResponse{
+		CacheEntryHash:        "value",
+		FirstFailureTimestamp: 1,
+		ManifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{"one", "two"},
+		},
+		MostRecentError:                 "error",
+		NumberOfCachedResponsesReturned: 2,
+		NumberOfConsecutiveFailures:     3,
+	}
+
+	post := pre.shallowCopy()
+	assert.Equal(t, pre, post)
+
+	unequal := &CachedManifestResponse{
+		CacheEntryHash:        "diff-value",
+		FirstFailureTimestamp: 1,
+		ManifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{"one", "two"},
+		},
+		MostRecentError:                 "error",
+		NumberOfCachedResponsesReturned: 2,
+		NumberOfConsecutiveFailures:     3,
+	}
+	assert.NotEqual(t, pre, unequal)
+}
+
+func TestCachedManifestResponse_ShallowCopyExpectedFields(t *testing.T) {
+
+	// Attempt to ensure that the developer updated CachedManifestResponse.shallowCopy(), by doing a sanity test of the structure here
+
+	val := &CachedManifestResponse{}
+
+	str, err := json.Marshal(val)
+	if err != nil {
+		assert.FailNow(t, "Unable to marshal", err)
+		return
+	}
+
+	jsonMap := map[string]interface{}{}
+	err = json.Unmarshal(str, &jsonMap)
+	if err != nil {
+		assert.FailNow(t, "Unable to unmarshal", err)
+		return
+	}
+
+	expectedFields := []string{"cacheEntryHash", "manifestResponse", "mostRecentError", "firstFailureTimestamp",
+		"numberOfConsecutiveFailures", "numberOfCachedResponsesReturned"}
+
+	assert.Equal(t, len(jsonMap), len(expectedFields))
+
+	// If this test failed, you probably also forgot to update CachedManifestResponse.shallowCopy(), so
+	// go do that first :)
+
+	for _, expectedField := range expectedFields {
+		assert.Truef(t, strings.Contains(string(str), "\""+expectedField+"\""), "Missing field: %s", expectedField)
+	}
+
 }

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -54,3 +54,25 @@ func (i *InMemoryCache) OnUpdated(ctx context.Context, key string, callback func
 func (i *InMemoryCache) NotifyUpdated(key string) error {
 	return nil
 }
+
+// Items return a list of items in the cache; requires passing a constructor function
+// so that the items can be decoded from gob format.
+func (i *InMemoryCache) Items(createNewObject func() interface{}) (map[string]interface{}, error) {
+
+	result := map[string]interface{}{}
+
+	for key, value := range i.memCache.Items() {
+
+		buf := value.Object.(bytes.Buffer)
+		obj := createNewObject()
+		err := gob.NewDecoder(&buf).Decode(obj)
+		if err != nil {
+			return nil, err
+		}
+
+		result[key] = obj
+
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
This PR adds a hash of the full contents of `CachedManifestResponse` (excluding the hash itself) to what is persisted to Redis for generated manifests. This allows detection of the case where the cache contents are empty or incomplete (as described in the original issue). Hash mismatches are treated as cache misses, so manifest regeneration will occur in these cases.

Feedback welcome re: the specific algorithm used (current design: FNV-64a), and whether to hash the full cache entry or just the manifest response (current design: full cache entry).

Parent issue: https://github.com/argoproj/argo-cd/issues/4423

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
