### PR TITLE
chore: Fix some annoyances when running locally

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -22,6 +22,7 @@ RUN  apt-get update && apt-get install --fix-missing -y \
         wget \
         gcc \
         sudo \
+        tini \
         zip && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -100,6 +101,7 @@ RUN useradd -l -u ${UID} -d /home/user -s /bin/bash user && \
     ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
     ln -s /opt/yarn-v1.22.4/bin/yarn /usr/local/bin/yarn && \
-    ln -s /opt/yarn-v1.22.4/bin/yarnpkg /usr/local/bin/yarnpkg
+    ln -s /opt/yarn-v1.22.4/bin/yarnpkg /usr/local/bin/yarnpkg && \
+    mkdir -p /var/lib/registry && chmod -R 777 /var/lib/registry
 
 ENTRYPOINT ["/usr/local/bin/uid_entrypoint.sh"]

--- a/test/container/Procfile
+++ b/test/container/Procfile
@@ -4,6 +4,7 @@ dex: sh -c "test $ARGOCD_IN_CI = true && exit 0; ARGOCD_BINARY_NAME=argocd-dex g
 redis: sh -c "/usr/local/bin/redis-server --save "" --appendonly no --port ${ARGOCD_E2E_REDIS_PORT:-6379}"
 repo-server: sh -c "FORCE_LOG_COLORS=1 ARGOCD_FAKE_IN_CLUSTER=true ARGOCD_GNUPGHOME=${ARGOCD_GNUPGHOME:-/tmp/argocd-local/gpg/keys} ARGOCD_GPG_DATA_PATH=${ARGOCD_GPG_DATA_PATH:-/tmp/argocd-local/gpg/source} ARGOCD_BINARY_NAME=argocd-repo-server go run ./cmd/main.go --loglevel debug --port ${ARGOCD_E2E_REPOSERVER_PORT:-8081} --redis localhost:${ARGOCD_E2E_REDIS_PORT:-6379}"
 ui: sh -c "test $ARGOCD_IN_CI = true && exit 0; cd ui && ARGOCD_E2E_YARN_HOST=0.0.0.0 ${ARGOCD_E2E_YARN_CMD:-yarn} start"
+reaper: ./test/container/reaper.sh
 sshd: sudo sh -c "test $ARGOCD_E2E_TEST = true && /usr/sbin/sshd -p 2222 -D -e"
 fcgiwrap: sudo sh -c "test $ARGOCD_E2E_TEST = true && (fcgiwrap -s unix:/var/run/fcgiwrap.socket & sleep 1 && chmod 777 /var/run/fcgiwrap.socket && wait)"
 nginx: sudo sh -c "test $ARGOCD_E2E_TEST = true && nginx -g 'daemon off;' -c $(pwd)/test/fixture/testrepos/nginx.conf"

--- a/test/container/reaper.sh
+++ b/test/container/reaper.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Simple helper script to kill all running processes in the container that
+# have belong to the root user.
+
+# DO NOT RUN OUTSIDE THE DOCKER CONTAINER EXECUTING ARGO CD TESTS.
+# YOU HAVE BEEN WARNED.
+
+somefunc() {
+	echo "Killing all processes"
+	sudo pkill -u root
+}
+
+echo "Running as $0 ($PWD)"
+if test "${PWD}" != "/go/src/github.com/argoproj/argo-cd"; then
+	echo "ERROR: We don't seem to be in Docker container. Exit." >&2
+	exit 1
+fi
+trap somefunc 2 15
+while :; do
+	sleep 1
+done

--- a/test/container/uid_entrypoint.sh
+++ b/test/container/uid_entrypoint.sh
@@ -9,4 +9,8 @@ fi
 export PATH=$PATH:/usr/local/go/bin:/go/bin
 export GOROOT=/usr/local/go
 
-"$@"
+if test "$$" = "1"; then
+        exec tini -- "$@"
+else
+        exec "$@"
+fi

--- a/test/fixture/testrepos/start-helm-registry.sh
+++ b/test/fixture/testrepos/start-helm-registry.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export HELM_EXPERIMENTAL_OCI=1
-docker run -p 5000:5000 --restart=always --name registry registry
+docker run -p 5000:5000 --rm --name registry registry


### PR DESCRIPTION
Fixes some annoyances with running Argo CD locally, as noted in #6545 

* Registry container is now removed for `start-local` and `start-e2e-local` after goreman exits
* Terminate all process in Docker container correctly when using `start` and `start-e2e` 

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

