### PR TITLE
fix: minor 'argocd-util config' commands fixes

### DIFF
--- a/cmd/argocd-util/commands/config.go
+++ b/cmd/argocd-util/commands/config.go
@@ -49,7 +49,6 @@ func NewGenerateConfigCommand(pathOpts *clientcmd.PathOptions) *cobra.Command {
 func NewGenAppConfigCommand() *cobra.Command {
 	var (
 		appOpts      cmdutil.AppOptions
-		fileURL      string
 		appName      string
 		labels       []string
 		outputFormat string
@@ -77,7 +76,7 @@ func NewGenAppConfigCommand() *cobra.Command {
 	argocd-util config app ksane --repo https://github.com/argoproj/argocd-example-apps.git --path plugins/kasane --dest-namespace default --dest-server https://kubernetes.default.svc --config-management-plugin kasane
 `,
 		Run: func(c *cobra.Command, args []string) {
-			app, err := cmdutil.ConstructApp(fileURL, appName, labels, args, appOpts, c.Flags())
+			app, err := cmdutil.ConstructApp("", appName, labels, args, appOpts, c.Flags())
 			errors.CheckError(err)
 
 			if app.Name == "" {
@@ -91,13 +90,8 @@ func NewGenAppConfigCommand() *cobra.Command {
 		},
 	}
 	command.Flags().StringVar(&appName, "name", "", "A name for the app, ignored if a file is set (DEPRECATED)")
-	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the app")
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "Labels to apply to the app")
 	command.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format. One of: json|yaml")
-
-	// Only complete files with appropriate extension.
-	err := command.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
-	errors.CheckError(err)
 
 	cmdutil.AddAppFlags(command, &appOpts)
 	return command
@@ -107,14 +101,13 @@ func NewGenAppConfigCommand() *cobra.Command {
 func NewGenProjectConfigCommand() *cobra.Command {
 	var (
 		opts         cmdutil.ProjectOpts
-		fileURL      string
 		outputFormat string
 	)
 	var command = &cobra.Command{
 		Use:   "proj PROJECT",
 		Short: "Generate declarative config for a project",
 		Run: func(c *cobra.Command, args []string) {
-			proj, err := cmdutil.ConstructAppProj(fileURL, args, opts, c)
+			proj, err := cmdutil.ConstructAppProj("", args, opts, c)
 			errors.CheckError(err)
 
 			var printResources []interface{}
@@ -122,12 +115,7 @@ func NewGenProjectConfigCommand() *cobra.Command {
 			errors.CheckError(cmdutil.PrintResources(printResources, outputFormat))
 		},
 	}
-	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the project")
 	command.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format. One of: json|yaml")
-	err := command.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
-	if err != nil {
-		log.Fatal(err)
-	}
 	cmdutil.AddProjFlags(command, &opts)
 	return command
 }

--- a/cmd/util/common.go
+++ b/cmd/util/common.go
@@ -24,21 +24,26 @@ func PrintResources(resources []interface{}, output string) error {
 		}
 		resources[i] = filteredResource
 	}
+	var obj interface{} = resources
+	if len(resources) == 1 {
+		obj = resources[0]
+	}
 
 	switch output {
 	case "json":
-		jsonBytes, err := json.MarshalIndent(resources, "", "  ")
+		jsonBytes, err := json.MarshalIndent(obj, "", "  ")
 		if err != nil {
 			return err
 		}
 
 		fmt.Println(string(jsonBytes))
 	case "yaml":
-		yamlBytes, err := yaml.Marshal(resources)
+		yamlBytes, err := yaml.Marshal(obj)
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(yamlBytes))
+		// marshaled YAML already ends with the new line character
+		fmt.Print(string(yamlBytes))
 	default:
 		return fmt.Errorf("unknown output format: %s", output)
 	}

--- a/docs/operator-manual/server-commands/argocd-util_config_app.md
+++ b/docs/operator-manual/server-commands/argocd-util_config_app.md
@@ -43,7 +43,6 @@ argocd-util config app APPNAME [flags]
       --directory-include string                  Set glob expression used to include files from application source path
       --directory-recurse                         Recurse directory
       --env string                                Application environment to monitor
-  -f, --file string                               Filename or URL to Kubernetes manifests for the app
       --helm-chart string                         Helm Chart name
       --helm-set stringArray                      Helm set values on the command line (can be repeated to set several values: --helm-set key1=val1 --helm-set key2=val2)
       --helm-set-file stringArray                 Helm set values from respective files specified via the command line (can be repeated to set several values: --helm-set-file key1=path1 --helm-set-file key2=path2)

--- a/docs/operator-manual/server-commands/argocd-util_config_proj.md
+++ b/docs/operator-manual/server-commands/argocd-util_config_proj.md
@@ -11,7 +11,6 @@ argocd-util config proj PROJECT [flags]
 ```
       --description string        Project description
   -d, --dest stringArray          Permitted destination server and namespace (e.g. https://192.168.99.100:8443,default)
-  -f, --file string               Filename or URL to Kubernetes manifests for the project
   -h, --help                      help for proj
       --orphaned-resources        Enables orphaned resources monitoring
       --orphaned-resources-warn   Specifies if applications should have a warning condition when orphaned resources detected


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR implements minor fixes for `argocd-util config` sub-commands:

- removes `--file` flag. The `config` sub-commands are only required to generate file content, so `--file` does not make sense.
- if command produces only one object then output should produce this one object instead of producing YAML/JSON serialized array with single object.