### PR TITLE
feat: add versioning to argocd docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+version: 2
+formats: all
+mkdocs:
+  fail_on_warning: false
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/assets/versions.css
+++ b/docs/assets/versions.css
@@ -1,0 +1,172 @@
+.md-header-nav__title {
+  display: flex;
+}
+
+.dropdown-caret {
+  display: inline-block !important;
+  position: absolute;
+  right: 4px;
+}
+
+.fa .fa-caret-down {
+  display: none !important;
+}
+
+.rst-other-versions {
+  text-align: right;
+}
+
+.rst-other-versions > dl, .rst-other-versions dt, .rst-other-versions small {
+  display: none;
+}
+
+.rst-other-versions > dl:first-child {
+  display: flex !important;
+  flex-direction: column;
+  line-height: 0px !important;
+}
+
+.rst-versions.shift-up .rst-other-versions {
+  display: flex !important;
+}
+
+.rst-versions .rst-other-versions {
+  display: none;
+}
+
+/* Version Warning */
+div[data-md-component=announce] {
+  background-color: rgba(255,145,0,.1);
+}
+div[data-md-component=announce]>div#announce-msg{
+  color: var(--md-admonition-fg-color);
+  font-size: .8rem;
+  text-align: center;
+  margin: 15px;
+}
+div[data-md-component=announce]>div#announce-msg>a{
+  color: var(--md-typeset-a-color);
+  text-decoration: underline;
+}
+
+/* from https://assets.readthedocs.org/static/css/badge_only.css,
+most styles have to be overriden here */
+.rst-versions{
+  position: relative !important;
+  bottom: 0;
+  left: 0;
+  width: 100px !important;
+  background: hsla(173, 100%, 24%, 1) !important;
+  font-family: inherit !important;
+  z-index: 0 !important;
+}
+.rst-versions a{
+  color:#2980B9;
+  text-decoration:none
+}
+.rst-versions .rst-badge-small{
+  display:none
+}
+.rst-versions .rst-current-version{
+  padding:12px;
+  background: hsla(173, 100%, 24%, 1) !important;
+  display:block;
+  text-align:right;
+  font-size:90%;
+  cursor:pointer;
+  color: white !important;
+  *zoom:1
+}
+.rst-versions .rst-current-version:before,.rst-versions .rst-current-version:after{
+  display:table;content:""
+}
+.rst-versions .rst-current-version:after{
+  clear:both
+}
+.rst-versions .rst-current-version .fa{
+  color:#fcfcfc
+}
+.rst-versions .rst-current-version .fa-caret-down{
+  display: none;
+}
+.rst-versions.shift-up .rst-other-versions{
+  display:block
+}
+.rst-versions .rst-other-versions{
+  font-size:90%;
+  padding:12px;
+  color:gray;
+  display:none
+}
+.rst-versions .rst-other-versions hr{
+  display: none !important;
+  height: 0px !important;
+  border: 0px;
+  margin: 0px !important;
+  padding: 0px;
+  border-top: none !important;
+}
+.rst-versions .rst-other-versions dd{
+  display:inline-block;
+  margin:0
+}
+.rst-versions .rst-other-versions dd a{
+  display:inline-block;
+  padding: 1em 0em !important;
+  color:#fcfcfc;
+  font-size: .6rem !important;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 80px;
+}
+.rst-versions .rst-other-versions dd a:hover{
+  font-size: .7rem !important;
+  font-weight: bold;
+}
+.rst-versions.rst-badge{
+  display: block !important;
+  width: 100px !important;
+  bottom: 0px !important;
+  right: 0px !important;
+  left:auto;
+  border:none;
+  text-align: center !important;
+  line-height: 0;
+}
+.rst-versions.rst-badge .icon-book{
+  display: none;
+}
+.rst-versions.rst-badge .fa-book{
+  display: none !important;
+}
+.rst-versions.rst-badge.shift-up .rst-current-version{
+  text-align: left !important;
+}
+.rst-versions.rst-badge.shift-up .rst-current-version .fa-book{
+  display: none !important;
+}
+.rst-versions.rst-badge.shift-up .rst-current-version .icon-book{
+  display: none !important;
+}
+.rst-versions.rst-badge .rst-current-version{
+  width: 70px !important;
+  height: 2.4rem !important;
+  line-height:2.4rem !important;
+  padding: 0px 5px !important;
+  display: inline-block !important;
+  font-size: .6rem !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  text-align: left !important;
+}
+@media screen and (max-width: 768px){
+  .rst-versions{
+      width:85%;
+      display:none
+  }
+  .rst-versions.shift{
+      display:block
+  }
+}

