### PR TITLE
feat: support caching helm repo index

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -188,6 +188,8 @@ const (
 	EnvEnableGRPCTimeHistogramEnv = "ARGOCD_ENABLE_GRPC_TIME_HISTOGRAM"
 	// EnvGithubAppCredsExpirationDuration controls the caching of Github app credentials. This value is in minutes (default: 60)
 	EnvGithubAppCredsExpirationDuration = "ARGOCD_GITHUB_APP_CREDS_EXPIRATION_DURATION"
+	// EnvHelmIndexCacheDuration controls how the helm repository index file is cached for (default: 0)
+	EnvHelmIndexCacheDuration = "ARGOCD_HELM_INDEX_CACHE_DURATION"
 )
 
 const (

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -78,7 +78,7 @@ func newServiceWithOpt(cf clientFunc) (*Service, *gitmocks.Client) {
 
 	chart := "my-chart"
 	version := semver.MustParse("1.1.0")
-	helmClient.On("GetIndex").Return(&helm.Index{Entries: map[string]helm.Entries{
+	helmClient.On("GetIndex", true).Return(&helm.Index{Entries: map[string]helm.Entries{
 		chart: {{Version: "1.0.0"}, {Version: version.String()}},
 	}}, nil)
 	helmClient.On("ExtractChart", chart, version).Return("./testdata/my-chart", io.NopCloser, nil)
@@ -1110,12 +1110,12 @@ func TestService_newHelmClientResolveRevision(t *testing.T) {
 	service := newService(".")
 
 	t.Run("EmptyRevision", func(t *testing.T) {
-		_, _, err := service.newHelmClientResolveRevision(&argoappv1.Repository{}, "", "")
+		_, _, err := service.newHelmClientResolveRevision(&argoappv1.Repository{}, "", "", true)
 		assert.EqualError(t, err, "invalid revision '': improper constraint: ")
 	})
 	t.Run("InvalidRevision", func(t *testing.T) {
-		_, _, err := service.newHelmClientResolveRevision(&argoappv1.Repository{}, "???", "")
-		assert.EqualError(t, err, "invalid revision '???': improper constraint: ???")
+		_, _, err := service.newHelmClientResolveRevision(&argoappv1.Repository{}, "???", "", true)
+		assert.EqualError(t, err, "invalid revision '???': improper constraint: ???", true)
 	})
 }
 

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1404,7 +1404,7 @@ func (s *Server) resolveRevision(ctx context.Context, app *appv1.Application, sy
 			return ambiguousRevision, ambiguousRevision, nil
 		}
 		client := helm.NewClient(repo.Repo, repo.GetHelmCreds(), repo.EnableOCI || app.Spec.Source.IsHelmOci())
-		index, err := client.GetIndex()
+		index, err := client.GetIndex(false)
 		if err != nil {
 			return "", "", err
 		}

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -161,7 +161,7 @@ func TestRepo(repo *argoappv1.Repository) error {
 				_, err := helm.NewClient(repo.Repo, repo.GetHelmCreds(), repo.EnableOCI).TestHelmOCI()
 				return err
 			} else {
-				_, err := helm.NewClient(repo.Repo, repo.GetHelmCreds(), repo.EnableOCI).GetIndex()
+				_, err := helm.NewClient(repo.Repo, repo.GetHelmCreds(), repo.EnableOCI).GetIndex(false)
 				return err
 			}
 		},

--- a/util/env/env.go
+++ b/util/env/env.go
@@ -3,6 +3,9 @@ package env
 import (
 	"os"
 	"strconv"
+	"time"
+
+	timeutil "github.com/argoproj/pkg/time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -31,4 +34,30 @@ func ParseNumFromEnv(env string, defaultValue, min, max int) int {
 		return defaultValue
 	}
 	return num
+}
+
+// Helper function to parse a time duration from an environment variable. Returns a
+// default if env is not set, is not parseable to a duration, exceeds max (if
+// max is greater than 0) or is less than min.
+func ParseDurationFromEnv(env string, defaultValue, min, max time.Duration) time.Duration {
+	str := os.Getenv(env)
+	if str == "" {
+		return defaultValue
+	}
+	durPtr, err := timeutil.ParseDuration(str)
+	if err != nil {
+		log.Warnf("Could not parse '%s' as a number from environment %s", str, env)
+		return defaultValue
+	}
+
+	dur := *durPtr
+	if dur < min {
+		log.Warnf("Value in %s is %s, which is less than minimum %s allowed", env, dur, min)
+		return defaultValue
+	}
+	if dur > max {
+		log.Warnf("Value in %s is %s, which is greater than maximum %s allowed", env, dur, max)
+		return defaultValue
+	}
+	return dur
 }

--- a/util/env/env_test.go
+++ b/util/env/env_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	util "github.com/argoproj/argo-cd/util/io"
 
@@ -59,4 +60,46 @@ func TestParseNumFromEnv_OutOfRangeValueSet(t *testing.T) {
 	num := ParseNumFromEnv("test", 10, 0, 100)
 
 	assert.Equal(t, 10, num)
+}
+
+func TestParseDurationFromEnv(t *testing.T) {
+	testKey := "key"
+	defaultVal := 2 * time.Second
+	min := 1 * time.Second
+	max := 3 * time.Second
+
+	testCases := []struct {
+		name     string
+		env      string
+		expected time.Duration
+	}{{
+		name:     "EnvNotSet",
+		expected: defaultVal,
+	}, {
+		name:     "ValidValueSet",
+		env:      "2s",
+		expected: time.Second * 2,
+	}, {
+		name:     "MoreThanMaxSet",
+		env:      "5s",
+		expected: defaultVal,
+	}, {
+		name:     "LessThanMinSet",
+		env:      "-1s",
+		expected: defaultVal,
+	}, {
+		name:     "InvalidSet",
+		env:      "hello",
+		expected: defaultVal,
+	}}
+
+	for i, tc := range testCases {
+		t.Run(testCases[i].name, func(t *testing.T) {
+			tc = testCases[i]
+			setEnv(t, testKey, tc.env)
+
+			val := ParseDurationFromEnv(testKey, defaultVal, min, max)
+			assert.Equal(t, tc.expected, val)
+		})
+	}
 }

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/stretchr/testify/assert"
@@ -13,12 +14,12 @@ import (
 func TestIndex(t *testing.T) {
 	t.Run("Invalid", func(t *testing.T) {
 		client := NewClient("", Creds{}, false)
-		_, err := client.GetIndex()
+		_, err := client.GetIndex(false)
 		assert.Error(t, err)
 	})
 	t.Run("Stable", func(t *testing.T) {
 		client := NewClient("https://argoproj.github.io/argo-helm", Creds{}, false)
-		index, err := client.GetIndex()
+		index, err := client.GetIndex(false)
 		assert.NoError(t, err)
 		assert.NotNil(t, index)
 	})
@@ -27,10 +28,24 @@ func TestIndex(t *testing.T) {
 			Username: "my-password",
 			Password: "my-username",
 		}, false)
-		index, err := client.GetIndex()
+		index, err := client.GetIndex(false)
 		assert.NoError(t, err)
 		assert.NotNil(t, index)
 	})
+
+	t.Run("Cached", func(t *testing.T) {
+		var prev time.Duration
+		indexDuration, prev = time.Minute, indexDuration
+		defer func() {
+			indexDuration = prev
+		}()
+
+		client := NewClient("https://argoproj.github.io/argo-helm", Creds{}, false)
+		index, err := client.GetIndex(false)
+		assert.NoError(t, err)
+		assert.NotNil(t, index)
+	})
+
 }
 
 func Test_nativeHelmChart_ExtractChart(t *testing.T) {

--- a/util/helm/mocks/Client.go
+++ b/util/helm/mocks/Client.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	helm "github.com/argoproj/argo-cd/util/helm"
-
 	io "github.com/argoproj/argo-cd/util/io"
 
 	mock "github.com/stretchr/testify/mock"
@@ -61,13 +60,13 @@ func (_m *Client) ExtractChart(chart string, version *semver.Version) (string, i
 	return r0, r1, r2
 }
 
-// GetIndex provides a mock function with given fields:
-func (_m *Client) GetIndex() (*helm.Index, error) {
-	ret := _m.Called()
+// GetIndex provides a mock function with given fields: noCache
+func (_m *Client) GetIndex(noCache bool) (*helm.Index, error) {
+	ret := _m.Called(noCache)
 
 	var r0 *helm.Index
-	if rf, ok := ret.Get(0).(func() *helm.Index); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(bool) *helm.Index); ok {
+		r0 = rf(noCache)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*helm.Index)
@@ -75,8 +74,8 @@ func (_m *Client) GetIndex() (*helm.Index, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(bool) error); ok {
+		r1 = rf(noCache)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -92,9 +91,7 @@ func (_m *Client) TestHelmOCI() (bool, error) {
 	if rf, ok := ret.Get(0).(func() bool); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(bool)
-		}
+		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error


### PR DESCRIPTION
Closes #5659

PR introduces repo server env variable `ARGOCD_HELM_INDEX_CACHE_DURATION` that allows enabling Helm repo index caching.

This change is not the final solution: it only a workaround for #5659 . The root cause is: https://github.com/argoproj/argo-cd/issues/1399 . Argo CD should cache resolved revision per repo and resolve it only once every 3 minutes.


In the past, we had to remove caching to fix the opposite bug: CI publishes new chart version, immediately tries to sync it but don't see a new version due to caching. So for backward compatibility caching is disabled and can be enabled using env variable (e.g. `ARGOCD_HELM_INDEX_CACHE_DURATION=60s`)