### PR TITLE
chore: Bring back kubectl to test-tools-image

### DIFF
--- a/hack/installers/install-kubectl-linux.sh
+++ b/hack/installers/install-kubectl-linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eux -o pipefail
+
+. $(dirname $0)/../tool-versions.sh
+
+# NOTE: keep the version synced with https://storage.googleapis.com/kubernetes-release/release/stable.txt
+[ -e $DOWNLOADS/kubectl ] || curl -sLf --retry 3 -o $DOWNLOADS/kubectl https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/$ARCHITECTURE/kubectl
+cp $DOWNLOADS/kubectl $BIN/
+chmod +x $BIN/kubectl

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -40,6 +40,7 @@ RUN ./install.sh dep-linux && \
     ./install.sh ksonnet-linux && \
     ./install.sh helm2-linux && \
     ./install.sh helm-linux && \
+    ./install.sh kubectl-linux && \
     ./install.sh kustomize-linux && \
     ./install.sh codegen-tools && \
     ./install.sh codegen-go-tools && \


### PR DESCRIPTION
Brings back kubectl to test-tools-image, which was accidentally removed in #5101

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

