### PR TITLE
fix: improve 'argocd-util proj generate-spec' usability

### DIFF
--- a/cmd/argocd-util/commands/app.go
+++ b/cmd/argocd-util/commands/app.go
@@ -60,6 +60,7 @@ func NewAppCommand() *cobra.Command {
 func NewGenAppSpecCommand() *cobra.Command {
 	var (
 		appOpts      cmdutil.AppOptions
+		fileURL      string
 		appName      string
 		labels       []string
 		outputFormat string
@@ -87,7 +88,7 @@ func NewGenAppSpecCommand() *cobra.Command {
 	argocd-util app generate-spec ksane --repo https://github.com/argoproj/argocd-example-apps.git --path plugins/kasane --dest-namespace default --dest-server https://kubernetes.default.svc --config-management-plugin kasane
 `,
 		Run: func(c *cobra.Command, args []string) {
-			app, err := cmdutil.ConstructApp("", appName, labels, args, appOpts, c.Flags())
+			app, err := cmdutil.ConstructApp(fileURL, appName, labels, args, appOpts, c.Flags())
 			errors.CheckError(err)
 
 			if app.Name == "" {
@@ -101,8 +102,13 @@ func NewGenAppSpecCommand() *cobra.Command {
 		},
 	}
 	command.Flags().StringVar(&appName, "name", "", "A name for the app, ignored if a file is set (DEPRECATED)")
+	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the app")
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "Labels to apply to the app")
 	command.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format. One of: json|yaml")
+
+	// Only complete files with appropriate extension.
+	err := command.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
+	errors.CheckError(err)
 
 	cmdutil.AddAppFlags(command, &appOpts)
 	return command

--- a/cmd/argocd-util/commands/project.go
+++ b/cmd/argocd-util/commands/project.go
@@ -39,13 +39,14 @@ func NewProjectsCommand() *cobra.Command {
 func NewGenProjectSpecCommand() *cobra.Command {
 	var (
 		opts         cmdutil.ProjectOpts
+		fileURL      string
 		outputFormat string
 	)
 	var command = &cobra.Command{
 		Use:   "generate-spec PROJECT",
 		Short: "Generate declarative config for a project",
 		Run: func(c *cobra.Command, args []string) {
-			proj, err := cmdutil.ConstructAppProj("", args, opts, c)
+			proj, err := cmdutil.ConstructAppProj(fileURL, args, opts, c)
 			errors.CheckError(err)
 
 			var printResources []interface{}
@@ -54,6 +55,12 @@ func NewGenProjectSpecCommand() *cobra.Command {
 		},
 	}
 	command.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format. One of: json|yaml")
+	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the project")
+
+	// Only complete files with appropriate extension.
+	err := command.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
+	errors.CheckError(err)
+
 	cmdutil.AddProjFlags(command, &opts)
 	return command
 }

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -129,23 +128,7 @@ func NewProjectSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 			proj, err := projIf.Get(context.Background(), &projectpkg.ProjectQuery{Name: projName})
 			errors.CheckError(err)
 
-			visited := 0
-			c.Flags().Visit(func(f *pflag.Flag) {
-				visited++
-				switch f.Name {
-				case "description":
-					proj.Spec.Description = opts.Description
-				case "dest":
-					proj.Spec.Destinations = opts.GetDestinations()
-				case "src":
-					proj.Spec.SourceRepos = opts.Sources
-				case "signature-keys":
-					proj.Spec.SignatureKeys = opts.GetSignatureKeys()
-				case "orphaned-resources", "orphaned-resources-warn":
-					proj.Spec.OrphanedResources = cmdutil.GetOrphanedResourcesSettings(c, opts)
-				}
-			})
-			if visited == 0 {
+			if visited := cmdutil.SetProjSpecOptions(c.Flags(), &proj.Spec, &opts); visited == 0 {
 				log.Error("Please set at least one option to update")
 				c.HelpFunc()(c, args)
 				os.Exit(1)

--- a/cmd/util/project_test.go
+++ b/cmd/util/project_test.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProjectOpts_ResourceLists(t *testing.T) {
+	opts := ProjectOpts{
+		allowedNamespacedResources: []string{"ConfigMap"},
+		deniedNamespacedResources:  []string{"apps/DaemonSet"},
+		allowedClusterResources:    []string{"apiextensions.k8s.io/CustomResourceDefinition"},
+		deniedClusterResources:     []string{"rbac.authorization.k8s.io/ClusterRole"},
+	}
+
+	assert.ElementsMatch(t,
+		[]v1.GroupKind{{Kind: "ConfigMap"}}, opts.GetAllowedNamespacedResources(),
+		[]v1.GroupKind{{Group: "apps", Kind: "DaemonSet"}}, opts.GetDeniedNamespacedResources(),
+		[]v1.GroupKind{{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}}, opts.GetAllowedClusterResources(),
+		[]v1.GroupKind{{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}}, opts.GetDeniedClusterResources(),
+	)
+}

--- a/docs/operator-manual/server-commands/argocd-util_app_generate-spec.md
+++ b/docs/operator-manual/server-commands/argocd-util_app_generate-spec.md
@@ -43,6 +43,7 @@ argocd-util app generate-spec APPNAME [flags]
       --directory-include string                  Set glob expression used to include files from application source path
       --directory-recurse                         Recurse directory
       --env string                                Application environment to monitor
+  -f, --file string                               Filename or URL to Kubernetes manifests for the app
       --helm-chart string                         Helm Chart name
       --helm-set stringArray                      Helm set values on the command line (can be repeated to set several values: --helm-set key1=val1 --helm-set key2=val2)
       --helm-set-file stringArray                 Helm set values from respective files specified via the command line (can be repeated to set several values: --helm-set-file key1=path1 --helm-set-file key2=path2)

--- a/docs/operator-manual/server-commands/argocd-util_proj_generate-spec.md
+++ b/docs/operator-manual/server-commands/argocd-util_proj_generate-spec.md
@@ -9,14 +9,19 @@ argocd-util proj generate-spec PROJECT [flags]
 ### Options
 
 ```
-      --description string        Project description
-  -d, --dest stringArray          Permitted destination server and namespace (e.g. https://192.168.99.100:8443,default)
-  -h, --help                      help for generate-spec
-      --orphaned-resources        Enables orphaned resources monitoring
-      --orphaned-resources-warn   Specifies if applications should have a warning condition when orphaned resources detected
-  -o, --output string             Output format. One of: json|yaml (default "yaml")
-      --signature-keys strings    GnuPG public key IDs for commit signature verification
-  -s, --src stringArray           Permitted source repository URL
+      --allow-cluster-resource stringArray      List of allowed cluster level resources
+      --allow-namespaced-resource stringArray   List of allowed namespaced resources
+      --deny-cluster-resource stringArray       List of denied cluster level resources
+      --deny-namespaced-resource stringArray    List of denied namespaced resources
+      --description string                      Project description
+  -d, --dest stringArray                        Permitted destination server and namespace (e.g. https://192.168.99.100:8443,default)
+  -f, --file string                             Filename or URL to Kubernetes manifests for the project
+  -h, --help                                    help for generate-spec
+      --orphaned-resources                      Enables orphaned resources monitoring
+      --orphaned-resources-warn                 Specifies if applications should have a warning condition when orphaned resources detected
+  -o, --output string                           Output format. One of: json|yaml (default "yaml")
+      --signature-keys strings                  GnuPG public key IDs for commit signature verification
+  -s, --src stringArray                         Permitted source repository URL
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_create.md
+++ b/docs/user-guide/commands/argocd_proj_create.md
@@ -9,15 +9,19 @@ argocd proj create PROJECT [flags]
 ### Options
 
 ```
-      --description string        Project description
-  -d, --dest stringArray          Permitted destination server and namespace (e.g. https://192.168.99.100:8443,default)
-  -f, --file string               Filename or URL to Kubernetes manifests for the project
-  -h, --help                      help for create
-      --orphaned-resources        Enables orphaned resources monitoring
-      --orphaned-resources-warn   Specifies if applications should have a warning condition when orphaned resources detected
-      --signature-keys strings    GnuPG public key IDs for commit signature verification
-  -s, --src stringArray           Permitted source repository URL
-      --upsert                    Allows to override a project with the same name even if supplied project spec is different from existing spec
+      --allow-cluster-resource stringArray      List of allowed cluster level resources
+      --allow-namespaced-resource stringArray   List of allowed namespaced resources
+      --deny-cluster-resource stringArray       List of denied cluster level resources
+      --deny-namespaced-resource stringArray    List of denied namespaced resources
+      --description string                      Project description
+  -d, --dest stringArray                        Permitted destination server and namespace (e.g. https://192.168.99.100:8443,default)
+  -f, --file string                             Filename or URL to Kubernetes manifests for the project
+  -h, --help                                    help for create
+      --orphaned-resources                      Enables orphaned resources monitoring
+      --orphaned-resources-warn                 Specifies if applications should have a warning condition when orphaned resources detected
+      --signature-keys strings                  GnuPG public key IDs for commit signature verification
+  -s, --src stringArray                         Permitted source repository URL
+      --upsert                                  Allows to override a project with the same name even if supplied project spec is different from existing spec
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_set.md
+++ b/docs/user-guide/commands/argocd_proj_set.md
@@ -9,13 +9,17 @@ argocd proj set PROJECT [flags]
 ### Options
 
 ```
-      --description string        Project description
-  -d, --dest stringArray          Permitted destination server and namespace (e.g. https://192.168.99.100:8443,default)
-  -h, --help                      help for set
-      --orphaned-resources        Enables orphaned resources monitoring
-      --orphaned-resources-warn   Specifies if applications should have a warning condition when orphaned resources detected
-      --signature-keys strings    GnuPG public key IDs for commit signature verification
-  -s, --src stringArray           Permitted source repository URL
+      --allow-cluster-resource stringArray      List of allowed cluster level resources
+      --allow-namespaced-resource stringArray   List of allowed namespaced resources
+      --deny-cluster-resource stringArray       List of denied cluster level resources
+      --deny-namespaced-resource stringArray    List of denied namespaced resources
+      --description string                      Project description
+  -d, --dest stringArray                        Permitted destination server and namespace (e.g. https://192.168.99.100:8443,default)
+  -h, --help                                    help for set
+      --orphaned-resources                      Enables orphaned resources monitoring
+      --orphaned-resources-warn                 Specifies if applications should have a warning condition when orphaned resources detected
+      --signature-keys strings                  GnuPG public key IDs for commit signature verification
+  -s, --src stringArray                         Permitted source repository URL
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Note on DCO:

PR improves the usability of `argocd-util proj generate-spec` command:

* adds flags to controller resource allow/deny lists
* re-adds `--file` flag and allows to override only specified fields (same for `argocd-util app generate-spec`).

The `--file` flag support allows to "modify" previously generated specs. E.g. 

```bash
# generate app spec and store it in file
argocd-util app generate-spec guestbook \
    --repo  https://github.com/argoproj/argocd-example-apps \
    --path guestbook \
    --dest-server https://kubernetes.default.svc \
    --dest-namespace default > /tmp/app.yaml

# append project to previously generated spec
argocd-util app generate-spec -f /tmp/app.yaml --project default
```
