### PR TITLE
chore: publish argoproj/argocd:latest using CI

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -33,9 +33,15 @@ jobs:
       - run: |
           docker login ghcr.io --username $USERNAME --password $PASSWORD
           docker push ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }}
+
+          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
+          docker tag ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} argoproj/argocd:latest
+          docker push argoproj/argocd:latest
         env:
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}
+          DOCKER_TOKEN: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
 
       # deploy
       - run: git clone "https://$TOKEN@github.com/argoproj/argoproj-deployments"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

For some reason dockerhub fails to build Argo CD image since Apr 12, 2021. It is not clear how to debug it. Let's just push image that we build during CI instead of using Dockerhub builds

<details>
  <summary>Logs</summary>

```
yarn install v1.22.4
[1/4] Resolving packages...
[91mwarning Resolution field "@types/react@16.9.3" is incompatible with requested version "@types/react@^17.0.2"
[0m
[2/4] Fetching packages...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
info There appears to be trouble with your network connection. Retrying...
[91merror An unexpected error occurred: "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz: ESOCKETTIMEDOUT".
```

</details>
