### PR TITLE
feat: Implement MinIO Tenant CRD health check

### DIFF
--- a/resource_customizations/minio.min.io/Tenant/health.lua
+++ b/resource_customizations/minio.min.io/Tenant/health.lua
@@ -36,11 +36,11 @@ if obj.status ~= nil then
             health_status.message = obj.status.currentState
             return health_status
         end
-        health_status.status = "Unknown"
+        health_status.status = "Progressing"
         health_status.message = obj.status.currentState
         return health_status
     end
 end
-health_status.status = "Missing"
+health_status.status = "Progressing"
 health_status.message = "No status info available"
 return health_status

--- a/resource_customizations/minio.min.io/Tenant/health.lua
+++ b/resource_customizations/minio.min.io/Tenant/health.lua
@@ -1,0 +1,46 @@
+health_status = {}
+if obj.status ~= nil then
+    if obj.status.currentState ~= nil then
+        if obj.status.currentState == "Initialized" then
+            health_status.status = "Healthy"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        if obj.status.currentState:find("^Provisioning") ~= nil then
+            health_status.status = "Progressing"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        if obj.status.currentState:find("^Waiting") ~= nil then
+            health_status.status = "Progressing"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        if obj.status.currentState:find("^Updating") ~= nil then
+            health_status.status = "Progressing"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        if obj.status.currentState == "Statefulset not controlled by operator" then
+            health_status.status = "Degraded"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        if obj.status.currentState == "Another MinIO Tenant already exists in the namespace" then
+            health_status.status = "Degraded"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        if obj.status.currentState == "Different versions across MinIO Pools" then
+            health_status.status = "Degraded"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        health_status.status = "Unknown"
+        health_status.message = obj.status.currentState
+        return health_status
+    end
+end
+health_status.status = "Missing"
+health_status.message = "No status info available"
+return health_status

--- a/resource_customizations/minio.min.io/Tenant/health_test.yaml
+++ b/resource_customizations/minio.min.io/Tenant/health_test.yaml
@@ -1,0 +1,37 @@
+tests:
+- healthStatus:
+    status: Healthy
+    message: "Initialized"
+  inputPath: testdata/initialized.yaml
+- healthStatus:
+    status: Progressing
+    message: "Provisioning MinIO Cluster IP Service"
+  inputPath: testdata/provisioning.yaml
+- healthStatus:
+    status: Progressing
+    message: "Waiting for Pods to be ready"
+  inputPath: testdata/waiting.yaml
+- healthStatus:
+    status: Progressing
+    message: "Updating MinIO Version"
+  inputPath: testdata/updating.yaml
+- healthStatus:
+    status: Degraded
+    message: "Statefulset not controlled by operator"
+  inputPath: testdata/out_of_control.yaml
+- healthStatus:
+    status: Degraded
+    message: "Another MinIO Tenant already exists in the namespace"
+  inputPath: testdata/another_tenant_exists.yaml
+- healthStatus:
+    status: Degraded
+    message: "Different versions across MinIO Pools"
+  inputPath: testdata/versions_mismatch.yaml
+- healthStatus:
+    status: Unknown
+    message: "<unknown status message>"
+  inputPath: testdata/unknown_status_message.yaml
+- healthStatus:
+    status: Missing
+    message: "No status info available"
+  inputPath: testdata/no_status.yaml

--- a/resource_customizations/minio.min.io/Tenant/health_test.yaml
+++ b/resource_customizations/minio.min.io/Tenant/health_test.yaml
@@ -28,10 +28,10 @@ tests:
     message: "Different versions across MinIO Pools"
   inputPath: testdata/versions_mismatch.yaml
 - healthStatus:
-    status: Unknown
+    status: Progressing
     message: "<unknown status message>"
   inputPath: testdata/unknown_status_message.yaml
 - healthStatus:
-    status: Missing
+    status: Progressing
     message: "No status info available"
   inputPath: testdata/no_status.yaml

--- a/resource_customizations/minio.min.io/Tenant/testdata/another_tenant_exists.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/another_tenant_exists.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Another MinIO Tenant already exists in the namespace

--- a/resource_customizations/minio.min.io/Tenant/testdata/initialized.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/initialized.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Initialized

--- a/resource_customizations/minio.min.io/Tenant/testdata/no_status.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/no_status.yaml
@@ -1,0 +1,12 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0

--- a/resource_customizations/minio.min.io/Tenant/testdata/out_of_control.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/out_of_control.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Statefulset not controlled by operator

--- a/resource_customizations/minio.min.io/Tenant/testdata/provisioning.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/provisioning.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Provisioning MinIO Cluster IP Service

--- a/resource_customizations/minio.min.io/Tenant/testdata/unknown_status_message.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/unknown_status_message.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: <unknown status message>

--- a/resource_customizations/minio.min.io/Tenant/testdata/updating.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/updating.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Updating MinIO Version

--- a/resource_customizations/minio.min.io/Tenant/testdata/versions_mismatch.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/versions_mismatch.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Different versions across MinIO Pools

--- a/resource_customizations/minio.min.io/Tenant/testdata/waiting.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/waiting.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Waiting for Pods to be ready


### PR DESCRIPTION
The PR adds health check for MinIO Tenant CRD which is used by [MinIO Operator](https://github.com/minio/operator)
List of [Standard Status messages for Tenant](https://github.com/minio/operator/blob/b5ad899041245b6f8f49009a1263cf3747687897/pkg/controller/cluster/main-controller.go#L114-L142)

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