--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -1,0 +1,45 @@
+setTimeout(function() {
+  const callbackName = 'callback_' + new Date().getTime();
+  window[callbackName] = function (response) {
+  const div = document.createElement('div');
+  div.innerHTML = response.html;
+  document.querySelector(".md-header-nav > .md-header-nav__title").appendChild(div);
+  const container = div.querySelector('.rst-versions');
+  var caret = document.createElement('div');
+  caret.innerHTML = "<i class='fa fa-caret-down dropdown-caret'></i>"
+  caret.classList.add('dropdown-caret')
+  div.querySelector('.rst-current-version').appendChild(caret);
+  div.querySelector('.rst-current-version').addEventListener('click', function() {
+      const classes = container.className.split(' ');
+      const index = classes.indexOf('shift-up');
+      if (index === -1) {
+          classes.push('shift-up');
+      } else {
+          classes.splice(index, 1);
+      }
+      container.className = classes.join(' ');
+  });
+  }
+
+  var CSSLink = document.createElement('link');
+  CSSLink.rel='stylesheet';
+  CSSLink.href = '/assets/versions.css';
+  document.getElementsByTagName('head')[0].appendChild(CSSLink);
+
+  // this project link will need to be changed depending on the project name
+  var script = document.createElement('script');
+  script.src = 'https://argo-cd.readthedocs.io/_/api/v2/footer_html/?'+
+      'callback=' + callbackName + '&project=argo-cd&page=&theme=mkdocs&format=jsonp&docroot=docs&source_suffix=.md&version=' + (window['READTHEDOCS_DATA'] || { version: 'latest' }).version;
+  document.getElementsByTagName('head')[0].appendChild(script);
+}, 0);
+
+// VERSION WARNINGS
+window.addEventListener("DOMContentLoaded", function() {
+  if ((window['READTHEDOCS_DATA']).version !== "latest") {
+    document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/latest/'>click here to go to the latest version.</a></div>"
+  }
+
+  // if ((window['READTHEDOCS_DATA']).version === "latest") {
+  //   document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>Yay you're on the latest version of docs!</div>"
+  // }
+}); 

--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -26,7 +26,6 @@ setTimeout(function() {
   CSSLink.href = '/assets/versions.css';
   document.getElementsByTagName('head')[0].appendChild(CSSLink);
 
-  // this project link will need to be changed depending on the project name
   var script = document.createElement('script');
   script.src = 'https://argo-cd.readthedocs.io/_/api/v2/footer_html/?'+
       'callback=' + callbackName + '&project=argo-cd&page=&theme=mkdocs&format=jsonp&docroot=docs&source_suffix=.md&version=' + (window['READTHEDOCS_DATA'] || { version: 'latest' }).version;
@@ -35,11 +34,10 @@ setTimeout(function() {
 
 // VERSION WARNINGS
 window.addEventListener("DOMContentLoaded", function() {
-  if ((window['READTHEDOCS_DATA']).version !== "latest") {
-    document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/latest/'>click here to go to the latest version.</a></div>"
+  if ((window['READTHEDOCS_DATA']).version === "latest") {
+    document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>click here to go to the latest stable version.</a></div>"
   }
-
-  // if ((window['READTHEDOCS_DATA']).version === "latest") {
-  //   document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>Yay you're on the latest version of docs!</div>"
-  // }
+  if ((window['READTHEDOCS_DATA']).version !== "latest" || (window['READTHEDOCS_DATA']).version !== "stable") {
+    document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>click here to go to the latest stable version.</a></div>"
+  }
 }); 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material
+markdown_include
+pygments==2.4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,8 +9,12 @@ theme:
     text: 'Work Sans'
   logo: 'assets/logo.png'
   favicon: 'assets/favicon.png'
-  language: en-custom
+  # language: en-custom
   custom_dir: overrides
+extra_javascript:
+- assets/versions.js
+extra_css:
+- assets/versions.css
 google_analytics:
 - 'UA-105170809-2'
 - 'auto'


### PR DESCRIPTION
This PR is to add versioning to the Argo CD docs. The core functionality of this versioning is done through [mike](https://github.com/jimporter/mike). Related to issue #5031.

Additional functionality:
- if the user is on version of the docs NOT called "latest", they get an a warning message (seen below) that will provide a link to the most current docs.
- if the user clicks on a link where version is not specified in the URL, they will be redirected to the latest version of the docs.

Screenshots:
![argocddocs-latest](https://user-images.githubusercontent.com/50851526/102786970-55ce9e80-436e-11eb-845a-a5903361dcd0.png)
![argocddocs-olderversion](https://user-images.githubusercontent.com/50851526/102786972-56ffcb80-436e-11eb-8907-84bb2e30ba65.png)


https://user-images.githubusercontent.com/50851526/102788557-cd9dc880-4370-11eb-93d4-8bdf80feddf7.mp4


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

