### PR TITLE
fix: Capitalization in toc header- Issue #4987

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ theme:
     text: 'Work Sans'
   logo: 'assets/logo.png'
   favicon: 'assets/favicon.png'
+  language: en-custom
+  custom_dir: overrides
 google_analytics:
 - 'UA-105170809-2'
 - 'auto'

--- a/overrides/partials/language/en-custom.html
+++ b/overrides/partials/language/en-custom.html
@@ -1,0 +1,3 @@
+{% macro t(key) %}{{ {
+  "toc.title": "Table of Contents"
+}[key] }}{% endmacro %} 


### PR DESCRIPTION
This PR will change the docs TOC to say "Table of Contents" rather than "Table of contents"

Fixes: #4987 
Signed-off-by: Regina Scott reginaelyse@gmail.com

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

![TableofContents](https://user-images.githubusercontent.com/50851526/101788391-0961a400-3ace-11eb-8fe2-5d929c472438.png)