### PR TITLE
fix: use json serialization to store cache instead of github.com/vmihailenco/msgpack

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -193,7 +193,7 @@ const (
 	MinClientVersion = "1.4.0"
 	// CacheVersion is a objects version cached using util/cache/cache.go.
 	// Number should be bumped in case of backward incompatible change to make sure cache is invalidated after upgrade.
-	CacheVersion = "1.8.2"
+	CacheVersion = "1.8.3"
 )
 
 // GetGnuPGHomePath retrieves the path to use for GnuPG home directory, which is either taken from GNUPGHOME environment or a default value

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -127,11 +127,11 @@ func appDetailsCacheKey(revision string, appSrc *appv1.ApplicationSource) string
 	return fmt.Sprintf("appdetails|%s|%d", revision, appSourceKey(appSrc))
 }
 
-func (c *Cache) GetAppDetails(revision string, appSrc *appv1.ApplicationSource, res interface{}) error {
+func (c *Cache) GetAppDetails(revision string, appSrc *appv1.ApplicationSource, res *apiclient.RepoAppDetailsResponse) error {
 	return c.cache.GetItem(appDetailsCacheKey(revision, appSrc), res)
 }
 
-func (c *Cache) SetAppDetails(revision string, appSrc *appv1.ApplicationSource, res interface{}) error {
+func (c *Cache) SetAppDetails(revision string, appSrc *appv1.ApplicationSource, res *apiclient.RepoAppDetailsResponse) error {
 	return c.cache.SetItem(appDetailsCacheKey(revision, appSrc), res, c.repoCacheExpiration, res == nil)
 }
 

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1026,7 +1026,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 
 	getCached := func(revision string, _ bool) (bool, interface{}, error) {
 		res := &apiclient.RepoAppDetailsResponse{}
-		err := s.cache.GetAppDetails(revision, q.Source, &res)
+		err := s.cache.GetAppDetails(revision, q.Source, res)
 		if err == nil {
 			log.Infof("app details cache hit: %s/%s", revision, q.Source.Path)
 			return true, res, nil

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -79,13 +79,13 @@ type Cache struct {
 }
 
 func (c *Cache) SetItem(key string, item interface{}, expiration time.Duration, delete bool) error {
-	if item == nil {
-		return fmt.Errorf("cannot set item to nil for key %s", key)
-	}
 	key = fmt.Sprintf("%s|%s", key, common.CacheVersion)
 	if delete {
 		return c.client.Delete(key)
 	} else {
+		if item == nil {
+			return fmt.Errorf("cannot set item to nil for key %s", key)
+		}
 		return c.client.Set(&Item{Object: item, Key: key, Expiration: expiration})
 	}
 }

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	ioutil "github.com/argoproj/argo-cd/util/io"
@@ -30,20 +31,28 @@ func (r *redisCache) Set(item *Item) error {
 		expiration = r.expiration
 	}
 
+	val, err := json.Marshal(item.Object)
+	if err != nil {
+		return err
+	}
+
 	return r.cache.Set(&rediscache.Item{
 		Key:   item.Key,
-		Value: item.Object,
+		Value: val,
 		TTL:   expiration,
 	})
 }
 
 func (r *redisCache) Get(key string, obj interface{}) error {
-	err := r.cache.Get(context.TODO(), key, obj)
-
+	var data []byte
+	err := r.cache.Get(context.TODO(), key, &data)
 	if err == rediscache.ErrCacheMiss {
-		return ErrCacheMiss
+		err = ErrCacheMiss
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, obj)
 }
 
 func (r *redisCache) Delete(key string) error {


### PR DESCRIPTION
PR changes how the cache data structures are serialized: switches serialization to json instead of using `github.com/vmihailenco/msgpack`. There are two reasons to switch:

* Resolve #4933 . The panic is happening in https://github.com/vmihailenco/bufpool . The repository is archived and it is not clear how to fix the problem.
* The msgpack might quietly return "empty" data structure instead of throwing an error if serialized data is corrupted. We've implemented protection for cache manifest (https://github.com/argoproj/argo-cd/issues/4238) but other cached data structures still might be deserialized incorrectly. It caused at least one incident already.

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>