### PR TITLE
chore: [backport to release-1.7] Fix release script for 1.7 branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           # Target version must match major.minor.patch and optional -rcX suffix
           # where X must be a number.
           TARGET_VERSION=${SOURCE_TAG#*release-v}
-          if ! echo ${TARGET_VERSION} | egrep '^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*$'; then
+          if ! echo "${TARGET_VERSION}" | egrep '^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*$'; then
             echo "::error::Target version '${TARGET_VERSION}' is malformed, refusing to continue." >&2
             exit 1
           fi
@@ -103,16 +103,16 @@ jobs:
             # Whatever is in commit history for the tag, we only want that
             # annotation from our tag. We discard everything else.
             if test "$begin" = "false"; then
-              if echo $line | grep -q "tag ${SOURCE_TAG#refs/tags/}"; then begin="true"; fi
+              if echo "$line" | grep -q "tag ${SOURCE_TAG#refs/tags/}"; then begin="true"; fi
               continue
             fi
             if test "$prefix" = "true"; then
                   if test -z "$line"; then prefix=false; fi
             else
-                  if echo $line | egrep -q '^commit [0-9a-f]+'; then
+                  if echo "$line" | egrep -q '^commit [0-9a-f]+'; then
                           break
                   fi
-                  echo $line >> ${RELEASE_NOTES}
+                  echo "$line" >> ${RELEASE_NOTES}
             fi
           done
 


### PR DESCRIPTION
Backport prevention of shell wildcard expansion in release notes during release creation.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

