### PR TITLE
docs: document Argo CD development process

### DIFF
--- a/controller/OWNERS
+++ b/controller/OWNERS
@@ -1,0 +1,2 @@
+owners:
+- alexmt

--- a/docs/developer-guide/development-process.md
+++ b/docs/developer-guide/development-process.md
@@ -1,0 +1,50 @@
+# Development Process
+
+Argo CD is being developed using the waterfall process:
+
+* Maintainers commit to work on set of features and enhancements and create Github milestone to track the work.
+* We are trying to avoid delaying release and prefer moving the feature into the next release if we cannot complete it on time.
+* The new release is published every **3 month**.
+* Critical bug-fixes are cherry-picked into the release branch and delivered using patch releases as frequently as needed.
+
+## Release Planning
+
+We are using Github milestones to perform release planning and tracking. Each release milestone includes two type of issues:
+
+* Issues that maintainers committed to working on. Maintainers decide which features they are committing to work on during the next release based on
+  their availability. Typically issues added offline by each maintainer and finalized during the contributors' meeting. Each such issue should be
+  assigned to maintainer who plans to implement and test it.
+* Nice to have improvements contributed by community contributors. Nice to have issues are typically not critical, smallish enhancements that could
+  be contributed by community contributors. Maintainers are not committing to implement them but committing to review PR from the community.
+
+The milestone should have a clear description of the most important features as well as the expected end date. This should provide clarity to end-users
+about what to expect from the next release and when.
+
+In addition to the next milestone, we need to maintain a draft of the upcoming release milestone. 
+
+## Unplanned Contributions
+
+The project is going to keep getting pull requests for features that we did not plan to work on. These contributions are still valuable and should be merged
+eventually. There is no guarantee that such contributions will be reviewed and merged during the current release. Maintainers are might decide to work on PR
+with the contributor and self-assign the PR. Otherwise, PR will be postponed but should be prioritized in the next release.
+
+## Release Testing
+
+We need to make sure that each change, both from maintainers and community contributors, is tested well and have someone who is going to fix last-minute
+bugs. In order to ensure it, each merged pull request must have an assigned maintainer before it gets merged. The assigned maintainer will be working on
+testing the introduced changes and fixing of any introduced bugs.
+
+We have a code freeze period two weeks before the release until the release branch is created. During code freeze no feature PR should be merged and it is ok
+to merge bug fixes.
+
+Maintainers assigned to merged PR should drive testing and work on fixing last-minute issues. For tracking purposes after verifying PR the assigned
+the maintainer should label it with a `verified` label.
+
+## Releasing
+
+The releasing procedure is described in [releasing](./releasing.md) document. Before closing the release milestone following should be verified:
+
+- [ ] All merged PRs has `verified` label
+- [ ] Roadmap is updated based one current release changes
+- [ ] Next release milestone is created
+- [ ] Upcoming release milestone is updated

--- a/docs/developer-guide/release-process-and-cadence.md
+++ b/docs/developer-guide/release-process-and-cadence.md
@@ -1,15 +1,15 @@
-# Development Process
+# Release Process And Cadence
 
-Argo CD is being developed using the waterfall process:
+Argo CD is being developed using the following process:
 
-* Maintainers commit to work on set of features and enhancements and create Github milestone to track the work.
+* Maintainers commit to work on set of features and enhancements and create GitHub milestone to track the work.
 * We are trying to avoid delaying release and prefer moving the feature into the next release if we cannot complete it on time.
 * The new release is published every **3 month**.
 * Critical bug-fixes are cherry-picked into the release branch and delivered using patch releases as frequently as needed.
 
 ## Release Planning
 
-We are using Github milestones to perform release planning and tracking. Each release milestone includes two type of issues:
+We are using GitHub milestones to perform release planning and tracking. Each release milestone includes two type of issues:
 
 * Issues that maintainers committed to working on. Maintainers decide which features they are committing to work on during the next release based on
   their availability. Typically issues added offline by each maintainer and finalized during the contributors' meeting. Each such issue should be
@@ -22,11 +22,9 @@ about what to expect from the next release and when.
 
 In addition to the next milestone, we need to maintain a draft of the upcoming release milestone. 
 
-## Unplanned Contributions
+## Community Contributions
 
-The project is going to keep getting pull requests for features that we did not plan to work on. These contributions are still valuable and should be merged
-eventually. There is no guarantee that such contributions will be reviewed and merged during the current release. Maintainers are might decide to work on PR
-with the contributor and self-assign the PR. Otherwise, PR will be postponed but should be prioritized in the next release.
+We receive a lot of contributions from our awesome community, and we're very grateful for that fact. However, reviewing and testing PRs is a lot of (unplanned) work and therefore, we cannot guarantee that contributions (especially large or complex ones) made by the community receive a timely review within a release's time frame. Maintainers may decide on their own to put work on a PR together with the contributor and in this case, the maintainer will self-assigned the PR and thereby committing to review, eventually merge and later test it on the release scope.
 
 ## Release Testing
 
@@ -37,14 +35,14 @@ testing the introduced changes and fixing of any introduced bugs.
 We have a code freeze period two weeks before the release until the release branch is created. During code freeze no feature PR should be merged and it is ok
 to merge bug fixes.
 
-Maintainers assigned to merged PR should drive testing and work on fixing last-minute issues. For tracking purposes after verifying PR the assigned
+Maintainers assigned to a PR that's been merged should drive testing and work on fixing last-minute issues. For tracking purposes after verifying PR the assigned
 the maintainer should label it with a `verified` label.
 
 ## Releasing
 
 The releasing procedure is described in [releasing](./releasing.md) document. Before closing the release milestone following should be verified:
 
-- [ ] All merged PRs has `verified` label
+- [ ] All merged PRs have the `verified` label
 - [ ] Roadmap is updated based one current release changes
 - [ ] Next release milestone is created
 - [ ] Upcoming release milestone is updated

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
   - Developer Guide:
     - developer-guide/index.md
     - developer-guide/contributing.md
+    - developer-guide/release-process-and-cadence.md
     - developer-guide/running-locally.md
     - developer-guide/debugging-remote-environment.md
     - developer-guide/use-gitpod.md

--- a/reposerver/OWNERS
+++ b/reposerver/OWNERS
@@ -1,0 +1,3 @@
+owners:
+- jgwest
+- mayzhang2000

--- a/ui/OWNERS
+++ b/ui/OWNERS
@@ -1,0 +1,3 @@
+owners:
+- rbreeze
+- reginapizza

--- a/util/db/OWNERS
+++ b/util/db/OWNERS
@@ -1,0 +1,2 @@
+owners:
+- alexmt

--- a/util/git/OWNERS
+++ b/util/git/OWNERS
@@ -1,0 +1,3 @@
+owners:
+- alexmt
+- jannfis

--- a/util/gpg/OWNERS
+++ b/util/gpg/OWNERS
@@ -1,0 +1,2 @@
+owners:
+- jannfis

--- a/util/helm/OWNERS
+++ b/util/helm/OWNERS
@@ -1,0 +1,3 @@
+owners:
+- alexmt
+- jannfis


### PR DESCRIPTION
PR is the follow-up for https://docs.google.com/document/d/1xwVSS-G9Waf8wWH8t2XaFJvGRFb7GjyTtoAsh5zlPk0/edit# proposal. The goal is to document the development and releasing process.

Action items if PR get's merged:

* Add end-date to current milestone
* Configure https://github.com/marketplace/actions/pull-request-assignee to enforce assigning PR
* Go through merged PRs and assign a maintainer
* Create 2.2 milestone draft