### PR TITLE
refactor(jwt): use typed access to claims

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -25,6 +25,7 @@ import (
 	"github.com/argoproj/argo-cd/util/errors"
 	grpc_util "github.com/argoproj/argo-cd/util/grpc"
 	"github.com/argoproj/argo-cd/util/io"
+	jwtutil "github.com/argoproj/argo-cd/util/jwt"
 	"github.com/argoproj/argo-cd/util/localconfig"
 	oidcutil "github.com/argoproj/argo-cd/util/oidc"
 	"github.com/argoproj/argo-cd/util/rand"
@@ -162,13 +163,13 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 }
 
 func userDisplayName(claims jwt.MapClaims) string {
-	if email, ok := claims["email"]; ok && email != nil {
-		return email.(string)
+	if email := jwtutil.StringField(claims, "email"); email != "" {
+		return email
 	}
-	if name, ok := claims["name"]; ok && name != nil {
-		return name.(string)
+	if name := jwtutil.StringField(claims, "name"); name != "" {
+		return name
 	}
-	return claims["sub"].(string)
+	return jwtutil.StringField(claims, "sub")
 }
 
 // oauth2Login opens a browser, runs a temporary HTTP server to delegate OAuth2 login flow and

--- a/cmd/argocd/commands/login_test.go
+++ b/cmd/argocd/commands/login_test.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+)
+
+//
+
+func Test_userDisplayName_email(t *testing.T) {
+	claims := jwt.MapClaims{"iss": "qux", "sub": "foo", "email": "firstname.lastname@example.com", "groups": []string{"baz"}}
+	actualName := userDisplayName(claims)
+	expectedName := "firstname.lastname@example.com"
+	assert.Equal(t, expectedName, actualName)
+}
+
+func Test_userDisplayName_name(t *testing.T) {
+	claims := jwt.MapClaims{"iss": "qux", "sub": "foo", "name": "Firstname Lastname", "groups": []string{"baz"}}
+	actualName := userDisplayName(claims)
+	expectedName := "Firstname Lastname"
+	assert.Equal(t, expectedName, actualName)
+}
+
+func Test_userDisplayName_sub(t *testing.T) {
+	claims := jwt.MapClaims{"iss": "qux", "sub": "foo", "groups": []string{"baz"}}
+	actualName := userDisplayName(claims)
+	expectedName := "foo"
+	assert.Equal(t, expectedName, actualName)
+}

--- a/cmd/argocd/commands/project_role.go
+++ b/cmd/argocd/commands/project_role.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/util/errors"
 	"github.com/argoproj/argo-cd/util/io"
+	"github.com/argoproj/argo-cd/util/jwt"
 )
 
 const (
@@ -247,13 +248,10 @@ func NewProjectRoleCreateTokenCommand(clientOpts *argocdclient.ClientOptions) *c
 			}
 
 			claims := token.Claims.(jwtgo.MapClaims)
