### PR TITLE
fix: argocd-util import --prune must also remove finalizers if present

### DIFF
--- a/docs/operator-manual/server-commands/argocd-util_import.md
+++ b/docs/operator-manual/server-commands/argocd-util_import.md
@@ -29,6 +29,7 @@ argocd-util import SOURCE [flags]
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server
+      --verbose                        Verbose output (versus only changed output)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Fixes `argocd-util import` so that it:
* removes finalizers on applications it needs to prune
* gracefully deals with objects which were already deleted/in the middle of deletion
* reduce verbosity by only printing changes by default

Signed-off-by: Jesse Suen <Jesse_Suen@intuit.com>


