### PR TITLE
feat: reduce newClientResolveRevision calls to speed up

### DIFF
--- a/util/git/git.go
+++ b/util/git/git.go
@@ -40,6 +40,18 @@ func IsTruncatedCommitSHA(sha string) bool {
 	return truncatedCommitSHARegex.MatchString(sha)
 }
 
+var gerritChangeRefRegex = regexp.MustCompile(`refs/changes/\d{2}/\d+/\d+`)
+
+// IsGerritChangeRef returns whether or not a string is a gerrit change ref
+func IsGerritChangeRef(ref string) bool {
+	return gerritChangeRefRegex.MatchString(ref)
+}
+
+// IsMutableRef returns whether or not a ref is mutable
+func IsMutableRef(ref string) bool {
+	return !(IsGerritChangeRef(ref) || IsCommitSHA(ref) || IsTruncatedCommitSHA(ref))
+}
+
 // SameURL returns whether or not the two repository URLs are equivalent in location
 func SameURL(leftRepo, rightRepo string) bool {
 	normalLeft := NormalizeGitURL(leftRepo)


### PR DESCRIPTION
newClientResolveRevision requires ls-remote which is quite expensive for large repository. It is not needed in some conditions though

* when the revision is guaranteed to be resolved already
* when the revision is expected to be immutable in resolution, e.g change ref in gerrit