### PR TITLE
fix: Normal logs should not go to stderr (#3491)

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -59,6 +59,7 @@ func NewCommand() *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
+			cli.SetLogOutput()
 			cli.SetGLogLevel(glogLevel)
 
 			config, err := clientConfig.ClientConfig()

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -78,6 +78,7 @@ func NewCommand() *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
+			cli.SetLogOutput()
 
 			tlsConfigCustomizer, err := tlsConfigCustomizerSrc()
 			errors.CheckError(err)

--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -69,6 +69,7 @@ func NewCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
+			cli.SetLogOutput()
 			cli.SetGLogLevel(glogLevel)
 
 			config, err := clientConfig.ClientConfig()


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

This PR fixes #3491. Send high level logs to Stderr and logs of normal execution to Stdout. 
This PR sends Info, Debug, Warn and Trace logs to stdout. Error, Panic and Fatal are sent to stderr.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

