### PR TITLE
fix: Use correct field for evaluating whether or not GitHub Enterprise is selected

### DIFF
--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -410,7 +410,7 @@ export class ReposList extends React.Component<RouteComponentProps<any>, {connec
                                 <div className='argo-form-row'>
                                     <FormField formApi={formApi} label='Type' field='ghType' component={FormSelect} componentProps={{options: ['GitHub', 'GitHub Enterprise']}} />
                                 </div>
-                                {formApi.getFormState().values.type === 'GitHub Enterprise' && (
+                                {formApi.getFormState().values.ghType === 'GitHub Enterprise' && (
                                     <React.Fragment>
                                         <div className='argo-form-row'>
                                             <FormField


### PR DESCRIPTION
Fixes #5986 

Signed-off-by: Jonah Back <jonah@jonahback.com>

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

