### PR TITLE
fix: improve fetching commit SHAs

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -263,8 +263,9 @@ func (m *nativeGitClient) IsLFSEnabled() bool {
 // Fetch fetches latest updates from origin
 func (m *nativeGitClient) Fetch(revision string) error {
 	var err error
-	if revision != "" {
-		err = m.runCredentialedCmd("git", "fetch", "origin", revision)
+	// Some git providers don't support fetching commit sha
+	if revision != "" && !IsCommitSHA(revision) && !IsTruncatedCommitSHA(revision) {
+		err = m.runCredentialedCmd("git", "fetch", "origin", revision, "--tags", "--force")
 	} else {
 		err = m.runCredentialedCmd("git", "fetch", "origin", "--tags", "--force")
 	}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

* Followup for https://github.com/argoproj/argo-cd/pull/4893 . Some git providers e.g. Bitbucket don't support `git fetch origin <revision>` if revision is a commit sha.
* The `git fetch origin <revision>` should fetch be executed with `--force` and `--tags` to support force pushes and load commit metadata