### PR TITLE
fix: path error in docs for argo ui contributing

### DIFF
--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -256,7 +256,7 @@ and others. Although you can make changes to these files and run them locally, i
 
     * `cd argo-ui`
     * `yarn link`
-    * `cd ../argo-cd`
+    * `cd ../argo-cd/ui`
     * `yarn link argo-ui`
 
     Once `argo-ui` package has been successfully linked, test out changes in your local development environment. 


### PR DESCRIPTION
Small error in the path in this part of the docs I added, after going through this process myself I realized my error here. `yarn add` command should be run from the `ui` folder. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

