### PR TITLE
fix: argocd cluster add <context> --in-cluster

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2278,7 +2278,7 @@ func (c *Cluster) RawRestConfig() *rest.Config {
 		} else {
 			config, err = clientcmd.BuildConfigFromFlags("", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
 		}
-	} else if c.Server == KubernetesInternalAPIServerAddr && c.Config.Username == "" && c.Config.Password == "" && c.Config.BearerToken == "" {
+	} else if c.Server == KubernetesInternalAPIServerAddr && c.Config.Username == "" && c.Config.Password == "" {
 		config, err = rest.InClusterConfig()
 	} else {
 		tlsClientConfig := rest.TLSClientConfig{

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2278,8 +2278,16 @@ func (c *Cluster) RawRestConfig() *rest.Config {
 		} else {
 			config, err = clientcmd.BuildConfigFromFlags("", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
 		}
-	} else if c.Server == KubernetesInternalAPIServerAddr && c.Config.Username == "" && c.Config.Password == "" {
+	} else if c.Server == KubernetesInternalAPIServerAddr && c.Config.Username == "" && c.Config.Password == "" && c.Config.BearerToken == "" {
 		config, err = rest.InClusterConfig()
+	} else if c.Server == KubernetesInternalAPIServerAddr {
+		config, err = rest.InClusterConfig()
+		if err == nil {
+			config.Username = c.Config.Username
+			config.Password = c.Config.Password
+			config.BearerToken = c.Config.BearerToken
+			config.BearerTokenFile = ""
+		}
 	} else {
 		tlsClientConfig := rest.TLSClientConfig{
 			Insecure:   c.Config.TLSClientConfig.Insecure,

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -11,21 +11,12 @@ import (
 	"github.com/dgrijalva/jwt-go/v4"
 	log "github.com/sirupsen/logrus"
 
-<<<<<<< HEAD
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
 	httputil "github.com/argoproj/argo-cd/v2/util/http"
 	jwtutil "github.com/argoproj/argo-cd/v2/util/jwt"
 	"github.com/argoproj/argo-cd/v2/util/session"
 	"github.com/argoproj/argo-cd/v2/util/settings"
-=======
-	"github.com/argoproj/argo-cd/common"
-	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
-	httputil "github.com/argoproj/argo-cd/util/http"
-	jwtutil "github.com/argoproj/argo-cd/util/jwt"
-	"github.com/argoproj/argo-cd/util/session"
-	"github.com/argoproj/argo-cd/util/settings"
->>>>>>> 8ed930ce5 (merge conflicts)
 )
 
 //NewHandler creates handler serving to do api/logout endpoint

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -11,12 +11,21 @@ import (
 	"github.com/dgrijalva/jwt-go/v4"
 	log "github.com/sirupsen/logrus"
 
+<<<<<<< HEAD
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
 	httputil "github.com/argoproj/argo-cd/v2/util/http"
 	jwtutil "github.com/argoproj/argo-cd/v2/util/jwt"
 	"github.com/argoproj/argo-cd/v2/util/session"
 	"github.com/argoproj/argo-cd/v2/util/settings"
+=======
+	"github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
+	httputil "github.com/argoproj/argo-cd/util/http"
+	jwtutil "github.com/argoproj/argo-cd/util/jwt"
+	"github.com/argoproj/argo-cd/util/session"
+	"github.com/argoproj/argo-cd/util/settings"
+>>>>>>> 8ed930ce5 (merge conflicts)
 )
 
 //NewHandler creates handler serving to do api/logout endpoint


### PR DESCRIPTION
fixes https://github.com/argoproj/argo-cd/issues/6233

We set bearer token if either of certData and KeyData is missing, even if `--in-cluster` option is provided. 
https://github.com/argoproj/argo-cd/blob/cc4eea0d6951f1025c9ebb487374658186fa8984/cmd/util/cluster.go#L96-L98


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

