### PR TITLE
chore: Fix bulleted list in Global Projects section of projects

### DIFF
--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -185,6 +185,7 @@ Note that each project role policy rule must be scoped to that project only. Use
 Global projects can be configured to provide configurations that other projects can inherit from. 
 
 Projects, which match `matchExpressions` specified in `argocd-cm` ConfigMap, inherit the following fields from the global project:
+
 * namespaceResourceBlacklist
 * namespaceResourceWhitelist
 * clusterResourceBlacklist


### PR DESCRIPTION
Fix adds a line of whitespace to make the mkdocs-flavoured markdown happy... I've verified the fix using `mkdocs build`.

Fixes https://github.com/argoproj/argo-cd/issues/4802

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

Signed-off-by: Jonathan West <jonwest@redhat.com>
