### PR TITLE
feat: Logs should favor containers over init containers (#4345)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -725,13 +725,13 @@ Are you sure you want to disable auto-sync and rollback application '${this.prop
             const containerGroups = [
                 {
                     offset: 0,
-                    title: 'INIT CONTAINERS',
-                    containers: state.spec.initContainers || []
-                },
-                {
-                    offset: (state.spec.initContainers || []).length,
                     title: 'CONTAINERS',
                     containers: state.spec.containers || []
+                },
+                {
+                    offset: (state.spec.containers || []).length,
+                    title: 'INIT CONTAINERS',
+                    containers: state.spec.initContainers || []
                 }
             ];
             tabs = tabs.concat([

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -10,7 +10,7 @@ import './pod-logs-viewer.scss';
 const maxLines = 100;
 
 export const PodsLogsViewer = (props: {applicationName: string; pod: models.ResourceNode & any; containerIndex: number}) => {
-    const containers = (props.pod.spec.initContainers || []).concat(props.pod.spec.containers || []);
+    const containers = (props.pod.spec.containers || []).concat(props.pod.spec.initContainers || []);
     const container = containers[props.containerIndex];
     if (!container) {
         return <div>Pod does not have container with index {props.containerIndex}</div>;
@@ -94,6 +94,7 @@ export const PodsLogsViewer = (props: {applicationName: string; pod: models.Reso
                                 <pre style={{height: '95%', textAlign: 'center'}}>Loading...</pre>
                             </div>
                         )}
+                        input={container.name}
                         load={() => {
                             return (
                                 services.applications

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1824,7 +1824,7 @@ are-we-there-yet@~1.1.2:
 
 "argo-ui@https://github.com/argoproj/argo-ui.git":
   version "1.0.0"
-  resolved "https://github.com/argoproj/argo-ui.git#80c75deefff940d3aa44edb04cccdf45308be84c"
+  resolved "https://github.com/argoproj/argo-ui.git#b6e535cf660686135de5568f9c93bf93cf7caf4e"
   dependencies:
     "@fortawesome/fontawesome-free" "^5.8.1"
     "@tippy.js/react" "^2.1.2"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/4345

Pod logs component shows init containers after normal containers. 