### PR TITLE
fix: rollout health could incorrectly report v0.9 rollouts as Progressing

### DIFF
--- a/resource_customizations/argoproj.io/Rollout/actions/discovery.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/discovery.lua
@@ -16,7 +16,7 @@ actions["retry"] = {["disabled"] = fullyPromoted or not(obj.status.abort)}
 actions["promote-full"] = {["disabled"] = true}
 if obj.status ~= nil and not(fullyPromoted) then
     generation = tonumber(obj.status.observedGeneration)
-    if generation == nil then
+    if generation == nil or generation > obj.metadata.generation then
         -- rollouts v0.9 - full promotion only supported for canary
         actions["promote-full"] = {["disabled"] = obj.spec.strategy.blueGreen ~= nil}
     else

--- a/resource_customizations/argoproj.io/Rollout/actions/promote-full/action.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/promote-full/action.lua
@@ -1,6 +1,6 @@
 if obj.status ~= nil then
     generation = tonumber(obj.status.observedGeneration)
-    if generation == nil then
+    if generation == nil or generation > obj.metadata.generation then
         -- rollouts v0.9 and below
         obj.status.abort = nil
         if obj.spec.strategy.canary.steps ~= nil then

--- a/resource_customizations/argoproj.io/Rollout/health_test.yaml
+++ b/resource_customizations/argoproj.io/Rollout/health_test.yaml
@@ -12,6 +12,10 @@ tests:
     message: ""
   inputPath: testdata/healthy_legacy_v0.9_observedGeneration.yaml
 - healthStatus:
+    status: Healthy
+    message: ""
+  inputPath: testdata/healthy_legacy_v0.9_observedGeneration_numeric.yaml
+- healthStatus:
     status: Degraded
     message: "The Rollout \"basic\" is invalid: spec.strategy.strategy: Required value: Rollout has missing field '.spec.strategy.canary or .spec.strategy.blueGreen'"
   inputPath: testdata/degraded_invalidSpec.yaml

--- a/resource_customizations/argoproj.io/Rollout/testdata/healthy_legacy_v0.9_observedGeneration_numeric.yaml
+++ b/resource_customizations/argoproj.io/Rollout/testdata/healthy_legacy_v0.9_observedGeneration_numeric.yaml
@@ -1,0 +1,60 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  creationTimestamp: "2020-11-13T00:44:55Z"
+  generation: 1
+  name: basic
+  namespace: argocd-e2e
+  resourceVersion: "182108"
+  selfLink: /apis/argoproj.io/v1alpha1/namespaces/argocd-e2e/rollouts/basic
+  uid: 34e4bbfc-222c-4968-bd60-2b30ae81110d
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: basic
+  strategy:
+    canary:
+      steps:
+      - setWeight: 50
+      - pause: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: basic
+    spec:
+      containers:
+      - image: nginx:1.19-alpine
+        name: basic
+        resources:
+          requests:
+            cpu: 1m
+            memory: 16Mi
+status:
+  HPAReplicas: 1
+  availableReplicas: 1
+  blueGreen: {}
+  canary: {}
+  conditions:
+  - lastTransitionTime: "2020-11-13T00:48:20Z"
+    lastUpdateTime: "2020-11-13T00:48:22Z"
+    message: ReplicaSet "basic-754cb84d5" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: "2020-11-13T00:48:22Z"
+    lastUpdateTime: "2020-11-13T00:48:22Z"
+    message: Rollout has minimum availability
+    reason: AvailableReason
+    status: "True"
+    type: Available
+  currentPodHash: 754cb84d5
+  currentStepHash: 757f5f97b
+  currentStepIndex: 2
+  observedGeneration: "8575574967"  ##  <---- uses legacy observedGeneration hash which are numbers
+  readyReplicas: 1
+  replicas: 1
+  selector: app=basic
+  stableRS: 754cb84d5
+  updatedReplicas: 1


### PR DESCRIPTION
The recent modifications I made to the Rollout health lua script could mis-identify a v0.9 Rollout which happened to have a numeric hash, as a v0.10 rollout, and incorrectly report the Rollout as Progressing, even though it was not.

Signed-off-by: Jesse Suen <Jesse_Suen@intuit.com>
