### PR TITLE
fix: RevisionFormField component crashes in 'refs' API returns no tags

### DIFF
--- a/ui/src/app/applications/components/revision-form-field/revision-form-field.tsx
+++ b/ui/src/app/applications/components/revision-form-field/revision-form-field.tsx
@@ -22,7 +22,7 @@ export class RevisionFormField extends React.PureComponent<RevisionFormFieldProp
                         if (src.repoURL) {
                             return services.repos
                                 .revisions(src.repoURL)
-                                .then(revisionsRes => ['HEAD'].concat(revisionsRes.branches).concat(revisionsRes.tags))
+                                .then(revisionsRes => ['HEAD'].concat(revisionsRes.branches || []).concat(revisionsRes.tags || []))
                                 .catch(() => []);
                         }
                         return [];


### PR DESCRIPTION
Minor fix in RevisionFormField component.

The `revisionsRes.branches.concat(revisionsRes.tags)` returns `['master', undefined]` instead of `['master']` if `revisionsRes.tags` is undefined. 