### PR TITLE
feat: Support kubectl replace instead of apply (#2730)

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -169,7 +169,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		sync.WithResourcesFilter(func(key kube.ResourceKey, target *unstructured.Unstructured, live *unstructured.Unstructured) bool {
 			return len(syncOp.Resources) == 0 || argo.ContainsSyncResource(key.Name, key.Namespace, schema.GroupVersionKind{Kind: key.Kind, Group: key.Group}, syncOp.Resources)
 		}),
-		sync.WithManifestValidation(!syncOp.SyncOptions.HasOption("Validate=false")),
+		sync.WithManifestValidation(!syncOp.SyncOptions.HasOption(common.SyncOptionsDisableValidation)),
 		sync.WithNamespaceCreation(syncOp.SyncOptions.HasOption("CreateNamespace=true"), func(un *unstructured.Unstructured) bool {
 			if un != nil && kube.GetAppInstanceLabel(un, cdcommon.LabelKeyAppInstance) != "" {
 				kube.UnsetLabel(un, cdcommon.LabelKeyAppInstance)
@@ -178,9 +178,10 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 			return false
 		}),
 		sync.WithSyncWaveHook(delayBetweenSyncWaves),
-		sync.WithPruneLast(syncOp.SyncOptions.HasOption("PruneLast=true")),
+		sync.WithPruneLast(syncOp.SyncOptions.HasOption(common.SyncOptionPruneLast)),
 		sync.WithResourceModificationChecker(syncOp.SyncOptions.HasOption("ApplyOutOfSyncOnly=true"), compareResult.diffResultList),
 		sync.WithPrunePropagationPolicy(&prunePropagationPolicy),
+		sync.WithReplace(syncOp.SyncOptions.HasOption(common.SyncOptionReplace)),
 	)
 
 	if err != nil {

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -111,3 +111,17 @@ metadata:
     argocd.argoproj.io/sync-options: PruneLast=true
 ```
 
+## Replace Resource Instead Of Applying Changes
+
+By default, Argo CD executes `kubectl apply` operation to apply the configuration stored in Git. In some cases
+`kubectl apply` is not suitable. For example, resource spec might be too big and won't fit into
+`kubectl.kubernetes.io/last-applied-configuration` annotation that is added by `kubectl apply`. In such cases you
+might use `Replace=true` sync option:
+
+
+```yaml
+syncOptions:
+- Replace=true
+```
+
+If the `Replace=true` sync option is set the Argo CD will use `kubectl replace` or `kubectl create` command to apply changes.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/alicebob/miniredis/v2 v2.14.2
-	github.com/argoproj/gitops-engine v0.2.1-0.20210315215247-5d680d6b808b
+	github.com/argoproj/gitops-engine v0.2.1-0.20210318043518-89ddd0dffbc9
 	github.com/argoproj/pkg v0.2.0
 	github.com/bombsimon/logrusr v1.0.0
 	github.com/bradleyfalzon/ghinstallation v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj/gitops-engine v0.2.1-0.20210315215247-5d680d6b808b h1:aGJMo7zt5zd0YOGSXlXm1g5rgWOuryiLYsrXC09iiqU=
-github.com/argoproj/gitops-engine v0.2.1-0.20210315215247-5d680d6b808b/go.mod h1:IBHhAkqlC+3r/wBWUitWSidQhPzlLoSTWp2htq3dyQk=
+github.com/argoproj/gitops-engine v0.2.1-0.20210318043518-89ddd0dffbc9 h1:owSD7H4d5DSGwav49vATZ+KCvrfDMgC1OhMKgOIJzVk=
+github.com/argoproj/gitops-engine v0.2.1-0.20210318043518-89ddd0dffbc9/go.mod h1:IBHhAkqlC+3r/wBWUitWSidQhPzlLoSTWp2htq3dyQk=
 github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=
 github.com/argoproj/pkg v0.2.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1566,3 +1566,24 @@ func TestAppWaitOperationInProgress(t *testing.T) {
 			errors.CheckError(err)
 		})
 }
+
+func TestSyncOptionReplace(t *testing.T) {
+	Given(t).
+		Path("config-map").
+		When().
+		PatchFile("config-map.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Replace=true"}}]`).
+		Create().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			assert.Equal(t, app.Status.OperationState.SyncResult.Resources[0].Message, "ConfigMap/my-map created")
+		}).
+		When().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		And(func(app *Application) {
+			assert.Equal(t, app.Status.OperationState.SyncResult.Resources[0].Message, "configmap/my-map replaced")
+		})
+}

