### PR TITLE
docs: The default keycloak realm is master

### DIFF
--- a/docs/operator-manual/user-management/keycloak.md
+++ b/docs/operator-manual/user-management/keycloak.md
@@ -8,7 +8,7 @@ to determine privileges in Argo.
 
 ## Creating a new client in Keycloak
 
-First we need to setup a new client. Start by logging into your keycloak server, select the realm you want to use (Master by default)
+First we need to setup a new client. Start by logging into your keycloak server, select the realm you want to use (`master` by default)
 and then go to __Clients__ and click the __create__ button top right.
 
 ![Keycloak add client](../../assets/keycloak-add-client.png "Keycloak add client")
@@ -83,14 +83,14 @@ data:
   url: https://argocd.example.com
   oidc.config: |
     name: Keycloak
-    issuer: https://keycloak.example.com/auth/realms/Master
+    issuer: https://keycloak.example.com/auth/realms/master
     clientID: argocd
     clientSecret: $oidc.keycloak.clientSecret
     requestedScopes: ["openid", "profile", "email", "groups"]
 ```
 
 Make sure that:
-- __issuer__ ends with the correct realm (in this example _Master_)
+- __issuer__ ends with the correct realm (in this example _master_)
 - __clientID__ is set to the Client ID you configured in Keycloak
 - __clientSecret__ points to the right key you created in the _argocd-secret_ Secret
 - __requestedScopes__ contains the _groups_ claim if you didn't add it to the Default scopes


### PR DESCRIPTION
Visually it looks like `Master`, but it actually `master`



---

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
