### PR TITLE
fix: Use correct API version when generating app and project manifests

### DIFF
--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -527,7 +527,7 @@ func ConstructApp(fileURL, appName string, labels, args []string, appOpts AppOpt
 		app = argoappv1.Application{
 			TypeMeta: v1.TypeMeta{
 				Kind:       application.ApplicationKind,
-				APIVersion: application.Group + "/v1aplha1",
+				APIVersion: application.Group + "/v1alpha1",
 			},
 			ObjectMeta: v1.ObjectMeta{
 				Name: appName,

--- a/cmd/util/project.go
+++ b/cmd/util/project.go
@@ -124,7 +124,7 @@ func ConstructAppProj(fileURL string, args []string, opts ProjectOpts, c *cobra.
 		proj = v1alpha1.AppProject{
 			TypeMeta: v1.TypeMeta{
 				Kind:       application.AppProjectKind,
-				APIVersion: application.Group + "/v1aplha1",
+				APIVersion: application.Group + "/v1alpha1",
 			},
 			ObjectMeta: v1.ObjectMeta{Name: projName},
 			Spec: v1alpha1.AppProjectSpec{


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

