### PR TITLE
fix: prevent 'cannot read property "filter" of undefined' during nodes filtering

### DIFF
--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -119,7 +119,7 @@ export function compareNodes(first: ResourceTreeNode, second: ResourceTreeNode) 
         return Math.sign(numberA - numberB);
     }
     function getRevision(a: ResourceTreeNode) {
-        const filtered = a.info.filter(b => b.name === 'Revision' && b)[0];
+        const filtered = (a.info || []).filter(b => b.name === 'Revision' && b)[0];
         if (filtered == null) {
             return '';
         }


### PR DESCRIPTION
Closes #6298 

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>
