### PR TITLE
fix: do not display empty tool version fields for server

### DIFF
--- a/cmd/argocd/commands/version.go
+++ b/cmd/argocd/commands/version.go
@@ -116,18 +116,40 @@ func printServerVersion(version *version.VersionMessage, short bool) {
 		return
 	}
 
-	fmt.Printf("  BuildDate: %s\n", version.BuildDate)
-	fmt.Printf("  GitCommit: %s\n", version.GitCommit)
-	fmt.Printf("  GitTreeState: %s\n", version.GitTreeState)
+	if version.BuildDate != "" {
+		fmt.Printf("  BuildDate: %s\n", version.BuildDate)
+	}
+	if version.GitCommit != "" {
+		fmt.Printf("  GitCommit: %s\n", version.GitCommit)
+	}
+	if version.GitTreeState != "" {
+		fmt.Printf("  GitTreeState: %s\n", version.GitTreeState)
+	}
 	if version.GitTag != "" {
 		fmt.Printf("  GitTag: %s\n", version.GitTag)
 	}
-	fmt.Printf("  GoVersion: %s\n", version.GoVersion)
-	fmt.Printf("  Compiler: %s\n", version.Compiler)
-	fmt.Printf("  Platform: %s\n", version.Platform)
-	fmt.Printf("  Ksonnet Version: %s\n", version.KsonnetVersion)
-	fmt.Printf("  Kustomize Version: %s\n", version.KustomizeVersion)
-	fmt.Printf("  Helm Version: %s\n", version.HelmVersion)
-	fmt.Printf("  Kubectl Version: %s\n", version.KubectlVersion)
-	fmt.Printf("  Jsonnet Version: %s\n", version.JsonnetVersion)
+	if version.GoVersion != "" {
+		fmt.Printf("  GoVersion: %s\n", version.GoVersion)
+	}
+	if version.Compiler != "" {
+		fmt.Printf("  Compiler: %s\n", version.Compiler)
+	}
+	if version.Platform != "" {
+		fmt.Printf("  Platform: %s\n", version.Platform)
+	}
+	if version.KsonnetVersion != "" {
+		fmt.Printf("  Ksonnet Version: %s\n", version.KsonnetVersion)
+	}
+	if version.KustomizeVersion != "" {
+		fmt.Printf("  Kustomize Version: %s\n", version.KustomizeVersion)
+	}
+	if version.HelmVersion != "" {
+		fmt.Printf("  Helm Version: %s\n", version.HelmVersion)
+	}
+	if version.KubectlVersion != "" {
+		fmt.Printf("  Kubectl Version: %s\n", version.KubectlVersion)
+	}
+	if version.JsonnetVersion != "" {
+		fmt.Printf("  Jsonnet Version: %s\n", version.JsonnetVersion)
+	}
 }


### PR DESCRIPTION
CLOSES https://github.com/argoproj/argo-cd/issues/5519

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).

