### PR TITLE
feat: Add resource.Quantity as a known field type for diffing.

### DIFF
--- a/util/argo/normalizers/knowntypes_normalizer.go
+++ b/util/argo/normalizers/knowntypes_normalizer.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -24,6 +25,13 @@ type knownTypeField struct {
 
 type knownTypesNormalizer struct {
 	typeFields map[schema.GroupKind][]knownTypeField
+}
+
+// Register some non-code-generated types here. The bulk of them are in corev1_known_types.go
+func init() {
+	knownTypes["core/Quantity"] = func() interface{} {
+		return &resource.Quantity{}
+	}
 }
 
 // NewKnownTypesNormalizer create a normalizer that re-format custom resource fields using built-in Kubernetes types.
@@ -99,7 +107,7 @@ func normalize(obj map[string]interface{}, field knownTypeField, fieldPath []str
 		}
 	}
 
-	if fieldVal, ok, err := unstructured.NestedMap(obj, fieldPath...); ok && err == nil {
+	if fieldVal, ok, err := unstructured.NestedFieldNoCopy(obj, fieldPath...); ok && err == nil {
 		newFieldVal, err := remarshal(fieldVal, field)
 		if err != nil {
 			return err
@@ -113,7 +121,7 @@ func normalize(obj map[string]interface{}, field knownTypeField, fieldPath []str
 	return nil
 }
 
-func remarshal(fieldVal map[string]interface{}, field knownTypeField) (map[string]interface{}, error) {
+func remarshal(fieldVal interface{}, field knownTypeField) (interface{}, error) {
 	data, err := json.Marshal(fieldVal)
 	if err != nil {
 		return nil, err
@@ -127,7 +135,7 @@ func remarshal(fieldVal map[string]interface{}, field knownTypeField) (map[strin
 	if err != nil {
 		return nil, err
 	}
-	newFieldVal := map[string]interface{}{}
+	var newFieldVal interface{}
 	err = json.Unmarshal(data, &newFieldVal)
 	if err != nil {
 		return nil, err

--- a/util/argo/normalizers/knowntypes_normalizer_test.go
+++ b/util/argo/normalizers/knowntypes_normalizer_test.go
@@ -197,6 +197,37 @@ spec:
 	assert.Equal(t, "2", cpu)
 }
 
+func TestNormalize_Quantity(t *testing.T) {
+	rollout := mustUnmarshalYAML(`apiVersion: some.io/v1alpha1
+kind: TestCRD
+metadata:
+  name: canary-demo
+spec:
+  ram: 1.25G`)
+	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{
+		crdGroupKind: {
+			KnownTypeFields: []v1alpha1.KnownTypeField{{
+				Type:  "core/Quantity",
+				Field: "spec.ram",
+			}},
+		},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = normalizer.Normalize(rollout)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	ram, ok, err := unstructured.NestedFieldNoCopy(rollout.Object, "spec", "ram")
+	if !assert.NoError(t, err) || !assert.True(t, ok) {
+		return
+	}
+	assert.Equal(t, "1250M", ram)
+}
+
 func TestFieldDoesNotExist(t *testing.T) {
 	rollout := mustUnmarshalYAML(someCRDYaml)
 	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{


### PR DESCRIPTION
This adds support for direct use of Quantity fields in custom resources. I'm only mostly sure the changes to `normalize` are correct though, it seems this system previously couldn't handle a direct field as opposed to a nested substruct.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

