### PR TITLE
docs: update faq.md for the target version of SealedSecret

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -189,7 +189,7 @@ fixed CRD if you want this feature to work at all.
 The controller of the `SealedSecret` resource may expose the status condition on resource it provisioned. Since
 version `v2.0.0` ArgoCD picks up that status condition to derive a health status for the `SealedSecret`.
 
-Versions before `v0.15.0` of the `SealedSecret` controller are affected by an issue regarding this status
+Versions before `v0.16.0` of the `SealedSecret` controller are affected by an issue regarding this status
 conditions updates, which is why this feature is disabled by default in these versions. Status condition updates may be
 enabled by starting the `SealedSecret` controller with the `--update-status` command line parameter or by setting
 the `SEALED_SECRETS_UPDATE_STATUS` environment variable.


### PR DESCRIPTION
Looking at [the release notes of Sealed-secret](https://github.com/bitnami-labs/sealed-secrets/blob/main/RELEASE-NOTES.md#v0150), it is stated that `--update-status` or `SEALED_SECRETS_UPDATE_STATUS=1` will be the default starting from v0.17.0, so I thought the description should be corrected.

Checklist:

* [c] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