--- a/ui/src/app/applications/components/application-sync-options/application-sync-options.scss
+++ b/ui/src/app/applications/components/application-sync-options/application-sync-options.scss
@@ -1,14 +1,21 @@
-.application-sync-options__select {
-    position: relative;
-    padding-left: 12.5em;
+@import 'node_modules/argo-ui/src/styles/config';
 
-    .select__focus-receiver {
-        position: absolute;
+.application-sync-options {
+    &__select {
+        position: relative;
+        padding-left: 12.5em;
+
+        .select__focus-receiver {
+            position: absolute;
+        }
+
+        label {
+            position: absolute;
+            left: 0;
+            top: 0.75em;
+        }
     }
-
-    label {
-        position: absolute;
-        left: 0;
-        top: 0.75em;
+    .fa-exclamation-triangle {
+        color: $argo-status-warning-color;
     }
 }

--- a/ui/src/app/applications/components/application-sync-options/application-sync-options.tsx
+++ b/ui/src/app/applications/components/application-sync-options/application-sync-options.tsx
@@ -1,9 +1,11 @@
-import {Checkbox, Select} from 'argo-ui';
+import {Checkbox, Select, Tooltip} from 'argo-ui';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactForm from 'react-form';
 
 require('./application-sync-options.scss');
+
+const REPLACE_WARNING = `The resource will be synced using 'kubectl replace/create' command that is a potentially destructive action.`;
 
 export interface ApplicationSyncOptionProps {
     options: string[];
@@ -36,7 +38,7 @@ function selectOption(name: string, label: string, defaultVal: string, values: s
     );
 }
 
-function booleanOption(name: string, label: string, defaultVal: boolean, props: ApplicationSyncOptionProps, invert: boolean) {
+function booleanOption(name: string, label: string, defaultVal: boolean, props: ApplicationSyncOptionProps, invert: boolean, warning: string = null) {
     const options = [...(props.options || [])];
     const prefix = `${name}=`;
     const index = options.findIndex(item => item.startsWith(prefix));
@@ -55,7 +57,12 @@ function booleanOption(name: string, label: string, defaultVal: boolean, props: 
                     }
                 }}
             />
-            <label htmlFor={`sync-option-${name}`}>{label}</label>
+            <label htmlFor={`sync-option-${name}`}>{label}</label>{' '}
+            {warning && (
+                <Tooltip content={warning}>
+                    <i className='fa fa-exclamation-triangle' />
+                </Tooltip>
+            )}
         </React.Fragment>
     );
 }
@@ -79,13 +86,14 @@ const syncOptions: Array<(props: ApplicationSyncOptionProps) => React.ReactNode>
     props => booleanOption('CreateNamespace', 'Auto-Create Namespace', false, props, false),
     props => booleanOption('PruneLast', 'Prune Last', false, props, false),
     props => booleanOption('ApplyOutOfSyncOnly', 'Apply Out of Sync Only', false, props, false),
+    props => booleanOption('Replace', 'Replace', false, props, false, REPLACE_WARNING),
     props => selectOption('PrunePropagationPolicy', 'Prune Propagation Policy', 'foreground', ['foreground', 'background', 'orphan'], props)
 ];
 
 const optionStyle = {marginTop: '0.5em'};
 
 export const ApplicationSyncOptions = (props: ApplicationSyncOptionProps) => (
-    <div className='row'>
+    <div className='row application-sync-options'>
         {syncOptions.map((render, i) => (
             <div
                 key={i}


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/2730
Depends on https://github.com/argoproj/gitops-engine/pull/246

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>




PR introduces support for `Replace=true` sync option. If the option is set then Argo CD uses `kubectl replace/create` instead of `kubectl apply`.


![image](https://user-images.githubusercontent.com/426437/111548042-58574f00-8737-11eb-920c-f0d7ed2e70fb.png)
