### PR TITLE
Troubleshooting docs update: Cluster sub command not available

### DIFF
--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -82,10 +82,10 @@ kubectl exec -n argocd -it \
   $(kubectl get pods -n argocd -l app.kubernetes.io/name=argocd-application-controller -o jsonpath='{.items[0].metadata.name}') bash
 ```
 
-2 Use `argocd-util cluster kubeconfig` command to export kubeconfig file from the configured Secret:
+2 Use `argocd-util kubeconfig` command to export kubeconfig file from the configured Secret:
 
 ```
-argocd-util cluster kubeconfig https://<api-server-url> /tmp/kubeconfig --namespace argocd
+argocd-util kubeconfig https://<api-server-url> /tmp/kubeconfig --namespace argocd
 ```
 
 3 Use `kubectl` to get more details about connection issues, fix them and apply changes back to secret:


### PR DESCRIPTION
Signed-off-by: Patrik Jonsson <patrik.jonsson@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

