### PR TITLE
feat: Upgrade Helm to v3.6.0 and pass --kube-version to templating

### DIFF
--- a/hack/installers/checksums/helm-v3.6.0-linux-amd64.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.6.0-linux-amd64.tar.gz.sha256
@@ -1,0 +1,1 @@
+0a9c80b0f211791d6a9d36022abd0d6fd125139abe6d1dcf4c5bf3bc9dcec9c8  helm-v3.6.0-linux-amd64.tar.gz

--- a/hack/installers/checksums/helm-v3.6.0-linux-arm64.tar.gz.sha256
+++ b/hack/installers/checksums/helm-v3.6.0-linux-arm64.tar.gz.sha256
@@ -1,0 +1,1 @@
+8a16f23866b1e74b347bcdd7f8731ebcfa37f35fc27c75dd29b13e87aed8484c  helm-v3.6.0-linux-arm64.tar.gz

--- a/hack/tool-versions.sh
+++ b/hack/tool-versions.sh
@@ -9,7 +9,7 @@
 # SHA256 sum of the binary.
 ###############################################################################
 helm2_version=2.17.0
-helm3_version=3.5.1
+helm3_version=3.6.0
 jq_version=1.6
 ksonnet_version=0.13.1
 kubectl_version=1.17.8

--- a/util/helm/helmver.go
+++ b/util/helm/helmver.go
@@ -19,7 +19,7 @@ var (
 	HelmV3 = HelmVer{
 		binaryName:                  "helm",
 		templateNameArg:             "--name-template",
-		kubeVersionSupported:        false,
+		kubeVersionSupported:        true,
 		showCommand:                 "show",
 		pullCommand:                 "pull",
 		initSupported:               false,


### PR DESCRIPTION
This PR upgrades Helm to v3.6.0, which contains a new feature to pass `--kube-version` to `helm template` (https://github.com/helm/helm/pull/9040). 

Also, enable this feature in our code.

Also fixes #5833

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

