### PR TITLE
feat: add new rollout actions (abort, retry, promote-full, terminate). improve health check

### DIFF
--- a/resource_customizations/argoproj.io/AnalysisRun/actions/action_test.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/actions/action_test.yaml
@@ -1,0 +1,13 @@
+discoveryTests:
+- inputPath: testdata/runningAnalysisRun.yaml
+  result:
+  - name: terminate
+    disabled: false
+- inputPath: testdata/failedAnalysisRun.yaml
+  result:
+  - name: terminate
+    disabled: true
+actionTests:
+- action: terminate
+  inputPath: testdata/runningAnalysisRun.yaml
+  expectedOutputPath: testdata/runningAnalysisRun_terminated.yaml

--- a/resource_customizations/argoproj.io/AnalysisRun/actions/discovery.lua
+++ b/resource_customizations/argoproj.io/AnalysisRun/actions/discovery.lua
@@ -1,0 +1,8 @@
+actions = {}
+actions["terminate"] = {["disabled"] = (obj.spec.terminate or
+    obj.status.phase == "Successful" or
+    obj.status.phase == "Failed" or
+    obj.status.phase == "Error" or
+    obj.status.phase == "Inconclusive"
+)}
+return actions

--- a/resource_customizations/argoproj.io/AnalysisRun/actions/terminate/action.lua
+++ b/resource_customizations/argoproj.io/AnalysisRun/actions/terminate/action.lua
@@ -1,0 +1,2 @@
+obj.spec.terminate = true
+return obj

--- a/resource_customizations/argoproj.io/AnalysisRun/actions/testdata/failedAnalysisRun.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/actions/testdata/failedAnalysisRun.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  name: canary-demo-analysis-template-6c6bb7cf6f-9k5rj
+  namespace: default
+spec:
+  analysisSpec:
+    metrics:
+      - failureCondition: len(result) > 0
+        interval: 10
+        name: memory-usage
+        provider:
+          prometheus:
+            address: 'http://prometheus-operator-prometheus.prometheus-operator:9090'
+            query: >
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview",status!~"[4-5].*"}[2m]))
+              /
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview"}[2m]))
+        successCondition: len(result) > 0
+status:
+  metricResults:
+    - count: 1
+      failed: 1
+      measurements:
+        - finishedAt: '2019-10-28T18:23:23Z'
+          startedAt: '2019-10-28T18:23:23Z'
+          phase: Failed
+          value: '[0.9768211920529802]'
+      name: memory-usage
+      phase: Failed
+  phase: Failed

--- a/resource_customizations/argoproj.io/AnalysisRun/actions/testdata/runningAnalysisRun.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/actions/testdata/runningAnalysisRun.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  name: canary-demo-analysis-template-6c6bb7cf6f-5bpxj
+  namespace: default
+spec:
+  analysisSpec:
+    metrics:
+      - failureCondition: len(result) == 0
+        interval: 10
+        name: memory-usage
+        provider:
+          prometheus:
+            address: 'http://prometheus-operator-prometheus.prometheus-operator:9090'
+            query: >
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview",status!~"[4-5].*"}[2m]))
+              /
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview"}[2m]))
+        successCondition: len(result) > 0
+status:
+  metricResults:
+    - count: 2
+      measurements:
+        - finishedAt: '2019-10-28T18:22:05Z'
+          startedAt: '2019-10-28T18:22:05Z'
+          phase: Successful
+          value: '[0.9721293199554069]'
+        - finishedAt: '2019-10-28T18:22:15Z'
+          startedAt: '2019-10-28T18:22:15Z'
+          phase: Successful
+          value: '[0.9721293199554069]'
+      name: memory-usage
+      phase: Running
+      successful: 2
+  phase: Running

--- a/resource_customizations/argoproj.io/AnalysisRun/actions/testdata/runningAnalysisRun_terminated.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/actions/testdata/runningAnalysisRun_terminated.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  name: canary-demo-analysis-template-6c6bb7cf6f-5bpxj
+  namespace: default
+spec:
+  terminate: true
+  analysisSpec:
+    metrics:
+      - failureCondition: len(result) == 0
+        interval: 10
+        name: memory-usage
+        provider:
+          prometheus:
+            address: 'http://prometheus-operator-prometheus.prometheus-operator:9090'
+            query: >
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview",status!~"[4-5].*"}[2m]))
+              /
+              sum(rate(nginx_ingress_controller_requests{ingress="canary-demo-preview"}[2m]))
+        successCondition: len(result) > 0
+status:
+  metricResults:
+    - count: 2
+      measurements:
+        - finishedAt: '2019-10-28T18:22:05Z'
+          startedAt: '2019-10-28T18:22:05Z'
+          phase: Successful
+          value: '[0.9721293199554069]'
+        - finishedAt: '2019-10-28T18:22:15Z'
+          startedAt: '2019-10-28T18:22:15Z'
+          phase: Successful
+          value: '[0.9721293199554069]'
+      name: memory-usage
+      phase: Running
+      successful: 2
+  phase: Running

