### PR TITLE
docs: Add CLI installation with Homebrew for Linux and WSL

### DIFF
--- a/docs/cli_installation.md
+++ b/docs/cli_installation.md
@@ -2,7 +2,15 @@
 
 You can download the latest Argo CD version from [the latest release page of this repository](https://github.com/argoproj/argo-cd/releases/latest), which will include the `argocd` CLI.
 
-## Linux
+## Linux and WSL
+
+### Homebrew
+
+```bash
+brew install argocd
+```
+
+### Download With Curl
 
 You can view the latest version of Argo CD at the link above or run the following command to grab the version:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,7 +28,7 @@ This will create a new namespace, `argocd`, where Argo CD services and applicati
 
 Download the latest Argo CD version from [https://github.com/argoproj/argo-cd/releases/latest](https://github.com/argoproj/argo-cd/releases/latest). More detailed installation instructions can be found via the [CLI installation documentation](cli_installation.md).
 
-Also available in Mac Homebrew:
+Also available in Mac, Linux and WSL Homebrew:
 
 ```bash
 brew install argocd


### PR DESCRIPTION
Update CLI installation because Homebrew formula has been bottled on Linux (and WSL).