### PR TITLE
fix: revert use streaming API for Application List UI view

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -21,7 +21,7 @@ import {ApplicationTiles} from './applications-tiles';
 
 require('./applications-list.scss');
 
-const EVENTS_BUFFER_TIMEOUT = 300;
+const EVENTS_BUFFER_TIMEOUT = 500;
 const WATCH_RETRY_TIMEOUT = 500;
 const APP_FIELDS = [
     'metadata.name',
@@ -37,61 +37,54 @@ const APP_FIELDS = [
     'status.operationState.operation.sync',
     'status.summary'
 ];
+const APP_LIST_FIELDS = ['metadata.resourceVersion', ...APP_FIELDS.map(field => `items.${field}`)];
 const APP_WATCH_FIELDS = ['result.type', ...APP_FIELDS.map(field => `result.application.${field}`)];
 
-function loadApplications(page: number, pageSize: number): Observable<models.Application[]> {
-    const applications = new Array<models.Application>();
-    return (
-        services.applications
-            .watch({}, {fields: APP_WATCH_FIELDS})
-            .repeat()
-            .retryWhen(errors => errors.delay(WATCH_RETRY_TIMEOUT))
-            // batch events to avoid constant re-rendering and improve UI performance
-            .bufferTime(EVENTS_BUFFER_TIMEOUT)
-            .map(appChanges => {
-                const eventTypes = new Set<models.WatchType>();
-                appChanges.forEach(appChange => {
-                    const index = applications.findIndex(item => item.metadata.name === appChange.application.metadata.name);
-                    eventTypes.add(appChange.type);
-                    switch (appChange.type) {
-                        case 'DELETED':
-                            if (index > -1) {
-                                applications.splice(index, 1);
-                            }
-                            break;
-                        default:
-                            if (index > -1) {
-                                applications[index] = appChange.application;
-                            } else {
-                                applications.unshift(appChange.application);
-                            }
-                            break;
-                    }
-                });
-                applications.sort((first, second) => first.metadata.name.localeCompare(second.metadata.name));
-                return {applications, updated: appChanges.length > 0, eventTypes};
-            })
-            .skipWhile(state => {
-                // keep accumulating applications until we loaded enough for current page
-                // or all 'ADDED' events are loaded and we start getting 'DELETED' and 'MODIFIED'
-                // or we've have not received any updates during last 0.3 seconds (EVENTS_BUFFER_TIMEOUT)
-                const addedOnly = state.eventTypes.has('ADDED') || state.eventTypes.size === 1;
-                const noEnough = state.applications.length < page * pageSize;
-                return noEnough && addedOnly && state.updated;
-            })
-            .map(item => item.applications)
-    );
+function loadApplications(): Observable<models.Application[]> {
+    return Observable.fromPromise(services.applications.list([], {fields: APP_LIST_FIELDS})).flatMap(applicationsList => {
+        const applications = applicationsList.items;
+        return Observable.merge(
+            Observable.from([applications]),
+            services.applications
+                .watch({resourceVersion: applicationsList.metadata.resourceVersion}, {fields: APP_WATCH_FIELDS})
+                .repeat()
+                .retryWhen(errors => errors.delay(WATCH_RETRY_TIMEOUT))
+                // batch events to avoid constant re-rendering and improve UI performance
+                .bufferTime(EVENTS_BUFFER_TIMEOUT)
+                .map(appChanges => {
+                    appChanges.forEach(appChange => {
+                        const index = applications.findIndex(item => item.metadata.name === appChange.application.metadata.name);
+                        switch (appChange.type) {
+                            case 'DELETED':
+                                if (index > -1) {
+                                    applications.splice(index, 1);
+                                }
+                                break;
+                            default:
+                                if (index > -1) {
+                                    applications[index] = appChange.application;
+                                } else {
+                                    applications.unshift(appChange.application);
+                                }
+                                break;
+                        }
+                    });
+                    return {applications, updated: appChanges.length > 0};
+                })
+                .filter(item => item.updated)
+                .map(item => item.applications)
+        );
+    });
 }
 
-const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; pageSize: number; search: string}) => React.ReactNode}) => (
+const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: number; search: string}) => React.ReactNode}) => (
     <ObservableQuery>
         {q => (
             <DataLoader
                 load={() =>
-                    Observable.combineLatest(services.viewPreferences.getPreferences(), q).map(items => {
+                    Observable.combineLatest(services.viewPreferences.getPreferences().map(item => item.appList), q).map(items => {
                         const params = items[1];
-                        const viewPref: AppsListPreferences = {...items[0].appList};
-                        const pageSizes = {...items[0].pageSizes};
+                        const viewPref: AppsListPreferences = {...items[0]};
                         if (params.get('proj') != null) {
                             viewPref.projectsFilter = params
                                 .get('proj')
@@ -132,8 +125,7 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                 .map(decodeURIComponent)
                                 .filter(item => !!item);
                         }
-                        const pageSize = pageSizes['applications-list'] || 10;
-                        return {...viewPref, page: parseInt(params.get('page') || '0', 10), search: params.get('search') || '', pageSize};
+                        return {...viewPref, page: parseInt(params.get('page') || '0', 10), search: params.get('search') || ''};
                     })
                 }>
                 {pref => children(pref)}
@@ -306,7 +298,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                 {pref => (
                                     <DataLoader
                                         ref={loaderRef}
-                                        load={() => AppUtils.handlePageVisibility(() => loadApplications(pref.page, pref.pageSize))}
+                                        load={() => AppUtils.handlePageVisibility(() => loadApplications())}
                                         loadingRenderer={() => (
                                             <div className='argo-container'>
                                                 <MockupList height={100} marginTop={30} />


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR reverts changes implemented by https://github.com/argoproj/argo-cd/pull/5719

The problem with streaming API is that UI cannot reliably tell if the backend has no data or it is just slow. As a result, UI might intermittently show that there are no Argo CD applications and then load applications. This creates a bad impression. I've spent few hours trying to find workaround: different timeouts, list + watch but no luck. 

Instead of trying to implement workaround on UI side I think we should focus on root cause that causes slowness: https://github.com/argoproj/argo-cd/issues/4296