--- a/resource_customizations/argoproj.io/AnalysisRun/health.lua
+++ b/resource_customizations/argoproj.io/AnalysisRun/health.lua
@@ -1,4 +1,12 @@
 hs = {}
+
+function messageOrDefault(field, default)
+    if field ~= nil then
+      return field
+    end
+    return default
+  end
+
 if obj.status ~= nil then
     if obj.status.phase == "Pending" then
         hs.status = "Progressing"
@@ -10,31 +18,19 @@ if obj.status ~= nil then
     end
     if obj.status.phase == "Successful" then
         hs.status = "Healthy"
-        hs.message = "Analysis run completed successfully"
+        hs.message = messageOrDefault(obj.status.message, "Analysis run completed successfully")
     end
     if obj.status.phase == "Failed" then
         hs.status = "Degraded"
-        if obj.status.message ~= nil then
-            hs.message = obj.status.message
-        else
-            hs.message = "Analysis run failed"
-        end
+        hs.message = messageOrDefault(obj.status.message, "Analysis run failed")
     end
     if obj.status.phase == "Error" then
         hs.status = "Degraded"
-        if obj.status.message ~= nil then
-            hs.message = obj.status.message
-        else
-            hs.message = "Analysis run had an error"
-        end
+        hs.message = messageOrDefault(obj.status.message, "Analysis run had an error")
     end
     if obj.status.phase == "Inconclusive" then
         hs.status = "Unknown"
-        if obj.status.message ~= nil then
-            hs.message = obj.status.message
-        else
-            hs.message = "Analysis run was inconclusive"
-        end
+        hs.message = messageOrDefault(obj.status.message, "Analysis run was inconclusive")
     end
     return hs
 end

--- a/resource_customizations/argoproj.io/AnalysisRun/health_test.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/health_test.yaml
@@ -39,3 +39,7 @@ tests:
     status: Unknown
     message: "Status Message: Assessed as Inconclusive"
   inputPath: testdata/inconclusiveAnalysisRunWithStatusMessage.yaml
+- healthStatus:
+    status: Healthy
+    message: "run terminated"
+  inputPath: testdata/terminatedAnalysisRun.yaml

--- a/resource_customizations/argoproj.io/AnalysisRun/testdata/terminatedAnalysisRun.yaml
+++ b/resource_customizations/argoproj.io/AnalysisRun/testdata/terminatedAnalysisRun.yaml
@@ -1,0 +1,71 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisRun
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: '2'
+  creationTimestamp: '2020-11-06T18:39:45Z'
+  generation: 4
+  labels:
+    rollout-type: Step
+    rollouts-pod-template-hash: ff68867ff
+    step-index: '0'
+  name: rollout-canary-ff68867ff-2-0
+  namespace: default
+  ownerReferences:
+    - apiVersion: argoproj.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Rollout
+      name: rollout-canary
+      uid: 0223237a-0dc1-45f6-881c-fe1873b1771f
+  resourceVersion: '1381'
+  selfLink: >-
+    /apis/argoproj.io/v1alpha1/namespaces/default/analysisruns/rollout-canary-ff68867ff-2-0
+  uid: 863da27d-df03-41d2-a528-cc2f1ec25358
+spec:
+  args:
+    - name: exit-code
+      value: '0'
+    - name: duration
+      value: 1h
+  metrics:
+    - name: sleep-job
+      provider:
+        job:
+          metadata:
+            creationTimestamp: null
+          spec:
+            backoffLimit: 0
+            template:
+              metadata:
+                creationTimestamp: null
+              spec:
+                containers:
+                  - args:
+                      - 'sleep {{args.duration}} && exit {{args.exit-code}}'
+                    command:
+                      - sh
+                      - '-c'
+                      - '-x'
+                    image: 'nginx:1.19-alpine'
+                    name: sleep-job
+                    resources: {}
+                restartPolicy: Never
+  terminate: true
+status:
+  message: run terminated
+  metricResults:
+    - count: 1
+      measurements:
+        - finishedAt: '2020-11-06T18:42:58Z'
+          message: metric terminated
+          metadata:
+            job-name: 863da27d-df03-41d2-a528-cc2f1ec25358.sleep-job.1
+          phase: Successful
+          startedAt: '2020-11-06T18:39:45Z'
+      message: metric terminated
+      name: sleep-job
+      phase: Successful
+      successful: 1
+  phase: Successful
+  startedAt: '2020-11-06T18:39:45Z'

--- a/resource_customizations/argoproj.io/Rollout/actions/abort/action.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/abort/action.lua
@@ -1,0 +1,2 @@
+obj.status.abort = true
+return obj

--- a/resource_customizations/argoproj.io/Rollout/actions/action_test.yaml
+++ b/resource_customizations/argoproj.io/Rollout/actions/action_test.yaml
@@ -5,11 +5,23 @@ discoveryTests:
       disabled: false
     - name: restart
       disabled: false
+    - name: abort
+      disabled: false
+    - name: retry
+      disabled: true
+    - name: promote-full
+      disabled: true
 - inputPath: testdata/pre_v0.6_not_paused_rollout.yaml
   result:
     - name: restart
       disabled: false
     - name: resume
