### PR TITLE
feat: Add additional strimzi custom resource health checks

### DIFF
--- a/resource_customizations/kafka.strimzi.io/Kafka/health.lua
+++ b/resource_customizations/kafka.strimzi.io/Kafka/health.lua
@@ -1,0 +1,21 @@
+hs = {}
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil then
+    for i, condition in ipairs(obj.status.conditions) do
+      if condition.type == "NotReady" and condition.status == "True" and condition.reason ~= "Creating" then
+        hs.status = "Degraded"
+        hs.message = condition.message
+        return hs
+      end
+      if condition.type == "Ready" and condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = ""
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for Kafka Cluster"
+return hs

--- a/resource_customizations/kafka.strimzi.io/Kafka/health_test.yaml
+++ b/resource_customizations/kafka.strimzi.io/Kafka/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "Waiting for Kafka Cluster"
+  inputPath: testdata/progressing_noStatus.yaml
+- healthStatus:
+    status: Degraded
+    message: "Error"
+    message: "Exceeded timeout of 300000ms while waiting for StatefulSet resource my-cluster-zookeeper in namespace default to be ready"
+  inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Healthy
+  inputPath: testdata/healthy.yaml

--- a/resource_customizations/kafka.strimzi.io/Kafka/testdata/degraded.yaml
+++ b/resource_customizations/kafka.strimzi.io/Kafka/testdata/degraded.yaml
@@ -1,0 +1,47 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  creationTimestamp: "2021-02-22T15:59:14Z"
+  generation: 1
+  name: my-cluster
+  namespace: default
+  resourceVersion: "134745509"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkas/my-cluster
+  uid: 69de4987-371b-4300-a3cc-545bfab1dc87
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      inter.broker.protocol.version: "2.7"
+      log.message.format.version: "2.7"
+      offsets.topics.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      transaction.state.log.replication.factor: 1
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: false
+      type: internal
+    replicas: 1
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral
+status:
+  clusterId: 463lY141TCqd6DDvPj5EDw
+  conditions:
+  - lastTransitionTime: 2021-02-22T16:05:43+0000
+    message: Exceeded timeout of 300000ms while waiting for StatefulSet resource my-cluster-zookeeper
+      in namespace default to be ready
+    reason: TimeoutException
+    status: "True"
+    type: NotReady
+  observedGeneration: 1

--- a/resource_customizations/kafka.strimzi.io/Kafka/testdata/healthy.yaml
+++ b/resource_customizations/kafka.strimzi.io/Kafka/testdata/healthy.yaml
@@ -1,0 +1,61 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  creationTimestamp: "2021-02-22T15:59:14Z"
+  generation: 1
+  name: my-cluster
+  namespace: default
+  resourceVersion: "134745509"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkas/my-cluster
+  uid: 69de4987-371b-4300-a3cc-545bfab1dc87
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      inter.broker.protocol.version: "2.7"
+      log.message.format.version: "2.7"
+      offsets.topics.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      transaction.state.log.replication.factor: 1
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: false
+      type: internal
+    replicas: 1
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral
+status:
+  clusterId: 463lY141TCqd6DDvPj5EDw
+  conditions:
+  - lastTransitionTime: 2021-02-22T16:05:43+0000
+    message: A Kafka cluster with a single replica and ephemeral storage will lose
+      topic messages after any restart or rolling update
+    reason: KafkaStorage
+    status: "True"
+    type: Warning
+  - lastTransitionTime: 2021-02-22T16:05:47+0000
+    status: "True"
+    type: Ready
+  listeners:
+  - addresses:
+    - host: my-cluster-kafka-bootstrap.default.svc
+      port: 9092
+    bootstrapServers: my-cluster-kafka-bootstrap.default.svc:9092
+    type: plain
+  - addresses:
+    - host: my-cluster-kafka-bootstrap.default.svc
+      port: 9093
+    bootstrapServers: my-cluster-kafka-bootstrap.default.svc:9093
+    type: tls
+  observedGeneration: 1

--- a/resource_customizations/kafka.strimzi.io/Kafka/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/kafka.strimzi.io/Kafka/testdata/progressing_noStatus.yaml
@@ -1,0 +1,37 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  creationTimestamp: "2021-02-22T15:59:14Z"
+  generation: 1
+  name: my-cluster
+  namespace: default
+  resourceVersion: "134745509"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkas/my-cluster
+  uid: 69de4987-371b-4300-a3cc-545bfab1dc87
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      inter.broker.protocol.version: "2.7"
+      log.message.format.version: "2.7"
+      offsets.topics.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      transaction.state.log.replication.factor: 1
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: false
+      type: internal
+    replicas: 1
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral

--- a/resource_customizations/kafka.strimzi.io/KafkaTopic/health.lua
+++ b/resource_customizations/kafka.strimzi.io/KafkaTopic/health.lua
@@ -1,0 +1,21 @@
+hs = {}
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil then
+    for i, condition in ipairs(obj.status.conditions) do
+      if condition.type == "NotReady" and condition.status == "True" then
+        hs.status = "Degraded"
+        hs.message = condition.message
+        return hs
+      end
+      if condition.type == "Ready" and condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = ""
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for Kafka Topic"
+return hs

--- a/resource_customizations/kafka.strimzi.io/KafkaTopic/health_test.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaTopic/health_test.yaml
@@ -1,0 +1,12 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "Waiting for Kafka Topic"
+  inputPath: testdata/progressing_noStatus.yaml
+- healthStatus:
+    status: Degraded
+    message: "Invalid value abcd for configuration retention.ms: Not a number of type LONG"
+  inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Healthy
+  inputPath: testdata/healthy.yaml

