### PR TITLE
fix: reset cached manifest generation errors after 1hr instead of 12 requests

### DIFF
--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -32,8 +32,8 @@ const (
 	gnuPGSourcePath = "/app/config/gpg/source"
 
 	defaultPauseGenerationAfterFailedGenerationAttempts = 3
-	defaultPauseGenerationOnFailureForMinutes           = 0
-	defaultPauseGenerationOnFailureForRequests          = 12
+	defaultPauseGenerationOnFailureForMinutes           = 60
+	defaultPauseGenerationOnFailureForRequests          = 0
 )
 
 func getGnuPGSourcePath() string {


### PR DESCRIPTION
PR changes default repo-server settings to cache manifest generation errors more aggressively. In real life controller make a lot of repo-server queries and quickly exhausts requests limit. Changing default to 60 minutes instead of 12 requests.

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>
