### PR TITLE
feat: exposed sync retry options via cli for app create

### DIFF
--- a/cmd/util/app_test.go
+++ b/cmd/util/app_test.go
@@ -164,4 +164,11 @@ func Test_setAppSpecOptions(t *testing.T) {
 		assert.NoError(t, f.SetFlag("sync-option", "!a=1"))
 		assert.Nil(t, f.spec.SyncPolicy)
 	})
+	t.Run("RetryLimit", func(t *testing.T) {
+		assert.NoError(t, f.SetFlag("retry-limit", "5"))
+		assert.True(t, f.spec.SyncPolicy.Retry.Limit == 5)
+
+		assert.NoError(t, f.SetFlag("retry-limit", "0"))
+		assert.Nil(t, f.spec.SyncPolicy)
+	})
 }

--- a/docs/operator-manual/server-commands/argocd-util_config_app.md
+++ b/docs/operator-manual/server-commands/argocd-util_config_app.md
@@ -70,6 +70,10 @@ argocd-util config app APPNAME [flags]
       --project string                            Application project name
       --release-name string                       Helm release-name
       --repo string                               Repository URL, ignored if a file is set
+      --retry-backoff-duration duration           Retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
+      --retry-backoff-factor int                  Factor multiplies the base duration after each failed retry (default 2)
+      --retry-backoff-max-duration duration       Max retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
+      --retry-limit int                           Max number of allowed sync retries
       --revision string                           The tracking source branch, tag, commit or Helm chart version the application will sync to
       --revision-history-limit int                How many items to keep in revision history (default 10)
       --self-heal                                 Set self healing when sync is automated

--- a/docs/user-guide/commands/argocd_app_create.md
+++ b/docs/user-guide/commands/argocd_app_create.md
@@ -69,6 +69,10 @@ argocd app create APPNAME [flags]
       --project string                            Application project name
       --release-name string                       Helm release-name
       --repo string                               Repository URL, ignored if a file is set
+      --retry-backoff-duration duration           Retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
+      --retry-backoff-factor int                  Factor multiplies the base duration after each failed retry (default 2)
+      --retry-backoff-max-duration duration       Max retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
+      --retry-limit int                           Max number of allowed sync retries
       --revision string                           The tracking source branch, tag, commit or Helm chart version the application will sync to
       --revision-history-limit int                How many items to keep in revision history (default 10)
       --self-heal                                 Set self healing when sync is automated

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -42,6 +42,10 @@ argocd app set APPNAME [flags]
       --project string                            Application project name
       --release-name string                       Helm release-name
       --repo string                               Repository URL, ignored if a file is set
+      --retry-backoff-duration duration           Retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
+      --retry-backoff-factor int                  Factor multiplies the base duration after each failed retry (default 2)
+      --retry-backoff-max-duration duration       Max retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
+      --retry-limit int                           Max number of allowed sync retries
       --revision string                           The tracking source branch, tag, commit or Helm chart version the application will sync to
       --revision-history-limit int                How many items to keep in revision history (default 10)
       --self-heal                                 Set self healing when sync is automated

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -650,7 +650,7 @@ type SyncPolicy struct {
 }
 
 func (p *SyncPolicy) IsZero() bool {
-	return p == nil || (p.Automated == nil && len(p.SyncOptions) == 0)
+	return p == nil || (p.Automated == nil && len(p.SyncOptions) == 0 && p.Retry == nil)
 }
 
 type RetryStrategy struct {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1987,6 +1987,7 @@ func TestSyncPolicy_IsZero(t *testing.T) {
 	assert.True(t, (&SyncPolicy{}).IsZero())
 	assert.False(t, (&SyncPolicy{Automated: &SyncPolicyAutomated{}}).IsZero())
 	assert.False(t, (&SyncPolicy{SyncOptions: SyncOptions{""}}).IsZero())
+	assert.False(t, (&SyncPolicy{Retry: &RetryStrategy{}}).IsZero())
 }
 
 func TestSyncOptions_HasOption(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Shubham Agarwal <shubhamagarawal19@gmail.com>

fixes: #5318 

This PR takes care of exposing the `Sync Retry Options` with `app create` command. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

