### PR TITLE
fix: API server should not print resource body when resource update fails

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -905,6 +905,10 @@ func (s *Server) PatchResource(ctx context.Context, q *application.ApplicationRe
 
 	manifest, err := s.kubectl.PatchResource(ctx, config, res.GroupKindVersion(), res.Name, res.Namespace, types.PatchType(q.PatchType), []byte(q.Patch))
 	if err != nil {
+		// don't expose real error for secrets since it might contain secret data
+		if res.Kind == kube.SecretKind && res.Group == "" {
+			return nil, fmt.Errorf("failed to patch Secret %s/%s", res.Namespace, res.Name)
+		}
 		return nil, err
 	}
 	manifest, err = replaceSecretValues(manifest)


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

fix: API server should not print resource body when resource update fails