### PR TITLE
fix: use current logrus config when logrus is created internally (#6234)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -200,6 +200,10 @@ const (
 	EnvHelmIndexCacheDuration = "ARGOCD_HELM_INDEX_CACHE_DURATION"
 	// EnvRepoServerConfigPath allows to override the configuration path for repo server
 	EnvAppConfigPath = "ARGOCD_APP_CONF_PATH"
+	// EnvLogFormat log format that is defined by `--logformat` option
+	EnvLogFormat = "ARGOCD_LOG_FORMAT"
+	// EnvLogLevel log level that is defined by `--loglevel` option
+	EnvLogLevel = "ARGOCD_LOG_LEVEL"
 )
 
 const (

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -515,7 +515,7 @@ func (ctrl *ApplicationController) managedResources(comparisonResult *comparison
 			}
 			resDiffPtr, err := diff.Diff(target, live,
 				diff.WithNormalizer(comparisonResult.diffNormalizer),
-				diff.WithLogr(logutils.NewLogrusLogger(log.New())),
+				diff.WithLogr(logutils.NewLogrusLogger(logutils.NewWithCurrentConfig())),
 				diff.IgnoreAggregatedRoles(compareOptions.IgnoreAggregatedRoles))
 			if err != nil {
 				return nil, err
@@ -1040,7 +1040,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 }
 
 func (ctrl *ApplicationController) setOperationState(app *appv1.Application, state *appv1.OperationState) {
-	kube.RetryUntilSucceed(context.Background(), updateOperationStateTimeout, "Update application operation state", logutils.NewLogrusLogger(log.New()), func() error {
+	kube.RetryUntilSucceed(context.Background(), updateOperationStateTimeout, "Update application operation state", logutils.NewLogrusLogger(logutils.NewWithCurrentConfig()), func() error {
 		if state.Phase == "" {
 			// expose any bugs where we neglect to set phase
 			panic("no phase was set")

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -468,7 +468,7 @@ func (c *liveStateCache) Init() error {
 func (c *liveStateCache) Run(ctx context.Context) error {
 	go c.watchSettings(ctx)
 
-	kube.RetryUntilSucceed(ctx, clustercache.ClusterRetryTimeout, "watch clusters", logutils.NewLogrusLogger(log.New()), func() error {
+	kube.RetryUntilSucceed(ctx, clustercache.ClusterRetryTimeout, "watch clusters", logutils.NewLogrusLogger(logutils.NewWithCurrentConfig()), func() error {
 		return c.db.WatchClusters(ctx, c.handleAddEvent, c.handleModEvent, c.handleDeleteEvent)
 	})
 

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -145,10 +145,10 @@ func ReadAndConfirmPassword() (string, error) {
 // SetLogFormat sets a logrus log format
 func SetLogFormat(logFormat string) {
 	switch strings.ToLower(logFormat) {
-	case "json":
-		os.Setenv(common.EnvLogFormat, "json")
-	case "text":
-		os.Setenv(common.EnvLogFormat, "text")
+	case utillog.JsonFormat:
+		os.Setenv(common.EnvLogFormat, utillog.JsonFormat)
+	case utillog.TextFormat:
+		os.Setenv(common.EnvLogFormat, utillog.TextFormat)
 	default:
 		log.Fatalf("Unknown log format '%s'", logFormat)
 	}

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -144,22 +144,22 @@ func ReadAndConfirmPassword() (string, error) {
 
 // SetLogFormat sets a logrus log format
 func SetLogFormat(logFormat string) {
-	log.SetFormatter(utillog.CreateFormatter(logFormat))
 	switch strings.ToLower(logFormat) {
 	case "json":
 		os.Setenv(common.EnvLogFormat, "json")
-	default:
+	case "text":
 		os.Setenv(common.EnvLogFormat, "text")
+	default:
+		log.Fatalf("Unknown log format '%s'", logFormat)
 	}
+
+	log.SetFormatter(utillog.CreateFormatter(logFormat))
 }
 
 // SetLogLevel parses and sets a logrus log level
 func SetLogLevel(logLevel string) {
 	level, err := log.ParseLevel(logLevel)
 	errors.CheckError(err)
-	if err != nil {
-		level = log.InfoLevel
-	}
 	os.Setenv(common.EnvLogLevel, level.String())
 }
 

--- a/util/exec/exec.go
+++ b/util/exec/exec.go
@@ -6,13 +6,10 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/argoproj/argo-cd/v2/util/log"
-
+	"github.com/argoproj/gitops-engine/pkg/utils/tracing"
 	argoexec "github.com/argoproj/pkg/exec"
 
-	tracing "github.com/argoproj/gitops-engine/pkg/utils/tracing"
+	"github.com/argoproj/argo-cd/v2/util/log"
 )
 
 var timeout time.Duration

--- a/util/exec/exec.go
+++ b/util/exec/exec.go
@@ -35,7 +35,7 @@ func Run(cmd *exec.Cmd) (string, error) {
 
 func RunWithRedactor(cmd *exec.Cmd, redactor func(text string) string) (string, error) {
 	opts := argoexec.CmdOpts{Timeout: timeout}
-	span := tracing.NewLoggingTracer(log.NewLogrusLogger(logrus.New())).StartSpan(fmt.Sprintf("exec %v", cmd.Args[0]))
+	span := tracing.NewLoggingTracer(log.NewLogrusLogger(log.NewWithCurrentConfig())).StartSpan(fmt.Sprintf("exec %v", cmd.Args[0]))
 	span.SetBaggageItem("dir", fmt.Sprintf("%v", cmd.Dir))
 	if redactor != nil {
 		span.SetBaggageItem("args", redactor(fmt.Sprintf("%v", cmd.Args)))

--- a/util/kube/kubectl.go
+++ b/util/kube/kubectl.go
@@ -7,17 +7,16 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/gitops-engine/pkg/utils/tracing"
-	"github.com/sirupsen/logrus"
 )
 
 var tracer tracing.Tracer = &tracing.NopTracer{}
 
 func init() {
 	if os.Getenv("ARGOCD_TRACING_ENABLED") == "1" {
-		tracer = tracing.NewLoggingTracer(log.NewLogrusLogger(logrus.New()))
+		tracer = tracing.NewLoggingTracer(log.NewLogrusLogger(log.NewWithCurrentConfig()))
 	}
 }
 
 func NewKubectl() kube.Kubectl {
-	return &kube.KubectlCmd{Tracer: tracer, Log: log.NewLogrusLogger(logrus.New())}
+	return &kube.KubectlCmd{Tracer: tracer, Log: log.NewLogrusLogger(log.NewWithCurrentConfig())}
 }

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -2,12 +2,14 @@ package log
 
 import (
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/common"
+	"os"
+	"strings"
+
 	adapter "github.com/bombsimon/logrusr"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
-	"os"
-	"strings"
+
+	"github.com/argoproj/argo-cd/v2/common"
 )
 
 const (

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -2,14 +2,49 @@ package log
 
 import (
 	"fmt"
-
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/argoproj/argo-cd/v2/util/errors"
 	adapter "github.com/bombsimon/logrusr"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
+	"os"
+	"strings"
 )
 
 func NewLogrusLogger(fieldLogger logrus.FieldLogger) logr.Logger {
 	return adapter.NewLoggerWithFormatter(fieldLogger, func(val interface{}) string {
 		return fmt.Sprintf("%v", val)
 	})
+}
+
+// NewWithCurrentConfig create logrus logger by using current configuration
+func NewWithCurrentConfig() *logrus.Logger {
+	l := logrus.New()
+	l.SetFormatter(CreateFormatter(os.Getenv(common.EnvLogFormat)))
+
+	level, err := logrus.ParseLevel(os.Getenv(common.EnvLogLevel))
+	errors.CheckError(err)
+	l.SetLevel(level)
+
+	return l
+}
+
+// CreateFormatter create logrus formatter by string
+func CreateFormatter(logFormat string) logrus.Formatter {
+	var formatType logrus.Formatter
+	switch strings.ToLower(logFormat) {
+	case "json":
+		formatType = &logrus.JSONFormatter{}
+	case "text":
+		if os.Getenv("FORCE_LOG_COLORS") == "1" {
+			formatType = &logrus.TextFormatter{ForceColors: true}
+		} else {
+			formatType = &logrus.TextFormatter{}
+		}
+	default:
+		logrus.Fatalf("Unknown log format '%s'", logFormat)
+		formatType = &logrus.TextFormatter{}
+	}
+
+	return formatType
 }

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -11,6 +11,11 @@ import (
 	"strings"
 )
 
+const (
+	JsonFormat = "json"
+	TextFormat = "text"
+)
+
 func NewLogrusLogger(fieldLogger logrus.FieldLogger) logr.Logger {
 	return adapter.NewLoggerWithFormatter(fieldLogger, func(val interface{}) string {
 		return fmt.Sprintf("%v", val)
@@ -33,9 +38,9 @@ func NewWithCurrentConfig() *logrus.Logger {
 func CreateFormatter(logFormat string) logrus.Formatter {
 	var formatType logrus.Formatter
 	switch strings.ToLower(logFormat) {
-	case "json":
+	case JsonFormat:
 		formatType = &logrus.JSONFormatter{}
-	case "text":
+	case TextFormat:
 		if os.Getenv("FORCE_LOG_COLORS") == "1" {
 			formatType = &logrus.TextFormatter{ForceColors: true}
 		} else {

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -3,7 +3,6 @@ package log
 import (
 	"fmt"
 	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/util/errors"
 	adapter "github.com/bombsimon/logrusr"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
@@ -26,11 +25,7 @@ func NewLogrusLogger(fieldLogger logrus.FieldLogger) logr.Logger {
 func NewWithCurrentConfig() *logrus.Logger {
 	l := logrus.New()
 	l.SetFormatter(CreateFormatter(os.Getenv(common.EnvLogFormat)))
-
-	level, err := logrus.ParseLevel(os.Getenv(common.EnvLogLevel))
-	errors.CheckError(err)
-	l.SetLevel(level)
-
+	l.SetLevel(createLogLevel())
 	return l
 }
 
@@ -51,4 +46,12 @@ func CreateFormatter(logFormat string) logrus.Formatter {
 	}
 
 	return formatType
+}
+
+func createLogLevel() logrus.Level {
+	level, err := logrus.ParseLevel(os.Getenv(common.EnvLogLevel))
+	if err != nil {
+		level = logrus.InfoLevel
+	}
+	return level
 }

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -42,7 +42,6 @@ func CreateFormatter(logFormat string) logrus.Formatter {
 			formatType = &logrus.TextFormatter{}
 		}
 	default:
-		logrus.Fatalf("Unknown log format '%s'", logFormat)
 		formatType = &logrus.TextFormatter{}
 	}
 

--- a/util/log/logrus_test.go
+++ b/util/log/logrus_test.go
@@ -1,10 +1,11 @@
 package log
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateFormatter(t *testing.T) {

--- a/util/log/logrus_test.go
+++ b/util/log/logrus_test.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestCreateFormatter(t *testing.T) {
+	t.Run("log format is json", func(t *testing.T) {
+		result := CreateFormatter("json")
+		assert.Equal(t, &logrus.JSONFormatter{}, result)
+	})
+	t.Run("log format is text", func(t *testing.T) {
+		t.Run("FORCE_LOG_COLORS == 1", func(t *testing.T) {
+			os.Setenv("FORCE_LOG_COLORS", "1")
+			result := CreateFormatter("text")
+			assert.Equal(t, &logrus.TextFormatter{ForceColors: true}, result)
+		})
+		t.Run("FORCE_LOG_COLORS != 1", func(t *testing.T) {
+			os.Setenv("FORCE_LOG_COLORS", "0")
+			result := CreateFormatter("text")
+			assert.Equal(t, &logrus.TextFormatter{}, result)
+		})
+	})
+	t.Run("log format is not json or text", func(t *testing.T) {
+		result := CreateFormatter("xml")
+		assert.Equal(t, &logrus.TextFormatter{}, result)
+	})
+}


### PR DESCRIPTION
Signed-off-by: yu-croco <yuki.kita22@gmail.com>

This PR is for https://github.com/argoproj/argo-cd/issues/6234 .
Some of the log lines are printed as text even if I configured as `--logFormat=json`. This is because some of `logrus.New()` are not configured format and level.

[logrus](https://github.com/sirupsen/logrus) does not have method to return current log format, so I save the logger configuration on env when cli package methods( `SetLogLevel`, `SetLogFormat` ) are called. And I use the env when I create logrus.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

