### PR TITLE
chore: Use right protocol for argo-ui dependency

### DIFF
--- a/docs/developer-guide/dependencies.md
+++ b/docs/developer-guide/dependencies.md
@@ -45,7 +45,7 @@ If you make changes to the Argo UI component, and your Argo CD changes depend on
 1. Make changes to Argo UI and submit the PR request.
 2. Also, prepare your Argo CD changes, but don't create the PR just yet.
 3. **After** the Argo UI PR has been merged to master, then as part of your Argo CD changes:
-	- Run `yarn add https://github.com/argoproj/argo-ui.git`, and then,
+	- Run `yarn add git+https://github.com/argoproj/argo-ui.git`, and then,
 	- Check in the regenerated yarn.lock file as part of your Argo CD commit
 4. Create the Argo CD PR	 when you are ready. The PR build and test checks should pass.
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,7 @@
     "@types/react-router": "^4.0.27",
     "@types/react-router-dom": "^4.2.3",
     "@types/superagent": "^3.5.7",
-    "argo-ui": "https://github.com/argoproj/argo-ui.git",
+    "argo-ui": "git+https://github.com/argoproj/argo-ui.git",
     "classnames": "^2.2.5",
     "color": "^3.1.0",
     "cookie": "^0.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1822,9 +1822,9 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-"argo-ui@https://github.com/argoproj/argo-ui.git":
+"argo-ui@git+https://github.com/argoproj/argo-ui.git":
   version "1.0.0"
-  resolved "https://github.com/argoproj/argo-ui.git#967c28a377aeef4861b2b97ccf6693d64abef725"
+  resolved "git+https://github.com/argoproj/argo-ui.git#967c28a377aeef4861b2b97ccf6693d64abef725"
   dependencies:
     "@fortawesome/fontawesome-free" "^5.8.1"
     "@tippy.js/react" "^2.1.2"


### PR DESCRIPTION
Changes "https://" to "git+https://" URL, which lets other dependency managers correctly resolve & fetch the UI's dependency to argo-ui

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

