### PR TITLE
chore: Fix failing unit test for TestGetIstioVirtualServiceInfo

### DIFF
--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -195,7 +195,8 @@ func TestGetIstioVirtualServiceInfo(t *testing.T) {
 	info := &ResourceInfo{}
 	populateNodeInfo(testIstioVirtualService, info)
 	assert.Equal(t, 0, len(info.Info))
-	require.Len(t, info.NetworkingInfo.TargetRefs, 3)
+	require.NotNil(t, info.NetworkingInfo)
+	require.NotNil(t, info.NetworkingInfo.TargetRefs)
 	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
 		Kind:      kube.ServiceKind,
 		Name:      "service_full",

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/argoproj/pkg/errors"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -194,22 +195,22 @@ func TestGetIstioVirtualServiceInfo(t *testing.T) {
 	info := &ResourceInfo{}
 	populateNodeInfo(testIstioVirtualService, info)
 	assert.Equal(t, 0, len(info.Info))
-	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-		TargetRefs: []v1alpha1.ResourceRef{
-			{
-				Kind:      kube.ServiceKind,
-				Name:      "service_full",
-				Namespace: "demo"},
-			{
-				Kind:      kube.ServiceKind,
-				Name:      "service_namespace",
-				Namespace: "namespace"},
-			{
-				Kind:      kube.ServiceKind,
-				Name:      "service",
-				Namespace: "demo"},
-		},
-	}, info.NetworkingInfo)
+	require.Len(t, info.NetworkingInfo.TargetRefs, 3)
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Kind:      kube.ServiceKind,
+		Name:      "service_full",
+		Namespace: "demo",
+	})
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Kind:      kube.ServiceKind,
+		Name:      "service_namespace",
+		Namespace: "namespace",
+	})
+	assert.Contains(t, info.NetworkingInfo.TargetRefs, v1alpha1.ResourceRef{
+		Kind:      kube.ServiceKind,
+		Name:      "service",
+		Namespace: "demo",
+	})
 }
 
 func TestGetIngressInfo(t *testing.T) {


### PR DESCRIPTION
Unit test failed intermittently due to unstable order when copying elements from map to slice.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
