### PR TITLE
feat: regenerate active users token if it is expiring soon

### DIFF
--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -36,7 +36,7 @@ type Handler struct {
 	appClientset versioned.Interface
 	settingsMgr  *settings.SettingsManager
 	rootPath     string
-	verifyToken  func(tokenString string) (jwt.Claims, error)
+	verifyToken  func(tokenString string) (jwt.Claims, string, error)
 	revokeToken  func(ctx context.Context, id string, expiringAt time.Duration) error
 }
 
@@ -85,7 +85,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Set-Cookie", argocdCookie.String())
 	}
 
-	claims, err := h.verifyToken(tokenString)
+	claims, _, err := h.verifyToken(tokenString)
 	if err != nil {
 		http.Redirect(w, r, logoutRedirectURL, http.StatusSeeOther)
 		return

--- a/server/logout/logout_test.go
+++ b/server/logout/logout_test.go
@@ -180,25 +180,25 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 	sessionManager := session.NewSessionManager(settingsManagerWithOIDCConfig, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 
 	oidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfig, sessionManager, "", "default")
-	oidcHandler.verifyToken = func(tokenString string) (jwt.Claims, error) {
+	oidcHandler.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
-			return nil, errors.New("invalid jwt")
+			return nil, "", errors.New("invalid jwt")
 		}
-		return &jwt.StandardClaims{Issuer: "okta"}, nil
+		return &jwt.StandardClaims{Issuer: "okta"}, "", nil
 	}
 	nonoidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithoutOIDCConfig, sessionManager, "", "default")
-	nonoidcHandler.verifyToken = func(tokenString string) (jwt.Claims, error) {
+	nonoidcHandler.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
-			return nil, errors.New("invalid jwt")
+			return nil, "", errors.New("invalid jwt")
 		}
-		return &jwt.StandardClaims{Issuer: session.SessionManagerClaimsIssuer}, nil
+		return &jwt.StandardClaims{Issuer: session.SessionManagerClaimsIssuer}, "", nil
 	}
 	oidcHandlerWithoutLogoutURL := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfigButNoLogoutURL, sessionManager, "", "default")
-	oidcHandlerWithoutLogoutURL.verifyToken = func(tokenString string) (jwt.Claims, error) {
+	oidcHandlerWithoutLogoutURL.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
-			return nil, errors.New("invalid jwt")
+			return nil, "", errors.New("invalid jwt")
 		}
