### PR TITLE
fix: Ensure requested file from server is within a base path

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -546,3 +546,24 @@ func TestInitializeDefaultProject_ProjectAlreadyInitialized(t *testing.T) {
 
 	assert.Equal(t, proj.Spec, existingDefaultProject.Spec)
 }
+
+func TestFileExists(t *testing.T) {
+	t.Run("File exists and path is within dir", func(t *testing.T) {
+		exists := fileExists(".", "server.go")
+		assert.True(t, exists)
+		exists = fileExists(".", "account/account.go")
+		assert.True(t, exists)
+	})
+	t.Run("File does not exist", func(t *testing.T) {
+		exists := fileExists(".", "notexist.go")
+		assert.False(t, exists)
+	})
+	t.Run("Dir does not exist", func(t *testing.T) {
+		exists := fileExists("/notexisting", "server.go")
+		assert.False(t, exists)
+	})
+	t.Run("File outside of dir", func(t *testing.T) {
+		exists := fileExists(".", "../reposerver/server.go")
+		assert.False(t, exists)
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/security/code-scanning/7

This fix makes sure that a given file requested from server is within the configured base path. While I could not reproduce how to leverage the complaint from CodeQL, this had to be fixed since I believe CodeQL had a good reason for the complaint.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

