### PR TITLE
docs: Fix wrong link in troubleshooting.md for health assessment docs

### DIFF
--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -8,7 +8,7 @@ connectivity issues.
 Argo CD provides multiple ways to customize system behavior and has a lot of settings. It might be dangerous to modify
 settings on Argo CD used in production by multiple users. Before applying settings you can use `argocd-util` binary to
 make sure that settings are valid and Argo CD is working as expected. The `argocd-util` binary is available in `argocd`
-image and might be used using docker. 
+image and might be used using docker.
 You can download the latest `argocd-util` binary from [the latest release page of this repository](https://github.com/argoproj/argo-cd/releases/latest), which will include the `argocd-util` CLI.
 Example:
 
@@ -21,7 +21,7 @@ If you are using Linux you can extract `argocd-util` binary from docker image:
 
 ```bash
 docker run --rm -it -w /src -v $(pwd):/src argocd cp /usr/local/bin/argocd-util ./argocd-util
-``` 
+```
 
 The `argocd-util settings validate` command performs basic settings validation and print short summary
 of each settings group.
@@ -38,10 +38,11 @@ docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
   argocd-util settings resource-overrides ignore-differences ./deploy.yaml --argocd-cm-path ./argocd-cm.yaml
 ```
 
-* Health Assessment
+**Health Assessment**
 
-[Health assessment](../user-guide/diffing.md) allows excluding some resource fields from diffing process.
-The diffing customizations are configured in `resource.customizations` field of `argocd-cm` ConfigMap. 
+Argo CD provides built-in [health assessment](./health.md) for several kubernetes resources which can be further
+customized by writing your own health checks in [Lua](https://www.lua.org/).
+The health checks are configured in the `resource.customizations` field of `argocd-cm` ConfigMap.
 
 The following `argocd-util` command assess resource health using Lua script configured in the specified ConfigMap.
 
@@ -50,7 +51,7 @@ docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
   argocd-util settings resource-overrides health ./deploy.yaml --argocd-cm-path ./argocd-cm.yaml
 ```
 
-* Resource Actions
+**Resource Actions**
 
 Resource actions allows configuring named Lua script which performs resource modification.
 
@@ -59,14 +60,14 @@ applied modifications.
 
 ```bash
 docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
-  argocd-util settings resource-overrides run-action /tmp/deploy.yaml restart --argocd-cm-path /private/tmp/argocd-cm.yaml 
+  argocd-util settings resource-overrides run-action /tmp/deploy.yaml restart --argocd-cm-path /private/tmp/argocd-cm.yaml
 ```
 
 The following `argocd-util` command lists actions available for a given resource using Lua script configured in the specified ConfigMap.
 
 ```bash
 docker run --rm -it -w /src -v $(pwd):/src argoproj/argocd:<version> \
-  argocd-util settings resource-overrides list-actions /tmp/deploy.yaml --argocd-cm-path /private/tmp/argocd-cm.yaml 
+  argocd-util settings resource-overrides list-actions /tmp/deploy.yaml --argocd-cm-path /private/tmp/argocd-cm.yaml
 ```
 
 ## Cluster credentials
@@ -81,7 +82,7 @@ kubectl exec -n argocd -it \
   $(kubectl get pods -n argocd -l app.kubernetes.io/name=argocd-application-controller -o jsonpath='{.items[0].metadata.name}') bash
 ```
 
-2 Use `argocd-util kubeconfig` command to export kubeconfig file from the configured Secret: 
+2 Use `argocd-util kubeconfig` command to export kubeconfig file from the configured Secret:
 
 ```
 argocd-util kubeconfig https://<api-server-url> /tmp/kubeconfig --namespace argocd
@@ -92,4 +93,4 @@ argocd-util kubeconfig https://<api-server-url> /tmp/kubeconfig --namespace argo
 ```
 export KUBECONFIG=/tmp/kubeconfig
 kubectl get pods -v 9
-``` 
+```


### PR DESCRIPTION
Just some drive-by doc fix.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

