### PR TITLE
chore: fix 'make codegen-local' on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ mod-download: test-tools-image
 
 .PHONY: mod-download-local
 mod-download-local:
-	go mod download
+	go mod download && go mod tidy # go mod download changes go.sum https://github.com/golang/go/issues/42970
 
 .PHONY: mod-vendor
 mod-vendor: test-tools-image

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-cd
 
-go 1.14
+go 1.16
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -218,7 +218,6 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/hack/known_types/main.go
+++ b/hack/known_types/main.go
@@ -7,7 +7,6 @@ import (
 	"go/types"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -38,14 +37,8 @@ func newCommand() *cobra.Command {
 			packagePath := args[1]
 			outputPath := args[2]
 
-			var imprt types.Importer
-			if runtime.GOOS == "linux" {
-				// nolint:staticcheck
-				imprt = importer.For("source", nil)
-			} else {
-				imprt = importer.Default()
-			}
-
+			// nolint:staticcheck
+			imprt := importer.For("source", nil)
 			pkg, err := imprt.Import(packagePath)
 			if err != nil {
 				return err

--- a/manifests/ha/base/redis-ha/generate.sh
+++ b/manifests/ha/base/redis-ha/generate.sh
@@ -12,5 +12,5 @@ helm template argocd ./chart \
   >> ./chart/upstream_orig.yaml
 
 sed -e 's/check inter 1s/check inter 3s/' ./chart/upstream_orig.yaml >> ./chart/upstream.yaml && rm ./chart/upstream_orig.yaml
-sed -i 's/timeout server 30s/timeout server 6m/' ./chart/upstream.yaml
-sed -i 's/timeout client 30s/timeout client 6m/' ./chart/upstream.yaml
+sed -i.bak 's/timeout server 30s/timeout server 6m/' ./chart/upstream.yaml && rm ./chart/upstream.yaml.bak
+sed -i.bak 's/timeout client 30s/timeout client 6m/' ./chart/upstream.yaml && rm ./chart/upstream.yaml.bak


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR fixes `make codegen-local` on mac:

* forgotten `go mod edit -go=1.16` 
* accomodate differences in how sed command works on mac