### PR TITLE
fix: use correct operation type to track ls-remote performance

### DIFF
--- a/reposerver/metrics/gitwrapper.go
+++ b/reposerver/metrics/gitwrapper.go
@@ -29,7 +29,7 @@ func (w *gitClientWrapper) LsRemote(revision string) (string, error) {
 	if sha != revision {
 		// This is true only if specified revision is a tag, branch or HEAD and client had to use 'ls-remote'
 		w.metricsServer.IncGitRequest(w.repo, GitRequestTypeLsRemote)
-		defer w.metricsServer.ObserveGitRequestDuration(w.repo, GitRequestTypeFetch, time.Since(startTime))
+		defer w.metricsServer.ObserveGitRequestDuration(w.repo, GitRequestTypeLsRemote, time.Since(startTime))
 	}
 	return sha, err
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Fix for minor bug introduced in https://github.com/argoproj/argo-cd/pull/3828/files#diff-d6cb6a75446e511d13757cbce39244c93fd654bac648a985c947faf0239d63b3R32
