### PR TITLE
docs: update aws discrepancy in security.md

### DIFF
--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -55,7 +55,7 @@ and logs. This includes:
 To manage external clusters, Argo CD stores the credentials of the external cluster as a Kubernetes
 Secret in the argocd namespace. This secret contains the K8s API bearer token associated with the
 `argocd-manager` ServiceAccount created during `argocd cluster add`, along with connection options
-to that API server (TLS configuration/certs, aws-iam-authenticator RoleARN, etc...).
+to that API server (TLS configuration/certs, AWS role-arn, etc...).
 The information is used to reconstruct a REST config and kubeconfig to the cluster used by Argo CD
 services.
 
@@ -81,7 +81,7 @@ kubectl delete clusterrolebinding argocd-manager-role-binding
 argocd cluster rm https://your-kubernetes-cluster-addr
 ```
 <!-- markdownlint-disable MD027 -->
-> NOTE: for AWS EKS clusters, [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator)
+> NOTE: for AWS EKS clusters, the [get-token](https://docs.aws.amazon.com/cli/latest/reference/eks/get-token.html) command
   is used to authenticate to the external cluster, which uses IAM roles in lieu of locally stored
   tokens, so token rotation is not needed, and revocation is handled through IAM.
 <!-- markdownlint-enable MD027 -->


### PR DESCRIPTION
In PR #3010 the method of authentication w/ AWS changed. The previous method was still referenced in the docs.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