+      disabled: true
+    - name: abort
+      disabled: false
+    - name: retry
+      disabled: true
+    - name: promote-full
       disabled: true
 - inputPath: testdata/pre_v0.6_nil_paused_rollout.yaml
   result:
@@ -17,11 +29,23 @@ discoveryTests:
       disabled: false
     - name: resume
       disabled: true
+    - name: abort
+      disabled: false
+    - name: retry
+      disabled: true
+    - name: promote-full
+      disabled: true
 - inputPath: testdata/has_pause_condition_rollout.yaml
   result:
     - name: restart
       disabled: false
     - name: resume
+      disabled: false
+    - name: abort
+      disabled: false
+    - name: retry
+      disabled: true
+    - name: promote-full
       disabled: false
 - inputPath: testdata/no_pause_condition_rollout.yaml
   result:
@@ -29,6 +53,36 @@ discoveryTests:
       disabled: false
     - name: resume
       disabled: true
+    - name: abort
+      disabled: false
+    - name: retry
+      disabled: true
+    - name: promote-full
+      disabled: false
+- inputPath: testdata/healthy_rollout.yaml
+  result:
+    - name: restart
+      disabled: false
+    - name: resume
+      disabled: true
+    - name: abort
+      disabled: true
+    - name: retry
+      disabled: true
+    - name: promote-full
+      disabled: true
+- inputPath: testdata/aborted_rollout.yaml
+  result:
+    - name: restart
+      disabled: false
+    - name: resume
+      disabled: true
+    - name: abort
+      disabled: true
+    - name: retry
+      disabled: false
+    - name: promote-full
+      disabled: false
 actionTests:
 - action: resume
   inputPath: testdata/pre_v0.6_paused_rollout.yaml
@@ -36,6 +90,15 @@ actionTests:
 - action: resume
   inputPath: testdata/has_pause_condition_rollout.yaml
   expectedOutputPath: testdata/no_pause_condition_rollout.yaml
+- action: abort
+  inputPath: testdata/has_pause_condition_rollout.yaml
+  expectedOutputPath: testdata/has_pause_condition_rollout_aborted.yaml
 - action: restart
   inputPath: testdata/rollout_not_restarted.yaml
   expectedOutputPath: testdata/rollout_restarted.yaml
+- action: retry
+  inputPath: testdata/aborted_rollout.yaml
+  expectedOutputPath: testdata/retried_rollout.yaml
+- action: promote-full
+  inputPath: testdata/aborted_rollout.yaml
+  expectedOutputPath: testdata/promote-full_rollout.yaml

--- a/resource_customizations/argoproj.io/Rollout/actions/discovery.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/discovery.lua
@@ -1,18 +1,18 @@
 actions = {}
-actions["resume"] = {["disabled"] = false}
 actions["restart"] = {["disabled"] = false}
 
 local paused = false
-
 if obj.status ~= nil and obj.status.pauseConditions ~= nil then
     paused = table.getn(obj.status.pauseConditions) > 0
 elseif obj.spec.paused ~= nil then
     paused = obj.spec.paused
 end
-if paused then
-    actions["resume"]["disabled"] = false
-else
-    actions["resume"]["disabled"] = true
-end
+actions["resume"] = {["disabled"] = not(paused)}
+
+fullyPromoted = obj.status.currentPodHash == obj.status.stableRS
+actions["abort"] = {["disabled"] = fullyPromoted or obj.status.abort}
+actions["retry"] = {["disabled"] = fullyPromoted or not(obj.status.abort)}
+
+actions["promote-full"] = {["disabled"] = fullyPromoted or obj.spec.strategy.blueGreen ~= nil}
 
 return actions

--- a/resource_customizations/argoproj.io/Rollout/actions/promote-full/action.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/promote-full/action.lua
@@ -1,0 +1,5 @@
+obj.status.abort = nil
+if obj.spec.strategy.canary.steps ~= nil then
+    obj.status.currentStepIndex = table.getn(obj.spec.strategy.canary.steps)
+end
+return obj

--- a/resource_customizations/argoproj.io/Rollout/actions/retry/action.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/retry/action.lua
@@ -1,0 +1,2 @@
+obj.status.abort = nil
+return obj

