### PR TITLE
fix: refactor GetCluster unique key with server url and cluster name (#4928)

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -124,7 +124,7 @@
           "AccountService"
         ],
         "summary": "CreateToken creates a token",
-        "operationId": "CreateToken",
+        "operationId": "CreateTokenMixin10",
         "parameters": [
           {
             "type": "string",
@@ -157,7 +157,7 @@
           "AccountService"
         ],
         "summary": "DeleteToken deletes a token",
-        "operationId": "DeleteToken",
+        "operationId": "DeleteTokenMixin10",
         "parameters": [
           {
             "type": "string",
@@ -188,7 +188,7 @@
           "ApplicationService"
         ],
         "summary": "List returns list of applications",
-        "operationId": "List",
+        "operationId": "ListMixin9",
         "parameters": [
           {
             "type": "string",
@@ -239,7 +239,7 @@
           "ApplicationService"
         ],
         "summary": "Create creates an application",
-        "operationId": "Create",
+        "operationId": "CreateMixin9",
         "parameters": [
           {
             "name": "body",
@@ -266,7 +266,7 @@
           "ApplicationService"
         ],
         "summary": "Update updates an application",
-        "operationId": "Update",
+        "operationId": "UpdateMixin9",
         "parameters": [
           {
             "type": "string",
@@ -400,7 +400,7 @@
           "ApplicationService"
         ],
         "summary": "Get returns an application by name",
-        "operationId": "Get",
+        "operationId": "GetMixin9",
         "parameters": [
           {
             "type": "string",
@@ -452,7 +452,7 @@
           "ApplicationService"
         ],
         "summary": "Delete deletes an application",
-        "operationId": "Delete",
+        "operationId": "DeleteMixin9",
         "parameters": [
           {
             "type": "string",
@@ -1162,7 +1162,7 @@
           "ClusterService"
         ],
         "summary": "List returns list of clusters",
-        "operationId": "ListMixin3",
+        "operationId": "List",
         "parameters": [
           {
             "type": "string",
@@ -1189,7 +1189,7 @@
           "ClusterService"
         ],
         "summary": "Create creates a cluster",
-        "operationId": "CreateMixin3",
+        "operationId": "Create",
         "parameters": [
           {
             "name": "body",
@@ -1216,7 +1216,7 @@
           "ClusterService"
         ],
         "summary": "Update updates a cluster",
-        "operationId": "UpdateMixin3",
+        "operationId": "Update",
         "parameters": [
           {
             "type": "string",
@@ -1250,7 +1250,7 @@
           "ClusterService"
         ],
         "summary": "Get returns a cluster by server address",
-        "operationId": "GetMixin3",
+        "operationId": "GetMixin2",
         "parameters": [
           {
             "type": "string",
@@ -1278,7 +1278,7 @@
           "ClusterService"
         ],
         "summary": "Delete deletes a cluster",
-        "operationId": "DeleteMixin3",
+        "operationId": "Delete",
         "parameters": [
           {
             "type": "string",
@@ -1358,7 +1358,7 @@
           "GPGKeyService"
         ],
         "summary": "List all available repository certificates",
-        "operationId": "ListMixin4",
+        "operationId": "ListMixin7",
         "parameters": [
           {
             "type": "string",
@@ -1381,7 +1381,7 @@
           "GPGKeyService"
         ],
         "summary": "Create one or more GPG public keys in the server's configuration",
-        "operationId": "CreateMixin4",
+        "operationId": "CreateMixin7",
         "parameters": [
           {
             "description": "Raw key data of the GPG key(s) to create",
@@ -1407,7 +1407,7 @@
           "GPGKeyService"
         ],
         "summary": "Delete specified GPG public key from the server's configuration",
-        "operationId": "DeleteMixin4",
+        "operationId": "DeleteMixin7",
         "parameters": [
           {
             "type": "string",
@@ -1432,7 +1432,7 @@
           "GPGKeyService"
         ],
         "summary": "Get information about specified GPG public key from the server",
-        "operationId": "GetMixin4",
+        "operationId": "GetMixin7",
         "parameters": [
           {
             "type": "string",
@@ -1458,7 +1458,7 @@
           "ProjectService"
         ],
         "summary": "List returns list of projects",
-        "operationId": "ListMixin5",
+        "operationId": "ListMixin6",
         "parameters": [
           {
             "type": "string",
@@ -1480,7 +1480,7 @@
           "ProjectService"
         ],
         "summary": "Create a new project",
-        "operationId": "CreateMixin5",
+        "operationId": "CreateMixin6",
         "parameters": [
           {
             "name": "body",
@@ -1507,7 +1507,7 @@
           "ProjectService"
         ],
         "summary": "Get returns a project by name",
-        "operationId": "GetMixin5",
+        "operationId": "GetMixin6",
         "parameters": [
           {
             "type": "string",
@@ -1530,7 +1530,7 @@
           "ProjectService"
         ],
         "summary": "Delete deletes a project",
-        "operationId": "DeleteMixin5",
+        "operationId": "DeleteMixin6",
         "parameters": [
           {
             "type": "string",
@@ -1630,7 +1630,7 @@
           "ProjectService"
         ],
         "summary": "Update updates a project",
-        "operationId": "UpdateMixin5",
+        "operationId": "UpdateMixin6",
         "parameters": [
           {
             "type": "string",
@@ -1664,7 +1664,7 @@
           "ProjectService"
         ],
         "summary": "Create a new project token",
-        "operationId": "CreateTokenMixin5",
+        "operationId": "CreateToken",
         "parameters": [
           {
             "type": "string",
@@ -1703,7 +1703,7 @@
           "ProjectService"
         ],
         "summary": "Delete a new project token",
-        "operationId": "DeleteTokenMixin5",
+        "operationId": "DeleteToken",
         "parameters": [
           {
             "type": "string",
@@ -1948,7 +1948,7 @@
           "RepositoryService"
         ],
         "summary": "Get returns a repository or its credentials",
-        "operationId": "GetMixin7",
+        "operationId": "GetMixin3",
         "parameters": [
           {
             "type": "string",
@@ -2176,7 +2176,7 @@
           "SessionService"
         ],
         "summary": "Create a new JWT for authentication and set a cookie if using HTTP",
-        "operationId": "CreateMixin8",
+        "operationId": "CreateMixin11",
         "parameters": [
           {
             "name": "body",
@@ -2201,7 +2201,7 @@
           "SessionService"
         ],
         "summary": "Delete an existing JWT cookie if using HTTP",
-        "operationId": "DeleteMixin8",
+        "operationId": "DeleteMixin11",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -2235,7 +2235,7 @@
           "SettingsService"
         ],
         "summary": "Get returns Argo CD settings",
-        "operationId": "GetMixin10",
+        "operationId": "Get",
         "responses": {
           "200": {
             "description": "A successful response.",

--- a/cmd/argocd-util/commands/apps.go
+++ b/cmd/argocd-util/commands/apps.go
@@ -307,7 +307,7 @@ func reconcileApplications(
 	for _, app := range appsList.Items {
 		if prevServer != app.Spec.Destination.Server {
 			if prevServer != "" {
-				if clusterCache, err := stateCache.GetClusterCache(prevServer); err == nil {
+				if clusterCache, err := stateCache.GetClusterCache(prevServer, app.Spec.Destination.Name); err == nil {
 					clusterCache.Invalidate()
 				}
 			}

--- a/cmd/argocd-util/commands/apps_test.go
+++ b/cmd/argocd-util/commands/apps_test.go
@@ -89,7 +89,7 @@ func TestGetReconcileResults_Refresh(t *testing.T) {
 	deployment := test.NewDeployment()
 	kubeClientset := kubefake.NewSimpleClientset(deployment, &cm)
 	clusterCache := clustermocks.ClusterCache{}
-	clusterCache.On("IsNamespaced", mock.Anything).Return(true, nil)
+	clusterCache.On("IsNamespaced", mock.Anything, mock.Anything).Return(true, nil)
 	repoServerClient := mocks.RepoServerServiceClient{}
 	repoServerClient.On("GenerateManifest", mock.Anything, mock.Anything).Return(&apiclient.ManifestResponse{
 		Manifests: []string{test.DeploymentManifest},
@@ -99,10 +99,10 @@ func TestGetReconcileResults_Refresh(t *testing.T) {
 	liveStateCache.On("GetManagedLiveObjs", mock.Anything, mock.Anything).Return(map[kube.ResourceKey]*unstructured.Unstructured{
 		kube.GetResourceKey(deployment): deployment,
 	}, nil)
-	liveStateCache.On("GetVersionsInfo", mock.Anything).Return("v1.2.3", nil, nil)
+	liveStateCache.On("GetVersionsInfo", mock.Anything, mock.Anything).Return("v1.2.3", nil, nil)
 	liveStateCache.On("Init").Return(nil, nil)
-	liveStateCache.On("GetClusterCache", mock.Anything).Return(&clusterCache, nil)
-	liveStateCache.On("IsNamespaced", mock.Anything, mock.Anything).Return(true, nil)
+	liveStateCache.On("GetClusterCache", mock.Anything, mock.Anything).Return(&clusterCache, nil)
+	liveStateCache.On("IsNamespaced", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 
 	result, err := reconcileApplications(kubeClientset, appClientset, "default", &repoServerClientset, "",
 		func(argoDB db.ArgoDB, appInformer cache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) statecache.LiveStateCache {

--- a/cmd/argocd-util/commands/argocd_util.go
+++ b/cmd/argocd-util/commands/argocd_util.go
@@ -632,7 +632,7 @@ func NewClusterConfig() *cobra.Command {
 			kubeclientset, err := kubernetes.NewForConfig(conf)
 			errors.CheckError(err)
 
-			cluster, err := db.NewDB(namespace, settings.NewSettingsManager(context.Background(), kubeclientset, namespace), kubeclientset).GetCluster(context.Background(), serverUrl)
+			cluster, err := db.NewDB(namespace, settings.NewSettingsManager(context.Background(), kubeclientset, namespace), kubeclientset).GetCluster(context.Background(), serverUrl, "")
 			errors.CheckError(err)
 			err = kube.WriteKubeConfig(cluster.RawRestConfig(), namespace, output)
 			errors.CheckError(err)

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -108,21 +108,21 @@ func newFakeController(data *fakeData) *ApplicationController {
 	cancelApp := test.StartInformer(ctrl.appInformer)
 	defer cancelApp()
 	clusterCacheMock := mocks.ClusterCache{}
-	clusterCacheMock.On("IsNamespaced", mock.Anything).Return(true, nil)
+	clusterCacheMock.On("IsNamespaced", mock.Anything, mock.Anything).Return(true, nil)
 
 	mockStateCache := mockstatecache.LiveStateCache{}
 	ctrl.appStateManager.(*appStateManager).liveStateCache = &mockStateCache
 	ctrl.stateCache = &mockStateCache
-	mockStateCache.On("IsNamespaced", mock.Anything, mock.Anything).Return(true, nil)
+	mockStateCache.On("IsNamespaced", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 	mockStateCache.On("GetManagedLiveObjs", mock.Anything, mock.Anything).Return(data.managedLiveObjs, nil)
-	mockStateCache.On("GetVersionsInfo", mock.Anything).Return("v1.2.3", nil, nil)
+	mockStateCache.On("GetVersionsInfo", mock.Anything, mock.Anything).Return("v1.2.3", nil, nil)
 	response := make(map[kube.ResourceKey]argoappv1.ResourceNode)
 	for k, v := range data.namespacedResources {
 		response[k] = v.ResourceNode
 	}
-	mockStateCache.On("GetNamespaceTopLevelResources", mock.Anything, mock.Anything).Return(response, nil)
-	mockStateCache.On("GetClusterCache", mock.Anything).Return(&clusterCacheMock, nil)
-	mockStateCache.On("IterateHierarchy", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	mockStateCache.On("GetNamespaceTopLevelResources", mock.Anything, mock.Anything, mock.Anything).Return(response, nil)
+	mockStateCache.On("GetClusterCache", mock.Anything, mock.Anything).Return(&clusterCacheMock, nil)
+	mockStateCache.On("IterateHierarchy", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		key := args[1].(kube.ResourceKey)
 		action := args[2].(func(child argoappv1.ResourceNode, appName string))
 		appName := ""

--- a/controller/cache/mocks/LiveStateCache.go
+++ b/controller/cache/mocks/LiveStateCache.go
@@ -26,12 +26,12 @@ type LiveStateCache struct {
 }
 
 // GetClusterCache provides a mock function with given fields: server
-func (_m *LiveStateCache) GetClusterCache(server string) (cache.ClusterCache, error) {
-	ret := _m.Called(server)
+func (_m *LiveStateCache) GetClusterCache(server string, name string) (cache.ClusterCache, error) {
+	ret := _m.Called(server, name)
 
 	var r0 cache.ClusterCache
-	if rf, ok := ret.Get(0).(func(string) cache.ClusterCache); ok {
-		r0 = rf(server)
+	if rf, ok := ret.Get(0).(func(string, string) cache.ClusterCache); ok {
+		r0 = rf(server, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(cache.ClusterCache)
@@ -39,8 +39,8 @@ func (_m *LiveStateCache) GetClusterCache(server string) (cache.ClusterCache, er
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(server)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(server, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -88,12 +88,12 @@ func (_m *LiveStateCache) GetManagedLiveObjs(a *v1alpha1.Application, targetObjs
 }
 
 // GetNamespaceTopLevelResources provides a mock function with given fields: server, namespace
-func (_m *LiveStateCache) GetNamespaceTopLevelResources(server string, namespace string) (map[kube.ResourceKey]v1alpha1.ResourceNode, error) {
-	ret := _m.Called(server, namespace)
+func (_m *LiveStateCache) GetNamespaceTopLevelResources(server string, name string, namespace string) (map[kube.ResourceKey]v1alpha1.ResourceNode, error) {
+	ret := _m.Called(server, name, namespace)
 
 	var r0 map[kube.ResourceKey]v1alpha1.ResourceNode
-	if rf, ok := ret.Get(0).(func(string, string) map[kube.ResourceKey]v1alpha1.ResourceNode); ok {
-		r0 = rf(server, namespace)
+	if rf, ok := ret.Get(0).(func(string, string, string) map[kube.ResourceKey]v1alpha1.ResourceNode); ok {
+		r0 = rf(server, name, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[kube.ResourceKey]v1alpha1.ResourceNode)
@@ -101,8 +101,8 @@ func (_m *LiveStateCache) GetNamespaceTopLevelResources(server string, namespace
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(server, namespace)
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(server, name, namespace)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -111,19 +111,19 @@ func (_m *LiveStateCache) GetNamespaceTopLevelResources(server string, namespace
 }
 
 // GetVersionsInfo provides a mock function with given fields: serverURL
-func (_m *LiveStateCache) GetVersionsInfo(serverURL string) (string, []v1.APIGroup, error) {
-	ret := _m.Called(serverURL)
+func (_m *LiveStateCache) GetVersionsInfo(serverURL string, name string) (string, []v1.APIGroup, error) {
+	ret := _m.Called(serverURL, name)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(serverURL)
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(serverURL, name)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 []v1.APIGroup
-	if rf, ok := ret.Get(1).(func(string) []v1.APIGroup); ok {
-		r1 = rf(serverURL)
+	if rf, ok := ret.Get(1).(func(string, string) []v1.APIGroup); ok {
+		r1 = rf(serverURL, name)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]v1.APIGroup)
@@ -131,8 +131,8 @@ func (_m *LiveStateCache) GetVersionsInfo(serverURL string) (string, []v1.APIGro
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string) error); ok {
-		r2 = rf(serverURL)
+	if rf, ok := ret.Get(2).(func(string, string) error); ok {
+		r2 = rf(serverURL, name)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -155,19 +155,19 @@ func (_m *LiveStateCache) Init() error {
 }
 
 // IsNamespaced provides a mock function with given fields: server, gk
-func (_m *LiveStateCache) IsNamespaced(server string, gk schema.GroupKind) (bool, error) {
-	ret := _m.Called(server, gk)
+func (_m *LiveStateCache) IsNamespaced(server string, name string, gk schema.GroupKind) (bool, error) {
+	ret := _m.Called(server, name, gk)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(string, schema.GroupKind) bool); ok {
-		r0 = rf(server, gk)
+	if rf, ok := ret.Get(0).(func(string, string, schema.GroupKind) bool); ok {
+		r0 = rf(server, name, gk)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, schema.GroupKind) error); ok {
-		r1 = rf(server, gk)
+	if rf, ok := ret.Get(1).(func(string, string, schema.GroupKind) error); ok {
+		r1 = rf(server, name, gk)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -176,7 +176,7 @@ func (_m *LiveStateCache) IsNamespaced(server string, gk schema.GroupKind) (bool
 }
 
 // IterateHierarchy provides a mock function with given fields: server, key, action
-func (_m *LiveStateCache) IterateHierarchy(server string, key kube.ResourceKey, action func(v1alpha1.ResourceNode, string)) error {
+func (_m *LiveStateCache) IterateHierarchy(server string, name string, key kube.ResourceKey, action func(v1alpha1.ResourceNode, string)) error {
 	ret := _m.Called(server, key, action)
 
 	var r0 error

--- a/controller/state.go
+++ b/controller/state.go
@@ -149,7 +149,7 @@ func (m *appStateManager) getRepoObjs(app *v1alpha1.Application, source v1alpha1
 		return nil, nil, err
 	}
 	ts.AddCheckpoint("build_options_ms")
-	serverVersion, apiGroups, err := m.liveStateCache.GetVersionsInfo(app.Spec.Destination.Server)
+	serverVersion, apiGroups, err := m.liveStateCache.GetVersionsInfo(app.Spec.Destination.Server, app.Spec.Destination.Name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -369,7 +369,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *ap
 	ts.AddCheckpoint("git_ms")
 
 	var infoProvider kubeutil.ResourceInfoProvider
-	infoProvider, err = m.liveStateCache.GetClusterCache(app.Spec.Destination.Server)
+	infoProvider, err = m.liveStateCache.GetClusterCache(app.Spec.Destination.Server, app.Spec.Destination.Name)
 	if err != nil {
 		infoProvider = &resourceInfoProviderStub{}
 	}
@@ -489,7 +489,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *ap
 			resState.Status = v1alpha1.SyncStatusCodeSynced
 		}
 		// set unknown status to all resource that are not permitted in the app project
-		isNamespaced, err := m.liveStateCache.IsNamespaced(app.Spec.Destination.Server, gvk.GroupKind())
+		isNamespaced, err := m.liveStateCache.IsNamespaced(app.Spec.Destination.Server, app.Spec.Destination.Name, gvk.GroupKind())
 		if !project.IsGroupKindPermitted(gvk.GroupKind(), isNamespaced && err == nil) {
 			resState.Status = v1alpha1.SyncStatusCodeUnknown
 		}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -100,7 +100,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		return
 	}
 
-	clst, err := m.db.GetCluster(context.Background(), app.Spec.Destination.Server)
+	clst, err := m.db.GetCluster(context.Background(), app.Spec.Destination.Server, app.Spec.Destination.Name)
 	if err != nil {
 		state.Phase = common.OperationError
 		state.Message = err.Error()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/argoproj/gitops-engine v0.2.1
-	github.com/argoproj/pkg v0.2.0
+	github.com/argoproj/pkg v0.3.0
 	github.com/bombsimon/logrusr v1.0.0
 	github.com/casbin/casbin v1.9.1
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/argoproj/gitops-engine v0.2.1 h1:iXmTCCM0m2u/YVLMhJatU21awuAscGiirscn13rYQtE=
 github.com/argoproj/gitops-engine v0.2.1/go.mod h1:OxXp8YaT73rw9gEBnGBWg55af80nkV/uIjWCbJu1Nw0=
-github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=
-github.com/argoproj/pkg v0.2.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
+github.com/argoproj/pkg v0.3.0 h1:0xxNHc9duXZt1TlDVVsBzcGm8S/V5Bc3eNqawz3wFo8=
+github.com/argoproj/pkg v0.3.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -468,8 +468,10 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -808,6 +810,7 @@ golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -950,6 +953,7 @@ gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -779,7 +779,7 @@ func (s *Server) getApplicationClusterConfig(ctx context.Context, a *appv1.Appli
 	if err := argo.ValidateDestination(ctx, &a.Spec.Destination, s.db); err != nil {
 		return nil, err
 	}
-	clst, err := s.db.GetCluster(ctx, a.Spec.Destination.Server)
+	clst, err := s.db.GetCluster(ctx, a.Spec.Destination.Server, a.Spec.Destination.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -240,7 +240,7 @@ func ValidateRepo(
 
 	enrichSpec(spec, appDetails)
 
-	cluster, err := db.GetCluster(context.Background(), spec.Destination.Server)
+	cluster, err := db.GetCluster(context.Background(), spec.Destination.Server, spec.Destination.Name)
 	if err != nil {
 		conditions = append(conditions, argoappv1.ApplicationCondition{
 			Type:    argoappv1.ApplicationConditionInvalidSpecError,
@@ -334,7 +334,7 @@ func ValidatePermissions(ctx context.Context, spec *argoappv1.ApplicationSpec, p
 			})
 		}
 		// Ensure the k8s cluster the app is referencing, is configured in Argo CD
-		_, err := db.GetCluster(ctx, spec.Destination.Server)
+		_, err := db.GetCluster(ctx, spec.Destination.Server, spec.Destination.Name)
 		if err != nil {
 			if errStatus, ok := status.FromError(err); ok && errStatus.Code() == codes.NotFound {
 				conditions = append(conditions, argoappv1.ApplicationCondition{

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -251,7 +251,7 @@ func TestValidateRepo(t *testing.T) {
 
 	db.On("GetRepository", context.Background(), app.Spec.Source.RepoURL).Return(repo, nil)
 	db.On("ListHelmRepositories", context.Background()).Return(helmRepos, nil)
-	db.On("GetCluster", context.Background(), app.Spec.Destination.Server).Return(cluster, nil)
+	db.On("GetCluster", context.Background(), app.Spec.Destination.Server, app.Spec.Destination.Name).Return(cluster, nil)
 
 	var receivedRequest *apiclient.ManifestRequest
 
@@ -412,7 +412,7 @@ func TestValidatePermissions(t *testing.T) {
 		}
 		cluster := &argoappv1.Cluster{Server: "https://127.0.0.1:6443"}
 		db := &dbmocks.ArgoDB{}
-		db.On("GetCluster", context.Background(), spec.Destination.Server).Return(cluster, nil)
+		db.On("GetCluster", context.Background(), spec.Destination.Server, spec.Destination.Name).Return(cluster, nil)
 		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		assert.NoError(t, err)
 		assert.Len(t, conditions, 1)
@@ -445,7 +445,7 @@ func TestValidatePermissions(t *testing.T) {
 		}
 		cluster := &argoappv1.Cluster{Server: "https://127.0.0.1:6443"}
 		db := &dbmocks.ArgoDB{}
-		db.On("GetCluster", context.Background(), spec.Destination.Server).Return(cluster, nil)
+		db.On("GetCluster", context.Background(), spec.Destination.Server, spec.Destination.Name).Return(cluster, nil)
 		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		assert.NoError(t, err)
 		assert.Len(t, conditions, 1)
@@ -477,7 +477,7 @@ func TestValidatePermissions(t *testing.T) {
 			},
 		}
 		db := &dbmocks.ArgoDB{}
-		db.On("GetCluster", context.Background(), spec.Destination.Server).Return(nil, status.Errorf(codes.NotFound, "Cluster does not exist"))
+		db.On("GetCluster", context.Background(), spec.Destination.Server, spec.Destination.Name).Return(nil, status.Errorf(codes.NotFound, "Cluster does not exist"))
 		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		assert.NoError(t, err)
 		assert.Len(t, conditions, 1)
@@ -509,7 +509,7 @@ func TestValidatePermissions(t *testing.T) {
 			},
 		}
 		db := &dbmocks.ArgoDB{}
-		db.On("GetCluster", context.Background(), spec.Destination.Server).Return(nil, fmt.Errorf("Unknown error occurred"))
+		db.On("GetCluster", context.Background(), spec.Destination.Server, spec.Destination.Name).Return(nil, fmt.Errorf("Unknown error occurred"))
 		_, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		assert.Error(t, err)
 	})

--- a/util/db/cluster_norace_test.go
+++ b/util/db/cluster_norace_test.go
@@ -39,7 +39,7 @@ func TestWatchClusters_CreateRemoveCluster(t *testing.T) {
 			assert.Equal(t, new.Server, "https://minikube")
 			assert.Equal(t, new.Name, "minikube")
 
-			assert.NoError(t, db.DeleteCluster(context.Background(), "https://minikube"))
+			assert.NoError(t, db.DeleteCluster(context.Background(), "https://minikube", ""))
 		},
 		func(old *v1alpha1.Cluster, new *v1alpha1.Cluster) {
 			assert.Nil(t, new)
@@ -73,7 +73,7 @@ func TestWatchClusters_LocalClusterModifications(t *testing.T) {
 			assert.Equal(t, new.Server, common.KubernetesInternalAPIServerAddr)
 			assert.Equal(t, new.Name, "some name")
 
-			assert.NoError(t, db.DeleteCluster(context.Background(), common.KubernetesInternalAPIServerAddr))
+			assert.NoError(t, db.DeleteCluster(context.Background(), common.KubernetesInternalAPIServerAddr, ""))
 		},
 		func(old *v1alpha1.Cluster, new *v1alpha1.Cluster) {
 			assert.Equal(t, new.Server, common.KubernetesInternalAPIServerAddr)

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -115,7 +115,7 @@ func TestDeleteUnknownCluster(t *testing.T) {
 	})
 	settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
-	assert.EqualError(t, db.DeleteCluster(context.Background(), "http://unknown"), `rpc error: code = NotFound desc = cluster "http://unknown" not found`)
+	assert.EqualError(t, db.DeleteCluster(context.Background(), "http://unknown", ""), `rpc error: code = NotFound desc = cluster "http://unknown" not found`)
 }
 
 func runWatchTest(t *testing.T, db ArgoDB, actions []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster)) {

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -21,11 +21,11 @@ type ArgoDB interface {
 		handleModEvent func(oldCluster *appv1.Cluster, newCluster *appv1.Cluster),
 		handleDeleteEvent func(clusterServer string)) error
 	// Get returns a cluster from a query
-	GetCluster(ctx context.Context, server string) (*appv1.Cluster, error)
+	GetCluster(ctx context.Context, server string, name string) (*appv1.Cluster, error)
 	// UpdateCluster updates a cluster
 	UpdateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Cluster, error)
 	// DeleteCluster deletes a cluster by name
-	DeleteCluster(ctx context.Context, server string) error
+	DeleteCluster(ctx context.Context, server string, name string) error
 
 	// ListRepositories lists repositories
 	ListRepositories(ctx context.Context) ([]*appv1.Repository, error)

--- a/util/db/db_test.go
+++ b/util/db/db_test.go
@@ -313,7 +313,7 @@ func TestGetClusterSuccessful(t *testing.T) {
 	})
 
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
-	cluster, err := db.GetCluster(context.Background(), server)
+	cluster, err := db.GetCluster(context.Background(), server, name)
 	assert.NoError(t, err)
 	assert.Equal(t, server, cluster.Server)
 	assert.Equal(t, name, cluster.Name)
@@ -324,7 +324,7 @@ func TestGetNonExistingCluster(t *testing.T) {
 	clientset := getClientset(nil)
 
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
-	_, err := db.GetCluster(context.Background(), server)
+	_, err := db.GetCluster(context.Background(), server, "")
 	assert.NotNil(t, err)
 	status, ok := status.FromError(err)
 	assert.True(t, ok)
@@ -370,7 +370,7 @@ func TestDeleteClusterWithManagedSecret(t *testing.T) {
 	})
 
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
-	err := db.DeleteCluster(context.Background(), clusterURL)
+	err := db.DeleteCluster(context.Background(), clusterURL, clusterName)
 	assert.Nil(t, err)
 
 	_, err = clientset.CoreV1().Secrets(testNamespace).Get(context.Background(), clusterName, metav1.GetOptions{})
@@ -398,7 +398,7 @@ func TestDeleteClusterWithUnmanagedSecret(t *testing.T) {
 	})
 
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
-	err := db.DeleteCluster(context.Background(), clusterURL)
+	err := db.DeleteCluster(context.Background(), clusterURL, clusterName)
 	assert.Nil(t, err)
 
 	secret, err := clientset.CoreV1().Secrets(testNamespace).Get(context.Background(), clusterName, metav1.GetOptions{})

--- a/util/db/mocks/ArgoDB.go
+++ b/util/db/mocks/ArgoDB.go
@@ -141,12 +141,12 @@ func (_m *ArgoDB) CreateRepositoryCredentials(ctx context.Context, r *v1alpha1.R
 }
 
 // DeleteCluster provides a mock function with given fields: ctx, server
-func (_m *ArgoDB) DeleteCluster(ctx context.Context, server string) error {
-	ret := _m.Called(ctx, server)
+func (_m *ArgoDB) DeleteCluster(ctx context.Context, server string, name string) error {
+	ret := _m.Called(ctx, server, name)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, server)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, server, name)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -197,12 +197,12 @@ func (_m *ArgoDB) DeleteRepositoryCredentials(ctx context.Context, name string) 
 }
 
 // GetCluster provides a mock function with given fields: ctx, server
-func (_m *ArgoDB) GetCluster(ctx context.Context, server string) (*v1alpha1.Cluster, error) {
-	ret := _m.Called(ctx, server)
+func (_m *ArgoDB) GetCluster(ctx context.Context, server string, name string) (*v1alpha1.Cluster, error) {
+	ret := _m.Called(ctx, server, name)
 
 	var r0 *v1alpha1.Cluster
-	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.Cluster); ok {
-		r0 = rf(ctx, server)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v1alpha1.Cluster); ok {
+		r0 = rf(ctx, server, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1alpha1.Cluster)
@@ -210,8 +210,8 @@ func (_m *ArgoDB) GetCluster(ctx context.Context, server string) (*v1alpha1.Clus
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, server)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, server, name)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This is PR is to resolve [Duplicate cluster URL permission incorrect. #4928](https://github.com/argoproj/argo-cd/issues/4928)

I tried to refactor the `GetCluster` method receive parameters, support for getting cluster secret based on server_url and cluster_name.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
