### PR TITLE
fix: Enable kex algo diffie-hellman-group-exchange-sha256 for go-git ssh

### DIFF
--- a/test/fixture/testrepos/Procfile
+++ b/test/fixture/testrepos/Procfile
@@ -1,3 +1,5 @@
-sshd: mkdir -p /var/run/sshd && mkdir -p ~/.ssh && cat ./test/fixture/testrepos/id_rsa.pub > ~/.ssh/authorized_keys && /usr/sbin/sshd -p 2222 -D -e
+# To prevent regression of https://github.com/argoproj/argo-cd/pull/6253, we
+# start sshd with -o KexAlgorithms=diffie-hellman-group-exchange-sha256
+sshd: mkdir -p /var/run/sshd && mkdir -p ~/.ssh && cat ./test/fixture/testrepos/id_rsa.pub > ~/.ssh/authorized_keys && /usr/sbin/sshd -p 2222 -D -e -o KexAlgorithms=diffie-hellman-group-exchange-sha256
 fcgiwrap: fcgiwrap -s unix:/var/run/fcgiwrap.socket & sleep 1 && chmod 777 /var/run/fcgiwrap.socket && wait
 nginx: nginx -prefix=$(pwd) -g 'daemon off;' -c $(pwd)/test/fixture/testrepos/nginx.conf

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
-	ssh2 "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/memory"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -203,7 +202,9 @@ func newAuth(repoURL string, creds Creds) (transport.AuthMethod, error) {
 		if err != nil {
 			return nil, err
 		}
-		auth := &ssh2.PublicKeys{User: sshUser, Signer: signer}
+		auth := &PublicKeysWithOptions{}
+		auth.User = sshUser
+		auth.Signer = signer
 		if creds.insecure {
 			auth.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 		} else {

--- a/util/git/ssh.go
+++ b/util/git/ssh.go
@@ -1,0 +1,59 @@
+package git
+
+import (
+	"fmt"
+
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"golang.org/x/crypto/ssh"
+)
+
+// List of all currently supported algorithms for SSH key exchange
+// Unfortunately, crypto/ssh does not offer public constants or list for
+// this.
+var SupportedSSHKeyExchangeAlgorithms = []string{
+	"diffie-hellman-group1-sha1",
+	"diffie-hellman-group14-sha1",
+	"ecdh-sha2-nistp256",
+	"ecdh-sha2-nistp384",
+	"ecdh-sha2-nistp521",
+	"curve25519-sha256@libssh.org",
+	"diffie-hellman-group-exchange-sha1",
+	"diffie-hellman-group-exchange-sha256",
+}
+
+// List of default key exchange algorithms to use. We use those that are
+// available by default, we can become more opinionated later on (when
+// we support configuration of algorithms to use).
+var DefaultSSHKeyExchangeAlgorithms = SupportedSSHKeyExchangeAlgorithms
+
+// PublicKeysWithOptions is an auth method for go-git's SSH client that
+// inherits from PublicKeys, but provides the possibility to override
+// some client options.
+type PublicKeysWithOptions struct {
+	KexAlgorithms []string
+	gitssh.PublicKeys
+}
+
+// Name returns the name of the auth method
+func (a *PublicKeysWithOptions) Name() string {
+	return gitssh.PublicKeysName
+}
+
+// String returns the configured user and auth method name as string
+func (a *PublicKeysWithOptions) String() string {
+	return fmt.Sprintf("user: %s, name: %s", a.User, a.Name())
+}
+
+// ClientConfig returns a custom SSH client configuration
+func (a *PublicKeysWithOptions) ClientConfig() (*ssh.ClientConfig, error) {
+	// Algorithms used for kex can be configured
+	var kexAlgos []string
+	if len(a.KexAlgorithms) > 0 {
+		kexAlgos = a.KexAlgorithms
+	} else {
+		kexAlgos = DefaultSSHKeyExchangeAlgorithms
+	}
+	config := ssh.Config{KeyExchanges: kexAlgos}
+	opts := &ssh.ClientConfig{Config: config, User: a.User, Auth: []ssh.AuthMethod{ssh.PublicKeys(a.Signer)}}
+	return a.SetHostKeyCallback(opts)
+}


### PR DESCRIPTION
Fixes #6209 

PR introduces addition of `diffie-hellman-group-exchange-sha256` algorithm to list of available key exchange algorithms offered by the go-git SSH implementation. This will allow users hosting their Git repositories on hardened SSH servers to use Argo CD.

Going forward (targeted for v2.1), we will provide options to configure the key exchange algorithms to be used by Argo CD.

This should make it into v2.0.2.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

