### PR TITLE
fix: fix fetching commit SHAs (#5312)

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -263,8 +263,7 @@ func (m *nativeGitClient) IsLFSEnabled() bool {
 // Fetch fetches latest updates from origin
 func (m *nativeGitClient) Fetch(revision string) error {
 	var err error
-	// Some git providers don't support fetching commit sha
-	if revision != "" && !IsCommitSHA(revision) && !IsTruncatedCommitSHA(revision) {
+	if revision != "" {
 		err = m.runCredentialedCmd("git", "fetch", "origin", revision, "--tags", "--force")
 	} else {
 		err = m.runCredentialedCmd("git", "fetch", "origin", "--tags", "--force")


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <Alexander_Matyushentsev@intuit.com>

PR is a follow up for https://github.com/argoproj/argo-cd/commit/d8b545d107ac4e1f48761c8ab3fc738381b3efec. 

Repo server should execute `git fetch origin && git checkout <sha>` instead of `git fetch origin && git checkout FETCH_HEAD`