### PR TITLE
docs: Move security policy to SECURITY.md for integration with GitHub

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ prefer to stay anonymous, of course).
 
 Please report vulnerabilities by e-mail to all of the following people:
 
+* jfischer@redhat.com
 * Jesse_Suen@intuit.com
 * Alexander_Matyushentsev@intuit.com
 * Edward_Lee@intuit.com
-* jfischer@redhat.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy for Argo CD
+
+**v1.0 (2020-02-26)**
+
+## Preface
+
+As a deployment tool, Argo CD needs to have production access which makes
+security a very important topic. The Argoproj team takes security very
+seriously and is continuously working on improving it. 
+
+## Supported Versions
+
+We currently support the most recent minor release branch (e.g. `1.8`) and the
+minor version previous to that (e.g. `1.7`). We regularly perform patch releases
+(e.g. `1.8.5` and `1.7.12`) in these supported branches, which will contain fixes
+for security vulnerabilities and bugs. Prior releases might receive critical
+security fixes on a best effort basis, however, it cannot be guaranteed that
+security fixes get back-ported to these unsupported versions.
+
+In rare cases, where a security fix needs complex re-design of a feature or is
+otherwise very intrusive, and there's a workaround available, we may decide to
+provide a forward-fix only, e.g. to be released the next minor release, instead
+of providing it within a patch branch. 
+
+## Reporting a Vulnerability
+
+If you find a security related bug in ArgoCD, we kindly ask you for responsible
+disclosure and for giving us appropriate time to react, analyze and develop a
+fix to mitigate the found security vulnerability. 
+
+We will do our best to react quickly on your inquiry, and to coordinate a fix
+and disclosure with you. Sometimes, it might take a little longer for us to
+react (e.g. out of office conditions), so please bear with us in these cases.
+
+We will publish security advisiories using the Git Hub SA feature to keep our
+community well informed, and will credit you for your findings (unless you
+prefer to stay anonymous, of course).
+
+Please report vulnerabilities by e-mail to the following addresses:
+
+* Jesse_Suen@intuit.com
+* Alexander_Matyushentsev@intuit.com
+* Edward_Lee@intuit.com
+* jfischer@redhat.com
+
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy for Argo CD
 
-**v1.0 (2020-02-26)**
+Version: **v1.0 (2020-02-26)**
 
 ## Preface
 
@@ -10,23 +10,26 @@ seriously and is continuously working on improving it.
 
 ## Supported Versions
 
-We currently support the most recent minor release branch (e.g. `1.8`) and the
-minor version previous to that (e.g. `1.7`). We regularly perform patch releases
-(e.g. `1.8.5` and `1.7.12`) in these supported branches, which will contain fixes
-for security vulnerabilities and bugs. Prior releases might receive critical
-security fixes on a best effort basis, however, it cannot be guaranteed that
-security fixes get back-ported to these unsupported versions.
+We currently support the most recent release (`N`, e.g. `1.8`) and the release
+previous to the most recent one (`N-1`, e.g. `1.7`). With the release of
+`N+1`, `N-1` drops out of support and `N` becomes `N-1`.
+
+We regularly perform patch releases (e.g. `1.8.5` and `1.7.12`) for the
+supported versions, which will contain fixes for security vulnerabilities and
+important bugs. Prior releases might receive critical security fixes on a best
+effort basis, however, it cannot be guaranteed that security fixes get
+back-ported to these unsupported versions.
 
 In rare cases, where a security fix needs complex re-design of a feature or is
 otherwise very intrusive, and there's a workaround available, we may decide to
 provide a forward-fix only, e.g. to be released the next minor release, instead
-of providing it within a patch branch. 
+of releasing it within a patch branch for the currently supported releases.
 
 ## Reporting a Vulnerability
 
 If you find a security related bug in ArgoCD, we kindly ask you for responsible
 disclosure and for giving us appropriate time to react, analyze and develop a
-fix to mitigate the found security vulnerability. 
+fix to mitigate the found security vulnerability.
 
 We will do our best to react quickly on your inquiry, and to coordinate a fix
 and disclosure with you. Sometimes, it might take a little longer for us to
@@ -36,11 +39,9 @@ We will publish security advisiories using the Git Hub SA feature to keep our
 community well informed, and will credit you for your findings (unless you
 prefer to stay anonymous, of course).
 
-Please report vulnerabilities by e-mail to the following addresses:
+Please report vulnerabilities by e-mail to all of the following people:
 
 * Jesse_Suen@intuit.com
 * Alexander_Matyushentsev@intuit.com
 * Edward_Lee@intuit.com
 * jfischer@redhat.com
-
-

--- a/docs/security_considerations.md
+++ b/docs/security_considerations.md
@@ -1,5 +1,11 @@
 # Security Considerations
 
+!!!warning "Deprecation notice"
+    This page is now deprecated and serves as an archive only. For up-to-date
+    information, please have a look at our
+    [security policy](https://github.com/argoproj/argo-cd/security/policy) and
+    [published security advisories](https://github.com/argoproj/argo-cd/security/advisories).
+
 As a deployment tool, Argo CD needs to have production access which makes security a very important topic.
 The Argoproj team takes security very seriously and continuously working on improving it. Learn more about security
 related features in [Security](./operator-manual/security.md) section.
@@ -172,12 +178,6 @@ Upgrade to ArgoCD v1.5.0 or higher. No workaround available
 
 ## Reporting Vulnerabilities
 
-If you find a security related bug in ArgoCD, we kindly ask you for responsible
-disclosure and for giving us appropriate time to react, analyze and develop a
-fix to mitigate the found security vulnerability.
-
-Please report security vulnerabilities by e-mailing:
-
-* [Jesse_Suen@intuit.com](mailto:Jesse_Suen@intuit.com)
-* [Alexander_Matyushentsev@intuit.com](mailto:Alexander_Matyushentsev@intuit.com)
-* [Edward_Lee@intuit.com](mailto:Edward_Lee@intuit.com)
+Please have a look at our
+[security policy](https://github.com/argoproj/argo-cd/security/policy)
+for more details on how to report security vulnerabilities for Argo CD.


### PR DESCRIPTION
This PR:

* Moves security policy to SECURITY.md for integration with GitHub's _Security_ tab
* Archives security_considerations.md

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

