### PR TITLE
feat: implement 'argocd-util cluster stats' command

### DIFF
--- a/cmd/argocd-util/commands/app.go
+++ b/cmd/argocd-util/commands/app.go
@@ -10,10 +10,6 @@ import (
 	"sort"
 	"time"
 
-	cmdutil "github.com/argoproj/argo-cd/cmd/util"
-
-	appstatecache "github.com/argoproj/argo-cd/util/cache/appstate"
-
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	apiv1 "k8s.io/api/core/v1"
@@ -24,6 +20,7 @@ import (
 	kubecache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 
+	cmdutil "github.com/argoproj/argo-cd/cmd/util"
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/controller"
 	"github.com/argoproj/argo-cd/controller/cache"
@@ -33,6 +30,7 @@ import (
 	appinformers "github.com/argoproj/argo-cd/pkg/client/informers/externalversions"
 	"github.com/argoproj/argo-cd/reposerver/apiclient"
 	cacheutil "github.com/argoproj/argo-cd/util/cache"
+	appstatecache "github.com/argoproj/argo-cd/util/cache/appstate"
 	"github.com/argoproj/argo-cd/util/cli"
 	"github.com/argoproj/argo-cd/util/config"
 	"github.com/argoproj/argo-cd/util/db"

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -26,8 +26,8 @@ func InferShard() (int, error) {
 	return shard, nil
 }
 
-// getShardByID calculates cluster shard as `clusterSecret.UID % replicas count`
-func getShardByID(id string, replicas int) int {
+// GetShardByID calculates cluster shard as `clusterSecret.UID % replicas count`
+func GetShardByID(id string, replicas int) int {
 	if id == "" {
 		return 0
 	} else {
@@ -45,7 +45,7 @@ func GetClusterFilter(replicas int, shard int) func(c *v1alpha1.Cluster) bool {
 			if c.Shard != nil {
 				clusterShard = int(*c.Shard)
 			} else {
-				clusterShard = getShardByID(c.ID, replicas)
+				clusterShard = GetShardByID(c.ID, replicas)
 			}
 		}
 		return clusterShard == shard

--- a/controller/sharding/sharding_test.go
+++ b/controller/sharding/sharding_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestGetShardByID_NotEmptyID(t *testing.T) {
-	assert.Equal(t, 0, getShardByID("1", 2))
-	assert.Equal(t, 1, getShardByID("2", 2))
-	assert.Equal(t, 0, getShardByID("3", 2))
-	assert.Equal(t, 1, getShardByID("4", 2))
+	assert.Equal(t, 0, GetShardByID("1", 2))
+	assert.Equal(t, 1, GetShardByID("2", 2))
+	assert.Equal(t, 0, GetShardByID("3", 2))
+	assert.Equal(t, 1, GetShardByID("4", 2))
 }
 
 func TestGetShardByID_EmptyID(t *testing.T) {
-	shard := getShardByID("", 10)
+	shard := GetShardByID("", 10)
 	assert.Equal(t, 0, shard)
 }
 

--- a/docs/operator-manual/server-commands/argocd-util_cluster.md
+++ b/docs/operator-manual/server-commands/argocd-util_cluster.md
@@ -17,4 +17,5 @@ argocd-util cluster [flags]
 * [argocd-util](argocd-util.md)	 - argocd-util tools used by Argo CD
 * [argocd-util cluster generate-spec](argocd-util_cluster_generate-spec.md)	 - Generate declarative config for a cluster
 * [argocd-util cluster kubeconfig](argocd-util_cluster_kubeconfig.md)	 - Generates kubeconfig for the specified cluster
+* [argocd-util cluster stats](argocd-util_cluster_stats.md)	 - Prints information cluster statistics and inferred shard number
 

--- a/docs/operator-manual/server-commands/argocd-util_cluster_stats.md
+++ b/docs/operator-manual/server-commands/argocd-util_cluster_stats.md
@@ -1,0 +1,44 @@
+## argocd-util cluster stats
+
+Prints information cluster statistics and inferred shard number
+
+```
+argocd-util cluster stats [flags]
+```
+
+### Options
+
+```
+      --app-state-cache-expiration duration   Cache expiration for app state (default 1h0m0s)
+      --as string                             Username to impersonate for the operation
+      --as-group stringArray                  Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --certificate-authority string          Path to a cert file for the certificate authority
+      --client-certificate string             Path to a client certificate file for TLS
+      --client-key string                     Path to a client key file for TLS
+      --cluster string                        The name of the kubeconfig cluster to use
+      --context string                        The name of the kubeconfig context to use
+      --default-cache-expiration duration     Cache expiration default (default 24h0m0s)
+  -h, --help                                  help for stats
+      --insecure-skip-tls-verify              If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                     Path to a kube config. Only required if out-of-cluster
+  -n, --namespace string                      If present, the namespace scope for this CLI request
+      --password string                       Password for basic authentication to the API server
+      --port-forward-redis                    Automatically port-forward ha proxy redis from current namespace? (default true)
+      --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redisdb int                           Redis database.
+      --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified
+      --request-timeout string                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --sentinel stringArray                  Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
+      --sentinelmaster string                 Redis sentinel master group name. (default "master")
+      --server string                         The address and port of the Kubernetes API server
+      --shard int                             Cluster shard filter (default -1)
+      --tls-server-name string                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                          Bearer token for authentication to the API server
+      --user string                           The name of the kubeconfig user to use
+      --username string                       Username for basic authentication to the API server
+```
+
+### SEE ALSO
+
+* [argocd-util cluster](argocd-util_cluster.md)	 - Manage clusters configuration
+


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <Alexander_Matyushentsev@intuit.com>

PR implements `argocd-util cluster stats` command that prints information about number of monitored resources in the cluster and shard number e.g.:

```
SERVER                            SHARD  CONNECTION  APPS COUNT  RESOURCES COUNT
https://xxxxxxxxxxxxxx.com        5      Successful  2           1915
https://xxxxxxxxxxxxxx.com        4      Successful  2           1888
https://xxxxxxxxxxxxxx.com        6      Successful  39          18721
https://xxxxxxxxxxxxxx.com        2      Successful  4           10182
https://xxxxxxxxxxxxxx.com        2      Successful  114         47161
https://xxxxxxxxxxxxxx.com        8      Successful  10          15436
https://xxxxxxxxxxxxxx.com        3      Successful  10          10693
https://xxxxxxxxxxxxxx.com        8      Successful  2           1780
https://xxxxxxxxxxxxxx.com        1      Unknown     0           0
```