### PR TITLE
fix: typo in networkPolicy definition in manifests

### DIFF
--- a/manifests/base/dex/argocd-dex-server-network-policy.yaml
+++ b/manifests/base/dex/argocd-dex-server-network-policy.yaml
@@ -22,4 +22,4 @@ spec:
         - namespaceSelector: { }
       ports:
         - port: 5558
-        - protocol: TCP
+          protocol: TCP

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4560,7 +4560,7 @@ spec:
     - namespaceSelector: {}
     ports:
     - port: 5558
-    - protocol: TCP
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1947,7 +1947,7 @@ spec:
     - namespaceSelector: {}
     ports:
     - port: 5558
-    - protocol: TCP
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3731,7 +3731,7 @@ spec:
     - namespaceSelector: {}
     ports:
     - port: 5558
-    - protocol: TCP
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1118,7 +1118,7 @@ spec:
     - namespaceSelector: {}
     ports:
     - port: 5558
-    - protocol: TCP
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server


### PR DESCRIPTION
Unless the argocd-dex-server-network-policy NetworkPolicy was meant to
authorize ALL TCP traffic, which seems unlikely, this is a typo.

Signed-off-by: Antonin Bas <abas@vmware.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

