### PR TITLE
Separate manual sync options

### DIFF
--- a/ui/src/app/applications/components/application-sync-options.tsx
+++ b/ui/src/app/applications/components/application-sync-options.tsx
@@ -70,9 +70,9 @@ export const ApplicationManualSyncFlags = ReactForm.FormField((props: {fieldApi:
     } = props;
     const val = getValue() || false;
     return (
-        <React.Fragment>
+        <div style={optionStyle}>
             {Object.keys(ManualSyncFlags).map(flag => (
-                <div key={flag} style={optionStyle}>
+                <React.Fragment key={flag}>
                     <Checkbox
                         id={`sync-option-${flag}`}
                         checked={val[flag]}
@@ -83,10 +83,10 @@ export const ApplicationManualSyncFlags = ReactForm.FormField((props: {fieldApi:
                             setValue(update);
                         }}
                     />
-                    <label htmlFor={`sync-option-${flag}`}>{ManualSyncFlags[flag as keyof typeof ManualSyncFlags]}</label>
-                </div>
+                    <label htmlFor={`sync-option-${flag}`}>{ManualSyncFlags[flag as keyof typeof ManualSyncFlags]}</label>{' '}
+                </React.Fragment>
             ))}
-        </React.Fragment>
+        </div>
     );
 });
 

--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.scss
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.scss
@@ -1,0 +1,12 @@
+.application-sync-panel__resource {
+    margin-top: 0.5em;
+    white-space: nowrap;
+
+    label {
+        max-width: 40em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: inline-block;
+        vertical-align: middle;
+    }
+}

--- a/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
+++ b/ui/src/app/applications/components/application-sync-panel/application-sync-panel.tsx
@@ -1,13 +1,15 @@
 import {ErrorNotification, FormField, NotificationType, SlidingPanel} from 'argo-ui';
 import * as React from 'react';
-import {Checkbox, Form, FormApi, Text} from 'react-form';
+import {Form, FormApi, Text} from 'react-form';
 
-import {Spinner} from '../../../shared/components';
+import {CheckboxField, Spinner} from '../../../shared/components';
 import {Consumer} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {ApplicationManualSyncFlags, ApplicationSyncOptions, SyncFlags} from '../application-sync-options';
 import {ComparisonStatusIcon, nodeKey} from '../utils';
+
+require('./application-sync-panel.scss');
 
 export const ApplicationSyncPanel = ({application, selectedResource, hide}: {application: models.Application; selectedResource: string; hide: () => any}) => {
     const [form, setForm] = React.useState<FormApi>(null);
@@ -98,6 +100,9 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
 
                                     <div className='argo-form-row'>
                                         <div style={{marginBottom: '1em'}}>
+                                            <FormField formApi={formApi} field='syncFlags' component={ApplicationManualSyncFlags} />
+                                        </div>
+                                        <div style={{marginBottom: '1em'}}>
                                             <label>Sync Options</label>
                                             <ApplicationSyncOptions
                                                 options={formApi.values.syncOptions}
@@ -106,7 +111,6 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
                                                     formApi.setValue('syncOptions', opts);
                                                 }}
                                             />
-                                            <FormField formApi={formApi} field='syncFlags' component={ApplicationManualSyncFlags} />
                                         </div>
                                         <label>Synchronize resources:</label>
                                         <div style={{float: 'right'}}>
