### PR TITLE
fix: Bitbucket server webhook fails on diagnostics:ping (#6029)

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -341,7 +341,7 @@ func (a *ArgoCDWebhookHandler) Handler(w http.ResponseWriter, r *http.Request) {
 	case r.Header.Get("X-Hook-UUID") != "":
 		payload, err = a.bitbucket.Parse(r, bitbucket.RepoPushEvent)
 	case r.Header.Get("X-Event-Key") != "":
-		payload, err = a.bitbucketserver.Parse(r, bitbucketserver.RepositoryReferenceChangedEvent)
+		payload, err = a.bitbucketserver.Parse(r, bitbucketserver.RepositoryReferenceChangedEvent, bitbucketserver.DiagnosticsPingEvent)
 	default:
 		log.Debug("Ignoring unknown webhook event")
 		http.Error(w, "Unknown webhook event", http.StatusBadRequest)

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -85,6 +85,20 @@ func TestBitbucketServerRepositoryReferenceChangedEvent(t *testing.T) {
 	hook.Reset()
 }
 
+func TestBitbucketServerRepositoryDiagnosticPingEvent(t *testing.T) {
+	hook := test.NewGlobal()
+	h := NewMockHandler()
+	eventJSON := "{\"test\": true}"
+	req := httptest.NewRequest("POST", "/api/webhook", bytes.NewBufferString(eventJSON))
+	req.Header.Set("X-Event-Key", "diagnostics:ping")
+	w := httptest.NewRecorder()
+	h.Handler(w, req)
+	assert.Equal(t, w.Code, http.StatusOK)
+	expectedLogResult := "Ignoring webhook event"
+	assert.Equal(t, expectedLogResult, hook.LastEntry().Message)
+	hook.Reset()
+}
+
 func TestGogsPushEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler()


### PR DESCRIPTION
Signed-off-by: Marcel Hoyer <m.hoyer@cid.com>

Checklist:

* [x] Either ~(a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community~, (b) this is a bug fix, ~or (c) this does not need to be in the release notes~.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] ~I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~
* [ ] ~Does this PR require documentation updates?~
* [ ] ~I've updated documentation as required by this PR.~
* [ ] ~Optional. My organization is added to USERS.md.~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Fixes [#6029]