### PR TITLE
chore: Fail-fast in Makefile when not within $GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ ARGOCD_TEST_E2E?=true
 
 ARGOCD_LINT_GOGC?=20
 
+# We need to be in compat path in order for codegen to work
+REQUIRED_PWD=$(GOPATH)/src/github.com/argoproj/argo-cd
+
 # Runs any command in the argocd-test-utils container in server mode
 # Server mode container will start with uid 0 and drop privileges during runtime
 define run-in-test-server
@@ -135,52 +138,63 @@ endif
 .PHONY: all
 all: cli image argocd-util
 
+# We have some legacy requirements for being checked out within $GOPATH.
+# The ensure-gopath target can be used as dependency to ensure we are running
+# within these boundaries.
+.PHONY: ensure-gopath
+ensure-gopath:
+ifneq ("$(CURRENT_DIR)","$(REQUIRED_PWD)")
+	@echo "Due to legacy requirements for codegen, repository needs to be checked out within \$$GOPATH"
+	@echo "Location of this repo should be '$(REQUIRED_PWD)' but is '$(CURRENT_DIR)'"
+	@exit 1
+endif
+
 .PHONY: gogen
-gogen:
+gogen: ensure-gopath
 	export GO111MODULE=off
 	go generate ./util/argo/...
 
 .PHONY: protogen
-protogen:
+protogen: ensure-gopath
 	export GO111MODULE=off
 	./hack/generate-proto.sh
 
 .PHONY: openapigen
-openapigen:
+openapigen: ensure-gopath
 	export GO111MODULE=off
 	./hack/update-openapi.sh
 
 .PHONY: clientgen
-clientgen:
+clientgen: ensure-gopath
 	export GO111MODULE=off
 	./hack/update-codegen.sh
 
 .PHONY: clidocsgen
-clidocsgen:
+clidocsgen: ensure-gopath
 	go run tools/cmd-docs/main.go	
 
 .PHONY: codegen-local
-codegen-local: mod-vendor-local gogen protogen clientgen openapigen clidocsgen manifests-local
+codegen-local: ensure-gopath mod-vendor-local gogen protogen clientgen openapigen clidocsgen manifests-local
 	rm -rf vendor/
 
 .PHONY: codegen
-codegen: test-tools-image
+codegen: ensure-gopath test-tools-image
 	$(call run-in-test-client,make codegen-local)
 
 .PHONY: cli
-cli: test-tools-image
+cli: ensure-gopath test-tools-image
 	$(call run-in-test-client, GOOS=${HOST_OS} GOARCH=${HOST_ARCH} make cli-local)
 
 .PHONY: cli-local
-cli-local: clean-debug
+cli-local: ensure-gopath clean-debug
 	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 
 .PHONY: cli-argocd
-cli-argocd:
+cli-argocd: ensure-gopath
 	go build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd/argocd
 
 .PHONY: release-cli
-release-cli: clean-debug image
+release-cli: ensure-gopath clean-debug image
 	docker create --name tmp-argocd-linux $(IMAGE_PREFIX)argocd:$(IMAGE_TAG)
 	docker cp tmp-argocd-linux:/usr/local/bin/argocd ${DIST_DIR}/argocd-linux-amd64
 	docker cp tmp-argocd-linux:/usr/local/bin/argocd-darwin-amd64 ${DIST_DIR}/argocd-darwin-amd64
@@ -188,7 +202,7 @@ release-cli: clean-debug image
 	docker rm tmp-argocd-linux
 
 .PHONY: argocd-util
-argocd-util: clean-debug
+argocd-util: ensure-gopath clean-debug
 	# Build argocd-util as a statically linked binary, so it could run within the alpine-based dex container (argoproj/argo-cd#844)
 	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-util ./cmd/argocd-util
 
@@ -203,30 +217,30 @@ test-tools-image:
 	docker tag $(TEST_TOOLS_PREFIX)$(TEST_TOOLS_IMAGE) $(TEST_TOOLS_PREFIX)$(TEST_TOOLS_IMAGE):$(TEST_TOOLS_TAG)
 
 .PHONY: manifests-local
-manifests-local:
+manifests-local: ensure-gopath
 	./hack/update-manifests.sh
 
 .PHONY: manifests
-manifests: test-tools-image
+manifests: ensure-gopath test-tools-image
 	$(call run-in-test-client,make manifests-local IMAGE_NAMESPACE='${IMAGE_NAMESPACE}' IMAGE_TAG='${IMAGE_TAG}')
 
 
 # NOTE: we use packr to do the build instead of go, since we embed swagger files and policy.csv
 # files into the go binary
 .PHONY: server
-server: clean-debug
+server: ensure-gopath clean-debug
 	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-server ./cmd/argocd-server
 
 .PHONY: repo-server
