### PR TITLE
docs: Recommend `--embed-certs` flag for starting minikube

### DIFF
--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -28,7 +28,7 @@ The Docker version must be fairly recent, and support multi-stage builds. You sh
 * We will assume that your Go workspace is at `~/go`.
 
 !!! note
-    **Attention minikube users**: By default, minikube will create Kubernetes client configuration that uses authentication data from files. This is incompatible with the virtualized toolchain. So if you intend to use the virtualized toolchain, you have to embed this authentication data into the client configuration. To do so, issue `minikube config set embed-certs true` and restart your minikube. Please also note that minikube using the Docker driver is currently not supported with the virtualized toolchain, because the Docker driver exposes the API server on 127.0.0.1 hard-coded. If in doubt, run `make verify-kube-connect` to find out.
+    **Attention minikube users**: By default, minikube will create Kubernetes client configuration that uses authentication data from files. This is incompatible with the virtualized toolchain. So if you intend to use the virtualized toolchain, you have to embed this authentication data into the client configuration. To do so, start minikube using `minikube start --embed-certs`. Please also note that minikube using the Docker driver is currently not supported with the virtualized toolchain, because the Docker driver exposes the API server on 127.0.0.1 hard-coded. If in doubt, run `make verify-kube-connect` to find out.
 
 ## Submitting PRs
 


### PR DESCRIPTION
Signed-off-by: Dominik Braun <mail@dominikbraun.io>

minikube doesn't embed client certificates directly into `$HOME/.kube/config` but stores them in separate files instead. The documentation suggests to change this using `minikube config set embed-certs true`. However, issuing this command [has no effect yet](https://github.com/kubernetes/minikube/issues/11253) and the certificates won't be embedded.

This PR introduces the suggestion to start minikube using `minikube start --embed-certs` instead, which works fine.