### PR TITLE
fix: Update the order of arguments to Match function (#4914)

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2498,9 +2498,9 @@ func (spec ApplicationSpec) GetRevisionHistoryLimit() int {
 
 func isResourceInList(res metav1.GroupKind, list []metav1.GroupKind) bool {
 	for _, item := range list {
-		ok, err := filepath.Match(item.Kind, res.Kind)
+		ok, err := filepath.Match(res.Kind, item.Kind)
 		if ok && err == nil {
-			ok, err = filepath.Match(item.Group, res.Group)
+			ok, err = filepath.Match(res.Group, item.Group)
 			if ok && err == nil {
 				return true
 			}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2155,3 +2155,45 @@ func TestSourceAllowsConcurrentProcessing_KustomizeParams(t *testing.T) {
 
 	assert.False(t, src.AllowsConcurrentProcessing())
 }
+
+func TestIsResourceInList(t *testing.T) {
+	resourceList := []metav1.GroupKind{
+		{Group: "sample.group.test", Kind: "Alpha"},
+		{Group: "sample.group.test", Kind: "Beta"},
+		{Group: "sample.group.test", Kind: "Gamma"},
+	}
+
+	tests := []struct {
+		name string
+		res  metav1.GroupKind
+		want bool
+	}{
+		{
+			name: "Resource present in list",
+			res:  metav1.GroupKind{Group: "sample.group.test", Kind: "Gamma"},
+			want: true,
+		},
+		{
+			name: "Resource absent in list",
+			res:  metav1.GroupKind{Group: "sample", Kind: "test"},
+			want: false,
+		},
+		{
+			name: "Valid Wildcard pattern",
+			res:  metav1.GroupKind{Group: "*.group.test", Kind: "*"},
+			want: true,
+		},
+		{
+			name: "Invalid Wildcard pattern",
+			res:  metav1.GroupKind{Group: "---", Kind: "*"},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isResourceInList(test.res, resourceList)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR updates the order of arguments passed to filepath.Match. With this change users can use wildcard patterns to define the resources to be included.

Fixes: #4914
Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
