### PR TITLE
fix: app create with -f ignored labels from file

### DIFF
--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -471,12 +471,6 @@ func SetParameterOverrides(app *argoappv1.Application, parameters []string) {
 	}
 }
 
-func SetLabels(app *argoappv1.Application, labels []string) {
-	mapLabels, err := label.Parse(labels)
-	errors.CheckError(err)
-	app.SetLabels(mapLabels)
-}
-
 func readAppFromStdin(app *argoappv1.Application) error {
 	reader := bufio.NewReader(os.Stdin)
 	err := config.UnmarshalReader(reader, &app)
@@ -521,7 +515,7 @@ func ConstructApp(fileURL, appName string, labels, args []string, appOpts AppOpt
 		}
 		SetAppSpecOptions(flags, &app.Spec, &appOpts)
 		SetParameterOverrides(&app, appOpts.Parameters)
-		SetLabels(&app, labels)
+		mergeLabels(&app, labels)
 	} else {
 		// read arguments
 		if len(args) == 1 {
@@ -541,7 +535,24 @@ func ConstructApp(fileURL, appName string, labels, args []string, appOpts AppOpt
 		}
 		SetAppSpecOptions(flags, &app.Spec, &appOpts)
 		SetParameterOverrides(&app, appOpts.Parameters)
-		SetLabels(&app, labels)
+		mergeLabels(&app, labels)
 	}
 	return &app, nil
+}
+
+func mergeLabels(app *argoappv1.Application, labels []string) {
+	mapLabels, err := label.Parse(labels)
+	errors.CheckError(err)
+
+	mergedLabels := make(map[string]string)
+
+	for name, value := range app.GetLabels() {
+		mergedLabels[name] = value
+	}
+
+	for name, value := range mapLabels {
+		mergedLabels[name] = value
+	}
+
+	app.SetLabels(mergedLabels)
 }


### PR DESCRIPTION
Since v1.7.5 ( #4322), `argocd app create -f` doesn't use any labels specified inside the application file anymore. Refactor the `SetLabels` function to merge labels specified in the file with those from the command line arguments. Extend the existing e2e test to verify that behavior.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

