### PR TITLE
fix: correct name for argocd-redis-ha-haproxy role/role binding

### DIFF
--- a/manifests/ha/base/redis-ha/kustomization.yaml
+++ b/manifests/ha/base/redis-ha/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 - chart/upstream.yaml
-- overlays/redis-haproxy.yaml
+- overlays/redis-ha-haproxy.yaml
 
 patchesJson6902:
 - target:
@@ -13,6 +13,20 @@ patchesJson6902:
     name: argocd-redis-ha-configmap
     namespace: argocd
   path: overlays/remove-namespace.yaml
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: Role
+    name: argocd-redis-ha
+    namespace: argocd
+  path: overlays/add-openshift-nonroot-scc.yaml  
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: Role
+    name: argocd-redis-ha-haproxy
+    namespace: argocd
+  path: overlays/add-openshift-nonroot-scc.yaml     
 - target:
     version: v1
     group: ""
@@ -26,33 +40,33 @@ patchesJson6902:
     kind: ServiceAccount
     name: argocd-redis-ha-haproxy
     namespace: argocd
-  path: overlays/remove-namespace.yaml
+  path: overlays/remove-namespace.yaml  
 - target:
     group: rbac.authorization.k8s.io
     version: v1
     kind: Role
     name: argocd-redis-ha
     namespace: argocd
-  path: overlays/remove-namespace.yaml
+  path: overlays/remove-namespace.yaml  
 - target:
     group: rbac.authorization.k8s.io
     version: v1
     kind: Role
-    name: argocd-redis-ha
+    name: argocd-redis-ha-haproxy
     namespace: argocd
-  path: overlays/add-openshift-nonroot-scc.yaml
-- target:
-    group: rbac.authorization.k8s.io
-    version: v1
-    kind: Role
-    name: argocd-redis-haproxy
-    namespace: argocd
-  path: overlays/add-openshift-nonroot-scc.yaml      
+  path: overlays/remove-namespace.yaml  
 - target:
     group: rbac.authorization.k8s.io
     version: v1
     kind: RoleBinding
     name: argocd-redis-ha
+    namespace: argocd
+  path: overlays/remove-namespace.yaml      
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: RoleBinding
+    name: argocd-redis-ha-haproxy
     namespace: argocd
   path: overlays/remove-namespace.yaml
 - target:

--- a/manifests/ha/base/redis-ha/kustomization.yaml
+++ b/manifests/ha/base/redis-ha/kustomization.yaml
@@ -40,21 +40,21 @@ patchesJson6902:
     kind: ServiceAccount
     name: argocd-redis-ha-haproxy
     namespace: argocd
-  path: overlays/remove-namespace.yaml  
+  path: overlays/remove-namespace.yaml 
 - target:
     group: rbac.authorization.k8s.io
     version: v1
     kind: Role
     name: argocd-redis-ha
     namespace: argocd
-  path: overlays/remove-namespace.yaml  
+  path: overlays/remove-namespace.yaml 
 - target:
     group: rbac.authorization.k8s.io
     version: v1
     kind: Role
     name: argocd-redis-ha-haproxy
     namespace: argocd
-  path: overlays/remove-namespace.yaml  
+  path: overlays/remove-namespace.yaml 
 - target:
     group: rbac.authorization.k8s.io
     version: v1

--- a/manifests/ha/base/redis-ha/overlays/redis-ha-haproxy.yaml
+++ b/manifests/ha/base/redis-ha/overlays/redis-ha-haproxy.yaml
@@ -3,9 +3,9 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-haproxy
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
-  name: argocd-redis-haproxy
+  name: argocd-redis-ha-haproxy
   namespace: argocd
 rules: []
 ---
@@ -14,15 +14,16 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-haproxy
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
     app.kubernetes.io/part-of: argocd
-  name: argocd-redis-haproxy
+  name: argocd-redis-ha-haproxy
   namespace: argocd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: argocd-redis-haproxy
+  name: argocd-redis-ha-haproxy
 subjects:
 - kind: ServiceAccount
-  name: argocd-redis-haproxy
+  name: argocd-redis-ha-haproxy
+
 

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -1976,25 +1976,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-haproxy
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-haproxy
-  namespace: argocd
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - nonroot
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2064,6 +2045,24 @@ rules:
   - endpoints
   verbs:
   - get
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis-ha-haproxy
+rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
@@ -2171,23 +2170,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-haproxy
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-haproxy
-  namespace: argocd
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-redis-haproxy
-subjects:
-- kind: ServiceAccount
-  name: argocd-redis-haproxy
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2231,6 +2213,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis-ha-haproxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-redis-ha-haproxy
+subjects:
+- kind: ServiceAccount
+  name: argocd-redis-ha-haproxy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1976,25 +1976,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-haproxy
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-haproxy
-  namespace: argocd
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - nonroot
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
@@ -2077,6 +2058,24 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis-ha-haproxy
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -2115,23 +2114,6 @@ rules:
   verbs:
   - create
   - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis-haproxy
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis-haproxy
-  namespace: argocd
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-redis-haproxy
-subjects:
-- kind: ServiceAccount
-  name: argocd-redis-haproxy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -2180,6 +2162,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha-haproxy
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis-ha-haproxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-redis-ha-haproxy
+subjects:
+- kind: ServiceAccount
+  name: argocd-redis-ha-haproxy
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION

Fixes: #5077

This PR corrects the name mismatch (`argocd-redis-haproxy` vs `argocd-redis-ha-haproxy`) between the redis-ha-haproxy service account coming from upstream helm chart and overriding role/rolebinding in kustomize.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
