### PR TITLE
Fix: Remove deprecated css function

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.scss
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.scss
@@ -120,7 +120,7 @@ $num-stats: 2;
             &--suspended {
                 background-color: $argo-status-warning-color;
                 &:hover {
-                    background-color: $argo-status-warning-color - #111;
+                    background-color: darken($argo-status-warning-color, 10%);
                 }
             }
             &--running,


### PR DESCRIPTION
Closes Issue #6559. 

Changed color to a 10% darkened version of the base color on hover, see original (left) and on hovered (right) below. 

![argo-status-warning-color-dark](https://user-images.githubusercontent.com/50851526/124036648-52c30380-d9cc-11eb-8833-714287b0f0bc.png)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

