### PR TITLE
fix: add "--fix-missing" to test container dependency installation command

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.16.0 as golang
 FROM ubuntu:20.10
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN  apt-get update && apt-get install -y \
+RUN  apt-get update && apt-get install --fix-missing -y \
         ca-certificates \
         curl \
         openssh-server \


### PR DESCRIPTION
This changed help fix the following:

```
#8 109.1 Get:171 http://archive.ubuntu.com/ubuntu groovy/main amd64 libnginx-mod-http-xslt-filter amd64 1.18.0-6ubuntu2 [14.3 kB]
#8 109.1 Get:172 http://archive.ubuntu.com/ubuntu groovy/main amd64 libnginx-mod-mail amd64 1.18.0-6ubuntu2 [43.9 kB]
#8 109.2 Get:173 http://archive.ubuntu.com/ubuntu groovy/main amd64 libnginx-mod-stream amd64 1.18.0-6ubuntu2 [68.3 kB]
#8 109.5 Get:174 http://archive.ubuntu.com/ubuntu groovy/main amd64 libnginx-mod-stream-geoip2 amd64 1.18.0-6ubuntu2 [9644 B]
#8 109.5 Get:175 http://archive.ubuntu.com/ubuntu groovy/main amd64 libsasl2-modules amd64 2.1.27+dfsg-2ubuntu1 [48.8 kB]
#8 109.5 Get:176 http://archive.ubuntu.com/ubuntu groovy/main amd64 libwrap0 amd64 7.6.q-30 [46.3 kB]
#8 109.5 Get:177 http://archive.ubuntu.com/ubuntu groovy/main amd64 make amd64 4.3-4ubuntu1 [167 kB]
#8 109.6 Get:178 http://archive.ubuntu.com/ubuntu groovy/main amd64 manpages-dev all 5.08-1 [2290 kB]
#8 110.6 Get:179 http://archive.ubuntu.com/ubuntu groovy/main amd64 ncurses-term all 6.2-1 [247 kB]
#8 110.7 Get:180 http://archive.ubuntu.com/ubuntu groovy/main amd64 nginx-core amd64 1.18.0-6ubuntu2 [427 kB]
#8 111.1 Get:181 http://archive.ubuntu.com/ubuntu groovy/main amd64 nginx amd64 1.18.0-6ubuntu2 [3980 B]
#8 111.1 Get:182 http://archive.ubuntu.com/ubuntu groovy-updates/main amd64 openssh-sftp-server amd64 1:8.3p1-1ubuntu0.1 [51.8 kB]
#8 111.1 Get:183 http://archive.ubuntu.com/ubuntu groovy-updates/main amd64 openssh-server amd64 1:8.3p1-1ubuntu0.1 [382 kB]
#8 111.3 Get:184 http://archive.ubuntu.com/ubuntu groovy/main amd64 patch amd64 2.7.6-6 [105 kB]
#8 111.5 Get:185 http://archive.ubuntu.com/ubuntu groovy/main amd64 python3-certifi all 2020.4.5.1-1 [151 kB]
#8 111.5 Get:186 http://archive.ubuntu.com/ubuntu groovy/main amd64 python3-chardet all 3.0.4-7 [80.2 kB]
#8 111.5 Get:187 http://archive.ubuntu.com/ubuntu groovy/main amd64 python3-idna all 2.10-1 [35.2 kB]
#8 111.5 Get:188 http://archive.ubuntu.com/ubuntu groovy/main amd64 python3-six all 1.15.0-1 [12.0 kB]
#8 111.5 Get:189 http://archive.ubuntu.com/ubuntu groovy/main amd64 python3-urllib3 all 1.25.9-1 [88.8 kB]
#8 111.5 Get:190 http://archive.ubuntu.com/ubuntu groovy/main amd64 python3-requests all 2.23.0+dfsg-2 [50.9 kB]
#8 111.5 Get:191 http://archive.ubuntu.com/ubuntu groovy/main amd64 unzip amd64 6.0-25ubuntu1 [169 kB]
#8 111.6 Get:192 http://archive.ubuntu.com/ubuntu groovy/main amd64 zip amd64 3.0-11build1 [167 kB]
#8 111.7 Get:193 http://archive.ubuntu.com/ubuntu groovy/main amd64 python3-distro all 1.5.0-1 [14.8 kB]
#8 111.7 Get:194 http://archive.ubuntu.com/ubuntu groovy/main amd64 ssh-import-id all 5.10-0ubuntu1 [10.0 kB]
#8 111.7 Fetched 94.3 MB in 1min 39s (953 kB/s)
#8 111.7 E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/b/brotli/libbrotli1_1.0.9-2_amd64.deb  Error reading from server. Remote end closed connection [IP: 91.189.88.152 80]
#8 111.7 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Signed-off-by: Shoubhik Bose <shbose@redhat.com>


