### PR TITLE
feat: prune last

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -167,6 +167,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 			return false
 		}),
 		sync.WithSyncWaveHook(delayBetweenSyncWaves),
+		sync.WithPruneLast(syncOp.SyncOptions.HasOption("PruneLast=true")),
 	)
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/argoproj/gitops-engine v0.2.1-0.20210106033502-32c6afc4a7a5
+	github.com/argoproj/gitops-engine v0.2.1-0.20210106174510-82f093536368
 	github.com/argoproj/pkg v0.2.0
 	github.com/bombsimon/logrusr v1.0.0
 	github.com/casbin/casbin v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,6 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj/gitops-engine v0.2.1-0.20210106033502-32c6afc4a7a5 h1:mEd8BjAntZ92l5VvbRS4e3y0U1aW1kfRuMETJ/5ekoc=
-github.com/argoproj/gitops-engine v0.2.1-0.20210106033502-32c6afc4a7a5/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
 github.com/argoproj/gitops-engine v0.2.1-0.20210106174510-82f093536368 h1:mf8dZx92WjX7EjWvTgEPlXcUWXs7I2KmNY8fH/xqiIk=
 github.com/argoproj/gitops-engine v0.2.1-0.20210106174510-82f093536368/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
 github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/argoproj/gitops-engine v0.2.1-0.20210106033502-32c6afc4a7a5 h1:mEd8BjAntZ92l5VvbRS4e3y0U1aW1kfRuMETJ/5ekoc=
 github.com/argoproj/gitops-engine v0.2.1-0.20210106033502-32c6afc4a7a5/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
+github.com/argoproj/gitops-engine v0.2.1-0.20210106174510-82f093536368 h1:mf8dZx92WjX7EjWvTgEPlXcUWXs7I2KmNY8fH/xqiIk=
+github.com/argoproj/gitops-engine v0.2.1-0.20210106174510-82f093536368/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
 github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=
 github.com/argoproj/pkg v0.2.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
fixes: #5080.
If sync option has PruneLast=true, or individual resource has annotation argocd.argoproj.io/sync-options: PruneLast=true, these prune tasks get assigned with a new sync wave.

the new sync wave is the last sync wave of non-prune tasks which is in sync phase + 1, so that these resources will be pruned after all sync phase resources are synced and healthy.

Signed-off-by: May Zhang <may_zhang@intuit.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
fixes: #5080.
If sync option has PruneLast=true, or individual resource has annotation argocd.argoproj.io/sync-options: PruneLast=true, these prune tasks get assigned with a new sync wave.

the new sync wave is the last sync wave of non-prune tasks which is in sync phase + 1, so that these resources will be pruned after all sync phase resources are synced and healthy.
