### PR TITLE
Add build for ARM64, remove assumption of running on AMD64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,9 @@ RUN make argocd-all
 ARG BUILD_ALL_CLIS=true
 RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
     make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all && \
-    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all \
+    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all && \
+    make BIN_NAME=argocd-linux-amd64 GOOS=linux GOARCH=amd64 argocd-all && \
+    make BIN_NAME=argocd-linux-arm64 GOOS=linux GOARCH=arm64 argocd-all \
     ; fi
 
 ####################################################################################################

--- a/server/server.go
+++ b/server/server.go
@@ -755,12 +755,20 @@ func newRedirectServer(port int, rootPath string) *http.Server {
 // registerDownloadHandlers registers HTTP handlers to support downloads directly from the API server
 // (e.g. argocd CLI)
 func registerDownloadHandlers(mux *http.ServeMux, base string) {
-	linuxPath, err := exec.LookPath("argocd")
+	linuxAmdPath, err := exec.LookPath("argocd-linux-amd64")
 	if err != nil {
-		log.Warnf("argocd not in PATH")
+		log.Warnf("argocd-linux-amd64 not in PATH")
 	} else {
 		mux.HandleFunc(base+"/argocd-linux-amd64", func(w http.ResponseWriter, r *http.Request) {
-			http.ServeFile(w, r, linuxPath)
+			http.ServeFile(w, r, linuxAmdPath)
+		})
+	}
+	linuxArmPath, err := exec.LookPath("argocd-linux-arm64")
+	if err != nil {
+		log.Warnf("argocd-linux-arm64 not in PATH")
+	} else {
+		mux.HandleFunc(base+"/argocd-linux-arm64", func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, linuxArmPath)
 		})
 	}
 	darwinPath, err := exec.LookPath("argocd-darwin-amd64")


### PR DESCRIPTION
This PR does two things - it adds a new build target for the cli (linux arm64), and it removes an assumption that the 'argocd' binary is built for amd64. This is a bug we noticed when running Argo CD on ARM-based instances - downloading the linux-amd64 binary for CLI  (argocd-linux-amd64) was actually built for arm64, since the container was running on ARM64. 

Signed-off-by: Jonah Back <jonah@jonahback.com>

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

