### PR TITLE
fix: Changed Dex connectors documentation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1410,7 +1410,7 @@ running Dex (e.g. Okta, OneLogin, Auth0, Microsoft, etc...)
 The optional, [Dex IDP OIDC provider](https://github.com/dexidp/dex) is still bundled as part of the
 default installation, in order to provide a seamless out-of-box experience, enabling Argo CD to
 integrate with non-OIDC providers, and to benefit from Dex's full range of
-[connectors](https://github.com/dexidp/dex/tree/master/Documentation/connectors).
+[connectors](https://dexidp.io/docs/connectors/).
 
 #### OIDC group bindings to Project Roles
 OIDC group claims from an OAuth2 provider can now be bound to a Argo CD project roles. Previously,

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -30,7 +30,7 @@ data:
 
   # A dex connector configuration (optional). See SSO configuration documentation:
   # https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/sso
-  # https://github.com/dexidp/dex/tree/master/Documentation/connectors
+  # https://dexidp.io/docs/connectors/
   dex.config: |
     connectors:
       # GitHub example

--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -132,7 +132,7 @@ func replaceListSecrets(obj []interface{}, secretValues map[string]string) []int
 
 // needsRedirectURI returns whether or not the given connector type needs a redirectURI
 // Update this list as necessary, as new connectors are added
-// https://github.com/dexidp/dex/tree/master/Documentation/connectors
+// https://dexidp.io/docs/connectors/
 func needsRedirectURI(connectorType string) bool {
 	switch connectorType {
 	case "oidc", "saml", "microsoft", "linkedin", "gitlab", "github", "bitbucket-cloud", "openshift":


### PR DESCRIPTION
The link to the DEX connectors documentation is pointing to a deprecated location and hence is causing a 404. This PR is solving this issue by pointing now to https://dexidp.io/docs.

