### PR TITLE
fix: support go 1.16 builds on ARM machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /tmp
-
+ENV GOBIN=/go/bin
 ADD hack/install.sh .
 ADD hack/installers installers
 ADD hack/tool-versions.sh .
@@ -119,8 +119,9 @@ RUN make argocd-all
 
 ARG BUILD_ALL_CLIS=true
 RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
-    make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all && \
-    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all \
+    make BIN_NAME=argocd-darwin-arm64 GOOS=darwin GOARCH=arm64 argocd-all && \
+    make BIN_NAME=argocd-darwin-amd64 GOOS=darwin GOARCH=amd64 argocd-all && \
+    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows GOARCH=amd64 argocd-all \
     ; fi
 
 ####################################################################################################

--- a/hack/installers/install-ksonnet-linux.sh
+++ b/hack/installers/install-ksonnet-linux.sh
@@ -8,10 +8,10 @@ case $ARCHITECTURE in
   arm|arm64)
     set +o pipefail
     # Clone the repository in $GOPATH/src/github.com/ksonnet/ksonnet
-    go get -u github.com/ksonnet/ksonnet || true
+    GO111MODULE=auto go get -u github.com/ksonnet/ksonnet || true
     set -o pipefail
     cd $GOPATH/src/github.com/ksonnet/ksonnet && git checkout tags/v$KSONNET_VERSION
-    cd $GOPATH/src/github.com/ksonnet/ksonnet && CGO_ENABLED=0 GO_LDFLAGS="-s" make install
+    cd $GOPATH/src/github.com/ksonnet/ksonnet && GO111MODULE=auto CGO_ENABLED=0 GO_LDFLAGS="-s" make install
     mv $GOPATH/bin/ks $BIN/ks
     ;;
   *)

--- a/hack/installers/install-packr-linux.sh
+++ b/hack/installers/install-packr-linux.sh
@@ -7,10 +7,8 @@ PACKR_VERSION=${packr_version}
 case $ARCHITECTURE in
   arm|arm64)
     # Clone the repository in $GOPATH/src/github.com/gobuffalo/packr
-    go get -u github.com/gobuffalo/packr
-    cd $GOPATH/src/github.com/gobuffalo/packr && git checkout tags/v$PACKR_VERSION
-    cd $GOPATH/src/github.com/gobuffalo/packr && CGO_ENABLED=0 make install
-    mv $GOPATH/bin/packr $BIN/packr
+     go install github.com/gobuffalo/packr/packr@v${PACKR_VERSION}
+     cp $GOBIN/packr $BIN/packr
     ;;
   *)
     [ -e $DOWNLOADS/parkr.tar.gz ] || curl -sLf --retry 3 -o $DOWNLOADS/parkr.tar.gz https://github.com/gobuffalo/packr/releases/download/v${PACKR_VERSION}/packr_${PACKR_VERSION}_linux_$ARCHITECTURE.tar.gz

--- a/hack/installers/install-protoc-linux.sh
+++ b/hack/installers/install-protoc-linux.sh
@@ -3,7 +3,15 @@ set -eux -o pipefail
 
 . $(dirname $0)/../tool-versions.sh
 
-[ -e $DOWNLOADS/protoc.zip ] || curl -sLf --retry 3 -o $DOWNLOADS/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip
+case $ARCHITECTURE in
+  arm|arm64)
+    [ -e $DOWNLOADS/protoc.zip ] || curl -sLf --retry 3 -o $DOWNLOADS/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-aarch_64.zip
+    ;;
+  *)
+    [ -e $DOWNLOADS/protoc.zip ] || curl -sLf --retry 3 -o $DOWNLOADS/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip
+    ;;
+esac
+
 unzip $DOWNLOADS/protoc.zip bin/protoc -d /usr/local/
 chmod +x /usr/local/bin/protoc
 unzip $DOWNLOADS/protoc.zip include/* -d /usr/local/


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>

Noticed on my M1 MacBook that the default build task doesn't work after upgrading to Go 1.16 - this change fixes that. 

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

