### PR TITLE
fix: WebUI failure when loading pod view 't.parentRefs is undefined' (#6490)

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -308,6 +308,9 @@ export class PodView extends React.Component<PodViewProps> {
             this.props.app.status.resources.forEach(res => statusByKey.set(nodeKey(res), res));
         }
         (tree.nodes || []).forEach((rnode: ResourceTreeNode) => {
+            // make sure each node has not null/undefined parentRefs field
+            rnode.parentRefs = rnode.parentRefs || [];
+
             if (sortMode !== 'node') {
                 parentsFor[rnode.uid] = rnode.parentRefs as PodGroup[];
                 const fullName = nodeKey(rnode);


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #6490 