### PR TITLE
feat: support token revocation

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -15,6 +15,8 @@ data:
 
   # Enables anonymous user access. The anonymous users get default role permissions specified argocd-rbac-cm.yaml.
   users.anonymous.enabled: "true"
+  # Specifies token expiration duration
+  users.session.duration: "24h"
 
   # Enables google analytics tracking is specified
   ga.trackingid: "UA-12345-1"

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.14
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
-	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
+	github.com/alicebob/miniredis/v2 v2.14.2
 	github.com/argoproj/gitops-engine v0.2.1-0.20210129183711-c5b7114c501f
 	github.com/argoproj/pkg v0.2.0
 	github.com/bombsimon/logrusr v1.0.0
@@ -60,7 +60,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/undefinedlabs/go-mpatch v1.0.6
 	github.com/vmihailenco/msgpack/v5 v5.1.0 // indirect
-	github.com/yuin/gopher-lua v0.0.0-20190115140932-732aa6820ec4
+	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/exp v0.0.0-20200821190819-94841d0725da // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b

--- a/go.sum
+++ b/go.sum
@@ -78,10 +78,12 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 h1:45bxf7AZMwWcqkLzDAQugVEwedisr5nRJ1r+7LYnv0U=
-github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
+github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
+github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j82Yjf3KFv7ApYzUI=
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
+github.com/alicebob/miniredis/v2 v2.14.2 h1:VeoqKUAsJfT2af61nDE7qhBzqn3J6xjnt9MFAbdrEtg=
+github.com/alicebob/miniredis/v2 v2.14.2/go.mod h1:gquAfGbzn92jvtrSC69+6zZnwSODVXVpYDRaGhWaL6I=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -718,8 +720,8 @@ github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0B
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/gopher-lua v0.0.0-20190115140932-732aa6820ec4 h1:1yOVVSFiradDwXpgdkDjlGOcGJqcohH/W49Zn8Ywgco=
-github.com/yuin/gopher-lua v0.0.0-20190115140932-732aa6820ec4/go.mod h1:fFiAh+CowNFr0NK5VASokuwKwkbacRmHsVA7Yb1Tqac=
+github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
+github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
@@ -858,6 +860,7 @@ golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -204,7 +204,7 @@ func (s *Server) CreateToken(ctx context.Context, r *account.CreateTokenRequest)
 
 		now := time.Now()
 		var err error
-		tokenString, err = s.sessionMgr.Create(r.Name, r.ExpiresIn, id)
+		tokenString, err = s.sessionMgr.Create(fmt.Sprintf("%s:%s", r.Name, settings.AccountCapabilityApiKey), r.ExpiresIn, id)
 		if err != nil {
 			return err
 		}

--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -64,11 +64,11 @@ func newTestAccountServerExt(ctx context.Context, enforceFn rbac.ClaimsEnforcerF
 	}
 	kubeclientset := fake.NewSimpleClientset(cm, secret)
 	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, testNamespace)
-	sessionMgr := sessionutil.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", sessionutil.NewInMemoryUserStateStorage())
+	sessionMgr := sessionutil.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", sessionutil.NewUserStateStorage(nil))
 	enforcer := rbac.NewEnforcer(kubeclientset, testNamespace, common.ArgoCDRBACConfigMapName, nil)
 	enforcer.SetClaimsEnforcerFunc(enforceFn)
 
