### PR TITLE
chore: Update haproxy for redis-ha to 2.0.22

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -770,7 +770,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: haproxy:2.0.20-alpine
+        image: haproxy:2.0.22-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -790,7 +790,7 @@ spec:
         runAsUser: 1000
       containers:
       - name: haproxy
-        image: haproxy:2.0.20-alpine
+        image: haproxy:2.0.22-alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -9,7 +9,7 @@ redis-ha:
   haproxy:
     enabled: true
     image:
-      tag: 2.0.20-alpine
+      tag: 2.0.22-alpine
     timeout:
       server: 6m
       client: 6m

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3664,7 +3664,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.0.20-alpine
+      - image: haproxy:2.0.22-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -3693,7 +3693,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.0.20-alpine
+        image: haproxy:2.0.22-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1111,7 +1111,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.0.20-alpine
+      - image: haproxy:2.0.22-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -1140,7 +1140,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.0.20-alpine
+        image: haproxy:2.0.22-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:


### PR DESCRIPTION
Updates the haproxy image used by redis-ha to 2.0.22 to fix recent security issues in SSL implementations.

Note that we do not use SSL/TLS features of haproxy, and therefore should not be affected. However, upgrading for correctness.

Related CVEs fixed by updating base image:

* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3450

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