--- a/resource_customizations/argoproj.io/Rollout/actions/testdata/aborted_rollout.yaml
+++ b/resource_customizations/argoproj.io/Rollout/actions/testdata/aborted_rollout.yaml
@@ -1,0 +1,81 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: '4'
+  creationTimestamp: '2020-11-06T09:09:54Z'
+  generation: 76
+  labels:
+    app.kubernetes.io/instance: rollouts-demo
+  name: rollout-canary
+  namespace: default
+  resourceVersion: '4977'
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/rollouts/rollout-canary
+  uid: a5047899-8288-43c2-95d7-a8e0a8b45ed6
+spec:
+  replicas: 2
+  restartAt: '2020-11-06T10:03:31Z'
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollout-canary
+  strategy:
+    canary:
+      steps:
+        - setWeight: 1
+        - pause: {}
+  template:
+    metadata:
+      annotations:
+        restart: asdfaaa
+      labels:
+        app: rollout-canary
+    spec:
+      containers:
+        - image: 'nginx:1.19-alpine'
+          imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sleep
+                  - '30'
+            preStop:
+              exec:
+                command:
+                  - sleep
+                  - '30'
+          name: rollouts-demo
+          ports:
+            - containerPort: 8080
+          resources: {}
+status:
+  HPAReplicas: 2
+  abort: true
+  abortedAt: '2020-11-06T10:08:32Z'
+  availableReplicas: 2
+  blueGreen: {}
+  canary:
+    stableRS: 69d59f5445
+  conditions:
+    - lastTransitionTime: '2020-11-06T10:06:38Z'
+      lastUpdateTime: '2020-11-06T10:06:38Z'
+      message: Rollout has minimum availability
+      reason: AvailableReason
+      status: 'True'
+      type: Available
+    - lastTransitionTime: '2020-11-06T10:08:32Z'
+      lastUpdateTime: '2020-11-06T10:08:32Z'
+      message: Rollout is aborted
+      reason: RolloutAborted
+      status: 'False'
+      type: Progressing
+  currentPodHash: 7797495b94
+  currentStepHash: 566d47875b
+  currentStepIndex: 0
+  observedGeneration: 74dbb4676d
+  readyReplicas: 2
+  replicas: 2
+  restartedAt: '2020-11-06T10:03:31Z'
+  selector: app=rollout-canary
+  stableRS: 69d59f5445

--- a/resource_customizations/argoproj.io/Rollout/actions/testdata/has_pause_condition_rollout_aborted.yaml
+++ b/resource_customizations/argoproj.io/Rollout/actions/testdata/has_pause_condition_rollout_aborted.yaml
@@ -1,0 +1,62 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: canary-demo
+  namespace: default
+spec:
+  replicas: 5
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: canary-demo
+  strategy:
+    canary:
+      analysis:
+        name: analysis
+        templateName: analysis-template
+      canaryService: canary-demo-preview
+      steps:
+      - setWeight: 40
+      - pause: {}
+      - setWeight: 60
+      - pause: {}
+      - setWeight: 80
+      - pause:
+          duration: 10
+  template:
+    metadata:
+      labels:
+        app: canary-demo
+    spec:
+      containers:
+      - image: argoproj/rollouts-demo:yellow
+        imagePullPolicy: Always
+        name: canary-demo
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 5m
+            memory: 32Mi
+status:
+  abort: true
+  HPAReplicas: 5
+  availableReplicas: 5
+  blueGreen: {}
+  canary:
+    currentBackgroundAnalysisRun: canary-demo-6758949f55-6-analysis
+    stableRS: 645d5dbc4c
+  controllerPause: true
+  currentPodHash: 6758949f55
+  currentStepHash: 59f8666948
+  currentStepIndex: 1
+  observedGeneration: 58b949649c
+  pauseConditions:
+  - reason: CanaryPauseStep
+    startTime: "2019-11-05T18:10:29Z"
+  readyReplicas: 5
+  replicas: 5
+  selector: app=canary-demo
+  updatedReplicas: 2

--- a/resource_customizations/argoproj.io/Rollout/actions/testdata/healthy_rollout.yaml
+++ b/resource_customizations/argoproj.io/Rollout/actions/testdata/healthy_rollout.yaml
@@ -1,0 +1,64 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: '2'
+  creationTimestamp: '2020-11-06T09:09:54Z'
+  generation: 12
+  labels:
+    app.kubernetes.io/instance: rollouts-demo
+  name: rollout-bluegreen
+  namespace: default
+  resourceVersion: '2232'
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/rollouts/rollout-bluegreen
+  uid: a5047899-8288-43c2-95d7-a8e0a8b45ed6
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollout-bluegreen
+  strategy:
+    blueGreen:
+      activeService: rollout-bluegreen-active
+      previewService: rollout-bluegreen-preview
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: rollout-bluegreen
+    spec:
+      containers:
+        - image: 'nginx:1.19-alpine'
+          imagePullPolicy: Always
+          name: rollouts-demo
+          ports:
+            - containerPort: 8080
+          resources: {}
+status:
+  HPAReplicas: 2
+  availableReplicas: 2
+  blueGreen:
+    activeSelector: '8576595585'
+    previewSelector: '8576595585'
+  canary: {}
+  conditions:
+    - lastTransitionTime: '2020-11-06T09:10:35Z'
+      lastUpdateTime: '2020-11-06T09:10:35Z'
+      message: Rollout has minimum availability
+      reason: AvailableReason
+      status: 'True'
+      type: Available
+    - lastTransitionTime: '2020-11-06T09:09:54Z'
+      lastUpdateTime: '2020-11-06T09:13:09Z'
+      message: ReplicaSet "rollout-bluegreen-8576595585" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: 'True'
+      type: Progressing
+  currentPodHash: '8576595585'
+  observedGeneration: 7b965d5d74
+  readyReplicas: 2
+  replicas: 2
+  selector: 'app=rollout-bluegreen,rollouts-pod-template-hash=8576595585'
+  stableRS: '8576595585'
+  updatedReplicas: 2

