### PR TITLE
fix: prevent short-circuit during env variable substitution

### DIFF
--- a/docs/operator-manual/upgrading/1.8-1.9.md
+++ b/docs/operator-manual/upgrading/1.8-1.9.md
@@ -1,0 +1,7 @@
+# v1.8 to 1.9
+
+## Environment variables expansion
+
+Argo CD supports using [environment variables](https://argoproj.github.io/argo-cd/user-guide/build-environment/) in
+config management tools parameters. The expansion logic has been improved and now expands missing environment variables
+into an empty string.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - argocd-util Tools: operator-manual/server-commands/argocd-util.md
     - Upgrading:
         - operator-manual/upgrading/overview.md
+        - operator-manual/upgrading/1.7-1.8.md
         - operator-manual/upgrading/1.6-1.7.md
         - operator-manual/upgrading/1.5-1.6.md
         - operator-manual/upgrading/1.4-1.5.md

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -126,13 +126,35 @@ func (e Env) Environ() []string {
 	return environ
 }
 
+var (
+	envVarPattern = regexp.MustCompile(`\$\{([A-Za-z0-9_]+)\}|\$([A-Za-z0-9_]+)`)
+)
+
 // does an operation similar to `envsubst` tool,
 // but unlike envsubst it does not change missing names into empty string
 // see https://linux.die.net/man/1/envsubst
 func (e Env) Envsubst(s string) string {
-	for _, v := range e {
-		s = strings.ReplaceAll(s, fmt.Sprintf("$%s", v.Name), v.Value)
-		s = strings.ReplaceAll(s, fmt.Sprintf("${%s}", v.Name), v.Value)
+	valByEnv := map[string]string{}
+	for _, item := range e {
+		valByEnv[item.Name] = item.Value
+	}
+	matches := envVarPattern.FindAllStringSubmatchIndex(s, -1)
+	for i := len(matches) - 1; i >= 0; i-- {
+		submatches := matches[i]
+		// three pair of indexes: first is matched expression and two groups
+		// first pair of indexes is matched expression and second pair is captured group indexes within matched expression
+		if len(submatches) == 6 {
+			name := ""
+			// only one of groups matches - surrounded with {} or not
+			if submatches[2] > -1 {
+				name = s[submatches[2]:submatches[3]]
+			} else if submatches[4] > -1 {
+				name = s[submatches[4]:submatches[5]]
+			}
+			if val, ok := valByEnv[name]; ok {
+				s = s[:submatches[0]] + val + s[submatches[1]:]
+			}
+		}
 	}
 	return s
 }

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1019,6 +1019,22 @@ func TestEnv_Envsubst(t *testing.T) {
 	assert.Equal(t, "", env.Envsubst(""))
 	assert.Equal(t, "bar", env.Envsubst("$FOO"))
 	assert.Equal(t, "bar", env.Envsubst("${FOO}"))
+	assert.Equal(t, "${FOO", env.Envsubst("${FOO"))
+	assert.Equal(t, "$BAR", env.Envsubst("$BAR"))
+	assert.Equal(t, "${BAR}", env.Envsubst("${BAR}"))
+	assert.Equal(t,
+		"echo bar; echo $BAR; echo bar; echo ${BAR}; echo ${FOO",
+		env.Envsubst("echo $FOO; echo $BAR; echo ${FOO}; echo ${BAR}; echo ${FOO"),
+	)
+}
+
+func TestEnv_Envsubst_Overlap(t *testing.T) {
+	env := Env{&EnvEntry{"ARGOCD_APP_NAMESPACE", "default"}, &EnvEntry{"ARGOCD_APP_NAME", "guestbook"}}
+
+	assert.Equal(t,
+		"namespace: default; name: guestbook",
+		env.Envsubst("namespace: $ARGOCD_APP_NAMESPACE; name: $ARGOCD_APP_NAME"),
+	)
 }
 
 func TestEnv_Environ(t *testing.T) {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1019,11 +1019,11 @@ func TestEnv_Envsubst(t *testing.T) {
 	assert.Equal(t, "", env.Envsubst(""))
 	assert.Equal(t, "bar", env.Envsubst("$FOO"))
 	assert.Equal(t, "bar", env.Envsubst("${FOO}"))
-	assert.Equal(t, "${FOO", env.Envsubst("${FOO"))
-	assert.Equal(t, "$BAR", env.Envsubst("$BAR"))
-	assert.Equal(t, "${BAR}", env.Envsubst("${BAR}"))
+	assert.Equal(t, "FOO", env.Envsubst("${FOO"))
+	assert.Equal(t, "", env.Envsubst("$BAR"))
+	assert.Equal(t, "", env.Envsubst("${BAR}"))
 	assert.Equal(t,
-		"echo bar; echo $BAR; echo bar; echo ${BAR}; echo ${FOO",
+		"echo bar; echo ; echo bar; echo ; echo FOO",
 		env.Envsubst("echo $FOO; echo $BAR; echo ${FOO}; echo ${BAR}; echo ${FOO"),
 	)
 }


### PR DESCRIPTION
PR fixes issue reported in https://github.com/argoproj/argo-cd/pull/3202 and prevents incorrect env variable replacement.

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>