### PR TITLE
fix: unset --plugin-env should return OK when not found

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -673,9 +673,10 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 				}
 				for _, env := range pluginEnvs {
 					err = app.Spec.Source.Plugin.RemoveEnvEntry(env)
-					errors.CheckError(err)
+					if err != nil {
+						updated = true
+					}
 				}
-				updated = true
 			}
 
 			if !updated {


### PR DESCRIPTION
Closes #6325 
