### PR TITLE
fix: Allow to pass Kubernetes configuration overrides

### DIFF
--- a/cmd/argocd-util/commands/app.go
+++ b/cmd/argocd-util/commands/app.go
@@ -247,7 +247,8 @@ func NewReconcileCommand() *cobra.Command {
 			if refresh {
 				if repoServerAddress == "" {
 					printLine("Repo server is not provided, trying to port-forward to argocd-repo-server pod.")
-					repoServerPort, err := kubeutil.PortForward("app.kubernetes.io/name=argocd-repo-server", 8081, namespace)
+					overrides := clientcmd.ConfigOverrides{}
+					repoServerPort, err := kubeutil.PortForward("app.kubernetes.io/name=argocd-repo-server", 8081, namespace, &overrides)
 					errors.CheckError(err)
 					repoServerAddress = fmt.Sprintf("localhost:%d", repoServerPort)
 				}

--- a/cmd/argocd-util/commands/cluster.go
+++ b/cmd/argocd-util/commands/cluster.go
@@ -79,7 +79,8 @@ func NewClusterStatsCommand() *cobra.Command {
 			errors.CheckError(err)
 			var cache *appstatecache.Cache
 			if portForwardRedis {
-				port, err := kubeutil.PortForward("app.kubernetes.io/name=argocd-redis-ha-haproxy", 6379, namespace)
+				overrides := clientcmd.ConfigOverrides{}
+				port, err := kubeutil.PortForward("app.kubernetes.io/name=argocd-redis-ha-haproxy", 6379, namespace, &overrides)
 				errors.CheckError(err)
 				client := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("localhost:%d", port)})
 				cache = appstatecache.NewCache(cacheutil.NewCache(cacheutil.NewRedisCache(client, time.Hour)), time.Hour)

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/argoproj/argo-cd/common"
 	accountpkg "github.com/argoproj/argo-cd/pkg/apiclient/account"
@@ -112,6 +113,7 @@ type ClientOptions struct {
 	PortForward          bool
 	PortForwardNamespace string
 	Headers              []string
+	KubeOverrides        *clientcmd.ConfigOverrides
 }
 
 type client struct {
@@ -191,7 +193,10 @@ func NewClient(opts *ClientOptions) (Client, error) {
 		c.ServerAddr = serverFromEnv
 	}
 	if opts.PortForward || opts.PortForwardNamespace != "" {
-		port, err := kube.PortForward("app.kubernetes.io/name=argocd-server", 8080, opts.PortForwardNamespace)
+		if opts.KubeOverrides == nil {
+			opts.KubeOverrides = &clientcmd.ConfigOverrides{}
+		}
+		port, err := kube.PortForward("app.kubernetes.io/name=argocd-server", 8080, opts.PortForwardNamespace, opts.KubeOverrides)
 		if err != nil {
 			return nil, err
 		}

--- a/util/kube/portforwarder.go
+++ b/util/kube/portforwarder.go
@@ -19,11 +19,10 @@ import (
 	"github.com/argoproj/argo-cd/util/io"
 )
 
-func PortForward(podSelector string, targetPort int, namespace string) (int, error) {
+func PortForward(podSelector string, targetPort int, namespace string, overrides *clientcmd.ConfigOverrides) (int, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	overrides := clientcmd.ConfigOverrides{}
-	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
+	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
 	config, err := clientConfig.ClientConfig()
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
This allows to override the Kubernetes configuration used to set up the
Port Forward.

Signed-off-by: Raphaël Pinson <raphael.pinson@camptocamp.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

