### PR TITLE
chore: Fix manifest generation in release and make quay.io the lead

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       # The name of the tag as supplied by the GitHub event
       SOURCE_TAG: ${{ github.ref }}
       # The image namespace where Docker image will be published to
-      IMAGE_NAMESPACE: argoproj
+      IMAGE_NAMESPACE: quay.io/argoproj
       # Whether to create & push image and release assets
       DRY_RUN: false
       # Whether a draft release should be created, instead of public one
@@ -197,10 +197,11 @@ jobs:
           QUAY_TOKEN: ${{ secrets.RELEASE_QUAY_TOKEN }}
         run: |
           set -ue
-          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
-          docker push ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION}
           docker login quay.io --username "${QUAY_USERNAME}" --password "${QUAY_TOKEN}"
-          docker tag ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION} quay.io/${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION}
+          docker push ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION}
+          # Remove the following when Docker Hub is gone
+          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
+          docker tag ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION} argoproj/argocd:v${TARGET_VERSION}
           docker push quay.io/${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION}
         if: ${{ env.DRY_RUN != 'true' }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -202,7 +202,7 @@ jobs:
           # Remove the following when Docker Hub is gone
           docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
           docker tag ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION} argoproj/argocd:v${TARGET_VERSION}
-          docker push quay.io/${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION}
+          docker push argoproj/argocd:v${TARGET_VERSION}
         if: ${{ env.DRY_RUN != 'true' }}
 
       - name: Read release notes file


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

