### PR TITLE
fix: userinfo /v1/session/userinfo should return authenticated=false if token has expired

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -917,6 +917,10 @@ func (a *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error
 			}
 		}
 	}
+	if claimsErr != nil {
+		// nolint:staticcheck
+		ctx = context.WithValue(ctx, util_session.AuthErrorCtxKey, claimsErr)
+	}
 
 	if claimsErr != nil {
 		argoCDSettings, err := a.settingsMgr.GetSettings()

--- a/server/server.go
+++ b/server/server.go
@@ -903,29 +903,7 @@ func (a *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error
 	if a.DisableAuth {
 		return ctx, nil
 	}
-
-	// Extract the token from the calling context (if present)
-	tokenString, ok, tokenErr := a.getTokenString(ctx)
-	if !ok {
-		// Failed to find a token.
-		// We may still be fine if the settings allow anonymous access though
-		argoCDSettings, err := a.settingsMgr.GetSettings()
-		if err != nil {
-			return ctx, status.Errorf(codes.Internal, "unable to load settings: %v", err)
-		}
-		if argoCDSettings.AnonymousUserEnabled {
-			return ctx, nil
-		}
-		return ctx, tokenErr
-	}
-
-	// Extract and verify the claims in the token
-	claims, newToken, claimsErr := a.getClaims(tokenString)
-	if claimsErr != nil {
-		// Failed to validate token
-		return ctx, claimsErr
-	}
-
+	claims, newToken, claimsErr := a.getClaims(ctx)
 	if claims != nil {
 		// Add claims to the context to inspect for RBAC
 		// nolint:staticcheck
@@ -940,22 +918,28 @@ func (a *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error
 		}
 	}
 
+	if claimsErr != nil {
+		argoCDSettings, err := a.settingsMgr.GetSettings()
+		if err != nil {
+			return ctx, status.Errorf(codes.Internal, "unable to load settings: %v", err)
+		}
+		if !argoCDSettings.AnonymousUserEnabled {
+			return ctx, claimsErr
+		}
+	}
+
 	return ctx, nil
 }
 
-func (a *ArgoCDServer) getTokenString(ctx context.Context) (string, bool, error) {
+func (a *ArgoCDServer) getClaims(ctx context.Context) (jwt.Claims, string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", false, ErrNoSession
+		return nil, "", ErrNoSession
 	}
 	tokenString := getToken(md)
 	if tokenString == "" {
-		return "", false, ErrNoSession
+		return nil, "", ErrNoSession
 	}
-	return tokenString, true, nil
-}
-
-func (a *ArgoCDServer) getClaims(tokenString string) (jwt.Claims, string, error) {
 	claims, newToken, err := a.sessionMgr.VerifyToken(tokenString)
 	if err != nil {
 		return claims, "", status.Errorf(codes.Unauthenticated, "invalid session: %v", err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -378,7 +378,6 @@ func TestAuthenticate(t *testing.T) {
 	type testData struct {
 		test             string
 		user             string
-		token            string
 		errorMsg         string
 		anonymousEnabled bool
 	}
@@ -396,12 +395,6 @@ func TestAuthenticate(t *testing.T) {
 		{
 			test:             "TestSessionNotPresentAnonymousEnabled",
 			anonymousEnabled: true,
-		},
-		{
-			test:             "TestInvalidSessionPresent",
-			anonymousEnabled: false,
-			token:            "i-am-invalid",
-			errorMsg:         "invalid session: token is malformed: token contains an invalid number of segments",
 		},
 	}
 
@@ -421,9 +414,7 @@ func TestAuthenticate(t *testing.T) {
 			}
 			argocd := NewServer(context.Background(), argoCDOpts)
 			ctx := context.Background()
-			if testData.token != "" {
-				ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs(apiclient.MetaDataTokenKey, testData.token))
-			} else if testData.user != "" {
+			if testData.user != "" {
 				token, err := argocd.sessionMgr.Create(testData.user, 0, "abc")
 				assert.NoError(t, err)
 				ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs(apiclient.MetaDataTokenKey, token))

--- a/ui/src/app/shared/components/page/page.scss
+++ b/ui/src/app/shared/components/page/page.scss
@@ -47,6 +47,7 @@
     border-radius: 3px;
     color: $argo-color-teal-7;
     padding: 3px;
+    cursor: pointer;
 
     &:focus {
         color: $argo-color-teal-5;

--- a/ui/src/app/shared/components/page/page.tsx
+++ b/ui/src/app/shared/components/page/page.tsx
@@ -27,7 +27,7 @@ export const AddAuthToToolbar = (init: Toolbar | Observable<Toolbar>, ctx: Conte
                             Log out
                         </button>
                     ) : (
-                        <button className='login-logout-button' key='login' onClick={() => ctx.navigation.goto('/login')}>
+                        <button className='login-logout-button' key='login' onClick={() => ctx.navigation.goto(`/login?return_url=${encodeURIComponent(location.href)}`)}>
                             Log in
                         </button>
                     )

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -55,6 +55,7 @@ type LoginAttempts struct {
 const (
 	// SessionManagerClaimsIssuer fills the "iss" field of the token.
 	SessionManagerClaimsIssuer = "argocd"
+	AuthErrorCtxKey            = "auth-error"
 
 	// invalidLoginError, for security purposes, doesn't say whether the username or password was invalid.  This does not mitigate the potential for timing attacks to determine which is which.
 	invalidLoginError           = "Invalid username or password"
@@ -559,7 +560,7 @@ func (mgr *SessionManager) RevokeToken(ctx context.Context, id string, expiringA
 }
 
 func LoggedIn(ctx context.Context) bool {
-	return Sub(ctx) != ""
+	return Sub(ctx) != "" && ctx.Value(AuthErrorCtxKey) == nil
 }
 
 // Username is a helper to extract a human readable username from a context


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/5687

PR rollbacks https://github.com/argoproj/argo-cd/pull/5897 since it broke re-load feature. Instead it implements another approach that fixes #5687. The /v1/session/userinfo API should return `{"authenticated": true}` only if the provided token is valid and not expired. So only second commit https://github.com/argoproj/argo-cd/pull/6282/commits/eea45f1104c12dc15b38a99b923b2a204c096aaa needs review.