--- a/resource_customizations/argoproj.io/Rollout/actions/testdata/promote-full_rollout.yaml
+++ b/resource_customizations/argoproj.io/Rollout/actions/testdata/promote-full_rollout.yaml
@@ -1,0 +1,81 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: '4'
+  creationTimestamp: '2020-11-06T09:09:54Z'
+  generation: 76
+  labels:
+    app.kubernetes.io/instance: rollouts-demo
+  name: rollout-canary
+  namespace: default
+  resourceVersion: '4977'
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/rollouts/rollout-canary
+  uid: a5047899-8288-43c2-95d7-a8e0a8b45ed6
+spec:
+  replicas: 2
+  restartAt: '2020-11-06T10:03:31Z'
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollout-canary
+  strategy:
+    canary:
+      steps:
+        - setWeight: 1
+        - pause: {}
+  template:
+    metadata:
+      annotations:
+        restart: asdfaaa
+      labels:
+        app: rollout-canary
+    spec:
+      containers:
+        - image: 'nginx:1.19-alpine'
+          imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sleep
+                  - '30'
+            preStop:
+              exec:
+                command:
+                  - sleep
+                  - '30'
+          name: rollouts-demo
+          ports:
+            - containerPort: 8080
+          resources: {}
+status:
+  HPAReplicas: 2
+  abort: null
+  abortedAt: '2020-11-06T10:08:32Z'
+  availableReplicas: 2
+  blueGreen: {}
+  canary:
+    stableRS: 69d59f5445
+  conditions:
+    - lastTransitionTime: '2020-11-06T10:06:38Z'
+      lastUpdateTime: '2020-11-06T10:06:38Z'
+      message: Rollout has minimum availability
+      reason: AvailableReason
+      status: 'True'
+      type: Available
+    - lastTransitionTime: '2020-11-06T10:08:32Z'
+      lastUpdateTime: '2020-11-06T10:08:32Z'
+      message: Rollout is aborted
+      reason: RolloutAborted
+      status: 'False'
+      type: Progressing
+  currentPodHash: 7797495b94
+  currentStepHash: 566d47875b
+  currentStepIndex: 2
+  observedGeneration: 74dbb4676d
+  readyReplicas: 2
+  replicas: 2
+  restartedAt: '2020-11-06T10:03:31Z'
+  selector: app=rollout-canary
+  stableRS: 69d59f5445

--- a/resource_customizations/argoproj.io/Rollout/actions/testdata/retried_rollout.yaml
+++ b/resource_customizations/argoproj.io/Rollout/actions/testdata/retried_rollout.yaml
@@ -1,0 +1,81 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    rollout.argoproj.io/revision: '4'
+  creationTimestamp: '2020-11-06T09:09:54Z'
+  generation: 76
+  labels:
+    app.kubernetes.io/instance: rollouts-demo
+  name: rollout-canary
+  namespace: default
+  resourceVersion: '4977'
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/rollouts/rollout-canary
+  uid: a5047899-8288-43c2-95d7-a8e0a8b45ed6
+spec:
+  replicas: 2
+  restartAt: '2020-11-06T10:03:31Z'
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollout-canary
+  strategy:
+    canary:
+      steps:
+        - setWeight: 1
+        - pause: {}
+  template:
+    metadata:
+      annotations:
+        restart: asdfaaa
+      labels:
+        app: rollout-canary
+    spec:
+      containers:
+        - image: 'nginx:1.19-alpine'
+          imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sleep
+                  - '30'
+            preStop:
+              exec:
+                command:
+                  - sleep
+                  - '30'
+          name: rollouts-demo
+          ports:
+            - containerPort: 8080
+          resources: {}
+status:
+  HPAReplicas: 2
+  abort: null
+  abortedAt: '2020-11-06T10:08:32Z'
+  availableReplicas: 2
+  blueGreen: {}
+  canary:
+    stableRS: 69d59f5445
+  conditions:
+    - lastTransitionTime: '2020-11-06T10:06:38Z'
+      lastUpdateTime: '2020-11-06T10:06:38Z'
+      message: Rollout has minimum availability
+      reason: AvailableReason
+      status: 'True'
+      type: Available
+    - lastTransitionTime: '2020-11-06T10:08:32Z'
+      lastUpdateTime: '2020-11-06T10:08:32Z'
+      message: Rollout is aborted
+      reason: RolloutAborted
+      status: 'False'
+      type: Progressing
+  currentPodHash: 7797495b94
+  currentStepHash: 566d47875b
+  currentStepIndex: 0
+  observedGeneration: 74dbb4676d
+  readyReplicas: 2
+  replicas: 2
+  restartedAt: '2020-11-06T10:03:31Z'
+  selector: app=rollout-canary
+  stableRS: 69d59f5445

