### PR TITLE
refactor: upgrade redis-ha to 4.12.14 & cleanup generate.sh

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -48,6 +48,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [hipages](https://hipages.com.au/)
 1. [Honestbank](https://honestbank.com)
 1. [IBM](https://www.ibm.com/)
+1. [Index Exchange](https://www.indexexchange.com/)
 1. [InsideBoard](https://www.insideboard.com)
 1. [Intuit](https://www.intuit.com/)
 1. [JovianX](https://www.jovianx.com/)

--- a/manifests/ha/base/redis-ha/chart/requirements.lock
+++ b/manifests/ha/base/redis-ha/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts
-  version: 4.12.9
-digest: sha256:c36edaae2ca31d21c92b162adbbc80091131c534728fb4879927a8f790874d6e
-generated: "2021-03-06T11:18:40.670161536+01:00"
+  version: 4.12.14
+digest: sha256:fc0ed1b72121f10a6c50cccc605f73582474d03e1453a9c1e5636b84a0ee829d
+generated: "2021-04-12T11:46:20.2865728-04:00"

--- a/manifests/ha/base/redis-ha/chart/requirements.yaml
+++ b/manifests/ha/base/redis-ha/chart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-ha
-  version: 4.12.9
+  version: 4.12.14
   repository: https://dandydeveloper.github.io/charts

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -5,11 +5,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argocd-redis-ha
-  namespace: argocd
+  namespace: "argocd"
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     app: argocd-redis-ha
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
@@ -17,11 +17,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argocd-redis-ha-haproxy
-  namespace: argocd
+  namespace: "argocd"
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     app: argocd-redis-ha
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -29,11 +29,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-redis-ha-configmap
-  namespace: argocd
+  namespace: "argocd"
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     app: argocd-redis-ha
 data:
   redis.conf: |
@@ -326,8 +326,8 @@ data:
     defaults REDIS
       mode tcp
       timeout connect 4s
-      timeout server 330s
-      timeout client 330s
+      timeout server 6m
+      timeout client 6m
       timeout check 2s
 
     listen health_check_http_url
@@ -457,11 +457,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-redis-ha-health-configmap
-  namespace: argocd
+  namespace: "argocd"
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     app: argocd-redis-ha
 data:
   redis_liveness.sh: |
@@ -506,12 +506,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argocd-redis-ha
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
 rules:
 - apiGroups:
     - ""
@@ -525,12 +525,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argocd-redis-ha-haproxy
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     component: argocd-redis-ha-haproxy
 rules:
 - apiGroups:
@@ -545,12 +545,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-redis-ha
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha
@@ -564,12 +564,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-redis-ha-haproxy
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     component: argocd-redis-ha-haproxy
 subjects:
 - kind: ServiceAccount
@@ -584,12 +584,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argocd-redis-ha-announce-0
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -614,12 +614,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argocd-redis-ha-announce-1
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -644,12 +644,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argocd-redis-ha-announce-2
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -674,12 +674,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argocd-redis-ha
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
   annotations:
 spec:
   type: ClusterIP
@@ -702,12 +702,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argocd-redis-ha-haproxy
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     component: argocd-redis-ha-haproxy
   annotations:
 spec:
@@ -726,12 +726,12 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: argocd-redis-ha-haproxy
-  namespace: argocd
+  namespace: "argocd"
   labels:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
 spec:
   strategy:
     type: RollingUpdate
@@ -749,7 +749,7 @@ spec:
         release: argocd
         revision: "1"
       annotations:
-        checksum/config: d2ea567716f714054660c172aa717a4ec9daa16d25dab418d8fd7a0c961b03e3
+        checksum/config: c55502ce732f78a70658dc77f00c02444cd6b6bede4b270f56d082fdaed1dc5f
     spec:
       # Needed when using unmodified rbac-setup.yml
       
@@ -832,13 +832,13 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: argocd-redis-ha-server
-  namespace: argocd
+  namespace: "argocd"
   labels:
     argocd-redis-ha: replica
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
   annotations:
     {}
 spec:

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -10,6 +10,10 @@ redis-ha:
     enabled: true
     image:
       tag: 2.0.20-alpine
+    timeout:
+      server: 6m
+      client: 6m
+    checkInterval: 3s
   image:
     tag: 6.2.1-alpine
   sentinel:

--- a/manifests/ha/base/redis-ha/generate.sh
+++ b/manifests/ha/base/redis-ha/generate.sh
@@ -11,7 +11,4 @@ helm template argocd ./chart \
   --no-hooks \
   >> ./chart/upstream_orig.yaml
 
-sed -e 's/check inter 1s/check inter 3s/' ./chart/upstream_orig.yaml >> ./chart/upstream.yaml && rm ./chart/upstream_orig.yaml
-sed -i.bak 's/timeout server 30s/timeout server 6m/' ./chart/upstream.yaml && rm ./chart/upstream.yaml.bak
-sed -i.bak 's/timeout client 30s/timeout client 6m/' ./chart/upstream.yaml && rm ./chart/upstream.yaml.bak
-sed -i.bak -E 's/^([[:space:]]){8}sentinel replaceme argocd/    bind/' ./chart/upstream.yaml && rm ./chart/upstream.yaml.bak
+sed -E 's/^([[:space:]]){8}sentinel replaceme argocd/    bind/' ./chart/upstream_orig.yaml >> ./chart/upstream.yaml && rm ./chart/upstream_orig.yaml

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2142,7 +2142,7 @@ kind: Role
 metadata:
   labels:
     app: redis-ha
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     component: argocd-redis-ha-haproxy
     heritage: Helm
     release: argocd
@@ -2302,7 +2302,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: redis-ha
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     component: argocd-redis-ha-haproxy
     heritage: Helm
     release: argocd
@@ -2407,7 +2407,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: argocd-redis-ha
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     heritage: Helm
     release: argocd
   name: argocd-redis-ha-health-configmap
@@ -2443,8 +2443,8 @@ data:
     defaults REDIS
       mode tcp
       timeout connect 4s
-      timeout server 330s
-      timeout client 330s
+      timeout server 6m
+      timeout client 6m
       timeout check 2s
 
     listen health_check_http_url
@@ -3202,7 +3202,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d2ea567716f714054660c172aa717a4ec9daa16d25dab418d8fd7a0c961b03e3
+        checksum/config: c55502ce732f78a70658dc77f00c02444cd6b6bede4b270f56d082fdaed1dc5f
       labels:
         app.kubernetes.io/name: argocd-redis-ha-haproxy
       name: argocd-redis-ha-haproxy

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2142,7 +2142,7 @@ kind: Role
 metadata:
   labels:
     app: redis-ha
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     component: argocd-redis-ha-haproxy
     heritage: Helm
     release: argocd
@@ -2251,7 +2251,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: redis-ha
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     component: argocd-redis-ha-haproxy
     heritage: Helm
     release: argocd
@@ -2322,7 +2322,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: argocd-redis-ha
-    chart: redis-ha-4.12.9
+    chart: redis-ha-4.12.14
     heritage: Helm
     release: argocd
   name: argocd-redis-ha-health-configmap
@@ -2358,8 +2358,8 @@ data:
     defaults REDIS
       mode tcp
       timeout connect 4s
-      timeout server 330s
-      timeout client 330s
+      timeout server 6m
+      timeout client 6m
       timeout check 2s
 
     listen health_check_http_url
@@ -3117,7 +3117,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d2ea567716f714054660c172aa717a4ec9daa16d25dab418d8fd7a0c961b03e3
+        checksum/config: c55502ce732f78a70658dc77f00c02444cd6b6bede4b270f56d082fdaed1dc5f
       labels:
         app.kubernetes.io/name: argocd-redis-ha-haproxy
       name: argocd-redis-ha-haproxy


### PR DESCRIPTION
Following this [upstream redis-ha PR](https://github.com/DandyDeveloper/charts/pull/94) all the required configurations set using sed in the generate script can now be set via the chart's values.

Signed-off-by: Aniek Gul <aniekgul@hotmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

