### PR TITLE
fix(ui): Add header and browser title to fullscreen logs viewer

### DIFF
--- a/ui/src/app/applications/components/application-fullscreen-logs/application-fullscreen-logs.tsx
+++ b/ui/src/app/applications/components/application-fullscreen-logs/application-fullscreen-logs.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
+import Helmet from 'react-helmet';
 import {RouteComponentProps} from 'react-router-dom';
 import {PodLogsProps, PodsLogsViewer} from '../pod-logs-viewer/pod-logs-viewer';
 import './application-fullscreen-logs.scss';
 
 export const ApplicationFullscreenLogs = (props: RouteComponentProps<PodLogsProps>) => {
+    const title = `${props.match.params.podName}/${props.match.params.containerName}`;
     return (
         <div className='application-fullscreen-logs'>
+            <Helmet title={`Argo CD - ${title}`} />
+            <h4 style={{fontSize: '18px', textAlign: 'center'}}>{title}</h4>
             <PodsLogsViewer {...props.match.params} fullscreen={true} />
         </div>
     );

--- a/ui/src/app/applications/components/application-fullscreen-logs/application-fullscreen-logs.tsx
+++ b/ui/src/app/applications/components/application-fullscreen-logs/application-fullscreen-logs.tsx
@@ -8,7 +8,7 @@ export const ApplicationFullscreenLogs = (props: RouteComponentProps<PodLogsProp
     const title = `${props.match.params.podName}/${props.match.params.containerName}`;
     return (
         <div className='application-fullscreen-logs'>
-            <Helmet title={`Argo CD - ${title}`} />
+            <Helmet title={`${title} - Argo CD`} />
             <h4 style={{fontSize: '18px', textAlign: 'center'}}>{title}</h4>
             <PodsLogsViewer {...props.match.params} fullscreen={true} />
         </div>


### PR DESCRIPTION

<img width="1089" alt="Screen Shot 2021-02-04 at 5 14 47 PM" src="https://user-images.githubusercontent.com/6250584/106976014-7da27780-670c-11eb-90cc-07c71f319f31.png">

Signed-off-by: Remington Breeze <remington@breeze.software>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

