### PR TITLE
docs: replace https://argoproj.github.io/argo-cd/ with https://argo-cd.readthedocs.io/

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Have you read the docs?
-    url: https://argoproj.github.io/argo-cd/
+    url: https://argo-cd.readthedocs.io/
     about: Much help can be found in the docs
   - name: Ask a question
     url: https://github.com/argoproj/argo-cd/discussions/new

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,5 @@ Checklist:
 * [ ] I've updated documentation as required by this PR.
 * [ ] Optional. My organization is added to USERS.md.
 * [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
-* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
+* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
 
 ## Documentation
 
-To learn more about Argo CD [go to the complete documentation](https://argoproj.github.io/argo-cd/).
+To learn more about Argo CD [go to the complete documentation](https://argo-cd.readthedocs.io/).
 Check live demo at https://cd.apps.argoproj.io/.
 
 ## Community Blogs and Presentations

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,7 +1,7 @@
 # Defined below are the security contacts for this repo.
 #
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
-# INSTRUCTIONS AT https://argoproj.github.io/argo-cd/security_considerations/#reporting-vulnerabilities
+# INSTRUCTIONS AT https://argo-cd.readthedocs.io/en/latest/security_considerations/#reporting-vulnerabilities
 
 alexmt
 edlee2121

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to [the Contribution Guide](https://argoproj.github.io/argo-cd/developer-guide/contributing/)
+Please refer to [the Contribution Guide](https://argo-cd.readthedocs.io/en/stable/developer-guide/contributing/)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to [the Contribution Guide](https://argo-cd.readthedocs.io/en/stable/developer-guide/contributing/)
+Please refer to [the Contribution Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/contributing/)

--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -34,10 +34,11 @@ setTimeout(function() {
 
 // VERSION WARNINGS
 window.addEventListener("DOMContentLoaded", function() {
-  if ((window['READTHEDOCS_DATA']).version === "latest") {
+  var rtdData = window['READTHEDOCS_DATA'] || { version: 'latest' };
+  if (rtdData.version === "latest") {
     document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for an unreleased version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>click here to go to the latest stable version.</a></div>"
   }
-  else if ((window['READTHEDOCS_DATA']).version !== "stable") {
+  else if (rtdData.version !== "stable") {
     document.querySelector("div[data-md-component=announce]").innerHTML = "<div id='announce-msg'>You are viewing the docs for a previous version of Argo CD, <a href='https://argo-cd.readthedocs.io/en/stable/'>click here to go to the latest stable version.</a></div>"
   }
-}); 
+});

--- a/docs/operator-manual/upgrading/1.8-1.9.md
+++ b/docs/operator-manual/upgrading/1.8-1.9.md
@@ -2,7 +2,7 @@
 
 ## Environment variables expansion
 
-Argo CD supports using [environment variables](https://argoproj.github.io/argo-cd/user-guide/build-environment/) in
+Argo CD supports using [environment variables](../../../user-guide/build-environment/) in
 config management tools parameters. The expansion logic has been improved and now expands missing environment variables
 into an empty string.
 

--- a/docs/operator-manual/upgrading/1.8-1.9.md
+++ b/docs/operator-manual/upgrading/1.8-1.9.md
@@ -2,7 +2,7 @@
 
 ## Environment variables expansion
 
-Argo CD supports using [environment variables](../../../user-guide/build-environment/) in
+Argo CD supports using [environment variables](/user-guide/build-environment/) in
 config management tools parameters. The expansion logic has been improved and now expands missing environment variables
 into an empty string.
 

--- a/docs/operator-manual/user-management/auth0.md
+++ b/docs/operator-manual/user-management/auth0.md
@@ -70,4 +70,4 @@ data:
 <br>
 
 !!! note "Storing Client Secrets"
-    Details on storing your clientSecret securely and correctly can be found on the [User Management Overview page](https://argoproj.github.io/argo-cd/operator-manual/user-management/#sensitive-data-and-sso-client-secrets).
+    Details on storing your clientSecret securely and correctly can be found on the [User Management Overview page](../../user-management/#sensitive-data-and-sso-client-secrets).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,7 +3,7 @@
 - [Roadmap](#roadmap)
     - [Core Functionality Bug Fixes](#core-functionality-bug-fixes)
     - [Performance](#performance)
-    - [ApplicationsSet](#applicationsset)
+    - [ApplicationSet](#applicationset)
     - [Large Applications support](#large-applications-support)
     - [Serviceability](#serviceability)
     - [GitOps Engine Enhancements](#gitops-engine-enhancements)
@@ -60,8 +60,8 @@ The [GitOps Engine](https://github.com/argoproj/gitops-engine) is a library that
 A lot of Argo CD features are still not available in GitOps engine. The following features have to be contributed to the GitOps Engine:
 
 * an ability to customize resources health assessment and existing CRD health [assessment functions](https://github.com/argoproj/argo-cd/tree/master/resource_customizations).
-* resource diffing [customization](https://argoproj.github.io/argo-cd/user-guide/diffing/).
-* config management [tools](https://argoproj.github.io/argo-cd/user-guide/application_sources/) integration.
+* resource diffing [customization](../user-guide/diffing/).
+* config management [tools](../user-guide/application_sources/) integration.
 * unified syncing annotations [argoproj/gitops-engine#43](https://github.com/argoproj/gitops-engine/issues/43).
 
 ### GitOps Agent

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,8 +60,8 @@ The [GitOps Engine](https://github.com/argoproj/gitops-engine) is a library that
 A lot of Argo CD features are still not available in GitOps engine. The following features have to be contributed to the GitOps Engine:
 
 * an ability to customize resources health assessment and existing CRD health [assessment functions](https://github.com/argoproj/argo-cd/tree/master/resource_customizations).
-* resource diffing [customization](../user-guide/diffing/).
-* config management [tools](../user-guide/application_sources/) integration.
+* resource diffing [customization](/user-guide/diffing/).
+* config management [tools](/user-guide/application_sources/) integration.
 * unified syncing annotations [argoproj/gitops-engine#43](https://github.com/argoproj/gitops-engine/issues/43).
 
 ### GitOps Agent

--- a/docs/security_considerations.md
+++ b/docs/security_considerations.md
@@ -113,7 +113,7 @@ An attacker could use this information in an attempt to deduce the state of the 
 **Mitigation and/or workaround:**
 
 The recommended mitigation as described in the user documentation is to use SSO integration. The default admin password
-should only be used for initial configuration and then [disabled](https://argoproj.github.io/argo-cd/operator-manual/user-management/#disable-admin-user)
+should only be used for initial configuration and then [disabled](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#disable-admin-user)
 or at least changed to a more secure password.
 
 ### CVE-2020-8827 - Insufficient anti-automation/anti-brute force

--- a/docs/security_considerations.md
+++ b/docs/security_considerations.md
@@ -113,7 +113,7 @@ An attacker could use this information in an attempt to deduce the state of the 
 **Mitigation and/or workaround:**
 
 The recommended mitigation as described in the user documentation is to use SSO integration. The default admin password
-should only be used for initial configuration and then [disabled](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#disable-admin-user)
+should only be used for initial configuration and then [disabled](../operator-manual/user-management/#disable-admin-user)
 or at least changed to a more secure password.
 
 ### CVE-2020-8827 - Insufficient anti-automation/anti-brute force

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -12,7 +12,7 @@ export const Help = () => (
                     <div className='columns large-4 small-6'>
                         <div className='help-box'>
                             <p>New to Argo CD?</p>
-                            <a className='argo-button argo-button--base' href='https://argoproj.github.io/argo-cd'>
+                            <a className='argo-button argo-button--base' href='https://argo-cd.readthedocs.io'>
                                 Read the docs
                             </a>
                         </div>


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Argo CD documentation is now available at https://argo-cd.readthedocs.io/ . The PR replaces all links to https://argoproj.github.io/argo-cd/ with https://argo-cd.readthedocs.io/ .

The https://argoproj.github.io/argo-cd/ is still alive and serve latest documentation version. If the user navigates to https://argoproj.github.io/argo-cd/ then latest version of documentation will be served with a warning message that suggest moving to latest stable.