### PR TITLE
fix: use red spinner color for terminating animation

### DIFF
--- a/ui/src/app/applications/components/__snapshots__/utils.test.tsx.snap
+++ b/ui/src/app/applications/components/__snapshots__/utils.test.tsx.snap
@@ -282,7 +282,7 @@ exports[`ResourceResultIcon.Hook.Terminating 1`] = `
   className="fa fa-circle-notch fa-spin"
   style={
     Object {
-      "color": "#0DADEA",
+      "color": "#DE303D",
     }
   }
 />

--- a/ui/src/app/shared/components/colors.ts
+++ b/ui/src/app/shared/components/colors.ts
@@ -3,6 +3,7 @@ const ARGO_WARNING_COLOR = '#f4c030';
 const ARGO_FAILED_COLOR = '#E96D76';
 const ARGO_RUNNING_COLOR = '#0DADEA';
 const ARGO_GRAY4_COLOR = '#CCD6DD';
+const ARGO_TERMINATING_COLOR = '#DE303D';
 
 export const COLORS = {
     connection_status: {
@@ -23,7 +24,7 @@ export const COLORS = {
         failed: ARGO_FAILED_COLOR,
         running: ARGO_RUNNING_COLOR,
         success: ARGO_SUCCESS_COLOR,
-        terminating: ARGO_RUNNING_COLOR
+        terminating: ARGO_TERMINATING_COLOR
     },
     sync: {
         synced: ARGO_SUCCESS_COLOR,


### PR DESCRIPTION
This will close issue #5159. Changes spinner icon color from cyan/blue (`ARGO_RUNNING_COLOR`) to it's own color, `ARGO_TERMINATING_COLOR` ([#DE303D](https://colorate.azurewebsites.net/Color/DE303D)), a bright red.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

