### PR TITLE
fix: get correct username from jwt token subject (#5836)

### DIFF
--- a/cmd/argocd/commands/account.go
+++ b/cmd/argocd/commands/account.go
@@ -99,7 +99,7 @@ func NewAccountUpdatePasswordCommand(clientOpts *argocdclient.ClientOptions) *co
 				errors.CheckError(err)
 				claims, err := configCtx.User.Claims()
 				errors.CheckError(err)
-				tokenString := passwordLogin(acdClient, claims.Subject, newPassword)
+				tokenString := passwordLogin(acdClient, localconfig.GetUsername(claims.Subject), newPassword)
 				localCfg.UpsertUser(localconfig.User{
 					Name:      localCfg.CurrentContext,
 					AuthToken: tokenString,

--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -55,8 +55,8 @@ func NewReloginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comm
 			claims, err := configCtx.User.Claims()
 			errors.CheckError(err)
 			if claims.Issuer == session.SessionManagerClaimsIssuer {
-				fmt.Printf("Relogging in as '%s'\n", claims.Subject)
-				tokenString = passwordLogin(acdClient, claims.Subject, password)
+				fmt.Printf("Relogging in as '%s'\n", localconfig.GetUsername(claims.Subject))
+				tokenString = passwordLogin(acdClient, localconfig.GetUsername(claims.Subject), password)
 			} else {
 				fmt.Println("Reinitiating SSO login")
 				setConn, setIf := acdClient.NewSettingsClientOrDie()

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -14,7 +14,10 @@ import (
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	httputil "github.com/argoproj/argo-cd/util/http"
+<<<<<<< HEAD
 	jwtutil "github.com/argoproj/argo-cd/util/jwt"
+=======
+>>>>>>> efe7ebb3 (fix: support longer cookie)
 	"github.com/argoproj/argo-cd/util/session"
 	"github.com/argoproj/argo-cd/util/settings"
 )

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -14,10 +14,7 @@ import (
 	"github.com/argoproj/argo-cd/common"
 	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	httputil "github.com/argoproj/argo-cd/util/http"
-<<<<<<< HEAD
 	jwtutil "github.com/argoproj/argo-cd/util/jwt"
-=======
->>>>>>> efe7ebb3 (fix: support longer cookie)
 	"github.com/argoproj/argo-cd/util/session"
 	"github.com/argoproj/argo-cd/util/settings"
 )

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"strings"
 
 	"github.com/dgrijalva/jwt-go/v4"
 
@@ -261,4 +262,13 @@ func DefaultLocalConfigPath() (string, error) {
 		return "", err
 	}
 	return path.Join(dir, "config"), nil
+}
+
+// Get username from subject in a claim
+func GetUsername(subject string) string {
+	parts := strings.Split(subject, ":")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return subject
 }

--- a/util/localconfig/localconfig_test.go
+++ b/util/localconfig/localconfig_test.go
@@ -1,0 +1,13 @@
+package localconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUsername(t *testing.T) {
+	assert.Equal(t, "admin", GetUsername("admin:login"))
+	assert.Equal(t, "admin", GetUsername("admin"))
+	assert.Equal(t, "", GetUsername(""))
+}


### PR DESCRIPTION
fixes #5836

Adapt change https://github.com/argoproj/argo-cd/blob/bde4ad4d820c0cb024ad5188d2f223bfe8521de2/server/session/session.go#L67

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

