### PR TITLE
feat: A way to display the diff of resource hooks

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -912,7 +912,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
 	command.Flags().BoolVar(&exitCode, "exit-code", true, "Return non-zero exit code when there is a diff")
-	command.Flags().BoolVar(&includeResourceHook, "include-resource-hook", false, "Display the diff of resource hooks")
+	command.Flags().BoolVar(&includeResourceHook, "include-resource-hook", false, "Display the diff of resource hooks. Used together with --local or --revision")
 	command.Flags().StringVar(&local, "local", "", "Compare live app to a local manifests")
 	command.Flags().StringVar(&revision, "revision", "", "Compare live app to a particular revision")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", "/", "Path to the repository root. Used together with --local allows setting the repository root")

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -796,12 +796,13 @@ type objKeyLiveTarget struct {
 // NewApplicationDiffCommand returns a new instance of an `argocd app diff` command
 func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		refresh       bool
-		hardRefresh   bool
-		exitCode      bool
-		local         string
-		revision      string
-		localRepoRoot string
+		refresh             bool
+		hardRefresh         bool
+		exitCode            bool
+		includeResourceHook bool
+		local               string
+		revision            string
+		localRepoRoot       string
 	)
 	shortDesc := "Perform a diff against the target and live state."
 	var command = &cobra.Command{
@@ -870,7 +871,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 
 			foundDiffs := false
 			for _, item := range items {
-				if item.target != nil && hook.IsHook(item.target) || item.live != nil && hook.IsHook(item.live) {
+				if item.target != nil && hook.IsHook(item.target) && !includeResourceHook || item.live != nil && hook.IsHook(item.live) && !includeResourceHook {
 					continue
 				}
 				overrides := make(map[string]argoappv1.ResourceOverride)
@@ -911,6 +912,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
 	command.Flags().BoolVar(&exitCode, "exit-code", true, "Return non-zero exit code when there is a diff")
+	command.Flags().BoolVar(&includeResourceHook, "include-resource-hook", false, "Display the diff of resource hooks")
 	command.Flags().StringVar(&local, "local", "", "Compare live app to a local manifests")
 	command.Flags().StringVar(&revision, "revision", "", "Compare live app to a particular revision")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", "/", "Path to the repository root. Used together with --local allows setting the repository root")

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -18,6 +18,7 @@ argocd app diff APPNAME [flags]
       --exit-code                Return non-zero exit code when there is a diff (default true)
       --hard-refresh             Refresh application data as well as target manifests cache
   -h, --help                     help for diff
+      --include-resource-hook    Display the diff of resource hooks
       --local string             Compare live app to a local manifests
       --local-repo-root string   Path to the repository root. Used together with --local allows setting the repository root (default "/")
       --refresh                  Refresh application data when retrieving

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -18,7 +18,7 @@ argocd app diff APPNAME [flags]
       --exit-code                Return non-zero exit code when there is a diff (default true)
       --hard-refresh             Refresh application data as well as target manifests cache
   -h, --help                     help for diff
-      --include-resource-hook    Display the diff of resource hooks
+      --include-resource-hook    Display the diff of resource hooks. Used together with --local or --revision
       --local string             Compare live app to a local manifests
       --local-repo-root string   Path to the repository root. Used together with --local allows setting the repository root (default "/")
       --refresh                  Refresh application data when retrieving

--- a/test/e2e/hook_test.go
+++ b/test/e2e/hook_test.go
@@ -71,7 +71,7 @@ func TestHookDiffWithResourceHook(t *testing.T) {
 		Create().
 		Then().
 		And(func(_ *Application) {
-			output, err := RunCli("app", "diff", Name(), "--include-resource-hook")
+			output, err := RunCli("app", "diff", Name(), "--include-resource-hook", "--local", "testdata/hook")
 			assert.Error(t, err)
 			assert.Contains(t, output, "name: pod")
 			assert.Contains(t, output, "name: hook")

--- a/test/e2e/hook_test.go
+++ b/test/e2e/hook_test.go
@@ -63,6 +63,21 @@ func TestHookDiff(t *testing.T) {
 		})
 }
 
+// make sure that that hooks appear in "argocd app diff --include-resource-hook"
+func TestHookDiffWithResourceHook(t *testing.T) {
+	Given(t).
+		Path("hook").
+		When().
+		Create().
+		Then().
+		And(func(_ *Application) {
+			output, err := RunCli("app", "diff", Name(), "--include-resource-hook")
+			assert.Error(t, err)
+			assert.Contains(t, output, "name: pod")
+			assert.Contains(t, output, "name: hook")
+		})
+}
+
 // make sure that if pre-sync fails, we fail the app and we do not create the pod
 func TestPreSyncHookFailure(t *testing.T) {
 	Given(t).


### PR DESCRIPTION
PR for add an option to display resource hooks in the cli command `argocd app diff`.
Because there are few case to compare target resource hooks and live state, include-resource-hook option is limited when comparing to a local manifests or particular revision.
closes https://github.com/argoproj/argo-cd/issues/5979 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

