### PR TITLE
fix: Handle GnuPG verification errors gracefully

### DIFF
--- a/util/gpg/gpg_test.go
+++ b/util/gpg/gpg_test.go
@@ -305,8 +305,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		res, err := ParseGitCommitVerification(string(c))
-		assert.NoError(t, err)
+		res := ParseGitCommitVerification(string(c))
 		assert.Equal(t, "4AEE18F83AFDEB23", res.KeyID)
 		assert.Equal(t, "RSA", res.Cipher)
 		assert.Equal(t, "ultimate", res.Trust)
@@ -320,8 +319,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		res, err := ParseGitCommitVerification(string(c))
-		assert.NoError(t, err)
+		res := ParseGitCommitVerification(string(c))
 		assert.Equal(t, "4AEE18F83AFDEB23", res.KeyID)
 		assert.Equal(t, "RSA", res.Cipher)
 		assert.Equal(t, TrustUnknown, res.Trust)
@@ -335,8 +333,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		res, err := ParseGitCommitVerification(string(c))
-		assert.NoError(t, err)
+		res := ParseGitCommitVerification(string(c))
 		assert.Equal(t, "4AEE18F83AFDEB23", res.KeyID)
 		assert.Equal(t, "RSA", res.Cipher)
 		assert.Equal(t, TrustUnknown, res.Trust)
@@ -350,8 +347,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		res, err := ParseGitCommitVerification(string(c))
-		assert.NoError(t, err)
+		res := ParseGitCommitVerification(string(c))
 		assert.Equal(t, "4AEE18F83AFDEB23", res.KeyID)
 		assert.Equal(t, "RSA", res.Cipher)
 		assert.Equal(t, "ultimate", res.Trust)
@@ -365,9 +361,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Could not parse output")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "Could not parse output")
 	}
 
 	// Bad case: Incomplete signature data #1
@@ -376,9 +372,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "end-of-file")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "end-of-file")
 	}
 
 	// Bad case: Incomplete signature data #2
@@ -387,9 +383,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "end-of-file")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "end-of-file")
 	}
 
 	// Bad case: No signature data #1
@@ -398,9 +394,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no verification data found")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "no verification data found")
 	}
 
 	// Bad case: Malformed signature data #1
@@ -409,9 +405,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no verification data found")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "no verification data found")
 	}
 
 	// Bad case: Malformed signature data #2
@@ -420,9 +416,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Could not parse key ID")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "Could not parse key ID")
 	}
 
 	// Bad case: Malformed signature data #3
@@ -431,9 +427,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Could not parse result of verify")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "Could not parse result of verify")
 	}
 
 	// Bad case: Invalid key ID in signature
@@ -442,9 +438,9 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 		if err != nil {
 			panic(err.Error())
 		}
-		_, err = ParseGitCommitVerification(string(c))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Invalid PGP key ID")
+		res := ParseGitCommitVerification(string(c))
+		assert.Equal(t, VerifyResultUnknown, res.Result)
+		assert.Contains(t, res.Message, "Invalid PGP key ID")
 	}
 }
 


### PR DESCRIPTION
Fixes #4828 

This changes behavior of signature result parsing, in that it will not error on failure but instead sets the verification result to `UNKNOWN`.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

