### PR TITLE
feat: Add health check for Sealed Secrets

### DIFF
--- a/resource_customizations/bitnami.com/SealedSecret/health.lua
+++ b/resource_customizations/bitnami.com/SealedSecret/health.lua
@@ -1,0 +1,20 @@
+health_status={}
+if obj.status ~= nil then
+    if obj.status.conditions ~= nil then
+        for i, condition in ipairs(obj.status.conditions) do
+            if condition.type == "Synced" and condition.status == "False" then
+                health_status.status = "Degraded"
+                health_status.message = condition.message
+                return health_status
+            end
+            if condition.type == "Synced" and condition.status == "True" then
+                health_status.status = "Healthy"
+                health_status.message = condition.message
+                return health_status
+            end
+        end
+    end
+end
+health_status.status = "Progressing"
+health_status.message = "Waiting for Sealed Secret to be decrypted"
+return health_status

--- a/resource_customizations/bitnami.com/SealedSecret/health_test.yaml
+++ b/resource_customizations/bitnami.com/SealedSecret/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "Waiting for Sealed Secret to be decrypted"
+  inputPath: testdata/progressing.yaml
+- healthStatus:
+    status: Degraded
+    message: "no key could decrypt secret (.dockerconfigjson)"
+  inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Healthy
+    message: ""
+  inputPath: testdata/healthy.yaml

--- a/resource_customizations/bitnami.com/SealedSecret/testdata/degraded.yaml
+++ b/resource_customizations/bitnami.com/SealedSecret/testdata/degraded.yaml
@@ -1,0 +1,24 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  labels:
+    app.kubernetes.io/instance: sealed-secrets
+  name: test
+  namespace: test
+spec:
+  encryptedData:
+    .dockerconfigjson: xyz
+  template:
+    metadata:
+      creationTimestamp: null
+      name: test
+      namespace: test
+    type: kubernetes.io/dockerconfigjson
+status:
+  conditions:
+  - lastTransitionTime: "2021-02-11T15:56:29Z"
+    lastUpdateTime: "2021-02-11T15:57:37Z"
+    message: no key could decrypt secret (.dockerconfigjson)
+    status: "False"
+    type: Synced
+  observedGeneration: 1

--- a/resource_customizations/bitnami.com/SealedSecret/testdata/healthy.yaml
+++ b/resource_customizations/bitnami.com/SealedSecret/testdata/healthy.yaml
@@ -1,0 +1,24 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  labels:
+    app.kubernetes.io/instance: sealed-secrets
+  name: test
+  namespace: test
+spec:
+  encryptedData:
+    .dockerconfigjson: xyz
+  template:
+    metadata:
+      creationTimestamp: null
+      name: test
+      namespace: test
+    type: kubernetes.io/dockerconfigjson
+status:
+  conditions:
+  - lastTransitionTime: "2021-02-11T15:56:29Z"
+    lastUpdateTime: "2021-02-11T15:57:37Z"
+    message: ""
+    status: "True"
+    type: Synced
+  observedGeneration: 1

--- a/resource_customizations/bitnami.com/SealedSecret/testdata/progressing.yaml
+++ b/resource_customizations/bitnami.com/SealedSecret/testdata/progressing.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  labels:
+    app.kubernetes.io/instance: sealed-secrets
+  name: test
+  namespace: test
+spec:
+  encryptedData:
+    .dockerconfigjson: xyz
+  template:
+    metadata:
+      creationTimestamp: null
+      name: test
+      namespace: test
+    type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
This PR adds a Lua script, which updates the health status of an application based on sealed secret's status

Fixes: #4754

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

