### PR TITLE
fix: re-use same http transport in grpc proxy to avoid goroutine leak

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -135,6 +135,7 @@ type client struct {
 	proxyListener   net.Listener
 	proxyServer     *grpc.Server
 	proxyUsersCount int
+	httpClient      *http.Client
 }
 
 // NewClient creates a new API client from a set of config options.
@@ -253,6 +254,16 @@ func NewClient(opts *ClientOptions) (Client, error) {
 	}
 	if opts.GRPCWebRootPath != "" {
 		c.GRPCWebRootPath = opts.GRPCWebRootPath
+	}
+	c.httpClient = &http.Client{}
+	if !c.PlainText {
+		tlsConfig, err := c.tlsConfig()
+		if err != nil {
+			return nil, err
+		}
+		c.httpClient.Transport = &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
 	}
 	if !c.GRPCWeb {
 		//test if we need to set it to true

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -77,18 +77,7 @@ func (c *client) executeRequest(fullMethodName string, msg []byte, md metadata.M
 	}
 	req.Header.Set("content-type", "application/grpc-web+proto")
 
-	client := &http.Client{}
-	if !c.PlainText {
-		tlsConfig, err := c.tlsConfig()
-		if err != nil {
-			return nil, err
-		}
-		client.Transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
-	}
-
-	resp, err := client.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +114,7 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 				return fmt.Errorf("Unable to get method name from stream context.")
 			}
 			msg := make([]byte, 0)
-			err = stream.RecvMsg(&msg)
+			err := stream.RecvMsg(&msg)
 			if err != nil {
 				return err
 			}
@@ -149,6 +138,7 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 				argoio.Close(resp.Body)
 			}()
 			defer argoio.Close(resp.Body)
+			c.httpClient.CloseIdleConnections()
 
 			for {
 				header := make([]byte, frameHeaderLength)


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/6026

PR changes grpc proxy so that it uses the same http client and stop leaking goroutins. Thanks to @uturunku1  for implementing this change!