-repo-server:
+repo-server: ensure-gopath
 	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-repo-server ./cmd/argocd-repo-server
 
 .PHONY: controller
-controller:
+controller: ensure-gopath
 	CGO_ENABLED=0 ${PACKR_CMD} build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-application-controller ./cmd/argocd-application-controller
 
 .PHONY: packr
-packr:
+packr: ensure-gopath
 	go build -o ${DIST_DIR}/packr github.com/gobuffalo/packr/packr/
 
 .PHONY: image
@@ -235,7 +249,7 @@ ifeq ($(DEV_IMAGE), true)
 # which speeds up builds. Dockerfile.dev needs to be copied into dist to perform the build, since
 # the dist directory is under .dockerignore.
 IMAGE_TAG="dev-$(shell git describe --always --dirty)"
-image: packr
+image: ensure-gopath packr
 	docker build -t argocd-base --target argocd-base .
 	docker build -t argocd-ui --target argocd-ui .
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 dist/packr build -v -i -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-server ./cmd/argocd-server
@@ -256,65 +270,65 @@ endif
 .PHONY: armimage
 # The "BUILD_ALL_CLIS" argument is to skip building the CLIs for darwin and windows
 # which would take a really long time.
-armimage:
+armimage: ensure-gopath
 	docker build -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG)-arm . --build-arg BUILD_ALL_CLIS="false"
 
 .PHONY: builder-image
-builder-image:
+builder-image: ensure-gopath
 	docker build  -t $(IMAGE_PREFIX)argo-cd-ci-builder:$(IMAGE_TAG) --target builder .
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argo-cd-ci-builder:$(IMAGE_TAG) ; fi
 
 .PHONY: mod-download
-mod-download: test-tools-image
+mod-download: ensure-gopath test-tools-image
 	$(call run-in-test-client,go mod download)
 
 .PHONY: mod-download-local
-mod-download-local:
+mod-download-local: ensure-gopath
 	go mod download
 
 .PHONY: mod-vendor
-mod-vendor: test-tools-image
+mod-vendor: ensure-gopath test-tools-image
 	$(call run-in-test-client,go mod vendor)
 
 .PHONY: mod-vendor-local
-mod-vendor-local: mod-download-local
+mod-vendor-local: ensure-gopath mod-download-local
 	go mod vendor
 
 # Deprecated - replace by install-local-tools
 .PHONY: install-lint-tools
-install-lint-tools:
+install-lint-tools: ensure-gopath
 	./hack/install.sh lint-tools
 
 # Run linter on the code
 .PHONY: lint
-lint: test-tools-image
+lint: ensure-gopath test-tools-image
 	$(call run-in-test-client,make lint-local)
 
 # Run linter on the code (local version)
 .PHONY: lint-local
-lint-local:
+lint-local: ensure-gopath
 	golangci-lint --version
 	# NOTE: If you get a "Killed" OOM message, try reducing the value of GOGC
 	# See https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
 	GOGC=$(ARGOCD_LINT_GOGC) GOMAXPROCS=2 golangci-lint run --fix --verbose --timeout 300s
 
 .PHONY: lint-ui
-lint-ui: test-tools-image
+lint-ui: ensure-gopath test-tools-image
 	$(call run-in-test-client,make lint-ui-local)
 
 .PHONY: lint-ui-local
-lint-ui-local:
+lint-ui-local: ensure-gopath
 	cd ui && yarn lint
 
 # Build all Go code
 .PHONY: build
-build: test-tools-image
+build: ensure-gopath test-tools-image
 	mkdir -p $(GOCACHE)
 	$(call run-in-test-client, make build-local)
 
 # Build all Go code (local version)
 .PHONY: build-local
-build-local:
+build-local: ensure-gopath
 	go build -v `go list ./... | grep -v 'resource_customizations\|test/e2e'`
 
 # Run all unit tests
@@ -322,13 +336,13 @@ build-local:
 # If TEST_MODULE is set (to fully qualified module name), only this specific
 # module will be tested.
 .PHONY: test
-test: test-tools-image
+test: ensure-gopath test-tools-image
 	mkdir -p $(GOCACHE)
 	$(call run-in-test-client,make TEST_MODULE=$(TEST_MODULE) test-local)
 
 # Run all unit tests (local version)
 .PHONY: test-local
-test-local:
+test-local: ensure-gopath
 	if test "$(TEST_MODULE)" = ""; then \
 		./hack/test.sh -coverprofile=coverage.out `go list ./... | grep -v 'test/e2e'`; \
 	else \
@@ -338,34 +352,34 @@ test-local:
 # Run the E2E test suite. E2E test servers (see start-e2e target) must be
 # started before.
 .PHONY: test-e2e