-	return NewServer(sessionMgr, settingsMgr, enforcer), session.NewServer(sessionMgr, nil, nil, nil)
+	return NewServer(sessionMgr, settingsMgr, enforcer), session.NewServer(sessionMgr, settingsMgr, nil, nil, nil)
 }
 
 func getAdminAccount(mgr *settings.SettingsManager) (*settings.Account, error) {

--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -12,7 +12,6 @@ import (
 	cacheutil "github.com/argoproj/argo-cd/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/util/cache/appstate"
 	"github.com/argoproj/argo-cd/util/oidc"
-	"github.com/argoproj/argo-cd/util/session"
 )
 
 var ErrCacheMiss = appstatecache.ErrCacheMiss
@@ -64,14 +63,6 @@ func (c *Cache) OnAppResourcesTreeChanged(ctx context.Context, appName string, c
 
 func (c *Cache) GetAppManagedResources(appName string, res *[]*appv1.ResourceDiff) error {
 	return c.cache.GetAppManagedResources(appName, res)
-}
-
-func (c *Cache) GetLoginAttempts(attempts *map[string]session.LoginAttempts) error {
-	return c.cache.GetItem("session|login.attempts", attempts)
-}
-
-func (c *Cache) SetLoginAttempts(attempts map[string]session.LoginAttempts) error {
-	return c.cache.SetItem("session|login.attempts", attempts, c.loginAttemptsExpiration, attempts == nil)
 }
 
 func (c *Cache) SetRepoConnectionState(repo string, state *appv1.ConnectionState) error {

--- a/server/logout/logout_test.go
+++ b/server/logout/logout_test.go
@@ -80,6 +80,7 @@ func TestConstructLogoutURL(t *testing.T) {
 		})
 	}
 }
