### PR TITLE
docs: remove obsolete ci section

### DIFF
--- a/docs/developer-guide/test-e2e.md
+++ b/docs/developer-guide/test-e2e.md
@@ -25,10 +25,6 @@ The Makefile's `start-e2e` target starts instances of ArgoCD on your local machi
 
 If you have changed the port for `argocd-server`, be sure to also set `ARGOCD_SERVER` environment variable to point to that port, e.g. `export ARGOCD_SERVER=localhost:8888` before running `make test-e2e` so that the test will communicate to the correct server component.
 
-## CI Set-up
-
-The tests are executed by Argo Workflow defined at `.argo-ci/ci.yaml`. CI job The builds an Argo CD image, deploy argo cd components into throw-away kubernetes cluster provisioned
-using k3s and run e2e tests against it.
 
 ## Test Isolation
 


### PR DESCRIPTION
* The CI files referred to here don't exist anymore.
* The developer guide isn't the appropriate place for the information anyway, I feel 🤔   Happy to move it to a different section :)