### PR TITLE
chore: Fix helm2 dependency tests

### DIFF
--- a/reposerver/repository/repository_norace_test.go
+++ b/reposerver/repository/repository_norace_test.go
@@ -27,12 +27,14 @@ func TestHelmDependencyWithConcurrency(t *testing.T) {
 	cleanup()
 	defer cleanup()
 
+	helmRepo := argoappv1.Repository{Name: "bitnami", Type: "helm", Repo: "https://charts.bitnami.com/bitnami"}
 	var wg sync.WaitGroup
 	wg.Add(3)
 	for i := 0; i < 3; i++ {
 		go func() {
 			res, err := helmTemplate("../../util/helm/testdata/helm2-dependency", "../..", nil, &apiclient.ManifestRequest{
 				ApplicationSource: &argoappv1.ApplicationSource{},
+				Repos:             []*argoappv1.Repository{&helmRepo},
 			}, false)
 
 			assert.NoError(t, err)

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -241,15 +241,17 @@ func TestGenerateKsonnetManifest(t *testing.T) {
 func TestGenerateHelmChartWithDependencies(t *testing.T) {
 	service := newService("../..")
 
+	helmRepo := argoappv1.Repository{Name: "bitnami", Type: "helm", Repo: "https://charts.bitnami.com/bitnami"}
 	q := apiclient.ManifestRequest{
 		Repo: &argoappv1.Repository{},
 		ApplicationSource: &argoappv1.ApplicationSource{
 			Path: "./util/helm/testdata/helm2-dependency",
 		},
+		Repos: []*argoappv1.Repository{&helmRepo},
 	}
 	res1, err := service.GenerateManifest(context.Background(), &q)
 	assert.Nil(t, err)
-	assert.Len(t, res1.Manifests, 12)
+	assert.Len(t, res1.Manifests, 10)
 }
 
 func TestManifestGenErrorCacheByNumRequests(t *testing.T) {

--- a/util/helm/helm_test.go
+++ b/util/helm/helm_test.go
@@ -94,6 +94,7 @@ func TestHelmGetParamsValueFiles(t *testing.T) {
 
 func TestHelmDependencyBuild(t *testing.T) {
 	testCases := map[string]string{"Helm": "dependency", "Helm2": "helm2-dependency"}
+	helmRepos := []HelmRepository{{Name: "bitnami", Repo: "https://charts.bitnami.com/bitnami"}}
 	for name := range testCases {
 		t.Run(name, func(t *testing.T) {
 			chart := testCases[name]
@@ -103,7 +104,7 @@ func TestHelmDependencyBuild(t *testing.T) {
 			}
 			clean()
 			defer clean()
-			h, err := NewHelmApp(fmt.Sprintf("./testdata/%s", chart), nil, false, "")
+			h, err := NewHelmApp(fmt.Sprintf("./testdata/%s", chart), helmRepos, false, "")
 			assert.NoError(t, err)
 			err = h.Init()
 			assert.NoError(t, err)

--- a/util/helm/testdata/helm2-dependency/requirements.lock
+++ b/util/helm/testdata/helm2-dependency/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://charts.helm.sh/stable
-  version: 4.4.2
-digest: sha256:c07f89818ebcd92a4dbaff719ebedc14e2569ee27447d3abf739e2dd11d13fcb
-generated: "2020-11-03T09:04:00.781031-08:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.0.7
+digest: sha256:6af34a77f088f79d80297001290927808d81346210ef1336ea5d26a1099213f2
+generated: "2020-11-07T16:37:58.659489501+01:00"

--- a/util/helm/testdata/helm2-dependency/requirements.yaml
+++ b/util/helm/testdata/helm2-dependency/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
-  version: 4.x.x
-  repository: https://charts.helm.sh/stable
+  version: 8.x.x
+  repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled
   tags:
     - wordpress-database


### PR DESCRIPTION
Seems that Helm v2 stable charts repositories are gone for good now.

The charts we use in unit-testing for testing helm dependencies (`wordpress` and `mariadb`) have been migrated to the [bitnami repository](https://charts.bitnami.com/bitnami).

This PR updates the unit tests and the chart used for testing.

The archived repository at `https://charts.helm.sh/stable` seems to be unreliable.

Signed-off-by: jannfis <jann@mistrust.net>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
