### PR TITLE
fix: spark application check fails on missing section

### DIFF
--- a/resource_customizations/sparkoperator.k8s.io/SparkApplication/health.lua
+++ b/resource_customizations/sparkoperator.k8s.io/SparkApplication/health.lua
@@ -7,9 +7,20 @@ if obj.status ~= nil then
       return health_k9sstatus
     end
     if obj.status.applicationState.state == "RUNNING" then
-      health_status.status = "Healthy"
-      health_status.message = "SparkApplication is in RunningState"
-      return health_status
+      if obj.status.executorState ~= nil then
+        count=0
+        executor_instances = obj.spec.executor.instances
+        for i, executorState in pairs(obj.status.executorState) do
+          if executorState == "RUNNING" then
+            count=count+1
+          end
+        end
+        if executor_instances == count then
+          health_status.status = "Healthy"
+          health_status.message = "SparkApplication is Running"
+          return health_status
+        end
+      end
     end
     if obj.status.applicationState.state == "SUBMITTED" then
       health_status.status = "Progressing"

--- a/resource_customizations/sparkoperator.k8s.io/SparkApplication/health.lua
+++ b/resource_customizations/sparkoperator.k8s.io/SparkApplication/health.lua
@@ -6,19 +6,10 @@ if obj.status ~= nil then
       health_status.message = "SparkApplication was added, enqueuing it for submission"
       return health_k9sstatus
     end
-    count=0
-    executor_instances = obj.spec.executor.instances
-    for i, executorState in pairs(obj.status.executorState) do
-      if executorState == "RUNNING" then
-          count=count+1
-        end
-    end
-    if executor_instances == count then
-      if obj.status.applicationState.state == "RUNNING" then
-        health_status.status = "Healthy"
-        health_status.message = "SparkApplication is in RunningState"
-        return health_status
-      end
+    if obj.status.applicationState.state == "RUNNING" then
+      health_status.status = "Healthy"
+      health_status.message = "SparkApplication is in RunningState"
+      return health_status
     end
     if obj.status.applicationState.state == "SUBMITTED" then
       health_status.status = "Progressing"

--- a/resource_customizations/sparkoperator.k8s.io/SparkApplication/health_test.yaml
+++ b/resource_customizations/sparkoperator.k8s.io/SparkApplication/health_test.yaml
@@ -9,5 +9,5 @@ tests:
   inputPath: testdata/degraded.yaml
 - healthStatus:
     status: Healthy
-    message: "SparkApplication is in RunningState"
+    message: "SparkApplication is Running"
   inputPath: testdata/healthy.yaml


### PR DESCRIPTION
This PR  fixes issue #6035.

Modify the check to safely validate optional `executorState` section.

### Running state immediately after job has been created

`obj.status.executorState` is not present yet and health check also throws exception.

```yml
kind: SparkApplication
apiVersion: sparkoperator.k8s.io/v1beta2
metadata:
  name: python
spec:
  type: Python
  sparkVersion: 3.0.1
  mode: cluster
  # The rest was omitted for clarity
status:
  applicationState:
    state: RUNNING
  driverInfo:
    podName: python-driver
    webUIAddress: '172.21.157.105:4040'
    webUIPort: 4040
    webUIServiceName: python-ui-svc
  executionAttempts: 1
  lastSubmissionAttemptTime: '2021-04-14T17:51:00Z'
  sparkApplicationId: spark-635eea7212384dc2beda105497a57b1a
  submissionAttempts: 1
  submissionID: b589f35c-5963-43b0-b28f-3653a890cb5b
  terminationTime: '2021-04-14T17:51:57Z'
```

### Running state after executors have been created

Please notice that `obj.status.executorState` is present now.

```yml
kind: SparkApplication
apiVersion: sparkoperator.k8s.io/v1beta2
metadata:
  name: python
spec:
  type: Python
  sparkVersion: 3.0.1
  mode: cluster
  # The rest was omitted for clarity
status:
  applicationState:
    state: RUNNING
  driverInfo:
    podName: python-driver
    webUIAddress: '172.21.157.105:4040'
    webUIPort: 4040
    webUIServiceName: python-ui-svc
  executionAttempts: 1
  executorState:
    pythonstreamingqueuestream-8630eb78d17ee8fa-exec-4: RUNNING
  lastSubmissionAttemptTime: '2021-04-14T17:51:00Z'
  sparkApplicationId: spark-635eea7212384dc2beda105497a57b1a
  submissionAttempts: 1
  submissionID: b589f35c-5963-43b0-b28f-3653a890cb5b
  terminationTime: '2021-04-14T17:51:57Z'
```

### Failed state

`obj.status.executorState` is not present at all.

```yml
kind: SparkApplication
apiVersion: sparkoperator.k8s.io/v1beta2
metadata:
  name: scala
spec:
  type: Scala
  sparkVersion: 3.0.1
  mode: cluster
  # The rest was omitted for clarity
status:
  applicationState:
    errorMessage: "Exception in thread \"main\" io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://172.21.0.1/api/v1/namespaces/demo-customer/pods. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. pods \"scala-driver\" is forbidden: exceeded quota: demo-customer, requested: memory=896Mi, used: memory=3268Mi, limited: memory=4Gi."
    state: FAILED
  driverInfo: {}
  lastSubmissionAttemptTime: '2021-04-14T17:51:14Z'
  submissionAttempts: 1
  terminationTime: null
```