-test-e2e: 
+test-e2e: ensure-gopath
 	$(call exec-in-test-server,make test-e2e-local)
 
 # Run the E2E test suite (local version)
 .PHONY: test-e2e-local
-test-e2e-local: cli-local
+test-e2e-local: ensure-gopath cli-local
 	# NO_PROXY ensures all tests don't go out through a proxy if one is configured on the test system
 	export GO111MODULE=off
 	ARGOCD_GPG_ENABLED=true NO_PROXY=* ./hack/test.sh -timeout 20m -v ./test/e2e
 
 # Spawns a shell in the test server container for debugging purposes
-debug-test-server: test-tools-image
+debug-test-server: ensure-gopath test-tools-image
 	$(call run-in-test-server,/bin/bash)
 
 # Spawns a shell in the test client container for debugging purposes
-debug-test-client: test-tools-image
+debug-test-client: ensure-gopath test-tools-image
 	$(call run-in-test-client,/bin/bash)
 
 # Starts e2e server in a container
 .PHONY: start-e2e
-start-e2e: test-tools-image
+start-e2e: ensure-gopath test-tools-image
 	docker version
 	mkdir -p ${GOCACHE}
 	$(call run-in-test-server,make ARGOCD_PROCFILE=test/container/Procfile start-e2e-local)
 
 # Starts e2e server locally (or within a container)
 .PHONY: start-e2e-local
-start-e2e-local: 
+start-e2e-local:  ensure-gopath
 	kubectl create ns argocd-e2e || true
 	kubectl config set-context --current --namespace=argocd-e2e
 	kustomize build test/manifests/base | kubectl apply -f -
@@ -387,21 +401,21 @@ start-e2e-local:
 
 # Cleans VSCode debug.test files from sub-dirs to prevent them from being included in packr boxes
 .PHONY: clean-debug
-clean-debug:
+clean-debug: ensure-gopath
 	-find ${CURRENT_DIR} -name debug.test | xargs rm -f
 
 .PHONY: clean
-clean: clean-debug
+clean: ensure-gopath clean-debug
 	-rm -rf ${CURRENT_DIR}/dist
 
 .PHONY: start
-start: test-tools-image
+start: ensure-gopath test-tools-image
 	docker version
 	$(call run-in-test-server,make ARGOCD_PROCFILE=test/container/Procfile start-local ARGOCD_START=${ARGOCD_START})
 
 # Starts a local instance of ArgoCD
 .PHONY: start-local
-start-local: mod-vendor-local
+start-local: ensure-gopath mod-vendor-local
 	# check we can connect to Docker to start Redis
 	killall goreman || true
 	kubectl create ns argocd || true
@@ -417,46 +431,46 @@ start-local: mod-vendor-local
 
 # Runs pre-commit validation with the virtualized toolchain
 .PHONY: pre-commit
-pre-commit: codegen build lint test
+pre-commit: ensure-gopath codegen build lint test
 
 # Runs pre-commit validation with the local toolchain
 .PHONY: pre-commit-local
-pre-commit-local: codegen-local build-local lint-local test-local
+pre-commit-local: ensure-gopath codegen-local build-local lint-local test-local
 
 .PHONY: release-precheck
-release-precheck: manifests
+release-precheck: ensure-gopath manifests
 	@if [ "$(GIT_TREE_STATE)" != "clean" ]; then echo 'git tree state is $(GIT_TREE_STATE)' ; exit 1; fi
 	@if [ -z "$(GIT_TAG)" ]; then echo 'commit must be tagged to perform release' ; exit 1; fi
 	@if [ "$(GIT_TAG)" != "v`cat VERSION`" ]; then echo 'VERSION does not match git tag'; exit 1; fi
 
 .PHONY: release
-release: pre-commit release-precheck image release-cli
+release: ensure-gopath pre-commit release-precheck image release-cli
 
 .PHONY: build-docs
-build-docs:
+build-docs: ensure-gopath
 	mkdocs build
 
 .PHONY: serve-docs
-serve-docs:
+serve-docs: ensure-gopath
 	mkdocs serve
 
 .PHONY: lint-docs
-lint-docs:
+lint-docs: ensure-gopath
 	#  https://github.com/dkhamsing/awesome_bot
 	find docs -name '*.md' -exec grep -l http {} + | xargs docker run --rm -v $(PWD):/mnt:ro dkhamsing/awesome_bot -t 3 --allow-dupe --allow-redirect --white-list `cat white-list | grep -v "#" | tr "\n" ','` --skip-save-results --
 
 .PHONY: publish-docs
