### PR TITLE
Make workflows work for forks by default

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -22,9 +22,10 @@ jobs:
           pip install -r docs/requirements.txt
           mkdocs build
       - name: deploy
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.HAVE_PERSONAL_TOKEN == 'true' }}
         uses: peaceiris/actions-gh-pages@v2.5.0
         env:
+          HAVE_PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN != '' }}
           PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
           PUBLISH_BRANCH: gh-pages
           PUBLISH_DIR: ./site

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -42,15 +42,20 @@ jobs:
           PASSWORD: ${{ secrets.TOKEN }}
           DOCKER_USERNAME: ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}
           DOCKER_TOKEN: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+        if: ${{ env.PASSWORD != '' && env.DOCKER_TOKEN != '' }}
 
       # deploy
       - run: git clone "https://$TOKEN@github.com/argoproj/argoproj-deployments"
         env:
           TOKEN: ${{ secrets.TOKEN }}
+        if: ${{ env.TOKEN != '' }}
       - run: |
           docker run -v $(pwd):/src -w /src --rm -t lyft/kustomizer:v3.3.0 kustomize edit set image quay.io/argoproj/argocd=ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }}
           git config --global user.email 'ci@argoproj.com'
           git config --global user.name 'CI'
           git diff --exit-code && echo 'Already deployed' || (git commit -am 'Upgrade argocd to ${{ steps.image.outputs.tag }}' && git push)
         working-directory: argoproj-deployments/argocd
+        env:
+          HAS_TOKEN: ${{ secrets.TOKEN != '' }}
+        if: ${{ env.HAS_TOKEN == 'true' }}
       # TODO: clean up old images once github supports it: https://github.community/t5/How-to-use-Git-and-GitHub/Deleting-images-from-Github-Package-Registry/m-p/41202/thread-id/9811


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Without this, when someone has a fork (with actions enabled) and pushes the default branch to their fork, these actions fail.