### PR TITLE
docs: Add the Schwarz IT to the list of users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -90,6 +90,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Robotinfra](https://www.robotinfra.com)
 1. [Saildrone](https://www.saildrone.com/)
 1. [Saloodo! GmbH](https://www.saloodo.com)
+1. [Schwarz IT](https://jobs.schwarz/it-mission)
 1. [Speee](https://speee.jp/)
 1. [Spendesk](https://spendesk.com/)
 1. [Sumo Logic](https://sumologic.com/)


### PR DESCRIPTION
We at the Schwarz IT use heavily ArgoCD  and   would like  to be in the list of Users

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

