### PR TITLE
fix: installing packr for arm is no longer working

### DIFF
--- a/hack/installers/install-packr-linux.sh
+++ b/hack/installers/install-packr-linux.sh
@@ -6,10 +6,8 @@ set -eux -o pipefail
 PACKR_VERSION=${packr_version}
 case $ARCHITECTURE in
   arm|arm64)
-    # Clone the repository in $GOPATH/src/github.com/gobuffalo/packr
-    go get -u github.com/gobuffalo/packr
-    cd $GOPATH/src/github.com/gobuffalo/packr && git checkout tags/v$PACKR_VERSION
-    cd $GOPATH/src/github.com/gobuffalo/packr && CGO_ENABLED=0 make install
+    go get -d github.com/gobuffalo/packr@v$PACKR_VERSION
+    cd $GOPATH/pkg/mod/github.com/gobuffalo/packr@v$PACKR_VERSION && CGO_ENABLED=0 make install
     mv $GOPATH/bin/packr $BIN/packr
     ;;
   *)


### PR DESCRIPTION
```
Since Go 1.11, "go get" uses the modules system. This changes
the location the package is downloaded.

Additionally, "go get -u" does more work than required; changing
this to "go get -d" speeds up the process.

Finally, since Go 1.13 "go get" can also check out tags directly,
avoiding an additional checkout.
```

`ksonnet` has a similar issue, but `ksonnet` can no longer be compiled for arm. See https://github.com/argoproj/argo-cd/pull/5271#issuecomment-809992972 for more details on that. So I left that out of this PR, as patching something that is still broken after that, felt not useful to me :)

Note: this is the first time ever I did anything with go, so .. be a bit mindful of that while looking at this change :)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] ~I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.~
* [ ] ~I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] ~Optional. My organization is added to USERS.md.~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
