### PR TITLE
docs: Add url parameter in example of Auth0 setting

### DIFF
--- a/docs/operator-manual/user-management/auth0.md
+++ b/docs/operator-manual/user-management/auth0.md
@@ -33,6 +33,7 @@ The important part to note here is that group-membership is a non-standard claim
 ...
 data:
   application.instanceLabelKey: argocd.argoproj.io/instance
+  url: https://your.argoingress.address
   oidc.config: |
     name: Auth0
     issuer: https://<yourtenant>.<eu|us>.auth0.com/


### PR DESCRIPTION
Added `url` parameter in example of Auth0 oidc setting.
We must set `url` parameter when we use oidc.