### PR TITLE
fix: EKS Clusters Broken Due To ReadOnly Filesystem

### DIFF
--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -135,9 +135,12 @@ spec:
           capabilities:
             drop:
               - all
+        workingDir: /home/argocd
         volumeMounts:
         - name: argocd-repo-server-tls
           mountPath: /app/config/controller/tls
+        - name: argocd-home
+          mountPath: /home/argocd
       serviceAccountName: argocd-application-controller
       affinity:
         podAntiAffinity:
@@ -155,6 +158,8 @@ spec:
                   app.kubernetes.io/part-of: argocd
               topologyKey: kubernetes.io/hostname
       volumes:
+      - emptyDir: {}
+        name: argocd-home
       - name: argocd-repo-server-tls
         secret:
           secretName: argocd-repo-server-tls

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4363,8 +4363,13 @@ spec:
         volumeMounts:
         - mountPath: /app/config/controller/tls
           name: argocd-repo-server-tls
+        - mountPath: /home/argocd
+          name: argocd-home
+        workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
+      - emptyDir: {}
+        name: argocd-home
       - name: argocd-repo-server-tls
         secret:
           items:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1750,8 +1750,13 @@ spec:
         volumeMounts:
         - mountPath: /app/config/controller/tls
           name: argocd-repo-server-tls
+        - mountPath: /home/argocd
+          name: argocd-home
+        workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
+      - emptyDir: {}
+        name: argocd-home
       - name: argocd-repo-server-tls
         secret:
           items:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3682,8 +3682,13 @@ spec:
         volumeMounts:
         - mountPath: /app/config/controller/tls
           name: argocd-repo-server-tls
+        - mountPath: /home/argocd
+          name: argocd-home
+        workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
+      - emptyDir: {}
+        name: argocd-home
       - name: argocd-repo-server-tls
         secret:
           items:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1069,8 +1069,13 @@ spec:
         volumeMounts:
         - mountPath: /app/config/controller/tls
           name: argocd-repo-server-tls
+        - mountPath: /home/argocd
+          name: argocd-home
+        workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
+      - emptyDir: {}
+        name: argocd-home
       - name: argocd-repo-server-tls
         secret:
           items:


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #6148 

Mount /home/argocd to emptyDir