### PR TITLE
refactor: disable gRPC metrics by default

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -182,6 +182,8 @@ const (
 	EnvControllerReplicas = "ARGOCD_CONTROLLER_REPLICAS"
 	// EnvControllerShard is the shard number that should be handled by controller
 	EnvControllerShard = "ARGOCD_CONTROLLER_SHARD"
+	// EnvEnableGRPCTimeHistogramEnv enables gRPC metrics collection
+	EnvEnableGRPCTimeHistogramEnv = "ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM"
 )
 
 const (

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -36,6 +36,8 @@ and might fail. To avoid failed syncs use `ARGOCD_GIT_ATTEMPTS_COUNT` environmen
 
 * `argocd_git_request_total` - Number of git requests. The metric provides two tags: `repo` - Git repo URL; `request_type` - `ls-remote` or `fetch`.
 
+* `ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM` (v1.8+) - environment variable that enables collecting RPC performance metrics. Enable it if you need to troubleshoot performance issue. Note: metric is expensive to both query and store!
+
 ### argocd-application-controller
 
 **settings:**
@@ -81,6 +83,8 @@ spec:
         - name: ARGOCD_CONTROLLER_REPLICAS
           value: "2"
 ```
+
+* `ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM`  (v1.8+)- environment variable that enables collecting RPC performance metrics. Enable it if you need to troubleshoot performance issue. Note: metric is expensive to both query and store!
 
 **metrics**
 

--- a/docs/operator-manual/upgrading/1.7-1.8.md
+++ b/docs/operator-manual/upgrading/1.7-1.8.md
@@ -38,4 +38,10 @@ data:
         return hs
 ```
 
+## gRPC metrics are disabled by default
+
+The gRPC metrics are not exposed by default by `argocd-server` and `argocd-repo-server` anymore. These metrics appear
+to be too expensive so we've decided to disable them by default. Metrics can be enabled using
+`ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM=true` environment variable.  
+
 From here on you can follow the [regular upgrade process](./overview.md).

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -2,6 +2,9 @@ package reposerver
 
 import (
 	"crypto/tls"
+	"os"
+
+	"github.com/argoproj/argo-cd/common"
 
 	versionpkg "github.com/argoproj/argo-cd/pkg/apiclient/version"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
@@ -49,7 +52,9 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 	tlsConfig := &tls.Config{Certificates: []tls.Certificate{*cert}}
 	tlsConfCustomizer(tlsConfig)
 
-	grpc_prometheus.EnableHandlingTimeHistogram()
+	if os.Getenv(common.EnvEnableGRPCTimeHistogramEnv) == "true" {
+		grpc_prometheus.EnableHandlingTimeHistogram()
+	}
 
 	serverLog := log.NewEntry(log.StandardLogger())
 	streamInterceptors := []grpc.StreamServerInterceptor{grpc_logrus.StreamServerInterceptor(serverLog), grpc_prometheus.StreamServerInterceptor, grpc_util.PanicLoggerStreamServerInterceptor(serverLog)}

--- a/server/server.go
+++ b/server/server.go
@@ -105,7 +105,6 @@ import (
 
 const maxConcurrentLoginRequestsCountEnv = "ARGOCD_MAX_CONCURRENT_LOGIN_REQUESTS_COUNT"
 const replicasCountEnv = "ARGOCD_API_SERVER_REPLICAS"
-const enableGRPCTimeHistogramEnv = "ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM"
 
 // ErrNoSession indicates no auth token was supplied as part of a request
 var ErrNoSession = status.Errorf(codes.Unauthenticated, "no session information")
@@ -139,7 +138,7 @@ func init() {
 	if replicasCount > 0 {
 		maxConcurrentLoginRequestsCount = maxConcurrentLoginRequestsCount / replicasCount
 	}
-	enableGRPCTimeHistogram = os.Getenv(enableGRPCTimeHistogramEnv) != "false"
+	enableGRPCTimeHistogram = os.Getenv(common.EnvEnableGRPCTimeHistogramEnv) == "true"
 }
 
 // ArgoCDServer is the API server for Argo CD


### PR DESCRIPTION
PR disables collecting gRPC performance metrics by default. The reason is that these metrics are VERY expensive and it is not a good idea to enable it by default for everyone. Disabling it by default and adding documentation that describes how to enable it if necessary