--- a/resource_customizations/argoproj.io/Rollout/health.lua
+++ b/resource_customizations/argoproj.io/Rollout/health.lua
@@ -1,20 +1,13 @@
 function checkReplicasStatus(obj)
   hs = {}
-  replicasCount = getNumberValueOrDefault(obj.spec.replicas)
-  replicasStatus = getNumberValueOrDefault(obj.status.replicas)
-  updatedReplicas = getNumberValueOrDefault(obj.status.updatedReplicas)
-  availableReplicas = getNumberValueOrDefault(obj.status.availableReplicas)
-
-  if updatedReplicas < replicasCount then
+  desiredReplicas = getNumberValueOrDefault(obj.spec.replicas, 1)
+  statusReplicas = getNumberValueOrDefault(obj.status.replicas, 0)
+  updatedReplicas = getNumberValueOrDefault(obj.status.updatedReplicas, 0)
+  availableReplicas = getNumberValueOrDefault(obj.status.availableReplicas, 0)
+  
+  if updatedReplicas < desiredReplicas then
     hs.status = "Progressing"
     hs.message = "Waiting for roll out to finish: More replicas need to be updated"
-    return hs
-  end
-  -- Since the scale down delay can be very high, BlueGreen does not wait for all the old replicas to scale
-  -- down before marking itself healthy. As a result, only evaluate this condition if the strategy is canary.
-  if obj.spec.strategy.canary ~= nil and replicasStatus > updatedReplicas then
-    hs.status = "Progressing"
-    hs.message = "Waiting for roll out to finish: old replicas are pending termination"
     return hs
   end
   if availableReplicas < updatedReplicas then
@@ -25,22 +18,23 @@ function checkReplicasStatus(obj)
   return nil
 end
 
--- In Argo Rollouts v0.8 we depreciate .status.canary.stableRS for .status.stableRS this func grabs the correct one
+-- In Argo Rollouts v0.8 we deprecated .status.canary.stableRS for .status.stableRS
+-- This func grabs the correct one.
 function getStableRS(obj)
-    if obj.status.stableRS ~= nil then
-        return obj.status.stableRS
-    end
-    if obj.status.canary ~= nil then
-            return obj.status.canary.stableRS
-    end
-    return ""
+  if obj.status.stableRS ~= nil then
+    return obj.status.stableRS
+  end
+  if obj.status.canary ~= nil then
+      return obj.status.canary.stableRS
+  end
+  return ""
 end
 
-function getNumberValueOrDefault(field)
+function getNumberValueOrDefault(field, default)
   if field ~= nil then
     return field
   end
-  return 0
+  return default
 end
 
 function checkPaused(obj)
@@ -58,91 +52,75 @@ function checkPaused(obj)
 end
 
 hs = {}
-if obj.status ~= nil then
-  if obj.status.conditions ~= nil then
-    for _, condition in ipairs(obj.status.conditions) do
-      if condition.type == "InvalidSpec" then
-        hs.status = "Degraded"
-        hs.message = condition.message
-        return hs
-      end
-      if condition.type == "Progressing" and condition.reason == "RolloutAborted" then
-        hs.status = "Degraded"
-        hs.message = condition.message
-        return hs
-      end
-      if condition.type == "Progressing" and condition.reason == "ProgressDeadlineExceeded" then
-        hs.status = "Degraded"
-        hs.message = condition.message
-        return hs
-      end
-    end
-  end
-  if obj.status.currentPodHash ~= nil then
-    if obj.spec.strategy.blueGreen ~= nil then
-      isPaused = checkPaused(obj)
-      if isPaused ~= nil then
-        return isPaused
-      end
-      replicasHS = checkReplicasStatus(obj)
-      if replicasHS ~= nil then
-        return replicasHS
-      end
-      if obj.status.blueGreen ~= nil and obj.status.blueGreen.activeSelector ~= nil and obj.status.blueGreen.activeSelector == obj.status.currentPodHash then
-        hs.status = "Healthy"
-        hs.message = "The active Service is serving traffic to the current pod spec"
-        return hs
-      end
-      hs.status = "Progressing"
-      hs.message = "The current pod spec is not receiving traffic from the active service"
-      return hs
-    end
-    if obj.spec.strategy.canary ~= nil then
-      currentRSIsStable = getStableRS(obj) == obj.status.currentPodHash
-      if obj.spec.strategy.canary.steps ~= nil and table.getn(obj.spec.strategy.canary.steps) > 0 then
-        stepCount = table.getn(obj.spec.strategy.canary.steps)
-        if obj.status.currentStepIndex ~= nil then
-          currentStepIndex = obj.status.currentStepIndex
-          isPaused = checkPaused(obj)
-          if isPaused ~= nil then
-            return isPaused
-          end
-      
-          if paused then
-            hs.status = "Suspended"
-            hs.message = "Rollout is paused"
-            return hs
-          end
-          if currentRSIsStable and stepCount == currentStepIndex then
-            replicasHS = checkReplicasStatus(obj)
-            if replicasHS ~= nil then
-              return replicasHS
-            end
-            hs.status = "Healthy"
-            hs.message = "The rollout has completed all steps"
-            return hs
-          end
-        end
-        hs.status = "Progressing"
-        hs.message = "Waiting for rollout to finish steps"
-        return hs
-      end
+if obj.status == nil then
+  hs.status = "Progressing"
+  hs.message = "Waiting for rollout to finish: status has not been reconciled."
+  return hs
+end
 
