### PR TITLE
fix: Fail gracefully when unable to unmarshal cluster secret

### DIFF
--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -83,15 +83,16 @@ func (db *db) ListClusters(ctx context.Context) (*appv1.ClusterList, error) {
 		return nil, err
 	}
 	clusterList := appv1.ClusterList{
-		Items: make([]appv1.Cluster, len(clusterSecrets)),
+		Items: make([]appv1.Cluster, 0),
 	}
 	hasInClusterCredentials := false
-	for i, clusterSecret := range clusterSecrets {
+	for _, clusterSecret := range clusterSecrets {
 		cluster, err := secretToCluster(clusterSecret)
 		if err != nil {
 			log.Errorf("could not unmarshal cluster secret %s", clusterSecret.Name)
+			continue
 		}
-		clusterList.Items[i] = *cluster
+		clusterList.Items = append(clusterList.Items, *cluster)
 		if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
 			hasInClusterCredentials = true
 		}

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -89,7 +89,7 @@ func (db *db) ListClusters(ctx context.Context) (*appv1.ClusterList, error) {
 	for i, clusterSecret := range clusterSecrets {
 		cluster, err := secretToCluster(clusterSecret)
 		if err != nil {
-			log.Errorf("could not unmarshal cluster secret: %v", err)
+			log.Errorf("could not unmarshal cluster secret %s", clusterSecret.Name)
 		}
 		clusterList.Items[i] = *cluster
 		if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
@@ -132,7 +132,7 @@ func (db *db) CreateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Clust
 	}
 	cluster, err := secretToCluster(clusterSecret)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "could not unmarshal cluster secret: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "could not unmarshal cluster secret %s", clusterSecret.Name)
 	}
 	return cluster, db.settingsMgr.ResyncInformers()
 }
@@ -161,7 +161,7 @@ func (db *db) WatchClusters(ctx context.Context,
 			if secretObj, ok := obj.(*apiv1.Secret); ok {
 				cluster, err := secretToCluster(secretObj)
 				if err != nil {
-					log.Errorf("could not unmarshal cluster secret: %v", err)
+					log.Errorf("could not unmarshal cluster secret %s", secretObj.Name)
 					return
 				}
 				if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
@@ -189,12 +189,12 @@ func (db *db) WatchClusters(ctx context.Context,
 				if newSecretObj, ok := newObj.(*apiv1.Secret); ok {
 					oldCluster, err := secretToCluster(oldSecretObj)
 					if err != nil {
-						log.Errorf("could not unmarshal old cluster secret: %v", err)
+						log.Errorf("could not unmarshal cluster secret %s", oldSecretObj.Name)
 						return
 					}
 					newCluster, err := secretToCluster(newSecretObj)
 					if err != nil {
-						log.Errorf("could not unmarshal new cluster secret: %v", err)
+						log.Errorf("could not unmarshal cluster secret %s", newSecretObj.Name)
 						return
 					}
 					if newCluster.Server == appv1.KubernetesInternalAPIServerAddr {
@@ -263,7 +263,7 @@ func (db *db) UpdateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Clust
 	}
 	cluster, err := secretToCluster(clusterSecret)
 	if err != nil {
-		log.Errorf("could not unmarshal cluster secret: %v", err)
+		log.Errorf("could not unmarshal cluster secret %s", clusterSecret.Name)
 		return nil, err
 	}
 	return cluster, db.settingsMgr.ResyncInformers()

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -241,4 +241,15 @@ func TestListClusters(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, clusters.Items, 2)
 	})
+
+	t.Run("Implicit in-cluster secret", func(t *testing.T) {
+		kubeclientset := fake.NewSimpleClientset(validSecret2)
+		settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
+		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
+
+		clusters, err := db.ListClusters(context.TODO())
+		require.NoError(t, err)
+		// ListClusters() should have added an implicit in-cluster secret to the list
+		assert.Len(t, clusters.Items, 2)
+	})
 }

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -37,7 +38,8 @@ func Test_secretToCluster(t *testing.T) {
 			"config": []byte("{\"username\":\"foo\"}"),
 		},
 	}
-	cluster := secretToCluster(secret)
+	cluster, err := secretToCluster(secret)
+	require.NoError(t, err)
 	assert.Equal(t, *cluster, v1alpha1.Cluster{
 		Name:   "test",
 		Server: "http://mycluster",
@@ -58,11 +60,29 @@ func Test_secretToCluster_NoConfig(t *testing.T) {
 			"server": []byte("http://mycluster"),
 		},
 	}
-	cluster := secretToCluster(secret)
+	cluster, err := secretToCluster(secret)
+	assert.NoError(t, err)
 	assert.Equal(t, *cluster, v1alpha1.Cluster{
 		Name:   "test",
 		Server: "http://mycluster",
 	})
+}
+
+func Test_secretToCluster_InvalidConfig(t *testing.T) {
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mycluster",
+			Namespace: fakeNamespace,
+		},
+		Data: map[string][]byte{
+			"name":   []byte("test"),
+			"server": []byte("http://mycluster"),
+			"config": []byte("{'tlsClientConfig':{'insecure':false}}"),
+		},
+	}
+	cluster, err := secretToCluster(secret)
+	require.Error(t, err)
+	assert.Nil(t, cluster)
 }
 
 func TestUpdateCluster(t *testing.T) {


### PR DESCRIPTION
Correctly handle errors when failing to parse cluster secrets instead of emitting a `panic()`

Fixes #6423 

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

