### PR TITLE
feat: add support to backup applicationsets

### DIFF
--- a/cmd/argocd-util/commands/argocd_util.go
+++ b/cmd/argocd-util/commands/argocd_util.go
@@ -28,10 +28,11 @@ const (
 )
 
 var (
-	configMapResource    = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
-	secretResource       = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
-	applicationsResource = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
-	appprojectsResource  = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "appprojects"}
+	configMapResource       = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	secretResource          = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	applicationsResource    = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+	appprojectsResource     = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "appprojects"}
+	appplicationSetResource = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applicationsets"}
 )
 
 // NewCommand returns a new instance of an argocd command
@@ -65,20 +66,22 @@ func NewCommand() *cobra.Command {
 }
 
 type argoCDClientsets struct {
-	configMaps   dynamic.ResourceInterface
-	secrets      dynamic.ResourceInterface
-	applications dynamic.ResourceInterface
-	projects     dynamic.ResourceInterface
+	configMaps      dynamic.ResourceInterface
+	secrets         dynamic.ResourceInterface
+	applications    dynamic.ResourceInterface
+	projects        dynamic.ResourceInterface
+	applicationSets dynamic.ResourceInterface
 }
 
 func newArgoCDClientsets(config *rest.Config, namespace string) *argoCDClientsets {
 	dynamicIf, err := dynamic.NewForConfig(config)
 	errors.CheckError(err)
 	return &argoCDClientsets{
-		configMaps:   dynamicIf.Resource(configMapResource).Namespace(namespace),
-		secrets:      dynamicIf.Resource(secretResource).Namespace(namespace),
-		applications: dynamicIf.Resource(applicationsResource).Namespace(namespace),
-		projects:     dynamicIf.Resource(appprojectsResource).Namespace(namespace),
+		configMaps:      dynamicIf.Resource(configMapResource).Namespace(namespace),
+		secrets:         dynamicIf.Resource(secretResource).Namespace(namespace),
+		applications:    dynamicIf.Resource(applicationsResource).Namespace(namespace),
+		projects:        dynamicIf.Resource(appprojectsResource).Namespace(namespace),
+		applicationSets: dynamicIf.Resource(appplicationSetResource).Namespace(namespace),
 	}
 }
 

--- a/cmd/argocd-util/commands/backup.go
+++ b/cmd/argocd-util/commands/backup.go
@@ -86,6 +86,15 @@ func NewExportCommand() *cobra.Command {
 			for _, app := range applications.Items {
 				export(writer, app)
 			}
+			applicationSets, err := acdClients.applicationSets.List(context.Background(), v1.ListOptions{})
+			if err != nil && !apierr.IsNotFound(err) {
+				errors.CheckError(err)
+			}
+			if applicationSets != nil {
+				for _, appSet := range applicationSets.Items {
+					export(writer, appSet)
+				}
+			}
 		},
 	}
 
@@ -186,6 +195,8 @@ func NewImportCommand() *cobra.Command {
 					dynClient = acdClients.projects
 				case "Application":
 					dynClient = acdClients.applications
+				case "ApplicationSet":
+					dynClient = acdClients.applicationSets
 				}
 				if !exists {
 					if !dryRun {


### PR DESCRIPTION
Currently, users can backup Argo CD data using `argocd-util export` command. This commit adds support to export and import ApplicationSets along with other Argo CD resources.

Closes: #5240 

Example:
The following command will also export ApplicationSets if they're present.

```shell
argocd-util export -o backup.yaml
```


Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

