### PR TITLE
fix: non-cascading application delete is broken

### DIFF
--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -113,7 +113,7 @@ export class ApplicationsService {
 
     public delete(name: string, propagationPolicy: string): Promise<boolean> {
         let cascade = true;
-        if (propagationPolicy === 'orphan') {
+        if (propagationPolicy === 'non-cascading') {
             propagationPolicy = '';
             cascade = false;
         }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The non-cascade application deletion is broken in `master`. It is always fails due to incorrect request sent by UI. PR fixes the issue