### PR TITLE
fix: pod logs viewer keep reloading completed container logs when logs following enabled

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -190,7 +190,7 @@ export const PodsLogsViewer = (props: PodLogsProps & {fullscreen?: boolean}) => 
                                 .filter(batch => batch.length > 0)
                                 .map(batch => batch[batch.length - 1]);
                             if (prefs.appDetails.followLogs) {
-                                logsSource = logsSource.repeat().retryWhen(errors => errors.delay(500));
+                                logsSource = logsSource.retryWhen(errors => errors.delay(500));
                             }
                             return logsSource;
                         }}>

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -211,6 +211,7 @@ export class ApplicationsService {
             const subscription = entries.subscribe(
                 entry => {
                     if (entry.last) {
+                        first = true;
                         observer.complete();
                         subscription.unsubscribe();
                     } else {

--- a/ui/src/app/shared/services/requests.ts
+++ b/ui/src/app/shared/services/requests.ts
@@ -80,7 +80,7 @@ export default {
             // check readyState periodically instead.
             const interval = setInterval(() => {
                 if (eventSource && eventSource.readyState === ReadyState.CLOSED) {
-                    observer.complete();
+                    observer.error('connection got closed unexpectedly');
                 }
             }, 500);
             return () => {


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Sorry, another bug fix for pod logs viewer. After the previous change was merged the logs viewer reliably retry failed attempts to fetch logs of running containers but incorrectly keep retrying to load logs of completed containers.

PR changes UI so that it retry only on errors. 