### PR TITLE
fix: argocd-util generate-spec should not print argocd-cm ConfigMap

### DIFF
--- a/cmd/argocd-util/commands/repo.go
+++ b/cmd/argocd-util/commands/repo.go
@@ -169,10 +169,6 @@ func NewGenRepoSpecCommand() *cobra.Command {
 				printResources = append(printResources, secret)
 			}
 
-			cm, err := kubeClientset.CoreV1().ConfigMaps(ArgoCDNamespace).Get(context.Background(), common.ArgoCDConfigMapName, v1.GetOptions{})
-			errors.CheckError(err)
-
-			printResources = append(printResources, cm)
 			errors.CheckError(cmdutil.PrintResources(printResources, outputFormat))
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The repository, repository credentials are no longer require field in `argocd-cm` ConfigMap. So `generate-spec` command should not longer generate config map YAML.