### PR TITLE
feat: selective sync (#3877)

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -84,7 +84,8 @@ type comparisonResult struct {
 	diffNormalizer       diff.Normalizer
 	appSourceType        v1alpha1.ApplicationSourceType
 	// timings maps phases of comparison to the duration it took to complete (for statistical purposes)
-	timings map[string]time.Duration
+	timings        map[string]time.Duration
+	diffResultList *diff.DiffResultList
 }
 
 func (res *comparisonResult) GetSyncStatus() *v1alpha1.SyncStatus {
@@ -554,6 +555,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *ap
 		managedResources:     managedResources,
 		reconciliationResult: reconciliation,
 		diffNormalizer:       diffNormalizer,
+		diffResultList:       diffResults,
 	}
 	if manifestInfo != nil {
 		compRes.appSourceType = v1alpha1.ApplicationSourceType(manifestInfo.SourceType)

--- a/docs/user-guide/selective_sync.md
+++ b/docs/user-guide/selective_sync.md
@@ -8,3 +8,10 @@ When doing so, bear in mind:
 
 * Your sync is not recorded in the history, and so rollback is not possible.
 * Hooks are not run.
+
+## Selective Sync Option
+
+>v1.8
+
+Turning on selective sync option which will sync only out-of-sync resources.
+See [sync options](sync-options.md#selective-sync) documentation for more details.

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -57,3 +57,31 @@ metadata:
 ```
 
 The dry run will still be executed if the CRD is already present in the cluster.
+
+## Selective Sync
+
+>v1.8
+
+Currently when syncing using auto sync ArgoCD applies every object in the application. 
+For applications containing thousands of objects this takes quite a long time and puts undue pressure on the api server.
+You can turn on selective sync behaviour which will sync only out-of-sync resources using this option. 
+
+You can add this option by following ways
+
+1) Add `ApplyOutOfSync=true` in manifest
+
+Example:
+
+```yaml
+syncPolicy:
+  syncOptions:
+    - ApplyOutOfSync=true
+``` 
+
+2) Set sync option via argocd cli
+
+Example:
+
+```bash
+$ argocd app set guestbook --sync-option ApplyOutOfSync=true
+```

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -64,7 +64,7 @@ The dry run will still be executed if the CRD is already present in the cluster.
 
 Currently when syncing using auto sync ArgoCD applies every object in the application. 
 For applications containing thousands of objects this takes quite a long time and puts undue pressure on the api server.
-You can turn on selective sync behaviour which will sync only out-of-sync resources using this option. 
+Turning on selective sync option which will sync only out-of-sync resources. 
 
 You can add this option by following ways
 
@@ -75,7 +75,7 @@ Example:
 ```yaml
 syncPolicy:
   syncOptions:
-    - ApplyOutOfSync=true
+    - ApplyOutOfSyncOnly=true
 ``` 
 
 2) Set sync option via argocd cli
@@ -83,5 +83,5 @@ syncPolicy:
 Example:
 
 ```bash
-$ argocd app set guestbook --sync-option ApplyOutOfSync=true
+$ argocd app set guestbook --sync-option ApplyOutOfSyncOnly=true
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/argoproj/gitops-engine v0.2.1-0.20210112204306-814d79df4954
+	github.com/argoproj/gitops-engine v0.2.1-0.20210129183711-c5b7114c501f
 	github.com/argoproj/pkg v0.2.0
 	github.com/bombsimon/logrusr v1.0.0
 	github.com/casbin/casbin v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj/gitops-engine v0.2.1-0.20210112204306-814d79df4954 h1:IJSkAuhE4DrLDJmGPa0eGCK20gjCQokkjk2Il7Pd/Sw=
-github.com/argoproj/gitops-engine v0.2.1-0.20210112204306-814d79df4954/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
+github.com/argoproj/gitops-engine v0.2.1-0.20210129183711-c5b7114c501f h1:QAf9m8jTw9TqRRNSBtygvZrrxWWUtF1F0qtVPrFogF8=
+github.com/argoproj/gitops-engine v0.2.1-0.20210129183711-c5b7114c501f/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
 github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=
 github.com/argoproj/pkg v0.2.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Signed-off-by: kshamajain99 <kshamajain99@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

issue: https://github.com/argoproj/argo-cd/issues/3877
gitops-engine changes: https://github.com/argoproj/gitops-engine/pull/213

This feature applies only out-of-sync resources when `ApplyOutOfSync=true` option is provided by user. 

#### Test performed:

Scenario: For an application with 10 deployments and 1 svc, deleting svc and syncing entire application (performing same action)

With `ApplyOutOfSync=true` enabled
```
INFO[0040] sync/terminate complete              application=guestbook duration=507.61639ms syncId=00001-NPWVT
```

Without `ApplyOutOfSync=true` enabled
```
INFO[0114] sync/terminate complete              application=guestbook duration=1.983608856s syncId=00002-orWNj
```