### PR TITLE
chore: Remove usages of k8s.io/kubernetes (#4055)

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -307,7 +307,7 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 
 	// "NodeLost" = https://github.com/kubernetes/kubernetes/blob/cb8ad64243d48d9a3c26b11b2e0945c098457282/pkg/util/node/node.go#L46
 	// But depending on the k8s.io/kubernetes package just for a constant
-	// is not worth it. 
+	// is not worth it.
 	// See https://github.com/argoproj/argo-cd/issues/5173
 	// and https://github.com/kubernetes/kubernetes/issues/90358#issuecomment-617859364
 	if pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {

--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -9,8 +9,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	resourcehelper "k8s.io/kubernetes/pkg/api/v1/resource"
-	k8snode "k8s.io/kubernetes/pkg/util/node"
+	resourcehelper "k8s.io/kubectl/pkg/util/resource"
 
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -306,7 +305,12 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 		}
 	}
 
-	if pod.DeletionTimestamp != nil && pod.Status.Reason == k8snode.NodeUnreachablePodReason {
+	// "NodeLost" = https://github.com/kubernetes/kubernetes/blob/cb8ad64243d48d9a3c26b11b2e0945c098457282/pkg/util/node/node.go#L46
+	// But depending on the k8s.io/kubernetes package just for a constant
+	// is not worth it. 
+	// See https://github.com/argoproj/argo-cd/issues/5173
+	// and https://github.com/kubernetes/kubernetes/issues/90358#issuecomment-617859364
+	if pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {
 		reason = "Unknown"
 	} else if pod.DeletionTimestamp != nil {
 		reason = "Terminating"

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,6 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd
 	k8s.io/kubectl v0.20.1
-	k8s.io/kubernetes v1.20.1
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	layeh.com/gopher-json v0.0.0-20190114024228-97fed8db8427
 	sigs.k8s.io/yaml v1.2.0

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/kubernetes/pkg/util/slice"
+	"k8s.io/kubectl/pkg/util/slice"
 
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/pkg/apiclient/account"


### PR DESCRIPTION
Towards #4055 and #5173 (once https://github.com/argoproj/gitops-engine/pull/205 and https://github.com/argoproj/gitops-engine/pull/206 have been merged at least).

The argo-cd repo only has a few direct references to k8s.io/kubernetes:

- k8s.io/kubernetes/pkg/util/slice has been migrated to k8s.io/kubectl/pkg/util/slice
- [k8s.io/kubernetes/pkg/api/v1/resource/PodRequestsAndLimits](https://github.com/kubernetes/kubernetes/blob/da75c266487c52425d3eb07df30229aea04bb28e/pkg/api/v1/resource/helpers.go#L35) has a (AFAICS) functionally identical implementation in [k8s.io/kubectl/pkg/util/resource](https://github.com/kubernetes/kubectl/blob/cfb4414565bb55f31d742b0762c2b1761fb74fc9/pkg/util/resource/resource.go#L34) (modulo a feature gate `features.PodOverhead` which I'm presuming is never set client side?)
- [k8s.io/kubernetes/pkg/util/node/NodeUnreachablePodReason](https://github.com/kubernetes/kubernetes/blob/cb8ad64243d48d9a3c26b11b2e0945c098457282/pkg/util/node/node.go) which is just a string constant and doesn't feel worth pulling in a whole package just to avoid a magic string usage. Especially as [other repos under the kubernetes org](https://github.com/search?q=org%3Akubernetes+%22NodeLost%22&type=code) already use the plain string instead of taking a code dependency.

I've run `make build` and `make test` on this change and it seems healthy.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 

