### PR TITLE
fix: commit message overflows box (#5043)

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -11,7 +11,7 @@
     box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
 
     &__item {
-        height: 75px;
+        max-height: 100px;
         margin: 10px 0;
         padding: 5px 20px;
         font-size: .8em;
@@ -78,5 +78,39 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+    }
+
+    & .info-popup-title {
+        font-size: 15px;
+        font-weight: bold;
+        &__timestamp{
+            display: inline-block;
+            font-weight: normal;
+        }
+    }
+
+    & .info-popup-content {
+        overflow-y: scroll;
+        margin: 20px 20px 0px 20px;
+        max-height: 300px;
+        &__data{
+            :first-child {
+                white-space: normal;
+                overflow: auto;
+            }
+        }
+    }
+
+    & .third-column-truncate{
+        overflow: hidden;
+        margin-bottom: 10px;
+        max-height: 60px;
+    }
+
+    & .view-application-status-full {
+        color: #8fa4B1;
+        cursor: pointer;
+        position: absolute;
+        bottom: 10px;
     }
 }

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -11,7 +11,7 @@
     box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
 
     &__item {
-        max-height: 100px;
+        max-height: 75px;
         margin: 10px 0;
         padding: 5px 20px;
         font-size: .8em;

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -1,6 +1,6 @@
 import {HelpIcon} from 'argo-ui';
 import * as React from 'react';
-import {DataLoader} from '../../../shared/components';
+import {DataLoader, InfoPopup} from '../../../shared/components';
 import {Revision} from '../../../shared/components/revision';
 import {Timestamp} from '../../../shared/components/timestamp';
 import * as models from '../../../shared/models';
@@ -19,6 +19,8 @@ interface Props {
 
 export const ApplicationStatusPanel = ({application, showOperation, showConditions}: Props) => {
     const today = new Date();
+    const [title, setTitle] = React.useState<JSX.Element>();
+    const [content, setContent] = React.useState<JSX.Element>();
 
     let daysSinceLastSynchronized = 0;
     const history = application.status.history || [];
@@ -35,8 +37,19 @@ export const ApplicationStatusPanel = ({application, showOperation, showConditio
         showOperation = null;
     }
 
+    function viewApplicationStatusFull(infoTitle: JSX.Element, infoContent: JSX.Element) {
+        setTitle(infoTitle);
+        setContent(infoContent);
+    }
+
+    function closeApplicationStatusFull() {
+        setTitle(null);
+        setContent(null);
+    }
+
     return (
         <div className='application-status-panel row'>
+            {title && content && <InfoPopup title={title} content={content} onClose={closeApplicationStatusFull} />}
             <div className='application-status-panel__item columns small-2'>
                 <div className='application-status-panel__item-value'>
                     <HealthStatusIcon state={application.status.health} />
@@ -59,7 +72,7 @@ export const ApplicationStatusPanel = ({application, showOperation, showConditio
                 </div>
             </div>
             {appOperationState && (
-                <div className='application-status-panel__item columns small-4 '>
+                <div className='application-status-panel__item columns small-4'>
                     <div className={`application-status-panel__item-value application-status-panel__item-value--${appOperationState.phase}`}>
                         <a onClick={() => showOperation && showOperation()}>
                             <OperationState app={application} />
@@ -72,21 +85,60 @@ export const ApplicationStatusPanel = ({application, showOperation, showConditio
                             />
                         </a>
                     </div>
-                    {appOperationState.syncResult && appOperationState.syncResult.revision && (
+                    <div className='third-column-truncate'>
+                        {appOperationState.syncResult && appOperationState.syncResult.revision && (
+                            <div className='application-status-panel__item-name'>
+                                To <Revision repoUrl={application.spec.source.repoURL} revision={appOperationState.syncResult.revision} />
+                            </div>
+                        )}
                         <div className='application-status-panel__item-name'>
-                            To <Revision repoUrl={application.spec.source.repoURL} revision={appOperationState.syncResult.revision} />
+                            {appOperationState.phase} <Timestamp date={appOperationState.finishedAt || appOperationState.startedAt} />
                         </div>
-                    )}
-                    <div className='application-status-panel__item-name'>
-                        {appOperationState.phase} <Timestamp date={appOperationState.finishedAt || appOperationState.startedAt} />
+                        {(appOperationState.syncResult && appOperationState.syncResult.revision && (
+                            <RevisionMetadataPanel
+                                appName={application.metadata.name}
+                                type={application.spec.source.chart && 'helm'}
+                                revision={appOperationState.syncResult.revision}
+                            />
+                        )) || <div className='application-status-panel__item-name'>{appOperationState.message}</div>}
+                        <br />
                     </div>
-                    {(appOperationState.syncResult && appOperationState.syncResult.revision && (
-                        <RevisionMetadataPanel
-                            appName={application.metadata.name}
-                            type={application.spec.source.chart && 'helm'}
-                            revision={appOperationState.syncResult.revision}
-                        />
-                    )) || <div className='application-status-panel__item-name'>{appOperationState.message}</div>}
+                    <button
+                        className='view-application-status-full'
+                        onClick={() =>
+                            viewApplicationStatusFull(
+                                // title of info popup
+                                <div className={`info-popup-title application-status-panel__item-value application-status-panel__item-value--${appOperationState.phase}`}>
+                                    <a onClick={() => showOperation && showOperation()}>
+                                        {utils.getOperationStateTitle(application)}
+                                        <div className='info-popup-title__timestamp'>
+                                            - {appOperationState.phase} <Timestamp date={appOperationState.finishedAt || appOperationState.startedAt} />
+                                        </div>
+                                    </a>
+                                </div>,
+                                // content of info-popup
+                                <div className='info-popup-content'>
+                                    {appOperationState.syncResult && appOperationState.syncResult.revision && (
+                                        <div className='info-popup-content__data'>
+                                            To <Revision repoUrl={application.spec.source.repoURL} revision={appOperationState.syncResult.revision} />
+                                        </div>
+                                    )}
+                                    {(appOperationState.syncResult && appOperationState.syncResult.revision && (
+                                        <div className='info-popup-content__data'>
+                                            <RevisionMetadataPanel
+                                                appName={application.metadata.name}
+                                                type={application.spec.source.chart && 'helm'}
+                                                revision={appOperationState.syncResult.revision}
+                                            />
+                                        </div>
+                                    )) || <div className='info-popup-content__data'>{appOperationState.message}</div>}
+                                    <br />
+                                    <div>It has been {daysSinceLastSynchronized} days since last sync.</div>
+                                </div>
+                            )
+                        }>
+                        Expand <i className='fas fa-angle-double-right' />
+                    </button>
                 </div>
             )}
             {application.status.conditions && (

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -466,7 +466,7 @@ export function getOperationType(application: appModels.Application) {
     return 'Unknown';
 }
 
-const getOperationStateTitle = (app: appModels.Application) => {
+export const getOperationStateTitle = (app: appModels.Application) => {
     const appOperationState = getAppOperationState(app);
     const operationType = getOperationType(app);
     switch (operationType) {

--- a/ui/src/app/shared/components/index.ts
+++ b/ui/src/app/shared/components/index.ts
@@ -18,6 +18,7 @@ export * from './tags-input/tags-input';
 export * from './monaco-editor';
 export * from './yaml-editor/yaml-editor';
 export * from './progress/progress-popup';
+export * from './info-popup/info-popup';
 export * from './repo';
 export * from './revision';
 export * from './timestamp';

--- a/ui/src/app/shared/components/info-popup/info-popup.tsx
+++ b/ui/src/app/shared/components/info-popup/info-popup.tsx
@@ -1,0 +1,21 @@
+import {Popup} from 'argo-ui';
+import * as React from 'react';
+
+const Title = ({title, onClose}: {title: JSX.Element; onClose: () => void}) => {
+    return (
+        <React.Fragment>
+            {' '}
+            <span>
+                {title} <i className='argo-icon-close' onClick={onClose} />
+            </span>
+        </React.Fragment>
+    );
+};
+
+export const InfoPopup = ({title, content, onClose}: {title: JSX.Element; content: JSX.Element; onClose: () => void}) => {
+    return (
+        <Popup title={<Title title={title} onClose={onClose} />}>
+            <div>{content}</div>
+        </Popup>
+    );
+};


### PR DESCRIPTION
This will fix issue #5043. Added an Expand button that will open a popup with information relating to the commit information if the user wishes to view it in its entirety. This will prevent longer commit messages from overflowing their container. 

![info-popup](https://user-images.githubusercontent.com/50851526/104498756-20525500-55aa-11eb-899c-092224b9d6ce.png)



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

