### PR TITLE
fix: Change icons so that there will be no two identical icons together

### DIFF
--- a/ui/src/app/applications/components/__snapshots__/utils.test.tsx.snap
+++ b/ui/src/app/applications/components/__snapshots__/utils.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`HealthStatusIcon.Suspended 1`] = `
 
 exports[`HealthStatusIcon.Unknown 1`] = `
 <i
-  className="fa fa-ghost"
+  className="fa fa-question-circle"
   qe-id="utils-health-status-title"
   style={
     Object {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -89,7 +89,7 @@ export const OperationPhaseIcon = ({app}: {app: appModels.Application}) => {
 };
 
 export const ComparisonStatusIcon = ({status, resource, label}: {status: appModels.SyncStatusCode; resource?: {requiresPruning?: boolean}; label?: boolean}) => {
-    let className = 'fa fa-ghost';
+    let className = 'fas fa-question-circle';
     let color = COLORS.sync.unknown;
     let title: string = 'Unknown';
 
@@ -155,7 +155,7 @@ export function syncStatusMessage(app: appModels.Application) {
 
 export const HealthStatusIcon = ({state}: {state: appModels.HealthStatus}) => {
     let color = COLORS.health.unknown;
-    let icon = 'fa-ghost';
+    let icon = 'fa-question-circle';
 
     switch (state.status) {
         case appModels.HealthStatuses.Healthy:
@@ -174,6 +174,10 @@ export const HealthStatusIcon = ({state}: {state: appModels.HealthStatus}) => {
             color = COLORS.health.progressing;
             icon = 'fa fa-circle-notch fa-spin';
             break;
+        case appModels.HealthStatuses.Missing:
+            color = COLORS.health.missing;
+            icon = 'fa-ghost';
+            break;
     }
     let title: string = state.status;
     if (state.message) {
@@ -184,7 +188,7 @@ export const HealthStatusIcon = ({state}: {state: appModels.HealthStatus}) => {
 
 export const ResourceResultIcon = ({resource}: {resource: appModels.ResourceResult}) => {
     let color = COLORS.sync_result.unknown;
-    let icon = 'fa-ghost';
+    let icon = 'fas fa-question-circle';
 
     if (!resource.hookType && resource.status) {
         switch (resource.status) {
@@ -461,7 +465,7 @@ export const SyncWindowStatusIcon = ({state, window}: {state: appModels.SyncWind
             color = COLORS.sync_window.allow;
             break;
         default:
-            className = 'fa fa-ghost';
+            className = 'fas fa-question-circle';
             color = COLORS.sync_window.unknown;
             current = 'Unknown';
             break;

--- a/ui/src/app/settings/components/project-details/project-details.tsx
+++ b/ui/src/app/settings/components/project-details/project-details.tsx
@@ -32,7 +32,7 @@ function helpTip(text: string) {
         <Tooltip content={text}>
             <span style={{fontSize: 'smaller'}}>
                 {' '}
-                <i className='fa fa-question-circle' />
+                <i className='fas fa-info-circle' />
             </span>
         </Tooltip>
     );

--- a/ui/src/app/settings/components/project-details/resource-lists-panel.tsx
+++ b/ui/src/app/settings/components/project-details/resource-lists-panel.tsx
@@ -14,7 +14,7 @@ function helpTip(text: string) {
         <Tooltip content={text}>
             <span style={{fontSize: 'smaller'}}>
                 {' '}
-                <i className='fa fa-question-circle' />
+                <i className='fas fa-info-circle' />
             </span>
         </Tooltip>
     );

--- a/ui/src/app/settings/components/project-sync-windows-edit/project-sync-windows-edit.tsx
+++ b/ui/src/app/settings/components/project-sync-windows-edit/project-sync-windows-edit.tsx
@@ -14,7 +14,7 @@ function helpTip(text: string) {
         <Tooltip content={text}>
             <span style={{fontSize: 'smaller'}}>
                 {' '}
-                <i className='fa fa-question-circle' />
+                <i className='fas fa-info-circle' />
             </span>
         </Tooltip>
     );

--- a/ui/src/app/shared/components/colors.ts
+++ b/ui/src/app/shared/components/colors.ts
@@ -13,7 +13,7 @@ export const COLORS = {
     health: {
         degraded: ARGO_FAILED_COLOR,
         healthy: ARGO_SUCCESS_COLOR,
-        missing: 'black',
+        missing: ARGO_GRAY4_COLOR,
         progressing: ARGO_RUNNING_COLOR,
         suspended: ARGO_GRAY4_COLOR,
         unknown: ARGO_GRAY4_COLOR


### PR DESCRIPTION
This PR will:

- Change question circle icon (currently used for help) to  [info icon](https://fontawesome.com/icons/info-circle?style=solid)
- Change `Unknown` health status icon to [question icon](https://fontawesome.com/icons/question-circle?style=solid)
- Leave `Missing` status icon as [ghost icon](https://fontawesome.com/icons/ghost)

This will hopefully fix the issue of two different statuses having the same icon be right next to each other (such as `Missing` and `Unknown` previously)

Fixes: #4817
Signed-off-by: Regina Scott reginaelyse@gmail.com

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

