### PR TITLE
fix: update helm version help text

### DIFF
--- a/ui/src/app/shared/components/revision-help-icon.tsx
+++ b/ui/src/app/shared/components/revision-help-icon.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 export const RevisionHelpIcon = ({type, top, right}: {type: string; top?: string; right?: string}) => (
     <div style={{position: 'absolute', top: top === undefined ? '1em' : top, right: right === undefined ? '0.5em' : right}}>
         {type === 'helm' ? (
-            <HelpIcon title='E.g. 1.2.0, 1.2.*, 1.*, or *' />
+            <HelpIcon title='E.g. 1.2.0, 1.2.x, 1.x, or x' />
         ) : (
             <HelpIcon title='Branches, tags, commit hashes and symbolic refs are allowed. E.g. "master", "v1.2.0", "0a1b2c3", or "HEAD".' />
         )}


### PR DESCRIPTION
Changes incorrect helm version help text on app creation page. Semver uses `x` instead of `*`

Closes https://github.com/argoproj/argo-cd/issues/3905

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>
