### PR TITLE
docs: Use latest GH release to avoid extra curl

### DIFF
--- a/docs/cli_installation.md
+++ b/docs/cli_installation.md
@@ -12,21 +12,20 @@ brew install argocd
 
 ### Download With Curl
 
-You can view the latest version of Argo CD at the link above or run the following command to grab the version:
+#### Download latest version
 
 ```bash
-VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+chmod +x /usr/local/bin/argocd
 ```
 
-Replace `VERSION` in the command below with the version of Argo CD you would like to download:
+#### Download concrete version
+
+Set `VERSION` replacing `<TAG>` in the command below with the version of Argo CD you would like to download:
 
 ```bash
+VERSION=<TAG> # Select desired TAG from https://github.com/argoproj/argo-cd/releases
 curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-linux-amd64
-```
-
-Make the `argocd` CLI executable:
-
-```bash
 chmod +x /usr/local/bin/argocd
 ```
 


### PR DESCRIPTION
It use latest GH release link to avoid an extra curl.

It also keeps a reference to the possibility to download an specific version just providing the TAG name.