### PR TITLE
docs: Onelogin - Update documentation for v2 openid setup

### DIFF
--- a/docs/operator-manual/user-management/onelogin.md
+++ b/docs/operator-manual/user-management/onelogin.md
@@ -115,7 +115,7 @@ data:
   url: https://<argocd.myproject.com>
   oidc.config: |
     name: OneLogin
-    issuer: https://openid-connect.onelogin.com/oidc
+    issuer: https://<subdomain>.onelogin.com/oidc/2
     clientID: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaaaaaa
     clientSecret: abcdef123456
 


### PR DESCRIPTION
Why do we need this change?
=======================
On April 20th, 2021 onelogin removed their v1 implementation of openid. You will get a 410 error if you try to use this url. As such update documentation to rely upon v2 api

What effects does this change have?
=======================
* Updates the onelogin documentation to correctly setup with the v2 implementation of openid

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

