### PR TITLE
refactor: applications-list page uses only watch API to quicker show application to the user

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -695,6 +695,9 @@ func (s *Server) Watch(q *application.ApplicationQuery, ws application.Applicati
 		if err != nil {
 			return err
 		}
+		sort.Slice(apps, func(i, j int) bool {
+			return apps[i].Name < apps[j].Name
+		})
 		for i := range apps {
 			sendIfPermitted(*apps[i], watch.Added)
 		}

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -120,7 +120,7 @@ export interface Application {
     operation?: Operation;
 }
 
-type WatchType = 'ADDED' | 'MODIFIED' | 'DELETED' | 'ERROR';
+export type WatchType = 'ADDED' | 'MODIFIED' | 'DELETED' | 'ERROR';
 
 export interface ApplicationWatchEvent {
     type: WatchType;


### PR DESCRIPTION
Note on DCO:

The PR is based on https://github.com/argoproj/argo-cd/pull/5342 . We've synced up with @rbreeze,  https://github.com/argoproj/argo-cd/pull/5342 again production Argo CD with 2k+ applications and improve the implementation:

* application list page uses only watch API to load the applications for application list page.
* UI waits until it gets enough application to render the currently selected page, or until UI receives non `ADDED` event, or just after 2 seconds timeout expire

As a result of these changes, the application list page should render applications sooner and so page responsiveness is improved.
