### PR TITLE
fix: webhook don't refresh apps pointing to HEAD

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -307,9 +307,7 @@ func ensureAbsPath(input string) string {
 func appRevisionHasChanged(app *v1alpha1.Application, revision string, touchedHead bool) bool {
 	targetRev := app.Spec.Source.TargetRevision
 	if targetRev == "HEAD" || targetRev == "" { // revision is head
-		if !touchedHead { // and head has not updated
-			return false // revision has not changed
-		}
+		return touchedHead
 	}
 
 	return targetRev == revision

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -155,3 +155,25 @@ func Test_getAppRefreshPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestAppRevisionHasChanged(t *testing.T) {
+	assert.True(t, appRevisionHasChanged(&v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{
+		Source: v1alpha1.ApplicationSource{},
+	}}, "master", true))
+
+	assert.False(t, appRevisionHasChanged(&v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{
+		Source: v1alpha1.ApplicationSource{},
+	}}, "master", false))
+
+	assert.False(t, appRevisionHasChanged(&v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{
+		Source: v1alpha1.ApplicationSource{
+			TargetRevision: "dev",
+		},
+	}}, "master", true))
+
+	assert.True(t, appRevisionHasChanged(&v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{
+		Source: v1alpha1.ApplicationSource{
+			TargetRevision: "dev",
+		},
+	}}, "dev", false))
+}


### PR DESCRIPTION
PR fixes the bug introduced in https://github.com/argoproj/argo-cd/pull/4699

The webhook should refresh applications pointing to git HEAD if head was updated.
