### PR TITLE
docs: update delete policy verbiage

### DIFF
--- a/docs/user-guide/resource_hooks.md
+++ b/docs/user-guide/resource_hooks.md
@@ -67,7 +67,7 @@ The following policies define when the hook will be deleted.
 |--------|-------------|
 | `HookSucceeded` | The hook resource is deleted after the hook succeeded (e.g. Job/Workflow completed successfully). |
 | `HookFailed` | The hook resource is deleted after the hook failed. |
-| `BeforeHookCreation` | Any existing hook resource is deleted before the new one is created (since v1.3). |
+| `BeforeHookCreation` | Any existing hook resource is deleted before the new one is created (since v1.3). It is meant to be used with `/metadata/name`. This is the default deletion policy. |
 
 As an alternative to hook deletion policies, both Jobs and Argo Workflows support the
 [`ttlSecondsAfterFinished`](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)


### PR DESCRIPTION
### Description

Updated the documentation as it's somewhat vague on the `BeforeHookCreation` policy.

Ref: https://github.com/argoproj/argo-cd/issues/4295