### PR TITLE
refactor: optimize number of redis calls by argocd-application-controller

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -77,7 +77,7 @@ func NewCommand() *cobra.Command {
 
 			cache, err := cacheSrc()
 			errors.CheckError(err)
-			cache.Cache.SetClient(cacheutil.NewTwoLevelClient(cache.Cache.GetClient(), time.Hour))
+			cache.Cache.SetClient(cacheutil.NewTwoLevelClient(cache.Cache.GetClient(), 10*time.Minute))
 
 			settingsMgr := settings.NewSettingsManager(ctx, kubeClient, namespace)
 			kubectl := kubeutil.NewKubectl()

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -985,6 +985,18 @@ type ApplicationTree struct {
 	Hosts []HostInfo `json:"hosts,omitempty" protobuf:"bytes,3,rep,name=hosts"`
 }
 
+func (t *ApplicationTree) Normalize() {
+	sort.Slice(t.Nodes, func(i, j int) bool {
+		return t.Nodes[i].FullName() < t.Nodes[j].FullName()
+	})
+	sort.Slice(t.OrphanedNodes, func(i, j int) bool {
+		return t.OrphanedNodes[i].FullName() < t.OrphanedNodes[j].FullName()
+	})
+	sort.Slice(t.Hosts, func(i, j int) bool {
+		return t.Hosts[i].Name < t.Hosts[j].Name
+	})
+}
+
 type ApplicationSummary struct {
 	// ExternalURLs holds all external URLs of application child resources.
 	ExternalURLs []string `json:"externalURLs,omitempty" protobuf:"bytes,1,opt,name=externalURLs"`
@@ -1053,6 +1065,10 @@ type ResourceNode struct {
 	CreatedAt       *metav1.Time            `json:"createdAt,omitempty" protobuf:"bytes,8,opt,name=createdAt"`
 }
 
+func (n *ResourceNode) FullName() string {
+	return fmt.Sprintf("%s/%s/%s/%s", n.Group, n.Kind, n.Namespace, n.Name)
+}
+
 func (n *ResourceNode) GroupKindVersion() schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group:   n.Group,
@@ -1098,6 +1114,10 @@ type ResourceDiff struct {
 	PredictedLiveState string `json:"predictedLiveState,omitempty" protobuf:"bytes,10,opt,name=predictedLiveState"`
 	ResourceVersion    string `json:"resourceVersion,omitempty" protobuf:"bytes,11,opt,name=resourceVersion"`
 	Modified           bool   `json:"modified,omitempty" protobuf:"bytes,12,opt,name=modified"`
+}
+
+func (r *ResourceDiff) FullName() string {
+	return fmt.Sprintf("%s/%s/%s/%s", r.Group, r.Kind, r.Namespace, r.Name)
 }
 
 // ConnectionStatus represents connection status

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -303,7 +303,8 @@ export class PodView extends React.Component<PodViewProps> {
                     renderMenu: () => this.props.nodeMenu(rnode)
                 };
             }
-
+        });
+        (tree.nodes || []).forEach((rnode: ResourceTreeNode) => {
             if (rnode.kind !== 'Pod') {
                 return;
             }

--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -3,6 +3,7 @@ package appstate
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -61,6 +62,9 @@ func (c *Cache) GetAppManagedResources(appName string, res *[]*appv1.ResourceDif
 }
 
 func (c *Cache) SetAppManagedResources(appName string, managedResources []*appv1.ResourceDiff) error {
+	sort.Slice(managedResources, func(i, j int) bool {
+		return managedResources[i].FullName() < managedResources[j].FullName()
+	})
 	return c.SetItem(appManagedResourcesKey(appName), managedResources, c.appStateCacheExpiration, managedResources == nil)
 }
 
@@ -82,6 +86,9 @@ func (c *Cache) OnAppResourcesTreeChanged(ctx context.Context, appName string, c
 }
 
 func (c *Cache) SetAppResourcesTree(appName string, resourcesTree *appv1.ApplicationTree) error {
+	if resourcesTree != nil {
+		resourcesTree.Normalize()
+	}
 	err := c.SetItem(appResourcesTreeKey(appName), resourcesTree, c.appStateCacheExpiration, resourcesTree == nil)
 	if err != nil {
 		return err

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -29,6 +29,21 @@ func (i *InMemoryCache) Set(item *Item) error {
 	return nil
 }
 
+func (i *InMemoryCache) HasSame(key string, obj interface{}) bool {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(obj)
+	if err != nil {
+		return false
+	}
+
+	bufIf, found := i.memCache.Get(key)
+	if !found {
+		return false
+	}
+	existingBuf := bufIf.(bytes.Buffer)
+	return bytes.Equal(buf.Bytes(), existingBuf.Bytes())
+}
+
 func (i *InMemoryCache) Get(key string, obj interface{}) error {
 	bufIf, found := i.memCache.Get(key)
 	if !found {

--- a/util/cache/twolevelclient.go
+++ b/util/cache/twolevelclient.go
@@ -10,11 +10,14 @@ func NewTwoLevelClient(client CacheClient, inMemoryExpiration time.Duration) *tw
 }
 
 type twoLevelClient struct {
-	inMemoryCache CacheClient
+	inMemoryCache *InMemoryCache
 	client        CacheClient
 }
 
 func (c *twoLevelClient) Set(item *Item) error {
+	if c.inMemoryCache.HasSame(item.Key, item.Object) {
+		return nil
+	}
 	_ = c.inMemoryCache.Set(item)
 	return c.client.Set(item)
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The `argocd-application-controller` uses Redis a LOT that results in significant traffic that might be costly in the cloud. PR introduces two-level caching: before reading/writing to redis controller check in-memory cache first and don't use redis if in-memory cache already has required entry. This is safe since the controller is the only writer to the Redis. 