### PR TITLE
fix: grpc web proxy must ensure to read full header

### DIFF
--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -152,7 +152,7 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 
 			for {
 				header := make([]byte, frameHeaderLength)
-				if _, err := resp.Body.Read(header); err != nil {
+				if _, err := io.ReadAtLeast(resp.Body, header, frameHeaderLength); err != nil {
 					if err == io.EOF {
 						err = io.ErrUnexpectedEOF
 					}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/5925

PR fixes a bug in grpc-web proxy implementation: the proxy must use `io.ReadAtLeast` to ensure that it receives full header content .