--- a/resource_customizations/kafka.strimzi.io/KafkaTopic/testdata/degraded.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaTopic/testdata/degraded.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  creationTimestamp: "2021-02-22T16:10:54Z"
+  generation: 1
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: my-topic
+  namespace: default
+  resourceVersion: "134751516"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkatopics/my-topic
+  uid: 13b7644a-ec46-4f24-a198-18962fda4b85
+spec:
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+  partitions: 1
+  replicas: 1
+status:
+  conditions:
+  - lastTransitionTime: "2021-02-22T16:10:55.003372Z"
+    message: 'Invalid value abcd for configuration retention.ms: Not a number of type
+      LONG'
+    reason: InvalidConfigurationException
+    status: "True"
+    type: NotReady
+  observedGeneration: 1

--- a/resource_customizations/kafka.strimzi.io/KafkaTopic/testdata/healthy.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaTopic/testdata/healthy.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  creationTimestamp: "2021-02-22T16:10:54Z"
+  generation: 1
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: my-topic
+  namespace: default
+  resourceVersion: "134751516"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkatopics/my-topic
+  uid: 13b7644a-ec46-4f24-a198-18962fda4b85
+spec:
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+  partitions: 1
+  replicas: 1
+status:
+  conditions:
+  - lastTransitionTime: "2021-02-22T16:10:55.003372Z"
+    status: "True"
+    type: Ready
+  observedGeneration: 1

--- a/resource_customizations/kafka.strimzi.io/KafkaTopic/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaTopic/testdata/progressing_noStatus.yaml
@@ -1,0 +1,18 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  creationTimestamp: "2021-02-22T16:10:54Z"
+  generation: 1
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: my-topic
+  namespace: default
+  resourceVersion: "134751516"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkatopics/my-topic
+  uid: 13b7644a-ec46-4f24-a198-18962fda4b85
+spec:
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+  partitions: 1
+  replicas: 1

--- a/resource_customizations/kafka.strimzi.io/KafkaUser/health.lua
+++ b/resource_customizations/kafka.strimzi.io/KafkaUser/health.lua
@@ -1,0 +1,21 @@
+hs = {}
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil then
+    for i, condition in ipairs(obj.status.conditions) do
+      if condition.type == "NotReady" and condition.status == "True" then
+        hs.status = "Degraded"
+        hs.message = condition.message
+        return hs
+      end
+      if condition.type == "Ready" and condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = ""
+        return hs
+      end
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for Kafka User"
+return hs

--- a/resource_customizations/kafka.strimzi.io/KafkaUser/health_test.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaUser/health_test.yaml
@@ -1,0 +1,12 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "Waiting for Kafka User"
+  inputPath: testdata/progressing_noStatus.yaml
+- healthStatus:
+    status: Degraded
+    message: "Authorization needs to be enabled in the Kafka custom resource"
+  inputPath: testdata/degraded.yaml
+- healthStatus:
+    status: Healthy
+  inputPath: testdata/healthy.yaml

--- a/resource_customizations/kafka.strimzi.io/KafkaUser/testdata/degraded.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaUser/testdata/degraded.yaml
@@ -1,0 +1,58 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  creationTimestamp: "2021-02-22T15:59:18Z"
+  generation: 1
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: my-user
+  namespace: default
+  resourceVersion: "134744742"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkausers/my-user
+  uid: 4610a4d8-bd73-4ab9-bed8-971ee5dabf7d
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+    - host: '*'
+      operation: Read
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Describe
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Read
+      resource:
+        name: my-group
+        patternType: literal
+        type: group
+    - host: '*'
+      operation: Write
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Create
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    type: simple
+status:
+  conditions:
+  - lastTransitionTime: "2021-02-22T16:05:09.386834Z"
+    message: Authorization needs to be enabled in the Kafka custom resource
+    reason: InvalidResourceException
+    status: "True"
+    type: NotReady
+  observedGeneration: 1
+  secret: my-user
+  username: CN=my-user

--- a/resource_customizations/kafka.strimzi.io/KafkaUser/testdata/healthy.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaUser/testdata/healthy.yaml
@@ -1,0 +1,56 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  creationTimestamp: "2021-02-22T15:59:18Z"
+  generation: 1
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: my-user
+  namespace: default
+  resourceVersion: "134744742"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkausers/my-user
+  uid: 4610a4d8-bd73-4ab9-bed8-971ee5dabf7d
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+    - host: '*'
+      operation: Read
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Describe
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Read
+      resource:
+        name: my-group
+        patternType: literal
+        type: group
+    - host: '*'
+      operation: Write
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Create
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    type: simple
+status:
+  conditions:
+  - lastTransitionTime: "2021-02-22T16:05:09.386834Z"
+    status: "True"
+    type: Ready
+  observedGeneration: 1
+  secret: my-user
+  username: CN=my-user

--- a/resource_customizations/kafka.strimzi.io/KafkaUser/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/kafka.strimzi.io/KafkaUser/testdata/progressing_noStatus.yaml
@@ -1,0 +1,48 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  creationTimestamp: "2021-02-22T15:59:18Z"
+  generation: 1
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: my-user
+  namespace: default
+  resourceVersion: "134744742"
+  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/default/kafkausers/my-user
+  uid: 4610a4d8-bd73-4ab9-bed8-971ee5dabf7d
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+    - host: '*'
+      operation: Read
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Describe
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Read
+      resource:
+        name: my-group
+        patternType: literal
+        type: group
+    - host: '*'
+      operation: Write
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    - host: '*'
+      operation: Create
+      resource:
+        name: my-topic
+        patternType: literal
+        type: topic
+    type: simple


### PR DESCRIPTION
Add additional strimzi custom resource health checks, including:
* Kafka
* KafkaTopic
* KafkaUser

Fixes #5577

Signed-off-by: Nick Groszewski <groszewn@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

