### PR TITLE
fix: unable to delete an Application if its target cluster is deleted, Argo CD enters infinite app deletion reconciliation loop

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2396,13 +2396,19 @@ func (r ResourceDiff) TargetObject() (*unstructured.Unstructured, error) {
 	return UnmarshalToUnstructured(r.TargetState)
 }
 
-// TODO: document this method
+// SetInferredServer sets the Server field of the destination. See IsServerInferred() for details.
 func (d *ApplicationDestination) SetInferredServer(server string) {
+
 	d.isServerInferred = true
 	d.Server = server
 }
 
-// TODO: document this method
+// An ApplicationDestination has an 'inferred server' if the ApplicationDestination
+// contains a Name, but not a Server URL. In this case it is necessary to retrieve
+// the Server URL by looking up the cluster name.
+//
+// As of this writing, looking up the cluster name, and setting the URL, is
+// performed by 'utils.ValidateDestination(...)', which then calls SetInferredServer.
 func (d *ApplicationDestination) IsServerInferred() bool {
 	return d.isServerInferred
 }

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -289,9 +289,15 @@ func enrichSpec(spec *argoappv1.ApplicationSpec, appDetails *apiclient.RepoAppDe
 	}
 }
 
-// ValidateDestination checks:
-// if we used destination name we infer the server url
-// if we used both name and server then we return an invalid spec error
+// ValidateDestination sets the 'Server' value of the ApplicationDestination, if it is not set.
+// NOTE: this function WILL write to the object pointed to by the 'dest' parameter.
+//
+// If an ApplicationDestination has a Name field, but has an empty Server (URL) field,
+// ValidationDestination will look up the cluster by name (to get the server URL), and
+// set the corresponding Server field value.
+//
+// It also checks:
+// - If we used both name and server then we return an invalid spec error
 func ValidateDestination(ctx context.Context, dest *argoappv1.ApplicationDestination, db db.ArgoDB) error {
 	if dest.Name != "" {
 		if dest.Server == "" {


### PR DESCRIPTION
### Description

On Application deletion, this PR verifies whether the target cluster (defined in the `destination` field of the `Application` resource) is defined within Argo CD (exists as a cluster secret, or is a local cluster). If the target cluster is not defined, it allows the Application to be deleted (rather than returning an error, as before).

### Details

If the target cluster is not defined, it is assumed that either:
a) the cluster was deleted from Argo CD (for example, via the Argo CD settings UI, or by deleting the cluster secret)
*or*
b) the Application spec is invalid (referencing a cluster that doesn't exist).

In both cases, since there are no cluster resources to clean up, we can safely allow the `Application` resource to be deleted.

So, if we detect that the Application targets a valid cluster:
- No change: everything works in this function as it currently does.

OTOH, if we detect the Application contains an invalid cluster:
- We empty the various Argo CD caches for the Application, as before.
- We skip the steps that would delete the live resources from the target cluster (because there is no target cluster)
- We report a warning, but allow the `Application` resource to be deleted (eg we remove the finalizer from the Application)

See parent issue for reproduction steps and details.

Fixes #5817 


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

