### PR TITLE
fix: improve project details page summary tab

### DIFF
--- a/ui/src/app/settings/components/project-details/project-details.scss
+++ b/ui/src/app/settings/components/project-details/project-details.scss
@@ -17,4 +17,23 @@
             color: $argo-color-gray-6;
         }
     }
+
+    &__list-title {
+        margin-top: 1em;
+        text-transform: uppercase;
+
+        &:first-of-type {
+            margin-top: 0;
+        }
+    }
+
+    .select__option {
+        line-height: 1.5;
+    }
+
+    .white-box__details {
+        .argo-button--short {
+            margin-top: 1em;
+        }
+    }
 }

--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -10,14 +10,12 @@ import {AppContext, Consumer} from '../../../shared/context';
 import {GroupKind, Groups, Project, ProjectSpec, ResourceKinds} from '../../../shared/models';
 import {CreateJWTTokenParams, DeleteJWTTokenParams, ProjectRoleParams, services} from '../../../shared/services';
 
+import {SyncWindowStatusIcon} from '../../../applications/components/utils';
+import {ProjectSyncWindowsParams} from '../../../shared/services/projects-service';
 import {ProjectEvents} from '../project-events/project-events';
-
 import {ProjectRoleEditPanel} from '../project-role-edit-panel/project-role-edit-panel';
 import {ProjectSyncWindowsEditPanel} from '../project-sync-windows-edit-panel/project-sync-windows-edit-panel';
-
-import {ProjectSyncWindowsParams} from '../../../shared/services/projects-service';
-
-import {SyncWindowStatusIcon} from '../../../applications/components/utils';
+import {ResourceListsPanel} from './resource-lists-panel';
 
 require('./project-details.scss');
 
@@ -88,6 +86,7 @@ function loadGlobal(name: string) {
                         })
                     );
                 });
+                merged.count += 1;
 
                 return merged;
             },
@@ -95,12 +94,13 @@ function loadGlobal(name: string) {
                 clusterResourceBlacklist: new Array<GroupKind>(),
                 namespaceResourceBlacklist: new Array<GroupKind>(),
                 namespaceResourceWhitelist: new Array<GroupKind>(),
+                clusterResourceWhitelist: new Array<GroupKind>(),
                 sourceRepos: [],
                 signatureKeys: [],
-                clusterResourceWhitelist: [],
                 destinations: [],
                 description: '',
-                roles: []
+                roles: [],
+                count: 0
             }
         )
     );
@@ -186,7 +186,7 @@ export class ProjectDetails extends React.Component<RouteComponentProps<{name: s
                                                         title: 'Events',
                                                         content: this.eventsTab(proj)
                                                     }
-                                                ]}
+                                                ].map(tab => ({...tab, isOnlyContentScrollable: true, extraVerticalScrollPadding: 160}))}
                                             />
                                             <SlidingPanel
                                                 isMiddle={true}
@@ -526,7 +526,7 @@ export class ProjectDetails extends React.Component<RouteComponentProps<{name: s
         }
     }
 
