### PR TITLE
docs: link docs about different PrunePropagationPolicy values

### DIFF
--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -88,6 +88,7 @@ $ argocd app set guestbook --sync-option ApplyOutOfSyncOnly=true
 
 By default, extraneous resources get pruned using foreground deletion policy. The propagation policy can be controlled
 using `PrunePropagationPolicy` sync option. Supported policies are background, foreground and orphan.
+More information about those policies could be found [here](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#controlling-how-the-garbage-collector-deletes-dependents).
 
 ```yaml
 syncOptions:


### PR DESCRIPTION
This part of the documentation is not clear enough. It takes a lot of digging to actually find a clear explanation of what those policies are bringing to the end-user.

Source: https://github.com/argoproj/argo-cd/discussions/6239

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

