### PR TITLE
fix: make start fails to start webpack-dev-server(#4968)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ start: test-tools-image
 
 # Starts a local instance of ArgoCD
 .PHONY: start-local
-start-local: mod-vendor-local
+start-local: mod-vendor-local dep-ui-local
 	# check we can connect to Docker to start Redis
 	killall goreman || true
 	kubectl create ns argocd || true


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 


This PR will fix the dependency issues in bringing up the UI server(webpack-dev-server). Full details of the issue is provided in issue #4968 

<img width="1042" alt="Screenshot 2020-12-07 at 3 08 14 PM" src="https://user-images.githubusercontent.com/43399466/101363231-25dfbf80-38c7-11eb-8d2e-8d6441ec15ea.png">