-      -- The detecting the health of the Canary deployment when there are no steps
-      replicasHS = checkReplicasStatus(obj)
-      if replicasHS ~= nil then
-        return replicasHS
-      end
-      if currentRSIsStable then
-        hs.status = "Healthy"
-        hs.message = "The rollout has completed canary deployment"
-        return hs
-      end
-      hs.status = "Progressing"
-      hs.message = "Waiting for rollout to finish canary deployment"
-    end
+for _, condition in ipairs(obj.status.conditions) do
+  if condition.type == "InvalidSpec" then
+    hs.status = "Degraded"
+    hs.message = condition.message
+    return hs
+  end
+  if condition.type == "Progressing" and condition.reason == "RolloutAborted" then
+    hs.status = "Degraded"
+    hs.message = condition.message
+    return hs
+  end
+  if condition.type == "Progressing" and condition.reason == "ProgressDeadlineExceeded" then
+    hs.status = "Degraded"
+    hs.message = condition.message
+    return hs
   end
 end
-hs.status = "Progressing"
-hs.message = "Waiting for rollout to finish: status has not been reconciled."
+
+isPaused = checkPaused(obj)
+if isPaused ~= nil then
+  return isPaused
+end
+
+if obj.status.currentPodHash == nil then
+  hs.status = "Progressing"
+  hs.message = "Waiting for rollout to finish: status has not been reconciled."
+  return hs
+end
+
+replicasHS = checkReplicasStatus(obj)
+if replicasHS ~= nil then
+  return replicasHS
+end
+
+
+stableRS = getStableRS(obj)
+
+if obj.spec.strategy.blueGreen ~= nil then
+  if obj.status.blueGreen == nil or obj.status.blueGreen.activeSelector ~= obj.status.currentPodHash then
+    hs.status = "Progressing"
+    hs.message = "active service cutover pending"
+    return hs
+  end
+  -- Starting in v0.8 blue-green uses status.stableRS. To drop support for v0.7, uncomment following
+  -- if stableRS == "" or stableRS ~= obj.status.currentPodHash then
+  if stableRS ~= "" and stableRS ~= obj.status.currentPodHash then
+    hs.status = "Progressing"
+    hs.message = "waiting for analysis to complete"
+    return hs
+  end
+elseif obj.spec.strategy.canary ~= nil then
+  if statusReplicas > updatedReplicas then
+    hs.status = "Progressing"
+    hs.message = "Waiting for roll out to finish: old replicas are pending termination"
+    return hs
+  end
+  if stableRS == "" or stableRS ~= obj.status.currentPodHash then
+    hs.status = "Progressing"
+    hs.message = "Waiting for rollout to finish steps"
+    return hs
+  end
+end
+
+hs.status = "Healthy"
+hs.message = ""
 return hs

--- a/resource_customizations/argoproj.io/Rollout/health_test.yaml
+++ b/resource_customizations/argoproj.io/Rollout/health_test.yaml
@@ -18,7 +18,6 @@ tests:
 #BlueGreen
 - healthStatus:
     status: Healthy
-    message: The active Service is serving traffic to the current pod spec
   inputPath: testdata/bluegreen/healthy_servingActiveService.yaml
 - healthStatus:
     status: Progressing
@@ -31,7 +30,7 @@ tests:
 #Canary
 - healthStatus:
     status: Progressing
-    message: Waiting for rollout to finish steps
+    message: "Waiting for roll out to finish: More replicas need to be updated"
   inputPath: testdata/canary/progressing_setWeightStep.yaml
 - healthStatus:
     status: Progressing
@@ -47,21 +46,17 @@ tests:
   inputPath: testdata/suspended_userPause.yaml
 - healthStatus:
     status: Healthy
-    message: The rollout has completed all steps
   inputPath: testdata/canary/healthy_executedAllStepsPreV0.8.yaml
 - healthStatus:
      status: Healthy
-     message: The rollout has completed all steps
   inputPath: testdata/canary/healthy_executedAllSteps.yaml
 - healthStatus:
     status: Progressing
-    message: 'Waiting for roll out to finish: old replicas are pending termination'
+    message: 'Waiting for roll out to finish: updated replicas are still becoming available'
   inputPath: testdata/canary/progressing_noSteps.yaml
 - healthStatus:
     status: Healthy
-    message: The rollout has completed canary deployment
   inputPath: testdata/canary/healthy_noSteps.yaml
 - healthStatus:
     status: Healthy
-    message: The rollout has completed canary deployment
   inputPath: testdata/canary/healthy_emptyStepsList.yaml