-			issuedAt := int64(claims["iat"].(float64))
-			expiresAt := int64(0)
-			if expires, ok := claims["exp"]; ok {
-				expiresAt = int64(expires.(float64))
-			}
-			id := claims["jti"].(string)
-			subject := claims["sub"].(string)
+			issuedAt, _ := jwt.IssuedAt(claims)
+			expiresAt := int64(jwt.Float64Field(claims, "exp"))
+			id := jwt.StringField(claims, "jti")
+			subject := jwt.StringField(claims, "sub")
 
 			if !outputTokenOnly {
 				fmt.Printf("Create token succeeded for %s.\n", subject)

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -85,7 +85,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	issuer := jwtutil.GetField(mapClaims, "iss")
+	issuer := jwtutil.StringField(mapClaims, "iss")
 
 	if argoCDSettings.OIDCConfig() == nil || argoCDSettings.OIDCConfig().LogoutURL == "" || issuer == session.SessionManagerClaimsIssuer {
 		http.Redirect(w, r, logoutRedirectURL, http.StatusSeeOther)

--- a/server/rbacpolicy/rbacpolicy.go
+++ b/server/rbacpolicy/rbacpolicy.go
@@ -92,7 +92,7 @@ func (p *RBACPolicyEnforcer) EnforceClaims(claims jwt.Claims, rvals ...interface
 		return false
 	}
 
-	subject := jwtutil.GetField(mapClaims, "sub")
+	subject := jwtutil.StringField(mapClaims, "sub")
 	// Check if the request is for an application resource. We have special enforcement which takes
 	// into consideration the project's token and group bindings
 	var runtimePolicy string
@@ -172,7 +172,7 @@ func (p *RBACPolicyEnforcer) enforceProjectToken(subject string, claims jwt.MapC
 	var iat int64 = -1
 	jti, err := jwtutil.GetID(claims)
 	if err != nil || jti == "" {
-		iat, err = jwtutil.GetIssuedAt(claims)
+		iat, err = jwtutil.IssuedAt(claims)
 		if err != nil {
 			return false
 		}

--- a/util/jwt/jwt.go
+++ b/util/jwt/jwt.go
@@ -2,7 +2,9 @@ package jwt
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"time"
 
 	jwtgo "github.com/dgrijalva/jwt-go"
 )
@@ -21,14 +23,24 @@ func MapClaims(claims jwtgo.Claims) (jwtgo.MapClaims, error) {
 	return mapClaims, nil
 }
 
-// GetField extracts a field from the claims as a string
-func GetField(claims jwtgo.MapClaims, fieldName string) string {
+// StringField extracts a field from the claims as a string
+func StringField(claims jwtgo.MapClaims, fieldName string) string {
 	if fieldIf, ok := claims[fieldName]; ok {
 		if field, ok := fieldIf.(string); ok {
 			return field
 		}
 	}
 	return ""
+}
+
+// Float64Field extracts a field from the claims as a float64
+func Float64Field(claims jwtgo.MapClaims, fieldName string) float64 {
+	if fieldIf, ok := claims[fieldName]; ok {
+		if field, ok := fieldIf.(float64); ok {
+			return field
+		}
+	}
+	return 0
 }
 
 // GetScopeValues extracts the values of specified scopes from the claims
@@ -67,9 +79,13 @@ func GetID(m jwtgo.MapClaims) (string, error) {
 	return "", fmt.Errorf("jti '%v' is not a string", m["jti"])
 }
 
-// GetIssuedAt returns the issued at as an int64
-func GetIssuedAt(m jwtgo.MapClaims) (int64, error) {
-	switch iat := m["iat"].(type) {
+// IssuedAt returns the issued at as an int64
+func IssuedAt(m jwtgo.MapClaims) (int64, error) {
+	iatField, ok := m["iat"]
+	if !ok {
+		return 0, errors.New("token does not have iat claim")
+	}
+	switch iat := iatField.(type) {
 	case float64:
 		return int64(iat), nil
 	case json.Number:
@@ -79,6 +95,12 @@ func GetIssuedAt(m jwtgo.MapClaims) (int64, error) {
 	default:
 		return 0, fmt.Errorf("iat '%v' is not a number", iat)
 	}
+}
+
+// IssuedAtTime returns the issued at as a time.Time
+func IssuedAtTime(m jwtgo.MapClaims) (time.Time, error) {
+	iat, err := IssuedAt(m)
+	return time.Unix(iat, 0), err
 }
 
 func Claims(in interface{}) jwtgo.Claims {

--- a/util/jwt/jwt_test.go
+++ b/util/jwt/jwt_test.go
@@ -1,7 +1,9 @@
 package jwt
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
@@ -35,4 +37,26 @@ func TestIsMember(t *testing.T) {
 func TestGetGroups(t *testing.T) {
 	assert.Empty(t, GetGroups(jwt.MapClaims{}, []string{"groups"}))
 	assert.Equal(t, []string{"foo"}, GetGroups(jwt.MapClaims{"groups": []string{"foo"}}, []string{"groups"}))
+}
+
+func TestIssuedAtTime_Int64(t *testing.T) {
+	// Tuesday, 1 December 2020 14:00:00
+	claims := jwt.MapClaims{"iat": int64(1606831200)}
+	issuedAt, err := IssuedAtTime(claims)
+	assert.Nil(t, err)
+	str := fmt.Sprint(issuedAt.UTC().Format("Mon Jan _2 15:04:05 2006"))
+	assert.Equal(t, "Tue Dec  1 14:00:00 2020", str)
+}
+
+func TestIssuedAtTime_Error_NoInt(t *testing.T) {
+	claims := jwt.MapClaims{"iat": 1606831200}
+	_, err := IssuedAtTime(claims)
+	assert.NotNil(t, err)
+}
+
+func TestIssuedAtTime_Error_Missing(t *testing.T) {
+	claims := jwt.MapClaims{}
+	iat, err := IssuedAtTime(claims)
+	assert.NotNil(t, err)
+	assert.Equal(t, time.Unix(0, 0), iat)
 }

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -132,19 +132,12 @@ func (e *Enforcer) EnforceErr(rvals ...interface{}) error {
 				if err != nil {
 					break
 				}
-				sub := jwtutil.GetField(claims, "sub")
-				if sub != "" {
+				if sub := jwtutil.StringField(claims, "sub"); sub != "" {
 					rvalsStrs = append(rvalsStrs, fmt.Sprintf("sub: %s", sub))
 				}
-				iatField, ok := claims["iat"]
-				if !ok {
-					break
+				if issuedAtTime, err := jwtutil.IssuedAtTime(claims); err == nil {
+					rvalsStrs = append(rvalsStrs, fmt.Sprintf("iat: %s", issuedAtTime.Format(time.RFC3339)))
 				}
-				iat, ok := iatField.(float64)
-				if !ok {
-					break
-				}
-				rvalsStrs = append(rvalsStrs, fmt.Sprintf("iat: %s", time.Unix(int64(iat), 0).Format(time.RFC3339)))
 			}
 			errMsg = fmt.Sprintf("%s: %s", errMsg, strings.Join(rvalsStrs, ", "))
 		}

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -218,7 +218,7 @@ func (mgr *SessionManager) Parse(tokenString string) (jwt.Claims, error) {
 		return nil, err
 	}
 
-	subject := jwtutil.GetField(claims, "sub")
+	subject := jwtutil.StringField(claims, "sub")
 	if rbacpolicy.IsProjectSubject(subject) {
 		return token.Claims, nil
 	}
@@ -228,11 +228,14 @@ func (mgr *SessionManager) Parse(tokenString string) (jwt.Claims, error) {
 		return nil, err
 	}
 
-	if id := jwtutil.GetField(claims, "jti"); id != "" && account.TokenIndex(id) == -1 {
+	if id := jwtutil.StringField(claims, "jti"); id != "" && account.TokenIndex(id) == -1 {
 		return nil, fmt.Errorf("account %s does not have token with id %s", subject, id)
 	}
 
-	issuedAt := time.Unix(int64(claims["iat"].(float64)), 0)
+	issuedAt, err := jwtutil.IssuedAtTime(claims)
+	if err != nil {
+		return nil, err
+	}
 	if account.PasswordMtime != nil && issuedAt.Before(*account.PasswordMtime) {
 		return nil, fmt.Errorf("Account password has changed since token issued")
 	}
@@ -474,11 +477,11 @@ func Username(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
-	switch jwtutil.GetField(mapClaims, "iss") {
+	switch jwtutil.StringField(mapClaims, "iss") {
 	case SessionManagerClaimsIssuer:
-		return jwtutil.GetField(mapClaims, "sub")
+		return jwtutil.StringField(mapClaims, "sub")
 	default:
-		return jwtutil.GetField(mapClaims, "email")
+		return jwtutil.StringField(mapClaims, "email")
 	}
 }
 
@@ -487,7 +490,7 @@ func Iss(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
-	return jwtutil.GetField(mapClaims, "iss")
+	return jwtutil.StringField(mapClaims, "iss")
 }
 
 func Iat(ctx context.Context) (time.Time, error) {
@@ -495,16 +498,7 @@ func Iat(ctx context.Context) (time.Time, error) {
 	if !ok {
 		return time.Time{}, errors.New("unable to extract token claims")
 	}
-	iatField, ok := mapClaims["iat"]
-	if !ok {
-		return time.Time{}, errors.New("token does not have iat claim")
-	}
-
-	if iat, ok := iatField.(float64); !ok {
-		return time.Time{}, errors.New("iat token field has unexpected type")
-	} else {
-		return time.Unix(int64(iat), 0), nil
-	}
+	return jwtutil.IssuedAtTime(mapClaims)
 }
 
 func Sub(ctx context.Context) string {
@@ -512,7 +506,7 @@ func Sub(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
-	return jwtutil.GetField(mapClaims, "sub")
+	return jwtutil.StringField(mapClaims, "sub")
 }
 
 func Groups(ctx context.Context, scopes []string) []string {


### PR DESCRIPTION
Small refactoring on using the jwt claims with typed access

Signed-off-by: Liviu Costea <email.lcostea@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

