### PR TITLE
fix: allows access to dex metrics from any pod

### DIFF
--- a/manifests/base/dex/argocd-dex-server-network-policy.yaml
+++ b/manifests/base/dex/argocd-dex-server-network-policy.yaml
@@ -18,5 +18,8 @@ spec:
           port: 5556
         - protocol: TCP
           port: 5557
+    - from:
+        - namespaceSelector: { }
+      ports:
+        - port: 5558
         - protocol: TCP
-          port: 5558


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes: https://github.com/argoproj/argo-cd/issues/6407

Dex exposes metrics on port 5558. Opening it by default to any pod