### PR TITLE
feat: Display creation time in application node and summary (#4903)

### DIFF
--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -242,9 +242,9 @@ function renderResourceNode(props: ApplicationResourceTreeProps, id: string, nod
                 </span>
             </div>
             <div className='application-resource-tree__node-labels'>
-                {node.createdAt ? (
+                {node.createdAt || rootNode ? (
                     <Moment className='application-resource-tree__node-label' fromNow={true} ago={true}>
-                        {node.createdAt}
+                        {node.createdAt || props.app.metadata.creationTimestamp}
                     </Moment>
                 ) : null}
                 {(node.info || []).map((tag, i) => (

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -7,6 +7,7 @@ import {Consumer} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 
+import * as moment from 'moment';
 import {ApplicationSyncOptionsField} from '../application-sync-options';
 import {RevisionFormField} from '../revision-form-field/revision-form-field';
 import {ComparisonStatusIcon, HealthStatusIcon, syncStatusMessage} from '../utils';
@@ -126,6 +127,13 @@ export const ApplicationSummary = (props: {app: models.Application; updateApp: (
             title: 'NAMESPACE',
             view: app.spec.destination.namespace,
             edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.destination.namespace' component={Text} />
+        },
+        {
+            title: 'CREATED_AT',
+            view: moment
+                .utc(app.metadata.creationTimestamp)
+                .local()
+                .format('MM/DD/YYYY HH:mm:ss')
         },
         {
             title: 'REPO URL',


### PR DESCRIPTION
This PR adds the creation time inside a bubble to the root node in the network view. It also adds `CREATED_AT` field to the application summary page
Network View:

![Screenshot from 2020-11-27 13-20-11](https://user-images.githubusercontent.com/21128732/100424309-682d2380-30b3-11eb-98a9-0f2e99452a4a.png)

Summary Page:

![Screenshot from 2020-11-27 13-20-23](https://user-images.githubusercontent.com/21128732/100424322-6c594100-30b3-11eb-9d44-e612a501493b.png)


Fixes: #4903

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
