### PR TITLE
feat: support resource prune propagation policy

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -105,6 +105,7 @@ spec:
     syncOptions:     # Sync options which modifies sync behavior
     - Validate=false # disables resource validation (equivalent to 'kubectl apply --validate=false') ( true by default ).
     - CreateNamespace=true # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
+    - PrunePropagationPolicy=foreground # Supported policies are background, foreground and orphan.
     # The retry feature is available since v1.7
     retry:
       limit: 5 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -83,3 +83,13 @@ Example:
 ```bash
 $ argocd app set guestbook --sync-option ApplyOutOfSyncOnly=true
 ```
+
+## Resources Prune Deletion Propagation Policy
+
+By default, extraneous resources get pruned using foreground deletion policy. The propagation policy can be controlled
+using `PrunePropagationPolicy` sync option. Supported policies are background, foreground and orphan.
+
+```yaml
+syncOptions:
+- PrunePropagationPolicy=foreground
+```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/alicebob/miniredis/v2 v2.14.2
-	github.com/argoproj/gitops-engine v0.2.1-0.20210222072927-aae8ded16113
+	github.com/argoproj/gitops-engine v0.2.1-0.20210312073615-89cb483bbbd8
 	github.com/argoproj/pkg v0.2.0
 	github.com/bombsimon/logrusr v1.0.0
 	github.com/bradleyfalzon/ghinstallation v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj/gitops-engine v0.2.1-0.20210222072927-aae8ded16113 h1:7xW08KK1p8cPETa0mzW+UHqo+bCU9dk+fPoZGg/J2b4=
-github.com/argoproj/gitops-engine v0.2.1-0.20210222072927-aae8ded16113/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
+github.com/argoproj/gitops-engine v0.2.1-0.20210312073615-89cb483bbbd8 h1:d5zTP9r+QHyf0zIKjvSuR5uqANmXk+VtwbQwZ/VXvks=
+github.com/argoproj/gitops-engine v0.2.1-0.20210312073615-89cb483bbbd8/go.mod h1:dmGvluybnmaSzsJA7PnrgCoSYQ5stFUNqS46F3gma+M=
 github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=
 github.com/argoproj/pkg v0.2.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Depends on https://github.com/argoproj/gitops-engine/pull/235

PR introduces the ability to specify resource prune propagation policy. The default stays 'foreground' but can be changed at the application level using sync option:

```yaml
syncOptions:
- PrunePropagationPolicy=foreground
```

Closes https://github.com/argoproj/argo-cd/issues/3928