-    private summaryTab(proj: Project, globalProj: ProjectSpec) {
+    private summaryTab(proj: Project, globalProj: ProjectSpec & {count: number}) {
         return (
             <div className='argo-container'>
                 <EditablePanel
@@ -669,408 +669,12 @@ export class ProjectDetails extends React.Component<RouteComponentProps<{name: s
                     items={[]}
                 />
 
-                <EditablePanel
-                    save={item => this.saveProject(item)}
-                    values={proj}
-                    title={<React.Fragment>CLUSTER RESOURCE ALLOW LIST {helpTip('Cluster-scoped K8s API Groups and Kinds which are permitted to be deployed')}</React.Fragment>}
-                    view={
-                        <React.Fragment>
-                            {proj.spec.clusterResourceWhitelist ? (
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {proj.spec.clusterResourceWhitelist.map((resource, i) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>{resource.kind}</div>
-                                            <div className='columns small-8'>{resource.group}</div>
-                                        </div>
-                                    ))}
-                                </React.Fragment>
-                            ) : (
-                                emptyMessage('cluster resource allow list')
-                            )}
-                        </React.Fragment>
-                    }
-                    edit={formApi => (
-                        <React.Fragment>
-                            <div className='row white-box__details-row'>
-                                <div className='columns small-4'>Kind</div>
-                                <div className='columns small-8'>Group</div>
-                            </div>
-                            {(formApi.values.spec.clusterResourceWhitelist || []).map((_: Project, i: number) => (
-                                <div className='row white-box__details-row' key={i}>
-                                    <div className='columns small-4'>
-                                        <FormField
-                                            formApi={formApi}
-                                            field={`spec.clusterResourceWhitelist[${i}].kind`}
-                                            component={AutocompleteField}
-                                            componentProps={{items: ResourceKinds}}
-                                        />
-                                    </div>
-                                    <div className='columns small-8'>
-                                        <FormField
-                                            formApi={formApi}
-                                            field={`spec.clusterResourceWhitelist[${i}].group`}
-                                            component={AutocompleteField}
-                                            componentProps={{items: Groups}}
-                                        />
-                                    </div>
-                                    <i
-                                        className='fa fa-times'
-                                        onClick={() => formApi.setValue('spec.clusterResourceWhitelist', removeEl(formApi.values.spec.clusterResourceWhitelist, i))}
-                                    />
-                                </div>
-                            ))}
-                            <button
-                                className='argo-button argo-button--short'
-                                onClick={() =>
-                                    formApi.setValue(
-                                        'spec.clusterResourceWhitelist',
-                                        (formApi.values.spec.clusterResourceWhitelist || []).concat({
-                                            group: '*',
-                                            kind: '*'
-                                        })
-                                    )
-                                }>
-                                ADD RESOURCE
-                            </button>
-                        </React.Fragment>
-                    )}
-                    items={[]}
-                />
-
-                {globalProj.clusterResourceWhitelist.length > 0 && (
-                    <div className='white-box editable-panel'>
-                        <div className='white-box__details'>
-                            <p>
-                                CLUSTER RESOURCE ALLOW LIST FROM GLOBAL PROJECT
-                                {helpTip('Cluster-scoped K8s API Groups and Kinds which are permitted to be deployed from global project')}
-                            </p>
-                            <React.Fragment>
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {globalProj.clusterResourceWhitelist.map((resource, i) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>{resource.kind}</div>
-                                            <div className='columns small-8'>{resource.group}</div>
-                                        </div>
-                                    ))}
-                                </React.Fragment>
-                            </React.Fragment>
-                        </div>
-                    </div>
-                )}
-
-                <EditablePanel
-                    save={item => this.saveProject(item)}
-                    values={proj}
-                    title={<React.Fragment>CLUSTER RESOURCE DENY LIST {helpTip('Cluster-scoped K8s API Groups and Kinds which are not permitted to be deployed')}</React.Fragment>}
-                    view={
-                        <React.Fragment>
-                            {proj.spec.clusterResourceBlacklist ? (
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {proj.spec.clusterResourceBlacklist.map((resource, i) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>{resource.kind}</div>
-                                            <div className='columns small-8'>{resource.group}</div>
-                                        </div>
-                                    ))}
-                                </React.Fragment>
-                            ) : (
-                                emptyMessage('cluster resource deny list')
-                            )}
-                        </React.Fragment>
-                    }
-                    edit={formApi => (
-                        <React.Fragment>
-                            <div className='row white-box__details-row'>
-                                <div className='columns small-4'>Kind</div>
-                                <div className='columns small-8'>Group</div>
-                            </div>
-                            {(formApi.values.spec.clusterResourceBlacklist || []).map((_: Project, i: number) => (
-                                <div className='row white-box__details-row' key={i}>
-                                    <div className='columns small-4'>
-                                        <FormField
-                                            formApi={formApi}
-                                            field={`spec.clusterResourceBlacklist[${i}].kind`}
-                                            component={AutocompleteField}
-                                            componentProps={{items: ResourceKinds}}
-                                        />
-                                    </div>
-                                    <div className='columns small-8'>
-                                        <FormField
-                                            formApi={formApi}
-                                            field={`spec.clusterResourceBlacklist[${i}].group`}
-                                            component={AutocompleteField}
-                                            componentProps={{items: Groups}}
-                                        />
-                                    </div>
-                                    <i
-                                        className='fa fa-times'
-                                        onClick={() => formApi.setValue('spec.clusterResourceBlacklist', removeEl(formApi.values.spec.clusterResourceBlacklist, i))}
-                                    />
-                                </div>
-                            ))}
-                            <button
-                                className='argo-button argo-button--short'
-                                onClick={() =>
-                                    formApi.setValue(
-                                        'spec.clusterResourceBlacklist',
-                                        (formApi.values.spec.clusterResourceBlacklist || []).concat({
-                                            group: '*',
-                                            kind: '*'
-                                        })
-                                    )
-                                }>
-                                ADD RESOURCE
-                            </button>
-                        </React.Fragment>
-                    )}
-                    items={[]}
-                />
-
-                {globalProj.clusterResourceBlacklist.length > 0 && (
-                    <div className='white-box editable-panel'>
-                        <div className='white-box__details'>
-                            <p>
-                                CLUSTER RESOURCE DENY LIST FROM GLOBAL PROJECT
-                                {helpTip('Cluster-scoped K8s API Groups and Kinds which are not permitted to be deployed from global project')}
-                            </p>
-                            <React.Fragment>
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {globalProj.clusterResourceBlacklist.map((resource, i) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>{resource.kind}</div>
-                                            <div className='columns small-8'>{resource.group}</div>
-                                        </div>
-                                    ))}
-                                </React.Fragment>
-                            </React.Fragment>
-                        </div>
-                    </div>
-                )}
-
-                <EditablePanel
-                    save={item => this.saveProject(item)}
-                    values={proj}
-                    title={<React.Fragment>NAMESPACE RESOURCE ALLOW LIST {helpTip('Namespace-scoped K8s API Groups and Kinds which are permitted to deploy')}</React.Fragment>}
-                    view={
-                        <React.Fragment>
-                            {proj.spec.namespaceResourceWhitelist ? (
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {proj.spec.namespaceResourceWhitelist.map((resource, i) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>{resource.kind}</div>
-                                            <div className='columns small-8'>{resource.group}</div>
-                                        </div>
-                                    ))}
-                                </React.Fragment>
-                            ) : (
-                                emptyMessage('namespace resource allow list')
-                            )}
-                        </React.Fragment>
-                    }
-                    edit={formApi => (
-                        <DataLoader load={() => services.clusters.list()}>
-                            {clusters => (
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {(formApi.values.spec.namespaceResourceWhitelist || []).map((_: Project, i: number) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>
-                                                <FormField
-                                                    formApi={formApi}
-                                                    field={`spec.namespaceResourceWhitelist[${i}].kind`}
-                                                    component={AutocompleteField}
-                                                    componentProps={{items: ResourceKinds}}
-                                                />
-                                            </div>
-                                            <div className='columns small-8'>
-                                                <FormField
-                                                    formApi={formApi}
-                                                    field={`spec.namespaceResourceWhitelist[${i}].group`}
-                                                    component={AutocompleteField}
-                                                    componentProps={{items: Groups}}
-                                                />
-                                            </div>
-                                            <i
-                                                className='fa fa-times'
-                                                onClick={() => formApi.setValue('spec.namespaceResourceWhitelist', removeEl(formApi.values.spec.namespaceResourceWhitelist, i))}
-                                            />
-                                        </div>
-                                    ))}
-                                    <button
-                                        className='argo-button argo-button--short'
-                                        onClick={() =>
-                                            formApi.setValue(
-                                                'spec.namespaceResourceWhitelist',
-                                                (formApi.values.spec.namespaceResourceWhitelist || []).concat({
-                                                    group: '*',
-                                                    kind: '*'
-                                                })
-                                            )
-                                        }>
-                                        ADD RESOURCE
-                                    </button>
-                                </React.Fragment>
-                            )}
-                        </DataLoader>
-                    )}
-                    items={[]}
-                />
-
-                {globalProj.namespaceResourceWhitelist.length > 0 && (
-                    <div className='white-box editable-panel'>
-                        <div className='white-box__details'>
-                            <p>
-                                NAMESPACE RESOURCE ALLOW LIST FROM GLOBAL PROJECT
-                                {helpTip('Namespace-scoped K8s API Groups and Kinds which are permitted to deploy from global project')}
-                            </p>
-                            <React.Fragment>
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {globalProj.namespaceResourceWhitelist.map((resource, i) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>{resource.kind}</div>
-                                            <div className='columns small-8'>{resource.group}</div>
-                                        </div>
-                                    ))}
-                                </React.Fragment>
-                            </React.Fragment>
-                        </div>
-                    </div>
-                )}
-
-                <EditablePanel
-                    save={item => this.saveProject(item)}
-                    values={proj}
-                    title={
-                        <React.Fragment>
-                            NAMESPACE RESOURCE DENY LIST {helpTip('Namespace-scoped K8s API Groups and Kinds which are prohibited from being deployed')}
-                        </React.Fragment>
-                    }
-                    view={
-                        <React.Fragment>
-                            {proj.spec.namespaceResourceBlacklist ? (
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {proj.spec.namespaceResourceBlacklist.map((resource, i) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>{resource.kind}</div>
-                                            <div className='columns small-8'>{resource.group}</div>
-                                        </div>
-                                    ))}
-                                </React.Fragment>
-                            ) : (
-                                emptyMessage('namespace resource deny list')
-                            )}
-                        </React.Fragment>
-                    }
-                    edit={formApi => (
-                        <DataLoader load={() => services.clusters.list()}>
-                            {clusters => (
-                                <React.Fragment>
-                                    <div className='row white-box__details-row'>
-                                        <div className='columns small-4'>Kind</div>
-                                        <div className='columns small-8'>Group</div>
-                                    </div>
-                                    {(formApi.values.spec.namespaceResourceBlacklist || []).map((_: Project, i: number) => (
-                                        <div className='row white-box__details-row' key={i}>
-                                            <div className='columns small-4'>
-                                                <FormField
-                                                    formApi={formApi}
-                                                    field={`spec.namespaceResourceBlacklist[${i}].kind`}
-                                                    component={AutocompleteField}
-                                                    componentProps={{items: ResourceKinds}}
-                                                />
-                                            </div>
-                                            <div className='columns small-8'>
-                                                <FormField
-                                                    formApi={formApi}
-                                                    field={`spec.namespaceResourceBlacklist[${i}].group`}
-                                                    component={AutocompleteField}
-                                                    componentProps={{items: Groups}}
-                                                />
-                                            </div>
-                                            <i
-                                                className='fa fa-times'
-                                                onClick={() => formApi.setValue('spec.namespaceResourceBlacklist', removeEl(formApi.values.spec.namespaceResourceBlacklist, i))}
-                                            />
-                                        </div>
-                                    ))}
-                                    <button
-                                        className='argo-button argo-button--short'
-                                        onClick={() =>
-                                            formApi.setValue(
-                                                'spec.namespaceResourceBlacklist',
-                                                (formApi.values.spec.namespaceResourceBlacklist || []).concat({
-                                                    group: '*',
-                                                    kind: '*'
-                                                })
-                                            )
-                                        }>
-                                        ADD RESOURCE
-                                    </button>
-                                </React.Fragment>
-                            )}
-                        </DataLoader>
-                    )}
-                    items={[]}
-                />
-
-                {globalProj.namespaceResourceBlacklist.length > 0 && (
-                    <div className='white-box editable-panel'>
-                        <div className='white-box__details'>
-                            <p>
-                                NAMESPACE RESOURCE DENY LIST FROM GLOBAL PROJECT
-                                {helpTip('Namespace-scoped K8s API Groups and Kinds which are prohibited from being deployed from global project')}
-                            </p>
-                            <React.Fragment>
-                                {globalProj.namespaceResourceBlacklist.length > 0 ? (
-                                    <React.Fragment>
-                                        <div className='row white-box__details-row'>
-                                            <div className='columns small-4'>Kind</div>
-                                            <div className='columns small-8'>Group</div>
-                                        </div>
-                                        {globalProj.namespaceResourceBlacklist.map((resource, i) => (
-                                            <div className='row white-box__details-row' key={i}>
-                                                <div className='columns small-4'>{resource.kind}</div>
-                                                <div className='columns small-8'>{resource.group}</div>
-                                            </div>
-                                        ))}
-                                    </React.Fragment>
-                                ) : (
-                                    emptyMessage('namespace resource allow list from global project')
-                                )}
-                            </React.Fragment>
-                        </div>
-                    </div>
+                <ResourceListsPanel proj={proj} saveProject={item => this.saveProject(item)} />
+                {globalProj.count > 0 && (
+                    <ResourceListsPanel
+                        title={<p>INHERITED FROM GLOBAL PROJECTS {helpTip('Global projects provide configurations that other projects can inherit from.')}</p>}
+                        proj={{metadata: null, spec: globalProj, status: null}}
+                    />
                 )}
 
                 <EditablePanel
@@ -1160,7 +764,7 @@ export class ProjectDetails extends React.Component<RouteComponentProps<{name: s
                                         ))}
                                     </React.Fragment>
                                 ) : (
-                                    emptyMessage('resource ignore list')
+                                    <p>The resource ignore list is empty</p>
                                 )}
                             </React.Fragment>
                         ) : (

--- a/ui/src/app/settings/components/project-details/resource-lists-panel.tsx
+++ b/ui/src/app/settings/components/project-details/resource-lists-panel.tsx
@@ -1,0 +1,132 @@
+import {AutocompleteField, FormField, Tooltip} from 'argo-ui';
+import * as React from 'react';
+import {FormApi} from 'react-form';
+
+import {EditablePanel} from '../../../shared/components';
+import {GroupKind, Groups, Project, ProjectSpec, ResourceKinds} from '../../../shared/models';
+
+function removeEl(items: any[], index: number) {
+    return items.slice(0, index).concat(items.slice(index + 1));
+}
+
+function helpTip(text: string) {
+    return (
+        <Tooltip content={text}>
+            <span style={{fontSize: 'smaller'}}>
+                {' '}
+                <i className='fa fa-question-circle' />
+            </span>
+        </Tooltip>
+    );
+}
+
+type field = keyof ProjectSpec;
+
+const infoByField: {[type: string]: {title: string; helpText: string}} = {
+    clusterResourceWhitelist: {
+        title: 'cluster resource allow list',
+        helpText: 'Cluster-scoped K8s API Groups and Kinds which are permitted to be deployed'
+    },
+    clusterResourceBlacklist: {
+        title: 'cluster resource deny list',
+        helpText: 'Cluster-scoped K8s API Groups and Kinds which are not permitted to be deployed'
+    },
+    namespaceResourceWhitelist: {
+        title: 'namespace resource allow list',
+        helpText: 'Namespace-scoped K8s API Groups and Kinds which are permitted to deploy'
+    },
+    namespaceResourceBlacklist: {
+        title: 'namespace resource deny list',
+        helpText: 'Namespace-scoped K8s API Groups and Kinds which are prohibited from being deployed'
+    }
+};
+
+function viewList(type: field, proj: Project) {
+    const info = infoByField[type];
+    const list = proj.spec[type] as Array<GroupKind>;
+    return (
+        <React.Fragment>
+            <p className='project-details__list-title'>
+                {info.title} {helpTip(info.helpText)}
+            </p>
+            {(list || []).length > 0 ? (
+                <React.Fragment>
+                    <div className='row white-box__details-row'>
+                        <div className='columns small-4'>Kind</div>
+                        <div className='columns small-8'>Group</div>
+                    </div>
+                    {list.map((resource, i) => (
+                        <div className='row white-box__details-row' key={i}>
+                            <div className='columns small-4'>{resource.kind}</div>
+                            <div className='columns small-8'>{resource.group}</div>
+                        </div>
+                    ))}
+                </React.Fragment>
+            ) : (
+                <p>The {info.title} is empty</p>
+            )}
+        </React.Fragment>
+    );
+}
+
+function editList(type: field, formApi: FormApi) {
+    const info = infoByField[type];
+
+    return (
+        <React.Fragment>
+            <p className='project-details__list-title'>
+                {info.title} {helpTip(info.helpText)}
+            </p>
+            <div className='row white-box__details-row'>
+                <div className='columns small-4'>Kind</div>
+                <div className='columns small-8'>Group</div>
+            </div>
+            {(formApi.values.spec[type] || []).map((_: Project, i: number) => (
+                <div className='row white-box__details-row' key={i}>
+                    <div className='columns small-4'>
+                        <FormField
+                            formApi={formApi}
+                            field={`spec.${type}[${i}].kind`}
+                            component={AutocompleteField}
+                            componentProps={{items: ResourceKinds, filterSuggestions: true}}
+                        />
+                    </div>
+                    <div className='columns small-8'>
+                        <FormField formApi={formApi} field={`spec.${type}[${i}].group`} component={AutocompleteField} componentProps={{items: Groups, filterSuggestions: true}} />
+                    </div>
+                    <i className='fa fa-times' onClick={() => formApi.setValue(`spec.${type}`, removeEl(formApi.values.spec[type], i))} />
+                </div>
+            ))}
+            <button className='argo-button argo-button--short' onClick={() => formApi.setValue(`spec.${type}`, (formApi.values.spec[type] || []).concat({group: '*', kind: '*'}))}>
+                ADD RESOURCE
+            </button>
+        </React.Fragment>
+    );
+}
+
+export const ResourceListsPanel = ({proj, saveProject, title}: {proj: Project; title?: React.ReactNode; saveProject?: (proj: Project) => any}) => (
+    <EditablePanel
+        save={saveProject}
+        values={proj}
+        view={
+            <React.Fragment>
+                {title}
+                {Object.keys(infoByField).map(key => (
+                    <React.Fragment key={key}>{viewList(key as field, proj)}</React.Fragment>
+                ))}
+            </React.Fragment>
+        }
+        edit={
+            saveProject &&
+            (formApi => (
+                <React.Fragment>
+                    {title}
+                    {Object.keys(infoByField).map(key => (
+                        <React.Fragment key={key}>{editList(key as field, formApi)}</React.Fragment>
+                    ))}
+                </React.Fragment>
+            ))
+        }
+        items={[]}
+    />
+);

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -743,7 +743,7 @@ export interface GnuPGPublicKeyList extends ItemsList<GnuPGPublicKey> {}
 // https://kubernetes.io/docs/reference/kubectl/overview/#resource-types
 
 export const ResourceKinds = [
-    'ANY',
+    '*',
     'Binding',
     'ComponentStatus',
     'ConfigMap',


### PR DESCRIPTION
PR implements the following improvements of the summary tab:

* Merges resources into one edit group. Typically users are going to edit all allow/deny cluster/namespace lists at once, so we should not force them to click edit/save multiple times.
* Moves all lists inherited from global projects into one panel.
* Ensures that the tabs header is not scrollable. 

![image](https://user-images.githubusercontent.com/426437/98397830-ce72d900-2014-11eb-87ab-c8784c43be5d.png)