-publish-docs: lint-docs
+publish-docs: ensure-gopath lint-docs
 	mkdocs gh-deploy
 
 # Verify that kubectl can connect to your K8s cluster from Docker
 .PHONY: verify-kube-connect
-verify-kube-connect: test-tools-image
+verify-kube-connect: ensure-gopath test-tools-image
 	$(call run-in-test-client,kubectl version)
 
 # Show the Go version of local and virtualized environments
 .PHONY: show-go-version
-show-go-version: test-tools-image
+show-go-version: ensure-gopath test-tools-image
 	@echo -n "Local Go version: "
 	@go version
 	@echo -n "Docker Go version: "
@@ -464,11 +478,11 @@ show-go-version: test-tools-image
 
 # Installs all tools required to build and test ArgoCD locally
 .PHONY: install-tools-local
-install-tools-local: install-test-tools-local install-codegen-tools-local install-go-tools-local
+install-tools-local: ensure-gopath install-test-tools-local install-codegen-tools-local install-go-tools-local
 
 # Installs all tools required for running unit & end-to-end tests (Linux packages)
 .PHONY: install-test-tools-local
-install-test-tools-local:
+install-test-tools-local: ensure-gopath
 	sudo ./hack/install.sh packr-linux
 	sudo ./hack/install.sh kubectl-linux
 	sudo ./hack/install.sh kustomize-linux
@@ -478,17 +492,17 @@ install-test-tools-local:
 
 # Installs all tools required for running codegen (Linux packages)
 .PHONY: install-codegen-tools-local
-install-codegen-tools-local:
+install-codegen-tools-local: ensure-gopath
 	sudo ./hack/install.sh codegen-tools
 
 # Installs all tools required for running codegen (Go packages)
 .PHONY: install-go-tools-local
-install-go-tools-local:
+install-go-tools-local: ensure-gopath
 	./hack/install.sh codegen-go-tools
 
 .PHONY: dep-ui
-dep-ui: test-tools-image
+dep-ui: ensure-gopath test-tools-image
 	$(call run-in-test-client,make dep-ui-local)
 
-dep-ui-local:
+dep-ui-local: ensure-gopath
 	cd ui && yarn install

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ mod-vendor-local: mod-download-local
 
 # Deprecated - replace by install-local-tools
 .PHONY: install-lint-tools
-install-lint-tools: ensure-gopath
+install-lint-tools:
 	./hack/install.sh lint-tools
 
 # Run linter on the code
@@ -323,7 +323,7 @@ lint-ui: test-tools-image
 	$(call run-in-test-client,make lint-ui-local)
 
 .PHONY: lint-ui-local
-lint-ui-local: ensure-gopath
+lint-ui-local:
 	cd ui && yarn lint
 
 # Build all Go code
@@ -407,11 +407,11 @@ start-e2e-local:
 
 # Cleans VSCode debug.test files from sub-dirs to prevent them from being included in packr boxes
 .PHONY: clean-debug
-clean-debug: ensure-gopath
+clean-debug:
 	-find ${CURRENT_DIR} -name debug.test | xargs rm -f
 
 .PHONY: clean
-clean: ensure-gopath clean-debug
+clean: clean-debug
 	-rm -rf ${CURRENT_DIR}/dist
 
 .PHONY: start
@@ -444,7 +444,7 @@ pre-commit: codegen build lint test
 pre-commit-local: codegen-local build-local lint-local test-local
 
 .PHONY: release-precheck
-release-precheck: ensure-gopath manifests
+release-precheck: manifests
 	@if [ "$(GIT_TREE_STATE)" != "clean" ]; then echo 'git tree state is $(GIT_TREE_STATE)' ; exit 1; fi
 	@if [ -z "$(GIT_TAG)" ]; then echo 'commit must be tagged to perform release' ; exit 1; fi
 	@if [ "$(GIT_TAG)" != "v`cat VERSION`" ]; then echo 'VERSION does not match git tag'; exit 1; fi


### PR DESCRIPTION
1. Allow Dockerized targets to run outside `$GOPATH`

2. We have a legacy requirement for `codegen` that the repository must be checked out to old Go standards within `$GOPATH`, i.e. to `$GOPATH/src/github.com/argoproj/argo-cd`. This legacy requirement is not easy to fix, so for the time being, `make` should fail fast with an explanatory message why it fails, and how to fix it, i.e:

```
$ pwd
/home/eris/src/argo-cd
$ make codegen-local 
Due to legacy requirements for codegen, repository needs to be checked out within $GOPATH
Location of this repo should be '/home/eris/go/src/github.com/argoproj/argo-cd' but is '/home/eris/src/argo-cd'
make: *** [Makefile:155: ensure-gopath] Error 1

```

Signed-off-by: jannfis <jann@mistrust.net>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
