### PR TITLE
fix: don't resolve revision for a local sync

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1358,7 +1358,11 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 		if len(syncReq.Resources) > 0 {
 			partial = "partial "
 		}
-		s.logAppEvent(a, ctx, argo.EventReasonOperationStarted, fmt.Sprintf("initiated %ssync to %s", partial, displayRevision))
+		reason := fmt.Sprintf("initiated %ssync to %s", partial, displayRevision)
+		if syncReq.Manifests != nil {
+			reason = fmt.Sprintf("initiated %ssync locally", partial)
+		}
+		s.logAppEvent(a, ctx, argo.EventReasonOperationStarted, reason)
 	}
 	return a, err
 }
@@ -1421,6 +1425,9 @@ func (s *Server) Rollback(ctx context.Context, rollbackReq *application.Applicat
 // resolveRevision resolves the revision specified either in the sync request, or the
 // application source, into a concrete revision that will be used for a sync operation.
 func (s *Server) resolveRevision(ctx context.Context, app *appv1.Application, syncReq *application.ApplicationSyncRequest) (string, string, error) {
+	if syncReq.Manifests != nil {
+		return "", "", nil
+	}
 	ambiguousRevision := syncReq.Revision
 	if ambiguousRevision == "" {
 		ambiguousRevision = app.Spec.Source.TargetRevision

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -490,6 +490,34 @@ func TestSyncHelm(t *testing.T) {
 	assert.Equal(t, "Unknown user initiated sync to 0.7.* (0.7.2)", events.Items[1].Message)
 }
 
+func TestSyncGit(t *testing.T) {
+	ctx := context.Background()
+	appServer := newTestAppServer()
+	testApp := newTestApp()
+	testApp.Spec.Source.RepoURL = "https://github.com/org/test"
+	testApp.Spec.Source.Path = "deploy"
+	testApp.Spec.Source.TargetRevision = "0.7.*"
+	app, err := appServer.Create(ctx, &application.ApplicationCreateRequest{Application: *testApp})
+	assert.NoError(t, err)
+	syncReq := &application.ApplicationSyncRequest{
+		Name: &app.Name,
+		Manifests: []string{
+			`apiVersion: v1
+			kind: ServiceAccount
+			metadata:
+			  name: test
+			  namespace: test`,
+		},
+	}
+	app, err = appServer.Sync(ctx, syncReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, app)
+	assert.NotNil(t, app.Operation)
+	events, err := appServer.kubeclientset.CoreV1().Events(appServer.ns).List(context.Background(), metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "Unknown user initiated sync locally", events.Items[1].Message)
+}
+
 func TestRollbackApp(t *testing.T) {
 	testApp := newTestApp()
 	testApp.Status.History = []appsv1.RevisionHistory{{


### PR DESCRIPTION
When syncing with the --local flag, Argo CD is trying to resolve revision and connect to the repository.  This PR adds a condition to skip resolving revision if the manifests are already found locally

Closes: #5849 

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