-		return &jwt.StandardClaims{Issuer: "okta"}, nil
+		return &jwt.StandardClaims{Issuer: "okta"}, "", nil
 	}
 
 	oidcTokenHeader := make(map[string][]string)

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -347,7 +347,7 @@ func TestProjectServer(t *testing.T) {
 		projectServer := NewServer("default", fake.NewSimpleClientset(), clientset, enforcer, sync.NewKeyLock(), sessionMgr, policyEnf, projInformer, settingsMgr)
 		tokenResponse, err := projectServer.CreateToken(context.Background(), &project.ProjectTokenCreateRequest{Project: projectWithRole.Name, Role: tokenName, ExpiresIn: 100})
 		assert.NoError(t, err)
-		claims, err := sessionMgr.Parse(tokenResponse.Token)
+		claims, _, err := sessionMgr.Parse(tokenResponse.Token)
 		assert.NoError(t, err)
 
 		mapClaims, err := jwtutil.MapClaims(claims)
@@ -367,7 +367,7 @@ func TestProjectServer(t *testing.T) {
 		projectServer := NewServer("default", fake.NewSimpleClientset(), clientset, enforcer, sync.NewKeyLock(), sessionMgr, policyEnf, projInformer, settingsMgr)
 		tokenResponse, err := projectServer.CreateToken(context.Background(), &project.ProjectTokenCreateRequest{Project: projectWithRole.Name, Role: tokenName, ExpiresIn: 1, Id: id})
 		assert.NoError(t, err)
-		claims, err := sessionMgr.Parse(tokenResponse.Token)
+		claims, _, err := sessionMgr.Parse(tokenResponse.Token)
 		assert.NoError(t, err)
 
 		mapClaims, err := jwtutil.MapClaims(claims)
@@ -388,7 +388,7 @@ func TestProjectServer(t *testing.T) {
 		tokenResponse, err := projectServer.CreateToken(context.Background(), &project.ProjectTokenCreateRequest{Project: projectWithRole.Name, Role: tokenName, ExpiresIn: 1, Id: id})
 
 		assert.NoError(t, err)
-		claims, err := sessionMgr.Parse(tokenResponse.Token)
+		claims, _, err := sessionMgr.Parse(tokenResponse.Token)
 		assert.NoError(t, err)
 
 		mapClaims, err := jwtutil.MapClaims(claims)

--- a/server/server.go
+++ b/server/server.go
@@ -916,6 +916,9 @@ func (a *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error
 		// nolint:staticcheck
 		ctx = context.WithValue(ctx, "claims", claims)
 		if newToken != "" {
+			// Session tokens that are expiring soon should be regenerated if user stays active.
+			// The renewed token is stored in outgoing ServerMetadata. Metadata is available to grpc-gateway
+			// response forwarder that will translate it into Set-Cookie header.
 			if err := grpc.SendHeader(ctx, metadata.New(map[string]string{renewTokenKey: newToken})); err != nil {
 				log.Warnf("Failed to set %s header", renewTokenKey)
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -106,6 +106,7 @@ import (
 
 const maxConcurrentLoginRequestsCountEnv = "ARGOCD_MAX_CONCURRENT_LOGIN_REQUESTS_COUNT"
 const replicasCountEnv = "ARGOCD_API_SERVER_REPLICAS"
+const renewTokenKey = "renew-token"
 
 // ErrNoSession indicates no auth token was supplied as part of a request
 var ErrNoSession = status.Errorf(codes.Unauthenticated, "no session information")
@@ -595,29 +596,43 @@ func (a *ArgoCDServer) newGRPCServer() *grpc.Server {
 	return grpcS
 }
 
-// TranslateGrpcCookieHeader conditionally sets a cookie on the response.
+// translateGrpcCookieHeader conditionally sets a cookie on the response.
 func (a *ArgoCDServer) translateGrpcCookieHeader(ctx context.Context, w http.ResponseWriter, resp golang_proto.Message) error {
 	if sessionResp, ok := resp.(*sessionpkg.SessionResponse); ok {
-		cookiePath := fmt.Sprintf("path=/%s", strings.TrimRight(strings.TrimLeft(a.ArgoCDServerOpts.RootPath, "/"), "/"))
-		flags := []string{cookiePath, "SameSite=lax", "httpOnly"}
-		if !a.Insecure {
-			flags = append(flags, "Secure")
-		}
 		token := sessionResp.Token
-		if token != "" {
-			var err error
-			token, err = zjwt.ZJWT(token)
-			if err != nil {
-				return err
-			}
-		}
-		cookies, err := httputil.MakeCookieMetadata(common.AuthCookieName, token, flags...)
+		err := a.setTokenCookie(token, w)
 		if err != nil {
 			return err
 		}
-		for _, cookie := range cookies {
-			w.Header().Add("Set-Cookie", cookie)
+	} else if md, ok := runtime.ServerMetadataFromContext(ctx); ok {
+		renewToken := md.HeaderMD[renewTokenKey]
+		if len(renewToken) > 0 {
+			return a.setTokenCookie(renewToken[0], w)
 		}
+	}
+
+	return nil
+}
+
+func (a *ArgoCDServer) setTokenCookie(token string, w http.ResponseWriter) error {
+	cookiePath := fmt.Sprintf("path=/%s", strings.TrimRight(strings.TrimLeft(a.ArgoCDServerOpts.RootPath, "/"), "/"))
+	flags := []string{cookiePath, "SameSite=lax", "httpOnly"}
+	if !a.Insecure {
+		flags = append(flags, "Secure")
+	}
+	if token != "" {
+		var err error
+		token, err = zjwt.ZJWT(token)
+		if err != nil {
+			return err
+		}
+	}
+	cookies, err := httputil.MakeCookieMetadata(common.AuthCookieName, token, flags...)
+	if err != nil {
+		return err
+	}
+	for _, cookie := range cookies {
+		w.Header().Add("Set-Cookie", cookie)
 	}
 	return nil
 }
@@ -895,11 +910,16 @@ func (a *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error
 	if a.DisableAuth {
 		return ctx, nil
 	}
-	claims, claimsErr := a.getClaims(ctx)
+	claims, newToken, claimsErr := a.getClaims(ctx)
 	if claims != nil {
 		// Add claims to the context to inspect for RBAC
 		// nolint:staticcheck
 		ctx = context.WithValue(ctx, "claims", claims)
+		if newToken != "" {
+			if err := grpc.SendHeader(ctx, metadata.New(map[string]string{renewTokenKey: newToken})); err != nil {
+				log.Warnf("Failed to set %s header", renewTokenKey)
+			}
+		}
 	}
 
 	if claimsErr != nil {
@@ -915,20 +935,20 @@ func (a *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error
 	return ctx, nil
 }
 
-func (a *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, error) {
+func (a *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, ErrNoSession
+		return nil, "", ErrNoSession
 	}
 	tokenString := getToken(md)
 	if tokenString == "" {
-		return nil, ErrNoSession
+		return nil, "", ErrNoSession
 	}
-	claims, err := a.sessionMgr.VerifyToken(tokenString)
+	claims, newToken, err := a.sessionMgr.VerifyToken(tokenString)
 	if err != nil {
-		return claims, status.Errorf(codes.Unauthenticated, "invalid session: %v", err)
+		return claims, "", status.Errorf(codes.Unauthenticated, "invalid session: %v", err)
 	}
-	return claims, nil
+	return claims, newToken, nil
 }
 
 // getToken extracts the token from gRPC metadata or cookie headers


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR is a follow-up for https://github.com/argoproj/argo-cd/pull/5477 that introduced built-in token expiration.  To make sure user experience is good API server will regenerate token for requests with valid token in case if token is expiring soon (5 minutes)