### PR TITLE
feat: Support unset plugin env variables (#5681)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -556,6 +556,7 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 		namePrefix       bool
 		kustomizeVersion bool
 		kustomizeImages  []string
+		pluginEnvs       []string
 		appOpts          cmdutil.AppOptions
 	)
 	var command = &cobra.Command{
@@ -661,9 +662,22 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 						}
 					}
 				}
-				if !updated {
-					return
+			}
+
+			if app.Spec.Source.Plugin != nil {
+				if len(pluginEnvs) == 0 {
+					c.HelpFunc()(c, args)
+					os.Exit(1)
 				}
+				for _, env := range pluginEnvs {
+					err = app.Spec.Source.Plugin.RemoveEnvEntry(env)
+					errors.CheckError(err)
+				}
+				updated = true
+			}
+
+			if !updated {
+				return
 			}
 
 			cmdutil.SetAppSpecOptions(c.Flags(), &app.Spec, &appOpts)
@@ -682,6 +696,7 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 	command.Flags().BoolVar(&namePrefix, "nameprefix", false, "Kustomize nameprefix")
 	command.Flags().BoolVar(&kustomizeVersion, "kustomize-version", false, "Kustomize version")
 	command.Flags().StringArrayVar(&kustomizeImages, "kustomize-image", []string{}, "Kustomize images name (e.g. --kustomize-image node --kustomize-image mysql)")
+	command.Flags().StringArrayVar(&pluginEnvs, "plugin-env", []string{}, "Unset plugin env variables (e.g --plugin-env name)")
 	return command
 }
 

--- a/docs/user-guide/commands/argocd_app_unset.md
+++ b/docs/user-guide/commands/argocd_app_unset.md
@@ -28,6 +28,7 @@ argocd app unset APPNAME parameters [flags]
       --nameprefix                    Kustomize nameprefix
       --namesuffix                    Kustomize namesuffix
   -p, --parameter stringArray         Unset a parameter override (e.g. -p guestbook=image)
+      --plugin-env stringArray        Unset plugin env variables (e.g --plugin-env name)
       --values stringArray            Unset one or more Helm values files
       --values-literal                Unset literal Helm values block
 ```

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -504,6 +504,18 @@ func (c *ApplicationSourcePlugin) AddEnvEntry(e *EnvEntry) {
 	}
 }
 
+// RemoveEnvEntry removes an EnvEntry if present, from a list of entries.
+func (c *ApplicationSourcePlugin) RemoveEnvEntry(key string) error {
+	for i, ce := range c.Env {
+		if ce.Name == key {
+			c.Env[i] = c.Env[len(c.Env)-1]
+			c.Env = c.Env[:len(c.Env)-1]
+			return nil
+		}
+	}
+	return fmt.Errorf("unable to find env variable with key %q for plugin %q", key, c.Name)
+}
+
 // ApplicationDestination holds information about the application's destination
 type ApplicationDestination struct {
 	// Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2190,3 +2190,43 @@ func TestUnSetCascadedDeletion(t *testing.T) {
 	a.UnSetCascadedDeletion()
 	assert.ElementsMatch(t, []string{"alpha", "beta", "gamma"}, a.GetFinalizers())
 }
+
+func TestRemoveEnvEntry(t *testing.T) {
+	t.Run("Remove element from the list", func(t *testing.T) {
+		plugins := &ApplicationSourcePlugin{
+			Name: "test",
+			Env: Env{
+				&EnvEntry{"foo", "bar"},
+				&EnvEntry{"alpha", "beta"},
+				&EnvEntry{"gamma", "delta"},
+			},
+		}
+		assert.NoError(t, plugins.RemoveEnvEntry("alpha"))
+		want := Env{&EnvEntry{"foo", "bar"}, &EnvEntry{"gamma", "delta"}}
+		assert.Equal(t, want, plugins.Env)
+	})
+	t.Run("Remove only element from the list", func(t *testing.T) {
+		plugins := &ApplicationSourcePlugin{
+			Name: "test",
+			Env:  Env{&EnvEntry{"foo", "bar"}},
+		}
+		assert.NoError(t, plugins.RemoveEnvEntry("foo"))
+		assert.Equal(t, Env{}, plugins.Env)
+	})
+	t.Run("Remove unknown element from the list", func(t *testing.T) {
+		plugins := &ApplicationSourcePlugin{
+			Name: "test",
+			Env:  Env{&EnvEntry{"foo", "bar"}},
+		}
+		err := plugins.RemoveEnvEntry("key")
+		assert.EqualError(t, err, `unable to find env variable with key "key" for plugin "test"`)
+		err = plugins.RemoveEnvEntry("bar")
+		assert.EqualError(t, err, `unable to find env variable with key "bar" for plugin "test"`)
+		assert.Equal(t, Env{&EnvEntry{"foo", "bar"}}, plugins.Env)
+	})
+	t.Run("Remove element from an empty list", func(t *testing.T) {
+		plugins := &ApplicationSourcePlugin{Name: "test"}
+		err := plugins.RemoveEnvEntry("key")
+		assert.EqualError(t, err, `unable to find env variable with key "key" for plugin "test"`)
+	})
+}


### PR DESCRIPTION
This commit adds a flag --plugin-env to the app unset command, using which the plugin env variables can be removed if present.

Example:

```shell
argocd app unset example --plugin-env key1 --plugin-env key2
```
Closes: #5681
Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

