### PR TITLE
feat: argocd-util can now validate RBAC configuration

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -124,7 +124,7 @@
           "AccountService"
         ],
         "summary": "CreateToken creates a token",
-        "operationId": "CreateTokenMixin7",
+        "operationId": "CreateTokenMixin10",
         "parameters": [
           {
             "type": "string",
@@ -157,7 +157,7 @@
           "AccountService"
         ],
         "summary": "DeleteToken deletes a token",
-        "operationId": "DeleteTokenMixin7",
+        "operationId": "DeleteTokenMixin10",
         "parameters": [
           {
             "type": "string",
@@ -188,7 +188,7 @@
           "ApplicationService"
         ],
         "summary": "List returns list of applications",
-        "operationId": "ListMixin10",
+        "operationId": "List",
         "parameters": [
           {
             "type": "string",
@@ -239,7 +239,7 @@
           "ApplicationService"
         ],
         "summary": "Create creates an application",
-        "operationId": "CreateMixin10",
+        "operationId": "Create",
         "parameters": [
           {
             "name": "body",
@@ -266,7 +266,7 @@
           "ApplicationService"
         ],
         "summary": "Update updates an application",
-        "operationId": "UpdateMixin10",
+        "operationId": "Update",
         "parameters": [
           {
             "type": "string",
@@ -400,7 +400,7 @@
           "ApplicationService"
         ],
         "summary": "Get returns an application by name",
-        "operationId": "GetMixin10",
+        "operationId": "GetMixin1",
         "parameters": [
           {
             "type": "string",
@@ -452,7 +452,7 @@
           "ApplicationService"
         ],
         "summary": "Delete deletes an application",
-        "operationId": "DeleteMixin10",
+        "operationId": "Delete",
         "parameters": [
           {
             "type": "string",
@@ -1162,7 +1162,7 @@
           "ClusterService"
         ],
         "summary": "List returns list of clusters",
-        "operationId": "ListMixin1",
+        "operationId": "ListMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1189,7 +1189,7 @@
           "ClusterService"
         ],
         "summary": "Create creates a cluster",
-        "operationId": "CreateMixin1",
+        "operationId": "CreateMixin5",
         "parameters": [
           {
             "name": "body",
@@ -1216,7 +1216,7 @@
           "ClusterService"
         ],
         "summary": "Update updates a cluster",
-        "operationId": "Update",
+        "operationId": "UpdateMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1250,7 +1250,7 @@
           "ClusterService"
         ],
         "summary": "Get returns a cluster by server address",
-        "operationId": "GetMixin1",
+        "operationId": "GetMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1278,7 +1278,7 @@
           "ClusterService"
         ],
         "summary": "Delete deletes a cluster",
-        "operationId": "DeleteMixin1",
+        "operationId": "DeleteMixin5",
         "parameters": [
           {
             "type": "string",
@@ -1358,7 +1358,7 @@
           "GPGKeyService"
         ],
         "summary": "List all available repository certificates",
-        "operationId": "List",
+        "operationId": "ListMixin2",
         "parameters": [
           {
             "type": "string",
@@ -1381,7 +1381,7 @@
           "GPGKeyService"
         ],
         "summary": "Create one or more GPG public keys in the server's configuration",
-        "operationId": "Create",
+        "operationId": "CreateMixin2",
         "parameters": [
           {
             "description": "Raw key data of the GPG key(s) to create",
@@ -1407,7 +1407,7 @@
           "GPGKeyService"
         ],
         "summary": "Delete specified GPG public key from the server's configuration",
-        "operationId": "Delete",
+        "operationId": "DeleteMixin2",
         "parameters": [
           {
             "type": "string",
@@ -1432,7 +1432,7 @@
           "GPGKeyService"
         ],
         "summary": "Get information about specified GPG public key from the server",
-        "operationId": "Get",
+        "operationId": "GetMixin2",
         "parameters": [
           {
             "type": "string",
@@ -1948,7 +1948,7 @@
           "RepositoryService"
         ],
         "summary": "Get returns a repository or its credentials",
-        "operationId": "GetMixin2",
+        "operationId": "Get",
         "parameters": [
           {
             "type": "string",
@@ -2235,7 +2235,7 @@
           "SettingsService"
         ],
         "summary": "Get returns Argo CD settings",
-        "operationId": "GetMixin4",
+        "operationId": "GetMixin8",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/cmd/argocd-util/commands/argocd_util.go
+++ b/cmd/argocd-util/commands/argocd_util.go
@@ -73,6 +73,7 @@ func NewCommand() *cobra.Command {
 	command.AddCommand(NewProjectsCommand())
 	command.AddCommand(NewSettingsCommand())
 	command.AddCommand(NewAppsCommand())
+	command.AddCommand(NewRBACCommand())
 
 	command.Flags().StringVar(&logFormat, "logformat", "text", "Set the logging format. One of: text|json")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")

--- a/cmd/argocd-util/commands/rbac.go
+++ b/cmd/argocd-util/commands/rbac.go
@@ -1,0 +1,327 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ghodss/yaml"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/server/rbacpolicy"
+	"github.com/argoproj/argo-cd/util/assets"
+	"github.com/argoproj/argo-cd/util/cli"
+	"github.com/argoproj/argo-cd/util/rbac"
+)
+
+// Provide a mapping of short-hand resource names to their RBAC counterparts
+var resourceMap map[string]string = map[string]string{
+	"account":     rbacpolicy.ResourceAccounts,
+	"app":         rbacpolicy.ResourceApplications,
+	"apps":        rbacpolicy.ResourceApplications,
+	"application": rbacpolicy.ResourceApplications,
+	"cert":        rbacpolicy.ResourceCertificates,
+	"certs":       rbacpolicy.ResourceCertificates,
+	"certificate": rbacpolicy.ResourceCertificates,
+	"cluster":     rbacpolicy.ResourceClusters,
+	"gpgkey":      rbacpolicy.ResourceGPGKeys,
+	"key":         rbacpolicy.ResourceGPGKeys,
+	"proj":        rbacpolicy.ResourceProjects,
+	"projs":       rbacpolicy.ResourceProjects,
+	"project":     rbacpolicy.ResourceProjects,
+	"repo":        rbacpolicy.ResourceRepositories,
+	"repos":       rbacpolicy.ResourceRepositories,
+	"repository":  rbacpolicy.ResourceRepositories,
+}
+
+// List of allowed RBAC resources
+var validRBACResources map[string]bool = map[string]bool{
+	rbacpolicy.ResourceAccounts:     true,
+	rbacpolicy.ResourceApplications: true,
+	rbacpolicy.ResourceCertificates: true,
+	rbacpolicy.ResourceClusters:     true,
+	rbacpolicy.ResourceGPGKeys:      true,
+	rbacpolicy.ResourceProjects:     true,
+	rbacpolicy.ResourceRepositories: true,
+}
+
+// List of allowed RBAC actions
+var validRBACActions map[string]bool = map[string]bool{
+	rbacpolicy.ActionCreate:   true,
+	rbacpolicy.ActionDelete:   true,
+	rbacpolicy.ActionGet:      true,
+	rbacpolicy.ActionOverride: true,
+	rbacpolicy.ActionSync:     true,
+	rbacpolicy.ActionUpdate:   true,
+}
+
+// NewRBACCommand is the command for 'rbac'
+func NewRBACCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "rbac",
+		Short: "Validate and test RBAC configuration",
+		Run: func(c *cobra.Command, args []string) {
+			c.HelpFunc()(c, args)
+		},
+	}
+	command.AddCommand(NewRBACCanCommand())
+	return command
+}
+
+// NewRBACCanRoleCommand is the command for 'rbac can-role'
+func NewRBACCanCommand() *cobra.Command {
+	var (
+		policyFile   string
+		defaultRole  string
+		useBuiltin   bool
+		strict       bool
+		quiet        bool
+		subject      string
+		action       string
+		resource     string
+		subResource  string
+		clientConfig clientcmd.ClientConfig
+	)
+	var command = &cobra.Command{
+		Use:   "can ROLE/SUBJECT ACTION RESOURCE [SUB-RESOURCE]",
+		Short: "Check RBAC permissions for a role or subject",
+		Long: `
+Check whether a given role or subject has appropriate RBAC permissions to do
+something.
+`,
+		Example: `
+# Check whether role some:role has permissions to create an application in the
+# 'default' project, using a local policy.csv file
+argocd-util rbac can some:role create application 'default/app' --policy-file policy.csv
+
+# Policy file can also be K8s config map with data keys like argocd-rbac-cm,
+# i.e. 'policy.csv' and (optionally) 'policy.default'
+argocd-util rbac can some:role create application 'default/app' --policy-file argocd-rbac-cm.yaml
+
+# If --policy-file is not given, the ConfigMap 'argocd-rbac-cm' from K8s is
+# used. You need to specify the argocd namespace, and make sure that your
+# current Kubernetes context is pointing to the cluster Argo CD is running in
+argocd-util rbac can some:role create application 'default/app' --namespace argocd
+
+# You can override a possibly configured default role
+argocd-util rbac can someuser create application 'default/app' --default-role role:readonly
+
+`,
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) < 3 || len(args) > 4 {
+				c.HelpFunc()(c, args)
+				os.Exit(0)
+			}
+			subject = args[0]
+			action = args[1]
+			resource = args[2]
+			if len(args) > 3 {
+				subResource = args[3]
+			}
+
+			userPolicy := ""
+			builtinPolicy := ""
+
+			var newDefaultRole string
+
+			namespace, _, err := clientConfig.Namespace()
+			if err != nil {
+				log.Fatalf("could not create k8s client: %v", err)
+			}
+			restConfig, err := clientConfig.ClientConfig()
+			if err != nil {
+				log.Fatalf("could not create k8s client: %v", err)
+			}
+
+			realClientset, err := kubernetes.NewForConfig(restConfig)
+			if err != nil {
+				log.Fatalf("could not create k8s client: %v", err)
+			}
+
+			userPolicy, newDefaultRole = getPolicy(policyFile, realClientset, namespace)
+
+			// Use built-in policy as augmentation if requested
+			if useBuiltin {
+				builtinPolicy = assets.BuiltinPolicyCSV
+			}
+
+			// If no explicit default role was given, but we have one defined from
+			// a policy, use this to check for enforce.
+			if newDefaultRole != "" && defaultRole == "" {
+				defaultRole = newDefaultRole
+			}
+
+			res := checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole, strict)
+			if res {
+				if !quiet {
+					fmt.Println("Yes")
+				}
+				os.Exit(0)
+			} else {
+				if !quiet {
+					fmt.Println("No")
+				}
+				os.Exit(1)
+			}
+		},
+	}
+
+	clientConfig = cli.AddKubectlFlagsToCmd(command)
+	command.Flags().StringVar(&policyFile, "policy-file", "", "path to the policy file to use")
+	command.Flags().StringVar(&defaultRole, "default-role", "", "name of the default role to use")
+	command.Flags().BoolVar(&useBuiltin, "use-builtin-policy", true, "whether to also use builtin-policy")
+	command.Flags().BoolVar(&strict, "strict", true, "whether to perform strict check on action and resource names")
+	command.Flags().BoolVarP(&quiet, "quiet", "q", false, "quiet mode - do not print results to stdout")
+	return command
+}
+
+// Load user policy file if requested or use Kubernetes client to get the
+// appropriate ConfigMap from the current context
+func getPolicy(policyFile string, kubeClient kubernetes.Interface, namespace string) (userPolicy string, defaultRole string) {
+	var err error
+	if policyFile != "" {
+		// load from file
+		userPolicy, defaultRole, err = getPolicyFromFile(policyFile)
+		if err != nil {
+			log.Fatalf("could not read policy file: %v", err)
+		}
+	} else {
+		cm, err := getPolicyConfigMap(kubeClient, namespace)
+		if err != nil {
+			log.Fatalf("could not get configmap: %v", err)
+		}
+		userPolicy, defaultRole = getPolicyFromConfigMap(cm)
+	}
+
+	return userPolicy, defaultRole
+}
+
+// getPolicyFromFile loads a RBAC policy from given path
+func getPolicyFromFile(policyFile string) (string, string, error) {
+	var (
+		userPolicy  string
+		defaultRole string
+	)
+
+	upol, err := ioutil.ReadFile(policyFile)
+	if err != nil {
+		log.Fatalf("error opening policy file: %v", err)
+		return "", "", err
+	}
+
+	// Try to unmarshal the input file as ConfigMap first. If it succeeds, we
+	// assume config map input. Otherwise, we treat it as
+	var upolCM *corev1.ConfigMap
+	err = yaml.Unmarshal(upol, &upolCM)
+	if err != nil {
+		userPolicy = string(upol)
+	} else {
+		userPolicy, defaultRole = getPolicyFromConfigMap(upolCM)
+	}
+
+	return userPolicy, defaultRole, nil
+}
+
+// Retrieve policy information from a ConfigMap
+func getPolicyFromConfigMap(cm *corev1.ConfigMap) (string, string) {
+	var (
+		userPolicy  string
+		defaultRole string
+		ok          bool
+	)
+	userPolicy, ok = cm.Data[rbac.ConfigMapPolicyCSVKey]
+	if !ok {
+		userPolicy = ""
+	}
+	if defaultRole == "" {
+		defaultRole, ok = cm.Data[rbac.ConfigMapPolicyDefaultKey]
+		if !ok {
+			defaultRole = ""
+		}
+	}
+
+	return userPolicy, defaultRole
+}
+
+// getPolicyConfigMap fetches the RBAC config map from K8s cluster
+func getPolicyConfigMap(client kubernetes.Interface, namespace string) (*corev1.ConfigMap, error) {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.Background(), common.ArgoCDRBACConfigMapName, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+// checkPolicy checks whether given subject is allowed to execute specified
+// action against specified resource
+func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole string, strict bool) bool {
+	enf := rbac.NewEnforcer(nil, "argocd", "argocd-rbac-cm", nil)
+	enf.SetDefaultRole(defaultRole)
+	if builtinPolicy != "" {
+		if err := enf.SetBuiltinPolicy(builtinPolicy); err != nil {
+			log.Fatalf("could not set built-in policy: %v", err)
+			return false
+		}
+	}
+	if userPolicy != "" {
+		if err := enf.SetUserPolicy(userPolicy); err != nil {
+			log.Fatalf("could not set user policy: %v", err)
+			return false
+		}
+	}
+
+	// User could have used a mutation of the resource name (i.e. 'cert' for
+	// 'certificate') - let's resolve it to the valid resource.
+	realResource := resolveRBACResourceName(resource)
+
+	// If in strict mode, validate that given RBAC resource and action are
+	// actually valid tokens.
+	if strict {
+		if !isValidRBACResource(realResource) {
+			log.Fatalf("error in RBAC request: '%s' is not a valid resource name", realResource)
+		}
+		if !isValidRBACAction(action) {
+			log.Fatalf("error in RBAC request: '%s' is not a valid action name", action)
+		}
+	}
+
+	// Application resources have a special notation - for simplicity's sake,
+	// if user gives no sub-resource (or specifies simple '*'), we construct
+	// the required notation by setting subresource to '*/*'.
+	if realResource == rbacpolicy.ResourceApplications {
+		if subResource == "*" || subResource == "" {
+			subResource = "*/*"
+		}
+	}
+
+	return enf.Enforce(subject, realResource, action, subResource)
+}
+
+// resolveRBACResourceName resolves a user supplied value to a valid RBAC
+// resource name. If no mapping is found, returns the value verbatim.
+func resolveRBACResourceName(name string) string {
+	if res, ok := resourceMap[name]; ok {
+		return res
+	} else {
+		return name
+	}
+}
+
+// isValidRBACAction checks whether a given action is a valid RBAC action
+func isValidRBACAction(action string) bool {
+	_, ok := validRBACActions[action]
+	return ok
+}
+
+// isValidRBACResource checks whether a given resource is a valid RBAC resource
+func isValidRBACResource(resource string) bool {
+	_, ok := validRBACResources[resource]
+	return ok
+}

--- a/cmd/argocd-util/commands/rbac.go
+++ b/cmd/argocd-util/commands/rbac.go
@@ -271,6 +271,10 @@ func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPoli
 		}
 	}
 	if userPolicy != "" {
+		if err := rbac.ValidatePolicy(userPolicy); err != nil {
+			log.Fatalf("invalid user policy: %v", err)
+			return false
+		}
 		if err := enf.SetUserPolicy(userPolicy); err != nil {
 			log.Fatalf("could not set user policy: %v", err)
 			return false

--- a/cmd/argocd-util/commands/rbac.go
+++ b/cmd/argocd-util/commands/rbac.go
@@ -133,15 +133,21 @@ argocd-util rbac can someuser create application 'default/app' --default-role ro
 
 			var newDefaultRole string
 
-			namespace, _, err := clientConfig.Namespace()
-			if err != nil {
-				log.Fatalf("could not create k8s client: %v", err)
-			}
-			restConfig, err := clientConfig.ClientConfig()
+			namespace, nsOverride, err := clientConfig.Namespace()
 			if err != nil {
 				log.Fatalf("could not create k8s client: %v", err)
 			}
 
+			// Exactly one of --namespace or --policy-file must be given.
+			if (!nsOverride && policyFile == "") || (nsOverride && policyFile != "") {
+				c.HelpFunc()(c, args)
+				log.Fatalf("please provide exactly one of --policy-file or --namespace")
+			}
+
+			restConfig, err := clientConfig.ClientConfig()
+			if err != nil {
+				log.Fatalf("could not create k8s client: %v", err)
+			}
 			realClientset, err := kubernetes.NewForConfig(restConfig)
 			if err != nil {
 				log.Fatalf("could not create k8s client: %v", err)

--- a/cmd/argocd-util/commands/rbac_test.go
+++ b/cmd/argocd-util/commands/rbac_test.go
@@ -4,9 +4,10 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/argoproj/argo-cd/util/assets"
+
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-cd/util/assets"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/argocd-util/commands/rbac_test.go
+++ b/cmd/argocd-util/commands/rbac_test.go
@@ -4,14 +4,13 @@ import (
 	"io/ioutil"
 	"testing"
 
-
 	"github.com/stretchr/testify/assert"
-
-	"github.com/argoproj/argo-cd/util/assets"
-
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/argoproj/argo-cd/util/assets"
 )
 
 func Test_isValidRBACAction(t *testing.T) {

--- a/cmd/argocd-util/commands/rbac_test.go
+++ b/cmd/argocd-util/commands/rbac_test.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/argoproj/argo-cd/util/assets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_isValidRBACAction(t *testing.T) {
+	for k := range validRBACActions {
+		t.Run(k, func(t *testing.T) {
+			ok := isValidRBACAction(k)
+			assert.True(t, ok)
+		})
+	}
+	t.Run("invalid", func(t *testing.T) {
+		ok := isValidRBACAction("invalid")
+		assert.False(t, ok)
+	})
+}
+
+func Test_isValidRBACResource(t *testing.T) {
+	for k := range validRBACResources {
+		t.Run(k, func(t *testing.T) {
+			ok := isValidRBACResource(k)
+			assert.True(t, ok)
+		})
+	}
+	t.Run("invalid", func(t *testing.T) {
+		ok := isValidRBACResource("invalid")
+		assert.False(t, ok)
+	})
+}
+
+func Test_PolicyFromCSV(t *testing.T) {
+	uPol, dRole := getPolicy("testdata/rbac/policy.csv", nil, "")
+	require.NotEmpty(t, uPol)
+	require.Empty(t, dRole)
+}
+
+func Test_PolicyFromYAML(t *testing.T) {
+	uPol, dRole := getPolicy("testdata/rbac/argocd-rbac-cm.yaml", nil, "")
+	require.NotEmpty(t, uPol)
+	require.Equal(t, "role:unknown", dRole)
+}
+
+func Test_PolicyFromK8s(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/rbac/policy.csv")
+	require.NoError(t, err)
+	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-rbac-cm",
+			Namespace: "argocd",
+		},
+		Data: map[string]string{
+			"policy.csv":     string(data),
+			"policy.default": "role:unknown",
+		},
+	})
+	uPol, dRole := getPolicy("", kubeclientset, "argocd")
+	require.NotEmpty(t, uPol)
+	require.Equal(t, "role:unknown", dRole)
+
+	t.Run("get applications", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "applications", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, true)
+		require.True(t, ok)
+	})
+	t.Run("get clusters", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "clusters", "*", assets.BuiltinPolicyCSV, uPol, dRole, true)
+		require.True(t, ok)
+	})
+	t.Run("get certificates", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", "*", assets.BuiltinPolicyCSV, uPol, dRole, true)
+		require.False(t, ok)
+	})
+	t.Run("get certificates by default role", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", "*", assets.BuiltinPolicyCSV, uPol, "role:readonly", true)
+		require.True(t, ok)
+	})
+	t.Run("get certificates by default role without builtin policy", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", "*", "", uPol, "role:readonly", true)
+		require.False(t, ok)
+	})
+}