+
 func TestHandlerConstructLogoutURL(t *testing.T) {
 	kubeClientWithOIDCConfig := fake.NewSimpleClientset(
 		&corev1.ConfigMap{
@@ -176,7 +177,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 	settingsManagerWithoutOIDCConfig := settings.NewSettingsManager(context.Background(), kubeClientWithoutOIDCConfig, "default")
 	settingsManagerWithOIDCConfigButNoLogoutURL := settings.NewSettingsManager(context.Background(), kubeClientWithOIDCConfigButNoLogoutURL, "default")
 
-	sessionManager := session.NewSessionManager(settingsManagerWithOIDCConfig, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+	sessionManager := session.NewSessionManager(settingsManagerWithOIDCConfig, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 
 	oidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfig, sessionManager, "", "default")
 	oidcHandler.verifyToken = func(tokenString string) (jwt.Claims, error) {

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -82,7 +82,7 @@ func TestProjectServer(t *testing.T) {
 	}
 
 	t.Run("TestNormalizeProj", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projectWithRole := existingProj.DeepCopy()
 		roleName := "roleName"
 		role1 := v1alpha1.ProjectRole{Name: roleName, JWTTokens: []v1alpha1.JWTToken{{IssuedAt: 1}}}
@@ -319,7 +319,7 @@ func TestProjectServer(t *testing.T) {
 	id := "testId"
 
 	t.Run("TestCreateTokenDenied", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projectWithRole := existingProj.DeepCopy()
 		projectWithRole.Spec.Roles = []v1alpha1.ProjectRole{{Name: tokenName}}
 		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(projectWithRole), enforcer, sync.NewKeyLock(), sessionMgr, policyEnf, projInformer, settingsMgr)
@@ -328,7 +328,7 @@ func TestProjectServer(t *testing.T) {
 	})
 
 	t.Run("TestCreateTokenSuccessfullyUsingGroup", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projectWithRole := existingProj.DeepCopy()
 		projectWithRole.Spec.Roles = []v1alpha1.ProjectRole{{Name: tokenName, Groups: []string{"my-group"}}}
 		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(projectWithRole), enforcer, sync.NewKeyLock(), sessionMgr, policyEnf, projInformer, settingsMgr)
@@ -343,7 +343,7 @@ func TestProjectServer(t *testing.T) {
 		projectWithRole.Spec.Roles = []v1alpha1.ProjectRole{{Name: tokenName}}
 		clientset := apps.NewSimpleClientset(projectWithRole)
 
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjListerFromInterface(clientset.ArgoprojV1alpha1().AppProjects("default")), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjListerFromInterface(clientset.ArgoprojV1alpha1().AppProjects("default")), "", session.NewUserStateStorage(nil))
 		projectServer := NewServer("default", fake.NewSimpleClientset(), clientset, enforcer, sync.NewKeyLock(), sessionMgr, policyEnf, projInformer, settingsMgr)
 		tokenResponse, err := projectServer.CreateToken(context.Background(), &project.ProjectTokenCreateRequest{Project: projectWithRole.Name, Role: tokenName, ExpiresIn: 100})
 		assert.NoError(t, err)
@@ -363,7 +363,7 @@ func TestProjectServer(t *testing.T) {
 		projectWithRole.Spec.Roles = []v1alpha1.ProjectRole{{Name: tokenName}}
 		clientset := apps.NewSimpleClientset(projectWithRole)
 
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjListerFromInterface(clientset.ArgoprojV1alpha1().AppProjects("default")), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjListerFromInterface(clientset.ArgoprojV1alpha1().AppProjects("default")), "", session.NewUserStateStorage(nil))
 		projectServer := NewServer("default", fake.NewSimpleClientset(), clientset, enforcer, sync.NewKeyLock(), sessionMgr, policyEnf, projInformer, settingsMgr)
 		tokenResponse, err := projectServer.CreateToken(context.Background(), &project.ProjectTokenCreateRequest{Project: projectWithRole.Name, Role: tokenName, ExpiresIn: 1, Id: id})
 		assert.NoError(t, err)
@@ -383,7 +383,7 @@ func TestProjectServer(t *testing.T) {
 		projectWithRole.Spec.Roles = []v1alpha1.ProjectRole{{Name: tokenName}}
 		clientset := apps.NewSimpleClientset(projectWithRole)
 
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjListerFromInterface(clientset.ArgoprojV1alpha1().AppProjects("default")), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjListerFromInterface(clientset.ArgoprojV1alpha1().AppProjects("default")), "", session.NewUserStateStorage(nil))
 		projectServer := NewServer("default", fake.NewSimpleClientset(), clientset, enforcer, sync.NewKeyLock(), sessionMgr, policyEnf, projInformer, settingsMgr)
 		tokenResponse, err := projectServer.CreateToken(context.Background(), &project.ProjectTokenCreateRequest{Project: projectWithRole.Name, Role: tokenName, ExpiresIn: 1, Id: id})
 
@@ -406,7 +406,7 @@ func TestProjectServer(t *testing.T) {
 	_ = enforcer.SetBuiltinPolicy(`p, *, *, *, *, deny`)
 
 	t.Run("TestDeleteTokenDenied", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projWithToken := existingProj.DeepCopy()
 		issuedAt := int64(1)
 		secondIssuedAt := issuedAt + 1
@@ -419,7 +419,7 @@ func TestProjectServer(t *testing.T) {
 	})
 
 	t.Run("TestDeleteTokenSuccessfullyWithGroup", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projWithToken := existingProj.DeepCopy()
 		issuedAt := int64(1)
 		secondIssuedAt := issuedAt + 1
@@ -435,7 +435,7 @@ func TestProjectServer(t *testing.T) {
 p, role:admin, projects, update, *, allow`)
 
 	t.Run("TestDeleteTokenSuccessfully", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projWithToken := existingProj.DeepCopy()
 		issuedAt := int64(1)
 		secondIssuedAt := issuedAt + 1
@@ -456,7 +456,7 @@ p, role:admin, projects, update, *, allow`)
 p, role:admin, projects, update, *, allow`)
 
 	t.Run("TestDeleteTokenByIdSuccessfully", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projWithToken := existingProj.DeepCopy()
 		issuedAt := int64(1)
 		secondIssuedAt := issuedAt + 1
@@ -479,7 +479,7 @@ p, role:admin, projects, update, *, allow`)
 	enforcer = newEnforcer(kubeclientset)
 
 	t.Run("TestCreateTwoTokensInRoleSuccess", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projWithToken := existingProj.DeepCopy()
 		tokenName := "testToken"
 		token := v1alpha1.ProjectRole{Name: tokenName, JWTTokens: []v1alpha1.JWTToken{{IssuedAt: 1}}}
@@ -644,7 +644,7 @@ p, role:admin, projects, update, *, allow`)
 	})
 
 	t.Run("TestSyncWindowsActive", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projectWithSyncWindows := existingProj.DeepCopy()
 		projectWithSyncWindows.Spec.SyncWindows = v1alpha1.SyncWindows{}
 		win := &v1alpha1.SyncWindow{Kind: "allow", Schedule: "* * * * *", Duration: "1h"}
@@ -657,7 +657,7 @@ p, role:admin, projects, update, *, allow`)
 	})
 
 	t.Run("TestGetSyncWindowsStateCannotGetProjectDetails", func(t *testing.T) {
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projectWithSyncWindows := existingProj.DeepCopy()
 		projectWithSyncWindows.Spec.SyncWindows = v1alpha1.SyncWindows{}
 		win := &v1alpha1.SyncWindow{Kind: "allow", Schedule: "* * * * *", Duration: "1h"}
@@ -676,7 +676,7 @@ p, role:admin, projects, update, *, allow`)
 		// nolint:staticcheck
 		ctx := context.WithValue(context.Background(), "claims", &jwt.MapClaims{"groups": []string{"my-group"}})
 
-		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewInMemoryUserStateStorage())
+		sessionMgr := session.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 		projectWithSyncWindows := existingProj.DeepCopy()
 		win := &v1alpha1.SyncWindow{Kind: "allow", Schedule: "* * * * *", Duration: "1h"}
 		projectWithSyncWindows.Spec.SyncWindows = append(projectWithSyncWindows.Spec.SyncWindows, win)

--- a/server/server.go
+++ b/server/server.go
@@ -157,7 +157,8 @@ type ArgoCDServer struct {
 	appLister      applisters.ApplicationNamespaceLister
 
 	// stopCh is the channel which when closed, will shutdown the Argo CD server
-	stopCh chan struct{}
+	stopCh           chan struct{}
+	userStateStorage util_session.UserStateStorage
 }
 
 type ArgoCDServerOpts struct {
@@ -216,7 +217,8 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts) *ArgoCDServer {
 	appInformer := factory.Argoproj().V1alpha1().Applications().Informer()
 	appLister := factory.Argoproj().V1alpha1().Applications().Lister().Applications(opts.Namespace)
 
-	sessionMgr := util_session.NewSessionManager(settingsMgr, projLister, opts.DexServerAddr, opts.Cache)
+	userStateStorage := util_session.NewUserStateStorage(opts.RedisClient)
+	sessionMgr := util_session.NewSessionManager(settingsMgr, projLister, opts.DexServerAddr, userStateStorage)
 	enf := rbac.NewEnforcer(opts.KubeClientset, opts.Namespace, common.ArgoCDRBACConfigMapName, nil)
 	enf.EnableEnforce(!opts.DisableAuth)
 	err = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
@@ -237,6 +239,7 @@ func NewServer(ctx context.Context, opts ArgoCDServerOpts) *ArgoCDServer {
 		appInformer:      appInformer,
 		appLister:        appLister,
 		policyEnforcer:   policyEnf,
+		userStateStorage: userStateStorage,
 	}
 }
 
@@ -261,6 +264,8 @@ func (a *ArgoCDServer) healthCheck(r *http.Request) error {
 // k8s.io/ go-to-protobuf uses protoc-gen-gogo, which comes from gogo/protobuf (a fork of
 // golang/protobuf).
 func (a *ArgoCDServer) Run(ctx context.Context, port int, metricsPort int) {
+	a.userStateStorage.Init(ctx)
+
 	grpcS := a.newGRPCServer()
 	grpcWebS := grpcweb.WrapServer(grpcS)
 	var httpS *http.Server
@@ -541,7 +546,7 @@ func (a *ArgoCDServer) newGRPCServer() *grpc.Server {
 	if maxConcurrentLoginRequestsCount > 0 {
 		loginRateLimiter = session.NewLoginRateLimiter(maxConcurrentLoginRequestsCount)
 	}
-	sessionService := session.NewServer(a.sessionMgr, a, a.policyEnforcer, loginRateLimiter)
+	sessionService := session.NewServer(a.sessionMgr, a.settingsMgr, a, a.policyEnforcer, loginRateLimiter)
 	projectLock := sync.NewKeyLock()
 	applicationService := application.NewServer(
 		a.Namespace,

--- a/server/server_norace_test.go
+++ b/server/server_norace_test.go
@@ -15,9 +15,8 @@ import (
 
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/pkg/apiclient"
-	"github.com/argoproj/argo-cd/test"
-
 	applicationpkg "github.com/argoproj/argo-cd/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/test"
 )
 
 func TestUserAgent(t *testing.T) {
@@ -27,7 +26,8 @@ func TestUserAgent(t *testing.T) {
 	// the data race, it APPEARS to be intentional, but in any case it's nothing we are doing in Argo CD
 	// that is causing this issue.
 
-	s := fakeServer()
+	s, closer := fakeServer()
+	defer closer()
 	cancelInformer := test.StartInformer(s.projInformer)
 	defer cancelInformer()
 	port, err := test.GetFreePort()
@@ -102,7 +102,8 @@ func Test_StaticHeaders(t *testing.T) {
 
 	// Test default policy "sameorigin"
 	{
-		s := fakeServer()
+		s, closer := fakeServer()
+		defer closer()
 		cancelInformer := test.StartInformer(s.projInformer)
 		defer cancelInformer()
 		port, err := test.GetFreePort()
@@ -131,7 +132,8 @@ func Test_StaticHeaders(t *testing.T) {
 
 	// Test custom policy
 	{
-		s := fakeServer()
+		s, closer := fakeServer()
+		defer closer()
 		s.XFrameOptions = "deny"
 		cancelInformer := test.StartInformer(s.projInformer)
 		defer cancelInformer()
@@ -161,7 +163,8 @@ func Test_StaticHeaders(t *testing.T) {
 
 	// Test disabled
 	{
-		s := fakeServer()
+		s, closer := fakeServer()
+		defer closer()
 		s.XFrameOptions = ""
 		cancelInformer := test.StartInformer(s.projInformer)
 		defer cancelInformer()

--- a/test/testdata.go
+++ b/test/testdata.go
@@ -3,6 +3,9 @@ package test
 import (
 	"context"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+
 	"github.com/argoproj/gitops-engine/pkg/utils/testing"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,4 +153,12 @@ func NewFakeProjLister(objects ...runtime.Object) applister.AppProjectNamespaceL
 	cancel := StartInformer(projInformer)
 	defer cancel()
 	return factory.Argoproj().V1alpha1().AppProjects().Lister().AppProjects(FakeArgoCDNamespace)
+}
+
+func NewInMemoryRedis() (*redis.Client, func()) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	return redis.NewClient(&redis.Options{Addr: mr.Addr()}), mr.Close
 }

--- a/util/jwt/jwt.go
+++ b/util/jwt/jwt.go
@@ -79,28 +79,38 @@ func GetID(m jwtgo.MapClaims) (string, error) {
 	return "", fmt.Errorf("jti '%v' is not a string", m["jti"])
 }
 
-// IssuedAt returns the issued at as an int64
-func IssuedAt(m jwtgo.MapClaims) (int64, error) {
-	iatField, ok := m["iat"]
+func numField(m jwtgo.MapClaims, key string) (int64, error) {
+	field, ok := m[key]
 	if !ok {
 		return 0, errors.New("token does not have iat claim")
 	}
-	switch iat := iatField.(type) {
+	switch val := field.(type) {
 	case float64:
-		return int64(iat), nil
+		return int64(val), nil
 	case json.Number:
-		return iat.Int64()
+		return val.Int64()
 	case int64:
-		return iat, nil
+		return val, nil
 	default:
-		return 0, fmt.Errorf("iat '%v' is not a number", iat)
+		return 0, fmt.Errorf("%s '%v' is not a number", key, val)
 	}
+}
+
+// IssuedAt returns the issued at as an int64
+func IssuedAt(m jwtgo.MapClaims) (int64, error) {
+	return numField(m, "iat")
 }
 
 // IssuedAtTime returns the issued at as a time.Time
 func IssuedAtTime(m jwtgo.MapClaims) (time.Time, error) {
 	iat, err := IssuedAt(m)
 	return time.Unix(iat, 0), err
+}
+
+// ExpirationTime returns the expiration as a time.Time
+func ExpirationTime(m jwtgo.MapClaims) (time.Time, error) {
+	exp, err := numField(m, "exp")
+	return time.Unix(exp, 0), err
 }
 
 func Claims(in interface{}) jwtgo.Claims {

--- a/util/session/sessionmanager_norace_test.go
+++ b/util/session/sessionmanager_norace_test.go
@@ -22,7 +22,7 @@ func TestRandomPasswordVerificationDelay(t *testing.T) {
 
 	var sleptFor time.Duration
 	settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClient("password", true), "argocd")
-	mgr := newSessionManager(settingsMgr, getProjLister(), NewInMemoryUserStateStorage())
+	mgr := newSessionManager(settingsMgr, getProjLister(), NewUserStateStorage(nil))
 	mgr.verificationDelayNoiseEnabled = true
 	mgr.sleep = func(d time.Duration) {
 		sleptFor = d

--- a/util/session/state.go
+++ b/util/session/state.go
@@ -1,0 +1,134 @@
+package session
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	log "github.com/sirupsen/logrus"
+
+	util "github.com/argoproj/argo-cd/util/io"
+)
+
+const (
+	revokedTokenPrefix = "revoked-token|"
+	newRevokedTokenKey = "new-revoked-token"
+)
+
+type userStateStorage struct {
+	attempts       map[string]LoginAttempts
+	redis          *redis.Client
+	revokedTokens  map[string]bool
+	lock           sync.RWMutex
+	resyncDuration time.Duration
+}
+
+func NewUserStateStorage(redis *redis.Client) *userStateStorage {
+	return &userStateStorage{
+		attempts:       map[string]LoginAttempts{},
+		revokedTokens:  map[string]bool{},
+		resyncDuration: time.Hour,
+		redis:          redis,
+	}
+}
+
+func (storage *userStateStorage) Init(ctx context.Context) {
+	go storage.watchRevokedTokens(ctx)
+	ticker := time.NewTicker(storage.resyncDuration)
+	go func() {
+		storage.loadRevokedTokensSafe()
+		for range ticker.C {
+			storage.loadRevokedTokensSafe()
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		ticker.Stop()
+	}()
+}
+
+func (storage *userStateStorage) watchRevokedTokens(ctx context.Context) {
+	pubsub := storage.redis.Subscribe(ctx, newRevokedTokenKey)
+	defer util.Close(pubsub)
+
+	ch := pubsub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case val := <-ch:
+			storage.lock.Lock()
+			storage.revokedTokens[val.Payload] = true
+			storage.lock.Unlock()
+		}
+	}
+}
+
+func (storage *userStateStorage) loadRevokedTokensSafe() {
+	for err := storage.loadRevokedTokens(); err != nil; {
+		log.Warnf("Failed to resync revoked tokens. retrying again in 1 minute: %v", err)
+		time.Sleep(time.Minute)
+	}
+}
+
+func (storage *userStateStorage) loadRevokedTokens() error {
+	storage.lock.Lock()
+	defer storage.lock.Unlock()
+	storage.revokedTokens = map[string]bool{}
+	iterator := storage.redis.Scan(context.Background(), 0, revokedTokenPrefix+"*", -1).Iterator()
+	for iterator.Next(context.Background()) {
+		parts := strings.Split(iterator.Val(), "|")
+		if len(parts) != 2 {
+			log.Warnf("Unexpected redis key prefixed with '%s'. Must have token id after the prefix but got: '%s'.",
+				revokedTokenPrefix,
+				iterator.Val())
+			continue
+		}
+		storage.revokedTokens[parts[1]] = true
+	}
+	if iterator.Err() != nil {
+		return iterator.Err()
+	}
+
+	return nil
+}
+
+func (storage *userStateStorage) GetLoginAttempts(attempts *map[string]LoginAttempts) error {
+	*attempts = storage.attempts
+	return nil
+}
+
+func (storage *userStateStorage) SetLoginAttempts(attempts map[string]LoginAttempts) error {
+	storage.attempts = attempts
+	return nil
+}
+
+func (storage *userStateStorage) RevokeToken(ctx context.Context, id string, expiringAt time.Duration) error {
+	storage.lock.Lock()
+	storage.revokedTokens[id] = true
+	storage.lock.Unlock()
+	if err := storage.redis.Set(ctx, revokedTokenPrefix+id, "", expiringAt).Err(); err != nil {
+		return err
+	}
+	return storage.redis.Publish(ctx, newRevokedTokenKey, id).Err()
+}
+
+func (storage *userStateStorage) IsTokenRevoked(id string) bool {
+	storage.lock.RLock()
+	defer storage.lock.RUnlock()
+	return storage.revokedTokens[id]
+}
+
+type UserStateStorage interface {
+	Init(ctx context.Context)
+	// GetLoginAttempts return number of concurrent login attempts
+	GetLoginAttempts(attempts *map[string]LoginAttempts) error
+	// SetLoginAttempts sets number of concurrent login attempts
+	SetLoginAttempts(attempts map[string]LoginAttempts) error
+	// RevokeToken revokes token with given id (information about revocation expires after specified timeout)
+	RevokeToken(ctx context.Context, id string, expiringAt time.Duration) error
+	// IsTokenRevoked checks if given token is revoked
+	IsTokenRevoked(id string) bool
+}

--- a/util/session/state_test.go
+++ b/util/session/state_test.go
@@ -1,0 +1,29 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/argoproj/argo-cd/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserStateStorage_LoadRevokedTokens(t *testing.T) {
+	redis, closer := test.NewInMemoryRedis()
+	defer closer()
+
+	err := redis.Set(context.Background(), revokedTokenPrefix+"abc", "", time.Hour).Err()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	storage := NewUserStateStorage(redis)
+	storage.Init(ctx)
+	time.Sleep(time.Millisecond * 100)
+
+	assert.True(t, storage.IsTokenRevoked("abc"))
+}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR implements revocation of session tokens issued by argocd/dex/oidc provider and local users token expiration.

**Revocation:** 

In order to avoid talking to dex/oidc during every request, revoked tokens are stored in denylist. The logout handler stores token id in redis key `revoked-token|<tokenID>` . Key expiration time matches the token expiration time, so it will disappear as soon as token is expired.

API Server is not talking to redis on every request. Informer like approach is implemented instead: 
*  list of revoked tokens is stored in memory. 
* every time when the new token is pushed to redis the `new-revoked-token`
* pub-sub message is published and all API servers receive a notification about a new revoked token.

**Revocation:** 

Session tokens now have an expiration. The default expiration timeout is 24hr and can be changed using `users.session.duration` setting. E.g. `users.session.duration: "2h"`

**Important Changes**

* ID is required to remember revoked tokens. Argo CD v1.8 does not generate ID for "session" tokens and uses it to distinguish API tokens from session tokens. In order to support token revocation, IDs are now generated for both types of tokens. Token "subject" includes "capability" e.g. `admin:login` or `my-account:apiKey`. For backward compatibility subjects without capability defaults to `apiKey`
* Tokens without id are rejected. So all users will have to re-login. This is acceptable since we are introducing tokens expiration either way.