### PR TITLE
feat: allow substitutions in plugin env variables

### DIFF
--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -33,7 +33,7 @@ Commands have access to
 
 1. The system environment variables
 2. [Standard build environment](build-environment.md)
-3. Variables in the application spec:
+3. Variables in the application spec (you can substitute any of the variables from the last 2 points):
 
 > v1.2
 
@@ -44,4 +44,6 @@ spec:
       env:
         - name: FOO
           value: bar
+        - name: REV
+          value: test-$ARGOCD_APP_REVISION
 ```

--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -33,7 +33,7 @@ Commands have access to
 
 1. The system environment variables
 2. [Standard build environment](build-environment.md)
-3. Variables in the application spec (you can substitute any of the variables from the last 2 points):
+3. Variables in the application spec (References to system and build variables will get interpolated in the variables' values):
 
 > v1.2
 

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1091,7 +1091,7 @@ func runConfigManagementPlugin(appPath string, envVars *v1alpha1.Env, q *apiclie
 
 	plugin := findPlugin(q.Plugins, q.ApplicationSource.Plugin.Name)
 	if plugin == nil {
-		return nil, fmt.Errorf("Config management plugin with name '%s' is not supported.", q.ApplicationSource.Plugin.Name)
+		return nil, fmt.Errorf("config management plugin with name '%s' is not supported", q.ApplicationSource.Plugin.Name)
 	}
 	env := append(os.Environ(), envVars.Environ()...)
 	if creds != nil {
@@ -1109,7 +1109,7 @@ func runConfigManagementPlugin(appPath string, envVars *v1alpha1.Env, q *apiclie
 	for i, v := range env {
 		parsedVar, err := v1alpha1.NewEnvEntry(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse env vars")
 		}
 		parsedEnv[i] = parsedVar
 	}

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1102,7 +1102,13 @@ func runConfigManagementPlugin(appPath string, envVars *v1alpha1.Env, q *apiclie
 		defer func() { _ = closer.Close() }()
 		env = append(env, environ...)
 	}
-	env = append(env, q.ApplicationSource.Plugin.Env.Environ()...)
+
+	pluginEnv := q.ApplicationSource.Plugin.Env
+	for i, j := range pluginEnv {
+		pluginEnv[i].Value = envVars.Envsubst(j.Value)
+	}
+	env = append(env, pluginEnv.Environ()...)
+
 	env = append(env, "KUBE_VERSION="+q.KubeVersion)
 	env = append(env, "KUBE_API_VERSIONS="+strings.Join(q.ApiVersions, ","))
 	if plugin.Init != nil {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -849,13 +849,19 @@ func TestRunCustomTool(t *testing.T) {
 		ApplicationSource: &argoappv1.ApplicationSource{
 			Plugin: &argoappv1.ApplicationSourcePlugin{
 				Name: "test",
+				Env: argoappv1.Env{
+					{
+						Name:  "TEST_REVISION",
+						Value: "prefix-$ARGOCD_APP_REVISION",
+					},
+				},
 			},
 		},
 		Plugins: []*argoappv1.ConfigManagementPlugin{{
 			Name: "test",
 			Generate: argoappv1.Command{
 				Command: []string{"sh", "-c"},
-				Args:    []string{`echo "{\"kind\": \"FakeObject\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GIT_ASKPASS\": \"$GIT_ASKPASS\", \"GIT_USERNAME\": \"$GIT_USERNAME\", \"GIT_PASSWORD\": \"$GIT_PASSWORD\"}}}"`},
+				Args:    []string{`echo "{\"kind\": \"FakeObject\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GIT_ASKPASS\": \"$GIT_ASKPASS\", \"GIT_USERNAME\": \"$GIT_USERNAME\", \"GIT_PASSWORD\": \"$GIT_PASSWORD\"}, \"labels\": {\"revision\": \"$TEST_REVISION\"}}}"`},
 			},
 		}},
 		Repo: &argoappv1.Repository{
@@ -863,17 +869,19 @@ func TestRunCustomTool(t *testing.T) {
 		},
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(res.Manifests))
 
 	obj := &unstructured.Unstructured{}
-	assert.Nil(t, json.Unmarshal([]byte(res.Manifests[0]), obj))
+	assert.NoError(t, json.Unmarshal([]byte(res.Manifests[0]), obj))
 
 	assert.Equal(t, obj.GetName(), "test-app")
 	assert.Equal(t, obj.GetNamespace(), "test-namespace")
 	assert.Equal(t, "git-ask-pass.sh", obj.GetAnnotations()["GIT_ASKPASS"])
 	assert.Equal(t, "foo", obj.GetAnnotations()["GIT_USERNAME"])
 	assert.Equal(t, "bar", obj.GetAnnotations()["GIT_PASSWORD"])
+	// Git client is mocked, so the revision is always mock.Anything
+	assert.Equal(t, map[string]string{"revision": "prefix-mock.Anything"}, obj.GetLabels())
 }
 
 func TestGenerateFromUTF16(t *testing.T) {


### PR DESCRIPTION
Related to #5293

Until there's a more robust solution for custom plugins I wanted to be able to pass specific args including e.g. the revision to `tanka`

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

