### PR TITLE
feat(helm): Do not fail when value files do not exist

### DIFF
--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -115,7 +116,11 @@ func (h *helm) GetParameters(valuesFiles []string) (map[string]string, error) {
 		if err == nil && (parsedURL.Scheme == "http" || parsedURL.Scheme == "https") {
 			fileValues, err = config.ReadRemoteFile(file)
 		} else {
-			fileValues, err = ioutil.ReadFile(path.Join(h.cmd.WorkDir, file))
+			filePath := path.Join(h.cmd.WorkDir, file)
+			if _, err := os.Stat(filePath); os.IsNotExist(err) {
+				continue
+			}
+			fileValues, err = ioutil.ReadFile(filePath)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read value file %s: %s", file, err)

--- a/util/helm/helm_test.go
+++ b/util/helm/helm_test.go
@@ -92,6 +92,16 @@ func TestHelmGetParamsValueFiles(t *testing.T) {
 	assert.Equal(t, slaveCountParam, "3")
 }
 
+func TestHelmGetParamsValueFilesThatExist(t *testing.T) {
+	h, err := NewHelmApp("./testdata/redis", nil, false, "")
+	assert.NoError(t, err)
+	params, err := h.GetParameters([]string{"values-missing.yaml", "values-production.yaml"})
+	assert.Nil(t, err)
+
+	slaveCountParam := params["cluster.slaveCount"]
+	assert.Equal(t, slaveCountParam, "3")
+}
+
 func TestHelmDependencyBuild(t *testing.T) {
 	testCases := map[string]string{"Helm": "dependency", "Helm2": "helm2-dependency"}
 	helmRepos := []HelmRepository{{Name: "bitnami", Repo: "https://charts.bitnami.com/bitnami"}}


### PR DESCRIPTION
Skip Helm value files that do not exit. This will allow the values that do exit
to be displayed.