### PR TITLE
refactor: optimize argocd-application-controller redis usage

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -77,6 +77,7 @@ func NewCommand() *cobra.Command {
 
 			cache, err := cacheSrc()
 			errors.CheckError(err)
+			cache.Cache.SetClient(cacheutil.NewTwoLevelClient(cache.Cache.GetClient(), time.Hour))
 
 			settingsMgr := settings.NewSettingsManager(ctx, kubeClient, namespace)
 			kubectl := kubeutil.NewKubectl()

--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -77,7 +77,7 @@ func NewCommand() *cobra.Command {
 
 			cache, err := cacheSrc()
 			errors.CheckError(err)
-			cache.Cache.SetClient(cacheutil.NewTwoLevelClient(cache.Cache.GetClient(), time.Hour))
+			cache.Cache.SetClient(cacheutil.NewTwoLevelClient(cache.Cache.GetClient(), 10*time.Minute))
 
 			settingsMgr := settings.NewSettingsManager(ctx, kubeClient, namespace)
 			kubectl := kubeutil.NewKubectl()

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -985,6 +985,18 @@ type ApplicationTree struct {
 	Hosts []HostInfo `json:"hosts,omitempty" protobuf:"bytes,3,rep,name=hosts"`
 }
 
+func (t *ApplicationTree) Normalize() {
+	sort.Slice(t.Nodes, func(i, j int) bool {
+		return t.Nodes[i].FullName() < t.Nodes[j].FullName()
+	})
+	sort.Slice(t.OrphanedNodes, func(i, j int) bool {
+		return t.OrphanedNodes[i].FullName() < t.OrphanedNodes[j].FullName()
+	})
+	sort.Slice(t.Hosts, func(i, j int) bool {
+		return t.Hosts[i].Name < t.Hosts[j].Name
+	})
+}
+
 type ApplicationSummary struct {
 	// ExternalURLs holds all external URLs of application child resources.
 	ExternalURLs []string `json:"externalURLs,omitempty" protobuf:"bytes,1,opt,name=externalURLs"`
@@ -1053,6 +1065,10 @@ type ResourceNode struct {
 	CreatedAt       *metav1.Time            `json:"createdAt,omitempty" protobuf:"bytes,8,opt,name=createdAt"`
 }
 
+func (n *ResourceNode) FullName() string {
+	return fmt.Sprintf("%s/%s/%s/%s", n.Group, n.Kind, n.Namespace, n.Name)
+}
+
 func (n *ResourceNode) GroupKindVersion() schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group:   n.Group,
@@ -1098,6 +1114,10 @@ type ResourceDiff struct {
 	PredictedLiveState string `json:"predictedLiveState,omitempty" protobuf:"bytes,10,opt,name=predictedLiveState"`
 	ResourceVersion    string `json:"resourceVersion,omitempty" protobuf:"bytes,11,opt,name=resourceVersion"`
 	Modified           bool   `json:"modified,omitempty" protobuf:"bytes,12,opt,name=modified"`
+}
+
+func (r *ResourceDiff) FullName() string {
+	return fmt.Sprintf("%s/%s/%s/%s", r.Group, r.Kind, r.Namespace, r.Name)
 }
 
 // ConnectionStatus represents connection status

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -985,6 +985,8 @@ type ApplicationTree struct {
 	Hosts []HostInfo `json:"hosts,omitempty" protobuf:"bytes,3,rep,name=hosts"`
 }
 
+// Normalize sorts application tree nodes and hosts. The persistent order allows to
+// effectively compare previously cached app tree and allows to unnecessary Redis requests.
 func (t *ApplicationTree) Normalize() {
 	sort.Slice(t.Nodes, func(i, j int) bool {
 		return t.Nodes[i].FullName() < t.Nodes[j].FullName()
@@ -1065,6 +1067,7 @@ type ResourceNode struct {
 	CreatedAt       *metav1.Time            `json:"createdAt,omitempty" protobuf:"bytes,8,opt,name=createdAt"`
 }
 
+// FullName returns node full name
 func (n *ResourceNode) FullName() string {
 	return fmt.Sprintf("%s/%s/%s/%s", n.Group, n.Kind, n.Namespace, n.Name)
 }
@@ -1116,6 +1119,7 @@ type ResourceDiff struct {
 	Modified           bool   `json:"modified,omitempty" protobuf:"bytes,12,opt,name=modified"`
 }
 
+// FullName returns full name of a node that was used for diffing
 func (r *ResourceDiff) FullName() string {
 	return fmt.Sprintf("%s/%s/%s/%s", r.Group, r.Kind, r.Namespace, r.Name)
 }

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -303,7 +303,8 @@ export class PodView extends React.Component<PodViewProps> {
                     renderMenu: () => this.props.nodeMenu(rnode)
                 };
             }
-
+        });
+        (tree.nodes || []).forEach((rnode: ResourceTreeNode) => {
             if (rnode.kind !== 'Pod') {
                 return;
             }

--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -3,6 +3,7 @@ package appstate
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -61,6 +62,9 @@ func (c *Cache) GetAppManagedResources(appName string, res *[]*appv1.ResourceDif
 }
 
 func (c *Cache) SetAppManagedResources(appName string, managedResources []*appv1.ResourceDiff) error {
+	sort.Slice(managedResources, func(i, j int) bool {
+		return managedResources[i].FullName() < managedResources[j].FullName()
+	})
 	return c.SetItem(appManagedResourcesKey(appName), managedResources, c.appStateCacheExpiration, managedResources == nil)
 }
 
@@ -82,6 +86,9 @@ func (c *Cache) OnAppResourcesTreeChanged(ctx context.Context, appName string, c
 }
 
 func (c *Cache) SetAppResourcesTree(appName string, resourcesTree *appv1.ApplicationTree) error {
+	if resourcesTree != nil {
+		resourcesTree.Normalize()
+	}
 	err := c.SetItem(appResourcesTreeKey(appName), resourcesTree, c.appStateCacheExpiration, resourcesTree == nil)
 	if err != nil {
 		return err

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -78,6 +78,14 @@ type Cache struct {
 	client CacheClient
 }
 
+func (c *Cache) GetClient() CacheClient {
+	return c.client
+}
+
+func (c *Cache) SetClient(client CacheClient) {
+	c.client = client
+}
+
 func (c *Cache) SetItem(key string, item interface{}, expiration time.Duration, delete bool) error {
 	key = fmt.Sprintf("%s|%s", key, common.CacheVersion)
 	if delete {

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -29,6 +29,21 @@ func (i *InMemoryCache) Set(item *Item) error {
 	return nil
 }
 
+func (i *InMemoryCache) HasSame(key string, obj interface{}) bool {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(obj)
+	if err != nil {
+		return false
+	}
+
+	bufIf, found := i.memCache.Get(key)
+	if !found {
+		return false
+	}
+	existingBuf := bufIf.(bytes.Buffer)
+	return bytes.Equal(buf.Bytes(), existingBuf.Bytes())
+}
+
 func (i *InMemoryCache) Get(key string, obj interface{}) error {
 	bufIf, found := i.memCache.Get(key)
 	if !found {

--- a/util/cache/twolevelclient.go
+++ b/util/cache/twolevelclient.go
@@ -10,11 +10,14 @@ func NewTwoLevelClient(client CacheClient, inMemoryExpiration time.Duration) *tw
 }
 
 type twoLevelClient struct {
-	inMemoryCache CacheClient
+	inMemoryCache *InMemoryCache
 	client        CacheClient
 }
 
 func (c *twoLevelClient) Set(item *Item) error {
+	if c.inMemoryCache.HasSame(item.Key, item.Object) {
+		return nil
+	}
 	_ = c.inMemoryCache.Set(item)
 	return c.client.Set(item)
 }

--- a/util/cache/twolevelclient.go
+++ b/util/cache/twolevelclient.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+func NewTwoLevelClient(client CacheClient, inMemoryExpiration time.Duration) *twoLevelClient {
+	return &twoLevelClient{inMemoryCache: NewInMemoryCache(inMemoryExpiration), client: client}
+}
+
+type twoLevelClient struct {
+	inMemoryCache CacheClient
+	client        CacheClient
+}
+
+func (c *twoLevelClient) Set(item *Item) error {
+	_ = c.inMemoryCache.Set(item)
+	return c.client.Set(item)
+}
+
+func (c *twoLevelClient) Get(key string, obj interface{}) error {
+	err := c.inMemoryCache.Get(key, obj)
+	if err == nil {
+		return nil
+	}
+
+	err = c.client.Get(key, obj)
+	if err == nil {
+		_ = c.inMemoryCache.Set(&Item{Key: key, Object: obj})
+	}
+	return err
+}
+
+func (c *twoLevelClient) Delete(key string) error {
+	err := c.inMemoryCache.Delete(key)
+	if err != nil {
+		return err
+	}
+	return c.client.Delete(key)
+}
+
+func (c *twoLevelClient) OnUpdated(ctx context.Context, key string, callback func() error) error {
+	return c.client.OnUpdated(ctx, key, callback)
+}
+
+func (c *twoLevelClient) NotifyUpdated(key string) error {
+	return c.client.NotifyUpdated(key)
+}

--- a/util/cache/twolevelclient.go
+++ b/util/cache/twolevelclient.go
@@ -3,50 +3,66 @@ package cache
 import (
 	"context"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
+// NewTwoLevelClient creates cache client that proxies requests to given external cache and tries to minimize
+// number of requests to external client by storing cache entries in local in-memory cache.
 func NewTwoLevelClient(client CacheClient, inMemoryExpiration time.Duration) *twoLevelClient {
-	return &twoLevelClient{inMemoryCache: NewInMemoryCache(inMemoryExpiration), client: client}
+	return &twoLevelClient{inMemoryCache: NewInMemoryCache(inMemoryExpiration), externalCache: client}
 }
 
 type twoLevelClient struct {
 	inMemoryCache *InMemoryCache
-	client        CacheClient
+	externalCache CacheClient
 }
 
+// Set stores the given value in both in-memory and external cache.
+// Skip storing the value in external cache if the same value already exists in memory to avoid requesting external cache.
 func (c *twoLevelClient) Set(item *Item) error {
-	if c.inMemoryCache.HasSame(item.Key, item.Object) {
+	has, err := c.inMemoryCache.HasSame(item.Key, item.Object)
+	if has {
 		return nil
 	}
-	_ = c.inMemoryCache.Set(item)
-	return c.client.Set(item)
+	if err != nil {
+		log.Warnf("Failed to check key '%s' in in-memory cache: %v", item.Key, err)
+	}
+	err = c.inMemoryCache.Set(item)
+	if err != nil {
+		log.Warnf("Failed to save key '%s' in in-memory cache: %v", item.Key, err)
+	}
+	return c.externalCache.Set(item)
 }
 
+// Get returns cache value from in-memory cache if it present. Otherwise loads it from external cache and persists
+// in memory to avoid future requests to external cache.
 func (c *twoLevelClient) Get(key string, obj interface{}) error {
 	err := c.inMemoryCache.Get(key, obj)
 	if err == nil {
 		return nil
 	}
 
-	err = c.client.Get(key, obj)
+	err = c.externalCache.Get(key, obj)
 	if err == nil {
 		_ = c.inMemoryCache.Set(&Item{Key: key, Object: obj})
 	}
 	return err
 }
 
+// Delete deletes cache for given key in both in-memory and external cache.
 func (c *twoLevelClient) Delete(key string) error {
 	err := c.inMemoryCache.Delete(key)
 	if err != nil {
 		return err
 	}
-	return c.client.Delete(key)
+	return c.externalCache.Delete(key)
 }
 
 func (c *twoLevelClient) OnUpdated(ctx context.Context, key string, callback func() error) error {
-	return c.client.OnUpdated(ctx, key, callback)
+	return c.externalCache.OnUpdated(ctx, key, callback)
 }
 
 func (c *twoLevelClient) NotifyUpdated(key string) error {
-	return c.client.NotifyUpdated(key)
+	return c.externalCache.NotifyUpdated(key)
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The `argocd-application-controller` uses Redis a LOT that results in significant traffic that might be costly in the cloud. PR introduces two-level caching: before reading/writing to redis controller check in-memory cache first and don't use redis if in-memory cache already has required entry. This is safe since the controller is the only writer to the Redis. 