### PR TITLE
fix: add insecure-skip-tls-verify on helm pull when Creds.InsecureSkipVerify is set to true

### DIFF
--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -73,6 +73,16 @@ func Test_nativeHelmChart_ExtractChart(t *testing.T) {
 	assert.True(t, info.IsDir())
 }
 
+func Test_nativeHelmChart_ExtractChart_insecure(t *testing.T) {
+	client := NewClient("https://argoproj.github.io/argo-helm", Creds{InsecureSkipVerify: true}, false)
+	path, closer, err := client.ExtractChart("argo-cd", "0.7.1")
+	assert.NoError(t, err)
+	defer io.Close(closer)
+	info, err := os.Stat(path)
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
 func Test_normalizeChartName(t *testing.T) {
 	t.Run("Test non-slashed name", func(t *testing.T) {
 		n := normalizeChartName("mychart")

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -219,6 +219,9 @@ func (c *Cmd) Fetch(repo, chartName, version, destination string, creds Creds) (
 	if creds.Password != "" {
 		args = append(args, "--password", creds.Password)
 	}
+	if creds.InsecureSkipVerify {
+		args = append(args, "--insecure-skip-tls-verify")
+	}
 
 	args = append(args, "--repo", repo, chartName)
 

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -219,7 +219,7 @@ func (c *Cmd) Fetch(repo, chartName, version, destination string, creds Creds) (
 	if creds.Password != "" {
 		args = append(args, "--password", creds.Password)
 	}
-	if creds.InsecureSkipVerify {
+	if creds.InsecureSkipVerify && c.insecureSkipVerifySupported {
 		args = append(args, "--insecure-skip-tls-verify")
 	}
 


### PR DESCRIPTION
When using an insecure helm repository you are allowed to add that on including the "--insecure-skip..." see (https://github.com/argoproj/argo-cd/blob/master/util/helm/cmd.go#L160)

But when doing an actual fetch for the helm chart this parameter gets omitted. 

This PR adds this to the Fetch method (https://github.com/argoproj/argo-cd/blob/master/util/helm/cmd.go#L211)
Fixes:
#4258 
#3693
#6376 


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

