### PR TITLE
docs: Fix dead link in documentation for GitHub SSO integration

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -122,7 +122,7 @@ There are two ways that SSO can be configured:
 
 ## Dex
 
-Argo CD embeds and bundles [Dex](https://github.com/coreos/dex) as part of its installation, for the
+Argo CD embeds and bundles [Dex](https://github.com/dexidp/dex) as part of its installation, for the
 purpose of delegating authentication to an external identity provider. Multiple types of identity
 providers are supported (OIDC, SAML, LDAP, GitHub, etc...). SSO configuration of Argo CD requires
 editing the `argocd-cm` ConfigMap with
@@ -153,7 +153,7 @@ kubectl edit configmap argocd-cm -n argocd
 
 * In the `url` key, input the base URL of Argo CD. In this example, it is `https://argocd.example.com`
 * In the `dex.config` key, add the `github` connector to the `connectors` sub field. See Dex's
-  [GitHub connector](https://github.com/coreos/dex/blob/master/Documentation/connectors/github.md)
+  [GitHub connector](https://github.com/dexidp/website/blob/main/content/docs/connectors/github.md)
   documentation for explanation of the fields. A minimal config should populate the clientID,
   clientSecret generated in Step 1.
 * You will very likely want to restrict logins to one or more GitHub organization. In the


### PR DESCRIPTION
The link to the dex GitHub connector on the following page was a dead link.
- https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#2-configure-argo-cd-for-sso

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

