### PR TITLE
fix: support loading oci helm dependencies referenced by chart stored in non-oci repo

### DIFF
--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -67,16 +67,19 @@ func (h *helm) Template(templateOpts *TemplateOpts) (string, error) {
 }
 
 func (h *helm) DependencyBuild() error {
-	for _, repo := range h.repos {
+	isHelmOci := h.cmd.IsHelmOci
+	defer func() {
+		h.cmd.IsHelmOci = isHelmOci
+	}()
+
+	for i := range h.repos {
+		repo := h.repos[i]
 		if repo.EnableOci {
 			h.cmd.IsHelmOci = true
 			_, err := h.cmd.Login(repo.Repo, repo.Creds)
-			h.cmd.IsHelmOci = false
 
 			defer func() {
-				h.cmd.IsHelmOci = true
 				_, _ = h.cmd.Logout(repo.Repo, repo.Creds)
-				h.cmd.IsHelmOci = false
 			}()
 
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR fixes bug reported in https://github.com/argoproj/argo-cd/discussions/5915

No e2e tests for the sake of time. Created ticket to address it asap: https://github.com/argoproj/argo-cd/issues/5918