### PR TITLE
fix: show operation status if app is being deleted

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -56,7 +56,7 @@ export const ApplicationStatusPanel = ({application, showOperation, showConditio
         new Map<string, number>()
     );
     const appOperationState = getAppOperationState(application);
-    if (application.metadata.deletionTimestamp) {
+    if (application.metadata.deletionTimestamp && !appOperationState) {
         showOperation = null;
     }
 

--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import {Application, HealthStatus, HealthStatuses, OperationPhases, ResourceResult, ResultCodes, SyncStatuses} from '../../shared/models';
-import {ComparisonStatusIcon, getAppOperationState, getOperationType, HealthStatusIcon, OperationPhaseIcon, OperationState, ResourceResultIcon} from './utils';
+import {ComparisonStatusIcon, getAppOperationState, getOperationType, HealthStatusIcon, OperationState, ResourceResultIcon} from './utils';
 
 const zero = new Date(0).toISOString();
 

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -471,12 +471,7 @@ export const ResourceResultIcon = ({resource}: {resource: appModels.ResourceResu
 };
 
 export const getAppOperationState = (app: appModels.Application): appModels.OperationState => {
-    if (app.metadata.deletionTimestamp) {
-        return {
-            phase: appModels.OperationPhases.Running,
-            startedAt: app.metadata.deletionTimestamp
-        } as appModels.OperationState;
-    } else if (app.operation) {
+    if (app.operation) {
         return {
             phase: appModels.OperationPhases.Running,
             message: (app.status && app.status.operationState && app.status.operationState.message) || 'waiting to start',
@@ -485,18 +480,23 @@ export const getAppOperationState = (app: appModels.Application): appModels.Oper
                 sync: {}
             }
         } as appModels.OperationState;
+    } else if (app.metadata.deletionTimestamp) {
+        return {
+            phase: appModels.OperationPhases.Running,
+            startedAt: app.metadata.deletionTimestamp
+        } as appModels.OperationState;
     } else {
         return app.status.operationState;
     }
 };
 
 export function getOperationType(application: appModels.Application) {
-    if (application.metadata.deletionTimestamp) {
-        return 'Delete';
-    }
-    const operation = application.operation || (application.status.operationState && application.status.operationState.operation);
+    const operation = application.operation || (application.status && application.status.operationState && application.status.operationState.operation);
     if (operation && operation.sync) {
         return 'Sync';
+    }
+    if (application.metadata.deletionTimestamp) {
+        return 'Delete';
     }
     return 'Unknown';
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Backend don't delete application is sync operation is running. So UI should show sync operation status so that user has a chance to terminate sync operation and unblock delete.