### PR TITLE
chore: Make e2e tests work on K8s v1.20

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -171,7 +171,7 @@ func TestImmutableChange(t *testing.T) {
 			SyncPhase: "Sync",
 			Status:    "SyncFailed",
 			HookPhase: "Failed",
-			Message:   fmt.Sprintf(`Service "my-service" is invalid`),
+			Message:   `Service "my-service" is invalid`,
 		})).
 		// now we can do this will a force
 		Given().

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -163,7 +163,7 @@ func TestImmutableChange(t *testing.T) {
 		Expect(OperationPhaseIs(OperationFailed)).
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		Expect(ResourceResultNumbering(1)).
-		Expect(ResourceResultIs(ResourceResult{
+		Expect(ResourceResultMatches(ResourceResult{
 			Kind:      "Service",
 			Version:   "v1",
 			Namespace: DeploymentNamespace(),
@@ -171,7 +171,7 @@ func TestImmutableChange(t *testing.T) {
 			SyncPhase: "Sync",
 			Status:    "SyncFailed",
 			HookPhase: "Failed",
-			Message:   fmt.Sprintf(`Service "my-service" is invalid: spec.clusterIP: Invalid value: "%s": field is immutable`, ip2),
+			Message:   fmt.Sprintf(`Service "my-service" is invalid`),
 		})).
 		// now we can do this will a force
 		Given().


### PR DESCRIPTION
K8s v1.20 apparently changed error message which is given when trying to update an immutable resource.

```
Service "my-service" is invalid: spec.clusterIPs[0]: Invalid value: []string{"10.43.0.44"}: may not change once set
```

This PR changes end-to-end tests to be more flexible what to expect in a condition, so that we can run them against pre and post v1.20 versions of K8s.

Signed-off-by: jannfis <jann@mistrust.net>

Checklist:

* [x] This does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

