### PR TITLE
chore: Allow ingress traffic to argocd-server by default

### DIFF
--- a/manifests/base/server/argocd-server-network-policy.yaml
+++ b/manifests/base/server/argocd-server-network-policy.yaml
@@ -6,5 +6,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-server
+  ingress:
+  - {}
   policyTypes:
   - Ingress

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4255,6 +4255,8 @@ kind: NetworkPolicy
 metadata:
   name: argocd-server-network-policy
 spec:
+  ingress:
+  - {}
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-server

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1702,6 +1702,8 @@ kind: NetworkPolicy
 metadata:
   name: argocd-server-network-policy
 spec:
+  ingress:
+  - {}
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3409,6 +3409,8 @@ kind: NetworkPolicy
 metadata:
   name: argocd-server-network-policy
 spec:
+  ingress:
+  - {}
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-server

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -856,6 +856,8 @@ kind: NetworkPolicy
 metadata:
   name: argocd-server-network-policy
 spec:
+  ingress:
+  - {}
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-server


### PR DESCRIPTION
Related to #6156, which introduced `NetworkPolicies` for Argo CD components but disallowed any Ingress traffic to the `argocd-server` pods by default. 

This PR changes default behavior to allow all Ingress traffic to `argocd-server`.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

