### PR TITLE
fix: Exclude kube-root-ca.crt ConfigMap from Orphaned Resources monit…

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -296,6 +296,9 @@ func isKnownOrphanedResourceExclusion(key kube.ResourceKey, proj *appv1.AppProje
 	if key.Group == "" && key.Kind == kube.ServiceAccountKind && key.Name == "default" {
 		return true
 	}
+	if key.Group == "" && key.Kind == "ConfigMap" && key.Name == "kube-root-ca.crt" {
+		return true
+	}
 	list := proj.Spec.OrphanedResources.Ignore
 	for _, item := range list {
 		if item.Kind == "" || glob.Match(item.Kind, key.Kind) {

--- a/docs/user-guide/orphaned-resources.md
+++ b/docs/user-guide/orphaned-resources.md
@@ -17,3 +17,4 @@ Not every resource in the Kubernetes cluster is controlled by the end user. Foll
 * Namespaced resources denied in the project. Usually, such resources are managed by cluster administrators and not supposed to be modified by namespace user.
 * `ServiceAccount` with name `default` ( and corresponding auto-generated `ServiceAccountToken` ).
 * `Service` with name `kubernetes` in the `default` namespace.
+* `ConfigMap` with name `kube-root-ca.crt` in all namespaces.


### PR DESCRIPTION
…oring by default (#5490)

Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

