### PR TITLE
fix: overriding version logic in warning banner

### DIFF
--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -37,7 +37,7 @@ window.addEventListener("DOMContentLoaded", function() {
   if ((window['READTHEDOCS_DATA']).version === "latest") {
     document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>click here to go to the latest stable version.</a></div>"
   }
-  if ((window['READTHEDOCS_DATA']).version !== "latest" || (window['READTHEDOCS_DATA']).version !== "stable") {
+  else if ((window['READTHEDOCS_DATA']).version !== "stable") {
     document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>click here to go to the latest stable version.</a></div>"
   }
 }); 


### PR DESCRIPTION
Fix for bug in version warning banner that overrides logic for if branch is latest.

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

