### PR TITLE
fix: add liveness probe to restart repo server if it fails to server tls requests (#5110)

### DIFF
--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -12,9 +12,11 @@ import (
 	"github.com/go-redis/redis/v8"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/reposerver"
+	"github.com/argoproj/argo-cd/reposerver/apiclient"
 	reposervercache "github.com/argoproj/argo-cd/reposerver/cache"
 	"github.com/argoproj/argo-cd/reposerver/metrics"
 	"github.com/argoproj/argo-cd/reposerver/repository"
@@ -23,6 +25,8 @@ import (
 	"github.com/argoproj/argo-cd/util/env"
 	"github.com/argoproj/argo-cd/util/errors"
 	"github.com/argoproj/argo-cd/util/gpg"
+	"github.com/argoproj/argo-cd/util/healthz"
+	ioutil "github.com/argoproj/argo-cd/util/io"
 	"github.com/argoproj/argo-cd/util/tls"
 )
 
@@ -96,6 +100,28 @@ func NewCommand() *cobra.Command {
 			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", listenPort))
 			errors.CheckError(err)
 
+			healthz.ServeHealthCheck(http.DefaultServeMux, func(r *http.Request) error {
+				if val, ok := r.URL.Query()["full"]; ok && len(val) > 0 && val[0] == "true" {
+					// connect to itself to make sure repo server is able to serve connection
+					// used by liveness probe to auto restart repo server
+					// see https://github.com/argoproj/argo-cd/issues/5110 for more information
+					conn, err := apiclient.NewConnection(fmt.Sprintf("localhost:%d", listenPort), 60)
+					if err != nil {
+						return err
+					}
+					defer ioutil.Close(conn)
+					client := grpc_health_v1.NewHealthClient(conn)
+					res, err := client.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{})
+					if err != nil {
+						return err
+					}
+					if res.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+						return fmt.Errorf("grpc health check status is '%v'", res.Status)
+					}
+					return nil
+				}
+				return nil
+			})
 			http.Handle("/metrics", metricsServer.GetHandler())
 			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)) }()
 

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -28,9 +28,17 @@ spec:
         ports:
         - containerPort: 8081
         - containerPort: 8084
+        livenessProbe:
+          httpGet:
+            path: /healthz?full=true
+            port: 8084
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          failureThreshold: 3
         readinessProbe:
-          tcpSocket:
-            port: 8081
+          httpGet:
+            path: /healthz
+            port: 8084
           initialDelaySeconds: 5
           periodSeconds: 10
         volumeMounts:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3002,15 +3002,23 @@ spec:
         - argocd-redis-ha-haproxy:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz?full=true
+            port: 8084
+          initialDelaySeconds: 30
+          periodSeconds: 5
         name: argocd-repo-server
         ports:
         - containerPort: 8081
         - containerPort: 8084
         readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8084
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 8081
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2917,15 +2917,23 @@ spec:
         - argocd-redis-ha-haproxy:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz?full=true
+            port: 8084
+          initialDelaySeconds: 30
+          periodSeconds: 5
         name: argocd-repo-server
         ports:
         - containerPort: 8081
         - containerPort: 8084
         readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8084
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 8081
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2555,15 +2555,23 @@ spec:
         - argocd-redis:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz?full=true
+            port: 8084
+          initialDelaySeconds: 30
+          periodSeconds: 5
         name: argocd-repo-server
         ports:
         - containerPort: 8081
         - containerPort: 8084
         readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8084
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 8081
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2470,15 +2470,23 @@ spec:
         - argocd-redis:6379
         image: argoproj/argocd:latest
         imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz?full=true
+            port: 8084
+          initialDelaySeconds: 30
+          periodSeconds: 5
         name: argocd-repo-server
         ports:
         - containerPort: 8081
         - containerPort: 8084
         readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8084
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 8081
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts


### PR DESCRIPTION
Workaround for #5110 . Add liveness probe that restart repo server if it fails to serve tls requests.

Please let me know what you think about liveness probe period and failure threshold. Currently, it is set to 5 seconds and 3 failures. So repo server might run in a bad state  up to 15 seconds.
