### PR TITLE
docs: fix typo in declarative setup

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -573,7 +573,7 @@ The `resource.exclusions` node is a list of objects. Each object can have:
 
 * `apiGroups` A list of globs to match the API group.
 * `kinds` A list of kinds to match. Can be `"*"` to match all.
-* `cluster` A list of globs to match the cluster.
+* `clusters` A list of globs to match the cluster.
 
 If all three match, then the resource is ignored.
 


### PR DESCRIPTION
Replaces `cluster` by `clusters` in the *Resource Exclusion/Inclusion* section. 