### PR TITLE
fix: enable access to metrics port in embedded network policies

### DIFF
--- a/manifests/base/application-controller/argocd-application-controller-network-policy.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-network-policy.yaml
@@ -6,5 +6,10 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-application-controller
+  ingress:
+    - from:
+        - namespaceSelector: { }
+      ports:
+        - port: 8082
   policyTypes:
   - Ingress

--- a/manifests/base/repo-server/argocd-repo-server-network-policy.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-network-policy.yaml
@@ -19,3 +19,7 @@ spec:
       ports:
         - protocol: TCP
           port: 8081
+    - from:
+        - namespaceSelector: { }
+      ports:
+        - port: 8084

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4174,6 +4174,11 @@ kind: NetworkPolicy
 metadata:
   name: argocd-application-controller-network-policy
 spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8082
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-application-controller
@@ -4263,6 +4268,10 @@ spec:
     ports:
     - port: 8081
       protocol: TCP
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8084
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-repo-server

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1621,6 +1621,11 @@ kind: NetworkPolicy
 metadata:
   name: argocd-application-controller-network-policy
 spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8082
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-application-controller
@@ -1710,6 +1715,10 @@ spec:
     ports:
     - port: 8081
       protocol: TCP
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8084
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-repo-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3348,6 +3348,11 @@ kind: NetworkPolicy
 metadata:
   name: argocd-application-controller-network-policy
 spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8082
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-application-controller
@@ -3418,6 +3423,10 @@ spec:
     ports:
     - port: 8081
       protocol: TCP
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8084
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-repo-server

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -795,6 +795,11 @@ kind: NetworkPolicy
 metadata:
   name: argocd-application-controller-network-policy
 spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8082
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-application-controller
@@ -865,6 +870,10 @@ spec:
     ports:
     - port: 8081
       protocol: TCP
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8084
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-repo-server


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Change network policies to provide access to metrics ports from any namespace. Tested changed end to end on https://cd.apps.argoproj.io. This K8S cluster now has network policies support.