### PR TITLE
fix: Properly escape HTML for error message from CLI SSO

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"html"
 	"net/http"
 	"os"
 	"strconv"
@@ -192,7 +193,7 @@ func oauth2Login(ctx context.Context, port int, oidcSettings *settingspkg.OIDCCo
 	var refreshToken string
 
 	handleErr := func(w http.ResponseWriter, errMsg string) {
-		http.Error(w, errMsg, http.StatusBadRequest)
+		http.Error(w, html.EscapeString(errMsg), http.StatusBadRequest)
 		completionChan <- errMsg
 	}
 
@@ -207,7 +208,7 @@ func oauth2Login(ctx context.Context, port int, oidcSettings *settingspkg.OIDCCo
 		log.Debugf("Callback: %s", r.URL)
 
 		if formErr := r.FormValue("error"); formErr != "" {
-			handleErr(w, formErr+": "+r.FormValue("error_description"))
+			handleErr(w, fmt.Sprintf("%s: %s", formErr, r.FormValue("error_description")))
 			return
 		}
 


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

Fixes https://github.com/argoproj/argo-cd/security/code-scanning/46

While I believe this is not a serious issue in the real world, and at least would require a rogue SSO backend for successful exploitation, it should be fixed. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

