### PR TITLE
fix: rewrite Host header in dex reverse proxy

### DIFF
--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -18,10 +18,10 @@ import (
 var messageRe = regexp.MustCompile(`<p>(.*)([\s\S]*?)<\/p>`)
 
 func decorateDirector(director func(req *http.Request), target *url.URL) func(req *http.Request) {
-    return func(req *http.Request) {
-        director(req)
-        req.Host = target.Host
-    }
+	return func(req *http.Request) {
+		director(req)
+		req.Host = target.Host
+	}
 }
 
 // NewDexHTTPReverseProxy returns a reverse proxy to the Dex server. Dex is assumed to be configured
@@ -33,8 +33,8 @@ func NewDexHTTPReverseProxy(serverAddr string, baseHRef string) func(writer http
 	errors.CheckError(err)
 	target.Path = baseHRef
 
-    proxy := httputil.NewSingleHostReverseProxy(target)
-    proxy.ModifyResponse = func(resp *http.Response) error {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ModifyResponse = func(resp *http.Response) error {
 		if resp.StatusCode == 500 {
 			b, err := ioutil.ReadAll(resp.Body)
 			if err != nil {

--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -17,6 +17,13 @@ import (
 
 var messageRe = regexp.MustCompile(`<p>(.*)([\s\S]*?)<\/p>`)
 
+func decorateDirector(director func(req *http.Request), target *url.URL) func(req *http.Request) {
+    return func(req *http.Request) {
+        director(req)
+        req.Host = target.Host
+    }
+}
+
 // NewDexHTTPReverseProxy returns a reverse proxy to the Dex server. Dex is assumed to be configured
 // with the external issuer URL muxed to the same path configured in server.go. In other words, if
 // Argo CD API server wants to proxy requests at /api/dex, then the dex config yaml issuer URL should
@@ -25,8 +32,9 @@ func NewDexHTTPReverseProxy(serverAddr string, baseHRef string) func(writer http
 	target, err := url.Parse(serverAddr)
 	errors.CheckError(err)
 	target.Path = baseHRef
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	proxy.ModifyResponse = func(resp *http.Response) error {
+
+    proxy := httputil.NewSingleHostReverseProxy(target)
+    proxy.ModifyResponse = func(resp *http.Response) error {
 		if resp.StatusCode == 500 {
 			b, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
@@ -52,6 +60,7 @@ func NewDexHTTPReverseProxy(serverAddr string, baseHRef string) func(writer http
 		}
 		return nil
 	}
+	proxy.Director = decorateDirector(proxy.Director, target)
 	return func(w http.ResponseWriter, r *http.Request) {
 		proxy.ServeHTTP(w, r)
 	}

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -270,10 +270,10 @@ func Test_GenerateDexConfig(t *testing.T) {
 }
 
 func Test_DexReverseProxy(t *testing.T) {
-    t.Run("Good case", func(t *testing.T) {
-	    var host string
+	t.Run("Good case", func(t *testing.T) {
+		var host string
 		fakeDex := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		    host = req.Host
+			host = req.Host
 			rw.WriteHeader(http.StatusOK)
 		}))
 		defer fakeDex.Close()

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -269,8 +270,10 @@ func Test_GenerateDexConfig(t *testing.T) {
 }
 
 func Test_DexReverseProxy(t *testing.T) {
-	t.Run("Good case", func(t *testing.T) {
+    t.Run("Good case", func(t *testing.T) {
+	    var host string
 		fakeDex := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		    host = req.Host
 			rw.WriteHeader(http.StatusOK)
 		}))
 		defer fakeDex.Close()
@@ -278,10 +281,12 @@ func Test_DexReverseProxy(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(NewDexHTTPReverseProxy(fakeDex.URL, "/")))
 		fmt.Printf("Fake API Server listening on %s\n", server.URL)
 		defer server.Close()
+		target, _ := url.Parse(fakeDex.URL)
 		resp, err := http.Get(server.URL)
 		assert.NotNil(t, resp)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, host, target.Host)
 		fmt.Printf("%s\n", resp.Status)
 	})
 


### PR DESCRIPTION
Fixes #3975

In Istio, HTTP traffic is routed to a [cluster](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/terminology) based on Host header. Dex reverse proxy does not rewrite Host header, so traffic does not get routed to `argocd-dex-server` cluster and no cluster-level configuration (e.g. mTLS) is applied. Because of this, request to dex-server fails in environments where strict mTLS is enabled or where [outbound traffic policy](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-OutboundTrafficPolicy-Mode) is set to `REGISTRY_ONLY`. 

Signed-off-by: Alexey Khalyavka <alexey.khalyavka@datarobot.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

