### PR TITLE
fix: docs version selector not rendering

### DIFF
--- a/docs/assets/versions.css
+++ b/docs/assets/versions.css
@@ -1,4 +1,4 @@
-.md-header-nav__title {
+.md-header__title {
   display: flex;
 }
 

--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -3,7 +3,7 @@ setTimeout(function() {
   window[callbackName] = function (response) {
   const div = document.createElement('div');
   div.innerHTML = response.html;
-  document.querySelector(".md-header-nav > .md-header-nav__title").appendChild(div);
+  document.querySelector(".md-header__inner > .md-header__title").appendChild(div);
   const container = div.querySelector('.rst-versions');
   var caret = document.createElement('div');
   caret.innerHTML = "<i class='fa fa-caret-down dropdown-caret'></i>"


### PR DESCRIPTION
Closes #5632 

This fix will need to be applied to all versions. Not sure what happened but I think that somehow the class names generated by mkdocs changed and caused the version selector to break. Not sure why this hasn't happened in [Argo CD Notifications docs](https://argocd-notifications.readthedocs.io/en/stable/) which is almost identical, if it happens down the line though this is all that should need to be changed to fix it. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

