### PR TITLE
feat: disable reconciliation if timeout.reconciliation is set to 0

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -75,7 +75,14 @@ func NewCommand() *cobra.Command {
 			namespace, _, err := clientConfig.Namespace()
 			errors.CheckError(err)
 
-			resyncDuration := time.Duration(appResyncPeriod) * time.Second
+			var resyncDuration time.Duration
+			if appResyncPeriod == 0 {
+				// Re-sync should be disabled if period is 0. Set duration to a very long duration
+				resyncDuration = time.Hour * 24 * 365 * 100
+			} else {
+				resyncDuration = time.Duration(appResyncPeriod) * time.Second
+			}
+
 			tlsConfig := apiclient.TLSConfiguration{
 				DisableTLS:       repoServerPlaintext,
 				StrictValidation: repoServerStrictTLS,

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -263,6 +263,6 @@ data:
   ui.bannerurl: "https://argoproj.github.io"
 
   # Application reconciliation timeout is the max amount of time required to discover if a new manifests version got
-  # published to the repository. Three minutes by default.
+  # published to the repository. Reconciliation by timeout is disabled if timeout is set to 0. Three minutes by default.
   # > Note: argocd-repo-server deployment must be manually restarted after changing the setting.
   timeout.reconciliation: 180s


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #1399 
Closes #6357

PR allows disabling app reconciliation if `timeout.reconciliation` setting is set to 0