### PR TITLE
chore: Upgrade go-jsonnet to v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/google/go-cmp v0.5.2
-	github.com/google/go-jsonnet v0.16.0
+	github.com/google/go-jsonnet v0.17.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-jsonnet v0.16.0 h1:Nb4EEOp+rdeGGyB1rQ5eisgSAqrTnhf9ip+X6lzZbY0=
-github.com/google/go-jsonnet v0.16.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
+github.com/google/go-jsonnet v0.17.0 h1:/9NIEfhK1NQRKl3sP2536b2+x5HnZMdql7x3yK/l8JY=
+github.com/google/go-jsonnet v0.17.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -878,7 +878,7 @@ func findManifests(appPath string, repoRoot string, env *v1alpha1.Env, directory
 			if err != nil {
 				return err
 			}
-			jsonStr, err := vm.EvaluateSnippet(path, string(out))
+			jsonStr, err := vm.EvaluateFile(path)
 			if err != nil {
 				return status.Errorf(codes.FailedPrecondition, "Failed to evaluate jsonnet %q: %v", f.Name(), err)
 			}

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -862,18 +862,7 @@ func findManifests(appPath string, repoRoot string, env *v1alpha1.Env, directory
 			return nil
 		}
 
-		out, err := utfutil.ReadFile(path, utfutil.UTF8)
-		if err != nil {
-			return err
-		}
-		if strings.HasSuffix(f.Name(), ".json") {
-			var obj unstructured.Unstructured
-			err = json.Unmarshal(out, &obj)
-			if err != nil {
-				return status.Errorf(codes.FailedPrecondition, "Failed to unmarshal %q: %v", f.Name(), err)
-			}
-			objs = append(objs, &obj)
-		} else if strings.HasSuffix(f.Name(), ".jsonnet") {
+		if strings.HasSuffix(f.Name(), ".jsonnet") {
 			vm, err := makeJsonnetVm(appPath, repoRoot, directory.Jsonnet, env)
 			if err != nil {
 				return err
@@ -897,24 +886,37 @@ func findManifests(appPath string, repoRoot string, env *v1alpha1.Env, directory
 				objs = append(objs, &jsonObj)
 			}
 		} else {
-			yamlObjs, err := kube.SplitYAML(out)
+			out, err := utfutil.ReadFile(path, utfutil.UTF8)
 			if err != nil {
-				if len(yamlObjs) > 0 {
-					// If we get here, we had a multiple objects in a single YAML file which had some
-					// valid k8s objects, but errors parsing others (within the same file). It's very
-					// likely the user messed up a portion of the YAML, so report on that.
-					return status.Errorf(codes.FailedPrecondition, "Failed to unmarshal %q: %v", f.Name(), err)
-				}
-				// Otherwise, let's see if it looks like a resource, if yes, we return error
-				if bytes.Contains(out, []byte("apiVersion:")) &&
-					bytes.Contains(out, []byte("kind:")) &&
-					bytes.Contains(out, []byte("metadata:")) {
-					return status.Errorf(codes.FailedPrecondition, "Failed to unmarshal %q: %v", f.Name(), err)
-				}
-				// Otherwise, it might be a unrelated YAML file which we will ignore
-				return nil
+				return err
 			}
-			objs = append(objs, yamlObjs...)
+			if strings.HasSuffix(f.Name(), ".json") {
+				var obj unstructured.Unstructured
+				err = json.Unmarshal(out, &obj)
+				if err != nil {
+					return status.Errorf(codes.FailedPrecondition, "Failed to unmarshal %q: %v", f.Name(), err)
+				}
+				objs = append(objs, &obj)
+			} else {
+				yamlObjs, err := kube.SplitYAML(out)
+				if err != nil {
+					if len(yamlObjs) > 0 {
+						// If we get here, we had a multiple objects in a single YAML file which had some
+						// valid k8s objects, but errors parsing others (within the same file). It's very
+						// likely the user messed up a portion of the YAML, so report on that.
+						return status.Errorf(codes.FailedPrecondition, "Failed to unmarshal %q: %v", f.Name(), err)
+					}
+					// Otherwise, let's see if it looks like a resource, if yes, we return error
+					if bytes.Contains(out, []byte("apiVersion:")) &&
+						bytes.Contains(out, []byte("kind:")) &&
+						bytes.Contains(out, []byte("metadata:")) {
+						return status.Errorf(codes.FailedPrecondition, "Failed to unmarshal %q: %v", f.Name(), err)
+					}
+					// Otherwise, it might be a unrelated YAML file which we will ignore
+					return nil
+				}
+				objs = append(objs, yamlObjs...)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
Jsonnet v0.17.0 has been released:

https://github.com/google/go-jsonnet/releases/tag/v0.17.0

One of the most notable performance improvements:

> * `std.manifestJsonEx` is now much faster.

Our Grafana deployment takes a couple minutes to build with v0.16.0, and only a few seconds with the native Go implementation of `std.manifestJsonEx`.

---

`vm.EvaluateSnippet` has been deprecated, its close replacement looks like `vm.EvaluateAnonymousSnippet`, but as per the release notes, this one does not support relative imports:

> We no longer treat fake names for ad hoc snippets or extvars as paths.

So I have replaced it by `vm.EvaluateFile`, and re-organized the conditions to spare Argo CD from reading the Jsonnet files before evaluating them.

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
