### PR TITLE
fix: UI should automatically retrigger SSO login after token expiration

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -57,8 +57,8 @@ const versionLoader = services.version.version();
 
 async function isExpiredSSO() {
     try {
-        const {loggedIn, iss} = await services.users.get();
-        if (loggedIn && iss !== 'argocd') {
+        const {iss} = await services.users.get();
+        if (iss && iss !== 'argocd') {
             const authSettings = await services.authService.settings();
             return ((authSettings.dexConfig && authSettings.dexConfig.connectors) || []).length > 0 || authSettings.oidcConfig;
         }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Follow up for https://github.com/argoproj/argo-cd/pull/6282. UI should automatically start SSO login flow if user it not logged in by has token with non `argocd` issuer (okta, dex etc). 