### PR TITLE
docs: Add documentation to run redis-ha in OpenShift

### DIFF
--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -12,8 +12,8 @@ A set HA of manifests are provided for users who wish to run Argo CD in a highly
 
 In OpenShift clusters, `argocd-redis-ha` service accounts need to be granted `nonroot` Security Context Constraints (SCC) by running the following OpenShift commands which allow Redis containers to run as non-root users.
 ```shell
-oc adm policy add-scc-to-user nonroot -z argocd-redis-ha
-oc adm policy add-scc-to-user nonroot -z argocd-redis-ha-haproxy
+$ oc adm policy add-scc-to-user nonroot -z argocd-redis-ha
+$ oc adm policy add-scc-to-user nonroot -z argocd-redis-ha-haproxy
 ```
 
 ## Scaling Up

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -9,6 +9,13 @@ A set HA of manifests are provided for users who wish to run Argo CD in a highly
 !!! note
     The HA installation will require at least three different nodes due to pod anti-affinity roles in the specs.
  
+
+In OpenShift clusters, `argocd-redis-ha` service accounts need to be granted `nonroot` Security Context Constraints (SCC) by running the following OpenShift commands which allow Redis containers to run as non-root users.
+```shell
+oc adm policy add-scc-to-user nonroot -z argocd-redis-ha
+oc adm policy add-scc-to-user nonroot -z argocd-redis-ha-haproxy
+```
+
 ## Scaling Up
 
 ### argocd-repo-server


### PR DESCRIPTION
This PR adds to documentation to describe `oc` commands should be run to allow redis-ha containers to run as non root user in Openshift clusters.  HA install yaml is derived from upstream redis-ha helm chart which starts redis containers as UID 1000. 


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
