### PR TITLE
chore: Update golang to v1.14.12

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Download all Go modules
         run: |
           go mod download
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Restore go build cache
         uses: actions/cache@v1
         with:
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Install required packages
         run: |
           sudo apt-get install git -y
@@ -147,7 +147,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Install required packages
         run: |
           sudo apt-get install git -y
@@ -196,7 +196,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Create symlink in GOPATH
         run: |
           mkdir -p ~/go/src/github.com/argoproj
@@ -354,7 +354,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
       - name: Install K3S
         env:
           INSTALL_K3S_VERSION: ${{ matrix.k3s-version }}+k3s1

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.14.1'
+          go-version: '1.14.12'
       - uses: actions/checkout@master
         with:
           path: src/github.com/argoproj/argo-cd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.2'
+          go-version: '1.14.12'
 
       - name: Setup Git author information
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=debian:10-slim
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM golang:1.14.1 as builder
+FROM golang:1.14.12 as builder
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 
@@ -103,7 +103,7 @@ RUN NODE_ENV='production' yarn build
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
 ####################################################################################################
-FROM golang:1.14.1 as argocd-build
+FROM golang:1.14.12 as argocd-build
 
 COPY --from=builder /usr/local/bin/packr /usr/local/bin/packr
 

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -2,7 +2,7 @@ FROM redis:5.0.10 as redis
 
 FROM node:12.18.4 as node
 
-FROM golang:1.14.1 as golang
+FROM golang:1.14.12 as golang
 
 FROM debian:10-slim
 


### PR DESCRIPTION
### What?

This PR updates golang from v1.14.2 to v1.14.12

### Why?

Multiple bugs have been fixed in the v1.14.x branch of golang, with a [quite critical](https://nvd.nist.gov/vuln/detail/CVE-2020-28362) regarding `math/big` fixed in [v1.14.12](https://github.com/golang/go/issues?q=milestone%3AGo1.14.12+label%3ACherryPickApproved)

### Why not golang v1.15?

Go v1.15 contains a [breaking change](https://golang.org/doc/go1.15#commonname) that might affect numerous users. Before we upgrade to v1.15, we should coordinate & communicate this.

Signed-off-by: jannfis <jann@mistrust.net>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
