### PR TITLE
fix: test/remote/Makefile image path fix

### DIFF
--- a/test/remote/Makefile
+++ b/test/remote/Makefile
@@ -21,5 +21,5 @@ image-push: image
 .PHONY: manifests
 manifests:
 	@cd manifests && \
-		kustomize edit set image quay.io/jfischer-redhat/argocd-e2e-cluster=$(IMAGE_PREFIX)$(IMAGE_NAME):$(IMAGE_TAG) && \
+		kustomize edit set image argocd-e2e-cluster=$(IMAGE_PREFIX)$(IMAGE_NAME):$(IMAGE_TAG) && \
 		kustomize build .


### PR DESCRIPTION
Signed-off-by: Dewan Ahmed <dewan.ishtiaque@hotmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

## Testing on local
### Prior to this change, e2e-repositories.yaml looks like this (notice 'image')
spec:
containers:
- command:
- goreman
- start
image: argocd-e2e-cluster:latest
imagePullPolicy: Always
name: argocd-e2e-server
ports:

### After this change, e2e-repositories.yaml looks like this (notice 'image')
spec:
selector:
matchLabels:
app.kubernetes.io/name: argocd-e2e-server
template:
metadata:
labels:
app.kubernetes.io/name: argocd-e2e-server
spec:
containers:
- command:
- goreman
- start
image: quay.io/jfischer-redhat/argocd-e2e-cluster:latest
imagePullPolicy: Always
name: argocd-e2e-server
ports:

This effect is also observed on the kustomization.yaml.