### PR TITLE
fix: argocd-test-server does not get removed/deleted upon SIGINT(#4969)

### DIFF
--- a/test/container/uid_entrypoint.sh
+++ b/test/container/uid_entrypoint.sh
@@ -9,4 +9,4 @@ fi
 export PATH=$PATH:/usr/local/go/bin:/go/bin
 export GOROOT=/usr/local/go
 
-exec "$@"
+"$@"


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

problem is, argo container has an entrypoint script which exec's GNU make, effectively having make becoming PID 1 in the container. Since Linux handles PID 1 special regarding signals, the signal is passed down to the children of the make process, but does nothing for the PID 1 process itself.

This simple change will address the issue. 