@@ -127,17 +131,15 @@ export const ApplicationSyncPanel = ({application, selectedResource, hide}: {app
                                         {!formApi.values.resources.every((item: boolean) => item) && (
                                             <div className='application-details__warning'>WARNING: partial synchronization is not recorded in history</div>
                                         )}
-                                        <div style={{paddingLeft: '1em'}}>
+                                        <div>
                                             {application.status.resources
                                                 .filter(item => !item.hook)
                                                 .map((item, i) => {
                                                     const resKey = nodeKey(item);
                                                     return (
-                                                        <div key={resKey}>
-                                                            <Checkbox id={resKey} field={`resources[${i}]`} />{' '}
-                                                            <label htmlFor={resKey}>
-                                                                {resKey} <ComparisonStatusIcon status={item.status} resource={item} />
-                                                            </label>
+                                                        <div key={resKey} className='application-sync-panel__resource'>
+                                                            <CheckboxField id={resKey} field={`resources[${i}]`} /> <label htmlFor={resKey}>{resKey}</label>{' '}
+                                                            <ComparisonStatusIcon status={item.status} resource={item} />
                                                         </div>
                                                     );
                                                 })}

--- a/ui/src/app/applications/components/applications-sync-panel/applications-sync-panel.tsx
+++ b/ui/src/app/applications/components/applications-sync-panel/applications-sync-panel.tsx
@@ -1,7 +1,7 @@
 import {ErrorNotification, FormField, NotificationType, SlidingPanel} from 'argo-ui';
 import * as React from 'react';
-import {Checkbox, Form, FormApi} from 'react-form';
-import {ProgressPopup} from '../../../shared/components';
+import {Form, FormApi} from 'react-form';
+import {CheckboxField, ProgressPopup} from '../../../shared/components';
 import {Consumer} from '../../../shared/context';
 import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
@@ -78,11 +78,14 @@ export const ApplicationsSyncPanel = ({show, apps, hide}: {show: boolean; apps: 
                         getApi={setForm}>
                         {formApi => (
                             <React.Fragment>
-                                <div className='argo-form-row'>
+                                <div className='argo-form-row' style={{marginTop: 0}}>
                                     <h4>Sync app(s)</h4>
                                     {progress !== null && <ProgressPopup onClose={() => setProgress(null)} percentage={progress.percentage} title={progress.title} />}
-                                    <label>Options:</label>
-                                    <div style={{paddingLeft: '1em', marginBottom: '1em'}}>
+                                    <div style={{marginBottom: '1em'}}>
+                                        <FormField formApi={formApi} field='syncFlags' component={ApplicationManualSyncFlags} />
+                                    </div>
+                                    <div style={{marginBottom: '1em'}}>
+                                        <label>Sync Options</label>
                                         <ApplicationSyncOptions
                                             options={formApi.values.syncOptions}
                                             onChanged={opts => {
@@ -90,7 +93,6 @@ export const ApplicationsSyncPanel = ({show, apps, hide}: {show: boolean; apps: 
                                                 formApi.setValue('syncOptions', opts);
                                             }}
                                         />
-                                        <FormField formApi={formApi} field='syncFlags' component={ApplicationManualSyncFlags} />
                                     </div>
                                     <label>
                                         Apps (<a onClick={() => apps.forEach((_, i) => formApi.setValue('app/' + i, true))}>all</a>/
@@ -100,10 +102,10 @@ export const ApplicationsSyncPanel = ({show, apps, hide}: {show: boolean; apps: 
                                         /<a onClick={() => apps.forEach((_, i) => formApi.setValue('app/' + i, false))}>none</a>
                                         ):
                                     </label>
-                                    <div style={{paddingLeft: '1em'}}>
+                                    <div>
                                         {apps.map((app, i) => (
-                                            <label key={app.metadata.name}>
-                                                <Checkbox field={`app/${i}`} />
+                                            <label key={app.metadata.name} style={{marginTop: '0.5em', cursor: 'pointer'}}>
+                                                <CheckboxField field={`app/${i}`} />
                                                 &nbsp;
                                                 {app.metadata.name}
                                                 &nbsp;

--- a/ui/src/app/shared/components/checkbox/checkbox-field.tsx
+++ b/ui/src/app/shared/components/checkbox/checkbox-field.tsx
@@ -2,10 +2,10 @@ import {Checkbox} from 'argo-ui';
 import * as React from 'react';
 import * as ReactForm from 'react-form';
 
-export const CheckboxField = ReactForm.FormField((props: {fieldApi: ReactForm.FieldApi; className: string; checked: boolean}) => {
+export const CheckboxField = ReactForm.FormField((props: {fieldApi: ReactForm.FieldApi; id: string; className: string; checked: boolean}) => {
     const {
         fieldApi: {getValue, setValue}
     } = props;
 
-    return <Checkbox checked={!!getValue()} onChange={setValue} />;
+    return <Checkbox id={props.id} checked={!!getValue()} onChange={setValue} />;
 });


### PR DESCRIPTION
Note on DCO:

PR improves single appication sync panel and multiple applications sync panels design:

* visually separate manual sync options from app-level sync options
* makes sure all checkboxes and labels are aligned in the same way
* uses the same checkbox styling

Sync apps:

After:
![image](https://user-images.githubusercontent.com/426437/110860622-d9af6d00-8271-11eb-802f-d52cb647f647.png)

Before:

![image](https://user-images.githubusercontent.com/426437/110860861-298e3400-8272-11eb-8600-53f7ba2c46c1.png)

Sync app:

After
![image](https://user-images.githubusercontent.com/426437/110860700-f481e180-8271-11eb-98ad-8716483bc0af.png)

Before

![image](https://user-images.githubusercontent.com/426437/110860837-21ce8f80-8272-11eb-8815-8b5902108893.png)

