### PR TITLE
chore: Separate "online" mode from "production" mode in yarn build

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -259,7 +259,7 @@ jobs:
           yarn build
         env:
           NODE_ENV: production
-          NODE_ONLINe_ENV: online
+          NODE_ONLINE_ENV: online
         working-directory: ui/
       - name: Run ESLint
         run: yarn lint

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -259,6 +259,7 @@ jobs:
           yarn build
         env:
           NODE_ENV: production
+          NODE_ONLINe_ENV: online
         working-directory: ui/
       - name: Run ESLint
         run: yarn lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ ADD ["ui/", "."]
 
 ARG ARGO_VERSION=latest
 ENV ARGO_VERSION=$ARGO_VERSION
-RUN NODE_ENV='production' yarn build
+RUN NODE_ENV='production' NODE_ONLINE_ENV='online' yarn build
 
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries

--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -8,7 +8,9 @@ const webpack = require('webpack');
 const path = require('path');
 
 const isProd = process.env.NODE_ENV === 'production';
-console.log(`Bundling in ${isProd ? 'production' : 'development'} mode...`);
+const isOnline = process.env.NODE_ONLINE_ENV === 'online';
+
+console.log(`Bundling in ${isProd ? 'production' : 'development'} mode ${isOnline ? 'online' : 'offline'}...`);
 
 const proxyConf = {
     'target': process.env.ARGOCD_API_URL || 'http://localhost:8080',
@@ -57,6 +59,7 @@ const config = {
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+            'process.env.NODE_ONLINE_ENV': JSON.stringify(process.env.NODE_ONLINE_ENV || 'offline'),
             SYSTEM_INFO: JSON.stringify({
                 version: process.env.ARGO_VERSION || 'latest',
             }),
@@ -89,7 +92,7 @@ const config = {
             filename: 'fonts.css',
             // local: false in dev prevents pulling fonts on each code change
             // https://github.com/gabiseabra/google-fonts-webpack-plugin/issues/2
-            local: isProd,
+            local: isOnline,
             path: 'assets/fonts/google-fonts'
 		})
     ],


### PR DESCRIPTION
Signed-off-by: William Tam <email.wtam@gmail.com>

This PR separates "online" from "production" mode during yarn build.   It does not change any current behavior but it allows a build process to bundle in production mode offline if desire.

In Dockerfile, we can configure build mode with a new variable `NODE_ONLINE_ENV`
RUN NODE_ENV='production' NODE_ONLINE_ENV='online' yarn build

The following message will be printed to indicate 
`Bundling in production mode online...`

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