--- a/cmd/argocd-util/commands/testdata/rbac/argocd-rbac-cm.yaml
+++ b/cmd/argocd-util/commands/testdata/rbac/argocd-rbac-cm.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  policy.csv: |
+    p, role:user, clusters, get, *, allow
+    p, role:user, clusters, get, https://kubernetes*, deny
+    p, role:user, projects, get, *, allow
+    p, role:user, applications, get, *, allow
+    p, role:user, applications, create, */*, allow
+    p, role:user, applications, delete, *, allow
+    p, role:user, applications, delete, */guestbook, deny
+    g, test, role:user
+  policy.default: role:unknown
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+  namespace: argocd

--- a/cmd/argocd-util/commands/testdata/rbac/policy.csv
+++ b/cmd/argocd-util/commands/testdata/rbac/policy.csv
@@ -1,0 +1,9 @@
+p, role:user, clusters, get, *, allow
+p, role:user, clusters, get, https://kubernetes*, deny
+p, role:user, projects, get, *, allow
+p, role:user, applications, get, *, allow
+p, role:user, applications, create, */*, allow
+p, role:user, applications, delete, *, allow
+p, role:user, applications, delete, */guestbook, deny
+p, role:test, certificates, get, *, allow
+g, test, role:user

--- a/docs/operator-manual/server-commands/argocd-util.md
+++ b/docs/operator-manual/server-commands/argocd-util.md
@@ -26,6 +26,7 @@ argocd-util [flags]
 * [argocd-util import](argocd-util_import.md)	 - Import Argo CD data from stdin (specify `-') or a file
 * [argocd-util kubeconfig](argocd-util_kubeconfig.md)	 - Generates kubeconfig for the specified cluster
 * [argocd-util projects](argocd-util_projects.md)	 - Utility commands operate on ArgoCD Projects
+* [argocd-util rbac](argocd-util_rbac.md)	 - Validate and test RBAC configuration
 * [argocd-util rundex](argocd-util_rundex.md)	 - Runs dex generating a config using settings from the Argo CD configmap and secret
 * [argocd-util settings](argocd-util_settings.md)	 - Provides set of commands for settings validation and troubleshooting
 * [argocd-util version](argocd-util_version.md)	 - Print version information

--- a/docs/operator-manual/server-commands/argocd-util_rbac.md
+++ b/docs/operator-manual/server-commands/argocd-util_rbac.md
@@ -1,0 +1,24 @@
+## argocd-util rbac
+
+Validate and test RBAC configuration
+
+### Synopsis
+
+Validate and test RBAC configuration
+
+```
+argocd-util rbac [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rbac
+```
+
+### SEE ALSO
+
+* [argocd-util](argocd-util.md)	 - argocd-util tools used by Argo CD
+* [argocd-util rbac can](argocd-util_rbac_can.md)	 - Check RBAC permissions for a role or subject
+* [argocd-util rbac validate](argocd-util_rbac_validate.md)	 - Validate RBAC policy
+

--- a/docs/operator-manual/server-commands/argocd-util_rbac_can.md
+++ b/docs/operator-manual/server-commands/argocd-util_rbac_can.md
@@ -1,0 +1,70 @@
+## argocd-util rbac can
+
+Check RBAC permissions for a role or subject
+
+### Synopsis
+
+
+Check whether a given role or subject has appropriate RBAC permissions to do
+something.
+
+
+```
+argocd-util rbac can ROLE/SUBJECT ACTION RESOURCE [SUB-RESOURCE] [flags]
+```
+
+### Examples
+
+```
+
+# Check whether role some:role has permissions to create an application in the
+# 'default' project, using a local policy.csv file
+argocd-util rbac can some:role create application 'default/app' --policy-file policy.csv
+
+# Policy file can also be K8s config map with data keys like argocd-rbac-cm,
+# i.e. 'policy.csv' and (optionally) 'policy.default'
+argocd-util rbac can some:role create application 'default/app' --policy-file argocd-rbac-cm.yaml
+
+# If --policy-file is not given, the ConfigMap 'argocd-rbac-cm' from K8s is
+# used. You need to specify the argocd namespace, and make sure that your
+# current Kubernetes context is pointing to the cluster Argo CD is running in
+argocd-util rbac can some:role create application 'default/app' --namespace argocd
+
+# You can override a possibly configured default role
+argocd-util rbac can someuser create application 'default/app' --default-role role:readonly
+
+
+```
+
+### Options
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --default-role string            name of the default role to use
+  -h, --help                           help for can
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --policy-file string             path to the policy file to use
+  -q, --quiet                          quiet mode - do not print results to stdout
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --server string                  The address and port of the Kubernetes API server
+      --strict                         whether to perform strict check on action and resource names (default true)
+      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                   Bearer token for authentication to the API server
+      --use-builtin-policy             whether to also use builtin-policy (default true)
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+### SEE ALSO
+
+* [argocd-util rbac](argocd-util_rbac.md)	 - Validate and test RBAC configuration
+

--- a/docs/operator-manual/server-commands/argocd-util_rbac_validate.md
+++ b/docs/operator-manual/server-commands/argocd-util_rbac_validate.md
@@ -1,0 +1,26 @@
+## argocd-util rbac validate
+
+Validate RBAC policy
+
+### Synopsis
+
+
+Validates an RBAC policy for being syntactically correct. The policy must be
+a local file, and in either CSV or K8s ConfigMap format.
+
+
+```
+argocd-util rbac validate --policy-file=POLICYFILE [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for validate
+      --policy-file string   path to the policy file to use
+```
+
+### SEE ALSO
+
+* [argocd-util rbac](argocd-util_rbac.md)	 - Validate and test RBAC configuration
+


### PR DESCRIPTION
Closes #4842

This PR adds a new group of commands to `argocd-util`, so that users can validate and test their RBAC policies against a local CSV file, a local YAML representation of a ConfigMap or a live ConfigMap in the cluster.

The first two new commands are:

* `argocd-util rbac can SUBJECT ACTION RESOURCE [SUB-RESOURCE]` - test whether a given subject has permissions to execute given action for given resource (and possibly, sub-resource).
* `argocd-util rbac validate` - test whether a local file contains a valid policy definition to be used by Casbin

Policy can either be given as file, using `--policy-file FILE`, or read from the current cluster context in namespace given by `--namespace NAMESPACE`. In the latter case, the name of the ConfigMap in the cluster is hard wired to `argocd-rbac-cm`.

User can chose to perform the test with the built-in policy augmented to the local policy (`--use-builtin-policy`, defaults to `true`) and set a default role (similar to `policy.default`) using `--default-role ROLE`.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
