### PR TITLE
docs: Correct default docker desktop context name

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -97,9 +97,9 @@ argocd cluster add
 ```
 
 Choose a context name from the list and supply it to `argocd cluster add CONTEXTNAME`. For example,
-for docker-for-desktop context, run:
+for docker-desktop context, run:
 ```bash
-argocd cluster add docker-for-desktop
+argocd cluster add docker-desktop
 ```
 
 The above command installs a ServiceAccount (`argocd-manager`), into the kube-system namespace of 


### PR DESCRIPTION
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 


In the getting started guide, the docker desktop context is listed as 'docker-for-desktop'. This has changed and should be 'docker-desktop'. It is probably a good idea to update this for users getting started who may just use the information as is and then run into problems if they don't update their ~/.kube/config file. This would provide a better more seamless out of the box setup experience. Trivial for knowledgeable users, but a stumble for new users using a stock docker desktop install. 

**To Reproduce**
See https://argoproj.github.io/argo-cd/getting_started/