### PR TITLE
chore: Update inline docs for types.go

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -2517,7 +2517,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "URL of the repo",
+            "description": "Repo contains the URL to the remote repository",
             "name": "repo.repo",
             "in": "path",
             "required": true
@@ -2863,7 +2863,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "RepoURL is the repository URL of the application manifests",
+            "description": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
             "name": "source.repoURL",
             "in": "path",
             "required": true
@@ -3437,14 +3437,15 @@
     },
     "applicationv1alpha1EnvEntry": {
       "type": "object",
+      "title": "EnvEntry represents an entry in the application's environment",
       "properties": {
         "name": {
           "type": "string",
-          "title": "the name, usually uppercase"
+          "title": "Name is the name of the variable, usually expressed in uppercase"
         },
         "value": {
           "type": "string",
-          "title": "the value"
+          "title": "Value is the value of the variable"
         }
       }
     },
@@ -4594,7 +4595,7 @@
         },
         "signatureKeys": {
           "type": "array",
-          "title": "List of PGP key IDs that commits to be synced to must be signed with",
+          "title": "SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync",
           "items": {
             "$ref": "#/definitions/v1alpha1SignatureKey"
           }
@@ -4617,10 +4618,11 @@
     },
     "v1alpha1AppProjectStatus": {
       "type": "object",
-      "title": "AppProjectStatus contains information about appproj",
+      "title": "AppProjectStatus contains status information for AppProject CRs",
       "properties": {
         "jwtTokensByRole": {
           "type": "object",
+          "title": "JWTTokensByRole contains a list of JWT tokens issued for a given role",
           "additionalProperties": {
             "$ref": "#/definitions/v1alpha1JWTTokens"
           }
@@ -4647,7 +4649,7 @@
     },
     "v1alpha1ApplicationCondition": {
       "type": "object",
-      "title": "ApplicationCondition contains details about current application condition",
+      "title": "ApplicationCondition contains details about an application condition, which is usally an error or warning",
       "properties": {
         "lastTransitionTime": {
           "$ref": "#/definitions/v1Time"
@@ -4664,19 +4666,19 @@
     },
     "v1alpha1ApplicationDestination": {
       "type": "object",
-      "title": "ApplicationDestination contains deployment destination information",
+      "title": "ApplicationDestination holds information about the application's destination",
       "properties": {
         "name": {
           "type": "string",
-          "title": "Name of the destination cluster which can be used instead of server (url) field"
+          "title": "Name is an alternate way of specifying the target cluster by its symbolic name"
         },
         "namespace": {
           "type": "string",
-          "title": "Namespace overrides the environment namespace value in the ksonnet app.yaml"
+          "title": "Namespace specifies the target namespace for the application's resources.\nThe namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace"
         },
         "server": {
           "type": "string",
-          "title": "Server overrides the environment server value in the ksonnet app.yaml"
+          "title": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API"
         }
       }
     },
@@ -4696,12 +4698,12 @@
       }
     },
     "v1alpha1ApplicationSource": {
-      "description": "ApplicationSource contains information about github repository, path within repository and target application environment.",
       "type": "object",
+      "title": "ApplicationSource contains all required information about the source of an application",
       "properties": {
         "chart": {
-          "type": "string",
-          "title": "Chart is a Helm chart name"
+          "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
+          "type": "string"
         },
         "directory": {
           "$ref": "#/definitions/v1alpha1ApplicationSourceDirectory"
@@ -4716,36 +4718,40 @@
           "$ref": "#/definitions/v1alpha1ApplicationSourceKustomize"
         },
         "path": {
-          "type": "string",
-          "title": "Path is a directory path within the Git repository"
+          "description": "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
+          "type": "string"
         },
         "plugin": {
           "$ref": "#/definitions/v1alpha1ApplicationSourcePlugin"
         },
         "repoURL": {
           "type": "string",
-          "title": "RepoURL is the repository URL of the application manifests"
+          "title": "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests"
         },
         "targetRevision": {
-          "type": "string",
-          "title": "TargetRevision defines the commit, tag, or branch in which to sync the application to.\nIf omitted, will sync to HEAD"
+          "description": "TargetRevision defines the revision of the source to sync the application to.\nIn case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.\nIn case of Helm, this is a semver tag for the Chart's version.",
+          "type": "string"
         }
       }
     },
     "v1alpha1ApplicationSourceDirectory": {
       "type": "object",
+      "title": "ApplicationSourceDirectory holds options for applications of type plain YAML or Jsonnet",
       "properties": {
         "exclude": {
-          "type": "string"
+          "type": "string",
+          "title": "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation"
         },
         "include": {
-          "type": "string"
+          "type": "string",
+          "title": "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation"
         },
         "jsonnet": {
           "$ref": "#/definitions/v1alpha1ApplicationSourceJsonnet"
         },
         "recurse": {
-          "type": "boolean"
+          "type": "boolean",
+          "title": "Recurse specifies whether to scan a directory recursively for manifests"
         }
       }
     },
@@ -4762,14 +4768,14 @@
         },
         "parameters": {
           "type": "array",
-          "title": "Parameters are parameters to the helm template",
+          "title": "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
           "items": {
             "$ref": "#/definitions/v1alpha1HelmParameter"
           }
         },
         "releaseName": {
           "type": "string",
-          "title": "The Helm release name. If omitted it will use the application name"
+          "title": "ReleaseName is the Helm release name to use. If omitted it will use the application name"
         },
         "valueFiles": {
           "type": "array",
@@ -4780,17 +4786,17 @@
         },
         "values": {
           "type": "string",
-          "title": "Values is Helm values, typically defined as a block"
+          "title": "Values specifies Helm values to be passed to helm template, typically defined as a block"
         },
         "version": {
           "type": "string",
-          "title": "Version is the Helm version to use for templating with"
+          "title": "Version is the Helm version to use for templating (either \"2\" or \"3\")"
         }
       }
     },
     "v1alpha1ApplicationSourceJsonnet": {
       "type": "object",
-      "title": "ApplicationSourceJsonnet holds jsonnet specific options",
+      "title": "ApplicationSourceJsonnet holds options specific to applications of type Jsonnet",
       "properties": {
         "extVars": {
           "type": "array",
@@ -4834,46 +4840,46 @@
     },
     "v1alpha1ApplicationSourceKustomize": {
       "type": "object",
-      "title": "ApplicationSourceKustomize holds kustomize specific options",
+      "title": "ApplicationSourceKustomize holds options specific to an Application source specific to Kustomize",
       "properties": {
         "commonAnnotations": {
           "type": "object",
-          "title": "CommonAnnotations adds additional kustomize commonAnnotations",
+          "title": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
           "additionalProperties": {
             "type": "string"
           }
         },
         "commonLabels": {
           "type": "object",
-          "title": "CommonLabels adds additional kustomize commonLabels",
+          "title": "CommonLabels is a list of additional labels to add to rendered manifests",
           "additionalProperties": {
             "type": "string"
           }
         },
         "images": {
           "type": "array",
-          "title": "Images are kustomize image overrides",
+          "title": "Images is a list of Kustomize image override specifications",
           "items": {
             "type": "string"
           }
         },
         "namePrefix": {
           "type": "string",
-          "title": "NamePrefix is a prefix appended to resources for kustomize apps"
+          "title": "NamePrefix is a prefix appended to resources for Kustomize apps"
         },
         "nameSuffix": {
           "type": "string",
-          "title": "NameSuffix is a suffix appended to resources for kustomize apps"
+          "title": "NameSuffix is a suffix appended to resources for Kustomize apps"
         },
         "version": {
           "type": "string",
-          "title": "Version contains optional Kustomize version"
+          "title": "Version controls which version of Kustomize to use for rendering manifests"
         }
       }
     },
     "v1alpha1ApplicationSourcePlugin": {
       "type": "object",
-      "title": "ApplicationSourcePlugin holds config management plugin specific options",
+      "title": "ApplicationSourcePlugin holds options specific to config management plugins",
       "properties": {
         "env": {
           "type": "array",
@@ -4895,24 +4901,24 @@
         },
         "ignoreDifferences": {
           "type": "array",
-          "title": "IgnoreDifferences controls resources fields which should be ignored during comparison",
+          "title": "IgnoreDifferences is a list of resources and their fields which should be ignored during comparison",
           "items": {
             "$ref": "#/definitions/v1alpha1ResourceIgnoreDifferences"
           }
         },
         "info": {
           "type": "array",
-          "title": "Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application",
+          "title": "Info contains a list of information (URLs, email addresses, and plain text) that relates to the application",
           "items": {
             "$ref": "#/definitions/v1alpha1Info"
           }
         },
         "project": {
-          "description": "Project is a application project name. Empty name means that application belongs to 'default' project.",
+          "description": "Project is a reference to the project this application belongs to.\nThe empty string means that application belongs to the 'default' project.",
           "type": "string"
         },
         "revisionHistoryLimit": {
-          "description": "This limits this number of items kept in the apps revision history.\nThis should only be changed in exceptional circumstances.\nSetting to zero will store no history. This will reduce storage used.\nIncreasing will increase the space used to store the history, so we do not recommend increasing it.\nDefault is 10.",
+          "description": "RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.\nThis should only be changed in exceptional circumstances.\nSetting to zero will store no history. This will reduce storage used.\nIncreasing will increase the space used to store the history, so we do not recommend increasing it.\nDefault is 10.",
           "type": "string",
           "format": "int64"
         },
@@ -4926,10 +4932,11 @@
     },
     "v1alpha1ApplicationStatus": {
       "type": "object",
-      "title": "ApplicationStatus contains information about application sync, health status",
+      "title": "ApplicationStatus contains status information for the application",
       "properties": {
         "conditions": {
           "type": "array",
+          "title": "Conditions is a list of currently observed application conditions",
           "items": {
             "$ref": "#/definitions/v1alpha1ApplicationCondition"
           }
@@ -4939,6 +4946,7 @@
         },
         "history": {
           "type": "array",
+          "title": "History contains information about the application's sync history",
           "items": {
             "$ref": "#/definitions/v1alpha1RevisionHistory"
           }
@@ -4954,12 +4962,14 @@
         },
         "resources": {
           "type": "array",
+          "title": "Resources is a list of Kubernetes resources managed by this application",
           "items": {
             "$ref": "#/definitions/v1alpha1ResourceStatus"
           }
         },
         "sourceType": {
-          "type": "string"
+          "type": "string",
+          "title": "SourceType specifies the type of this application"
         },
         "summary": {
           "$ref": "#/definitions/v1alpha1ApplicationSummary"
@@ -4971,6 +4981,7 @@
     },
     "v1alpha1ApplicationSummary": {
       "type": "object",
+      "title": "ApplicationSummary contains information about URLs and container images used by an application",
       "properties": {
         "externalURLs": {
           "description": "ExternalURLs holds all external URLs of application child resources.",
@@ -4990,7 +5001,7 @@
     },
     "v1alpha1ApplicationTree": {
       "type": "object",
-      "title": "ApplicationTree holds nodes which belongs to the application",
+      "title": "ApplicationTree holds nodes which belongs to the application\nTODO: describe purpose of this type",
       "properties": {
         "hosts": {
           "type": "array",
@@ -5029,7 +5040,7 @@
     },
     "v1alpha1Backoff": {
       "type": "object",
-      "title": "Backoff is a backoff strategy to use within retryStrategy",
+      "title": "Backoff is the backoff strategy to use on subsequent retries for failing syncs",
       "properties": {
         "duration": {
           "type": "string",
@@ -5064,7 +5075,7 @@
           "title": "Name of the cluster. If omitted, will use the server address"
         },
         "namespaces": {
-          "description": "Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.",
+          "description": "Holds list of namespaces which are accessible in that cluster. Cluster level resources will be ignored if namespace list is not empty.",
           "type": "array",
           "items": {
             "type": "string"
@@ -5090,6 +5101,7 @@
     },
     "v1alpha1ClusterCacheInfo": {
       "type": "object",
+      "title": "ClusterCacheInfo contains information about the cluster cache",
       "properties": {
         "apisCount": {
           "type": "string",
@@ -5134,10 +5146,12 @@
     },
     "v1alpha1ClusterInfo": {
       "type": "object",
+      "title": "ClusterInfo contains information about the cluster",
       "properties": {
         "applicationsCount": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "title": "ApplicationsCount is the number of applications managed by Argo CD on the cluster"
         },
         "cacheInfo": {
           "$ref": "#/definitions/v1alpha1ClusterCacheInfo"
@@ -5146,7 +5160,8 @@
           "$ref": "#/definitions/v1alpha1ConnectionState"
         },
         "serverVersion": {
-          "type": "string"
+          "type": "string",
+          "title": "ServerVersion contains information about the Kubernetes version of the cluster"
         }
       }
     },
@@ -5212,16 +5227,18 @@
     },
     "v1alpha1ConnectionState": {
       "type": "object",
-      "title": "ConnectionState contains information about remote resource connection state",
+      "title": "ConnectionState contains information about remote resource connection state, currently used for clusters and repositories",
       "properties": {
         "attemptedAt": {
           "$ref": "#/definitions/v1Time"
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "title": "Message contains human readable information about the connection status"
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "title": "Status contains the current status indicator for the connection"
         }
       }
     },
@@ -5263,27 +5280,27 @@
       "properties": {
         "fingerprint": {
           "type": "string",
-          "title": "Fingerprint of the key"
+          "title": "Fingerprint is the fingerprint of the key"
         },
         "keyData": {
           "type": "string",
-          "title": "Key data"
+          "title": "KeyData holds the raw key data, in base64 encoded format"
         },
         "keyID": {
           "type": "string",
-          "title": "KeyID in hexadecimal string format"
+          "title": "KeyID specifies the key ID, in hexadecimal string format"
         },
         "owner": {
           "type": "string",
-          "title": "Owner identification"
+          "title": "Owner holds the owner identification, e.g. a name and e-mail address"
         },
         "subType": {
           "type": "string",
-          "title": "Key sub type (e.g. rsa4096)"
+          "title": "SubType holds the key's sub type (e.g. rsa4096)"
         },
         "trust": {
           "type": "string",
-          "title": "Trust level"
+          "title": "Trust holds the level of trust assigned to this key"
         }
       }
     },
@@ -5304,32 +5321,35 @@
     },
     "v1alpha1HealthStatus": {
       "type": "object",
+      "title": "HealthStatus contains information about the currently observed health state of an application or resource",
       "properties": {
         "message": {
-          "type": "string"
+          "type": "string",
+          "title": "Message is a human-readable informational message describing the health status"
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "title": "Status holds the status code of the application or resource"
         }
       }
     },
     "v1alpha1HelmFileParameter": {
       "type": "object",
-      "title": "HelmFileParameter is a file parameter to a helm template",
+      "title": "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
       "properties": {
         "name": {
           "type": "string",
-          "title": "Name is the name of the helm parameter"
+          "title": "Name is the name of the Helm parameter"
         },
         "path": {
           "type": "string",
-          "title": "Path is the path value for the helm parameter"
+          "title": "Path is the path to the file containing the values for the Helm parameter"
         }
       }
     },
     "v1alpha1HelmParameter": {
       "type": "object",
-      "title": "HelmParameter is a parameter to a helm template",
+      "title": "HelmParameter is a parameter that's passed to helm template during manifest generation",
       "properties": {
         "forceString": {
           "type": "boolean",
@@ -5337,17 +5357,17 @@
         },
         "name": {
           "type": "string",
-          "title": "Name is the name of the helm parameter"
+          "title": "Name is the name of the Helm parameter"
         },
         "value": {
           "type": "string",
-          "title": "Value is the value for the helm parameter"
+          "title": "Value is the value for the Helm parameter"
         }
       }
     },
     "v1alpha1HostInfo": {
       "type": "object",
-      "title": "HostInfo holds host name and resources metrics",
+      "title": "HostInfo holds host name and resources metrics\nTODO: describe purpose of this type\nTODO: describe members of this type",
       "properties": {
         "name": {
           "type": "string"
@@ -5365,6 +5385,7 @@
     },
     "v1alpha1HostResourceInfo": {
       "type": "object",
+      "title": "TODO: describe this type",
       "properties": {
         "capacity": {
           "type": "string",
@@ -5396,7 +5417,7 @@
     },
     "v1alpha1InfoItem": {
       "type": "object",
-      "title": "InfoItem contains human readable information about object",
+      "title": "InfoItem contains arbitrary, human readable information about an application",
       "properties": {
         "name": {
           "description": "Name is a human readable title for this piece of information.",
@@ -5427,6 +5448,7 @@
     },
     "v1alpha1JWTTokens": {
       "type": "object",
+      "title": "JWTTokens represents a list of JWT tokens",
       "properties": {
         "items": {
           "type": "array",
@@ -5438,7 +5460,7 @@
     },
     "v1alpha1JsonnetVar": {
       "type": "object",
-      "title": "JsonnetVar is a jsonnet variable",
+      "title": "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
       "properties": {
         "code": {
           "type": "boolean"
@@ -5453,7 +5475,7 @@
     },
     "v1alpha1KnownTypeField": {
       "type": "object",
-      "title": "KnownTypeField contains mapping between CRD field and known Kubernetes type",
+      "title": "KnownTypeField contains mapping between CRD field and known Kubernetes type.\nThis is mainly used for unit conversion in unknown resources (e.g. 0.1 == 100mi)\nTODO: Describe the members of this type",
       "properties": {
         "field": {
           "type": "string"
@@ -5493,11 +5515,12 @@
       }
     },
     "v1alpha1Operation": {
-      "description": "Operation contains requested operation parameters.",
       "type": "object",
+      "title": "Operation contains information about a requested or running operation",
       "properties": {
         "info": {
           "type": "array",
+          "title": "Info is a list of informational items for this operation",
           "items": {
             "$ref": "#/definitions/v1alpha1Info"
           }
@@ -5515,27 +5538,27 @@
     },
     "v1alpha1OperationInitiator": {
       "type": "object",
-      "title": "OperationInitiator holds information about the operation initiator",
+      "title": "OperationInitiator contains information about the initiator of an operation",
       "properties": {
         "automated": {
           "description": "Automated is set to true if operation was initiated automatically by the application controller.",
           "type": "boolean"
         },
         "username": {
-          "description": "Name of a user who started operation.",
-          "type": "string"
+          "type": "string",
+          "title": "Username contains the name of a user who started operation"
         }
       }
     },
     "v1alpha1OperationState": {
-      "description": "OperationState contains information about state of currently performing operation on application.",
       "type": "object",
+      "title": "OperationState contains information about state of a running operation",
       "properties": {
         "finishedAt": {
           "$ref": "#/definitions/v1Time"
         },
         "message": {
-          "description": "Message hold any pertinent messages when attempting to perform operation (typically errors).",
+          "description": "Message holds any pertinent messages when attempting to perform operation (typically errors).",
           "type": "string"
         },
         "operation": {
@@ -5560,6 +5583,7 @@
     },
     "v1alpha1OrphanedResourceKey": {
       "type": "object",
+      "title": "OrphanedResourceKey is a reference to a resource to be ignored from",
       "properties": {
         "group": {
           "type": "string"
@@ -5578,6 +5602,7 @@
       "properties": {
         "ignore": {
           "type": "array",
+          "title": "Ignore contains a list of resources that are to be excluded from orphaned resources monitoring",
           "items": {
             "$ref": "#/definitions/v1alpha1OrphanedResourceKey"
           }
@@ -5590,6 +5615,7 @@
     },
     "v1alpha1OverrideIgnoreDiff": {
       "type": "object",
+      "title": "TODO: describe this type",
       "properties": {
         "jSONPointers": {
           "type": "array",
@@ -5636,25 +5662,25 @@
     },
     "v1alpha1RepoCreds": {
       "type": "object",
-      "title": "RepoCreds holds a repository credentials definition",
+      "title": "RepoCreds holds the definition for repository credentials",
       "properties": {
         "githubAppEnterpriseBaseUrl": {
           "type": "string",
-          "title": "Github App Enterprise base url if empty will default to https://api.github.com"
+          "title": "GithubAppEnterpriseBaseURL specifies the GitHub API URL for GitHub app authentication. If empty will default to https://api.github.com"
         },
         "githubAppID": {
           "type": "string",
           "format": "int64",
-          "title": "Github App ID of the app used to access the repo"
+          "title": "GithubAppId specifies the Github App ID of the app used to access the repo for GitHub app authentication"
         },
         "githubAppInstallationID": {
           "type": "string",
           "format": "int64",
-          "title": "Github App Installation ID of the installed GitHub App"
+          "title": "GithubAppInstallationId specifies the ID of the installed GitHub App for GitHub app authentication"
         },
         "githubAppPrivateKey": {
           "type": "string",
-          "title": "Github App Private Key PEM data"
+          "title": "GithubAppPrivateKey specifies the private key PEM data for authentication via GitHub app"
         },
         "password": {
           "type": "string",
@@ -5662,15 +5688,15 @@
         },
         "sshPrivateKey": {
           "type": "string",
-          "title": "SSH private key data for authenticating at the repo server (only Git repos)"
+          "title": "SSHPrivateKey contains the private key data for authenticating at the repo server using SSH (only Git repos)"
         },
         "tlsClientCertData": {
           "type": "string",
-          "title": "TLS client cert data for authenticating at the repo server"
+          "title": "TLSClientCertData specifies the TLS client cert data for authenticating at the repo server"
         },
         "tlsClientCertKey": {
           "type": "string",
-          "title": "TLS client cert key for authenticating at the repo server"
+          "title": "TLSClientCertKey specifies the TLS client cert key for authenticating at the repo server"
         },
         "url": {
           "type": "string",
@@ -5705,26 +5731,26 @@
           "$ref": "#/definitions/v1alpha1ConnectionState"
         },
         "enableLfs": {
-          "type": "boolean",
-          "title": "Whether git-lfs support should be enabled for this repo"
+          "description": "EnableLFS specifies whether git-lfs support should be enabled for this repo. Only valid for Git repositories.",
+          "type": "boolean"
         },
         "enableOCI": {
           "type": "boolean",
-          "title": "Whether helm-oci support should be enabled for this repo"
+          "title": "EnableOCI specifies whether helm-oci support should be enabled for this repo"
         },
         "githubAppEnterpriseBaseUrl": {
           "type": "string",
-          "title": "Github App Enterprise base url if empty will default to https://api.github.com"
+          "title": "GithubAppEnterpriseBaseURL specifies the base URL of GitHub Enterprise installation. If empty will default to https://api.github.com"
         },
         "githubAppID": {
           "type": "string",
           "format": "int64",
-          "title": "Github App ID of the app used to access the repo"
+          "title": "GithubAppId specifies the ID of the GitHub app used to access the repo"
         },
         "githubAppInstallationID": {
           "type": "string",
           "format": "int64",
-          "title": "Github App Installation ID of the installed GitHub App"
+          "title": "GithubAppInstallationId specifies the installation ID of the GitHub App used to access the repo"
         },
         "githubAppPrivateKey": {
           "type": "string",
@@ -5736,43 +5762,43 @@
         },
         "insecure": {
           "type": "boolean",
-          "title": "Whether the repo is insecure"
+          "title": "Insecure specifies whether the connection to the repository ignores any errors when verifying TLS certificates or SSH host keys"
         },
         "insecureIgnoreHostKey": {
           "type": "boolean",
-          "title": "InsecureIgnoreHostKey should not be used anymore, Insecure is favoured\nonly for Git repos"
+          "title": "InsecureIgnoreHostKey should not be used anymore, Insecure is favoured\nUsed only for Git repos"
         },
         "name": {
           "type": "string",
-          "title": "only for Helm repos"
+          "title": "Name specifies a name to be used for this repo. Only used with Helm repos"
         },
         "password": {
           "type": "string",
-          "title": "Password for authenticating at the repo server"
+          "title": "Password contains the password or PAT used for authenticating at the remote repository"
         },
         "repo": {
           "type": "string",
-          "title": "URL of the repo"
+          "title": "Repo contains the URL to the remote repository"
         },
         "sshPrivateKey": {
-          "type": "string",
-          "title": "SSH private key data for authenticating at the repo server\nonly for Git repos"
+          "description": "SSHPrivateKey contains the PEM data for authenticating at the repo server. Only used with Git repos.",
+          "type": "string"
         },
         "tlsClientCertData": {
           "type": "string",
-          "title": "TLS client cert data for authenticating at the repo server"
+          "title": "TLSClientCertData contains a certificate in PEM format for authenticating at the repo server"
         },
         "tlsClientCertKey": {
           "type": "string",
-          "title": "TLS client cert key for authenticating at the repo server"
+          "title": "TLSClientCertKey contains a private key in PEM format for authenticating at the repo server"
         },
         "type": {
-          "type": "string",
-          "title": "type of the repo, maybe \"git or \"helm, \"git\" is assumed if empty or absent"
+          "description": "Type specifies the type of the repo. Can be either \"git\" or \"helm. \"git\" is assumed if empty or absent.",
+          "type": "string"
         },
         "username": {
           "type": "string",
-          "title": "Username for authenticating at the repo server"
+          "title": "Username contains the user name used for authenticating at the remote repository"
         }
       }
     },
@@ -5783,23 +5809,23 @@
         "certData": {
           "type": "string",
           "format": "byte",
-          "title": "Actual certificate data, protocol dependent"
+          "title": "CertData contains the actual certificate data, dependent on the certificate type"
         },
         "certInfo": {
           "type": "string",
-          "title": "Additional certificate info (e.g. SSH fingerprint, X509 CommonName)"
+          "title": "CertInfo will hold additional certificate info, depdendent on the certificate type (e.g. SSH fingerprint, X509 CommonName)"
         },
         "certSubType": {
           "type": "string",
-          "title": "The sub type of the cert, i.e. \"ssh-rsa\""
+          "title": "CertSubType specifies the sub type of the cert, i.e. \"ssh-rsa\""
         },
         "certType": {
           "type": "string",
-          "title": "Type of certificate - currently \"https\" or \"ssh\""
+          "title": "CertType specifies the type of the certificate - currently one of \"https\" or \"ssh\""
         },
         "serverName": {
           "type": "string",
-          "title": "Name of the server the certificate is intended for"
+          "title": "ServerName specifies the DNS name of the server this certificate is intended for"
         }
       }
     },
@@ -5836,6 +5862,7 @@
     },
     "v1alpha1ResourceAction": {
       "type": "object",
+      "title": "TODO: describe this type\nTODO: describe members of this type",
       "properties": {
         "disabled": {
           "type": "boolean"
@@ -5853,6 +5880,7 @@
     },
     "v1alpha1ResourceActionParam": {
       "type": "object",
+      "title": "TODO: describe this type\nTODO: describe members of this type",
       "properties": {
         "default": {
           "type": "string"
@@ -5870,7 +5898,7 @@
     },
     "v1alpha1ResourceDiff": {
       "type": "object",
-      "title": "ResourceDiff holds the diff of a live and target resource object",
+      "title": "ResourceDiff holds the diff of a live and target resource object\nTODO: describe members of this type",
       "properties": {
         "diff": {
           "type": "string",
@@ -5941,7 +5969,7 @@
     },
     "v1alpha1ResourceNetworkingInfo": {
       "type": "object",
-      "title": "ResourceNetworkingInfo holds networking resource related information",
+      "title": "ResourceNetworkingInfo holds networking resource related information\nTODO: describe members of this type",
       "properties": {
         "externalURLs": {
           "description": "ExternalURLs holds list of URLs which should be available externally. List is populated for ingress resources using rules hostnames.",
@@ -5978,7 +6006,7 @@
     },
     "v1alpha1ResourceNode": {
       "type": "object",
-      "title": "ResourceNode contains information about live resource and its children",
+      "title": "ResourceNode contains information about live resource and its children\nTODO: describe members of this type",
       "properties": {
         "createdAt": {
           "$ref": "#/definitions/v1Time"
@@ -6017,7 +6045,7 @@
     },
     "v1alpha1ResourceOverride": {
       "type": "object",
-      "title": "ResourceOverride holds configuration to customize resource diffing and health assessment",
+      "title": "ResourceOverride holds configuration to customize resource diffing and health assessment\nTODO: describe the members of this type",
       "properties": {
         "actions": {
           "type": "string"
@@ -6038,7 +6066,7 @@
     },
     "v1alpha1ResourceRef": {
       "type": "object",
-      "title": "ResourceRef includes fields which unique identify resource",
+      "title": "ResourceRef includes fields which uniquely identify a resource",
       "properties": {
         "group": {
           "type": "string"
@@ -6065,45 +6093,50 @@
       "title": "ResourceResult holds the operation result details of a specific resource",
       "properties": {
         "group": {
-          "type": "string"
+          "type": "string",
+          "title": "Group specifies the API group of the resource"
         },
         "hookPhase": {
-          "type": "string",
-          "title": "the state of any operation associated with this resource OR hook\nnote: can contain values for non-hook resources"
+          "description": "HookPhase contains the state of any operation associated with this resource OR hook\nThis can also contain values for non-hook resources.",
+          "type": "string"
         },
         "hookType": {
           "type": "string",
-          "title": "the type of the hook, empty for non-hook resources"
+          "title": "HookType specifies the type of the hook. Empty for non-hook resources"
         },
         "kind": {
-          "type": "string"
+          "type": "string",
+          "title": "Kind specifies the API kind of the resource"
         },
         "message": {
           "type": "string",
-          "title": "message for the last sync OR operation"
+          "title": "Message contains an informational or error message for the last sync OR operation"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "title": "Name specifies the name of the resource"
         },
         "namespace": {
-          "type": "string"
+          "type": "string",
+          "title": "Namespace specifies the target namespace of the resource"
         },
         "status": {
           "type": "string",
-          "title": "the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks"
+          "title": "Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks"
         },
         "syncPhase": {
           "type": "string",
-          "title": "indicates the particular phase of the sync that this is for"
+          "title": "SyncPhase indicates the particular phase of the sync that this result was acquired in"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "title": "Version specifies the API version of the resource"
         }
       }
     },
     "v1alpha1ResourceStatus": {
       "type": "object",
-      "title": "ResourceStatus holds the current sync and health status of a resource",
+      "title": "ResourceStatus holds the current sync and health status of a resource\nTODO: describe members of this type",
       "properties": {
         "group": {
           "type": "string"
@@ -6136,20 +6169,21 @@
     },
     "v1alpha1RetryStrategy": {
       "type": "object",
+      "title": "RetryStrategy contains information about the strategy to apply when a sync failed",
       "properties": {
         "backoff": {
           "$ref": "#/definitions/v1alpha1Backoff"
         },
         "limit": {
+          "description": "Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.",
           "type": "string",
-          "format": "int64",
-          "title": "Limit is the maximum number of attempts when retrying a container"
+          "format": "int64"
         }
       }
     },
     "v1alpha1RevisionHistory": {
       "type": "object",
-      "title": "RevisionHistory contains information relevant to an application deployment",
+      "title": "RevisionHistory contains history information about a previous sync",
       "properties": {
         "deployStartedAt": {
           "$ref": "#/definitions/v1Time"
@@ -6164,7 +6198,7 @@
         },
         "revision": {
           "type": "string",
-          "title": "Revision holds the revision of the sync"
+          "title": "Revision holds the revision the sync was performed against"
         },
         "source": {
           "$ref": "#/definitions/v1alpha1ApplicationSource"
@@ -6173,7 +6207,7 @@
     },
     "v1alpha1RevisionMetadata": {
       "type": "object",
-      "title": "data about a specific revision within a repo",
+      "title": "RevisionMetadata contains metadata for a specific revision in a Git repository",
       "properties": {
         "author": {
           "type": "string",
@@ -6184,15 +6218,15 @@
         },
         "message": {
           "type": "string",
-          "title": "the message associated with the revision,\nprobably the commit message,\nthis is truncated to the first newline or 64 characters (which ever comes first)"
+          "title": "Message contains the message associated with the revision, most likely the commit message.\nThe message is truncated to the first newline or 64 characters (which ever comes first)"
         },
         "signatureInfo": {
-          "type": "string",
-          "title": "If revision was signed with GPG, and signature verification is enabled,\nthis contains a hint on the signer"
+          "description": "SignatureInfo contains a hint on the signer if the revision was signed with GPG, and signature verification is enabled.",
+          "type": "string"
         },
         "tags": {
           "type": "array",
-          "title": "tags on the revision,\nnote - tags can move from one revision to another",
+          "title": "Tags specifies any tags currently attached to the revision\nFloating tags can move from one revision to another",
           "items": {
             "type": "string"
           }
@@ -6210,12 +6244,12 @@
       }
     },
     "v1alpha1SyncOperation": {
-      "description": "SyncOperation contains sync operation details.",
+      "description": "SyncOperation contains details about a sync operation.",
       "type": "object",
       "properties": {
         "dryRun": {
           "type": "boolean",
-          "title": "DryRun will perform a `kubectl apply --dry-run` without actually performing the sync"
+          "title": "DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync"
         },
         "manifests": {
           "type": "array",
@@ -6226,17 +6260,17 @@
         },
         "prune": {
           "type": "boolean",
-          "title": "Prune deletes resources that are no longer tracked in git"
+          "title": "Prune specifies to delete resources from the cluster that are no longer tracked in git"
         },
         "resources": {
           "type": "array",
-          "title": "Resources describes which resources to sync",
+          "title": "Resources describes which resources shall be part of the sync",
           "items": {
             "$ref": "#/definitions/v1alpha1SyncOperationResource"
           }
         },
         "revision": {
-          "description": "Revision is the revision in which to sync the application to.\nIf omitted, will use the revision specified in app spec.",
+          "description": "Revision is the revision (Git) or chart version (Helm) which to sync the application to\nIf omitted, will use the revision specified in app spec.",
           "type": "string"
         },
         "source": {
@@ -6278,14 +6312,14 @@
       "properties": {
         "resources": {
           "type": "array",
-          "title": "Resources holds the sync result of each individual resource",
+          "title": "Resources contains a list of sync result items for each individual resource in a sync operation",
           "items": {
             "$ref": "#/definitions/v1alpha1ResourceResult"
           }
         },
         "revision": {
           "type": "string",
-          "title": "Revision holds the revision of the sync"
+          "title": "Revision holds the revision this sync operation was performed to"
         },
         "source": {
           "$ref": "#/definitions/v1alpha1ApplicationSource"
@@ -6321,26 +6355,28 @@
         },
         "prune": {
           "type": "boolean",
-          "title": "Prune will prune resources automatically as part of automated sync (default: false)"
+          "title": "Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)"
         },
         "selfHeal": {
           "type": "boolean",
-          "title": "SelfHeal enables auto-syncing if  (default: false)"
+          "title": "SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)"
         }
       }
     },
     "v1alpha1SyncStatus": {
-      "description": "SyncStatus is a comparison result of application spec and deployed application.",
       "type": "object",
+      "title": "SyncStatus contains information about the currently observed live and desired states of an application",
       "properties": {
         "comparedTo": {
           "$ref": "#/definitions/v1alpha1ComparedTo"
         },
         "revision": {
-          "type": "string"
+          "type": "string",
+          "title": "Revision contains information about the revision the comparison has been performed to"
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "title": "Status is the sync state of the comparison"
         }
       }
     },
@@ -6433,7 +6469,7 @@
           "title": "CertData holds PEM-encoded bytes (typically read from a client certificate file).\nCertData takes precedence over CertFile"
         },
         "insecure": {
-          "description": "Server should be accessed without verifying the TLS certificate. For testing only.",
+          "description": "Insecure specifies that the server should be accessed without verifying the TLS certificate. For testing only.",
           "type": "boolean"
         },
         "keyData": {

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -41,9 +41,10 @@ spec:
         metadata:
           type: object
         operation:
-          description: Operation contains requested operation parameters.
+          description: Operation contains information about a requested or running operation
           properties:
             info:
+              description: Info is a list of informational items for this operation
               items:
                 properties:
                   name:
@@ -56,20 +57,20 @@ spec:
                 type: object
               type: array
             initiatedBy:
-              description: OperationInitiator holds information about the operation initiator
+              description: InitiatedBy contains information about who initiated the operations
               properties:
                 automated:
                   description: Automated is set to true if operation was initiated automatically by the application controller.
                   type: boolean
                 username:
-                  description: Name of a user who started operation.
+                  description: Username contains the name of a user who started operation
                   type: string
               type: object
             retry:
-              description: Retry controls failed sync retry behavior
+              description: Retry controls the strategy to apply if a sync fails
               properties:
                 backoff:
-                  description: Backoff is a backoff strategy
+                  description: Backoff controls how to backoff on subsequent retries of failed syncs
                   properties:
                     duration:
                       description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -83,15 +84,15 @@ spec:
                       type: string
                   type: object
                 limit:
-                  description: Limit is the maximum number of attempts when retrying a container
+                  description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                   format: int64
                   type: integer
               type: object
             sync:
-              description: SyncOperation contains sync operation details.
+              description: Sync contains parameters for the operation
               properties:
                 dryRun:
-                  description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                  description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                   type: boolean
                 manifests:
                   description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -99,10 +100,10 @@ spec:
                     type: string
                   type: array
                 prune:
-                  description: Prune deletes resources that are no longer tracked in git
+                  description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                   type: boolean
                 resources:
-                  description: Resources describes which resources to sync
+                  description: Resources describes which resources shall be part of the sync
                   items:
                     description: SyncOperationResource contains resources to sync.
                     properties:
@@ -120,28 +121,30 @@ spec:
                     type: object
                   type: array
                 revision:
-                  description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                  description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                   type: string
                 source:
-                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                   properties:
                     chart:
-                      description: Chart is a Helm chart name
+                      description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                       type: string
                     directory:
                       description: Directory holds path/directory specific options
                       properties:
                         exclude:
+                          description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                           type: string
                         include:
+                          description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                           type: string
                         jsonnet:
-                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                          description: Jsonnet holds options specific to Jsonnet
                           properties:
                             extVars:
                               description: ExtVars is a list of Jsonnet External Variables
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -162,7 +165,7 @@ spec:
                             tlas:
                               description: TLAS is a list of Jsonnet Top-level Arguments
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -177,6 +180,7 @@ spec:
                               type: array
                           type: object
                         recurse:
+                          description: Recurse specifies whether to scan a directory recursively for manifests
                           type: boolean
                       type: object
                     helm:
@@ -185,34 +189,34 @@ spec:
                         fileParameters:
                           description: FileParameters are file parameters to the helm template
                           items:
-                            description: HelmFileParameter is a file parameter to a helm template
+                            description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                             properties:
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               path:
-                                description: Path is the path value for the helm parameter
+                                description: Path is the path to the file containing the values for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         parameters:
-                          description: Parameters are parameters to the helm template
+                          description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                           items:
-                            description: HelmParameter is a parameter to a helm template
+                            description: HelmParameter is a parameter that's passed to helm template during manifest generation
                             properties:
                               forceString:
                                 description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                 type: boolean
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               value:
-                                description: Value is the value for the helm parameter
+                                description: Value is the value for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         releaseName:
-                          description: The Helm release name. If omitted it will use the application name
+                          description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                           type: string
                         valueFiles:
                           description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -220,10 +224,10 @@ spec:
                             type: string
                           type: array
                         values:
-                          description: Values is Helm values, typically defined as a block
+                          description: Values specifies Helm values to be passed to helm template, typically defined as a block
                           type: string
                         version:
-                          description: Version is the Helm version to use for templating with
+                          description: Version is the Helm version to use for templating (either "2" or "3")
                           type: string
                       type: object
                     ksonnet:
@@ -255,42 +259,45 @@ spec:
                         commonAnnotations:
                           additionalProperties:
                             type: string
-                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                          description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                           type: object
                         commonLabels:
                           additionalProperties:
                             type: string
-                          description: CommonLabels adds additional kustomize commonLabels
+                          description: CommonLabels is a list of additional labels to add to rendered manifests
                           type: object
                         images:
-                          description: Images are kustomize image overrides
+                          description: Images is a list of Kustomize image override specifications
                           items:
+                            description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                             type: string
                           type: array
                         namePrefix:
-                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                          description: NamePrefix is a prefix appended to resources for Kustomize apps
                           type: string
                         nameSuffix:
-                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                          description: NameSuffix is a suffix appended to resources for Kustomize apps
                           type: string
                         version:
-                          description: Version contains optional Kustomize version
+                          description: Version controls which version of Kustomize to use for rendering manifests
                           type: string
                       type: object
                     path:
-                      description: Path is a directory path within the Git repository
+                      description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                       type: string
                     plugin:
                       description: ConfigManagementPlugin holds config management plugin specific options
                       properties:
                         env:
+                          description: Env is a list of environment variable entries
                           items:
+                            description: EnvEntry represents an entry in the application's environment
                             properties:
                               name:
-                                description: the name, usually uppercase
+                                description: Name is the name of the variable, usually expressed in uppercase
                                 type: string
                               value:
-                                description: the value
+                                description: Value is the value of the variable
                                 type: string
                             required:
                             - name
@@ -301,10 +308,10 @@ spec:
                           type: string
                       type: object
                     repoURL:
-                      description: RepoURL is the repository URL of the application manifests
+                      description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                      description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -338,20 +345,20 @@ spec:
           description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
           properties:
             destination:
-              description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+              description: Destination is a reference to the target Kubernetes server and namespace
               properties:
                 name:
-                  description: Name of the destination cluster which can be used instead of server (url) field
+                  description: Name is an alternate way of specifying the target cluster by its symbolic name
                   type: string
                 namespace:
-                  description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                  description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                   type: string
                 server:
-                  description: Server overrides the environment server value in the ksonnet app.yaml
+                  description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                   type: string
               type: object
             ignoreDifferences:
-              description: IgnoreDifferences controls resources fields which should be ignored during comparison
+              description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
               items:
                 description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
                 properties:
@@ -373,7 +380,7 @@ spec:
                 type: object
               type: array
             info:
-              description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+              description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
               items:
                 properties:
                   name:
@@ -386,32 +393,34 @@ spec:
                 type: object
               type: array
             project:
-              description: Project is a application project name. Empty name means that application belongs to 'default' project.
+              description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
               type: string
             revisionHistoryLimit:
-              description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+              description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
               format: int64
               type: integer
             source:
-              description: Source is a reference to the location ksonnet application definition
+              description: Source is a reference to the location of the application's manifests or chart
               properties:
                 chart:
-                  description: Chart is a Helm chart name
+                  description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                   type: string
                 directory:
                   description: Directory holds path/directory specific options
                   properties:
                     exclude:
+                      description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                       type: string
                     include:
+                      description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                       type: string
                     jsonnet:
-                      description: ApplicationSourceJsonnet holds jsonnet specific options
+                      description: Jsonnet holds options specific to Jsonnet
                       properties:
                         extVars:
                           description: ExtVars is a list of Jsonnet External Variables
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -432,7 +441,7 @@ spec:
                         tlas:
                           description: TLAS is a list of Jsonnet Top-level Arguments
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -447,6 +456,7 @@ spec:
                           type: array
                       type: object
                     recurse:
+                      description: Recurse specifies whether to scan a directory recursively for manifests
                       type: boolean
                   type: object
                 helm:
@@ -455,34 +465,34 @@ spec:
                     fileParameters:
                       description: FileParameters are file parameters to the helm template
                       items:
-                        description: HelmFileParameter is a file parameter to a helm template
+                        description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                         properties:
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           path:
-                            description: Path is the path value for the helm parameter
+                            description: Path is the path to the file containing the values for the Helm parameter
                             type: string
                         type: object
                       type: array
                     parameters:
-                      description: Parameters are parameters to the helm template
+                      description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                       items:
-                        description: HelmParameter is a parameter to a helm template
+                        description: HelmParameter is a parameter that's passed to helm template during manifest generation
                         properties:
                           forceString:
                             description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                             type: boolean
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           value:
-                            description: Value is the value for the helm parameter
+                            description: Value is the value for the Helm parameter
                             type: string
                         type: object
                       type: array
                     releaseName:
-                      description: The Helm release name. If omitted it will use the application name
+                      description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                       type: string
                     valueFiles:
                       description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -490,10 +500,10 @@ spec:
                         type: string
                       type: array
                     values:
-                      description: Values is Helm values, typically defined as a block
+                      description: Values specifies Helm values to be passed to helm template, typically defined as a block
                       type: string
                     version:
-                      description: Version is the Helm version to use for templating with
+                      description: Version is the Helm version to use for templating (either "2" or "3")
                       type: string
                   type: object
                 ksonnet:
@@ -525,42 +535,45 @@ spec:
                     commonAnnotations:
                       additionalProperties:
                         type: string
-                      description: CommonAnnotations adds additional kustomize commonAnnotations
+                      description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                       type: object
                     commonLabels:
                       additionalProperties:
                         type: string
-                      description: CommonLabels adds additional kustomize commonLabels
+                      description: CommonLabels is a list of additional labels to add to rendered manifests
                       type: object
                     images:
-                      description: Images are kustomize image overrides
+                      description: Images is a list of Kustomize image override specifications
                       items:
+                        description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                         type: string
                       type: array
                     namePrefix:
-                      description: NamePrefix is a prefix appended to resources for kustomize apps
+                      description: NamePrefix is a prefix appended to resources for Kustomize apps
                       type: string
                     nameSuffix:
-                      description: NameSuffix is a suffix appended to resources for kustomize apps
+                      description: NameSuffix is a suffix appended to resources for Kustomize apps
                       type: string
                     version:
-                      description: Version contains optional Kustomize version
+                      description: Version controls which version of Kustomize to use for rendering manifests
                       type: string
                   type: object
                 path:
-                  description: Path is a directory path within the Git repository
+                  description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                   type: string
                 plugin:
                   description: ConfigManagementPlugin holds config management plugin specific options
                   properties:
                     env:
+                      description: Env is a list of environment variable entries
                       items:
+                        description: EnvEntry represents an entry in the application's environment
                         properties:
                           name:
-                            description: the name, usually uppercase
+                            description: Name is the name of the variable, usually expressed in uppercase
                             type: string
                           value:
-                            description: the value
+                            description: Value is the value of the variable
                             type: string
                         required:
                         - name
@@ -571,16 +584,16 @@ spec:
                       type: string
                   type: object
                 repoURL:
-                  description: RepoURL is the repository URL of the application manifests
+                  description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                   type: string
                 targetRevision:
-                  description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                  description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                   type: string
               required:
               - repoURL
               type: object
             syncPolicy:
-              description: SyncPolicy controls when a sync will be performed
+              description: SyncPolicy controls when and how a sync will be performed
               properties:
                 automated:
                   description: Automated will keep an application synced to the target revision
@@ -589,17 +602,17 @@ spec:
                       description: 'AllowEmpty allows apps have zero live resources (default: false)'
                       type: boolean
                     prune:
-                      description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                      description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
                       type: boolean
                     selfHeal:
-                      description: 'SelfHeal enables auto-syncing if  (default: false)'
+                      description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
                       type: boolean
                   type: object
                 retry:
                   description: Retry controls failed sync retry behavior
                   properties:
                     backoff:
-                      description: Backoff is a backoff strategy
+                      description: Backoff controls how to backoff on subsequent retries of failed syncs
                       properties:
                         duration:
                           description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -613,7 +626,7 @@ spec:
                           type: string
                       type: object
                     limit:
-                      description: Limit is the maximum number of attempts when retrying a container
+                      description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                       format: int64
                       type: integer
                   type: object
@@ -629,14 +642,15 @@ spec:
           - source
           type: object
         status:
-          description: ApplicationStatus contains information about application sync, health status
+          description: ApplicationStatus contains status information for the application
           properties:
             conditions:
+              description: Conditions is a list of currently observed application conditions
               items:
-                description: ApplicationCondition contains details about current application condition
+                description: ApplicationCondition contains details about an application condition, which is usally an error or warning
                 properties:
                   lastTransitionTime:
-                    description: LastTransitionTime is the time the condition was first observed.
+                    description: LastTransitionTime is the time the condition was last observed
                     format: date-time
                     type: string
                   message:
@@ -651,24 +665,26 @@ spec:
                 type: object
               type: array
             health:
+              description: Health contains information about the application's current health status
               properties:
                 message:
+                  description: Message is a human-readable informational message describing the health status
                   type: string
                 status:
-                  description: Represents resource health status
+                  description: Status holds the status code of the application or resource
                   type: string
               type: object
             history:
-              description: RevisionHistories is a array of history, oldest first and newest last
+              description: History contains information about the application's sync history
               items:
-                description: RevisionHistory contains information relevant to an application deployment
+                description: RevisionHistory contains history information about a previous sync
                 properties:
                   deployStartedAt:
-                    description: DeployStartedAt holds the time the deployment started
+                    description: DeployStartedAt holds the time the sync operation started
                     format: date-time
                     type: string
                   deployedAt:
-                    description: DeployedAt holds the time the deployment completed
+                    description: DeployedAt holds the time the sync operation completed
                     format: date-time
                     type: string
                   id:
@@ -676,28 +692,30 @@ spec:
                     format: int64
                     type: integer
                   revision:
-                    description: Revision holds the revision of the sync
+                    description: Revision holds the revision the sync was performed against
                     type: string
                   source:
-                    description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                    description: Source is a reference to the application source used for the sync operation
                     properties:
                       chart:
-                        description: Chart is a Helm chart name
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                         type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
                           exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                             type: string
                           include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                             type: string
                           jsonnet:
-                            description: ApplicationSourceJsonnet holds jsonnet specific options
+                            description: Jsonnet holds options specific to Jsonnet
                             properties:
                               extVars:
                                 description: ExtVars is a list of Jsonnet External Variables
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -718,7 +736,7 @@ spec:
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -733,6 +751,7 @@ spec:
                                 type: array
                             type: object
                           recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
                             type: boolean
                         type: object
                       helm:
@@ -741,34 +760,34 @@ spec:
                           fileParameters:
                             description: FileParameters are file parameters to the helm template
                             items:
-                              description: HelmFileParameter is a file parameter to a helm template
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                               properties:
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 path:
-                                  description: Path is the path value for the helm parameter
+                                  description: Path is the path to the file containing the values for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           parameters:
-                            description: Parameters are parameters to the helm template
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                             items:
-                              description: HelmParameter is a parameter to a helm template
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
                               properties:
                                 forceString:
                                   description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                   type: boolean
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 value:
-                                  description: Value is the value for the helm parameter
+                                  description: Value is the value for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           releaseName:
-                            description: The Helm release name. If omitted it will use the application name
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                             type: string
                           valueFiles:
                             description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -776,10 +795,10 @@ spec:
                               type: string
                             type: array
                           values:
-                            description: Values is Helm values, typically defined as a block
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
                             type: string
                           version:
-                            description: Version is the Helm version to use for templating with
+                            description: Version is the Helm version to use for templating (either "2" or "3")
                             type: string
                         type: object
                       ksonnet:
@@ -811,42 +830,45 @@ spec:
                           commonAnnotations:
                             additionalProperties:
                               type: string
-                            description: CommonAnnotations adds additional kustomize commonAnnotations
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                             type: object
                           commonLabels:
                             additionalProperties:
                               type: string
-                            description: CommonLabels adds additional kustomize commonLabels
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
                             type: object
                           images:
-                            description: Images are kustomize image overrides
+                            description: Images is a list of Kustomize image override specifications
                             items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                               type: string
                             type: array
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources for kustomize apps
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources for kustomize apps
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
                             type: string
                           version:
-                            description: Version contains optional Kustomize version
+                            description: Version controls which version of Kustomize to use for rendering manifests
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the Git repository
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                         type: string
                       plugin:
                         description: ConfigManagementPlugin holds config management plugin specific options
                         properties:
                           env:
+                            description: Env is a list of environment variable entries
                             items:
+                              description: EnvEntry represents an entry in the application's environment
                               properties:
                                 name:
-                                  description: the name, usually uppercase
+                                  description: Name is the name of the variable, usually expressed in uppercase
                                   type: string
                                 value:
-                                  description: the value
+                                  description: Value is the value of the variable
                                   type: string
                               required:
                               - name
@@ -857,10 +879,10 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the repository URL of the application manifests
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
@@ -876,19 +898,20 @@ spec:
               format: date-time
               type: string
             operationState:
-              description: OperationState contains information about state of currently performing operation on application.
+              description: OperationState contains information about any ongoing operations, such as a sync
               properties:
                 finishedAt:
                   description: FinishedAt contains time of operation completion
                   format: date-time
                   type: string
                 message:
-                  description: Message hold any pertinent messages when attempting to perform operation (typically errors).
+                  description: Message holds any pertinent messages when attempting to perform operation (typically errors).
                   type: string
                 operation:
                   description: Operation is the original requested operation
                   properties:
                     info:
+                      description: Info is a list of informational items for this operation
                       items:
                         properties:
                           name:
@@ -901,20 +924,20 @@ spec:
                         type: object
                       type: array
                     initiatedBy:
-                      description: OperationInitiator holds information about the operation initiator
+                      description: InitiatedBy contains information about who initiated the operations
                       properties:
                         automated:
                           description: Automated is set to true if operation was initiated automatically by the application controller.
                           type: boolean
                         username:
-                          description: Name of a user who started operation.
+                          description: Username contains the name of a user who started operation
                           type: string
                       type: object
                     retry:
-                      description: Retry controls failed sync retry behavior
+                      description: Retry controls the strategy to apply if a sync fails
                       properties:
                         backoff:
-                          description: Backoff is a backoff strategy
+                          description: Backoff controls how to backoff on subsequent retries of failed syncs
                           properties:
                             duration:
                               description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -928,15 +951,15 @@ spec:
                               type: string
                           type: object
                         limit:
-                          description: Limit is the maximum number of attempts when retrying a container
+                          description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                           format: int64
                           type: integer
                       type: object
                     sync:
-                      description: SyncOperation contains sync operation details.
+                      description: Sync contains parameters for the operation
                       properties:
                         dryRun:
-                          description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                          description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                           type: boolean
                         manifests:
                           description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -944,10 +967,10 @@ spec:
                             type: string
                           type: array
                         prune:
-                          description: Prune deletes resources that are no longer tracked in git
+                          description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                           type: boolean
                         resources:
-                          description: Resources describes which resources to sync
+                          description: Resources describes which resources shall be part of the sync
                           items:
                             description: SyncOperationResource contains resources to sync.
                             properties:
@@ -965,28 +988,30 @@ spec:
                             type: object
                           type: array
                         revision:
-                          description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                          description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                           type: string
                         source:
-                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                           properties:
                             chart:
-                              description: Chart is a Helm chart name
+                              description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                               type: string
                             directory:
                               description: Directory holds path/directory specific options
                               properties:
                                 exclude:
+                                  description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                                   type: string
                                 include:
+                                  description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                                   type: string
                                 jsonnet:
-                                  description: ApplicationSourceJsonnet holds jsonnet specific options
+                                  description: Jsonnet holds options specific to Jsonnet
                                   properties:
                                     extVars:
                                       description: ExtVars is a list of Jsonnet External Variables
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1007,7 +1032,7 @@ spec:
                                     tlas:
                                       description: TLAS is a list of Jsonnet Top-level Arguments
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1022,6 +1047,7 @@ spec:
                                       type: array
                                   type: object
                                 recurse:
+                                  description: Recurse specifies whether to scan a directory recursively for manifests
                                   type: boolean
                               type: object
                             helm:
@@ -1030,34 +1056,34 @@ spec:
                                 fileParameters:
                                   description: FileParameters are file parameters to the helm template
                                   items:
-                                    description: HelmFileParameter is a file parameter to a helm template
+                                    description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                     properties:
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       path:
-                                        description: Path is the path value for the helm parameter
+                                        description: Path is the path to the file containing the values for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 parameters:
-                                  description: Parameters are parameters to the helm template
+                                  description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                                   items:
-                                    description: HelmParameter is a parameter to a helm template
+                                    description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                     properties:
                                       forceString:
                                         description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                         type: boolean
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       value:
-                                        description: Value is the value for the helm parameter
+                                        description: Value is the value for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 releaseName:
-                                  description: The Helm release name. If omitted it will use the application name
+                                  description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                                   type: string
                                 valueFiles:
                                   description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1065,10 +1091,10 @@ spec:
                                     type: string
                                   type: array
                                 values:
-                                  description: Values is Helm values, typically defined as a block
+                                  description: Values specifies Helm values to be passed to helm template, typically defined as a block
                                   type: string
                                 version:
-                                  description: Version is the Helm version to use for templating with
+                                  description: Version is the Helm version to use for templating (either "2" or "3")
                                   type: string
                               type: object
                             ksonnet:
@@ -1100,42 +1126,45 @@ spec:
                                 commonAnnotations:
                                   additionalProperties:
                                     type: string
-                                  description: CommonAnnotations adds additional kustomize commonAnnotations
+                                  description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                                   type: object
                                 commonLabels:
                                   additionalProperties:
                                     type: string
-                                  description: CommonLabels adds additional kustomize commonLabels
+                                  description: CommonLabels is a list of additional labels to add to rendered manifests
                                   type: object
                                 images:
-                                  description: Images are kustomize image overrides
+                                  description: Images is a list of Kustomize image override specifications
                                   items:
+                                    description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                     type: string
                                   type: array
                                 namePrefix:
-                                  description: NamePrefix is a prefix appended to resources for kustomize apps
+                                  description: NamePrefix is a prefix appended to resources for Kustomize apps
                                   type: string
                                 nameSuffix:
-                                  description: NameSuffix is a suffix appended to resources for kustomize apps
+                                  description: NameSuffix is a suffix appended to resources for Kustomize apps
                                   type: string
                                 version:
-                                  description: Version contains optional Kustomize version
+                                  description: Version controls which version of Kustomize to use for rendering manifests
                                   type: string
                               type: object
                             path:
-                              description: Path is a directory path within the Git repository
+                              description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                               type: string
                             plugin:
                               description: ConfigManagementPlugin holds config management plugin specific options
                               properties:
                                 env:
+                                  description: Env is a list of environment variable entries
                                   items:
+                                    description: EnvEntry represents an entry in the application's environment
                                     properties:
                                       name:
-                                        description: the name, usually uppercase
+                                        description: Name is the name of the variable, usually expressed in uppercase
                                         type: string
                                       value:
-                                        description: the value
+                                        description: Value is the value of the variable
                                         type: string
                                     required:
                                     - name
@@ -1146,10 +1175,10 @@ spec:
                                   type: string
                               type: object
                             repoURL:
-                              description: RepoURL is the repository URL of the application manifests
+                              description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                              description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -1194,34 +1223,39 @@ spec:
                   description: SyncResult is the result of a Sync operation
                   properties:
                     resources:
-                      description: Resources holds the sync result of each individual resource
+                      description: Resources contains a list of sync result items for each individual resource in a sync operation
                       items:
                         description: ResourceResult holds the operation result details of a specific resource
                         properties:
                           group:
+                            description: Group specifies the API group of the resource
                             type: string
                           hookPhase:
-                            description: 'the state of any operation associated with this resource OR hook note: can contain values for non-hook resources'
+                            description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
                             type: string
                           hookType:
-                            description: the type of the hook, empty for non-hook resources
+                            description: HookType specifies the type of the hook. Empty for non-hook resources
                             type: string
                           kind:
+                            description: Kind specifies the API kind of the resource
                             type: string
                           message:
-                            description: message for the last sync OR operation
+                            description: Message contains an informational or error message for the last sync OR operation
                             type: string
                           name:
+                            description: Name specifies the name of the resource
                             type: string
                           namespace:
+                            description: Namespace specifies the target namespace of the resource
                             type: string
                           status:
-                            description: the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                            description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
                             type: string
                           syncPhase:
-                            description: indicates the particular phase of the sync that this is for
+                            description: SyncPhase indicates the particular phase of the sync that this result was acquired in
                             type: string
                           version:
+                            description: Version specifies the API version of the resource
                             type: string
                         required:
                         - group
@@ -1232,28 +1266,30 @@ spec:
                         type: object
                       type: array
                     revision:
-                      description: Revision holds the revision of the sync
+                      description: Revision holds the revision this sync operation was performed to
                       type: string
                     source:
                       description: Source records the application source information of the sync, used for comparing auto-sync
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1274,7 +1310,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1289,6 +1325,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1297,34 +1334,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1332,10 +1369,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1367,42 +1404,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1413,10 +1453,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1434,17 +1474,20 @@ spec:
               format: date-time
               type: string
             resources:
+              description: Resources is a list of Kubernetes resources managed by this application
               items:
-                description: ResourceStatus holds the current sync and health status of a resource
+                description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
                 properties:
                   group:
                     type: string
                   health:
+                    description: HealthStatus contains information about the currently observed health state of an application or resource
                     properties:
                       message:
+                        description: Message is a human-readable informational message describing the health status
                         type: string
                       status:
-                        description: Represents resource health status
+                        description: Status holds the status code of the application or resource
                         type: string
                     type: object
                   hook:
@@ -1465,8 +1508,10 @@ spec:
                 type: object
               type: array
             sourceType:
+              description: SourceType specifies the type of this application
               type: string
             summary:
+              description: Summary contains a list of URLs and container images used by this application
               properties:
                 externalURLs:
                   description: ExternalURLs holds all external URLs of application child resources.
@@ -1480,44 +1525,46 @@ spec:
                   type: array
               type: object
             sync:
-              description: SyncStatus is a comparison result of application spec and deployed application.
+              description: Sync contains information about the application's current sync status
               properties:
                 comparedTo:
-                  description: ComparedTo contains application source and target which was used for resources comparison
+                  description: ComparedTo contains information about what has been compared
                   properties:
                     destination:
-                      description: ApplicationDestination contains deployment destination information
+                      description: Destination is a reference to the application's destination used for comparison
                       properties:
                         name:
-                          description: Name of the destination cluster which can be used instead of server (url) field
+                          description: Name is an alternate way of specifying the target cluster by its symbolic name
                           type: string
                         namespace:
-                          description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                          description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                           type: string
                         server:
-                          description: Server overrides the environment server value in the ksonnet app.yaml
+                          description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                           type: string
                       type: object
                     source:
-                      description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                      description: Source is a reference to the application's source used for comparison
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1538,7 +1585,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1553,6 +1600,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1561,34 +1609,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1596,10 +1644,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1631,42 +1679,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1677,10 +1728,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1690,9 +1741,10 @@ spec:
                   - source
                   type: object
                 revision:
+                  description: Revision contains information about the revision the comparison has been performed to
                   type: string
                 status:
-                  description: SyncStatusCode is a type which represents possible comparison results
+                  description: Status is the sync state of the comparison
                   type: string
               required:
               - status

--- a/manifests/crds/appproject-crd.yaml
+++ b/manifests/crds/appproject-crd.yaml
@@ -65,16 +65,16 @@ spec:
             destinations:
               description: Destinations contains list of destinations available for deployment
               items:
-                description: ApplicationDestination contains deployment destination information
+                description: ApplicationDestination holds information about the application's destination
                 properties:
                   name:
-                    description: Name of the destination cluster which can be used instead of server (url) field
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
                     type: string
                   namespace:
-                    description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
-                    description: Server overrides the environment server value in the ksonnet app.yaml
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                     type: string
                 type: object
               type: array
@@ -110,7 +110,9 @@ spec:
               description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
               properties:
                 ignore:
+                  description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
                   items:
+                    description: OrphanedResourceKey is a reference to a resource to be ignored from
                     properties:
                       group:
                         type: string
@@ -167,7 +169,7 @@ spec:
                 type: object
               type: array
             signatureKeys:
-              description: List of PGP key IDs that commits to be synced to must be signed with
+              description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
               items:
                 description: SignatureKey is the specification of a key required to verify commit signatures with
                 properties:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -42,9 +42,10 @@ spec:
         metadata:
           type: object
         operation:
-          description: Operation contains requested operation parameters.
+          description: Operation contains information about a requested or running operation
           properties:
             info:
+              description: Info is a list of informational items for this operation
               items:
                 properties:
                   name:
@@ -57,20 +58,20 @@ spec:
                 type: object
               type: array
             initiatedBy:
-              description: OperationInitiator holds information about the operation initiator
+              description: InitiatedBy contains information about who initiated the operations
               properties:
                 automated:
                   description: Automated is set to true if operation was initiated automatically by the application controller.
                   type: boolean
                 username:
-                  description: Name of a user who started operation.
+                  description: Username contains the name of a user who started operation
                   type: string
               type: object
             retry:
-              description: Retry controls failed sync retry behavior
+              description: Retry controls the strategy to apply if a sync fails
               properties:
                 backoff:
-                  description: Backoff is a backoff strategy
+                  description: Backoff controls how to backoff on subsequent retries of failed syncs
                   properties:
                     duration:
                       description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -84,15 +85,15 @@ spec:
                       type: string
                   type: object
                 limit:
-                  description: Limit is the maximum number of attempts when retrying a container
+                  description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                   format: int64
                   type: integer
               type: object
             sync:
-              description: SyncOperation contains sync operation details.
+              description: Sync contains parameters for the operation
               properties:
                 dryRun:
-                  description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                  description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                   type: boolean
                 manifests:
                   description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -100,10 +101,10 @@ spec:
                     type: string
                   type: array
                 prune:
-                  description: Prune deletes resources that are no longer tracked in git
+                  description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                   type: boolean
                 resources:
-                  description: Resources describes which resources to sync
+                  description: Resources describes which resources shall be part of the sync
                   items:
                     description: SyncOperationResource contains resources to sync.
                     properties:
@@ -121,28 +122,30 @@ spec:
                     type: object
                   type: array
                 revision:
-                  description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                  description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                   type: string
                 source:
-                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                   properties:
                     chart:
-                      description: Chart is a Helm chart name
+                      description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                       type: string
                     directory:
                       description: Directory holds path/directory specific options
                       properties:
                         exclude:
+                          description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                           type: string
                         include:
+                          description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                           type: string
                         jsonnet:
-                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                          description: Jsonnet holds options specific to Jsonnet
                           properties:
                             extVars:
                               description: ExtVars is a list of Jsonnet External Variables
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -163,7 +166,7 @@ spec:
                             tlas:
                               description: TLAS is a list of Jsonnet Top-level Arguments
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -178,6 +181,7 @@ spec:
                               type: array
                           type: object
                         recurse:
+                          description: Recurse specifies whether to scan a directory recursively for manifests
                           type: boolean
                       type: object
                     helm:
@@ -186,34 +190,34 @@ spec:
                         fileParameters:
                           description: FileParameters are file parameters to the helm template
                           items:
-                            description: HelmFileParameter is a file parameter to a helm template
+                            description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                             properties:
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               path:
-                                description: Path is the path value for the helm parameter
+                                description: Path is the path to the file containing the values for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         parameters:
-                          description: Parameters are parameters to the helm template
+                          description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                           items:
-                            description: HelmParameter is a parameter to a helm template
+                            description: HelmParameter is a parameter that's passed to helm template during manifest generation
                             properties:
                               forceString:
                                 description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                 type: boolean
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               value:
-                                description: Value is the value for the helm parameter
+                                description: Value is the value for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         releaseName:
-                          description: The Helm release name. If omitted it will use the application name
+                          description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                           type: string
                         valueFiles:
                           description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -221,10 +225,10 @@ spec:
                             type: string
                           type: array
                         values:
-                          description: Values is Helm values, typically defined as a block
+                          description: Values specifies Helm values to be passed to helm template, typically defined as a block
                           type: string
                         version:
-                          description: Version is the Helm version to use for templating with
+                          description: Version is the Helm version to use for templating (either "2" or "3")
                           type: string
                       type: object
                     ksonnet:
@@ -256,42 +260,45 @@ spec:
                         commonAnnotations:
                           additionalProperties:
                             type: string
-                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                          description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                           type: object
                         commonLabels:
                           additionalProperties:
                             type: string
-                          description: CommonLabels adds additional kustomize commonLabels
+                          description: CommonLabels is a list of additional labels to add to rendered manifests
                           type: object
                         images:
-                          description: Images are kustomize image overrides
+                          description: Images is a list of Kustomize image override specifications
                           items:
+                            description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                             type: string
                           type: array
                         namePrefix:
-                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                          description: NamePrefix is a prefix appended to resources for Kustomize apps
                           type: string
                         nameSuffix:
-                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                          description: NameSuffix is a suffix appended to resources for Kustomize apps
                           type: string
                         version:
-                          description: Version contains optional Kustomize version
+                          description: Version controls which version of Kustomize to use for rendering manifests
                           type: string
                       type: object
                     path:
-                      description: Path is a directory path within the Git repository
+                      description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                       type: string
                     plugin:
                       description: ConfigManagementPlugin holds config management plugin specific options
                       properties:
                         env:
+                          description: Env is a list of environment variable entries
                           items:
+                            description: EnvEntry represents an entry in the application's environment
                             properties:
                               name:
-                                description: the name, usually uppercase
+                                description: Name is the name of the variable, usually expressed in uppercase
                                 type: string
                               value:
-                                description: the value
+                                description: Value is the value of the variable
                                 type: string
                             required:
                             - name
@@ -302,10 +309,10 @@ spec:
                           type: string
                       type: object
                     repoURL:
-                      description: RepoURL is the repository URL of the application manifests
+                      description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                      description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -339,20 +346,20 @@ spec:
           description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
           properties:
             destination:
-              description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+              description: Destination is a reference to the target Kubernetes server and namespace
               properties:
                 name:
-                  description: Name of the destination cluster which can be used instead of server (url) field
+                  description: Name is an alternate way of specifying the target cluster by its symbolic name
                   type: string
                 namespace:
-                  description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                  description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                   type: string
                 server:
-                  description: Server overrides the environment server value in the ksonnet app.yaml
+                  description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                   type: string
               type: object
             ignoreDifferences:
-              description: IgnoreDifferences controls resources fields which should be ignored during comparison
+              description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
               items:
                 description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
                 properties:
@@ -374,7 +381,7 @@ spec:
                 type: object
               type: array
             info:
-              description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+              description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
               items:
                 properties:
                   name:
@@ -387,32 +394,34 @@ spec:
                 type: object
               type: array
             project:
-              description: Project is a application project name. Empty name means that application belongs to 'default' project.
+              description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
               type: string
             revisionHistoryLimit:
-              description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+              description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
               format: int64
               type: integer
             source:
-              description: Source is a reference to the location ksonnet application definition
+              description: Source is a reference to the location of the application's manifests or chart
               properties:
                 chart:
-                  description: Chart is a Helm chart name
+                  description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                   type: string
                 directory:
                   description: Directory holds path/directory specific options
                   properties:
                     exclude:
+                      description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                       type: string
                     include:
+                      description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                       type: string
                     jsonnet:
-                      description: ApplicationSourceJsonnet holds jsonnet specific options
+                      description: Jsonnet holds options specific to Jsonnet
                       properties:
                         extVars:
                           description: ExtVars is a list of Jsonnet External Variables
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -433,7 +442,7 @@ spec:
                         tlas:
                           description: TLAS is a list of Jsonnet Top-level Arguments
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -448,6 +457,7 @@ spec:
                           type: array
                       type: object
                     recurse:
+                      description: Recurse specifies whether to scan a directory recursively for manifests
                       type: boolean
                   type: object
                 helm:
@@ -456,34 +466,34 @@ spec:
                     fileParameters:
                       description: FileParameters are file parameters to the helm template
                       items:
-                        description: HelmFileParameter is a file parameter to a helm template
+                        description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                         properties:
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           path:
-                            description: Path is the path value for the helm parameter
+                            description: Path is the path to the file containing the values for the Helm parameter
                             type: string
                         type: object
                       type: array
                     parameters:
-                      description: Parameters are parameters to the helm template
+                      description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                       items:
-                        description: HelmParameter is a parameter to a helm template
+                        description: HelmParameter is a parameter that's passed to helm template during manifest generation
                         properties:
                           forceString:
                             description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                             type: boolean
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           value:
-                            description: Value is the value for the helm parameter
+                            description: Value is the value for the Helm parameter
                             type: string
                         type: object
                       type: array
                     releaseName:
-                      description: The Helm release name. If omitted it will use the application name
+                      description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                       type: string
                     valueFiles:
                       description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -491,10 +501,10 @@ spec:
                         type: string
                       type: array
                     values:
-                      description: Values is Helm values, typically defined as a block
+                      description: Values specifies Helm values to be passed to helm template, typically defined as a block
                       type: string
                     version:
-                      description: Version is the Helm version to use for templating with
+                      description: Version is the Helm version to use for templating (either "2" or "3")
                       type: string
                   type: object
                 ksonnet:
@@ -526,42 +536,45 @@ spec:
                     commonAnnotations:
                       additionalProperties:
                         type: string
-                      description: CommonAnnotations adds additional kustomize commonAnnotations
+                      description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                       type: object
                     commonLabels:
                       additionalProperties:
                         type: string
-                      description: CommonLabels adds additional kustomize commonLabels
+                      description: CommonLabels is a list of additional labels to add to rendered manifests
                       type: object
                     images:
-                      description: Images are kustomize image overrides
+                      description: Images is a list of Kustomize image override specifications
                       items:
+                        description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                         type: string
                       type: array
                     namePrefix:
-                      description: NamePrefix is a prefix appended to resources for kustomize apps
+                      description: NamePrefix is a prefix appended to resources for Kustomize apps
                       type: string
                     nameSuffix:
-                      description: NameSuffix is a suffix appended to resources for kustomize apps
+                      description: NameSuffix is a suffix appended to resources for Kustomize apps
                       type: string
                     version:
-                      description: Version contains optional Kustomize version
+                      description: Version controls which version of Kustomize to use for rendering manifests
                       type: string
                   type: object
                 path:
-                  description: Path is a directory path within the Git repository
+                  description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                   type: string
                 plugin:
                   description: ConfigManagementPlugin holds config management plugin specific options
                   properties:
                     env:
+                      description: Env is a list of environment variable entries
                       items:
+                        description: EnvEntry represents an entry in the application's environment
                         properties:
                           name:
-                            description: the name, usually uppercase
+                            description: Name is the name of the variable, usually expressed in uppercase
                             type: string
                           value:
-                            description: the value
+                            description: Value is the value of the variable
                             type: string
                         required:
                         - name
@@ -572,16 +585,16 @@ spec:
                       type: string
                   type: object
                 repoURL:
-                  description: RepoURL is the repository URL of the application manifests
+                  description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                   type: string
                 targetRevision:
-                  description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                  description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                   type: string
               required:
               - repoURL
               type: object
             syncPolicy:
-              description: SyncPolicy controls when a sync will be performed
+              description: SyncPolicy controls when and how a sync will be performed
               properties:
                 automated:
                   description: Automated will keep an application synced to the target revision
@@ -590,17 +603,17 @@ spec:
                       description: 'AllowEmpty allows apps have zero live resources (default: false)'
                       type: boolean
                     prune:
-                      description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                      description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
                       type: boolean
                     selfHeal:
-                      description: 'SelfHeal enables auto-syncing if  (default: false)'
+                      description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
                       type: boolean
                   type: object
                 retry:
                   description: Retry controls failed sync retry behavior
                   properties:
                     backoff:
-                      description: Backoff is a backoff strategy
+                      description: Backoff controls how to backoff on subsequent retries of failed syncs
                       properties:
                         duration:
                           description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -614,7 +627,7 @@ spec:
                           type: string
                       type: object
                     limit:
-                      description: Limit is the maximum number of attempts when retrying a container
+                      description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                       format: int64
                       type: integer
                   type: object
@@ -630,14 +643,15 @@ spec:
           - source
           type: object
         status:
-          description: ApplicationStatus contains information about application sync, health status
+          description: ApplicationStatus contains status information for the application
           properties:
             conditions:
+              description: Conditions is a list of currently observed application conditions
               items:
-                description: ApplicationCondition contains details about current application condition
+                description: ApplicationCondition contains details about an application condition, which is usally an error or warning
                 properties:
                   lastTransitionTime:
-                    description: LastTransitionTime is the time the condition was first observed.
+                    description: LastTransitionTime is the time the condition was last observed
                     format: date-time
                     type: string
                   message:
@@ -652,24 +666,26 @@ spec:
                 type: object
               type: array
             health:
+              description: Health contains information about the application's current health status
               properties:
                 message:
+                  description: Message is a human-readable informational message describing the health status
                   type: string
                 status:
-                  description: Represents resource health status
+                  description: Status holds the status code of the application or resource
                   type: string
               type: object
             history:
-              description: RevisionHistories is a array of history, oldest first and newest last
+              description: History contains information about the application's sync history
               items:
-                description: RevisionHistory contains information relevant to an application deployment
+                description: RevisionHistory contains history information about a previous sync
                 properties:
                   deployStartedAt:
-                    description: DeployStartedAt holds the time the deployment started
+                    description: DeployStartedAt holds the time the sync operation started
                     format: date-time
                     type: string
                   deployedAt:
-                    description: DeployedAt holds the time the deployment completed
+                    description: DeployedAt holds the time the sync operation completed
                     format: date-time
                     type: string
                   id:
@@ -677,28 +693,30 @@ spec:
                     format: int64
                     type: integer
                   revision:
-                    description: Revision holds the revision of the sync
+                    description: Revision holds the revision the sync was performed against
                     type: string
                   source:
-                    description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                    description: Source is a reference to the application source used for the sync operation
                     properties:
                       chart:
-                        description: Chart is a Helm chart name
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                         type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
                           exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                             type: string
                           include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                             type: string
                           jsonnet:
-                            description: ApplicationSourceJsonnet holds jsonnet specific options
+                            description: Jsonnet holds options specific to Jsonnet
                             properties:
                               extVars:
                                 description: ExtVars is a list of Jsonnet External Variables
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -719,7 +737,7 @@ spec:
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -734,6 +752,7 @@ spec:
                                 type: array
                             type: object
                           recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
                             type: boolean
                         type: object
                       helm:
@@ -742,34 +761,34 @@ spec:
                           fileParameters:
                             description: FileParameters are file parameters to the helm template
                             items:
-                              description: HelmFileParameter is a file parameter to a helm template
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                               properties:
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 path:
-                                  description: Path is the path value for the helm parameter
+                                  description: Path is the path to the file containing the values for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           parameters:
-                            description: Parameters are parameters to the helm template
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                             items:
-                              description: HelmParameter is a parameter to a helm template
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
                               properties:
                                 forceString:
                                   description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                   type: boolean
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 value:
-                                  description: Value is the value for the helm parameter
+                                  description: Value is the value for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           releaseName:
-                            description: The Helm release name. If omitted it will use the application name
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                             type: string
                           valueFiles:
                             description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -777,10 +796,10 @@ spec:
                               type: string
                             type: array
                           values:
-                            description: Values is Helm values, typically defined as a block
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
                             type: string
                           version:
-                            description: Version is the Helm version to use for templating with
+                            description: Version is the Helm version to use for templating (either "2" or "3")
                             type: string
                         type: object
                       ksonnet:
@@ -812,42 +831,45 @@ spec:
                           commonAnnotations:
                             additionalProperties:
                               type: string
-                            description: CommonAnnotations adds additional kustomize commonAnnotations
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                             type: object
                           commonLabels:
                             additionalProperties:
                               type: string
-                            description: CommonLabels adds additional kustomize commonLabels
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
                             type: object
                           images:
-                            description: Images are kustomize image overrides
+                            description: Images is a list of Kustomize image override specifications
                             items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                               type: string
                             type: array
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources for kustomize apps
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources for kustomize apps
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
                             type: string
                           version:
-                            description: Version contains optional Kustomize version
+                            description: Version controls which version of Kustomize to use for rendering manifests
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the Git repository
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                         type: string
                       plugin:
                         description: ConfigManagementPlugin holds config management plugin specific options
                         properties:
                           env:
+                            description: Env is a list of environment variable entries
                             items:
+                              description: EnvEntry represents an entry in the application's environment
                               properties:
                                 name:
-                                  description: the name, usually uppercase
+                                  description: Name is the name of the variable, usually expressed in uppercase
                                   type: string
                                 value:
-                                  description: the value
+                                  description: Value is the value of the variable
                                   type: string
                               required:
                               - name
@@ -858,10 +880,10 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the repository URL of the application manifests
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
@@ -877,19 +899,20 @@ spec:
               format: date-time
               type: string
             operationState:
-              description: OperationState contains information about state of currently performing operation on application.
+              description: OperationState contains information about any ongoing operations, such as a sync
               properties:
                 finishedAt:
                   description: FinishedAt contains time of operation completion
                   format: date-time
                   type: string
                 message:
-                  description: Message hold any pertinent messages when attempting to perform operation (typically errors).
+                  description: Message holds any pertinent messages when attempting to perform operation (typically errors).
                   type: string
                 operation:
                   description: Operation is the original requested operation
                   properties:
                     info:
+                      description: Info is a list of informational items for this operation
                       items:
                         properties:
                           name:
@@ -902,20 +925,20 @@ spec:
                         type: object
                       type: array
                     initiatedBy:
-                      description: OperationInitiator holds information about the operation initiator
+                      description: InitiatedBy contains information about who initiated the operations
                       properties:
                         automated:
                           description: Automated is set to true if operation was initiated automatically by the application controller.
                           type: boolean
                         username:
-                          description: Name of a user who started operation.
+                          description: Username contains the name of a user who started operation
                           type: string
                       type: object
                     retry:
-                      description: Retry controls failed sync retry behavior
+                      description: Retry controls the strategy to apply if a sync fails
                       properties:
                         backoff:
-                          description: Backoff is a backoff strategy
+                          description: Backoff controls how to backoff on subsequent retries of failed syncs
                           properties:
                             duration:
                               description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -929,15 +952,15 @@ spec:
                               type: string
                           type: object
                         limit:
-                          description: Limit is the maximum number of attempts when retrying a container
+                          description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                           format: int64
                           type: integer
                       type: object
                     sync:
-                      description: SyncOperation contains sync operation details.
+                      description: Sync contains parameters for the operation
                       properties:
                         dryRun:
-                          description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                          description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                           type: boolean
                         manifests:
                           description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -945,10 +968,10 @@ spec:
                             type: string
                           type: array
                         prune:
-                          description: Prune deletes resources that are no longer tracked in git
+                          description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                           type: boolean
                         resources:
-                          description: Resources describes which resources to sync
+                          description: Resources describes which resources shall be part of the sync
                           items:
                             description: SyncOperationResource contains resources to sync.
                             properties:
@@ -966,28 +989,30 @@ spec:
                             type: object
                           type: array
                         revision:
-                          description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                          description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                           type: string
                         source:
-                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                           properties:
                             chart:
-                              description: Chart is a Helm chart name
+                              description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                               type: string
                             directory:
                               description: Directory holds path/directory specific options
                               properties:
                                 exclude:
+                                  description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                                   type: string
                                 include:
+                                  description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                                   type: string
                                 jsonnet:
-                                  description: ApplicationSourceJsonnet holds jsonnet specific options
+                                  description: Jsonnet holds options specific to Jsonnet
                                   properties:
                                     extVars:
                                       description: ExtVars is a list of Jsonnet External Variables
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1008,7 +1033,7 @@ spec:
                                     tlas:
                                       description: TLAS is a list of Jsonnet Top-level Arguments
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1023,6 +1048,7 @@ spec:
                                       type: array
                                   type: object
                                 recurse:
+                                  description: Recurse specifies whether to scan a directory recursively for manifests
                                   type: boolean
                               type: object
                             helm:
@@ -1031,34 +1057,34 @@ spec:
                                 fileParameters:
                                   description: FileParameters are file parameters to the helm template
                                   items:
-                                    description: HelmFileParameter is a file parameter to a helm template
+                                    description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                     properties:
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       path:
-                                        description: Path is the path value for the helm parameter
+                                        description: Path is the path to the file containing the values for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 parameters:
-                                  description: Parameters are parameters to the helm template
+                                  description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                                   items:
-                                    description: HelmParameter is a parameter to a helm template
+                                    description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                     properties:
                                       forceString:
                                         description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                         type: boolean
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       value:
-                                        description: Value is the value for the helm parameter
+                                        description: Value is the value for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 releaseName:
-                                  description: The Helm release name. If omitted it will use the application name
+                                  description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                                   type: string
                                 valueFiles:
                                   description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1066,10 +1092,10 @@ spec:
                                     type: string
                                   type: array
                                 values:
-                                  description: Values is Helm values, typically defined as a block
+                                  description: Values specifies Helm values to be passed to helm template, typically defined as a block
                                   type: string
                                 version:
-                                  description: Version is the Helm version to use for templating with
+                                  description: Version is the Helm version to use for templating (either "2" or "3")
                                   type: string
                               type: object
                             ksonnet:
@@ -1101,42 +1127,45 @@ spec:
                                 commonAnnotations:
                                   additionalProperties:
                                     type: string
-                                  description: CommonAnnotations adds additional kustomize commonAnnotations
+                                  description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                                   type: object
                                 commonLabels:
                                   additionalProperties:
                                     type: string
-                                  description: CommonLabels adds additional kustomize commonLabels
+                                  description: CommonLabels is a list of additional labels to add to rendered manifests
                                   type: object
                                 images:
-                                  description: Images are kustomize image overrides
+                                  description: Images is a list of Kustomize image override specifications
                                   items:
+                                    description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                     type: string
                                   type: array
                                 namePrefix:
-                                  description: NamePrefix is a prefix appended to resources for kustomize apps
+                                  description: NamePrefix is a prefix appended to resources for Kustomize apps
                                   type: string
                                 nameSuffix:
-                                  description: NameSuffix is a suffix appended to resources for kustomize apps
+                                  description: NameSuffix is a suffix appended to resources for Kustomize apps
                                   type: string
                                 version:
-                                  description: Version contains optional Kustomize version
+                                  description: Version controls which version of Kustomize to use for rendering manifests
                                   type: string
                               type: object
                             path:
-                              description: Path is a directory path within the Git repository
+                              description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                               type: string
                             plugin:
                               description: ConfigManagementPlugin holds config management plugin specific options
                               properties:
                                 env:
+                                  description: Env is a list of environment variable entries
                                   items:
+                                    description: EnvEntry represents an entry in the application's environment
                                     properties:
                                       name:
-                                        description: the name, usually uppercase
+                                        description: Name is the name of the variable, usually expressed in uppercase
                                         type: string
                                       value:
-                                        description: the value
+                                        description: Value is the value of the variable
                                         type: string
                                     required:
                                     - name
@@ -1147,10 +1176,10 @@ spec:
                                   type: string
                               type: object
                             repoURL:
-                              description: RepoURL is the repository URL of the application manifests
+                              description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                              description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -1195,34 +1224,39 @@ spec:
                   description: SyncResult is the result of a Sync operation
                   properties:
                     resources:
-                      description: Resources holds the sync result of each individual resource
+                      description: Resources contains a list of sync result items for each individual resource in a sync operation
                       items:
                         description: ResourceResult holds the operation result details of a specific resource
                         properties:
                           group:
+                            description: Group specifies the API group of the resource
                             type: string
                           hookPhase:
-                            description: 'the state of any operation associated with this resource OR hook note: can contain values for non-hook resources'
+                            description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
                             type: string
                           hookType:
-                            description: the type of the hook, empty for non-hook resources
+                            description: HookType specifies the type of the hook. Empty for non-hook resources
                             type: string
                           kind:
+                            description: Kind specifies the API kind of the resource
                             type: string
                           message:
-                            description: message for the last sync OR operation
+                            description: Message contains an informational or error message for the last sync OR operation
                             type: string
                           name:
+                            description: Name specifies the name of the resource
                             type: string
                           namespace:
+                            description: Namespace specifies the target namespace of the resource
                             type: string
                           status:
-                            description: the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                            description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
                             type: string
                           syncPhase:
-                            description: indicates the particular phase of the sync that this is for
+                            description: SyncPhase indicates the particular phase of the sync that this result was acquired in
                             type: string
                           version:
+                            description: Version specifies the API version of the resource
                             type: string
                         required:
                         - group
@@ -1233,28 +1267,30 @@ spec:
                         type: object
                       type: array
                     revision:
-                      description: Revision holds the revision of the sync
+                      description: Revision holds the revision this sync operation was performed to
                       type: string
                     source:
                       description: Source records the application source information of the sync, used for comparing auto-sync
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1275,7 +1311,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1290,6 +1326,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1298,34 +1335,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1333,10 +1370,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1368,42 +1405,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1414,10 +1454,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1435,17 +1475,20 @@ spec:
               format: date-time
               type: string
             resources:
+              description: Resources is a list of Kubernetes resources managed by this application
               items:
-                description: ResourceStatus holds the current sync and health status of a resource
+                description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
                 properties:
                   group:
                     type: string
                   health:
+                    description: HealthStatus contains information about the currently observed health state of an application or resource
                     properties:
                       message:
+                        description: Message is a human-readable informational message describing the health status
                         type: string
                       status:
-                        description: Represents resource health status
+                        description: Status holds the status code of the application or resource
                         type: string
                     type: object
                   hook:
@@ -1466,8 +1509,10 @@ spec:
                 type: object
               type: array
             sourceType:
+              description: SourceType specifies the type of this application
               type: string
             summary:
+              description: Summary contains a list of URLs and container images used by this application
               properties:
                 externalURLs:
                   description: ExternalURLs holds all external URLs of application child resources.
@@ -1481,44 +1526,46 @@ spec:
                   type: array
               type: object
             sync:
-              description: SyncStatus is a comparison result of application spec and deployed application.
+              description: Sync contains information about the application's current sync status
               properties:
                 comparedTo:
-                  description: ComparedTo contains application source and target which was used for resources comparison
+                  description: ComparedTo contains information about what has been compared
                   properties:
                     destination:
-                      description: ApplicationDestination contains deployment destination information
+                      description: Destination is a reference to the application's destination used for comparison
                       properties:
                         name:
-                          description: Name of the destination cluster which can be used instead of server (url) field
+                          description: Name is an alternate way of specifying the target cluster by its symbolic name
                           type: string
                         namespace:
-                          description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                          description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                           type: string
                         server:
-                          description: Server overrides the environment server value in the ksonnet app.yaml
+                          description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                           type: string
                       type: object
                     source:
-                      description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                      description: Source is a reference to the application's source used for comparison
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1539,7 +1586,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1554,6 +1601,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1562,34 +1610,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1597,10 +1645,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1632,42 +1680,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1678,10 +1729,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1691,9 +1742,10 @@ spec:
                   - source
                   type: object
                 revision:
+                  description: Revision contains information about the revision the comparison has been performed to
                   type: string
                 status:
-                  description: SyncStatusCode is a type which represents possible comparison results
+                  description: Status is the sync state of the comparison
                   type: string
               required:
               - status
@@ -1776,16 +1828,16 @@ spec:
             destinations:
               description: Destinations contains list of destinations available for deployment
               items:
-                description: ApplicationDestination contains deployment destination information
+                description: ApplicationDestination holds information about the application's destination
                 properties:
                   name:
-                    description: Name of the destination cluster which can be used instead of server (url) field
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
                     type: string
                   namespace:
-                    description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
-                    description: Server overrides the environment server value in the ksonnet app.yaml
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                     type: string
                 type: object
               type: array
@@ -1821,7 +1873,9 @@ spec:
               description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
               properties:
                 ignore:
+                  description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
                   items:
+                    description: OrphanedResourceKey is a reference to a resource to be ignored from
                     properties:
                       group:
                         type: string
@@ -1878,7 +1932,7 @@ spec:
                 type: object
               type: array
             signatureKeys:
-              description: List of PGP key IDs that commits to be synced to must be signed with
+              description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
               items:
                 description: SignatureKey is the specification of a key required to verify commit signatures with
                 properties:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -42,9 +42,10 @@ spec:
         metadata:
           type: object
         operation:
-          description: Operation contains requested operation parameters.
+          description: Operation contains information about a requested or running operation
           properties:
             info:
+              description: Info is a list of informational items for this operation
               items:
                 properties:
                   name:
@@ -57,20 +58,20 @@ spec:
                 type: object
               type: array
             initiatedBy:
-              description: OperationInitiator holds information about the operation initiator
+              description: InitiatedBy contains information about who initiated the operations
               properties:
                 automated:
                   description: Automated is set to true if operation was initiated automatically by the application controller.
                   type: boolean
                 username:
-                  description: Name of a user who started operation.
+                  description: Username contains the name of a user who started operation
                   type: string
               type: object
             retry:
-              description: Retry controls failed sync retry behavior
+              description: Retry controls the strategy to apply if a sync fails
               properties:
                 backoff:
-                  description: Backoff is a backoff strategy
+                  description: Backoff controls how to backoff on subsequent retries of failed syncs
                   properties:
                     duration:
                       description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -84,15 +85,15 @@ spec:
                       type: string
                   type: object
                 limit:
-                  description: Limit is the maximum number of attempts when retrying a container
+                  description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                   format: int64
                   type: integer
               type: object
             sync:
-              description: SyncOperation contains sync operation details.
+              description: Sync contains parameters for the operation
               properties:
                 dryRun:
-                  description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                  description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                   type: boolean
                 manifests:
                   description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -100,10 +101,10 @@ spec:
                     type: string
                   type: array
                 prune:
-                  description: Prune deletes resources that are no longer tracked in git
+                  description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                   type: boolean
                 resources:
-                  description: Resources describes which resources to sync
+                  description: Resources describes which resources shall be part of the sync
                   items:
                     description: SyncOperationResource contains resources to sync.
                     properties:
@@ -121,28 +122,30 @@ spec:
                     type: object
                   type: array
                 revision:
-                  description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                  description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                   type: string
                 source:
-                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                   properties:
                     chart:
-                      description: Chart is a Helm chart name
+                      description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                       type: string
                     directory:
                       description: Directory holds path/directory specific options
                       properties:
                         exclude:
+                          description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                           type: string
                         include:
+                          description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                           type: string
                         jsonnet:
-                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                          description: Jsonnet holds options specific to Jsonnet
                           properties:
                             extVars:
                               description: ExtVars is a list of Jsonnet External Variables
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -163,7 +166,7 @@ spec:
                             tlas:
                               description: TLAS is a list of Jsonnet Top-level Arguments
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -178,6 +181,7 @@ spec:
                               type: array
                           type: object
                         recurse:
+                          description: Recurse specifies whether to scan a directory recursively for manifests
                           type: boolean
                       type: object
                     helm:
@@ -186,34 +190,34 @@ spec:
                         fileParameters:
                           description: FileParameters are file parameters to the helm template
                           items:
-                            description: HelmFileParameter is a file parameter to a helm template
+                            description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                             properties:
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               path:
-                                description: Path is the path value for the helm parameter
+                                description: Path is the path to the file containing the values for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         parameters:
-                          description: Parameters are parameters to the helm template
+                          description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                           items:
-                            description: HelmParameter is a parameter to a helm template
+                            description: HelmParameter is a parameter that's passed to helm template during manifest generation
                             properties:
                               forceString:
                                 description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                 type: boolean
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               value:
-                                description: Value is the value for the helm parameter
+                                description: Value is the value for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         releaseName:
-                          description: The Helm release name. If omitted it will use the application name
+                          description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                           type: string
                         valueFiles:
                           description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -221,10 +225,10 @@ spec:
                             type: string
                           type: array
                         values:
-                          description: Values is Helm values, typically defined as a block
+                          description: Values specifies Helm values to be passed to helm template, typically defined as a block
                           type: string
                         version:
-                          description: Version is the Helm version to use for templating with
+                          description: Version is the Helm version to use for templating (either "2" or "3")
                           type: string
                       type: object
                     ksonnet:
@@ -256,42 +260,45 @@ spec:
                         commonAnnotations:
                           additionalProperties:
                             type: string
-                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                          description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                           type: object
                         commonLabels:
                           additionalProperties:
                             type: string
-                          description: CommonLabels adds additional kustomize commonLabels
+                          description: CommonLabels is a list of additional labels to add to rendered manifests
                           type: object
                         images:
-                          description: Images are kustomize image overrides
+                          description: Images is a list of Kustomize image override specifications
                           items:
+                            description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                             type: string
                           type: array
                         namePrefix:
-                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                          description: NamePrefix is a prefix appended to resources for Kustomize apps
                           type: string
                         nameSuffix:
-                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                          description: NameSuffix is a suffix appended to resources for Kustomize apps
                           type: string
                         version:
-                          description: Version contains optional Kustomize version
+                          description: Version controls which version of Kustomize to use for rendering manifests
                           type: string
                       type: object
                     path:
-                      description: Path is a directory path within the Git repository
+                      description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                       type: string
                     plugin:
                       description: ConfigManagementPlugin holds config management plugin specific options
                       properties:
                         env:
+                          description: Env is a list of environment variable entries
                           items:
+                            description: EnvEntry represents an entry in the application's environment
                             properties:
                               name:
-                                description: the name, usually uppercase
+                                description: Name is the name of the variable, usually expressed in uppercase
                                 type: string
                               value:
-                                description: the value
+                                description: Value is the value of the variable
                                 type: string
                             required:
                             - name
@@ -302,10 +309,10 @@ spec:
                           type: string
                       type: object
                     repoURL:
-                      description: RepoURL is the repository URL of the application manifests
+                      description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                      description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -339,20 +346,20 @@ spec:
           description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
           properties:
             destination:
-              description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+              description: Destination is a reference to the target Kubernetes server and namespace
               properties:
                 name:
-                  description: Name of the destination cluster which can be used instead of server (url) field
+                  description: Name is an alternate way of specifying the target cluster by its symbolic name
                   type: string
                 namespace:
-                  description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                  description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                   type: string
                 server:
-                  description: Server overrides the environment server value in the ksonnet app.yaml
+                  description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                   type: string
               type: object
             ignoreDifferences:
-              description: IgnoreDifferences controls resources fields which should be ignored during comparison
+              description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
               items:
                 description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
                 properties:
@@ -374,7 +381,7 @@ spec:
                 type: object
               type: array
             info:
-              description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+              description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
               items:
                 properties:
                   name:
@@ -387,32 +394,34 @@ spec:
                 type: object
               type: array
             project:
-              description: Project is a application project name. Empty name means that application belongs to 'default' project.
+              description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
               type: string
             revisionHistoryLimit:
-              description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+              description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
               format: int64
               type: integer
             source:
-              description: Source is a reference to the location ksonnet application definition
+              description: Source is a reference to the location of the application's manifests or chart
               properties:
                 chart:
-                  description: Chart is a Helm chart name
+                  description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                   type: string
                 directory:
                   description: Directory holds path/directory specific options
                   properties:
                     exclude:
+                      description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                       type: string
                     include:
+                      description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                       type: string
                     jsonnet:
-                      description: ApplicationSourceJsonnet holds jsonnet specific options
+                      description: Jsonnet holds options specific to Jsonnet
                       properties:
                         extVars:
                           description: ExtVars is a list of Jsonnet External Variables
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -433,7 +442,7 @@ spec:
                         tlas:
                           description: TLAS is a list of Jsonnet Top-level Arguments
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -448,6 +457,7 @@ spec:
                           type: array
                       type: object
                     recurse:
+                      description: Recurse specifies whether to scan a directory recursively for manifests
                       type: boolean
                   type: object
                 helm:
@@ -456,34 +466,34 @@ spec:
                     fileParameters:
                       description: FileParameters are file parameters to the helm template
                       items:
-                        description: HelmFileParameter is a file parameter to a helm template
+                        description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                         properties:
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           path:
-                            description: Path is the path value for the helm parameter
+                            description: Path is the path to the file containing the values for the Helm parameter
                             type: string
                         type: object
                       type: array
                     parameters:
-                      description: Parameters are parameters to the helm template
+                      description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                       items:
-                        description: HelmParameter is a parameter to a helm template
+                        description: HelmParameter is a parameter that's passed to helm template during manifest generation
                         properties:
                           forceString:
                             description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                             type: boolean
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           value:
-                            description: Value is the value for the helm parameter
+                            description: Value is the value for the Helm parameter
                             type: string
                         type: object
                       type: array
                     releaseName:
-                      description: The Helm release name. If omitted it will use the application name
+                      description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                       type: string
                     valueFiles:
                       description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -491,10 +501,10 @@ spec:
                         type: string
                       type: array
                     values:
-                      description: Values is Helm values, typically defined as a block
+                      description: Values specifies Helm values to be passed to helm template, typically defined as a block
                       type: string
                     version:
-                      description: Version is the Helm version to use for templating with
+                      description: Version is the Helm version to use for templating (either "2" or "3")
                       type: string
                   type: object
                 ksonnet:
@@ -526,42 +536,45 @@ spec:
                     commonAnnotations:
                       additionalProperties:
                         type: string
-                      description: CommonAnnotations adds additional kustomize commonAnnotations
+                      description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                       type: object
                     commonLabels:
                       additionalProperties:
                         type: string
-                      description: CommonLabels adds additional kustomize commonLabels
+                      description: CommonLabels is a list of additional labels to add to rendered manifests
                       type: object
                     images:
-                      description: Images are kustomize image overrides
+                      description: Images is a list of Kustomize image override specifications
                       items:
+                        description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                         type: string
                       type: array
                     namePrefix:
-                      description: NamePrefix is a prefix appended to resources for kustomize apps
+                      description: NamePrefix is a prefix appended to resources for Kustomize apps
                       type: string
                     nameSuffix:
-                      description: NameSuffix is a suffix appended to resources for kustomize apps
+                      description: NameSuffix is a suffix appended to resources for Kustomize apps
                       type: string
                     version:
-                      description: Version contains optional Kustomize version
+                      description: Version controls which version of Kustomize to use for rendering manifests
                       type: string
                   type: object
                 path:
-                  description: Path is a directory path within the Git repository
+                  description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                   type: string
                 plugin:
                   description: ConfigManagementPlugin holds config management plugin specific options
                   properties:
                     env:
+                      description: Env is a list of environment variable entries
                       items:
+                        description: EnvEntry represents an entry in the application's environment
                         properties:
                           name:
-                            description: the name, usually uppercase
+                            description: Name is the name of the variable, usually expressed in uppercase
                             type: string
                           value:
-                            description: the value
+                            description: Value is the value of the variable
                             type: string
                         required:
                         - name
@@ -572,16 +585,16 @@ spec:
                       type: string
                   type: object
                 repoURL:
-                  description: RepoURL is the repository URL of the application manifests
+                  description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                   type: string
                 targetRevision:
-                  description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                  description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                   type: string
               required:
               - repoURL
               type: object
             syncPolicy:
-              description: SyncPolicy controls when a sync will be performed
+              description: SyncPolicy controls when and how a sync will be performed
               properties:
                 automated:
                   description: Automated will keep an application synced to the target revision
@@ -590,17 +603,17 @@ spec:
                       description: 'AllowEmpty allows apps have zero live resources (default: false)'
                       type: boolean
                     prune:
-                      description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                      description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
                       type: boolean
                     selfHeal:
-                      description: 'SelfHeal enables auto-syncing if  (default: false)'
+                      description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
                       type: boolean
                   type: object
                 retry:
                   description: Retry controls failed sync retry behavior
                   properties:
                     backoff:
-                      description: Backoff is a backoff strategy
+                      description: Backoff controls how to backoff on subsequent retries of failed syncs
                       properties:
                         duration:
                           description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -614,7 +627,7 @@ spec:
                           type: string
                       type: object
                     limit:
-                      description: Limit is the maximum number of attempts when retrying a container
+                      description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                       format: int64
                       type: integer
                   type: object
@@ -630,14 +643,15 @@ spec:
           - source
           type: object
         status:
-          description: ApplicationStatus contains information about application sync, health status
+          description: ApplicationStatus contains status information for the application
           properties:
             conditions:
+              description: Conditions is a list of currently observed application conditions
               items:
-                description: ApplicationCondition contains details about current application condition
+                description: ApplicationCondition contains details about an application condition, which is usally an error or warning
                 properties:
                   lastTransitionTime:
-                    description: LastTransitionTime is the time the condition was first observed.
+                    description: LastTransitionTime is the time the condition was last observed
                     format: date-time
                     type: string
                   message:
@@ -652,24 +666,26 @@ spec:
                 type: object
               type: array
             health:
+              description: Health contains information about the application's current health status
               properties:
                 message:
+                  description: Message is a human-readable informational message describing the health status
                   type: string
                 status:
-                  description: Represents resource health status
+                  description: Status holds the status code of the application or resource
                   type: string
               type: object
             history:
-              description: RevisionHistories is a array of history, oldest first and newest last
+              description: History contains information about the application's sync history
               items:
-                description: RevisionHistory contains information relevant to an application deployment
+                description: RevisionHistory contains history information about a previous sync
                 properties:
                   deployStartedAt:
-                    description: DeployStartedAt holds the time the deployment started
+                    description: DeployStartedAt holds the time the sync operation started
                     format: date-time
                     type: string
                   deployedAt:
-                    description: DeployedAt holds the time the deployment completed
+                    description: DeployedAt holds the time the sync operation completed
                     format: date-time
                     type: string
                   id:
@@ -677,28 +693,30 @@ spec:
                     format: int64
                     type: integer
                   revision:
-                    description: Revision holds the revision of the sync
+                    description: Revision holds the revision the sync was performed against
                     type: string
                   source:
-                    description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                    description: Source is a reference to the application source used for the sync operation
                     properties:
                       chart:
-                        description: Chart is a Helm chart name
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                         type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
                           exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                             type: string
                           include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                             type: string
                           jsonnet:
-                            description: ApplicationSourceJsonnet holds jsonnet specific options
+                            description: Jsonnet holds options specific to Jsonnet
                             properties:
                               extVars:
                                 description: ExtVars is a list of Jsonnet External Variables
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -719,7 +737,7 @@ spec:
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -734,6 +752,7 @@ spec:
                                 type: array
                             type: object
                           recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
                             type: boolean
                         type: object
                       helm:
@@ -742,34 +761,34 @@ spec:
                           fileParameters:
                             description: FileParameters are file parameters to the helm template
                             items:
-                              description: HelmFileParameter is a file parameter to a helm template
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                               properties:
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 path:
-                                  description: Path is the path value for the helm parameter
+                                  description: Path is the path to the file containing the values for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           parameters:
-                            description: Parameters are parameters to the helm template
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                             items:
-                              description: HelmParameter is a parameter to a helm template
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
                               properties:
                                 forceString:
                                   description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                   type: boolean
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 value:
-                                  description: Value is the value for the helm parameter
+                                  description: Value is the value for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           releaseName:
-                            description: The Helm release name. If omitted it will use the application name
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                             type: string
                           valueFiles:
                             description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -777,10 +796,10 @@ spec:
                               type: string
                             type: array
                           values:
-                            description: Values is Helm values, typically defined as a block
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
                             type: string
                           version:
-                            description: Version is the Helm version to use for templating with
+                            description: Version is the Helm version to use for templating (either "2" or "3")
                             type: string
                         type: object
                       ksonnet:
@@ -812,42 +831,45 @@ spec:
                           commonAnnotations:
                             additionalProperties:
                               type: string
-                            description: CommonAnnotations adds additional kustomize commonAnnotations
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                             type: object
                           commonLabels:
                             additionalProperties:
                               type: string
-                            description: CommonLabels adds additional kustomize commonLabels
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
                             type: object
                           images:
-                            description: Images are kustomize image overrides
+                            description: Images is a list of Kustomize image override specifications
                             items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                               type: string
                             type: array
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources for kustomize apps
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources for kustomize apps
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
                             type: string
                           version:
-                            description: Version contains optional Kustomize version
+                            description: Version controls which version of Kustomize to use for rendering manifests
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the Git repository
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                         type: string
                       plugin:
                         description: ConfigManagementPlugin holds config management plugin specific options
                         properties:
                           env:
+                            description: Env is a list of environment variable entries
                             items:
+                              description: EnvEntry represents an entry in the application's environment
                               properties:
                                 name:
-                                  description: the name, usually uppercase
+                                  description: Name is the name of the variable, usually expressed in uppercase
                                   type: string
                                 value:
-                                  description: the value
+                                  description: Value is the value of the variable
                                   type: string
                               required:
                               - name
@@ -858,10 +880,10 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the repository URL of the application manifests
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
@@ -877,19 +899,20 @@ spec:
               format: date-time
               type: string
             operationState:
-              description: OperationState contains information about state of currently performing operation on application.
+              description: OperationState contains information about any ongoing operations, such as a sync
               properties:
                 finishedAt:
                   description: FinishedAt contains time of operation completion
                   format: date-time
                   type: string
                 message:
-                  description: Message hold any pertinent messages when attempting to perform operation (typically errors).
+                  description: Message holds any pertinent messages when attempting to perform operation (typically errors).
                   type: string
                 operation:
                   description: Operation is the original requested operation
                   properties:
                     info:
+                      description: Info is a list of informational items for this operation
                       items:
                         properties:
                           name:
@@ -902,20 +925,20 @@ spec:
                         type: object
                       type: array
                     initiatedBy:
-                      description: OperationInitiator holds information about the operation initiator
+                      description: InitiatedBy contains information about who initiated the operations
                       properties:
                         automated:
                           description: Automated is set to true if operation was initiated automatically by the application controller.
                           type: boolean
                         username:
-                          description: Name of a user who started operation.
+                          description: Username contains the name of a user who started operation
                           type: string
                       type: object
                     retry:
-                      description: Retry controls failed sync retry behavior
+                      description: Retry controls the strategy to apply if a sync fails
                       properties:
                         backoff:
-                          description: Backoff is a backoff strategy
+                          description: Backoff controls how to backoff on subsequent retries of failed syncs
                           properties:
                             duration:
                               description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -929,15 +952,15 @@ spec:
                               type: string
                           type: object
                         limit:
-                          description: Limit is the maximum number of attempts when retrying a container
+                          description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                           format: int64
                           type: integer
                       type: object
                     sync:
-                      description: SyncOperation contains sync operation details.
+                      description: Sync contains parameters for the operation
                       properties:
                         dryRun:
-                          description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                          description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                           type: boolean
                         manifests:
                           description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -945,10 +968,10 @@ spec:
                             type: string
                           type: array
                         prune:
-                          description: Prune deletes resources that are no longer tracked in git
+                          description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                           type: boolean
                         resources:
-                          description: Resources describes which resources to sync
+                          description: Resources describes which resources shall be part of the sync
                           items:
                             description: SyncOperationResource contains resources to sync.
                             properties:
@@ -966,28 +989,30 @@ spec:
                             type: object
                           type: array
                         revision:
-                          description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                          description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                           type: string
                         source:
-                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                           properties:
                             chart:
-                              description: Chart is a Helm chart name
+                              description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                               type: string
                             directory:
                               description: Directory holds path/directory specific options
                               properties:
                                 exclude:
+                                  description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                                   type: string
                                 include:
+                                  description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                                   type: string
                                 jsonnet:
-                                  description: ApplicationSourceJsonnet holds jsonnet specific options
+                                  description: Jsonnet holds options specific to Jsonnet
                                   properties:
                                     extVars:
                                       description: ExtVars is a list of Jsonnet External Variables
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1008,7 +1033,7 @@ spec:
                                     tlas:
                                       description: TLAS is a list of Jsonnet Top-level Arguments
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1023,6 +1048,7 @@ spec:
                                       type: array
                                   type: object
                                 recurse:
+                                  description: Recurse specifies whether to scan a directory recursively for manifests
                                   type: boolean
                               type: object
                             helm:
@@ -1031,34 +1057,34 @@ spec:
                                 fileParameters:
                                   description: FileParameters are file parameters to the helm template
                                   items:
-                                    description: HelmFileParameter is a file parameter to a helm template
+                                    description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                     properties:
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       path:
-                                        description: Path is the path value for the helm parameter
+                                        description: Path is the path to the file containing the values for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 parameters:
-                                  description: Parameters are parameters to the helm template
+                                  description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                                   items:
-                                    description: HelmParameter is a parameter to a helm template
+                                    description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                     properties:
                                       forceString:
                                         description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                         type: boolean
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       value:
-                                        description: Value is the value for the helm parameter
+                                        description: Value is the value for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 releaseName:
-                                  description: The Helm release name. If omitted it will use the application name
+                                  description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                                   type: string
                                 valueFiles:
                                   description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1066,10 +1092,10 @@ spec:
                                     type: string
                                   type: array
                                 values:
-                                  description: Values is Helm values, typically defined as a block
+                                  description: Values specifies Helm values to be passed to helm template, typically defined as a block
                                   type: string
                                 version:
-                                  description: Version is the Helm version to use for templating with
+                                  description: Version is the Helm version to use for templating (either "2" or "3")
                                   type: string
                               type: object
                             ksonnet:
@@ -1101,42 +1127,45 @@ spec:
                                 commonAnnotations:
                                   additionalProperties:
                                     type: string
-                                  description: CommonAnnotations adds additional kustomize commonAnnotations
+                                  description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                                   type: object
                                 commonLabels:
                                   additionalProperties:
                                     type: string
-                                  description: CommonLabels adds additional kustomize commonLabels
+                                  description: CommonLabels is a list of additional labels to add to rendered manifests
                                   type: object
                                 images:
-                                  description: Images are kustomize image overrides
+                                  description: Images is a list of Kustomize image override specifications
                                   items:
+                                    description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                     type: string
                                   type: array
                                 namePrefix:
-                                  description: NamePrefix is a prefix appended to resources for kustomize apps
+                                  description: NamePrefix is a prefix appended to resources for Kustomize apps
                                   type: string
                                 nameSuffix:
-                                  description: NameSuffix is a suffix appended to resources for kustomize apps
+                                  description: NameSuffix is a suffix appended to resources for Kustomize apps
                                   type: string
                                 version:
-                                  description: Version contains optional Kustomize version
+                                  description: Version controls which version of Kustomize to use for rendering manifests
                                   type: string
                               type: object
                             path:
-                              description: Path is a directory path within the Git repository
+                              description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                               type: string
                             plugin:
                               description: ConfigManagementPlugin holds config management plugin specific options
                               properties:
                                 env:
+                                  description: Env is a list of environment variable entries
                                   items:
+                                    description: EnvEntry represents an entry in the application's environment
                                     properties:
                                       name:
-                                        description: the name, usually uppercase
+                                        description: Name is the name of the variable, usually expressed in uppercase
                                         type: string
                                       value:
-                                        description: the value
+                                        description: Value is the value of the variable
                                         type: string
                                     required:
                                     - name
@@ -1147,10 +1176,10 @@ spec:
                                   type: string
                               type: object
                             repoURL:
-                              description: RepoURL is the repository URL of the application manifests
+                              description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                              description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -1195,34 +1224,39 @@ spec:
                   description: SyncResult is the result of a Sync operation
                   properties:
                     resources:
-                      description: Resources holds the sync result of each individual resource
+                      description: Resources contains a list of sync result items for each individual resource in a sync operation
                       items:
                         description: ResourceResult holds the operation result details of a specific resource
                         properties:
                           group:
+                            description: Group specifies the API group of the resource
                             type: string
                           hookPhase:
-                            description: 'the state of any operation associated with this resource OR hook note: can contain values for non-hook resources'
+                            description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
                             type: string
                           hookType:
-                            description: the type of the hook, empty for non-hook resources
+                            description: HookType specifies the type of the hook. Empty for non-hook resources
                             type: string
                           kind:
+                            description: Kind specifies the API kind of the resource
                             type: string
                           message:
-                            description: message for the last sync OR operation
+                            description: Message contains an informational or error message for the last sync OR operation
                             type: string
                           name:
+                            description: Name specifies the name of the resource
                             type: string
                           namespace:
+                            description: Namespace specifies the target namespace of the resource
                             type: string
                           status:
-                            description: the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                            description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
                             type: string
                           syncPhase:
-                            description: indicates the particular phase of the sync that this is for
+                            description: SyncPhase indicates the particular phase of the sync that this result was acquired in
                             type: string
                           version:
+                            description: Version specifies the API version of the resource
                             type: string
                         required:
                         - group
@@ -1233,28 +1267,30 @@ spec:
                         type: object
                       type: array
                     revision:
-                      description: Revision holds the revision of the sync
+                      description: Revision holds the revision this sync operation was performed to
                       type: string
                     source:
                       description: Source records the application source information of the sync, used for comparing auto-sync
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1275,7 +1311,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1290,6 +1326,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1298,34 +1335,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1333,10 +1370,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1368,42 +1405,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1414,10 +1454,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1435,17 +1475,20 @@ spec:
               format: date-time
               type: string
             resources:
+              description: Resources is a list of Kubernetes resources managed by this application
               items:
-                description: ResourceStatus holds the current sync and health status of a resource
+                description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
                 properties:
                   group:
                     type: string
                   health:
+                    description: HealthStatus contains information about the currently observed health state of an application or resource
                     properties:
                       message:
+                        description: Message is a human-readable informational message describing the health status
                         type: string
                       status:
-                        description: Represents resource health status
+                        description: Status holds the status code of the application or resource
                         type: string
                     type: object
                   hook:
@@ -1466,8 +1509,10 @@ spec:
                 type: object
               type: array
             sourceType:
+              description: SourceType specifies the type of this application
               type: string
             summary:
+              description: Summary contains a list of URLs and container images used by this application
               properties:
                 externalURLs:
                   description: ExternalURLs holds all external URLs of application child resources.
@@ -1481,44 +1526,46 @@ spec:
                   type: array
               type: object
             sync:
-              description: SyncStatus is a comparison result of application spec and deployed application.
+              description: Sync contains information about the application's current sync status
               properties:
                 comparedTo:
-                  description: ComparedTo contains application source and target which was used for resources comparison
+                  description: ComparedTo contains information about what has been compared
                   properties:
                     destination:
-                      description: ApplicationDestination contains deployment destination information
+                      description: Destination is a reference to the application's destination used for comparison
                       properties:
                         name:
-                          description: Name of the destination cluster which can be used instead of server (url) field
+                          description: Name is an alternate way of specifying the target cluster by its symbolic name
                           type: string
                         namespace:
-                          description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                          description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                           type: string
                         server:
-                          description: Server overrides the environment server value in the ksonnet app.yaml
+                          description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                           type: string
                       type: object
                     source:
-                      description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                      description: Source is a reference to the application's source used for comparison
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1539,7 +1586,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1554,6 +1601,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1562,34 +1610,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1597,10 +1645,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1632,42 +1680,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1678,10 +1729,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1691,9 +1742,10 @@ spec:
                   - source
                   type: object
                 revision:
+                  description: Revision contains information about the revision the comparison has been performed to
                   type: string
                 status:
-                  description: SyncStatusCode is a type which represents possible comparison results
+                  description: Status is the sync state of the comparison
                   type: string
               required:
               - status
@@ -1776,16 +1828,16 @@ spec:
             destinations:
               description: Destinations contains list of destinations available for deployment
               items:
-                description: ApplicationDestination contains deployment destination information
+                description: ApplicationDestination holds information about the application's destination
                 properties:
                   name:
-                    description: Name of the destination cluster which can be used instead of server (url) field
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
                     type: string
                   namespace:
-                    description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
-                    description: Server overrides the environment server value in the ksonnet app.yaml
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                     type: string
                 type: object
               type: array
@@ -1821,7 +1873,9 @@ spec:
               description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
               properties:
                 ignore:
+                  description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
                   items:
+                    description: OrphanedResourceKey is a reference to a resource to be ignored from
                     properties:
                       group:
                         type: string
@@ -1878,7 +1932,7 @@ spec:
                 type: object
               type: array
             signatureKeys:
-              description: List of PGP key IDs that commits to be synced to must be signed with
+              description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
               items:
                 description: SignatureKey is the specification of a key required to verify commit signatures with
                 properties:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -42,9 +42,10 @@ spec:
         metadata:
           type: object
         operation:
-          description: Operation contains requested operation parameters.
+          description: Operation contains information about a requested or running operation
           properties:
             info:
+              description: Info is a list of informational items for this operation
               items:
                 properties:
                   name:
@@ -57,20 +58,20 @@ spec:
                 type: object
               type: array
             initiatedBy:
-              description: OperationInitiator holds information about the operation initiator
+              description: InitiatedBy contains information about who initiated the operations
               properties:
                 automated:
                   description: Automated is set to true if operation was initiated automatically by the application controller.
                   type: boolean
                 username:
-                  description: Name of a user who started operation.
+                  description: Username contains the name of a user who started operation
                   type: string
               type: object
             retry:
-              description: Retry controls failed sync retry behavior
+              description: Retry controls the strategy to apply if a sync fails
               properties:
                 backoff:
-                  description: Backoff is a backoff strategy
+                  description: Backoff controls how to backoff on subsequent retries of failed syncs
                   properties:
                     duration:
                       description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -84,15 +85,15 @@ spec:
                       type: string
                   type: object
                 limit:
-                  description: Limit is the maximum number of attempts when retrying a container
+                  description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                   format: int64
                   type: integer
               type: object
             sync:
-              description: SyncOperation contains sync operation details.
+              description: Sync contains parameters for the operation
               properties:
                 dryRun:
-                  description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                  description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                   type: boolean
                 manifests:
                   description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -100,10 +101,10 @@ spec:
                     type: string
                   type: array
                 prune:
-                  description: Prune deletes resources that are no longer tracked in git
+                  description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                   type: boolean
                 resources:
-                  description: Resources describes which resources to sync
+                  description: Resources describes which resources shall be part of the sync
                   items:
                     description: SyncOperationResource contains resources to sync.
                     properties:
@@ -121,28 +122,30 @@ spec:
                     type: object
                   type: array
                 revision:
-                  description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                  description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                   type: string
                 source:
-                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                   properties:
                     chart:
-                      description: Chart is a Helm chart name
+                      description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                       type: string
                     directory:
                       description: Directory holds path/directory specific options
                       properties:
                         exclude:
+                          description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                           type: string
                         include:
+                          description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                           type: string
                         jsonnet:
-                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                          description: Jsonnet holds options specific to Jsonnet
                           properties:
                             extVars:
                               description: ExtVars is a list of Jsonnet External Variables
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -163,7 +166,7 @@ spec:
                             tlas:
                               description: TLAS is a list of Jsonnet Top-level Arguments
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -178,6 +181,7 @@ spec:
                               type: array
                           type: object
                         recurse:
+                          description: Recurse specifies whether to scan a directory recursively for manifests
                           type: boolean
                       type: object
                     helm:
@@ -186,34 +190,34 @@ spec:
                         fileParameters:
                           description: FileParameters are file parameters to the helm template
                           items:
-                            description: HelmFileParameter is a file parameter to a helm template
+                            description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                             properties:
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               path:
-                                description: Path is the path value for the helm parameter
+                                description: Path is the path to the file containing the values for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         parameters:
-                          description: Parameters are parameters to the helm template
+                          description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                           items:
-                            description: HelmParameter is a parameter to a helm template
+                            description: HelmParameter is a parameter that's passed to helm template during manifest generation
                             properties:
                               forceString:
                                 description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                 type: boolean
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               value:
-                                description: Value is the value for the helm parameter
+                                description: Value is the value for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         releaseName:
-                          description: The Helm release name. If omitted it will use the application name
+                          description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                           type: string
                         valueFiles:
                           description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -221,10 +225,10 @@ spec:
                             type: string
                           type: array
                         values:
-                          description: Values is Helm values, typically defined as a block
+                          description: Values specifies Helm values to be passed to helm template, typically defined as a block
                           type: string
                         version:
-                          description: Version is the Helm version to use for templating with
+                          description: Version is the Helm version to use for templating (either "2" or "3")
                           type: string
                       type: object
                     ksonnet:
@@ -256,42 +260,45 @@ spec:
                         commonAnnotations:
                           additionalProperties:
                             type: string
-                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                          description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                           type: object
                         commonLabels:
                           additionalProperties:
                             type: string
-                          description: CommonLabels adds additional kustomize commonLabels
+                          description: CommonLabels is a list of additional labels to add to rendered manifests
                           type: object
                         images:
-                          description: Images are kustomize image overrides
+                          description: Images is a list of Kustomize image override specifications
                           items:
+                            description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                             type: string
                           type: array
                         namePrefix:
-                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                          description: NamePrefix is a prefix appended to resources for Kustomize apps
                           type: string
                         nameSuffix:
-                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                          description: NameSuffix is a suffix appended to resources for Kustomize apps
                           type: string
                         version:
-                          description: Version contains optional Kustomize version
+                          description: Version controls which version of Kustomize to use for rendering manifests
                           type: string
                       type: object
                     path:
-                      description: Path is a directory path within the Git repository
+                      description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                       type: string
                     plugin:
                       description: ConfigManagementPlugin holds config management plugin specific options
                       properties:
                         env:
+                          description: Env is a list of environment variable entries
                           items:
+                            description: EnvEntry represents an entry in the application's environment
                             properties:
                               name:
-                                description: the name, usually uppercase
+                                description: Name is the name of the variable, usually expressed in uppercase
                                 type: string
                               value:
-                                description: the value
+                                description: Value is the value of the variable
                                 type: string
                             required:
                             - name
@@ -302,10 +309,10 @@ spec:
                           type: string
                       type: object
                     repoURL:
-                      description: RepoURL is the repository URL of the application manifests
+                      description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                      description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -339,20 +346,20 @@ spec:
           description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
           properties:
             destination:
-              description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+              description: Destination is a reference to the target Kubernetes server and namespace
               properties:
                 name:
-                  description: Name of the destination cluster which can be used instead of server (url) field
+                  description: Name is an alternate way of specifying the target cluster by its symbolic name
                   type: string
                 namespace:
-                  description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                  description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                   type: string
                 server:
-                  description: Server overrides the environment server value in the ksonnet app.yaml
+                  description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                   type: string
               type: object
             ignoreDifferences:
-              description: IgnoreDifferences controls resources fields which should be ignored during comparison
+              description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
               items:
                 description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
                 properties:
@@ -374,7 +381,7 @@ spec:
                 type: object
               type: array
             info:
-              description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+              description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
               items:
                 properties:
                   name:
@@ -387,32 +394,34 @@ spec:
                 type: object
               type: array
             project:
-              description: Project is a application project name. Empty name means that application belongs to 'default' project.
+              description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
               type: string
             revisionHistoryLimit:
-              description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+              description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
               format: int64
               type: integer
             source:
-              description: Source is a reference to the location ksonnet application definition
+              description: Source is a reference to the location of the application's manifests or chart
               properties:
                 chart:
-                  description: Chart is a Helm chart name
+                  description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                   type: string
                 directory:
                   description: Directory holds path/directory specific options
                   properties:
                     exclude:
+                      description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                       type: string
                     include:
+                      description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                       type: string
                     jsonnet:
-                      description: ApplicationSourceJsonnet holds jsonnet specific options
+                      description: Jsonnet holds options specific to Jsonnet
                       properties:
                         extVars:
                           description: ExtVars is a list of Jsonnet External Variables
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -433,7 +442,7 @@ spec:
                         tlas:
                           description: TLAS is a list of Jsonnet Top-level Arguments
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -448,6 +457,7 @@ spec:
                           type: array
                       type: object
                     recurse:
+                      description: Recurse specifies whether to scan a directory recursively for manifests
                       type: boolean
                   type: object
                 helm:
@@ -456,34 +466,34 @@ spec:
                     fileParameters:
                       description: FileParameters are file parameters to the helm template
                       items:
-                        description: HelmFileParameter is a file parameter to a helm template
+                        description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                         properties:
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           path:
-                            description: Path is the path value for the helm parameter
+                            description: Path is the path to the file containing the values for the Helm parameter
                             type: string
                         type: object
                       type: array
                     parameters:
-                      description: Parameters are parameters to the helm template
+                      description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                       items:
-                        description: HelmParameter is a parameter to a helm template
+                        description: HelmParameter is a parameter that's passed to helm template during manifest generation
                         properties:
                           forceString:
                             description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                             type: boolean
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           value:
-                            description: Value is the value for the helm parameter
+                            description: Value is the value for the Helm parameter
                             type: string
                         type: object
                       type: array
                     releaseName:
-                      description: The Helm release name. If omitted it will use the application name
+                      description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                       type: string
                     valueFiles:
                       description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -491,10 +501,10 @@ spec:
                         type: string
                       type: array
                     values:
-                      description: Values is Helm values, typically defined as a block
+                      description: Values specifies Helm values to be passed to helm template, typically defined as a block
                       type: string
                     version:
-                      description: Version is the Helm version to use for templating with
+                      description: Version is the Helm version to use for templating (either "2" or "3")
                       type: string
                   type: object
                 ksonnet:
@@ -526,42 +536,45 @@ spec:
                     commonAnnotations:
                       additionalProperties:
                         type: string
-                      description: CommonAnnotations adds additional kustomize commonAnnotations
+                      description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                       type: object
                     commonLabels:
                       additionalProperties:
                         type: string
-                      description: CommonLabels adds additional kustomize commonLabels
+                      description: CommonLabels is a list of additional labels to add to rendered manifests
                       type: object
                     images:
-                      description: Images are kustomize image overrides
+                      description: Images is a list of Kustomize image override specifications
                       items:
+                        description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                         type: string
                       type: array
                     namePrefix:
-                      description: NamePrefix is a prefix appended to resources for kustomize apps
+                      description: NamePrefix is a prefix appended to resources for Kustomize apps
                       type: string
                     nameSuffix:
-                      description: NameSuffix is a suffix appended to resources for kustomize apps
+                      description: NameSuffix is a suffix appended to resources for Kustomize apps
                       type: string
                     version:
-                      description: Version contains optional Kustomize version
+                      description: Version controls which version of Kustomize to use for rendering manifests
                       type: string
                   type: object
                 path:
-                  description: Path is a directory path within the Git repository
+                  description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                   type: string
                 plugin:
                   description: ConfigManagementPlugin holds config management plugin specific options
                   properties:
                     env:
+                      description: Env is a list of environment variable entries
                       items:
+                        description: EnvEntry represents an entry in the application's environment
                         properties:
                           name:
-                            description: the name, usually uppercase
+                            description: Name is the name of the variable, usually expressed in uppercase
                             type: string
                           value:
-                            description: the value
+                            description: Value is the value of the variable
                             type: string
                         required:
                         - name
@@ -572,16 +585,16 @@ spec:
                       type: string
                   type: object
                 repoURL:
-                  description: RepoURL is the repository URL of the application manifests
+                  description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                   type: string
                 targetRevision:
-                  description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                  description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                   type: string
               required:
               - repoURL
               type: object
             syncPolicy:
-              description: SyncPolicy controls when a sync will be performed
+              description: SyncPolicy controls when and how a sync will be performed
               properties:
                 automated:
                   description: Automated will keep an application synced to the target revision
@@ -590,17 +603,17 @@ spec:
                       description: 'AllowEmpty allows apps have zero live resources (default: false)'
                       type: boolean
                     prune:
-                      description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                      description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
                       type: boolean
                     selfHeal:
-                      description: 'SelfHeal enables auto-syncing if  (default: false)'
+                      description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
                       type: boolean
                   type: object
                 retry:
                   description: Retry controls failed sync retry behavior
                   properties:
                     backoff:
-                      description: Backoff is a backoff strategy
+                      description: Backoff controls how to backoff on subsequent retries of failed syncs
                       properties:
                         duration:
                           description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -614,7 +627,7 @@ spec:
                           type: string
                       type: object
                     limit:
-                      description: Limit is the maximum number of attempts when retrying a container
+                      description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                       format: int64
                       type: integer
                   type: object
@@ -630,14 +643,15 @@ spec:
           - source
           type: object
         status:
-          description: ApplicationStatus contains information about application sync, health status
+          description: ApplicationStatus contains status information for the application
           properties:
             conditions:
+              description: Conditions is a list of currently observed application conditions
               items:
-                description: ApplicationCondition contains details about current application condition
+                description: ApplicationCondition contains details about an application condition, which is usally an error or warning
                 properties:
                   lastTransitionTime:
-                    description: LastTransitionTime is the time the condition was first observed.
+                    description: LastTransitionTime is the time the condition was last observed
                     format: date-time
                     type: string
                   message:
@@ -652,24 +666,26 @@ spec:
                 type: object
               type: array
             health:
+              description: Health contains information about the application's current health status
               properties:
                 message:
+                  description: Message is a human-readable informational message describing the health status
                   type: string
                 status:
-                  description: Represents resource health status
+                  description: Status holds the status code of the application or resource
                   type: string
               type: object
             history:
-              description: RevisionHistories is a array of history, oldest first and newest last
+              description: History contains information about the application's sync history
               items:
-                description: RevisionHistory contains information relevant to an application deployment
+                description: RevisionHistory contains history information about a previous sync
                 properties:
                   deployStartedAt:
-                    description: DeployStartedAt holds the time the deployment started
+                    description: DeployStartedAt holds the time the sync operation started
                     format: date-time
                     type: string
                   deployedAt:
-                    description: DeployedAt holds the time the deployment completed
+                    description: DeployedAt holds the time the sync operation completed
                     format: date-time
                     type: string
                   id:
@@ -677,28 +693,30 @@ spec:
                     format: int64
                     type: integer
                   revision:
-                    description: Revision holds the revision of the sync
+                    description: Revision holds the revision the sync was performed against
                     type: string
                   source:
-                    description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                    description: Source is a reference to the application source used for the sync operation
                     properties:
                       chart:
-                        description: Chart is a Helm chart name
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                         type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
                           exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                             type: string
                           include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                             type: string
                           jsonnet:
-                            description: ApplicationSourceJsonnet holds jsonnet specific options
+                            description: Jsonnet holds options specific to Jsonnet
                             properties:
                               extVars:
                                 description: ExtVars is a list of Jsonnet External Variables
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -719,7 +737,7 @@ spec:
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -734,6 +752,7 @@ spec:
                                 type: array
                             type: object
                           recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
                             type: boolean
                         type: object
                       helm:
@@ -742,34 +761,34 @@ spec:
                           fileParameters:
                             description: FileParameters are file parameters to the helm template
                             items:
-                              description: HelmFileParameter is a file parameter to a helm template
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                               properties:
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 path:
-                                  description: Path is the path value for the helm parameter
+                                  description: Path is the path to the file containing the values for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           parameters:
-                            description: Parameters are parameters to the helm template
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                             items:
-                              description: HelmParameter is a parameter to a helm template
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
                               properties:
                                 forceString:
                                   description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                   type: boolean
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 value:
-                                  description: Value is the value for the helm parameter
+                                  description: Value is the value for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           releaseName:
-                            description: The Helm release name. If omitted it will use the application name
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                             type: string
                           valueFiles:
                             description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -777,10 +796,10 @@ spec:
                               type: string
                             type: array
                           values:
-                            description: Values is Helm values, typically defined as a block
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
                             type: string
                           version:
-                            description: Version is the Helm version to use for templating with
+                            description: Version is the Helm version to use for templating (either "2" or "3")
                             type: string
                         type: object
                       ksonnet:
@@ -812,42 +831,45 @@ spec:
                           commonAnnotations:
                             additionalProperties:
                               type: string
-                            description: CommonAnnotations adds additional kustomize commonAnnotations
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                             type: object
                           commonLabels:
                             additionalProperties:
                               type: string
-                            description: CommonLabels adds additional kustomize commonLabels
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
                             type: object
                           images:
-                            description: Images are kustomize image overrides
+                            description: Images is a list of Kustomize image override specifications
                             items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                               type: string
                             type: array
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources for kustomize apps
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources for kustomize apps
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
                             type: string
                           version:
-                            description: Version contains optional Kustomize version
+                            description: Version controls which version of Kustomize to use for rendering manifests
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the Git repository
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                         type: string
                       plugin:
                         description: ConfigManagementPlugin holds config management plugin specific options
                         properties:
                           env:
+                            description: Env is a list of environment variable entries
                             items:
+                              description: EnvEntry represents an entry in the application's environment
                               properties:
                                 name:
-                                  description: the name, usually uppercase
+                                  description: Name is the name of the variable, usually expressed in uppercase
                                   type: string
                                 value:
-                                  description: the value
+                                  description: Value is the value of the variable
                                   type: string
                               required:
                               - name
@@ -858,10 +880,10 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the repository URL of the application manifests
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
@@ -877,19 +899,20 @@ spec:
               format: date-time
               type: string
             operationState:
-              description: OperationState contains information about state of currently performing operation on application.
+              description: OperationState contains information about any ongoing operations, such as a sync
               properties:
                 finishedAt:
                   description: FinishedAt contains time of operation completion
                   format: date-time
                   type: string
                 message:
-                  description: Message hold any pertinent messages when attempting to perform operation (typically errors).
+                  description: Message holds any pertinent messages when attempting to perform operation (typically errors).
                   type: string
                 operation:
                   description: Operation is the original requested operation
                   properties:
                     info:
+                      description: Info is a list of informational items for this operation
                       items:
                         properties:
                           name:
@@ -902,20 +925,20 @@ spec:
                         type: object
                       type: array
                     initiatedBy:
-                      description: OperationInitiator holds information about the operation initiator
+                      description: InitiatedBy contains information about who initiated the operations
                       properties:
                         automated:
                           description: Automated is set to true if operation was initiated automatically by the application controller.
                           type: boolean
                         username:
-                          description: Name of a user who started operation.
+                          description: Username contains the name of a user who started operation
                           type: string
                       type: object
                     retry:
-                      description: Retry controls failed sync retry behavior
+                      description: Retry controls the strategy to apply if a sync fails
                       properties:
                         backoff:
-                          description: Backoff is a backoff strategy
+                          description: Backoff controls how to backoff on subsequent retries of failed syncs
                           properties:
                             duration:
                               description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -929,15 +952,15 @@ spec:
                               type: string
                           type: object
                         limit:
-                          description: Limit is the maximum number of attempts when retrying a container
+                          description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                           format: int64
                           type: integer
                       type: object
                     sync:
-                      description: SyncOperation contains sync operation details.
+                      description: Sync contains parameters for the operation
                       properties:
                         dryRun:
-                          description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                          description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                           type: boolean
                         manifests:
                           description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -945,10 +968,10 @@ spec:
                             type: string
                           type: array
                         prune:
-                          description: Prune deletes resources that are no longer tracked in git
+                          description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                           type: boolean
                         resources:
-                          description: Resources describes which resources to sync
+                          description: Resources describes which resources shall be part of the sync
                           items:
                             description: SyncOperationResource contains resources to sync.
                             properties:
@@ -966,28 +989,30 @@ spec:
                             type: object
                           type: array
                         revision:
-                          description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                          description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                           type: string
                         source:
-                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                           properties:
                             chart:
-                              description: Chart is a Helm chart name
+                              description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                               type: string
                             directory:
                               description: Directory holds path/directory specific options
                               properties:
                                 exclude:
+                                  description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                                   type: string
                                 include:
+                                  description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                                   type: string
                                 jsonnet:
-                                  description: ApplicationSourceJsonnet holds jsonnet specific options
+                                  description: Jsonnet holds options specific to Jsonnet
                                   properties:
                                     extVars:
                                       description: ExtVars is a list of Jsonnet External Variables
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1008,7 +1033,7 @@ spec:
                                     tlas:
                                       description: TLAS is a list of Jsonnet Top-level Arguments
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1023,6 +1048,7 @@ spec:
                                       type: array
                                   type: object
                                 recurse:
+                                  description: Recurse specifies whether to scan a directory recursively for manifests
                                   type: boolean
                               type: object
                             helm:
@@ -1031,34 +1057,34 @@ spec:
                                 fileParameters:
                                   description: FileParameters are file parameters to the helm template
                                   items:
-                                    description: HelmFileParameter is a file parameter to a helm template
+                                    description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                     properties:
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       path:
-                                        description: Path is the path value for the helm parameter
+                                        description: Path is the path to the file containing the values for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 parameters:
-                                  description: Parameters are parameters to the helm template
+                                  description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                                   items:
-                                    description: HelmParameter is a parameter to a helm template
+                                    description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                     properties:
                                       forceString:
                                         description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                         type: boolean
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       value:
-                                        description: Value is the value for the helm parameter
+                                        description: Value is the value for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 releaseName:
-                                  description: The Helm release name. If omitted it will use the application name
+                                  description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                                   type: string
                                 valueFiles:
                                   description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1066,10 +1092,10 @@ spec:
                                     type: string
                                   type: array
                                 values:
-                                  description: Values is Helm values, typically defined as a block
+                                  description: Values specifies Helm values to be passed to helm template, typically defined as a block
                                   type: string
                                 version:
-                                  description: Version is the Helm version to use for templating with
+                                  description: Version is the Helm version to use for templating (either "2" or "3")
                                   type: string
                               type: object
                             ksonnet:
@@ -1101,42 +1127,45 @@ spec:
                                 commonAnnotations:
                                   additionalProperties:
                                     type: string
-                                  description: CommonAnnotations adds additional kustomize commonAnnotations
+                                  description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                                   type: object
                                 commonLabels:
                                   additionalProperties:
                                     type: string
-                                  description: CommonLabels adds additional kustomize commonLabels
+                                  description: CommonLabels is a list of additional labels to add to rendered manifests
                                   type: object
                                 images:
-                                  description: Images are kustomize image overrides
+                                  description: Images is a list of Kustomize image override specifications
                                   items:
+                                    description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                     type: string
                                   type: array
                                 namePrefix:
-                                  description: NamePrefix is a prefix appended to resources for kustomize apps
+                                  description: NamePrefix is a prefix appended to resources for Kustomize apps
                                   type: string
                                 nameSuffix:
-                                  description: NameSuffix is a suffix appended to resources for kustomize apps
+                                  description: NameSuffix is a suffix appended to resources for Kustomize apps
                                   type: string
                                 version:
-                                  description: Version contains optional Kustomize version
+                                  description: Version controls which version of Kustomize to use for rendering manifests
                                   type: string
                               type: object
                             path:
-                              description: Path is a directory path within the Git repository
+                              description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                               type: string
                             plugin:
                               description: ConfigManagementPlugin holds config management plugin specific options
                               properties:
                                 env:
+                                  description: Env is a list of environment variable entries
                                   items:
+                                    description: EnvEntry represents an entry in the application's environment
                                     properties:
                                       name:
-                                        description: the name, usually uppercase
+                                        description: Name is the name of the variable, usually expressed in uppercase
                                         type: string
                                       value:
-                                        description: the value
+                                        description: Value is the value of the variable
                                         type: string
                                     required:
                                     - name
@@ -1147,10 +1176,10 @@ spec:
                                   type: string
                               type: object
                             repoURL:
-                              description: RepoURL is the repository URL of the application manifests
+                              description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                              description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -1195,34 +1224,39 @@ spec:
                   description: SyncResult is the result of a Sync operation
                   properties:
                     resources:
-                      description: Resources holds the sync result of each individual resource
+                      description: Resources contains a list of sync result items for each individual resource in a sync operation
                       items:
                         description: ResourceResult holds the operation result details of a specific resource
                         properties:
                           group:
+                            description: Group specifies the API group of the resource
                             type: string
                           hookPhase:
-                            description: 'the state of any operation associated with this resource OR hook note: can contain values for non-hook resources'
+                            description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
                             type: string
                           hookType:
-                            description: the type of the hook, empty for non-hook resources
+                            description: HookType specifies the type of the hook. Empty for non-hook resources
                             type: string
                           kind:
+                            description: Kind specifies the API kind of the resource
                             type: string
                           message:
-                            description: message for the last sync OR operation
+                            description: Message contains an informational or error message for the last sync OR operation
                             type: string
                           name:
+                            description: Name specifies the name of the resource
                             type: string
                           namespace:
+                            description: Namespace specifies the target namespace of the resource
                             type: string
                           status:
-                            description: the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                            description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
                             type: string
                           syncPhase:
-                            description: indicates the particular phase of the sync that this is for
+                            description: SyncPhase indicates the particular phase of the sync that this result was acquired in
                             type: string
                           version:
+                            description: Version specifies the API version of the resource
                             type: string
                         required:
                         - group
@@ -1233,28 +1267,30 @@ spec:
                         type: object
                       type: array
                     revision:
-                      description: Revision holds the revision of the sync
+                      description: Revision holds the revision this sync operation was performed to
                       type: string
                     source:
                       description: Source records the application source information of the sync, used for comparing auto-sync
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1275,7 +1311,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1290,6 +1326,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1298,34 +1335,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1333,10 +1370,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1368,42 +1405,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1414,10 +1454,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1435,17 +1475,20 @@ spec:
               format: date-time
               type: string
             resources:
+              description: Resources is a list of Kubernetes resources managed by this application
               items:
-                description: ResourceStatus holds the current sync and health status of a resource
+                description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
                 properties:
                   group:
                     type: string
                   health:
+                    description: HealthStatus contains information about the currently observed health state of an application or resource
                     properties:
                       message:
+                        description: Message is a human-readable informational message describing the health status
                         type: string
                       status:
-                        description: Represents resource health status
+                        description: Status holds the status code of the application or resource
                         type: string
                     type: object
                   hook:
@@ -1466,8 +1509,10 @@ spec:
                 type: object
               type: array
             sourceType:
+              description: SourceType specifies the type of this application
               type: string
             summary:
+              description: Summary contains a list of URLs and container images used by this application
               properties:
                 externalURLs:
                   description: ExternalURLs holds all external URLs of application child resources.
@@ -1481,44 +1526,46 @@ spec:
                   type: array
               type: object
             sync:
-              description: SyncStatus is a comparison result of application spec and deployed application.
+              description: Sync contains information about the application's current sync status
               properties:
                 comparedTo:
-                  description: ComparedTo contains application source and target which was used for resources comparison
+                  description: ComparedTo contains information about what has been compared
                   properties:
                     destination:
-                      description: ApplicationDestination contains deployment destination information
+                      description: Destination is a reference to the application's destination used for comparison
                       properties:
                         name:
-                          description: Name of the destination cluster which can be used instead of server (url) field
+                          description: Name is an alternate way of specifying the target cluster by its symbolic name
                           type: string
                         namespace:
-                          description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                          description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                           type: string
                         server:
-                          description: Server overrides the environment server value in the ksonnet app.yaml
+                          description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                           type: string
                       type: object
                     source:
-                      description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                      description: Source is a reference to the application's source used for comparison
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1539,7 +1586,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1554,6 +1601,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1562,34 +1610,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1597,10 +1645,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1632,42 +1680,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1678,10 +1729,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1691,9 +1742,10 @@ spec:
                   - source
                   type: object
                 revision:
+                  description: Revision contains information about the revision the comparison has been performed to
                   type: string
                 status:
-                  description: SyncStatusCode is a type which represents possible comparison results
+                  description: Status is the sync state of the comparison
                   type: string
               required:
               - status
@@ -1776,16 +1828,16 @@ spec:
             destinations:
               description: Destinations contains list of destinations available for deployment
               items:
-                description: ApplicationDestination contains deployment destination information
+                description: ApplicationDestination holds information about the application's destination
                 properties:
                   name:
-                    description: Name of the destination cluster which can be used instead of server (url) field
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
                     type: string
                   namespace:
-                    description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
-                    description: Server overrides the environment server value in the ksonnet app.yaml
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                     type: string
                 type: object
               type: array
@@ -1821,7 +1873,9 @@ spec:
               description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
               properties:
                 ignore:
+                  description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
                   items:
+                    description: OrphanedResourceKey is a reference to a resource to be ignored from
                     properties:
                       group:
                         type: string
@@ -1878,7 +1932,7 @@ spec:
                 type: object
               type: array
             signatureKeys:
-              description: List of PGP key IDs that commits to be synced to must be signed with
+              description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
               items:
                 description: SignatureKey is the specification of a key required to verify commit signatures with
                 properties:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -42,9 +42,10 @@ spec:
         metadata:
           type: object
         operation:
-          description: Operation contains requested operation parameters.
+          description: Operation contains information about a requested or running operation
           properties:
             info:
+              description: Info is a list of informational items for this operation
               items:
                 properties:
                   name:
@@ -57,20 +58,20 @@ spec:
                 type: object
               type: array
             initiatedBy:
-              description: OperationInitiator holds information about the operation initiator
+              description: InitiatedBy contains information about who initiated the operations
               properties:
                 automated:
                   description: Automated is set to true if operation was initiated automatically by the application controller.
                   type: boolean
                 username:
-                  description: Name of a user who started operation.
+                  description: Username contains the name of a user who started operation
                   type: string
               type: object
             retry:
-              description: Retry controls failed sync retry behavior
+              description: Retry controls the strategy to apply if a sync fails
               properties:
                 backoff:
-                  description: Backoff is a backoff strategy
+                  description: Backoff controls how to backoff on subsequent retries of failed syncs
                   properties:
                     duration:
                       description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -84,15 +85,15 @@ spec:
                       type: string
                   type: object
                 limit:
-                  description: Limit is the maximum number of attempts when retrying a container
+                  description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                   format: int64
                   type: integer
               type: object
             sync:
-              description: SyncOperation contains sync operation details.
+              description: Sync contains parameters for the operation
               properties:
                 dryRun:
-                  description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                  description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                   type: boolean
                 manifests:
                   description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -100,10 +101,10 @@ spec:
                     type: string
                   type: array
                 prune:
-                  description: Prune deletes resources that are no longer tracked in git
+                  description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                   type: boolean
                 resources:
-                  description: Resources describes which resources to sync
+                  description: Resources describes which resources shall be part of the sync
                   items:
                     description: SyncOperationResource contains resources to sync.
                     properties:
@@ -121,28 +122,30 @@ spec:
                     type: object
                   type: array
                 revision:
-                  description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                  description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                   type: string
                 source:
-                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                   properties:
                     chart:
-                      description: Chart is a Helm chart name
+                      description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                       type: string
                     directory:
                       description: Directory holds path/directory specific options
                       properties:
                         exclude:
+                          description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                           type: string
                         include:
+                          description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                           type: string
                         jsonnet:
-                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                          description: Jsonnet holds options specific to Jsonnet
                           properties:
                             extVars:
                               description: ExtVars is a list of Jsonnet External Variables
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -163,7 +166,7 @@ spec:
                             tlas:
                               description: TLAS is a list of Jsonnet Top-level Arguments
                               items:
-                                description: JsonnetVar is a jsonnet variable
+                                description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                 properties:
                                   code:
                                     type: boolean
@@ -178,6 +181,7 @@ spec:
                               type: array
                           type: object
                         recurse:
+                          description: Recurse specifies whether to scan a directory recursively for manifests
                           type: boolean
                       type: object
                     helm:
@@ -186,34 +190,34 @@ spec:
                         fileParameters:
                           description: FileParameters are file parameters to the helm template
                           items:
-                            description: HelmFileParameter is a file parameter to a helm template
+                            description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                             properties:
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               path:
-                                description: Path is the path value for the helm parameter
+                                description: Path is the path to the file containing the values for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         parameters:
-                          description: Parameters are parameters to the helm template
+                          description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                           items:
-                            description: HelmParameter is a parameter to a helm template
+                            description: HelmParameter is a parameter that's passed to helm template during manifest generation
                             properties:
                               forceString:
                                 description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                 type: boolean
                               name:
-                                description: Name is the name of the helm parameter
+                                description: Name is the name of the Helm parameter
                                 type: string
                               value:
-                                description: Value is the value for the helm parameter
+                                description: Value is the value for the Helm parameter
                                 type: string
                             type: object
                           type: array
                         releaseName:
-                          description: The Helm release name. If omitted it will use the application name
+                          description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                           type: string
                         valueFiles:
                           description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -221,10 +225,10 @@ spec:
                             type: string
                           type: array
                         values:
-                          description: Values is Helm values, typically defined as a block
+                          description: Values specifies Helm values to be passed to helm template, typically defined as a block
                           type: string
                         version:
-                          description: Version is the Helm version to use for templating with
+                          description: Version is the Helm version to use for templating (either "2" or "3")
                           type: string
                       type: object
                     ksonnet:
@@ -256,42 +260,45 @@ spec:
                         commonAnnotations:
                           additionalProperties:
                             type: string
-                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                          description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                           type: object
                         commonLabels:
                           additionalProperties:
                             type: string
-                          description: CommonLabels adds additional kustomize commonLabels
+                          description: CommonLabels is a list of additional labels to add to rendered manifests
                           type: object
                         images:
-                          description: Images are kustomize image overrides
+                          description: Images is a list of Kustomize image override specifications
                           items:
+                            description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                             type: string
                           type: array
                         namePrefix:
-                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                          description: NamePrefix is a prefix appended to resources for Kustomize apps
                           type: string
                         nameSuffix:
-                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                          description: NameSuffix is a suffix appended to resources for Kustomize apps
                           type: string
                         version:
-                          description: Version contains optional Kustomize version
+                          description: Version controls which version of Kustomize to use for rendering manifests
                           type: string
                       type: object
                     path:
-                      description: Path is a directory path within the Git repository
+                      description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                       type: string
                     plugin:
                       description: ConfigManagementPlugin holds config management plugin specific options
                       properties:
                         env:
+                          description: Env is a list of environment variable entries
                           items:
+                            description: EnvEntry represents an entry in the application's environment
                             properties:
                               name:
-                                description: the name, usually uppercase
+                                description: Name is the name of the variable, usually expressed in uppercase
                                 type: string
                               value:
-                                description: the value
+                                description: Value is the value of the variable
                                 type: string
                             required:
                             - name
@@ -302,10 +309,10 @@ spec:
                           type: string
                       type: object
                     repoURL:
-                      description: RepoURL is the repository URL of the application manifests
+                      description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                      description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -339,20 +346,20 @@ spec:
           description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
           properties:
             destination:
-              description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+              description: Destination is a reference to the target Kubernetes server and namespace
               properties:
                 name:
-                  description: Name of the destination cluster which can be used instead of server (url) field
+                  description: Name is an alternate way of specifying the target cluster by its symbolic name
                   type: string
                 namespace:
-                  description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                  description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                   type: string
                 server:
-                  description: Server overrides the environment server value in the ksonnet app.yaml
+                  description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                   type: string
               type: object
             ignoreDifferences:
-              description: IgnoreDifferences controls resources fields which should be ignored during comparison
+              description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
               items:
                 description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
                 properties:
@@ -374,7 +381,7 @@ spec:
                 type: object
               type: array
             info:
-              description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+              description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
               items:
                 properties:
                   name:
@@ -387,32 +394,34 @@ spec:
                 type: object
               type: array
             project:
-              description: Project is a application project name. Empty name means that application belongs to 'default' project.
+              description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
               type: string
             revisionHistoryLimit:
-              description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+              description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
               format: int64
               type: integer
             source:
-              description: Source is a reference to the location ksonnet application definition
+              description: Source is a reference to the location of the application's manifests or chart
               properties:
                 chart:
-                  description: Chart is a Helm chart name
+                  description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                   type: string
                 directory:
                   description: Directory holds path/directory specific options
                   properties:
                     exclude:
+                      description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                       type: string
                     include:
+                      description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                       type: string
                     jsonnet:
-                      description: ApplicationSourceJsonnet holds jsonnet specific options
+                      description: Jsonnet holds options specific to Jsonnet
                       properties:
                         extVars:
                           description: ExtVars is a list of Jsonnet External Variables
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -433,7 +442,7 @@ spec:
                         tlas:
                           description: TLAS is a list of Jsonnet Top-level Arguments
                           items:
-                            description: JsonnetVar is a jsonnet variable
+                            description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                             properties:
                               code:
                                 type: boolean
@@ -448,6 +457,7 @@ spec:
                           type: array
                       type: object
                     recurse:
+                      description: Recurse specifies whether to scan a directory recursively for manifests
                       type: boolean
                   type: object
                 helm:
@@ -456,34 +466,34 @@ spec:
                     fileParameters:
                       description: FileParameters are file parameters to the helm template
                       items:
-                        description: HelmFileParameter is a file parameter to a helm template
+                        description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                         properties:
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           path:
-                            description: Path is the path value for the helm parameter
+                            description: Path is the path to the file containing the values for the Helm parameter
                             type: string
                         type: object
                       type: array
                     parameters:
-                      description: Parameters are parameters to the helm template
+                      description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                       items:
-                        description: HelmParameter is a parameter to a helm template
+                        description: HelmParameter is a parameter that's passed to helm template during manifest generation
                         properties:
                           forceString:
                             description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                             type: boolean
                           name:
-                            description: Name is the name of the helm parameter
+                            description: Name is the name of the Helm parameter
                             type: string
                           value:
-                            description: Value is the value for the helm parameter
+                            description: Value is the value for the Helm parameter
                             type: string
                         type: object
                       type: array
                     releaseName:
-                      description: The Helm release name. If omitted it will use the application name
+                      description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                       type: string
                     valueFiles:
                       description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -491,10 +501,10 @@ spec:
                         type: string
                       type: array
                     values:
-                      description: Values is Helm values, typically defined as a block
+                      description: Values specifies Helm values to be passed to helm template, typically defined as a block
                       type: string
                     version:
-                      description: Version is the Helm version to use for templating with
+                      description: Version is the Helm version to use for templating (either "2" or "3")
                       type: string
                   type: object
                 ksonnet:
@@ -526,42 +536,45 @@ spec:
                     commonAnnotations:
                       additionalProperties:
                         type: string
-                      description: CommonAnnotations adds additional kustomize commonAnnotations
+                      description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                       type: object
                     commonLabels:
                       additionalProperties:
                         type: string
-                      description: CommonLabels adds additional kustomize commonLabels
+                      description: CommonLabels is a list of additional labels to add to rendered manifests
                       type: object
                     images:
-                      description: Images are kustomize image overrides
+                      description: Images is a list of Kustomize image override specifications
                       items:
+                        description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                         type: string
                       type: array
                     namePrefix:
-                      description: NamePrefix is a prefix appended to resources for kustomize apps
+                      description: NamePrefix is a prefix appended to resources for Kustomize apps
                       type: string
                     nameSuffix:
-                      description: NameSuffix is a suffix appended to resources for kustomize apps
+                      description: NameSuffix is a suffix appended to resources for Kustomize apps
                       type: string
                     version:
-                      description: Version contains optional Kustomize version
+                      description: Version controls which version of Kustomize to use for rendering manifests
                       type: string
                   type: object
                 path:
-                  description: Path is a directory path within the Git repository
+                  description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                   type: string
                 plugin:
                   description: ConfigManagementPlugin holds config management plugin specific options
                   properties:
                     env:
+                      description: Env is a list of environment variable entries
                       items:
+                        description: EnvEntry represents an entry in the application's environment
                         properties:
                           name:
-                            description: the name, usually uppercase
+                            description: Name is the name of the variable, usually expressed in uppercase
                             type: string
                           value:
-                            description: the value
+                            description: Value is the value of the variable
                             type: string
                         required:
                         - name
@@ -572,16 +585,16 @@ spec:
                       type: string
                   type: object
                 repoURL:
-                  description: RepoURL is the repository URL of the application manifests
+                  description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                   type: string
                 targetRevision:
-                  description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                  description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                   type: string
               required:
               - repoURL
               type: object
             syncPolicy:
-              description: SyncPolicy controls when a sync will be performed
+              description: SyncPolicy controls when and how a sync will be performed
               properties:
                 automated:
                   description: Automated will keep an application synced to the target revision
@@ -590,17 +603,17 @@ spec:
                       description: 'AllowEmpty allows apps have zero live resources (default: false)'
                       type: boolean
                     prune:
-                      description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                      description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
                       type: boolean
                     selfHeal:
-                      description: 'SelfHeal enables auto-syncing if  (default: false)'
+                      description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
                       type: boolean
                   type: object
                 retry:
                   description: Retry controls failed sync retry behavior
                   properties:
                     backoff:
-                      description: Backoff is a backoff strategy
+                      description: Backoff controls how to backoff on subsequent retries of failed syncs
                       properties:
                         duration:
                           description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -614,7 +627,7 @@ spec:
                           type: string
                       type: object
                     limit:
-                      description: Limit is the maximum number of attempts when retrying a container
+                      description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                       format: int64
                       type: integer
                   type: object
@@ -630,14 +643,15 @@ spec:
           - source
           type: object
         status:
-          description: ApplicationStatus contains information about application sync, health status
+          description: ApplicationStatus contains status information for the application
           properties:
             conditions:
+              description: Conditions is a list of currently observed application conditions
               items:
-                description: ApplicationCondition contains details about current application condition
+                description: ApplicationCondition contains details about an application condition, which is usally an error or warning
                 properties:
                   lastTransitionTime:
-                    description: LastTransitionTime is the time the condition was first observed.
+                    description: LastTransitionTime is the time the condition was last observed
                     format: date-time
                     type: string
                   message:
@@ -652,24 +666,26 @@ spec:
                 type: object
               type: array
             health:
+              description: Health contains information about the application's current health status
               properties:
                 message:
+                  description: Message is a human-readable informational message describing the health status
                   type: string
                 status:
-                  description: Represents resource health status
+                  description: Status holds the status code of the application or resource
                   type: string
               type: object
             history:
-              description: RevisionHistories is a array of history, oldest first and newest last
+              description: History contains information about the application's sync history
               items:
-                description: RevisionHistory contains information relevant to an application deployment
+                description: RevisionHistory contains history information about a previous sync
                 properties:
                   deployStartedAt:
-                    description: DeployStartedAt holds the time the deployment started
+                    description: DeployStartedAt holds the time the sync operation started
                     format: date-time
                     type: string
                   deployedAt:
-                    description: DeployedAt holds the time the deployment completed
+                    description: DeployedAt holds the time the sync operation completed
                     format: date-time
                     type: string
                   id:
@@ -677,28 +693,30 @@ spec:
                     format: int64
                     type: integer
                   revision:
-                    description: Revision holds the revision of the sync
+                    description: Revision holds the revision the sync was performed against
                     type: string
                   source:
-                    description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                    description: Source is a reference to the application source used for the sync operation
                     properties:
                       chart:
-                        description: Chart is a Helm chart name
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                         type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
                           exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                             type: string
                           include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                             type: string
                           jsonnet:
-                            description: ApplicationSourceJsonnet holds jsonnet specific options
+                            description: Jsonnet holds options specific to Jsonnet
                             properties:
                               extVars:
                                 description: ExtVars is a list of Jsonnet External Variables
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -719,7 +737,7 @@ spec:
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -734,6 +752,7 @@ spec:
                                 type: array
                             type: object
                           recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
                             type: boolean
                         type: object
                       helm:
@@ -742,34 +761,34 @@ spec:
                           fileParameters:
                             description: FileParameters are file parameters to the helm template
                             items:
-                              description: HelmFileParameter is a file parameter to a helm template
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                               properties:
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 path:
-                                  description: Path is the path value for the helm parameter
+                                  description: Path is the path to the file containing the values for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           parameters:
-                            description: Parameters are parameters to the helm template
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                             items:
-                              description: HelmParameter is a parameter to a helm template
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
                               properties:
                                 forceString:
                                   description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                   type: boolean
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 value:
-                                  description: Value is the value for the helm parameter
+                                  description: Value is the value for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           releaseName:
-                            description: The Helm release name. If omitted it will use the application name
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                             type: string
                           valueFiles:
                             description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -777,10 +796,10 @@ spec:
                               type: string
                             type: array
                           values:
-                            description: Values is Helm values, typically defined as a block
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
                             type: string
                           version:
-                            description: Version is the Helm version to use for templating with
+                            description: Version is the Helm version to use for templating (either "2" or "3")
                             type: string
                         type: object
                       ksonnet:
@@ -812,42 +831,45 @@ spec:
                           commonAnnotations:
                             additionalProperties:
                               type: string
-                            description: CommonAnnotations adds additional kustomize commonAnnotations
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                             type: object
                           commonLabels:
                             additionalProperties:
                               type: string
-                            description: CommonLabels adds additional kustomize commonLabels
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
                             type: object
                           images:
-                            description: Images are kustomize image overrides
+                            description: Images is a list of Kustomize image override specifications
                             items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                               type: string
                             type: array
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources for kustomize apps
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources for kustomize apps
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
                             type: string
                           version:
-                            description: Version contains optional Kustomize version
+                            description: Version controls which version of Kustomize to use for rendering manifests
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the Git repository
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                         type: string
                       plugin:
                         description: ConfigManagementPlugin holds config management plugin specific options
                         properties:
                           env:
+                            description: Env is a list of environment variable entries
                             items:
+                              description: EnvEntry represents an entry in the application's environment
                               properties:
                                 name:
-                                  description: the name, usually uppercase
+                                  description: Name is the name of the variable, usually expressed in uppercase
                                   type: string
                                 value:
-                                  description: the value
+                                  description: Value is the value of the variable
                                   type: string
                               required:
                               - name
@@ -858,10 +880,10 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the repository URL of the application manifests
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
@@ -877,19 +899,20 @@ spec:
               format: date-time
               type: string
             operationState:
-              description: OperationState contains information about state of currently performing operation on application.
+              description: OperationState contains information about any ongoing operations, such as a sync
               properties:
                 finishedAt:
                   description: FinishedAt contains time of operation completion
                   format: date-time
                   type: string
                 message:
-                  description: Message hold any pertinent messages when attempting to perform operation (typically errors).
+                  description: Message holds any pertinent messages when attempting to perform operation (typically errors).
                   type: string
                 operation:
                   description: Operation is the original requested operation
                   properties:
                     info:
+                      description: Info is a list of informational items for this operation
                       items:
                         properties:
                           name:
@@ -902,20 +925,20 @@ spec:
                         type: object
                       type: array
                     initiatedBy:
-                      description: OperationInitiator holds information about the operation initiator
+                      description: InitiatedBy contains information about who initiated the operations
                       properties:
                         automated:
                           description: Automated is set to true if operation was initiated automatically by the application controller.
                           type: boolean
                         username:
-                          description: Name of a user who started operation.
+                          description: Username contains the name of a user who started operation
                           type: string
                       type: object
                     retry:
-                      description: Retry controls failed sync retry behavior
+                      description: Retry controls the strategy to apply if a sync fails
                       properties:
                         backoff:
-                          description: Backoff is a backoff strategy
+                          description: Backoff controls how to backoff on subsequent retries of failed syncs
                           properties:
                             duration:
                               description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
@@ -929,15 +952,15 @@ spec:
                               type: string
                           type: object
                         limit:
-                          description: Limit is the maximum number of attempts when retrying a container
+                          description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
                           format: int64
                           type: integer
                       type: object
                     sync:
-                      description: SyncOperation contains sync operation details.
+                      description: Sync contains parameters for the operation
                       properties:
                         dryRun:
-                          description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+                          description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
                           type: boolean
                         manifests:
                           description: Manifests is an optional field that overrides sync source with a local directory for development
@@ -945,10 +968,10 @@ spec:
                             type: string
                           type: array
                         prune:
-                          description: Prune deletes resources that are no longer tracked in git
+                          description: Prune specifies to delete resources from the cluster that are no longer tracked in git
                           type: boolean
                         resources:
-                          description: Resources describes which resources to sync
+                          description: Resources describes which resources shall be part of the sync
                           items:
                             description: SyncOperationResource contains resources to sync.
                             properties:
@@ -966,28 +989,30 @@ spec:
                             type: object
                           type: array
                         revision:
-                          description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
+                          description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                           type: string
                         source:
-                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
+                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                           properties:
                             chart:
-                              description: Chart is a Helm chart name
+                              description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                               type: string
                             directory:
                               description: Directory holds path/directory specific options
                               properties:
                                 exclude:
+                                  description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                                   type: string
                                 include:
+                                  description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                                   type: string
                                 jsonnet:
-                                  description: ApplicationSourceJsonnet holds jsonnet specific options
+                                  description: Jsonnet holds options specific to Jsonnet
                                   properties:
                                     extVars:
                                       description: ExtVars is a list of Jsonnet External Variables
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1008,7 +1033,7 @@ spec:
                                     tlas:
                                       description: TLAS is a list of Jsonnet Top-level Arguments
                                       items:
-                                        description: JsonnetVar is a jsonnet variable
+                                        description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                         properties:
                                           code:
                                             type: boolean
@@ -1023,6 +1048,7 @@ spec:
                                       type: array
                                   type: object
                                 recurse:
+                                  description: Recurse specifies whether to scan a directory recursively for manifests
                                   type: boolean
                               type: object
                             helm:
@@ -1031,34 +1057,34 @@ spec:
                                 fileParameters:
                                   description: FileParameters are file parameters to the helm template
                                   items:
-                                    description: HelmFileParameter is a file parameter to a helm template
+                                    description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                     properties:
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       path:
-                                        description: Path is the path value for the helm parameter
+                                        description: Path is the path to the file containing the values for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 parameters:
-                                  description: Parameters are parameters to the helm template
+                                  description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                                   items:
-                                    description: HelmParameter is a parameter to a helm template
+                                    description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                     properties:
                                       forceString:
                                         description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                         type: boolean
                                       name:
-                                        description: Name is the name of the helm parameter
+                                        description: Name is the name of the Helm parameter
                                         type: string
                                       value:
-                                        description: Value is the value for the helm parameter
+                                        description: Value is the value for the Helm parameter
                                         type: string
                                     type: object
                                   type: array
                                 releaseName:
-                                  description: The Helm release name. If omitted it will use the application name
+                                  description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                                   type: string
                                 valueFiles:
                                   description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1066,10 +1092,10 @@ spec:
                                     type: string
                                   type: array
                                 values:
-                                  description: Values is Helm values, typically defined as a block
+                                  description: Values specifies Helm values to be passed to helm template, typically defined as a block
                                   type: string
                                 version:
-                                  description: Version is the Helm version to use for templating with
+                                  description: Version is the Helm version to use for templating (either "2" or "3")
                                   type: string
                               type: object
                             ksonnet:
@@ -1101,42 +1127,45 @@ spec:
                                 commonAnnotations:
                                   additionalProperties:
                                     type: string
-                                  description: CommonAnnotations adds additional kustomize commonAnnotations
+                                  description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                                   type: object
                                 commonLabels:
                                   additionalProperties:
                                     type: string
-                                  description: CommonLabels adds additional kustomize commonLabels
+                                  description: CommonLabels is a list of additional labels to add to rendered manifests
                                   type: object
                                 images:
-                                  description: Images are kustomize image overrides
+                                  description: Images is a list of Kustomize image override specifications
                                   items:
+                                    description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                     type: string
                                   type: array
                                 namePrefix:
-                                  description: NamePrefix is a prefix appended to resources for kustomize apps
+                                  description: NamePrefix is a prefix appended to resources for Kustomize apps
                                   type: string
                                 nameSuffix:
-                                  description: NameSuffix is a suffix appended to resources for kustomize apps
+                                  description: NameSuffix is a suffix appended to resources for Kustomize apps
                                   type: string
                                 version:
-                                  description: Version contains optional Kustomize version
+                                  description: Version controls which version of Kustomize to use for rendering manifests
                                   type: string
                               type: object
                             path:
-                              description: Path is a directory path within the Git repository
+                              description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                               type: string
                             plugin:
                               description: ConfigManagementPlugin holds config management plugin specific options
                               properties:
                                 env:
+                                  description: Env is a list of environment variable entries
                                   items:
+                                    description: EnvEntry represents an entry in the application's environment
                                     properties:
                                       name:
-                                        description: the name, usually uppercase
+                                        description: Name is the name of the variable, usually expressed in uppercase
                                         type: string
                                       value:
-                                        description: the value
+                                        description: Value is the value of the variable
                                         type: string
                                     required:
                                     - name
@@ -1147,10 +1176,10 @@ spec:
                                   type: string
                               type: object
                             repoURL:
-                              description: RepoURL is the repository URL of the application manifests
+                              description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                              description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -1195,34 +1224,39 @@ spec:
                   description: SyncResult is the result of a Sync operation
                   properties:
                     resources:
-                      description: Resources holds the sync result of each individual resource
+                      description: Resources contains a list of sync result items for each individual resource in a sync operation
                       items:
                         description: ResourceResult holds the operation result details of a specific resource
                         properties:
                           group:
+                            description: Group specifies the API group of the resource
                             type: string
                           hookPhase:
-                            description: 'the state of any operation associated with this resource OR hook note: can contain values for non-hook resources'
+                            description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
                             type: string
                           hookType:
-                            description: the type of the hook, empty for non-hook resources
+                            description: HookType specifies the type of the hook. Empty for non-hook resources
                             type: string
                           kind:
+                            description: Kind specifies the API kind of the resource
                             type: string
                           message:
-                            description: message for the last sync OR operation
+                            description: Message contains an informational or error message for the last sync OR operation
                             type: string
                           name:
+                            description: Name specifies the name of the resource
                             type: string
                           namespace:
+                            description: Namespace specifies the target namespace of the resource
                             type: string
                           status:
-                            description: the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                            description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
                             type: string
                           syncPhase:
-                            description: indicates the particular phase of the sync that this is for
+                            description: SyncPhase indicates the particular phase of the sync that this result was acquired in
                             type: string
                           version:
+                            description: Version specifies the API version of the resource
                             type: string
                         required:
                         - group
@@ -1233,28 +1267,30 @@ spec:
                         type: object
                       type: array
                     revision:
-                      description: Revision holds the revision of the sync
+                      description: Revision holds the revision this sync operation was performed to
                       type: string
                     source:
                       description: Source records the application source information of the sync, used for comparing auto-sync
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1275,7 +1311,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1290,6 +1326,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1298,34 +1335,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1333,10 +1370,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1368,42 +1405,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1414,10 +1454,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1435,17 +1475,20 @@ spec:
               format: date-time
               type: string
             resources:
+              description: Resources is a list of Kubernetes resources managed by this application
               items:
-                description: ResourceStatus holds the current sync and health status of a resource
+                description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
                 properties:
                   group:
                     type: string
                   health:
+                    description: HealthStatus contains information about the currently observed health state of an application or resource
                     properties:
                       message:
+                        description: Message is a human-readable informational message describing the health status
                         type: string
                       status:
-                        description: Represents resource health status
+                        description: Status holds the status code of the application or resource
                         type: string
                     type: object
                   hook:
@@ -1466,8 +1509,10 @@ spec:
                 type: object
               type: array
             sourceType:
+              description: SourceType specifies the type of this application
               type: string
             summary:
+              description: Summary contains a list of URLs and container images used by this application
               properties:
                 externalURLs:
                   description: ExternalURLs holds all external URLs of application child resources.
@@ -1481,44 +1526,46 @@ spec:
                   type: array
               type: object
             sync:
-              description: SyncStatus is a comparison result of application spec and deployed application.
+              description: Sync contains information about the application's current sync status
               properties:
                 comparedTo:
-                  description: ComparedTo contains application source and target which was used for resources comparison
+                  description: ComparedTo contains information about what has been compared
                   properties:
                     destination:
-                      description: ApplicationDestination contains deployment destination information
+                      description: Destination is a reference to the application's destination used for comparison
                       properties:
                         name:
-                          description: Name of the destination cluster which can be used instead of server (url) field
+                          description: Name is an alternate way of specifying the target cluster by its symbolic name
                           type: string
                         namespace:
-                          description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                          description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                           type: string
                         server:
-                          description: Server overrides the environment server value in the ksonnet app.yaml
+                          description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                           type: string
                       type: object
                     source:
-                      description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                      description: Source is a reference to the application's source used for comparison
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
                             exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
                               type: string
                             include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
                               type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1539,7 +1586,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1554,6 +1601,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1562,34 +1610,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1597,10 +1645,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
                               type: string
                             version:
-                              description: Version is the Helm version to use for templating with
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1632,42 +1680,45 @@ spec:
                             commonAnnotations:
                               additionalProperties:
                                 type: string
-                              description: CommonAnnotations adds additional kustomize commonAnnotations
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
                               type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1678,10 +1729,10 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -1691,9 +1742,10 @@ spec:
                   - source
                   type: object
                 revision:
+                  description: Revision contains information about the revision the comparison has been performed to
                   type: string
                 status:
-                  description: SyncStatusCode is a type which represents possible comparison results
+                  description: Status is the sync state of the comparison
                   type: string
               required:
               - status
@@ -1776,16 +1828,16 @@ spec:
             destinations:
               description: Destinations contains list of destinations available for deployment
               items:
-                description: ApplicationDestination contains deployment destination information
+                description: ApplicationDestination holds information about the application's destination
                 properties:
                   name:
-                    description: Name of the destination cluster which can be used instead of server (url) field
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
                     type: string
                   namespace:
-                    description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
-                    description: Server overrides the environment server value in the ksonnet app.yaml
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                     type: string
                 type: object
               type: array
@@ -1821,7 +1873,9 @@ spec:
               description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
               properties:
                 ignore:
+                  description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
                   items:
+                    description: OrphanedResourceKey is a reference to a resource to be ignored from
                     properties:
                       group:
                         type: string
@@ -1878,7 +1932,7 @@ spec:
                 type: object
               type: array
             signatureKeys:
-              description: List of PGP key IDs that commits to be synced to must be signed with
+              description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
               items:
                 description: SignatureKey is the specification of a key required to verify commit signatures with
                 properties:

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -77,15 +77,16 @@ message AppProjectSpec {
   // NamespaceResourceWhitelist contains list of whitelisted namespace level resources
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.GroupKind namespaceResourceWhitelist = 9;
 
-  // List of PGP key IDs that commits to be synced to must be signed with
+  // SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
   repeated SignatureKey signatureKeys = 10;
 
   // ClusterResourceBlacklist contains list of blacklisted cluster level resources
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.GroupKind clusterResourceBlacklist = 11;
 }
 
-// AppProjectStatus contains information about appproj
+// AppProjectStatus contains status information for AppProject CRs
 message AppProjectStatus {
+  // JWTTokensByRole contains a list of JWT tokens issued for a given role
   map<string, JWTTokens> jwtTokensByRole = 1;
 }
 
@@ -107,7 +108,7 @@ message Application {
   optional Operation operation = 4;
 }
 
-// ApplicationCondition contains details about current application condition
+// ApplicationCondition contains details about an application condition, which is usally an error or warning
 message ApplicationCondition {
   // Type is an application condition type
   optional string type = 1;
@@ -115,19 +116,20 @@ message ApplicationCondition {
   // Message contains human-readable message indicating details about condition
   optional string message = 2;
 
-  // LastTransitionTime is the time the condition was first observed.
+  // LastTransitionTime is the time the condition was last observed
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 }
 
-// ApplicationDestination contains deployment destination information
+// ApplicationDestination holds information about the application's destination
 message ApplicationDestination {
-  // Server overrides the environment server value in the ksonnet app.yaml
+  // Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
   optional string server = 1;
 
-  // Namespace overrides the environment namespace value in the ksonnet app.yaml
+  // Namespace specifies the target namespace for the application's resources.
+  // The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
   optional string namespace = 2;
 
-  // Name of the destination cluster which can be used instead of server (url) field
+  // Name is an alternate way of specifying the target cluster by its symbolic name
   optional string name = 3;
 }
 
@@ -139,16 +141,17 @@ message ApplicationList {
   repeated Application items = 2;
 }
 
-// ApplicationSource contains information about github repository, path within repository and target application environment.
+// ApplicationSource contains all required information about the source of an application
 message ApplicationSource {
-  // RepoURL is the repository URL of the application manifests
+  // RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
   optional string repoURL = 1;
 
-  // Path is a directory path within the Git repository
+  // Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
   optional string path = 2;
 
-  // TargetRevision defines the commit, tag, or branch in which to sync the application to.
-  // If omitted, will sync to HEAD
+  // TargetRevision defines the revision of the source to sync the application to.
+  // In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+  // In case of Helm, this is a semver tag for the Chart's version.
   optional string targetRevision = 4;
 
   // Helm holds helm specific options
@@ -166,17 +169,22 @@ message ApplicationSource {
   // ConfigManagementPlugin holds config management plugin specific options
   optional ApplicationSourcePlugin plugin = 11;
 
-  // Chart is a Helm chart name
+  // Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
   optional string chart = 12;
 }
 
+// ApplicationSourceDirectory holds options for applications of type plain YAML or Jsonnet
 message ApplicationSourceDirectory {
+  // Recurse specifies whether to scan a directory recursively for manifests
   optional bool recurse = 1;
 
+  // Jsonnet holds options specific to Jsonnet
   optional ApplicationSourceJsonnet jsonnet = 2;
 
+  // Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
   optional string exclude = 3;
 
+  // Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
   optional string include = 4;
 }
 
@@ -185,23 +193,23 @@ message ApplicationSourceHelm {
   // ValuesFiles is a list of Helm value files to use when generating a template
   repeated string valueFiles = 1;
 
-  // Parameters are parameters to the helm template
+  // Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
   repeated HelmParameter parameters = 2;
 
-  // The Helm release name. If omitted it will use the application name
+  // ReleaseName is the Helm release name to use. If omitted it will use the application name
   optional string releaseName = 3;
 
-  // Values is Helm values, typically defined as a block
+  // Values specifies Helm values to be passed to helm template, typically defined as a block
   optional string values = 4;
 
   // FileParameters are file parameters to the helm template
   repeated HelmFileParameter fileParameters = 5;
 
-  // Version is the Helm version to use for templating with
+  // Version is the Helm version to use for templating (either "2" or "3")
   optional string version = 6;
 }
 
-// ApplicationSourceJsonnet holds jsonnet specific options
+// ApplicationSourceJsonnet holds options specific to applications of type Jsonnet
 message ApplicationSourceJsonnet {
   // ExtVars is a list of Jsonnet External Variables
   repeated JsonnetVar extVars = 1;
@@ -222,28 +230,28 @@ message ApplicationSourceKsonnet {
   repeated KsonnetParameter parameters = 2;
 }
 
-// ApplicationSourceKustomize holds kustomize specific options
+// ApplicationSourceKustomize holds options specific to an Application source specific to Kustomize
 message ApplicationSourceKustomize {
-  // NamePrefix is a prefix appended to resources for kustomize apps
+  // NamePrefix is a prefix appended to resources for Kustomize apps
   optional string namePrefix = 1;
 
-  // NameSuffix is a suffix appended to resources for kustomize apps
+  // NameSuffix is a suffix appended to resources for Kustomize apps
   optional string nameSuffix = 2;
 
-  // Images are kustomize image overrides
+  // Images is a list of Kustomize image override specifications
   repeated string images = 3;
 
-  // CommonLabels adds additional kustomize commonLabels
+  // CommonLabels is a list of additional labels to add to rendered manifests
   map<string, string> commonLabels = 4;
 
-  // Version contains optional Kustomize version
+  // Version controls which version of Kustomize to use for rendering manifests
   optional string version = 5;
 
-  // CommonAnnotations adds additional kustomize commonAnnotations
+  // CommonAnnotations is a list of additional annotations to add to rendered manifests
   map<string, string> commonAnnotations = 6;
 }
 
-// ApplicationSourcePlugin holds config management plugin specific options
+// ApplicationSourcePlugin holds options specific to config management plugins
 message ApplicationSourcePlugin {
   optional string name = 1;
 
@@ -252,25 +260,26 @@ message ApplicationSourcePlugin {
 
 // ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
 message ApplicationSpec {
-  // Source is a reference to the location ksonnet application definition
+  // Source is a reference to the location of the application's manifests or chart
   optional ApplicationSource source = 1;
 
-  // Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+  // Destination is a reference to the target Kubernetes server and namespace
   optional ApplicationDestination destination = 2;
 
-  // Project is a application project name. Empty name means that application belongs to 'default' project.
+  // Project is a reference to the project this application belongs to.
+  // The empty string means that application belongs to the 'default' project.
   optional string project = 3;
 
-  // SyncPolicy controls when a sync will be performed
+  // SyncPolicy controls when and how a sync will be performed
   optional SyncPolicy syncPolicy = 4;
 
-  // IgnoreDifferences controls resources fields which should be ignored during comparison
+  // IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
   repeated ResourceIgnoreDifferences ignoreDifferences = 5;
 
-  // Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+  // Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
   repeated Info info = 6;
 
-  // This limits this number of items kept in the apps revision history.
+  // RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.
   // This should only be changed in exceptional circumstances.
   // Setting to zero will store no history. This will reduce storage used.
   // Increasing will increase the space used to store the history, so we do not recommend increasing it.
@@ -278,32 +287,41 @@ message ApplicationSpec {
   optional int64 revisionHistoryLimit = 7;
 }
 
-// ApplicationStatus contains information about application sync, health status
+// ApplicationStatus contains status information for the application
 message ApplicationStatus {
+  // Resources is a list of Kubernetes resources managed by this application
   repeated ResourceStatus resources = 1;
 
+  // Sync contains information about the application's current sync status
   optional SyncStatus sync = 2;
 
+  // Health contains information about the application's current health status
   optional HealthStatus health = 3;
 
+  // History contains information about the application's sync history
   repeated RevisionHistory history = 4;
 
+  // Conditions is a list of currently observed application conditions
   repeated ApplicationCondition conditions = 5;
 
   // ReconciledAt indicates when the application state was reconciled using the latest git version
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time reconciledAt = 6;
 
+  // OperationState contains information about any ongoing operations, such as a sync
   optional OperationState operationState = 7;
 
   // ObservedAt indicates when the application state was updated without querying latest git state
   // Deprecated: controller no longer updates ObservedAt field
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time observedAt = 8;
 
+  // SourceType specifies the type of this application
   optional string sourceType = 9;
 
+  // Summary contains a list of URLs and container images used by this application
   optional ApplicationSummary summary = 10;
 }
 
+// ApplicationSummary contains information about URLs and container images used by an application
 message ApplicationSummary {
   // ExternalURLs holds all external URLs of application child resources.
   repeated string externalURLs = 1;
@@ -313,6 +331,7 @@ message ApplicationSummary {
 }
 
 // ApplicationTree holds nodes which belongs to the application
+// TODO: describe purpose of this type
 message ApplicationTree {
   // Nodes contains list of nodes which either directly managed by the application and children of directly managed nodes.
   repeated ResourceNode nodes = 1;
@@ -336,7 +355,7 @@ message ApplicationWatchEvent {
   optional Application application = 2;
 }
 
-// Backoff is a backoff strategy to use within retryStrategy
+// Backoff is the backoff strategy to use on subsequent retries for failing syncs
 message Backoff {
   // Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
   optional string duration = 1;
@@ -367,19 +386,20 @@ message Cluster {
   // The server version
   optional string serverVersion = 5;
 
-  // Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
+  // Holds list of namespaces which are accessible in that cluster. Cluster level resources will be ignored if namespace list is not empty.
   repeated string namespaces = 6;
 
   // RefreshRequestedAt holds time when cluster cache refresh has been requested
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time refreshRequestedAt = 7;
 
-  // Holds information about cluster cache
+  // Info holds information about cluster cache and state
   optional ClusterInfo info = 8;
 
   // Shard contains optional shard number. Calculated on the fly by the application controller if not specified.
   optional int64 shard = 9;
 }
 
+// ClusterCacheInfo contains information about the cluster cache
 message ClusterCacheInfo {
   // ResourcesCount holds number of observed Kubernetes resources
   optional int64 resourcesCount = 1;
@@ -414,13 +434,18 @@ message ClusterConfig {
   optional ExecProviderConfig execProviderConfig = 6;
 }
 
+// ClusterInfo contains information about the cluster
 message ClusterInfo {
+  // ConnectionState contains information about the connection to the cluster
   optional ConnectionState connectionState = 1;
 
+  // ServerVersion contains information about the Kubernetes version of the cluster
   optional string serverVersion = 2;
 
+  // CacheInfo contains information about the cluster cache
   optional ClusterCacheInfo cacheInfo = 3;
 
+  // ApplicationsCount is the number of applications managed by Argo CD on the cluster
   optional int64 applicationsCount = 4;
 }
 
@@ -440,8 +465,10 @@ message Command {
 
 // ComparedTo contains application source and target which was used for resources comparison
 message ComparedTo {
+  // Source is a reference to the application's source used for comparison
   optional ApplicationSource source = 1;
 
+  // Destination is a reference to the application's destination used for comparison
   optional ApplicationDestination destination = 2;
 }
 
@@ -463,20 +490,24 @@ message ConfigManagementPlugin {
   optional Command generate = 3;
 }
 
-// ConnectionState contains information about remote resource connection state
+// ConnectionState contains information about remote resource connection state, currently used for clusters and repositories
 message ConnectionState {
+  // Status contains the current status indicator for the connection
   optional string status = 1;
 
+  // Message contains human readable information about the connection status
   optional string message = 2;
 
+  // ModifiedAt contains the timestamp when this connection status has been determined
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time attemptedAt = 3;
 }
 
+// EnvEntry represents an entry in the application's environment
 message EnvEntry {
-  // the name, usually uppercase
+  // Name is the name of the variable, usually expressed in uppercase
   optional string name = 1;
 
-  // the value
+  // Value is the value of the variable
   optional string value = 2;
 }
 
@@ -501,22 +532,22 @@ message ExecProviderConfig {
 
 // GnuPGPublicKey is a representation of a GnuPG public key
 message GnuPGPublicKey {
-  // KeyID in hexadecimal string format
+  // KeyID specifies the key ID, in hexadecimal string format
   optional string keyID = 1;
 
-  // Fingerprint of the key
+  // Fingerprint is the fingerprint of the key
   optional string fingerprint = 2;
 
-  // Owner identification
+  // Owner holds the owner identification, e.g. a name and e-mail address
   optional string owner = 3;
 
-  // Trust level
+  // Trust holds the level of trust assigned to this key
   optional string trust = 4;
 
-  // Key sub type (e.g. rsa4096)
+  // SubType holds the key's sub type (e.g. rsa4096)
   optional string subType = 5;
 
-  // Key data
+  // KeyData holds the raw key data, in base64 encoded format
   optional string keyData = 6;
 }
 
@@ -527,27 +558,30 @@ message GnuPGPublicKeyList {
   repeated GnuPGPublicKey items = 2;
 }
 
+// HealthStatus contains information about the currently observed health state of an application or resource
 message HealthStatus {
+  // Status holds the status code of the application or resource
   optional string status = 1;
 
+  // Message is a human-readable informational message describing the health status
   optional string message = 2;
 }
 
-// HelmFileParameter is a file parameter to a helm template
+// HelmFileParameter is a file parameter that's passed to helm template during manifest generation
 message HelmFileParameter {
-  // Name is the name of the helm parameter
+  // Name is the name of the Helm parameter
   optional string name = 1;
 
-  // Path is the path value for the helm parameter
+  // Path is the path to the file containing the values for the Helm parameter
   optional string path = 2;
 }
 
-// HelmParameter is a parameter to a helm template
+// HelmParameter is a parameter that's passed to helm template during manifest generation
 message HelmParameter {
-  // Name is the name of the helm parameter
+  // Name is the name of the Helm parameter
   optional string name = 1;
 
-  // Value is the value for the helm parameter
+  // Value is the value for the Helm parameter
   optional string value = 2;
 
   // ForceString determines whether to tell Helm to interpret booleans and numbers as strings
@@ -555,6 +589,8 @@ message HelmParameter {
 }
 
 // HostInfo holds host name and resources metrics
+// TODO: describe purpose of this type
+// TODO: describe members of this type
 message HostInfo {
   optional string name = 1;
 
@@ -563,6 +599,7 @@ message HostInfo {
   optional k8s.io.api.core.v1.NodeSystemInfo systemInfo = 3;
 }
 
+// TODO: describe this type
 message HostResourceInfo {
   optional string resourceName = 1;
 
@@ -579,7 +616,7 @@ message Info {
   optional string value = 2;
 }
 
-// InfoItem contains human readable information about object
+// InfoItem contains arbitrary, human readable information about an application
 message InfoItem {
   // Name is a human readable title for this piece of information.
   optional string name = 1;
@@ -597,11 +634,12 @@ message JWTToken {
   optional string id = 3;
 }
 
+// JWTTokens represents a list of JWT tokens
 message JWTTokens {
   repeated JWTToken items = 1;
 }
 
-// JsonnetVar is a jsonnet variable
+// JsonnetVar represents a variable to be passed to jsonnet during manifest generation
 message JsonnetVar {
   optional string name = 1;
 
@@ -610,7 +648,9 @@ message JsonnetVar {
   optional bool code = 3;
 }
 
-// KnownTypeField contains mapping between CRD field and known Kubernetes type
+// KnownTypeField contains mapping between CRD field and known Kubernetes type.
+// This is mainly used for unit conversion in unknown resources (e.g. 0.1 == 100mi)
+// TODO: Describe the members of this type
 message KnownTypeField {
   optional string field = 1;
 
@@ -635,28 +675,31 @@ message KustomizeOptions {
   optional string binaryPath = 2;
 }
 
-// Operation contains requested operation parameters.
+// Operation contains information about a requested or running operation
 message Operation {
+  // Sync contains parameters for the operation
   optional SyncOperation sync = 1;
 
+  // InitiatedBy contains information about who initiated the operations
   optional OperationInitiator initiatedBy = 2;
 
+  // Info is a list of informational items for this operation
   repeated Info info = 3;
 
-  // Retry controls failed sync retry behavior
+  // Retry controls the strategy to apply if a sync fails
   optional RetryStrategy retry = 4;
 }
 
-// OperationInitiator holds information about the operation initiator
+// OperationInitiator contains information about the initiator of an operation
 message OperationInitiator {
-  // Name of a user who started operation.
+  // Username contains the name of a user who started operation
   optional string username = 1;
 
   // Automated is set to true if operation was initiated automatically by the application controller.
   optional bool automated = 2;
 }
 
-// OperationState contains information about state of currently performing operation on application.
+// OperationState contains information about state of a running operation
 message OperationState {
   // Operation is the original requested operation
   optional Operation operation = 1;
@@ -664,7 +707,7 @@ message OperationState {
   // Phase is the current phase of the operation
   optional string phase = 2;
 
-  // Message hold any pertinent messages when attempting to perform operation (typically errors).
+  // Message holds any pertinent messages when attempting to perform operation (typically errors).
   optional string message = 3;
 
   // SyncResult is the result of a Sync operation
@@ -680,6 +723,7 @@ message OperationState {
   optional int64 retryCount = 8;
 }
 
+// OrphanedResourceKey is a reference to a resource to be ignored from
 message OrphanedResourceKey {
   optional string group = 1;
 
@@ -693,9 +737,11 @@ message OrphanedResourcesMonitorSettings {
   // Warn indicates if warning condition should be created for apps which have orphaned resources
   optional bool warn = 1;
 
+  // Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
   repeated OrphanedResourceKey ignore = 2;
 }
 
+// TODO: describe this type
 message OverrideIgnoreDiff {
   repeated string jSONPointers = 1;
 }
@@ -718,7 +764,7 @@ message ProjectRole {
   repeated string groups = 5;
 }
 
-// RepoCreds holds a repository credentials definition
+// RepoCreds holds the definition for repository credentials
 message RepoCreds {
   // URL is the URL that this credentials matches to
   optional string url = 1;
@@ -729,25 +775,25 @@ message RepoCreds {
   // Password for authenticating at the repo server
   optional string password = 3;
 
-  // SSH private key data for authenticating at the repo server (only Git repos)
+  // SSHPrivateKey contains the private key data for authenticating at the repo server using SSH (only Git repos)
   optional string sshPrivateKey = 4;
 
-  // TLS client cert data for authenticating at the repo server
+  // TLSClientCertData specifies the TLS client cert data for authenticating at the repo server
   optional string tlsClientCertData = 5;
 
-  // TLS client cert key for authenticating at the repo server
+  // TLSClientCertKey specifies the TLS client cert key for authenticating at the repo server
   optional string tlsClientCertKey = 6;
 
-  // Github App Private Key PEM data
+  // GithubAppPrivateKey specifies the private key PEM data for authentication via GitHub app
   optional string githubAppPrivateKey = 7;
 
-  // Github App ID of the app used to access the repo
+  // GithubAppId specifies the Github App ID of the app used to access the repo for GitHub app authentication
   optional int64 githubAppID = 8;
 
-  // Github App Installation ID of the installed GitHub App
+  // GithubAppInstallationId specifies the ID of the installed GitHub App for GitHub app authentication
   optional int64 githubAppInstallationID = 9;
 
-  // Github App Enterprise base url if empty will default to https://api.github.com
+  // GithubAppEnterpriseBaseURL specifies the GitHub API URL for GitHub app authentication. If empty will default to https://api.github.com
   optional string githubAppEnterpriseBaseUrl = 10;
 }
 
@@ -760,78 +806,77 @@ message RepoCredsList {
 
 // Repository is a repository holding application configurations
 message Repository {
-  // URL of the repo
+  // Repo contains the URL to the remote repository
   optional string repo = 1;
 
-  // Username for authenticating at the repo server
+  // Username contains the user name used for authenticating at the remote repository
   optional string username = 2;
 
-  // Password for authenticating at the repo server
+  // Password contains the password or PAT used for authenticating at the remote repository
   optional string password = 3;
 
-  // SSH private key data for authenticating at the repo server
-  // only for Git repos
+  // SSHPrivateKey contains the PEM data for authenticating at the repo server. Only used with Git repos.
   optional string sshPrivateKey = 4;
 
-  // Current state of repository server connecting
+  // ConnectionState contains information about the current state of connection to the repository server
   optional ConnectionState connectionState = 5;
 
   // InsecureIgnoreHostKey should not be used anymore, Insecure is favoured
-  // only for Git repos
+  // Used only for Git repos
   optional bool insecureIgnoreHostKey = 6;
 
-  // Whether the repo is insecure
+  // Insecure specifies whether the connection to the repository ignores any errors when verifying TLS certificates or SSH host keys
   optional bool insecure = 7;
 
-  // Whether git-lfs support should be enabled for this repo
+  // EnableLFS specifies whether git-lfs support should be enabled for this repo. Only valid for Git repositories.
   optional bool enableLfs = 8;
 
-  // TLS client cert data for authenticating at the repo server
+  // TLSClientCertData contains a certificate in PEM format for authenticating at the repo server
   optional string tlsClientCertData = 9;
 
-  // TLS client cert key for authenticating at the repo server
+  // TLSClientCertKey contains a private key in PEM format for authenticating at the repo server
   optional string tlsClientCertKey = 10;
 
-  // type of the repo, maybe "git or "helm, "git" is assumed if empty or absent
+  // Type specifies the type of the repo. Can be either "git" or "helm. "git" is assumed if empty or absent.
   optional string type = 11;
 
-  // only for Helm repos
+  // Name specifies a name to be used for this repo. Only used with Helm repos
   optional string name = 12;
 
   // Whether credentials were inherited from a credential set
   optional bool inheritedCreds = 13;
 
-  // Whether helm-oci support should be enabled for this repo
+  // EnableOCI specifies whether helm-oci support should be enabled for this repo
   optional bool enableOCI = 14;
 
   // Github App Private Key PEM data
   optional string githubAppPrivateKey = 15;
 
-  // Github App ID of the app used to access the repo
+  // GithubAppId specifies the ID of the GitHub app used to access the repo
   optional int64 githubAppID = 16;
 
-  // Github App Installation ID of the installed GitHub App
+  // GithubAppInstallationId specifies the installation ID of the GitHub App used to access the repo
   optional int64 githubAppInstallationID = 17;
 
-  // Github App Enterprise base url if empty will default to https://api.github.com
+  // GithubAppEnterpriseBaseURL specifies the base URL of GitHub Enterprise installation. If empty will default to https://api.github.com
   optional string githubAppEnterpriseBaseUrl = 18;
 }
 
 // A RepositoryCertificate is either SSH known hosts entry or TLS certificate
 message RepositoryCertificate {
-  // Name of the server the certificate is intended for
+  // ServerName specifies the DNS name of the server this certificate is intended for
   optional string serverName = 1;
 
-  // Type of certificate - currently "https" or "ssh"
+  // CertType specifies the type of the certificate - currently one of "https" or "ssh"
   optional string certType = 2;
 
-  // The sub type of the cert, i.e. "ssh-rsa"
+  // CertSubType specifies the sub type of the cert, i.e. "ssh-rsa"
   optional string certSubType = 3;
 
-  // Actual certificate data, protocol dependent
+  // CertData contains the actual certificate data, dependent on the certificate type
   optional bytes certData = 4;
 
-  // Additional certificate info (e.g. SSH fingerprint, X509 CommonName)
+  // CertInfo will hold additional certificate info, depdendent on the certificate type (e.g. SSH fingerprint, X509 CommonName)
   optional string certInfo = 5;
 }
 
@@ -850,6 +895,8 @@ message RepositoryList {
   repeated Repository items = 2;
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 message ResourceAction {
   optional string name = 1;
 
@@ -858,12 +905,16 @@ message ResourceAction {
   optional bool disabled = 3;
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 message ResourceActionDefinition {
   optional string name = 1;
 
   optional string actionLua = 2;
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 message ResourceActionParam {
   optional string name = 1;
 
@@ -874,6 +925,8 @@ message ResourceActionParam {
   optional string default = 4;
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 message ResourceActions {
   optional string actionDiscoveryLua = 1;
 
@@ -881,6 +934,7 @@ message ResourceActions {
 }
 
 // ResourceDiff holds the diff of a live and target resource object
+// TODO: describe members of this type
 message ResourceDiff {
   optional string group = 1;
 
@@ -927,6 +981,7 @@ message ResourceIgnoreDifferences {
 }
 
 // ResourceNetworkingInfo holds networking resource related information
+// TODO: describe members of this type
 message ResourceNetworkingInfo {
   map<string, string> targetLabels = 1;
 
@@ -941,6 +996,7 @@ message ResourceNetworkingInfo {
 }
 
 // ResourceNode contains information about live resource and its children
+// TODO: describe members of this type
 message ResourceNode {
   optional ResourceRef resourceRef = 1;
 
@@ -960,6 +1016,7 @@ message ResourceNode {
 }
 
 // ResourceOverride holds configuration to customize resource diffing and health assessment
+// TODO: describe the members of this type
 message ResourceOverride {
   optional string healthLua = 1;
 
@@ -970,7 +1027,7 @@ message ResourceOverride {
   repeated KnownTypeField knownTypeFields = 4;
 }
 
-// ResourceRef includes fields which unique identify resource
+// ResourceRef includes fields which uniquely identify a resource
 message ResourceRef {
   optional string group = 1;
 
@@ -987,34 +1044,40 @@ message ResourceRef {
 
 // ResourceResult holds the operation result details of a specific resource
 message ResourceResult {
+  // Group specifies the API group of the resource
   optional string group = 1;
 
+  // Version specifies the API version of the resource
   optional string version = 2;
 
+  // Kind specifies the API kind of the resource
   optional string kind = 3;
 
+  // Namespace specifies the target namespace of the resource
   optional string namespace = 4;
 
+  // Name specifies the name of the resource
   optional string name = 5;
 
-  // the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+  // Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
   optional string status = 6;
 
-  // message for the last sync OR operation
+  // Message contains an informational or error message for the last sync OR operation
   optional string message = 7;
 
-  // the type of the hook, empty for non-hook resources
+  // HookType specifies the type of the hook. Empty for non-hook resources
   optional string hookType = 8;
 
-  // the state of any operation associated with this resource OR hook
-  // note: can contain values for non-hook resources
+  // HookPhase contains the state of any operation associated with this resource OR hook
+  // This can also contain values for non-hook resources.
   optional string hookPhase = 9;
 
-  // indicates the particular phase of the sync that this is for
+  // SyncPhase indicates the particular phase of the sync that this result was acquired in
   optional string syncPhase = 10;
 }
 
 // ResourceStatus holds the current sync and health status of a resource
+// TODO: describe members of this type
 message ResourceStatus {
   optional string group = 1;
 
@@ -1035,52 +1098,52 @@ message ResourceStatus {
   optional bool requiresPruning = 9;
 }
 
+// RetryStrategy contains information about the strategy to apply when a sync failed
 message RetryStrategy {
-  // Limit is the maximum number of attempts when retrying a container
+  // Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
   optional int64 limit = 1;
 
-  // Backoff is a backoff strategy
+  // Backoff controls how to backoff on subsequent retries of failed syncs
   optional Backoff backoff = 2;
 }
 
-// RevisionHistory contains information relevant to an application deployment
+// RevisionHistory contains history information about a previous sync
 message RevisionHistory {
-  // Revision holds the revision of the sync
+  // Revision holds the revision the sync was performed against
   optional string revision = 2;
 
-  // DeployedAt holds the time the deployment completed
+  // DeployedAt holds the time the sync operation completed
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time deployedAt = 4;
 
   // ID is an auto incrementing identifier of the RevisionHistory
   optional int64 id = 5;
 
+  // Source is a reference to the application source used for the sync operation
   optional ApplicationSource source = 6;
 
-  // DeployStartedAt holds the time the deployment started
+  // DeployStartedAt holds the time the sync operation started
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time deployStartedAt = 7;
 }
 
-// data about a specific revision within a repo
+// RevisionMetadata contains metadata for a specific revision in a Git repository
 message RevisionMetadata {
   // who authored this revision,
   // typically their name and email, e.g. "John Doe <john_doe@my-company.com>",
   // but might not match this example
   optional string author = 1;
 
-  // when the revision was authored
+  // Date specifies when the revision was authored
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time date = 2;
 
-  // tags on the revision,
-  // note - tags can move from one revision to another
+  // Tags specifies any tags currently attached to the revision
+  // Floating tags can move from one revision to another
   repeated string tags = 3;
 
-  // the message associated with the revision,
-  // probably the commit message,
-  // this is truncated to the first newline or 64 characters (which ever comes first)
+  // Message contains the message associated with the revision, most likely the commit message.
+  // The message is truncated to the first newline or 64 characters (which ever comes first)
   optional string message = 4;
 
-  // If revision was signed with GPG, and signature verification is enabled,
-  // this contains a hint on the signer
+  // SignatureInfo contains a hint on the signer if the revision was signed with GPG, and signature verification is enabled.
   optional string signatureInfo = 5;
 }
 
@@ -1090,26 +1153,26 @@ message SignatureKey {
   optional string keyID = 1;
 }
 
-// SyncOperation contains sync operation details.
+// SyncOperation contains details about a sync operation.
 message SyncOperation {
-  // Revision is the revision in which to sync the application to.
+  // Revision is the revision (Git) or chart version (Helm) which to sync the application to
   // If omitted, will use the revision specified in app spec.
   optional string revision = 1;
 
-  // Prune deletes resources that are no longer tracked in git
+  // Prune specifies to delete resources from the cluster that are no longer tracked in git
   optional bool prune = 2;
 
-  // DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+  // DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
   optional bool dryRun = 3;
 
   // SyncStrategy describes how to perform the sync
   optional SyncStrategy syncStrategy = 4;
 
-  // Resources describes which resources to sync
+  // Resources describes which resources shall be part of the sync
   repeated SyncOperationResource resources = 6;
 
   // Source overrides the source definition set in the application.
-  // This is typically set in a Rollback operation and nil during a Sync operation
+  // This is typically set in a Rollback operation and is nil during a Sync operation
   optional ApplicationSource source = 7;
 
   // Manifests is an optional field that overrides sync source with a local directory for development
@@ -1132,10 +1195,10 @@ message SyncOperationResource {
 
 // SyncOperationResult represent result of sync operation
 message SyncOperationResult {
-  // Resources holds the sync result of each individual resource
+  // Resources contains a list of sync result items for each individual resource in a sync operation
   repeated ResourceResult resources = 1;
 
-  // Revision holds the revision of the sync
+  // Revision holds the revision this sync operation was performed to
   optional string revision = 2;
 
   // Source records the application source information of the sync, used for comparing auto-sync
@@ -1156,22 +1219,25 @@ message SyncPolicy {
 
 // SyncPolicyAutomated controls the behavior of an automated sync
 message SyncPolicyAutomated {
-  // Prune will prune resources automatically as part of automated sync (default: false)
+  // Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)
   optional bool prune = 1;
 
-  // SelfHeal enables auto-syncing if  (default: false)
+  // SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)
   optional bool selfHeal = 2;
 
   // AllowEmpty allows apps have zero live resources (default: false)
   optional bool allowEmpty = 3;
 }
 
-// SyncStatus is a comparison result of application spec and deployed application.
+// SyncStatus contains information about the currently observed live and desired states of an application
 message SyncStatus {
+  // Status is the sync state of the comparison
   optional string status = 1;
 
+  // ComparedTo contains information about what has been compared
   optional ComparedTo comparedTo = 2;
 
+  // Revision contains information about the revision the comparison has been performed to
   optional string revision = 3;
 }
 
@@ -1226,7 +1292,7 @@ message SyncWindow {
 
 // TLSClientConfig contains settings to enable transport layer security
 message TLSClientConfig {
-  // Server should be accessed without verifying the TLS certificate. For testing only.
+  // Insecure specifies that the server should be accessed without verifying the TLS certificate. For testing only.
   optional bool insecure = 1;
 
   // ServerName is passed to the server for SNI and is used in the client to check server

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -351,7 +351,7 @@ func schema_pkg_apis_application_v1alpha1_AppProjectSpec(ref common.ReferenceCal
 					},
 					"signatureKeys": {
 						SchemaProps: spec.SchemaProps{
-							Description: "List of PGP key IDs that commits to be synced to must be signed with",
+							Description: "SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -389,12 +389,13 @@ func schema_pkg_apis_application_v1alpha1_AppProjectStatus(ref common.ReferenceC
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "AppProjectStatus contains information about appproj",
+				Description: "AppProjectStatus contains status information for AppProject CRs",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"jwtTokensByRole": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"object"},
+							Description: "JWTTokensByRole contains a list of JWT tokens issued for a given role",
+							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
 								Schema: &spec.Schema{
@@ -471,7 +472,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationCondition(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ApplicationCondition contains details about current application condition",
+				Description: "ApplicationCondition contains details about an application condition, which is usally an error or warning",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
@@ -492,7 +493,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationCondition(ref common.Refere
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LastTransitionTime is the time the condition was first observed.",
+							Description: "LastTransitionTime is the time the condition was last observed",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -509,26 +510,26 @@ func schema_pkg_apis_application_v1alpha1_ApplicationDestination(ref common.Refe
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ApplicationDestination contains deployment destination information",
+				Description: "ApplicationDestination holds information about the application's destination",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"server": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Server overrides the environment server value in the ksonnet app.yaml",
+							Description: "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace overrides the environment namespace value in the ksonnet app.yaml",
+							Description: "Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the destination cluster which can be used instead of server (url) field",
+							Description: "Name is an alternate way of specifying the target cluster by its symbolic name",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -592,12 +593,12 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSource(ref common.Reference
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ApplicationSource contains information about github repository, path within repository and target application environment.",
+				Description: "ApplicationSource contains all required information about the source of an application",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"repoURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RepoURL is the repository URL of the application manifests",
+							Description: "RepoURL is the URL to the repository (Git or Helm) that contains the application manifests",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -605,14 +606,14 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSource(ref common.Reference
 					},
 					"path": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Path is a directory path within the Git repository",
+							Description: "Path is a directory path within the Git repository, and is only valid for applications sourced from Git.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"targetRevision": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD",
+							Description: "TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -649,7 +650,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSource(ref common.Reference
 					},
 					"chart": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Chart is a Helm chart name",
+							Description: "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -667,30 +668,35 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceDirectory(ref common.
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "ApplicationSourceDirectory holds options for applications of type plain YAML or Jsonnet",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"recurse": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "Recurse specifies whether to scan a directory recursively for manifests",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"jsonnet": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSourceJsonnet"),
+							Description: "Jsonnet holds options specific to Jsonnet",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSourceJsonnet"),
 						},
 					},
 					"exclude": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"include": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Include contains a glob pattern to match paths against that should be explicitly included during manifest generation",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -725,7 +731,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceHelm(ref common.Refer
 					},
 					"parameters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Parameters are parameters to the helm template",
+							Description: "Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -739,14 +745,14 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceHelm(ref common.Refer
 					},
 					"releaseName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The Helm release name. If omitted it will use the application name",
+							Description: "ReleaseName is the Helm release name to use. If omitted it will use the application name",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Values is Helm values, typically defined as a block",
+							Description: "Values specifies Helm values to be passed to helm template, typically defined as a block",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -767,7 +773,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceHelm(ref common.Refer
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Version is the Helm version to use for templating with",
+							Description: "Version is the Helm version to use for templating (either \"2\" or \"3\")",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -784,7 +790,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceJsonnet(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ApplicationSourceJsonnet holds jsonnet specific options",
+				Description: "ApplicationSourceJsonnet holds options specific to applications of type Jsonnet",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"extVars": {
@@ -878,26 +884,26 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceKustomize(ref common.
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ApplicationSourceKustomize holds kustomize specific options",
+				Description: "ApplicationSourceKustomize holds options specific to an Application source specific to Kustomize",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"namePrefix": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NamePrefix is a prefix appended to resources for kustomize apps",
+							Description: "NamePrefix is a prefix appended to resources for Kustomize apps",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"nameSuffix": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NameSuffix is a suffix appended to resources for kustomize apps",
+							Description: "NameSuffix is a suffix appended to resources for Kustomize apps",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"images": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Images are kustomize image overrides",
+							Description: "Images is a list of Kustomize image override specifications",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -912,7 +918,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceKustomize(ref common.
 					},
 					"commonLabels": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CommonLabels adds additional kustomize commonLabels",
+							Description: "CommonLabels is a list of additional labels to add to rendered manifests",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -928,14 +934,14 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourceKustomize(ref common.
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Version contains optional Kustomize version",
+							Description: "Version controls which version of Kustomize to use for rendering manifests",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"commonAnnotations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CommonAnnotations adds additional kustomize commonAnnotations",
+							Description: "CommonAnnotations is a list of additional annotations to add to rendered manifests",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -959,7 +965,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSourcePlugin(ref common.Ref
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ApplicationSourcePlugin holds config management plugin specific options",
+				Description: "ApplicationSourcePlugin holds options specific to config management plugins",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -997,21 +1003,21 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSpec(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Source is a reference to the location ksonnet application definition",
+							Description: "Source is a reference to the location of the application's manifests or chart",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSource"),
 						},
 					},
 					"destination": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml",
+							Description: "Destination is a reference to the target Kubernetes server and namespace",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationDestination"),
 						},
 					},
 					"project": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Project is a application project name. Empty name means that application belongs to 'default' project.",
+							Description: "Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -1019,13 +1025,13 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSpec(ref common.ReferenceCa
 					},
 					"syncPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SyncPolicy controls when a sync will be performed",
+							Description: "SyncPolicy controls when and how a sync will be performed",
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.SyncPolicy"),
 						},
 					},
 					"ignoreDifferences": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IgnoreDifferences controls resources fields which should be ignored during comparison",
+							Description: "IgnoreDifferences is a list of resources and their fields which should be ignored during comparison",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1039,7 +1045,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSpec(ref common.ReferenceCa
 					},
 					"info": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application",
+							Description: "Info contains a list of information (URLs, email addresses, and plain text) that relates to the application",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1053,7 +1059,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSpec(ref common.ReferenceCa
 					},
 					"revisionHistoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.",
+							Description: "RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -1071,12 +1077,13 @@ func schema_pkg_apis_application_v1alpha1_ApplicationStatus(ref common.Reference
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ApplicationStatus contains information about application sync, health status",
+				Description: "ApplicationStatus contains status information for the application",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Resources is a list of Kubernetes resources managed by this application",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1089,19 +1096,22 @@ func schema_pkg_apis_application_v1alpha1_ApplicationStatus(ref common.Reference
 					},
 					"sync": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.SyncStatus"),
+							Description: "Sync contains information about the application's current sync status",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.SyncStatus"),
 						},
 					},
 					"health": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.HealthStatus"),
+							Description: "Health contains information about the application's current health status",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.HealthStatus"),
 						},
 					},
 					"history": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "History contains information about the application's sync history",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1114,7 +1124,8 @@ func schema_pkg_apis_application_v1alpha1_ApplicationStatus(ref common.Reference
 					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Conditions is a list of currently observed application conditions",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1133,7 +1144,8 @@ func schema_pkg_apis_application_v1alpha1_ApplicationStatus(ref common.Reference
 					},
 					"operationState": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.OperationState"),
+							Description: "OperationState contains information about any ongoing operations, such as a sync",
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.OperationState"),
 						},
 					},
 					"observedAt": {
@@ -1144,14 +1156,16 @@ func schema_pkg_apis_application_v1alpha1_ApplicationStatus(ref common.Reference
 					},
 					"sourceType": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "SourceType specifies the type of this application",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"summary": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSummary"),
+							Description: "Summary contains a list of URLs and container images used by this application",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSummary"),
 						},
 					},
 				},
@@ -1166,7 +1180,8 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSummary(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "ApplicationSummary contains information about URLs and container images used by an application",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"externalURLs": {
 						SchemaProps: spec.SchemaProps{
@@ -1295,7 +1310,7 @@ func schema_pkg_apis_application_v1alpha1_Backoff(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Backoff is a backoff strategy to use within retryStrategy",
+				Description: "Backoff is the backoff strategy to use on subsequent retries for failing syncs",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"duration": {
@@ -1371,7 +1386,7 @@ func schema_pkg_apis_application_v1alpha1_Cluster(ref common.ReferenceCallback) 
 					},
 					"namespaces": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.",
+							Description: "Holds list of namespaces which are accessible in that cluster. Cluster level resources will be ignored if namespace list is not empty.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1392,7 +1407,7 @@ func schema_pkg_apis_application_v1alpha1_Cluster(ref common.ReferenceCallback) 
 					},
 					"info": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Holds information about cluster cache",
+							Description: "Info holds information about cluster cache and state",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ClusterInfo"),
 						},
@@ -1417,7 +1432,8 @@ func schema_pkg_apis_application_v1alpha1_ClusterCacheInfo(ref common.ReferenceC
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "ClusterCacheInfo contains information about the cluster cache",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"resourcesCount": {
 						SchemaProps: spec.SchemaProps{
@@ -1506,31 +1522,36 @@ func schema_pkg_apis_application_v1alpha1_ClusterInfo(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "ClusterInfo contains information about the cluster",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"connectionState": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ConnectionState"),
+							Description: "ConnectionState contains information about the connection to the cluster",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ConnectionState"),
 						},
 					},
 					"serverVersion": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ServerVersion contains information about the Kubernetes version of the cluster",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"cacheInfo": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ClusterCacheInfo"),
+							Description: "CacheInfo contains information about the cluster cache",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ClusterCacheInfo"),
 						},
 					},
 					"applicationsCount": {
 						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int64",
+							Description: "ApplicationsCount is the number of applications managed by Argo CD on the cluster",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int64",
 						},
 					},
 				},
@@ -1627,14 +1648,16 @@ func schema_pkg_apis_application_v1alpha1_ComparedTo(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSource"),
+							Description: "Source is a reference to the application's source used for comparison",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSource"),
 						},
 					},
 					"destination": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationDestination"),
+							Description: "Destination is a reference to the application's destination used for comparison",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationDestination"),
 						},
 					},
 				},
@@ -1718,26 +1741,29 @@ func schema_pkg_apis_application_v1alpha1_ConnectionState(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ConnectionState contains information about remote resource connection state",
+				Description: "ConnectionState contains information about remote resource connection state, currently used for clusters and repositories",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Status contains the current status indicator for the connection",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Message contains human readable information about the connection status",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"attemptedAt": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Description: "ModifiedAt contains the timestamp when this connection status has been determined",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 				},
@@ -1753,11 +1779,12 @@ func schema_pkg_apis_application_v1alpha1_EnvEntry(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "EnvEntry represents an entry in the application's environment",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "the name, usually uppercase",
+							Description: "Name is the name of the variable, usually expressed in uppercase",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -1765,7 +1792,7 @@ func schema_pkg_apis_application_v1alpha1_EnvEntry(ref common.ReferenceCallback)
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "the value",
+							Description: "Value is the value of the variable",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -1852,7 +1879,7 @@ func schema_pkg_apis_application_v1alpha1_GnuPGPublicKey(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"keyID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "KeyID in hexadecimal string format",
+							Description: "KeyID specifies the key ID, in hexadecimal string format",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -1860,35 +1887,35 @@ func schema_pkg_apis_application_v1alpha1_GnuPGPublicKey(ref common.ReferenceCal
 					},
 					"fingerprint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Fingerprint of the key",
+							Description: "Fingerprint is the fingerprint of the key",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"owner": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Owner identification",
+							Description: "Owner holds the owner identification, e.g. a name and e-mail address",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"trust": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Trust level",
+							Description: "Trust holds the level of trust assigned to this key",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"subType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Key sub type (e.g. rsa4096)",
+							Description: "SubType holds the key's sub type (e.g. rsa4096)",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"keyData": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Key data",
+							Description: "KeyData holds the raw key data, in base64 encoded format",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1939,18 +1966,21 @@ func schema_pkg_apis_application_v1alpha1_HealthStatus(ref common.ReferenceCallb
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "HealthStatus contains information about the currently observed health state of an application or resource",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Status holds the status code of the application or resource",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Message is a human-readable informational message describing the health status",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -1963,19 +1993,19 @@ func schema_pkg_apis_application_v1alpha1_HelmFileParameter(ref common.Reference
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "HelmFileParameter is a file parameter to a helm template",
+				Description: "HelmFileParameter is a file parameter that's passed to helm template during manifest generation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the helm parameter",
+							Description: "Name is the name of the Helm parameter",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"path": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Path is the path value for the helm parameter",
+							Description: "Path is the path to the file containing the values for the Helm parameter",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1990,19 +2020,19 @@ func schema_pkg_apis_application_v1alpha1_HelmParameter(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "HelmParameter is a parameter to a helm template",
+				Description: "HelmParameter is a parameter that's passed to helm template during manifest generation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the helm parameter",
+							Description: "Name is the name of the Helm parameter",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value is the value for the helm parameter",
+							Description: "Value is the value for the Helm parameter",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2127,7 +2157,7 @@ func schema_pkg_apis_application_v1alpha1_InfoItem(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "InfoItem contains human readable information about object",
+				Description: "InfoItem contains arbitrary, human readable information about an application",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -2187,7 +2217,8 @@ func schema_pkg_apis_application_v1alpha1_JWTTokens(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "JWTTokens represents a list of JWT tokens",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"items": {
 						SchemaProps: spec.SchemaProps{
@@ -2214,7 +2245,7 @@ func schema_pkg_apis_application_v1alpha1_JsonnetVar(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "JsonnetVar is a jsonnet variable",
+				Description: "JsonnetVar represents a variable to be passed to jsonnet during manifest generation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -2248,7 +2279,7 @@ func schema_pkg_apis_application_v1alpha1_KnownTypeField(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "KnownTypeField contains mapping between CRD field and known Kubernetes type",
+				Description: "KnownTypeField contains mapping between CRD field and known Kubernetes type. This is mainly used for unit conversion in unknown resources (e.g. 0.1 == 100mi)",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"field": {
@@ -2337,23 +2368,26 @@ func schema_pkg_apis_application_v1alpha1_Operation(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Operation contains requested operation parameters.",
+				Description: "Operation contains information about a requested or running operation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"sync": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.SyncOperation"),
+							Description: "Sync contains parameters for the operation",
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.SyncOperation"),
 						},
 					},
 					"initiatedBy": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.OperationInitiator"),
+							Description: "InitiatedBy contains information about who initiated the operations",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.OperationInitiator"),
 						},
 					},
 					"info": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Info is a list of informational items for this operation",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -2365,7 +2399,7 @@ func schema_pkg_apis_application_v1alpha1_Operation(ref common.ReferenceCallback
 					},
 					"retry": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Retry controls failed sync retry behavior",
+							Description: "Retry controls the strategy to apply if a sync fails",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.RetryStrategy"),
 						},
@@ -2382,12 +2416,12 @@ func schema_pkg_apis_application_v1alpha1_OperationInitiator(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "OperationInitiator holds information about the operation initiator",
+				Description: "OperationInitiator contains information about the initiator of an operation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"username": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of a user who started operation.",
+							Description: "Username contains the name of a user who started operation",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2409,7 +2443,7 @@ func schema_pkg_apis_application_v1alpha1_OperationState(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "OperationState contains information about state of currently performing operation on application.",
+				Description: "OperationState contains information about state of a running operation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"operation": {
@@ -2429,7 +2463,7 @@ func schema_pkg_apis_application_v1alpha1_OperationState(ref common.ReferenceCal
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Message hold any pertinent messages when attempting to perform operation (typically errors).",
+							Description: "Message holds any pertinent messages when attempting to perform operation (typically errors).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2473,7 +2507,8 @@ func schema_pkg_apis_application_v1alpha1_OrphanedResourceKey(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "OrphanedResourceKey is a reference to a resource to be ignored from",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
@@ -2515,7 +2550,8 @@ func schema_pkg_apis_application_v1alpha1_OrphanedResourcesMonitorSettings(ref c
 					},
 					"ignore": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Ignore contains a list of resources that are to be excluded from orphaned resources monitoring",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -2640,7 +2676,7 @@ func schema_pkg_apis_application_v1alpha1_RepoCreds(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "RepoCreds holds a repository credentials definition",
+				Description: "RepoCreds holds the definition for repository credentials",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"url": {
@@ -2667,49 +2703,49 @@ func schema_pkg_apis_application_v1alpha1_RepoCreds(ref common.ReferenceCallback
 					},
 					"sshPrivateKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SSH private key data for authenticating at the repo server (only Git repos)",
+							Description: "SSHPrivateKey contains the private key data for authenticating at the repo server using SSH (only Git repos)",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"tlsClientCertData": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TLS client cert data for authenticating at the repo server",
+							Description: "TLSClientCertData specifies the TLS client cert data for authenticating at the repo server",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"tlsClientCertKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TLS client cert key for authenticating at the repo server",
+							Description: "TLSClientCertKey specifies the TLS client cert key for authenticating at the repo server",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"githubAppPrivateKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Github App Private Key PEM data",
+							Description: "GithubAppPrivateKey specifies the private key PEM data for authentication via GitHub app",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"githubAppID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Github App ID of the app used to access the repo",
+							Description: "GithubAppId specifies the Github App ID of the app used to access the repo for GitHub app authentication",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
 					},
 					"githubAppInstallationID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Github App Installation ID of the installed GitHub App",
+							Description: "GithubAppInstallationId specifies the ID of the installed GitHub App for GitHub app authentication",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
 					},
 					"githubAppEnterpriseBaseUrl": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Github App Enterprise base url if empty will default to https://api.github.com",
+							Description: "GithubAppEnterpriseBaseURL specifies the GitHub API URL for GitHub app authentication. If empty will default to https://api.github.com",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2765,7 +2801,7 @@ func schema_pkg_apis_application_v1alpha1_Repository(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"repo": {
 						SchemaProps: spec.SchemaProps{
-							Description: "URL of the repo",
+							Description: "Repo contains the URL to the remote repository",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2773,77 +2809,77 @@ func schema_pkg_apis_application_v1alpha1_Repository(ref common.ReferenceCallbac
 					},
 					"username": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Username for authenticating at the repo server",
+							Description: "Username contains the user name used for authenticating at the remote repository",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"password": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Password for authenticating at the repo server",
+							Description: "Password contains the password or PAT used for authenticating at the remote repository",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"sshPrivateKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SSH private key data for authenticating at the repo server only for Git repos",
+							Description: "SSHPrivateKey contains the PEM data for authenticating at the repo server. Only used with Git repos.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"connectionState": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Current state of repository server connecting",
+							Description: "ConnectionState contains information about the current state of connection to the repository server",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ConnectionState"),
 						},
 					},
 					"insecureIgnoreHostKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "InsecureIgnoreHostKey should not be used anymore, Insecure is favoured only for Git repos",
+							Description: "InsecureIgnoreHostKey should not be used anymore, Insecure is favoured Used only for Git repos",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"insecure": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether the repo is insecure",
+							Description: "Insecure specifies whether the connection to the repository ignores any errors when verifying TLS certificates or SSH host keys",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"enableLfs": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether git-lfs support should be enabled for this repo",
+							Description: "EnableLFS specifies whether git-lfs support should be enabled for this repo. Only valid for Git repositories.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"tlsClientCertData": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TLS client cert data for authenticating at the repo server",
+							Description: "TLSClientCertData contains a certificate in PEM format for authenticating at the repo server",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"tlsClientCertKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TLS client cert key for authenticating at the repo server",
+							Description: "TLSClientCertKey contains a private key in PEM format for authenticating at the repo server",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "type of the repo, maybe \"git or \"helm, \"git\" is assumed if empty or absent",
+							Description: "Type specifies the type of the repo. Can be either \"git\" or \"helm. \"git\" is assumed if empty or absent.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "only for Helm repos",
+							Description: "Name specifies a name to be used for this repo. Only used with Helm repos",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2857,7 +2893,7 @@ func schema_pkg_apis_application_v1alpha1_Repository(ref common.ReferenceCallbac
 					},
 					"enableOCI": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether helm-oci support should be enabled for this repo",
+							Description: "EnableOCI specifies whether helm-oci support should be enabled for this repo",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -2871,21 +2907,21 @@ func schema_pkg_apis_application_v1alpha1_Repository(ref common.ReferenceCallbac
 					},
 					"githubAppID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Github App ID of the app used to access the repo",
+							Description: "GithubAppId specifies the ID of the GitHub app used to access the repo",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
 					},
 					"githubAppInstallationID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Github App Installation ID of the installed GitHub App",
+							Description: "GithubAppInstallationId specifies the installation ID of the GitHub App used to access the repo",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
 					},
 					"githubAppEnterpriseBaseUrl": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Github App Enterprise base url if empty will default to https://api.github.com",
+							Description: "GithubAppEnterpriseBaseURL specifies the base URL of GitHub Enterprise installation. If empty will default to https://api.github.com",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2908,7 +2944,7 @@ func schema_pkg_apis_application_v1alpha1_RepositoryCertificate(ref common.Refer
 				Properties: map[string]spec.Schema{
 					"serverName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the server the certificate is intended for",
+							Description: "ServerName specifies the DNS name of the server this certificate is intended for",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2916,7 +2952,7 @@ func schema_pkg_apis_application_v1alpha1_RepositoryCertificate(ref common.Refer
 					},
 					"certType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type of certificate - currently \"https\" or \"ssh\"",
+							Description: "CertType specifies the type of the certificate - currently one of \"https\" or \"ssh\"",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2924,7 +2960,7 @@ func schema_pkg_apis_application_v1alpha1_RepositoryCertificate(ref common.Refer
 					},
 					"certSubType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The sub type of the cert, i.e. \"ssh-rsa\"",
+							Description: "CertSubType specifies the sub type of the cert, i.e. \"ssh-rsa\"",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2932,14 +2968,14 @@ func schema_pkg_apis_application_v1alpha1_RepositoryCertificate(ref common.Refer
 					},
 					"certData": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Actual certificate data, protocol dependent",
+							Description: "CertData contains the actual certificate data, dependent on the certificate type",
 							Type:        []string{"string"},
 							Format:      "byte",
 						},
 					},
 					"certInfo": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Additional certificate info (e.g. SSH fingerprint, X509 CommonName)",
+							Description: "CertInfo will hold additional certificate info, depdendent on the certificate type (e.g. SSH fingerprint, X509 CommonName)",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -3551,7 +3587,7 @@ func schema_pkg_apis_application_v1alpha1_ResourceRef(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ResourceRef includes fields which unique identify resource",
+				Description: "ResourceRef includes fields which uniquely identify a resource",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"group": {
@@ -3605,70 +3641,75 @@ func schema_pkg_apis_application_v1alpha1_ResourceResult(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Group specifies the API group of the resource",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Version specifies the API version of the resource",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Kind specifies the API kind of the resource",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Namespace specifies the target namespace of the resource",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Name specifies the name of the resource",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks",
+							Description: "Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Description: "message for the last sync OR operation",
+							Description: "Message contains an informational or error message for the last sync OR operation",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"hookType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "the type of the hook, empty for non-hook resources",
+							Description: "HookType specifies the type of the hook. Empty for non-hook resources",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"hookPhase": {
 						SchemaProps: spec.SchemaProps{
-							Description: "the state of any operation associated with this resource OR hook note: can contain values for non-hook resources",
+							Description: "HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"syncPhase": {
 						SchemaProps: spec.SchemaProps{
-							Description: "indicates the particular phase of the sync that this is for",
+							Description: "SyncPhase indicates the particular phase of the sync that this result was acquired in",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3752,18 +3793,19 @@ func schema_pkg_apis_application_v1alpha1_RetryStrategy(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "RetryStrategy contains information about the strategy to apply when a sync failed",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"limit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Limit is the maximum number of attempts when retrying a container",
+							Description: "Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
 					},
 					"backoff": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Backoff is a backoff strategy",
+							Description: "Backoff controls how to backoff on subsequent retries of failed syncs",
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.Backoff"),
 						},
 					},
@@ -3779,12 +3821,12 @@ func schema_pkg_apis_application_v1alpha1_RevisionHistory(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "RevisionHistory contains information relevant to an application deployment",
+				Description: "RevisionHistory contains history information about a previous sync",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Revision holds the revision of the sync",
+							Description: "Revision holds the revision the sync was performed against",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -3792,7 +3834,7 @@ func schema_pkg_apis_application_v1alpha1_RevisionHistory(ref common.ReferenceCa
 					},
 					"deployedAt": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DeployedAt holds the time the deployment completed",
+							Description: "DeployedAt holds the time the sync operation completed",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
@@ -3807,13 +3849,14 @@ func schema_pkg_apis_application_v1alpha1_RevisionHistory(ref common.ReferenceCa
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSource"),
+							Description: "Source is a reference to the application source used for the sync operation",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSource"),
 						},
 					},
 					"deployStartedAt": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DeployStartedAt holds the time the deployment started",
+							Description: "DeployStartedAt holds the time the sync operation started",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -3830,7 +3873,7 @@ func schema_pkg_apis_application_v1alpha1_RevisionMetadata(ref common.ReferenceC
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "data about a specific revision within a repo",
+				Description: "RevisionMetadata contains metadata for a specific revision in a Git repository",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"author": {
@@ -3842,14 +3885,14 @@ func schema_pkg_apis_application_v1alpha1_RevisionMetadata(ref common.ReferenceC
 					},
 					"date": {
 						SchemaProps: spec.SchemaProps{
-							Description: "when the revision was authored",
+							Description: "Date specifies when the revision was authored",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"tags": {
 						SchemaProps: spec.SchemaProps{
-							Description: "tags on the revision, note - tags can move from one revision to another",
+							Description: "Tags specifies any tags currently attached to the revision Floating tags can move from one revision to another",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3864,14 +3907,14 @@ func schema_pkg_apis_application_v1alpha1_RevisionMetadata(ref common.ReferenceC
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Description: "the message associated with the revision, probably the commit message, this is truncated to the first newline or 64 characters (which ever comes first)",
+							Description: "Message contains the message associated with the revision, most likely the commit message. The message is truncated to the first newline or 64 characters (which ever comes first)",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"signatureInfo": {
 						SchemaProps: spec.SchemaProps{
-							Description: "If revision was signed with GPG, and signature verification is enabled, this contains a hint on the signer",
+							Description: "SignatureInfo contains a hint on the signer if the revision was signed with GPG, and signature verification is enabled.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3911,26 +3954,26 @@ func schema_pkg_apis_application_v1alpha1_SyncOperation(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SyncOperation contains sync operation details.",
+				Description: "SyncOperation contains details about a sync operation.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.",
+							Description: "Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"prune": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Prune deletes resources that are no longer tracked in git",
+							Description: "Prune specifies to delete resources from the cluster that are no longer tracked in git",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"dryRun": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DryRun will perform a `kubectl apply --dry-run` without actually performing the sync",
+							Description: "DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -3943,7 +3986,7 @@ func schema_pkg_apis_application_v1alpha1_SyncOperation(ref common.ReferenceCall
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources describes which resources to sync",
+							Description: "Resources describes which resources shall be part of the sync",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3957,7 +4000,7 @@ func schema_pkg_apis_application_v1alpha1_SyncOperation(ref common.ReferenceCall
 					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation",
+							Description: "Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation",
 							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ApplicationSource"),
 						},
 					},
@@ -4048,7 +4091,7 @@ func schema_pkg_apis_application_v1alpha1_SyncOperationResult(ref common.Referen
 				Properties: map[string]spec.Schema{
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources holds the sync result of each individual resource",
+							Description: "Resources contains a list of sync result items for each individual resource in a sync operation",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4061,7 +4104,7 @@ func schema_pkg_apis_application_v1alpha1_SyncOperationResult(ref common.Referen
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Revision holds the revision of the sync",
+							Description: "Revision holds the revision this sync operation was performed to",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -4134,14 +4177,14 @@ func schema_pkg_apis_application_v1alpha1_SyncPolicyAutomated(ref common.Referen
 				Properties: map[string]spec.Schema{
 					"prune": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Prune will prune resources automatically as part of automated sync (default: false)",
+							Description: "Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"selfHeal": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SelfHeal enables auto-syncing if  (default: false)",
+							Description: "SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -4163,26 +4206,29 @@ func schema_pkg_apis_application_v1alpha1_SyncStatus(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SyncStatus is a comparison result of application spec and deployed application.",
+				Description: "SyncStatus contains information about the currently observed live and desired states of an application",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "Status is the sync state of the comparison",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"comparedTo": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ComparedTo"),
+							Description: "ComparedTo contains information about what has been compared",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1.ComparedTo"),
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Revision contains information about the revision the comparison has been performed to",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -4356,7 +4402,7 @@ func schema_pkg_apis_application_v1alpha1_TLSClientConfig(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"insecure": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Server should be accessed without verifying the TLS certificate. For testing only.",
+							Description: "Insecure specifies that the server should be accessed without verifying the TLS certificate. For testing only.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -97,10 +97,12 @@ type EnvEntry struct {
 	Value string `json:"value" protobuf:"bytes,2,opt,name=value"`
 }
 
+// IsZero returns true if a variable is considered empty or unset
 func (a *EnvEntry) IsZero() bool {
 	return a == nil || a.Name == "" && a.Value == ""
 }
 
+// NewEnvEntry parses a string in format name=value and returns an EnvEntry object
 func NewEnvEntry(text string) (*EnvEntry, error) {
 	parts := strings.SplitN(text, "=", 2)
 	if len(parts) != 2 {
@@ -112,12 +114,15 @@ func NewEnvEntry(text string) (*EnvEntry, error) {
 	}, nil
 }
 
+// Env is a list of environment variable entries
 type Env []*EnvEntry
 
+// IsZero returns true if a list of variables is considered empty
 func (e Env) IsZero() bool {
 	return len(e) == 0
 }
 
+// Environ returns a list of environment variables in name=value format from a list of variables
 func (e Env) Environ() []string {
 	var environ []string
 	for _, item := range e {
@@ -128,7 +133,7 @@ func (e Env) Environ() []string {
 	return environ
 }
 
-// does an operation similar to `envsubst` tool,
+// Envsubst interpolates variable references in a string from a list of variables
 func (e Env) Envsubst(s string) string {
 	valByEnv := map[string]string{}
 	for _, item := range e {
@@ -176,10 +181,12 @@ func (a *ApplicationSource) AllowsConcurrentProcessing() bool {
 	return true
 }
 
+// IsHelm returns true when the application source is of type Helm
 func (a *ApplicationSource) IsHelm() bool {
 	return a.Chart != ""
 }
 
+// IsHelmOci returns true when the application source is of type Helm OCI
 func (a *ApplicationSource) IsHelmOci() bool {
 	if a.Chart == "" {
 		return false
@@ -187,6 +194,7 @@ func (a *ApplicationSource) IsHelmOci() bool {
 	return helm.IsHelmOciChart(a.Chart)
 }
 
+// IsZero returns true if the application source is considered empty
 func (a *ApplicationSource) IsZero() bool {
 	return a == nil ||
 		a.RepoURL == "" &&
@@ -199,6 +207,7 @@ func (a *ApplicationSource) IsZero() bool {
 			a.Plugin.IsZero()
 }
 
+// ApplicationSourceType specifies the type of the application's source
 type ApplicationSourceType string
 
 const (
@@ -209,6 +218,7 @@ const (
 	ApplicationSourceTypePlugin    ApplicationSourceType = "Plugin"
 )
 
+// RefreshType specifies how to refresh the sources of a given application
 type RefreshType string
 
 const (
@@ -232,26 +242,27 @@ type ApplicationSourceHelm struct {
 	Version string `json:"version,omitempty" protobuf:"bytes,6,opt,name=version"`
 }
 
-// HelmParameter is a parameter to a helm template
+// HelmParameter is a parameter that's passed to helm template during manifest generation
 type HelmParameter struct {
-	// Name is the name of the helm parameter
+	// Name is the name of the Helm parameter
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-	// Value is the value for the helm parameter
+	// Value is the value for the Helm parameter
 	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
 	// ForceString determines whether to tell Helm to interpret booleans and numbers as strings
 	ForceString bool `json:"forceString,omitempty" protobuf:"bytes,3,opt,name=forceString"`
 }
 
-// HelmFileParameter is a file parameter to a helm template
+// HelmFileParameter is a file parameter that's passed to helm template during manifest generation
 type HelmFileParameter struct {
-	// Name is the name of the helm parameter
+	// Name is the name of the Helm parameter
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-	// Path is the path value for the helm parameter
+	// Path is the path to the file containing the values for the Helm parameter
 	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"`
 }
 
 var helmParameterRx = regexp.MustCompile(`([^\\]),`)
 
+// NewHelmParameter parses a string in format name=value into a HelmParameter object and returns it
 func NewHelmParameter(text string, forceString bool) (*HelmParameter, error) {
 	parts := strings.SplitN(text, "=", 2)
 	if len(parts) != 2 {
@@ -264,6 +275,7 @@ func NewHelmParameter(text string, forceString bool) (*HelmParameter, error) {
 	}, nil
 }
 
+// NewHelmFileParameter parses a string in format name=value into a HelmFileParameter object and returns it
 func NewHelmFileParameter(text string) (*HelmFileParameter, error) {
 	parts := strings.SplitN(text, "=", 2)
 	if len(parts) != 2 {
@@ -275,6 +287,8 @@ func NewHelmFileParameter(text string) (*HelmFileParameter, error) {
 	}, nil
 }
 
+// AddParameter adds a HelmParameter to the application source. If a parameter with the same name already
+// exists, its value will be overwritten. Otherwise, the HelmParameter will be appended as a new entry.
 func (in *ApplicationSourceHelm) AddParameter(p HelmParameter) {
 	found := false
 	for i, cp := range in.Parameters {
@@ -289,6 +303,8 @@ func (in *ApplicationSourceHelm) AddParameter(p HelmParameter) {
 	}
 }
 
+// AddFileParameter adds a HelmFileParameter to the application source. If a file parameter with the same name already
+// exists, its value will be overwritten. Otherwise, the HelmFileParameter will be appended as a new entry.
 func (in *ApplicationSourceHelm) AddFileParameter(p HelmFileParameter) {
 	found := false
 	for i, cp := range in.FileParameters {
@@ -303,10 +319,12 @@ func (in *ApplicationSourceHelm) AddFileParameter(p HelmFileParameter) {
 	}
 }
 
+// IsZero Returns true if the Helm options in an application source are considered zero
 func (h *ApplicationSourceHelm) IsZero() bool {
 	return h == nil || (h.Version == "") && (h.ReleaseName == "") && len(h.ValueFiles) == 0 && len(h.Parameters) == 0 && len(h.FileParameters) == 0 && h.Values == ""
 }
 
+// KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
 type KustomizeImage string
 
 func (i KustomizeImage) delim() string {
@@ -318,7 +336,7 @@ func (i KustomizeImage) delim() string {
 	return ":"
 }
 
-// if the image name matches (i.e. up to the first delimiter)
+// Match returns true if the image name matches (i.e. up to the first delimiter)
 func (i KustomizeImage) Match(j KustomizeImage) bool {
 	delim := j.delim()
 	if !strings.Contains(string(j), delim) {
@@ -327,9 +345,10 @@ func (i KustomizeImage) Match(j KustomizeImage) bool {
 	return strings.HasPrefix(string(i), strings.Split(string(j), delim)[0])
 }
 
+// KustomizeImages is a list of Kustomize images
 type KustomizeImages []KustomizeImage
 
-// find the image or -1
+// Find returns a positive integer representing the index in the list of images
 func (images KustomizeImages) Find(image KustomizeImage) int {
 	for i, a := range images {
 		if a.Match(image) {
@@ -339,13 +358,13 @@ func (images KustomizeImages) Find(image KustomizeImage) int {
 	return -1
 }
 
-// ApplicationSourceKustomize holds kustomize specific options
+// ApplicationSourceKustomize holds options specific to an Application source specific to Kustomize
 type ApplicationSourceKustomize struct {
-	// NamePrefix is a prefix appended to resources for kustomize apps
+	// NamePrefix is a prefix appended to resources for Kustomize apps
 	NamePrefix string `json:"namePrefix,omitempty" protobuf:"bytes,1,opt,name=namePrefix"`
-	// NameSuffix is a suffix appended to resources for kustomize apps
+	// NameSuffix is a suffix appended to resources for Kustomize apps
 	NameSuffix string `json:"nameSuffix,omitempty" protobuf:"bytes,2,opt,name=nameSuffix"`
-	// Images is a list of kustomize image override specifications
+	// Images is a list of Kustomize image override specifications
 	Images KustomizeImages `json:"images,omitempty" protobuf:"bytes,3,opt,name=images"`
 	// CommonLabels is a list of additional labels to add to rendered manifests
 	CommonLabels map[string]string `json:"commonLabels,omitempty" protobuf:"bytes,4,opt,name=commonLabels"`
@@ -355,6 +374,7 @@ type ApplicationSourceKustomize struct {
 	CommonAnnotations map[string]string `json:"commonAnnotations,omitempty" protobuf:"bytes,6,opt,name=commonAnnotations"`
 }
 
+// AllowsConcurrentProcessing returns true if multiple processes can run Kustomize builds on the same source at the same time
 func (k *ApplicationSourceKustomize) AllowsConcurrentProcessing() bool {
 	return len(k.Images) == 0 &&
 		len(k.CommonLabels) == 0 &&
@@ -362,6 +382,7 @@ func (k *ApplicationSourceKustomize) AllowsConcurrentProcessing() bool {
 		k.NameSuffix == ""
 }
 
+// IsZero returns true when the Kustomize options are considered empty
 func (k *ApplicationSourceKustomize) IsZero() bool {
 	return k == nil ||
 		k.NamePrefix == "" &&
@@ -372,7 +393,7 @@ func (k *ApplicationSourceKustomize) IsZero() bool {
 			len(k.CommonAnnotations) == 0
 }
 
-// either updates or adds the images
+// MergeImage merges a new Kustomize image identifier in to a list of images
 func (k *ApplicationSourceKustomize) MergeImage(image KustomizeImage) {
 	i := k.Images.Find(image)
 	if i >= 0 {
@@ -382,13 +403,14 @@ func (k *ApplicationSourceKustomize) MergeImage(image KustomizeImage) {
 	}
 }
 
-// JsonnetVar is a jsonnet variable
+// JsonnetVar represents a variable to be passed to jsonnet during manifest generation
 type JsonnetVar struct {
 	Name  string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	Value string `json:"value" protobuf:"bytes,2,opt,name=value"`
 	Code  bool   `json:"code,omitempty" protobuf:"bytes,3,opt,name=code"`
 }
 
+// NewJsonnetVar parses a Jsonnet variable from a string in the format name=value
 func NewJsonnetVar(s string, code bool) JsonnetVar {
 	parts := strings.SplitN(s, "=", 2)
 	if len(parts) == 2 {
@@ -398,7 +420,7 @@ func NewJsonnetVar(s string, code bool) JsonnetVar {
 	}
 }
 
-// ApplicationSourceJsonnet holds jsonnet specific options
+// ApplicationSourceJsonnet holds options specific to applications of type Jsonnet
 type ApplicationSourceJsonnet struct {
 	// ExtVars is a list of Jsonnet External Variables
 	ExtVars []JsonnetVar `json:"extVars,omitempty" protobuf:"bytes,1,opt,name=extVars"`
@@ -408,6 +430,7 @@ type ApplicationSourceJsonnet struct {
 	Libs []string `json:"libs,omitempty" protobuf:"bytes,3,opt,name=libs"`
 }
 
+// IsZero returns true if the JSonnet options of an application are considered to be empty
 func (j *ApplicationSourceJsonnet) IsZero() bool {
 	return j == nil || len(j.ExtVars) == 0 && len(j.TLAs) == 0 && len(j.Libs) == 0
 }
@@ -427,35 +450,46 @@ type KsonnetParameter struct {
 	Value     string `json:"value" protobuf:"bytes,3,opt,name=value"`
 }
 
+// AllowsConcurrentProcessing returns true if multiple processes can run ksonnet builds on the same source at the same time
 func (k *ApplicationSourceKsonnet) AllowsConcurrentProcessing() bool {
 	return len(k.Parameters) == 0
 }
 
+// IsZero returns true if the KSonnet options of an application are considered to be empty
 func (k *ApplicationSourceKsonnet) IsZero() bool {
 	return k == nil || k.Environment == "" && len(k.Parameters) == 0
 }
 
+// ApplicationSourceDirectory holds options for applications of type plain YAML or Jsonnet
 type ApplicationSourceDirectory struct {
-	Recurse bool                     `json:"recurse,omitempty" protobuf:"bytes,1,opt,name=recurse"`
+	// Recurse specifies whether to scan a directory recursively for manifests
+	Recurse bool `json:"recurse,omitempty" protobuf:"bytes,1,opt,name=recurse"`
+	// Jsonnet holds options specific to Jsonnet
 	Jsonnet ApplicationSourceJsonnet `json:"jsonnet,omitempty" protobuf:"bytes,2,opt,name=jsonnet"`
-	Exclude string                   `json:"exclude,omitempty" protobuf:"bytes,3,opt,name=exclude"`
-	Include string                   `json:"include,omitempty" protobuf:"bytes,4,opt,name=include"`
+	// Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+	Exclude string `json:"exclude,omitempty" protobuf:"bytes,3,opt,name=exclude"`
+	// Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+	Include string `json:"include,omitempty" protobuf:"bytes,4,opt,name=include"`
 }
 
+// IsZero returns true if the ApplicationSourceDirectory is considered empty
 func (d *ApplicationSourceDirectory) IsZero() bool {
 	return d == nil || !d.Recurse && d.Jsonnet.IsZero()
 }
 
-// ApplicationSourcePlugin holds config management plugin specific options
+// ApplicationSourcePlugin holds options specific to config management plugins
 type ApplicationSourcePlugin struct {
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	Env  `json:"env,omitempty" protobuf:"bytes,2,opt,name=env"`
 }
 
+// IsZero returns true if the ApplicationSourcePlugin is considered empty
 func (c *ApplicationSourcePlugin) IsZero() bool {
 	return c == nil || c.Name == "" && c.Env.IsZero()
 }
 
+// AddEnvEntry merges an EnvEntry into a list of entries. If an entry with the same name already exists,
+// its value will be overwritten. Otherwise, the entry is appended to the list.
 func (c *ApplicationSourcePlugin) AddEnvEntry(e *EnvEntry) {
 	found := false
 	for i, ce := range c.Env {
@@ -470,62 +504,77 @@ func (c *ApplicationSourcePlugin) AddEnvEntry(e *EnvEntry) {
 	}
 }
 
-// ApplicationDestination contains deployment destination information
+// ApplicationDestination holds information about the application's destination
 type ApplicationDestination struct {
-	// Server overrides the environment server value in the ksonnet app.yaml
+	// Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
 	Server string `json:"server,omitempty" protobuf:"bytes,1,opt,name=server"`
-	// Namespace overrides the environment namespace value in the ksonnet app.yaml
+	// Namespace specifies the target namespace for the application's resources.
+	// The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
-	// Name of the destination cluster which can be used instead of server (url) field
+	// Name is an alternate way of specifying the target cluster by its symbolic name
 	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
 
 	// nolint:govet
 	isServerInferred bool `json:"-"`
 }
 
-// ApplicationStatus contains information about application sync, health status
+// ApplicationStatus contains status information for the application
 type ApplicationStatus struct {
-	Resources  []ResourceStatus       `json:"resources,omitempty" protobuf:"bytes,1,opt,name=resources"`
-	Sync       SyncStatus             `json:"sync,omitempty" protobuf:"bytes,2,opt,name=sync"`
-	Health     HealthStatus           `json:"health,omitempty" protobuf:"bytes,3,opt,name=health"`
-	History    RevisionHistories      `json:"history,omitempty" protobuf:"bytes,4,opt,name=history"`
+	// Resources is a list of Kubernetes resources managed by this application
+	Resources []ResourceStatus `json:"resources,omitempty" protobuf:"bytes,1,opt,name=resources"`
+	// Sync contains information about the application's current sync status
+	Sync SyncStatus `json:"sync,omitempty" protobuf:"bytes,2,opt,name=sync"`
+	// Health contains information about the application's current health status
+	Health HealthStatus `json:"health,omitempty" protobuf:"bytes,3,opt,name=health"`
+	// History contains information about the application's sync history
+	History RevisionHistories `json:"history,omitempty" protobuf:"bytes,4,opt,name=history"`
+	// Conditions is a list of currently observed application conditions
 	Conditions []ApplicationCondition `json:"conditions,omitempty" protobuf:"bytes,5,opt,name=conditions"`
 	// ReconciledAt indicates when the application state was reconciled using the latest git version
-	ReconciledAt   *metav1.Time    `json:"reconciledAt,omitempty" protobuf:"bytes,6,opt,name=reconciledAt"`
+	ReconciledAt *metav1.Time `json:"reconciledAt,omitempty" protobuf:"bytes,6,opt,name=reconciledAt"`
+	// OperationState contains information about any ongoing operations, such as a sync
 	OperationState *OperationState `json:"operationState,omitempty" protobuf:"bytes,7,opt,name=operationState"`
 	// ObservedAt indicates when the application state was updated without querying latest git state
 	// Deprecated: controller no longer updates ObservedAt field
-	ObservedAt *metav1.Time          `json:"observedAt,omitempty" protobuf:"bytes,8,opt,name=observedAt"`
+	ObservedAt *metav1.Time `json:"observedAt,omitempty" protobuf:"bytes,8,opt,name=observedAt"`
+	// SourceType specifies the type of this application
 	SourceType ApplicationSourceType `json:"sourceType,omitempty" protobuf:"bytes,9,opt,name=sourceType"`
-	Summary    ApplicationSummary    `json:"summary,omitempty" protobuf:"bytes,10,opt,name=summary"`
+	// Summary contains a list of URLs and container images used by this application
+	Summary ApplicationSummary `json:"summary,omitempty" protobuf:"bytes,10,opt,name=summary"`
 }
 
+// JWTTokens represents a list of JWT tokens
 type JWTTokens struct {
 	Items []JWTToken `json:"items,omitempty" protobuf:"bytes,1,opt,name=items"`
 }
 
-// AppProjectStatus contains information about appproj
+// AppProjectStatus contains status information for AppProject CRs
 type AppProjectStatus struct {
+	// JWTTokensByRole contains a list of JWT tokens issued for a given role
 	JWTTokensByRole map[string]JWTTokens `json:"jwtTokensByRole,omitempty" protobuf:"bytes,1,opt,name=jwtTokensByRole"`
 }
 
-// OperationInitiator holds information about the operation initiator
+// OperationInitiator contains information about the initiator of an operation
 type OperationInitiator struct {
-	// Name of a user who started operation.
+	// Username contains the name of a user who started operation
 	Username string `json:"username,omitempty" protobuf:"bytes,1,opt,name=username"`
 	// Automated is set to true if operation was initiated automatically by the application controller.
 	Automated bool `json:"automated,omitempty" protobuf:"bytes,2,opt,name=automated"`
 }
 
-// Operation contains requested operation parameters.
+// Operation contains information about a requested or running operation
 type Operation struct {
-	Sync        *SyncOperation     `json:"sync,omitempty" protobuf:"bytes,1,opt,name=sync"`
+	// Sync contains parameters for the operation
+	Sync *SyncOperation `json:"sync,omitempty" protobuf:"bytes,1,opt,name=sync"`
+	// InitiatedBy contains information about who initiated the operations
 	InitiatedBy OperationInitiator `json:"initiatedBy,omitempty" protobuf:"bytes,2,opt,name=initiatedBy"`
-	Info        []*Info            `json:"info,omitempty" protobuf:"bytes,3,name=info"`
-	// Retry controls failed sync retry behavior
+	// Info is a list of informational items for this operation
+	Info []*Info `json:"info,omitempty" protobuf:"bytes,3,name=info"`
+	// Retry controls the strategy to apply if a sync fails
 	Retry RetryStrategy `json:"retry,omitempty" protobuf:"bytes,4,opt,name=retry"`
 }
 
+// DryRun returns true if an operation was requested to be performed in dry run mode
 func (o *Operation) DryRun() bool {
 	if o.Sync != nil {
 		return o.Sync.DryRun
@@ -544,10 +593,12 @@ type SyncOperationResource struct {
 // RevisionHistories is a array of history, oldest first and newest last
 type RevisionHistories []RevisionHistory
 
+// LastRevisionHistory returns the latest history item from the revision history
 func (in RevisionHistories) LastRevisionHistory() RevisionHistory {
 	return in[len(in)-1]
 }
 
+// Trunc truncates the list of history items to size n
 func (in RevisionHistories) Trunc(n int) RevisionHistories {
 	i := len(in) - n
 	if i > 0 {
@@ -564,21 +615,21 @@ func (r SyncOperationResource) HasIdentity(name string, namespace string, gvk sc
 	return false
 }
 
-// SyncOperation contains sync operation details.
+// SyncOperation contains details about a sync operation.
 type SyncOperation struct {
-	// Revision is the revision in which to sync the application to.
+	// Revision is the revision (Git) or chart version (Helm) which to sync the application to
 	// If omitted, will use the revision specified in app spec.
 	Revision string `json:"revision,omitempty" protobuf:"bytes,1,opt,name=revision"`
-	// Prune deletes resources that are no longer tracked in git
+	// Prune specifies to delete resources from the cluster that are no longer tracked in git
 	Prune bool `json:"prune,omitempty" protobuf:"bytes,2,opt,name=prune"`
-	// DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
+	// DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
 	DryRun bool `json:"dryRun,omitempty" protobuf:"bytes,3,opt,name=dryRun"`
 	// SyncStrategy describes how to perform the sync
 	SyncStrategy *SyncStrategy `json:"syncStrategy,omitempty" protobuf:"bytes,4,opt,name=syncStrategy"`
-	// Resources describes which resources to sync
+	// Resources describes which resources shall be part of the sync
 	Resources []SyncOperationResource `json:"resources,omitempty" protobuf:"bytes,6,opt,name=resources"`
 	// Source overrides the source definition set in the application.
-	// This is typically set in a Rollback operation and nil during a Sync operation
+	// This is typically set in a Rollback operation and is nil during a Sync operation
 	Source *ApplicationSource `json:"source,omitempty" protobuf:"bytes,7,opt,name=source"`
 	// Manifests is an optional field that overrides sync source with a local directory for development
 	Manifests []string `json:"manifests,omitempty" protobuf:"bytes,8,opt,name=manifests"`
@@ -586,17 +637,18 @@ type SyncOperation struct {
 	SyncOptions SyncOptions `json:"syncOptions,omitempty" protobuf:"bytes,9,opt,name=syncOptions"`
 }
 
+// IsApplyStrategy returns true if the sync strategy is "apply"
 func (o *SyncOperation) IsApplyStrategy() bool {
 	return o.SyncStrategy != nil && o.SyncStrategy.Apply != nil
 }
 
-// OperationState contains information about state of currently performing operation on application.
+// OperationState contains information about state of a running operation
 type OperationState struct {
 	// Operation is the original requested operation
 	Operation Operation `json:"operation" protobuf:"bytes,1,opt,name=operation"`
 	// Phase is the current phase of the operation
 	Phase synccommon.OperationPhase `json:"phase" protobuf:"bytes,2,opt,name=phase"`
-	// Message hold any pertinent messages when attempting to perform operation (typically errors).
+	// Message holds any pertinent messages when attempting to perform operation (typically errors).
 	Message string `json:"message,omitempty" protobuf:"bytes,3,opt,name=message"`
 	// SyncResult is the result of a Sync operation
 	SyncResult *SyncOperationResult `json:"syncResult,omitempty" protobuf:"bytes,4,opt,name=syncResult"`
@@ -615,6 +667,8 @@ type Info struct {
 
 type SyncOptions []string
 
+// AddOption adds a sync option to the list of sync options and returns the modified list.
+// If option was already set, returns the unmodified list of sync options.
 func (o SyncOptions) AddOption(option string) SyncOptions {
 	for _, j := range o {
 		if j == option {
@@ -624,6 +678,8 @@ func (o SyncOptions) AddOption(option string) SyncOptions {
 	return append(o, option)
 }
 
+// RemoveOption removes a sync option from the list of sync options and returns the modified list.
+// If option has not been already set, returns the unmodified list of sync options.
 func (o SyncOptions) RemoveOption(option string) SyncOptions {
 	for i, j := range o {
 		if j == option {
@@ -633,6 +689,7 @@ func (o SyncOptions) RemoveOption(option string) SyncOptions {
 	return o
 }
 
+// HasOption returns true if the list of sync options contains given option
 func (o SyncOptions) HasOption(option string) bool {
 	for _, i := range o {
 		if option == i {
@@ -652,15 +709,16 @@ type SyncPolicy struct {
 	Retry *RetryStrategy `json:"retry,omitempty" protobuf:"bytes,3,opt,name=retry"`
 }
 
+// IsZero returns true if the sync policy is empty
 func (p *SyncPolicy) IsZero() bool {
 	return p == nil || (p.Automated == nil && len(p.SyncOptions) == 0 && p.Retry == nil)
 }
 
+// RetryStrategy contains information about the strategy to apply when a sync failed
 type RetryStrategy struct {
-	// Limit is the maximum number of attempts when retrying a container
+	// Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
 	Limit int64 `json:"limit,omitempty" protobuf:"bytes,1,opt,name=limit"`
-
-	// Backoff is a backoff strategy
+	// Backoff controls how to backoff on subsequent retries of failed syncs
 	Backoff *Backoff `json:"backoff,omitempty" protobuf:"bytes,2,opt,name=backoff,casttype=Backoff"`
 }
 
@@ -677,6 +735,7 @@ func parseStringToDuration(durationString string) (time.Duration, error) {
 	return suspendDuration, nil
 }
 
+// NextRetryAt calculates the earliest time the next retry should be performed on a failing sync
 func (r *RetryStrategy) NextRetryAt(lastAttempt time.Time, retryCounts int64) (time.Time, error) {
 	maxDuration := common.DefaultSyncRetryMaxDuration
 	duration := common.DefaultSyncRetryDuration
@@ -707,7 +766,7 @@ func (r *RetryStrategy) NextRetryAt(lastAttempt time.Time, retryCounts int64) (t
 	return lastAttempt.Add(timeToWait), nil
 }
 
-// Backoff is a backoff strategy to use within retryStrategy
+// Backoff is the backoff strategy to use on subsequent retries for failing syncs
 type Backoff struct {
 	// Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
 	Duration string `json:"duration,omitempty" protobuf:"bytes,1,opt,name=duration"`
@@ -719,9 +778,9 @@ type Backoff struct {
 
 // SyncPolicyAutomated controls the behavior of an automated sync
 type SyncPolicyAutomated struct {
-	// Prune will prune resources automatically as part of automated sync (default: false)
+	// Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)
 	Prune bool `json:"prune,omitempty" protobuf:"bytes,1,opt,name=prune"`
-	// SelfHeal enables auto-syncing if  (default: false)
+	// SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)
 	SelfHeal bool `json:"selfHeal,omitempty" protobuf:"bytes,2,opt,name=selfHeal"`
 	// AllowEmpty allows apps have zero live resources (default: false)
 	AllowEmpty bool `json:"allowEmpty,omitempty" protobuf:"bytes,3,opt,name=allowEmpty"`
@@ -735,6 +794,7 @@ type SyncStrategy struct {
 	Hook *SyncStrategyHook `json:"hook,omitempty" protobuf:"bytes,2,opt,name=hook"`
 }
 
+// Force returns true if the sync strategy specifies to perform a forced sync
 func (m *SyncStrategy) Force() bool {
 	if m == nil {
 		return false
@@ -763,31 +823,29 @@ type SyncStrategyHook struct {
 	SyncStrategyApply `json:",inline" protobuf:"bytes,1,opt,name=syncStrategyApply"`
 }
 
-// data about a specific revision within a repo
+// RevisionMetadata contains metadata for a specific revision in a Git repository
 type RevisionMetadata struct {
 	// who authored this revision,
 	// typically their name and email, e.g. "John Doe <john_doe@my-company.com>",
 	// but might not match this example
 	Author string `json:"author,omitempty" protobuf:"bytes,1,opt,name=author"`
-	// when the revision was authored
+	// Date specifies when the revision was authored
 	Date metav1.Time `json:"date" protobuf:"bytes,2,opt,name=date"`
-	// tags on the revision,
-	// note - tags can move from one revision to another
+	// Tags specifies any tags currently attached to the revision
+	// Floating tags can move from one revision to another
 	Tags []string `json:"tags,omitempty" protobuf:"bytes,3,opt,name=tags"`
-	// the message associated with the revision,
-	// probably the commit message,
-	// this is truncated to the first newline or 64 characters (which ever comes first)
+	// Message contains the message associated with the revision, most likely the commit message.
+	// The message is truncated to the first newline or 64 characters (which ever comes first)
 	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
-	// If revision was signed with GPG, and signature verification is enabled,
-	// this contains a hint on the signer
+	// SignatureInfo contains a hint on the signer if the revision was signed with GPG, and signature verification is enabled.
 	SignatureInfo string `json:"signatureInfo,omitempty" protobuf:"bytes,5,opt,name=signatureInfo"`
 }
 
 // SyncOperationResult represent result of sync operation
 type SyncOperationResult struct {
-	// Resources holds the sync result of each individual resource
+	// Resources contains a list of sync result items for each individual resource in a sync operation
 	Resources ResourceResults `json:"resources,omitempty" protobuf:"bytes,1,opt,name=resources"`
-	// Revision holds the revision of the sync
+	// Revision holds the revision this sync operation was performed to
 	Revision string `json:"revision" protobuf:"bytes,2,opt,name=revision"`
 	// Source records the application source information of the sync, used for comparing auto-sync
 	Source ApplicationSource `json:"source,omitempty" protobuf:"bytes,3,opt,name=source"`
@@ -795,24 +853,30 @@ type SyncOperationResult struct {
 
 // ResourceResult holds the operation result details of a specific resource
 type ResourceResult struct {
-	Group     string `json:"group" protobuf:"bytes,1,opt,name=group"`
-	Version   string `json:"version" protobuf:"bytes,2,opt,name=version"`
-	Kind      string `json:"kind" protobuf:"bytes,3,opt,name=kind"`
+	// Group specifies the API group of the resource
+	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
+	// Version specifies the API version of the resource
+	Version string `json:"version" protobuf:"bytes,2,opt,name=version"`
+	// Kind specifies the API kind of the resource
+	Kind string `json:"kind" protobuf:"bytes,3,opt,name=kind"`
+	// Namespace specifies the target namespace of the resource
 	Namespace string `json:"namespace" protobuf:"bytes,4,opt,name=namespace"`
-	Name      string `json:"name" protobuf:"bytes,5,opt,name=name"`
-	// the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+	// Name specifies the name of the resource
+	Name string `json:"name" protobuf:"bytes,5,opt,name=name"`
+	// Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
 	Status synccommon.ResultCode `json:"status,omitempty" protobuf:"bytes,6,opt,name=status"`
-	// message for the last sync OR operation
+	// Message contains an informational or error message for the last sync OR operation
 	Message string `json:"message,omitempty" protobuf:"bytes,7,opt,name=message"`
-	// the type of the hook, empty for non-hook resources
+	// HookType specifies the type of the hook. Empty for non-hook resources
 	HookType synccommon.HookType `json:"hookType,omitempty" protobuf:"bytes,8,opt,name=hookType"`
-	// the state of any operation associated with this resource OR hook
-	// note: can contain values for non-hook resources
+	// HookPhase contains the state of any operation associated with this resource OR hook
+	// This can also contain values for non-hook resources.
 	HookPhase synccommon.OperationPhase `json:"hookPhase,omitempty" protobuf:"bytes,9,opt,name=hookPhase"`
-	// indicates the particular phase of the sync that this is for
+	// SyncPhase indicates the particular phase of the sync that this result was acquired in
 	SyncPhase synccommon.SyncPhase `json:"syncPhase,omitempty" protobuf:"bytes,10,opt,name=syncPhase"`
 }
 
+// GroupVersionKind returns the GVK schema information for a given resource within a sync result
 func (r *ResourceResult) GroupVersionKind() schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group:   r.Group,
@@ -821,8 +885,10 @@ func (r *ResourceResult) GroupVersionKind() schema.GroupVersionKind {
 	}
 }
 
+// ResourceResults defines a list of resource results for a given operation
 type ResourceResults []*ResourceResult
 
+// Find returns the operation result for a specified resource and the index in the list where it was found
 func (r ResourceResults) Find(group string, kind string, namespace string, name string, phase synccommon.SyncPhase) (int, *ResourceResult) {
 	for i, res := range r {
 		if res.Group == group && res.Kind == kind && res.Namespace == namespace && res.Name == name && res.SyncPhase == phase {
@@ -832,6 +898,7 @@ func (r ResourceResults) Find(group string, kind string, namespace string, name 
 	return 0, nil
 }
 
+// PruningRequired returns a positive integer containing the number of resources that require pruning after an operation has been completed
 func (r ResourceResults) PruningRequired() (num int) {
 	for _, res := range r {
 		if res.Status == synccommon.ResultCodePruneSkipped {
@@ -841,16 +908,17 @@ func (r ResourceResults) PruningRequired() (num int) {
 	return num
 }
 
-// RevisionHistory contains information relevant to an application deployment
+// RevisionHistory contains history information about a previous sync
 type RevisionHistory struct {
-	// Revision holds the revision of the sync
+	// Revision holds the revision the sync was performed against
 	Revision string `json:"revision" protobuf:"bytes,2,opt,name=revision"`
-	// DeployedAt holds the time the deployment completed
+	// DeployedAt holds the time the sync operation completed
 	DeployedAt metav1.Time `json:"deployedAt" protobuf:"bytes,4,opt,name=deployedAt"`
 	// ID is an auto incrementing identifier of the RevisionHistory
-	ID     int64             `json:"id" protobuf:"bytes,5,opt,name=id"`
+	ID int64 `json:"id" protobuf:"bytes,5,opt,name=id"`
+	// Source is a reference to the application source used for the sync operation
 	Source ApplicationSource `json:"source,omitempty" protobuf:"bytes,6,opt,name=source"`
-	// DeployStartedAt holds the time the deployment started
+	// DeployStartedAt holds the time the sync operation started
 	DeployStartedAt *metav1.Time `json:"deployStartedAt,omitempty" protobuf:"bytes,7,opt,name=deployStartedAt"`
 }
 
@@ -886,8 +954,11 @@ type SyncStatusCode string
 
 // Possible comparison results
 const (
-	SyncStatusCodeUnknown   SyncStatusCode = "Unknown"
-	SyncStatusCodeSynced    SyncStatusCode = "Synced"
+	// SyncStatusCodeUnknown indicates that the status of a sync could not be reliably determined
+	SyncStatusCodeUnknown SyncStatusCode = "Unknown"
+	// SyncStatusCodeOutOfSync indicates that desired and live states match
+	SyncStatusCodeSynced SyncStatusCode = "Synced"
+	// SyncStatusCodeOutOfSync indicates that there is a drift beween desired and live states
 	SyncStatusCodeOutOfSync SyncStatusCode = "OutOfSync"
 )
 
@@ -918,35 +989,43 @@ const (
 	ApplicationConditionOrphanedResourceWarning = "OrphanedResourceWarning"
 )
 
-// ApplicationCondition contains details about current application condition
+// ApplicationCondition contains details about an application condition, which is usally an error or warning
 type ApplicationCondition struct {
 	// Type is an application condition type
 	Type ApplicationConditionType `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// Message contains human-readable message indicating details about condition
 	Message string `json:"message" protobuf:"bytes,2,opt,name=message"`
-	// LastTransitionTime is the time the condition was first observed.
+	// LastTransitionTime is the time the condition was last observed
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 }
 
 // ComparedTo contains application source and target which was used for resources comparison
 type ComparedTo struct {
-	Source      ApplicationSource      `json:"source" protobuf:"bytes,1,opt,name=source"`
+	// Source is a reference to the application's source used for comparison
+	Source ApplicationSource `json:"source" protobuf:"bytes,1,opt,name=source"`
+	// Destination is a reference to the application's destination used for comparison
 	Destination ApplicationDestination `json:"destination" protobuf:"bytes,2,opt,name=destination"`
 }
 
-// SyncStatus is a comparison result of application spec and deployed application.
+// SyncStatus contains information about the currently observed live and desired states of an application
 type SyncStatus struct {
-	Status     SyncStatusCode `json:"status" protobuf:"bytes,1,opt,name=status,casttype=SyncStatusCode"`
-	ComparedTo ComparedTo     `json:"comparedTo,omitempty" protobuf:"bytes,2,opt,name=comparedTo"`
-	Revision   string         `json:"revision,omitempty" protobuf:"bytes,3,opt,name=revision"`
+	// Status is the sync state of the comparison
+	Status SyncStatusCode `json:"status" protobuf:"bytes,1,opt,name=status,casttype=SyncStatusCode"`
+	// ComparedTo contains information about what has been compared
+	ComparedTo ComparedTo `json:"comparedTo,omitempty" protobuf:"bytes,2,opt,name=comparedTo"`
+	// Revision contains information about the revision the comparison has been performed to
+	Revision string `json:"revision,omitempty" protobuf:"bytes,3,opt,name=revision"`
 }
 
+// HealthStatus contains information about the currently observed health state of an application or resource
 type HealthStatus struct {
-	Status  health.HealthStatusCode `json:"status,omitempty" protobuf:"bytes,1,opt,name=status"`
-	Message string                  `json:"message,omitempty" protobuf:"bytes,2,opt,name=message"`
+	// Status holds the status code of the application or resource
+	Status health.HealthStatusCode `json:"status,omitempty" protobuf:"bytes,1,opt,name=status"`
+	// Message is a human-readable informational message describing the health status
+	Message string `json:"message,omitempty" protobuf:"bytes,2,opt,name=message"`
 }
 
-// InfoItem contains human readable information about object
+// InfoItem contains arbitrary, human readable information about an application
 type InfoItem struct {
 	// Name is a human readable title for this piece of information.
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
@@ -955,6 +1034,7 @@ type InfoItem struct {
 }
 
 // ResourceNetworkingInfo holds networking resource related information
+// TODO: describe members of this type
 type ResourceNetworkingInfo struct {
 	TargetLabels map[string]string        `json:"targetLabels,omitempty" protobuf:"bytes,1,opt,name=targetLabels"`
 	TargetRefs   []ResourceRef            `json:"targetRefs,omitempty" protobuf:"bytes,2,opt,name=targetRefs"`
@@ -964,6 +1044,7 @@ type ResourceNetworkingInfo struct {
 	ExternalURLs []string `json:"externalURLs,omitempty" protobuf:"bytes,5,opt,name=externalURLs"`
 }
 
+// TODO: describe this type
 type HostResourceInfo struct {
 	ResourceName         v1.ResourceName `json:"resourceName,omitempty" protobuf:"bytes,1,name=resourceName"`
 	RequestedByApp       int64           `json:"requestedByApp,omitempty" protobuf:"bytes,2,name=requestedByApp"`
@@ -972,6 +1053,8 @@ type HostResourceInfo struct {
 }
 
 // HostInfo holds host name and resources metrics
+// TODO: describe purpose of this type
+// TODO: describe members of this type
 type HostInfo struct {
 	Name          string             `json:"name,omitempty" protobuf:"bytes,1,name=name"`
 	ResourcesInfo []HostResourceInfo `json:"resourcesInfo,omitempty" protobuf:"bytes,2,name=resourcesInfo"`
@@ -979,6 +1062,7 @@ type HostInfo struct {
 }
 
 // ApplicationTree holds nodes which belongs to the application
+// TODO: describe purpose of this type
 type ApplicationTree struct {
 	// Nodes contains list of nodes which either directly managed by the application and children of directly managed nodes.
 	Nodes []ResourceNode `json:"nodes,omitempty" protobuf:"bytes,1,rep,name=nodes"`
@@ -1002,6 +1086,7 @@ func (t *ApplicationTree) Normalize() {
 	})
 }
 
+// ApplicationSummary contains information about URLs and container images used by an application
 type ApplicationSummary struct {
 	// ExternalURLs holds all external URLs of application child resources.
 	ExternalURLs []string `json:"externalURLs,omitempty" protobuf:"bytes,1,opt,name=externalURLs"`
@@ -1009,6 +1094,7 @@ type ApplicationSummary struct {
 	Images []string `json:"images,omitempty" protobuf:"bytes,2,opt,name=images"`
 }
 
+// TODO: Document purpose of this method
 func (t *ApplicationTree) FindNode(group string, kind string, namespace string, name string) *ResourceNode {
 	for _, n := range append(t.Nodes, t.OrphanedNodes...) {
 		if n.Group == group && n.Kind == kind && n.Namespace == namespace && n.Name == name {
@@ -1018,6 +1104,7 @@ func (t *ApplicationTree) FindNode(group string, kind string, namespace string, 
 	return nil
 }
 
+// TODO: Document purpose of this method
 func (t *ApplicationTree) GetSummary() ApplicationSummary {
 	urlsSet := make(map[string]bool)
 	imagesSet := make(map[string]bool)
@@ -1048,7 +1135,7 @@ func (t *ApplicationTree) GetSummary() ApplicationSummary {
 	return ApplicationSummary{ExternalURLs: urls, Images: images}
 }
 
-// ResourceRef includes fields which unique identify resource
+// ResourceRef includes fields which uniquely identify a resource
 type ResourceRef struct {
 	Group     string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	Version   string `json:"version,omitempty" protobuf:"bytes,2,opt,name=version"`
@@ -1059,6 +1146,7 @@ type ResourceRef struct {
 }
 
 // ResourceNode contains information about live resource and its children
+// TODO: describe members of this type
 type ResourceNode struct {
 	ResourceRef     `json:",inline" protobuf:"bytes,1,opt,name=resourceRef"`
 	ParentRefs      []ResourceRef           `json:"parentRefs,omitempty" protobuf:"bytes,2,opt,name=parentRefs"`
@@ -1070,11 +1158,13 @@ type ResourceNode struct {
 	CreatedAt       *metav1.Time            `json:"createdAt,omitempty" protobuf:"bytes,8,opt,name=createdAt"`
 }
 
-// FullName returns node full name
+// FullName returns a resource node's full name in the format "group/kind/namespace/name"
+// For cluster-scoped resources, namespace will be the empty string.
 func (n *ResourceNode) FullName() string {
 	return fmt.Sprintf("%s/%s/%s/%s", n.Group, n.Kind, n.Namespace, n.Name)
 }
 
+// GroupKindVersion returns the GVK schema type for given resource node
 func (n *ResourceNode) GroupKindVersion() schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group:   n.Group,
@@ -1084,6 +1174,7 @@ func (n *ResourceNode) GroupKindVersion() schema.GroupVersionKind {
 }
 
 // ResourceStatus holds the current sync and health status of a resource
+// TODO: describe members of this type
 type ResourceStatus struct {
 	Group           string         `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	Version         string         `json:"version,omitempty" protobuf:"bytes,2,opt,name=version"`
@@ -1096,11 +1187,13 @@ type ResourceStatus struct {
 	RequiresPruning bool           `json:"requiresPruning,omitempty" protobuf:"bytes,9,opt,name=requiresPruning"`
 }
 
+// GroupKindVersion returns the GVK schema type for given resource status
 func (r *ResourceStatus) GroupVersionKind() schema.GroupVersionKind {
 	return schema.GroupVersionKind{Group: r.Group, Version: r.Version, Kind: r.Kind}
 }
 
 // ResourceDiff holds the diff of a live and target resource object
+// TODO: describe members of this type
 type ResourceDiff struct {
 	Group     string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	Kind      string `json:"kind,omitempty" protobuf:"bytes,2,opt,name=kind"`
@@ -1122,25 +1215,32 @@ type ResourceDiff struct {
 	Modified           bool   `json:"modified,omitempty" protobuf:"bytes,12,opt,name=modified"`
 }
 
-// FullName returns full name of a node that was used for diffing
+// FullName returns full name of a node that was used for diffing in the format "group/kind/namespace/name"
+// For cluster-scoped resources, namespace will be the empty string.
 func (r *ResourceDiff) FullName() string {
 	return fmt.Sprintf("%s/%s/%s/%s", r.Group, r.Kind, r.Namespace, r.Name)
 }
 
-// ConnectionStatus represents connection status
+// ConnectionStatus represents the status indicator for a connection to a remote resource
 type ConnectionStatus = string
 
 const (
+	// ConnectionStatusSuccessful indicates that a connection has been successfully established
 	ConnectionStatusSuccessful = "Successful"
-	ConnectionStatusFailed     = "Failed"
-	ConnectionStatusUnknown    = "Unknown"
+	// ConnectionStatusFailed indicates that a connection attempt has failed
+	ConnectionStatusFailed = "Failed"
+	// ConnectionStatusUnknown indicates that the connection status could not be reliably determined
+	ConnectionStatusUnknown = "Unknown"
 )
 
-// ConnectionState contains information about remote resource connection state
+// ConnectionState contains information about remote resource connection state, currently used for clusters and repositories
 type ConnectionState struct {
-	Status     ConnectionStatus `json:"status" protobuf:"bytes,1,opt,name=status"`
-	Message    string           `json:"message" protobuf:"bytes,2,opt,name=message"`
-	ModifiedAt *metav1.Time     `json:"attemptedAt" protobuf:"bytes,3,opt,name=attemptedAt"`
+	// Status contains the current status indicator for the connection
+	Status ConnectionStatus `json:"status" protobuf:"bytes,1,opt,name=status"`
+	// Message contains human readable information about the connection status
+	Message string `json:"message" protobuf:"bytes,2,opt,name=message"`
+	// ModifiedAt contains the timestamp when this connection status has been determined
+	ModifiedAt *metav1.Time `json:"attemptedAt" protobuf:"bytes,3,opt,name=attemptedAt"`
 }
 
 // Cluster is the definition of a cluster resource
@@ -1159,16 +1259,17 @@ type Cluster struct {
 	// DEPRECATED: use Info.ServerVersion field instead.
 	// The server version
 	ServerVersion string `json:"serverVersion,omitempty" protobuf:"bytes,5,opt,name=serverVersion"`
-	// Holds list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
+	// Holds list of namespaces which are accessible in that cluster. Cluster level resources will be ignored if namespace list is not empty.
 	Namespaces []string `json:"namespaces,omitempty" protobuf:"bytes,6,opt,name=namespaces"`
 	// RefreshRequestedAt holds time when cluster cache refresh has been requested
 	RefreshRequestedAt *metav1.Time `json:"refreshRequestedAt,omitempty" protobuf:"bytes,7,opt,name=refreshRequestedAt"`
-	// Holds information about cluster cache
+	// Info holds information about cluster cache and state
 	Info ClusterInfo `json:"info,omitempty" protobuf:"bytes,8,opt,name=info"`
 	// Shard contains optional shard number. Calculated on the fly by the application controller if not specified.
 	Shard *int64 `json:"shard,omitempty" protobuf:"bytes,9,opt,name=shard"`
 }
 
+// Equals returns true if two cluster objects are considered to be equal
 func (c *Cluster) Equals(other *Cluster) bool {
 	if c.Server != other.Server {
 		return false
@@ -1193,13 +1294,19 @@ func (c *Cluster) Equals(other *Cluster) bool {
 	return reflect.DeepEqual(c.Config, other.Config)
 }
 
+// ClusterInfo contains information about the cluster
 type ClusterInfo struct {
-	ConnectionState   ConnectionState  `json:"connectionState,omitempty" protobuf:"bytes,1,opt,name=connectionState"`
-	ServerVersion     string           `json:"serverVersion,omitempty" protobuf:"bytes,2,opt,name=serverVersion"`
-	CacheInfo         ClusterCacheInfo `json:"cacheInfo,omitempty" protobuf:"bytes,3,opt,name=cacheInfo"`
-	ApplicationsCount int64            `json:"applicationsCount" protobuf:"bytes,4,opt,name=applicationsCount"`
+	// ConnectionState contains information about the connection to the cluster
+	ConnectionState ConnectionState `json:"connectionState,omitempty" protobuf:"bytes,1,opt,name=connectionState"`
+	// ServerVersion contains information about the Kubernetes version of the cluster
+	ServerVersion string `json:"serverVersion,omitempty" protobuf:"bytes,2,opt,name=serverVersion"`
+	// CacheInfo contains information about the cluster cache
+	CacheInfo ClusterCacheInfo `json:"cacheInfo,omitempty" protobuf:"bytes,3,opt,name=cacheInfo"`
+	// ApplicationsCount is the number of applications managed by Argo CD on the cluster
+	ApplicationsCount int64 `json:"applicationsCount" protobuf:"bytes,4,opt,name=applicationsCount"`
 }
 
+// ClusterCacheInfo contains information about the cluster cache
 type ClusterCacheInfo struct {
 	// ResourcesCount holds number of observed Kubernetes resources
 	ResourcesCount int64 `json:"resourcesCount,omitempty" protobuf:"bytes,1,opt,name=resourcesCount"`
@@ -1267,7 +1374,7 @@ type ClusterConfig struct {
 
 // TLSClientConfig contains settings to enable transport layer security
 type TLSClientConfig struct {
-	// Server should be accessed without verifying the TLS certificate. For testing only.
+	// Insecure specifies that the server should be accessed without verifying the TLS certificate. For testing only.
 	Insecure bool `json:"insecure" protobuf:"bytes,1,opt,name=insecure"`
 	// ServerName is passed to the server for SNI and is used in the client to check server
 	// certificates against. If ServerName is empty, the hostname used to contact the
@@ -1284,12 +1391,15 @@ type TLSClientConfig struct {
 	CAData []byte `json:"caData,omitempty" protobuf:"bytes,5,opt,name=caData"`
 }
 
-// KnownTypeField contains mapping between CRD field and known Kubernetes type
+// KnownTypeField contains mapping between CRD field and known Kubernetes type.
+// This is mainly used for unit conversion in unknown resources (e.g. 0.1 == 100mi)
+// TODO: Describe the members of this type
 type KnownTypeField struct {
 	Field string `json:"field,omitempty" protobuf:"bytes,1,opt,name=field"`
 	Type  string `json:"type,omitempty" protobuf:"bytes,2,opt,name=type"`
 }
 
+// TODO: describe this type
 type OverrideIgnoreDiff struct {
 	JSONPointers []string `json:"jsonPointers" protobuf:"bytes,1,rep,name=jSONPointers"`
 }
@@ -1302,6 +1412,7 @@ type rawResourceOverride struct {
 }
 
 // ResourceOverride holds configuration to customize resource diffing and health assessment
+// TODO: describe the members of this type
 type ResourceOverride struct {
 	HealthLua         string             `protobuf:"bytes,1,opt,name=healthLua"`
 	Actions           string             `protobuf:"bytes,3,opt,name=actions"`
@@ -1309,6 +1420,7 @@ type ResourceOverride struct {
 	KnownTypeFields   []KnownTypeField   `protobuf:"bytes,4,opt,name=knownTypeFields"`
 }
 
+// TODO: describe this method
 func (s *ResourceOverride) UnmarshalJSON(data []byte) error {
 	raw := &rawResourceOverride{}
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -1320,6 +1432,7 @@ func (s *ResourceOverride) UnmarshalJSON(data []byte) error {
 	return yaml.Unmarshal([]byte(raw.IgnoreDifferences), &s.IgnoreDifferences)
 }
 
+// TODO: describe this method
 func (s ResourceOverride) MarshalJSON() ([]byte, error) {
 	ignoreDifferencesData, err := yaml.Marshal(s.IgnoreDifferences)
 	if err != nil {
@@ -1329,6 +1442,7 @@ func (s ResourceOverride) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
+// TODO: describe this method
 func (o *ResourceOverride) GetActions() (ResourceActions, error) {
 	var actions ResourceActions
 	err := yaml.Unmarshal([]byte(o.Actions), &actions)
@@ -1338,22 +1452,30 @@ func (o *ResourceOverride) GetActions() (ResourceActions, error) {
 	return actions, nil
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 type ResourceActions struct {
 	ActionDiscoveryLua string                     `json:"discovery.lua,omitempty" yaml:"discovery.lua,omitempty" protobuf:"bytes,1,opt,name=actionDiscoveryLua"`
 	Definitions        []ResourceActionDefinition `json:"definitions,omitempty" protobuf:"bytes,2,rep,name=definitions"`
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 type ResourceActionDefinition struct {
 	Name      string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	ActionLua string `json:"action.lua" yaml:"action.lua" protobuf:"bytes,2,opt,name=actionLua"`
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 type ResourceAction struct {
 	Name     string                `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	Params   []ResourceActionParam `json:"params,omitempty" protobuf:"bytes,2,rep,name=params"`
 	Disabled bool                  `json:"disabled,omitempty" protobuf:"varint,3,opt,name=disabled"`
 }
 
+// TODO: describe this type
+// TODO: describe members of this type
 type ResourceActionParam struct {
 	Name    string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	Value   string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
@@ -1361,7 +1483,7 @@ type ResourceActionParam struct {
 	Default string `json:"default,omitempty" protobuf:"bytes,4,opt,name=default"`
 }
 
-// RepoCreds holds a repository credentials definition
+// RepoCreds holds the definition for repository credentials
 type RepoCreds struct {
 	// URL is the URL that this credentials matches to
 	URL string `json:"url" protobuf:"bytes,1,opt,name=url"`
@@ -1369,79 +1491,79 @@ type RepoCreds struct {
 	Username string `json:"username,omitempty" protobuf:"bytes,2,opt,name=username"`
 	// Password for authenticating at the repo server
 	Password string `json:"password,omitempty" protobuf:"bytes,3,opt,name=password"`
-	// SSH private key data for authenticating at the repo server (only Git repos)
+	// SSHPrivateKey contains the private key data for authenticating at the repo server using SSH (only Git repos)
 	SSHPrivateKey string `json:"sshPrivateKey,omitempty" protobuf:"bytes,4,opt,name=sshPrivateKey"`
-	// TLS client cert data for authenticating at the repo server
+	// TLSClientCertData specifies the TLS client cert data for authenticating at the repo server
 	TLSClientCertData string `json:"tlsClientCertData,omitempty" protobuf:"bytes,5,opt,name=tlsClientCertData"`
-	// TLS client cert key for authenticating at the repo server
+	// TLSClientCertKey specifies the TLS client cert key for authenticating at the repo server
 	TLSClientCertKey string `json:"tlsClientCertKey,omitempty" protobuf:"bytes,6,opt,name=tlsClientCertKey"`
-	// Github App Private Key PEM data
+	// GithubAppPrivateKey specifies the private key PEM data for authentication via GitHub app
 	GithubAppPrivateKey string `json:"githubAppPrivateKey,omitempty" protobuf:"bytes,7,opt,name=githubAppPrivateKey"`
-	// Github App ID of the app used to access the repo
+	// GithubAppId specifies the Github App ID of the app used to access the repo for GitHub app authentication
 	GithubAppId int64 `json:"githubAppID,omitempty" protobuf:"bytes,8,opt,name=githubAppID"`
-	// Github App Installation ID of the installed GitHub App
+	// GithubAppInstallationId specifies the ID of the installed GitHub App for GitHub app authentication
 	GithubAppInstallationId int64 `json:"githubAppInstallationID,omitempty" protobuf:"bytes,9,opt,name=githubAppInstallationID"`
-	// Github App Enterprise base url if empty will default to https://api.github.com
+	// GithubAppEnterpriseBaseURL specifies the GitHub API URL for GitHub app authentication. If empty will default to https://api.github.com
 	GitHubAppEnterpriseBaseURL string `json:"githubAppEnterpriseBaseUrl,omitempty" protobuf:"bytes,10,opt,name=githubAppEnterpriseBaseUrl"`
 }
 
 // Repository is a repository holding application configurations
 type Repository struct {
-	// URL of the repo
+	// Repo contains the URL to the remote repository
 	Repo string `json:"repo" protobuf:"bytes,1,opt,name=repo"`
-	// Username for authenticating at the repo server
+	// Username contains the user name used for authenticating at the remote repository
 	Username string `json:"username,omitempty" protobuf:"bytes,2,opt,name=username"`
-	// Password for authenticating at the repo server
+	// Password contains the password or PAT used for authenticating at the remote repository
 	Password string `json:"password,omitempty" protobuf:"bytes,3,opt,name=password"`
-	// SSH private key data for authenticating at the repo server
-	// only for Git repos
+	// SSHPrivateKey contains the PEM data for authenticating at the repo server. Only used with Git repos.
 	SSHPrivateKey string `json:"sshPrivateKey,omitempty" protobuf:"bytes,4,opt,name=sshPrivateKey"`
-	// Current state of repository server connecting
+	// ConnectionState contains information about the current state of connection to the repository server
 	ConnectionState ConnectionState `json:"connectionState,omitempty" protobuf:"bytes,5,opt,name=connectionState"`
 	// InsecureIgnoreHostKey should not be used anymore, Insecure is favoured
-	// only for Git repos
+	// Used only for Git repos
 	InsecureIgnoreHostKey bool `json:"insecureIgnoreHostKey,omitempty" protobuf:"bytes,6,opt,name=insecureIgnoreHostKey"`
-	// Whether the repo is insecure
+	// Insecure specifies whether the connection to the repository ignores any errors when verifying TLS certificates or SSH host keys
 	Insecure bool `json:"insecure,omitempty" protobuf:"bytes,7,opt,name=insecure"`
-	// Whether git-lfs support should be enabled for this repo
+	// EnableLFS specifies whether git-lfs support should be enabled for this repo. Only valid for Git repositories.
 	EnableLFS bool `json:"enableLfs,omitempty" protobuf:"bytes,8,opt,name=enableLfs"`
-	// TLS client cert data for authenticating at the repo server
+	// TLSClientCertData contains a certificate in PEM format for authenticating at the repo server
 	TLSClientCertData string `json:"tlsClientCertData,omitempty" protobuf:"bytes,9,opt,name=tlsClientCertData"`
-	// TLS client cert key for authenticating at the repo server
+	// TLSClientCertKey contains a private key in PEM format for authenticating at the repo server
 	TLSClientCertKey string `json:"tlsClientCertKey,omitempty" protobuf:"bytes,10,opt,name=tlsClientCertKey"`
-	// type of the repo, maybe "git or "helm, "git" is assumed if empty or absent
+	// Type specifies the type of the repo. Can be either "git" or "helm. "git" is assumed if empty or absent.
 	Type string `json:"type,omitempty" protobuf:"bytes,11,opt,name=type"`
-	// only for Helm repos
+	// Name specifies a name to be used for this repo. Only used with Helm repos
 	Name string `json:"name,omitempty" protobuf:"bytes,12,opt,name=name"`
 	// Whether credentials were inherited from a credential set
 	InheritedCreds bool `json:"inheritedCreds,omitempty" protobuf:"bytes,13,opt,name=inheritedCreds"`
-	// Whether helm-oci support should be enabled for this repo
+	// EnableOCI specifies whether helm-oci support should be enabled for this repo
 	EnableOCI bool `json:"enableOCI,omitempty" protobuf:"bytes,14,opt,name=enableOCI"`
 	// Github App Private Key PEM data
 	GithubAppPrivateKey string `json:"githubAppPrivateKey,omitempty" protobuf:"bytes,15,opt,name=githubAppPrivateKey"`
-	// Github App ID of the app used to access the repo
+	// GithubAppId specifies the ID of the GitHub app used to access the repo
 	GithubAppId int64 `json:"githubAppID,omitempty" protobuf:"bytes,16,opt,name=githubAppID"`
-	// Github App Installation ID of the installed GitHub App
+	// GithubAppInstallationId specifies the installation ID of the GitHub App used to access the repo
 	GithubAppInstallationId int64 `json:"githubAppInstallationID,omitempty" protobuf:"bytes,17,opt,name=githubAppInstallationID"`
-	// Github App Enterprise base url if empty will default to https://api.github.com
+	// GithubAppEnterpriseBaseURL specifies the base URL of GitHub Enterprise installation. If empty will default to https://api.github.com
 	GitHubAppEnterpriseBaseURL string `json:"githubAppEnterpriseBaseUrl,omitempty" protobuf:"bytes,18,opt,name=githubAppEnterpriseBaseUrl"`
 }
 
-// IsInsecure returns true if receiver has been configured to skip server verification
+// IsInsecure returns true if the repository has been configured to skip server verification
 func (repo *Repository) IsInsecure() bool {
 	return repo.InsecureIgnoreHostKey || repo.Insecure
 }
 
-// IsLFSEnabled returns true if LFS support is enabled on receiver
+// IsLFSEnabled returns true if LFS support is enabled on repository
 func (repo *Repository) IsLFSEnabled() bool {
 	return repo.EnableLFS
 }
 
-// HasCredentials returns true when the receiver has been configured any credentials
+// HasCredentials returns true when the repository has been configured with any credentials
 func (m *Repository) HasCredentials() bool {
 	return m.Username != "" || m.Password != "" || m.SSHPrivateKey != "" || m.TLSClientCertData != "" || m.GithubAppPrivateKey != ""
 }
 
+// CopyCredentialsFromRepo copies all credential information from source repository to receiving repository
 func (repo *Repository) CopyCredentialsFromRepo(source *Repository) {
 	if source != nil {
 		if repo.Username == "" {
@@ -1474,7 +1596,7 @@ func (repo *Repository) CopyCredentialsFromRepo(source *Repository) {
 	}
 }
 
-// CopyCredentialsFrom copies all credentials from source to receiver
+// CopyCredentialsFrom copies credentials from given credential template to receiving repository
 func (repo *Repository) CopyCredentialsFrom(source *RepoCreds) {
 	if source != nil {
 		if repo.Username == "" {
@@ -1507,6 +1629,7 @@ func (repo *Repository) CopyCredentialsFrom(source *RepoCreds) {
 	}
 }
 
+// GetGitCreds returns the credentials from a repository configuration used to authenticate at a Git repository
 func (repo *Repository) GetGitCreds() git.Creds {
 	if repo == nil {
 		return git.NopCreds{}
@@ -1523,6 +1646,7 @@ func (repo *Repository) GetGitCreds() git.Creds {
 	return git.NopCreds{}
 }
 
+// GetHelmCreds returns the credentials from a repository configuration used to authenticate at a Helm repository
 func (repo *Repository) GetHelmCreds() helm.Creds {
 	return helm.Creds{
 		Username:           repo.Username,
@@ -1561,8 +1685,10 @@ func (m *Repository) CopySettingsFrom(source *Repository) {
 	}
 }
 
+// Repositories defines a list of Repository configurations
 type Repositories []*Repository
 
+// Filter returns a list of repositories, which only contain items matched by the supplied predicate method
 func (r Repositories) Filter(predicate func(r *Repository) bool) Repositories {
 	var res Repositories
 	for i := range r {
@@ -1588,15 +1714,15 @@ type RepoCredsList struct {
 
 // A RepositoryCertificate is either SSH known hosts entry or TLS certificate
 type RepositoryCertificate struct {
-	// Name of the server the certificate is intended for
+	// ServerName specifies the DNS name of the server this certificate is intended for
 	ServerName string `json:"serverName" protobuf:"bytes,1,opt,name=serverName"`
-	// Type of certificate - currently "https" or "ssh"
+	// CertType specifies the type of the certificate - currently one of "https" or "ssh"
 	CertType string `json:"certType" protobuf:"bytes,2,opt,name=certType"`
-	// The sub type of the cert, i.e. "ssh-rsa"
+	// CertSubType specifies the sub type of the cert, i.e. "ssh-rsa"
 	CertSubType string `json:"certSubType" protobuf:"bytes,3,opt,name=certSubType"`
-	// Actual certificate data, protocol dependent
+	// CertData contains the actual certificate data, dependent on the certificate type
 	CertData []byte `json:"certData" protobuf:"bytes,4,opt,name=certData"`
-	// Additional certificate info (e.g. SSH fingerprint, X509 CommonName)
+	// CertInfo will hold additional certificate info, depdendent on the certificate type (e.g. SSH fingerprint, X509 CommonName)
 	CertInfo string `json:"certInfo" protobuf:"bytes,5,opt,name=certInfo"`
 }
 
@@ -1609,17 +1735,17 @@ type RepositoryCertificateList struct {
 
 // GnuPGPublicKey is a representation of a GnuPG public key
 type GnuPGPublicKey struct {
-	// KeyID in hexadecimal string format
+	// KeyID specifies the key ID, in hexadecimal string format
 	KeyID string `json:"keyID" protobuf:"bytes,1,opt,name=keyID"`
-	// Fingerprint of the key
+	// Fingerprint is the fingerprint of the key
 	Fingerprint string `json:"fingerprint,omitempty" protobuf:"bytes,2,opt,name=fingerprint"`
-	// Owner identification
+	// Owner holds the owner identification, e.g. a name and e-mail address
 	Owner string `json:"owner,omitempty" protobuf:"bytes,3,opt,name=owner"`
-	// Trust level
+	// Trust holds the level of trust assigned to this key
 	Trust string `json:"trust,omitempty" protobuf:"bytes,4,opt,name=trust"`
-	// Key sub type (e.g. rsa4096)
+	// SubType holds the key's sub type (e.g. rsa4096)
 	SubType string `json:"subType,omitempty" protobuf:"bytes,5,opt,name=subType"`
-	// Key data
+	// KeyData holds the raw key data, in base64 encoded format
 	KeyData string `json:"keyData,omitempty" protobuf:"bytes,6,opt,name=keyData"`
 }
 
@@ -1714,6 +1840,7 @@ func (p *AppProject) GetJWTToken(roleName string, issuedAt int64, id string) (*J
 	return nil, -1, fmt.Errorf("JWT token for role '%s' issued at '%d' does not exist in project '%s'", roleName, issuedAt, p.Name)
 }
 
+// RemoveJWTToken removes the specified JWT from an AppProject
 func (p AppProject) RemoveJWTToken(roleIndex int, issuedAt int64, id string) error {
 	roleName := p.Spec.Roles[roleIndex].Name
 	// For backward compatibility
@@ -1739,6 +1866,7 @@ func (p AppProject) RemoveJWTToken(roleIndex int, issuedAt int64, id string) err
 	}
 }
 
+// TODO: document this method
 func (p *AppProject) ValidateJWTTokenID(roleName string, id string) error {
 	role, _, err := p.GetRoleByName(roleName)
 	if err != nil {
@@ -1965,16 +2093,19 @@ func (p *AppProject) normalizePolicy(policy string) string {
 // OrphanedResourcesMonitorSettings holds settings of orphaned resources monitoring
 type OrphanedResourcesMonitorSettings struct {
 	// Warn indicates if warning condition should be created for apps which have orphaned resources
-	Warn   *bool                 `json:"warn,omitempty" protobuf:"bytes,1,name=warn"`
+	Warn *bool `json:"warn,omitempty" protobuf:"bytes,1,name=warn"`
+	// Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
 	Ignore []OrphanedResourceKey `json:"ignore,omitempty" protobuf:"bytes,2,opt,name=ignore"`
 }
 
+// OrphanedResourceKey is a reference to a resource to be ignored from
 type OrphanedResourceKey struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	Kind  string `json:"kind,omitempty" protobuf:"bytes,2,opt,name=kind"`
 	Name  string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
 }
 
+// IsWarn returns true if warnings are enabled for orphan resources monitoring
 func (s *OrphanedResourcesMonitorSettings) IsWarn() bool {
 	return s.Warn == nil || *s.Warn
 }
@@ -2005,7 +2136,7 @@ type AppProjectSpec struct {
 	SyncWindows SyncWindows `json:"syncWindows,omitempty" protobuf:"bytes,8,opt,name=syncWindows"`
 	// NamespaceResourceWhitelist contains list of whitelisted namespace level resources
 	NamespaceResourceWhitelist []metav1.GroupKind `json:"namespaceResourceWhitelist,omitempty" protobuf:"bytes,9,opt,name=namespaceResourceWhitelist"`
-	// List of PGP key IDs that commits to be synced to must be signed with
+	// SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
 	SignatureKeys []SignatureKey `json:"signatureKeys,omitempty" protobuf:"bytes,10,opt,name=signatureKeys"`
 	// ClusterResourceBlacklist contains list of blacklisted cluster level resources
 	ClusterResourceBlacklist []metav1.GroupKind `json:"clusterResourceBlacklist,omitempty" protobuf:"bytes,11,opt,name=clusterResourceBlacklist"`
@@ -2032,10 +2163,12 @@ type SyncWindow struct {
 	ManualSync bool `json:"manualSync,omitempty" protobuf:"bytes,7,opt,name=manualSync"`
 }
 
+// HasWindows returns true if any window is defined
 func (s *SyncWindows) HasWindows() bool {
 	return s != nil && len(*s) > 0
 }
 
+// Active returns a list of sync windows that are currently active
 func (s *SyncWindows) Active() *SyncWindows {
 	return s.active(time.Now())
 }
@@ -2064,6 +2197,7 @@ func (s *SyncWindows) active(currentTime time.Time) *SyncWindows {
 	return nil
 }
 
+// TODO: document this method
 func (s *SyncWindows) InactiveAllows() *SyncWindows {
 	return s.inactiveAllows(time.Now())
 }
@@ -2094,6 +2228,7 @@ func (s *SyncWindows) inactiveAllows(currentTime time.Time) *SyncWindows {
 	return nil
 }
 
+// AddWindow adds a sync window with the given parameters to the AppProject
 func (s *AppProjectSpec) AddWindow(knd string, sch string, dur string, app []string, ns []string, cl []string, ms bool) error {
 	if len(knd) == 0 || len(sch) == 0 || len(dur) == 0 {
 		return fmt.Errorf("cannot create window: require kind, schedule, duration and one or more of applications, namespaces and clusters")
@@ -2127,6 +2262,7 @@ func (s *AppProjectSpec) AddWindow(knd string, sch string, dur string, app []str
 
 }
 
+// DeleteWindow deletes a sync window with the given id from the AppProject
 func (s *AppProjectSpec) DeleteWindow(id int) error {
 	var exists bool
 	for i := range s.SyncWindows {
@@ -2142,6 +2278,7 @@ func (s *AppProjectSpec) DeleteWindow(id int) error {
 	return nil
 }
 
+// Matches returns a list of sync windows that are defined for a given application
 func (w *SyncWindows) Matches(app *Application) *SyncWindows {
 	if w.HasWindows() {
 		var matchingWindows SyncWindows
@@ -2178,6 +2315,7 @@ func (w *SyncWindows) Matches(app *Application) *SyncWindows {
 	return nil
 }
 
+// CanSync returns true if a sync window currently allows a sync. isManual indicates whether the sync has been triggered manually.
 func (w *SyncWindows) CanSync(isManual bool) bool {
 	if !w.HasWindows() {
 		return true
@@ -2251,6 +2389,7 @@ func (w *SyncWindows) manualEnabled() bool {
 	return false
 }
 
+// Active returns true if the sync window is currently active
 func (w SyncWindow) Active() bool {
 	return w.active(time.Now())
 }
@@ -2269,6 +2408,7 @@ func (w SyncWindow) active(currentTime time.Time) bool {
 	return nextWindow.Before(currentTime)
 }
 
+// Update updates a sync window's settings with the given parameter
 func (w *SyncWindow) Update(s string, d string, a []string, n []string, c []string) error {
 	if len(s) == 0 && len(d) == 0 && len(a) == 0 && len(n) == 0 && len(c) == 0 {
 		return fmt.Errorf("cannot update: require one or more of schedule, duration, application, namespace, or cluster")
@@ -2295,6 +2435,7 @@ func (w *SyncWindow) Update(s string, d string, a []string, n []string, c []stri
 	return nil
 }
 
+// Validate checks whether a sync window has valid configuration. The error returned indicates any problems that has been found.
 func (w *SyncWindow) Validate() error {
 	if w.Kind != "allow" && w.Kind != "deny" {
 		return fmt.Errorf("kind '%s' mismatch: can only be allow or deny", w.Kind)
@@ -2311,6 +2452,7 @@ func (w *SyncWindow) Validate() error {
 	return nil
 }
 
+// DestinationClusters returns a list of cluster URLs allowed as destination in an AppProject
 func (d AppProjectSpec) DestinationClusters() []string {
 	servers := make([]string, 0)
 
@@ -2363,7 +2505,7 @@ type KustomizeOptions struct {
 	BinaryPath string `protobuf:"bytes,2,opt,name=binaryPath"`
 }
 
-// ProjectPoliciesString returns Casbin formated string of a project's policies for each role
+// ProjectPoliciesString returns a Casbin formated string of a project's policies for each role
 func (proj *AppProject) ProjectPoliciesString() string {
 	var policies []string
 	for _, role := range proj.Spec.Roles {
@@ -2382,6 +2524,7 @@ func (app *Application) CascadedDeletion() bool {
 	return getFinalizerIndex(app.ObjectMeta, common.ResourcesFinalizerName) > -1
 }
 
+// IsRefreshRequested returns whether a refresh has been requested for an application, and if yes, the type of refresh that should be executed.
 func (app *Application) IsRefreshRequested() (RefreshType, bool) {
 	refreshType := RefreshTypeNormal
 	annotations := app.GetAnnotations()
@@ -2406,6 +2549,7 @@ func (app *Application) SetCascadedDeletion(prune bool) {
 	setFinalizer(&app.ObjectMeta, common.ResourcesFinalizerName, prune)
 }
 
+// Expired returns true if the application needs to be reconciled
 func (status *ApplicationStatus) Expired(statusRefreshTimeout time.Duration) bool {
 	return status.ReconciledAt == nil || status.ReconciledAt.Add(statusRefreshTimeout).Before(time.Now().UTC())
 }
@@ -2470,7 +2614,7 @@ func (status *ApplicationStatus) GetConditions(conditionTypes map[ApplicationCon
 	return result
 }
 
-// IsError returns true if condition is error condition
+// IsError returns true if a condition indicates an error condition
 func (condition *ApplicationCondition) IsError() bool {
 	return strings.HasSuffix(condition.Type, "Error")
 }
@@ -2480,6 +2624,7 @@ func (source *ApplicationSource) Equals(other ApplicationSource) bool {
 	return reflect.DeepEqual(*source, other)
 }
 
+// ExplicitType returns the type (e.g. Helm, Kustomize, etc) of the application. If either none or multiple types are defined, returns an error.
 func (source *ApplicationSource) ExplicitType() (*ApplicationSourceType, error) {
 	var appTypes []ApplicationSourceType
 	if source.Kustomize != nil {
@@ -2511,7 +2656,7 @@ func (source *ApplicationSource) ExplicitType() (*ApplicationSourceType, error) 
 	return &appType, nil
 }
 
-// Equals compares two instances of ApplicationDestination and return true if instances are equal.
+// Equals compares two instances of ApplicationDestination and returns true if instances are equal.
 func (dest ApplicationDestination) Equals(other ApplicationDestination) bool {
 	// ignore destination cluster name and isServerInferred fields during comparison
 	// since server URL is inferred from cluster name
@@ -2535,6 +2680,7 @@ func (spec ApplicationSpec) GetProject() string {
 	return spec.Project
 }
 
+// GetRevisionHistoryLimit returns the currently set revision history limit for an application
 func (spec ApplicationSpec) GetRevisionHistoryLimit() int {
 	if spec.RevisionHistoryLimit != nil {
 		return int(*spec.RevisionHistoryLimit)
@@ -2577,6 +2723,7 @@ func (proj AppProject) IsGroupKindPermitted(gk schema.GroupKind, namespaced bool
 	return isWhiteListed && !isBlackListed
 }
 
+// IsLiveResourcePermitted returns whether a live resource found in the cluster is permitted by an AppProject
 func (proj AppProject) IsLiveResourcePermitted(un *unstructured.Unstructured, server string) bool {
 	if !proj.IsGroupKindPermitted(un.GroupVersionKind().GroupKind(), un.GetNamespace() != "") {
 		return false
@@ -2610,10 +2757,12 @@ func setFinalizer(meta *metav1.ObjectMeta, name string, exist bool) {
 	}
 }
 
+// HasFinalizer returns true if a resource finalizer is set on an AppProject
 func (proj AppProject) HasFinalizer() bool {
 	return getFinalizerIndex(proj.ObjectMeta, common.ResourcesFinalizerName) > -1
 }
 
+// RemoveFinalizer removes a resource finalizer from an AppProject
 func (proj *AppProject) RemoveFinalizer() {
 	setFinalizer(&proj.ObjectMeta, common.ResourcesFinalizerName, false)
 }
@@ -2766,6 +2915,7 @@ func (c *Cluster) RESTConfig() *rest.Config {
 	return config
 }
 
+// UnmarshalToUnstructured unmarshals a resource representation in JSON to unstructured data
 func UnmarshalToUnstructured(resource string) (*unstructured.Unstructured, error) {
 	if resource == "" || resource == "null" {
 		return nil, nil
@@ -2778,23 +2928,28 @@ func UnmarshalToUnstructured(resource string) (*unstructured.Unstructured, error
 	return &obj, nil
 }
 
+// TODO: document this method
 func (r ResourceDiff) LiveObject() (*unstructured.Unstructured, error) {
 	return UnmarshalToUnstructured(r.LiveState)
 }
 
+// TODO: document this method
 func (r ResourceDiff) TargetObject() (*unstructured.Unstructured, error) {
 	return UnmarshalToUnstructured(r.TargetState)
 }
 
+// TODO: document this method
 func (d *ApplicationDestination) SetInferredServer(server string) {
 	d.isServerInferred = true
 	d.Server = server
 }
 
+// TODO: document this method
 func (d *ApplicationDestination) IsServerInferred() bool {
 	return d.isServerInferred
 }
 
+// MarshalJSON marshals an application destination to JSON format
 func (d *ApplicationDestination) MarshalJSON() ([]byte, error) {
 	type Alias ApplicationDestination
 	dest := d
@@ -2805,6 +2960,7 @@ func (d *ApplicationDestination) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(dest)})
 }
 
+// TODO: document this method
 func (proj *AppProject) NormalizeJWTTokens() bool {
 	needNormalize := false
 	for i, role := range proj.Spec.Roles {


### PR DESCRIPTION
This PR updates inline documentation for `pkg/apis/application/v1alpha1/types.go`, which is user visible in `swagger.json` and the `Application` and  `AppProject` CRDs. Along with this, most public methods in `types.go` have received a documentary comment. Those who I was not sure about and are stilling missing received a `TODO` indicator.

PR does not contain code changes (hopefully).

Checklist:

* [x]  (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

