### PR TITLE
test: Add locator for delete app confirmation field for UI tests (#4393)

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -428,7 +428,10 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                         <Spinner show={isAppCreatePending} style={{marginRight: '5px'}} />
                                         Create
                                     </button>{' '}
-                                    <button onClick={() => ctx.navigation.goto('.', {new: null})} className='argo-button argo-button--base-o'>
+                                    <button
+                                        qe-id='applications-list-button-cancel'
+                                        onClick={() => ctx.navigation.goto('.', {new: null})}
+                                        className='argo-button argo-button--base-o'>
                                         Cancel
                                     </button>
                                 </div>

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -31,7 +31,13 @@ export async function deleteApplication(appName: string, apis: ContextApis): Pro
             <div>
                 <p>Are you sure you want to delete the application '{appName}'?</p>
                 <div className='argo-form-row'>
-                    <FormField label={`Please type '${appName}' to confirm the deletion of the resource`} formApi={api} field='applicationName' component={Text} />
+                    <FormField
+                        label={`Please type '${appName}' to confirm the deletion of the resource`}
+                        formApi={api}
+                        field='applicationName'
+                        qeId='name-field-delete-confirmation'
+                        component={Text}
+                    />
                 </div>
                 <div className='argo-form-row'>
                     <Checkbox id='cascade-checkbox-delete-confirmation' field='cascadeCheckbox' /> <label htmlFor='cascade-checkbox-delete-confirmation'>Cascade</label>


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

The new prompt popup confirmation dialog should have a locator associated with the field, for automated UI testing purposes.  (Heads up: the OK and Cancel buttons need them too but that affects argo-ui)

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

