### PR TITLE
chore: Update Golang to v1.16.4

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.16.2'
+          go-version: '1.16.4'
       - uses: actions/checkout@master
         with:
           path: src/github.com/argoproj/argo-cd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.2'
+          go-version: '1.16.4'
 
       - name: Setup Git author information
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=docker.io/library/ubuntu:20.10
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM docker.io/library/golang:1.16.2 as builder
+FROM docker.io/library/golang:1.16.4 as builder
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -2,7 +2,7 @@ FROM redis:6.2.1 as redis
 
 FROM node:12.18.4 as node
 
-FROM golang:1.16.0 as golang
+FROM golang:1.16.4 as golang
 
 FROM registry:2.7.1 as registry
 


### PR DESCRIPTION
Update the Go version we use to build Argo CD to v1.16.4 due to a security fix in `net/http` (see [CVE-2021-31525](https://nvd.nist.gov/vuln/detail/CVE-2021-31525))

Candidate for cherry-pick to 2.0 branch. 1.8 is still on 1.14 and is not affected to this issue according to the CVE.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