--- a/resource_customizations/argoproj.io/Rollout/testdata/bluegreen/healthy_servingActiveService.yaml
+++ b/resource_customizations/argoproj.io/Rollout/testdata/bluegreen/healthy_servingActiveService.yaml
@@ -2,8 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"argoproj.io/v1alpha1","kind":"Rollout","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default","ksonnet.io/component":"guestbook-ui"},"name":"ks-guestbook-ui","namespace":"default"},"spec":{"minReadySeconds":30,"replicas":1,"selector":{"matchLabels":{"app":"ks-guestbook-ui"}},"strategy":{"blueGreen":{"activeService":"ks-guestbook-ui-active","previewService":"ks-guestbook-ui-preview"},"type":"BlueGreenUpdate"},"template":{"metadata":{"labels":{"app":"ks-guestbook-ui"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.2","name":"ks-guestbook-ui","ports":[{"containerPort":80}]}]}}}}
     rollout.argoproj.io/revision: "1"
   clusterName: ""
   creationTimestamp: 2019-01-22T16:52:54Z

--- a/resource_customizations/argoproj.io/Rollout/testdata/bluegreen/progressing_waitingUntilAvailable.yaml
+++ b/resource_customizations/argoproj.io/Rollout/testdata/bluegreen/progressing_waitingUntilAvailable.yaml
@@ -2,8 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"argoproj.io/v1alpha1","kind":"Rollout","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-default","ksonnet.io/component":"guestbook-ui"},"name":"ks-guestbook-ui","namespace":"default"},"spec":{"minReadySeconds":30,"replicas":3,"selector":{"matchLabels":{"app":"ks-guestbook-ui"}},"strategy":{"blueGreen":{"activeService":"ks-guestbook-ui-active","previewService":"ks-guestbook-ui-preview"},"type":"BlueGreenUpdate"},"template":{"metadata":{"labels":{"app":"ks-guestbook-ui"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.1","name":"ks-guestbook-ui","ports":[{"containerPort":83}]}]}}}}
     rollout.argoproj.io/revision: "1"
   clusterName: ""
   creationTimestamp: 2019-01-25T16:19:09Z

--- a/resource_customizations/argoproj.io/Rollout/testdata/canary/healthy_emptyStepsList.yaml
+++ b/resource_customizations/argoproj.io/Rollout/testdata/canary/healthy_emptyStepsList.yaml
@@ -2,8 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
-    kubectl.kubernetes.io/last-applied-configuration: >
-      {"apiVersion":"argoproj.io/v1alpha1","kind":"Rollout","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-canary","ksonnet.io/component":"guestbook-ui"},"name":"guestbook-canary","namespace":"default"},"spec":{"minReadySeconds":10,"replicas":5,"selector":{"matchLabels":{"app":"guestbook-canary"}},"strategy":{"canary":{"maxSurge":1,"maxUnavailable":0,"steps":[{"setWeight":20},{"pause":{"duration":30}},{"setWeight":40},{"pause":{}}]}},"template":{"metadata":{"labels":{"app":"guestbook-canary"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.1","name":"guestbook-canary","ports":[{"containerPort":80}]}]}}}}
     rollout.argoproj.io/revision: '2'
   clusterName: ''
   creationTimestamp: '2019-05-01T21:55:30Z'

--- a/resource_customizations/argoproj.io/Rollout/testdata/canary/progressing_noSteps.yaml
+++ b/resource_customizations/argoproj.io/Rollout/testdata/canary/progressing_noSteps.yaml
@@ -2,8 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
-    kubectl.kubernetes.io/last-applied-configuration: >
-      {"apiVersion":"argoproj.io/v1alpha1","kind":"Rollout","metadata":{"annotations":{},"labels":{"app.kubernetes.io/instance":"guestbook-canary","ksonnet.io/component":"guestbook-ui"},"name":"guestbook-canary","namespace":"default"},"spec":{"minReadySeconds":10,"replicas":5,"selector":{"matchLabels":{"app":"guestbook-canary"}},"strategy":{"canary":{"maxSurge":1,"maxUnavailable":0,"steps":[{"setWeight":20},{"pause":{"duration":30}},{"setWeight":40},{"pause":{}}]}},"template":{"metadata":{"labels":{"app":"guestbook-canary"}},"spec":{"containers":[{"image":"gcr.io/heptio-images/ks-guestbook-demo:0.1","name":"guestbook-canary","ports":[{"containerPort":80}]}]}}}}
     rollout.argoproj.io/revision: '2'
   clusterName: ''
   creationTimestamp: '2019-05-01T21:55:30Z'


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-cd/issues/4732

Improves health check to consider a rollout as progressing if `status.stableRS != status.currentPodHash`

Adds Rollout actions:
* `retry` - retries an aborted rollout
* `abort` - abort an updating rollout
* `promote-full` - fully promote a rollout

Add AnalysisRun action
* `terminate` - terminates a running analysis run

![image](https://user-images.githubusercontent.com/12677113/98402664-89eb3b80-201c-11eb-8c19-014fca0441d0.png)

