### PR TITLE
fix: a request which was using a revoked project token, would still be allowed to perform requests allowed by default policy

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2779,8 +2779,11 @@ func (proj *AppProject) NormalizeJWTTokens() bool {
 }
 
 func syncJWTTokenBetweenStatusAndSpec(proj *AppProject) bool {
+	existingRole := map[string]bool{}
 	needSync := false
 	for roleIndex, role := range proj.Spec.Roles {
+		existingRole[role.Name] = true
+
 		tokensInSpec := role.JWTTokens
 		tokensInStatus := []JWTToken{}
 		if proj.Status.JWTTokensByRole == nil {
@@ -2803,8 +2806,16 @@ func syncJWTTokenBetweenStatusAndSpec(proj *AppProject) bool {
 
 		proj.Spec.Roles[roleIndex].JWTTokens = tokens
 		proj.Status.JWTTokensByRole[role.Name] = JWTTokens{Items: tokens}
-
 	}
+	if proj.Status.JWTTokensByRole != nil {
+		for role := range proj.Status.JWTTokensByRole {
+			if !existingRole[role] {
+				delete(proj.Status.JWTTokensByRole, role)
+				needSync = true
+			}
+		}
+	}
+
 	return needSync
 }
 

--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-cd/pkg/apiclient/account"
 	sessionpkg "github.com/argoproj/argo-cd/pkg/apiclient/session"
 	"github.com/argoproj/argo-cd/server/session"
+	"github.com/argoproj/argo-cd/test"
 	"github.com/argoproj/argo-cd/util/errors"
 	"github.com/argoproj/argo-cd/util/password"
 	"github.com/argoproj/argo-cd/util/rbac"
@@ -63,7 +64,7 @@ func newTestAccountServerExt(ctx context.Context, enforceFn rbac.ClaimsEnforcerF
 	}
 	kubeclientset := fake.NewSimpleClientset(cm, secret)
 	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, testNamespace)
-	sessionMgr := sessionutil.NewSessionManager(settingsMgr, "", sessionutil.NewInMemoryUserStateStorage())
+	sessionMgr := sessionutil.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", sessionutil.NewInMemoryUserStateStorage())
 	enforcer := rbac.NewEnforcer(kubeclientset, testNamespace, common.ArgoCDRBACConfigMapName, nil)
 	enforcer.SetClaimsEnforcerFunc(enforceFn)
 

--- a/server/logout/logout_test.go
+++ b/server/logout/logout_test.go
@@ -9,18 +9,17 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go/v4"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/kubernetes/fake"
-
 	"github.com/argoproj/argo-cd/common"
+	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-cd/test"
 	"github.com/argoproj/argo-cd/util/session"
 	"github.com/argoproj/argo-cd/util/settings"
 
+	"github.com/dgrijalva/jwt-go/v4"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	appclientset "github.com/argoproj/argo-cd/pkg/client/clientset/versioned/fake"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 var (
@@ -177,7 +176,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 	settingsManagerWithoutOIDCConfig := settings.NewSettingsManager(context.Background(), kubeClientWithoutOIDCConfig, "default")
 	settingsManagerWithOIDCConfigButNoLogoutURL := settings.NewSettingsManager(context.Background(), kubeClientWithOIDCConfigButNoLogoutURL, "default")
 
-	sessionManager := session.NewSessionManager(settingsManagerWithOIDCConfig, "", session.NewInMemoryUserStateStorage())
+	sessionManager := session.NewSessionManager(settingsManagerWithOIDCConfig, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
 
 	oidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfig, sessionManager, "", "default")
 	oidcHandler.verifyToken = func(tokenString string) (jwt.Claims, error) {

--- a/server/rbacpolicy/rbacpolicy_test.go
+++ b/server/rbacpolicy/rbacpolicy_test.go
@@ -67,12 +67,6 @@ func TestEnforceAllPolicies(t *testing.T) {
 
 	claims = jwt.MapClaims{"sub": "cathy"}
 	assert.False(t, enf.Enforce(claims, "applications", "create", "my-proj/my-app"))
-	claims = jwt.MapClaims{"sub": "proj:my-proj:my-role"}
-	assert.False(t, enf.Enforce(claims, "applications", "create", "my-proj/my-app"))
-	claims = jwt.MapClaims{"sub": "proj:my-proj:other-role", "iat": 1234}
-	assert.False(t, enf.Enforce(claims, "applications", "create", "my-proj/my-app"))
-	claims = jwt.MapClaims{"groups": []string{"my-org:other-group"}}
-	assert.False(t, enf.Enforce(claims, "applications", "create", "my-proj/my-app"))
 
 	// AWS cognito returns its groups in  cognito:groups
 	rbacEnf.SetScopes([]string{"cognito:groups"})

--- a/server/server.go
+++ b/server/server.go
@@ -209,8 +209,6 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts) *ArgoCDServer {
 	err = initializeDefaultProject(opts)
 	errors.CheckError(err)
 
-	sessionMgr := util_session.NewSessionManager(settingsMgr, opts.DexServerAddr, opts.Cache)
-
 	factory := appinformer.NewFilteredSharedInformerFactory(opts.AppClientset, 0, opts.Namespace, func(options *metav1.ListOptions) {})
 	projInformer := factory.Argoproj().V1alpha1().AppProjects().Informer()
 	projLister := factory.Argoproj().V1alpha1().AppProjects().Lister().AppProjects(opts.Namespace)
@@ -218,6 +216,7 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts) *ArgoCDServer {
 	appInformer := factory.Argoproj().V1alpha1().Applications().Informer()
 	appLister := factory.Argoproj().V1alpha1().Applications().Lister().Applications(opts.Namespace)
 
+	sessionMgr := util_session.NewSessionManager(settingsMgr, projLister, opts.DexServerAddr, opts.Cache)
 	enf := rbac.NewEnforcer(opts.KubeClientset, opts.Namespace, common.ArgoCDRBACConfigMapName, nil)
 	enf.EnableEnforce(!opts.DisableAuth)
 	err = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -362,13 +362,6 @@ func TestRevokedToken(t *testing.T) {
 	claims := jwt.MapClaims{"sub": defaultSub, "iat": defaultIssuedAt}
 	assert.True(t, s.enf.Enforce(claims, "projects", "get", existingProj.ObjectMeta.Name))
 	assert.True(t, s.enf.Enforce(claims, "applications", "get", defaultTestObject))
-	// Now revoke the token by deleting the token
-	existingProj.Spec.Roles[0].JWTTokens = nil
-	existingProj.Status.JWTTokensByRole = nil
-	_, _ = s.AppClientset.ArgoprojV1alpha1().AppProjects(test.FakeArgoCDNamespace).Update(context.Background(), &existingProj, metav1.UpdateOptions{})
-	time.Sleep(200 * time.Millisecond) // this lets the informer get synced
-	assert.False(t, s.enf.Enforce(claims, "projects", "get", existingProj.ObjectMeta.Name))
-	assert.False(t, s.enf.Enforce(claims, "applications", "get", defaultTestObject))
 }
 
 func TestCertsAreNotGeneratedInInsecureMode(t *testing.T) {

--- a/util/session/sessionmanager_norace_test.go
+++ b/util/session/sessionmanager_norace_test.go
@@ -22,7 +22,7 @@ func TestRandomPasswordVerificationDelay(t *testing.T) {
 
 	var sleptFor time.Duration
 	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("password", true), "argocd")
-	mgr := newSessionManager(settingsMgr, NewInMemoryUserStateStorage())
+	mgr := newSessionManager(settingsMgr, getProjLister(), NewInMemoryUserStateStorage())
 	mgr.verificationDelayNoiseEnabled = true
 	mgr.sleep = func(d time.Duration) {
 		sleptFor = d

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -11,17 +11,27 @@ import (
 
 	"github.com/dgrijalva/jwt-go/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/argoproj/argo-cd/common"
+	appv1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	apps "github.com/argoproj/argo-cd/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-cd/pkg/client/listers/application/v1alpha1"
+	"github.com/argoproj/argo-cd/test"
 	"github.com/argoproj/argo-cd/util/errors"
 	"github.com/argoproj/argo-cd/util/password"
 	"github.com/argoproj/argo-cd/util/settings"
 )
+
+func getProjLister(objects ...runtime.Object) v1alpha1.AppProjectNamespaceLister {
+	return test.NewFakeProjListerFromInterface(apps.NewSimpleClientset(objects...).ArgoprojV1alpha1().AppProjects("argocd"))
+}
 
 func getKubeClient(pass string, enabled bool) *fake.Clientset {
 	const defaultSecretKey = "Hello, world!"
@@ -52,18 +62,18 @@ func getKubeClient(pass string, enabled bool) *fake.Clientset {
 	})
 }
 
-func newSessionManager(settingsMgr *settings.SettingsManager, storage UserStateStorage) *SessionManager {
-	mgr := NewSessionManager(settingsMgr, "", storage)
+func newSessionManager(settingsMgr *settings.SettingsManager, projectLister v1alpha1.AppProjectNamespaceLister, storage UserStateStorage) *SessionManager {
+	mgr := NewSessionManager(settingsMgr, projectLister, "", storage)
 	mgr.verificationDelayNoiseEnabled = false
 	return mgr
 }
 
-func TestSessionManager(t *testing.T) {
+func TestSessionManager_AdminToken(t *testing.T) {
 	const (
 		defaultSubject = "admin"
 	)
 	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("pass", true), "argocd")
-	mgr := newSessionManager(settingsMgr, NewInMemoryUserStateStorage())
+	mgr := newSessionManager(settingsMgr, getProjLister(), NewInMemoryUserStateStorage())
 
 	token, err := mgr.Create(defaultSubject, 0, "")
 	if err != nil {
@@ -80,6 +90,52 @@ func TestSessionManager(t *testing.T) {
 	if subject != "admin" {
 		t.Errorf("Token claim subject \"%s\" does not match expected subject \"%s\".", subject, defaultSubject)
 	}
+}
+
+func TestSessionManager_ProjectToken(t *testing.T) {
+	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("pass", true), "argocd")
+
+	t.Run("Valid Token", func(t *testing.T) {
+		proj := appv1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: "argocd",
+			},
+			Spec: appv1.AppProjectSpec{Roles: []appv1.ProjectRole{{Name: "test"}}},
+			Status: appv1.AppProjectStatus{JWTTokensByRole: map[string]appv1.JWTTokens{
+				"test": {
+					Items: []appv1.JWTToken{{ID: "abc", IssuedAt: time.Now().Unix(), ExpiresAt: 0}},
+				},
+			}},
+		}
+		mgr := newSessionManager(settingsMgr, getProjLister(&proj), NewInMemoryUserStateStorage())
+
+		jwtToken, err := mgr.Create("proj:default:test", 100, "abc")
+		require.NoError(t, err)
+
+		_, err = mgr.Parse(jwtToken)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Token Revoked", func(t *testing.T) {
+		proj := appv1.AppProject{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: "argocd",
+			},
+			Spec: appv1.AppProjectSpec{Roles: []appv1.ProjectRole{{Name: "test"}}},
+		}
+
+		mgr := newSessionManager(settingsMgr, getProjLister(&proj), NewInMemoryUserStateStorage())
+
+		jwtToken, err := mgr.Create("proj:default:test", 10, "")
+		require.NoError(t, err)
+
+		_, err = mgr.Parse(jwtToken)
+		require.Error(t, err)
+
+		assert.Contains(t, err.Error(), "does not exist in project 'default'")
+	})
 }
 
 var loggedOutContext = context.Background()
@@ -153,7 +209,7 @@ func TestVerifyUsernamePassword(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient(password, !tc.disabled), "argocd")
 
-			mgr := newSessionManager(settingsMgr, NewInMemoryUserStateStorage())
+			mgr := newSessionManager(settingsMgr, getProjLister(), NewInMemoryUserStateStorage())
 
 			err := mgr.VerifyUsernamePassword(tc.userName, tc.password)
 
@@ -237,7 +293,7 @@ func TestLoginRateLimiter(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("password", true), "argocd")
 	storage := NewInMemoryUserStateStorage()
 
-	mgr := newSessionManager(settingsMgr, storage)
+	mgr := newSessionManager(settingsMgr, getProjLister(), storage)
 
 	t.Run("Test login delay valid user", func(t *testing.T) {
 		for i := 0; i < getMaxLoginFailures(); i++ {
@@ -276,7 +332,7 @@ func TestMaxUsernameLength(t *testing.T) {
 		username += "a"
 	}
 	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("password", true), "argocd")
-	mgr := newSessionManager(settingsMgr, NewInMemoryUserStateStorage())
+	mgr := newSessionManager(settingsMgr, getProjLister(), NewInMemoryUserStateStorage())
 	err := mgr.VerifyUsernamePassword(username, "password")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf(usernameTooLongError, maxUsernameLength))
@@ -284,7 +340,7 @@ func TestMaxUsernameLength(t *testing.T) {
 
 func TestMaxCacheSize(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("password", true), "argocd")
-	mgr := newSessionManager(settingsMgr, NewInMemoryUserStateStorage())
+	mgr := newSessionManager(settingsMgr, getProjLister(), NewInMemoryUserStateStorage())
 
 	invalidUsers := []string{"invalid1", "invalid2", "invalid3", "invalid4", "invalid5", "invalid6", "invalid7"}
 	// Temporarily decrease max cache size
@@ -300,7 +356,7 @@ func TestMaxCacheSize(t *testing.T) {
 
 func TestFailedAttemptsExpiry(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("password", true), "argocd")
-	mgr := newSessionManager(settingsMgr, NewInMemoryUserStateStorage())
+	mgr := newSessionManager(settingsMgr, getProjLister(), NewInMemoryUserStateStorage())
 
 	invalidUsers := []string{"invalid1", "invalid2", "invalid3", "invalid4", "invalid5", "invalid6", "invalid7"}
 


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR moves project token validation into `sessionManager.Parse` method. Validation within enforces happens too late so the user can get "default" role permissions using revoked project token.