### PR TITLE
feat: Supported set metadata annotations with `argocd-util app generate-spec` command

### DIFF
--- a/cmd/argocd-util/commands/app.go
+++ b/cmd/argocd-util/commands/app.go
@@ -61,6 +61,7 @@ func NewGenAppSpecCommand() *cobra.Command {
 		appName      string
 		labels       []string
 		outputFormat string
+		annotations  []string
 	)
 	var command = &cobra.Command{
 		Use:   "generate-spec APPNAME",
@@ -85,7 +86,7 @@ func NewGenAppSpecCommand() *cobra.Command {
 	argocd-util app generate-spec ksane --repo https://github.com/argoproj/argocd-example-apps.git --path plugins/kasane --dest-namespace default --dest-server https://kubernetes.default.svc --config-management-plugin kasane
 `,
 		Run: func(c *cobra.Command, args []string) {
-			app, err := cmdutil.ConstructApp(fileURL, appName, labels, args, appOpts, c.Flags())
+			app, err := cmdutil.ConstructApp(fileURL, appName, labels, annotations, args, appOpts, c.Flags())
 			errors.CheckError(err)
 
 			if app.Name == "" {
@@ -101,6 +102,7 @@ func NewGenAppSpecCommand() *cobra.Command {
 	command.Flags().StringVar(&appName, "name", "", "A name for the app, ignored if a file is set (DEPRECATED)")
 	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the app")
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "Labels to apply to the app")
+	command.Flags().StringArrayVarP(&annotations, "annotations", "", []string{}, "Set metadata annotations")
 	command.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	// Only complete files with appropriate extension.

--- a/cmd/argocd-util/commands/app.go
+++ b/cmd/argocd-util/commands/app.go
@@ -102,7 +102,7 @@ func NewGenAppSpecCommand() *cobra.Command {
 	command.Flags().StringVar(&appName, "name", "", "A name for the app, ignored if a file is set (DEPRECATED)")
 	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the app")
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "Labels to apply to the app")
-	command.Flags().StringArrayVarP(&annotations, "annotations", "", []string{}, "Set metadata annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotations", "", []string{}, "Set metadata annotations (e.g. example=value)")
 	command.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	// Only complete files with appropriate extension.

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -101,11 +101,12 @@ func NewApplicationCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 // NewApplicationCreateCommand returns a new instance of an `argocd app create` command
 func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		appOpts cmdutil.AppOptions
-		fileURL string
-		appName string
-		upsert  bool
-		labels  []string
+		appOpts     cmdutil.AppOptions
+		fileURL     string
+		appName     string
+		upsert      bool
+		labels      []string
+		annotations []string
 	)
 	var command = &cobra.Command{
 		Use:   "create APPNAME",
@@ -132,7 +133,7 @@ func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 		Run: func(c *cobra.Command, args []string) {
 			argocdClient := argocdclient.NewClientOrDie(clientOpts)
 
-			app, err := cmdutil.ConstructApp(fileURL, appName, labels, args, appOpts, c.Flags())
+			app, err := cmdutil.ConstructApp(fileURL, appName, labels, annotations, args, appOpts, c.Flags())
 			errors.CheckError(err)
 
 			if app.Name == "" {
@@ -156,6 +157,7 @@ func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 	command.Flags().BoolVar(&upsert, "upsert", false, "Allows to override application with the same name even if supplied application spec is different from existing spec")
 	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the app")
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "Labels to apply to the app")
+	command.Flags().StringArrayVarP(&annotations, "annotations", "", []string{}, "Set metadata annotations")
 	// Only complete files with appropriate extension.
 	err := command.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
 	if err != nil {

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -157,7 +157,7 @@ func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 	command.Flags().BoolVar(&upsert, "upsert", false, "Allows to override application with the same name even if supplied application spec is different from existing spec")
 	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the app")
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "Labels to apply to the app")
-	command.Flags().StringArrayVarP(&annotations, "annotations", "", []string{}, "Set metadata annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotations", "", []string{}, "Set metadata annotations (e.g. example=value)")
 	// Only complete files with appropriate extension.
 	err := command.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
 	if err != nil {

--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -69,7 +69,6 @@ type AppOptions struct {
 	retryBackoffDuration            time.Duration
 	retryBackoffMaxDuration         time.Duration
 	retryBackoffFactor              int64
-	annotations                     []string
 }
 
 func AddAppFlags(command *cobra.Command, opts *AppOptions) {
@@ -119,7 +118,6 @@ func AddAppFlags(command *cobra.Command, opts *AppOptions) {
 	command.Flags().DurationVar(&opts.retryBackoffDuration, "sync-retry-backoff-duration", argoappv1.DefaultSyncRetryDuration, "Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h)")
 	command.Flags().DurationVar(&opts.retryBackoffMaxDuration, "sync-retry-backoff-max-duration", argoappv1.DefaultSyncRetryMaxDuration, "Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h)")
 	command.Flags().Int64Var(&opts.retryBackoffFactor, "sync-retry-backoff-factor", argoappv1.DefaultSyncRetryFactor, "Factor multiplies the base duration after each failed sync retry")
-	command.Flags().StringArrayVar(&opts.annotations, "annotations", []string{}, "Set metadata annotations")
 }
 
 func SetAppSpecOptions(flags *pflag.FlagSet, spec *argoappv1.ApplicationSpec, appOpts *AppOptions) int {
@@ -539,7 +537,7 @@ func readAppFromURI(fileURL string, app *argoappv1.Application) error {
 	return err
 }
 
-func ConstructApp(fileURL, appName string, labels, args []string, appOpts AppOptions, flags *pflag.FlagSet) (*argoappv1.Application, error) {
+func ConstructApp(fileURL, appName string, labels, annotations, args []string, appOpts AppOptions, flags *pflag.FlagSet) (*argoappv1.Application, error) {
 	var app argoappv1.Application
 	if fileURL == "-" {
 		// read stdin
@@ -565,7 +563,7 @@ func ConstructApp(fileURL, appName string, labels, args []string, appOpts AppOpt
 		SetAppSpecOptions(flags, &app.Spec, &appOpts)
 		SetParameterOverrides(&app, appOpts.Parameters)
 		mergeLabels(&app, labels)
-		setAnnotations(&app, appOpts.annotations)
+		setAnnotations(&app, annotations)
 	} else {
 		// read arguments
 		if len(args) == 1 {
@@ -586,7 +584,7 @@ func ConstructApp(fileURL, appName string, labels, args []string, appOpts AppOpt
 		SetAppSpecOptions(flags, &app.Spec, &appOpts)
 		SetParameterOverrides(&app, appOpts.Parameters)
 		mergeLabels(&app, labels)
-		setAnnotations(&app, appOpts.annotations)
+		setAnnotations(&app, annotations)
 	}
 	return &app, nil
 }

--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -612,6 +612,10 @@ func setAnnotations(app *argoappv1.Application, annotations []string) {
 	}
 	for _, a := range annotations {
 		annotation := strings.SplitN(a, "=", 2)
-		app.Annotations[annotation[0]] = annotation[1]
+		if len(annotation) == 2 {
+			app.Annotations[annotation[0]] = annotation[1]
+		} else {
+			app.Annotations[annotation[0]] = ""
+		}
 	}
 }

--- a/cmd/util/app_test.go
+++ b/cmd/util/app_test.go
@@ -184,4 +184,9 @@ func Test_setAnnotations(t *testing.T) {
 		setAnnotations(&app, []string{"hoge=foo=bar"})
 		assert.Equal(t, map[string]string{"hoge": "foo=bar"}, app.Annotations)
 	})
+	t.Run("Annotations empty value", func(t *testing.T) {
+		app := v1alpha1.Application{}
+		setAnnotations(&app, []string{"hoge"})
+		assert.Equal(t, map[string]string{"hoge": ""}, app.Annotations)
+	})
 }

--- a/cmd/util/app_test.go
+++ b/cmd/util/app_test.go
@@ -172,3 +172,16 @@ func Test_setAppSpecOptions(t *testing.T) {
 		assert.Nil(t, f.spec.SyncPolicy.Retry)
 	})
 }
+
+func Test_setAnnotations(t *testing.T) {
+	t.Run("Annotations", func(t *testing.T) {
+		app := v1alpha1.Application{}
+		setAnnotations(&app, []string{"hoge=foo", "huga=bar"})
+		assert.Equal(t, map[string]string{"hoge": "foo", "huga": "bar"}, app.Annotations)
+	})
+	t.Run("Annotations value contains equal", func(t *testing.T) {
+		app := v1alpha1.Application{}
+		setAnnotations(&app, []string{"hoge=foo=bar"})
+		assert.Equal(t, map[string]string{"hoge": "foo=bar"}, app.Annotations)
+	})
+}

--- a/docs/operator-manual/server-commands/argocd-util_app_generate-spec.md
+++ b/docs/operator-manual/server-commands/argocd-util_app_generate-spec.md
@@ -34,6 +34,7 @@ argocd-util app generate-spec APPNAME [flags]
 
 ```
       --allow-empty                                Set allow zero live resources when sync is automated
+      --annotations stringArray                    Set metadata annotations
       --auto-prune                                 Set automatic pruning when sync is automated
       --config-management-plugin string            Config management plugin name
       --dest-name string                           K8s cluster Name (e.g. minikube)

--- a/docs/operator-manual/server-commands/argocd-util_app_generate-spec.md
+++ b/docs/operator-manual/server-commands/argocd-util_app_generate-spec.md
@@ -34,7 +34,7 @@ argocd-util app generate-spec APPNAME [flags]
 
 ```
       --allow-empty                                Set allow zero live resources when sync is automated
-      --annotations stringArray                    Set metadata annotations
+      --annotations stringArray                    Set metadata annotations (e.g. example=value)
       --auto-prune                                 Set automatic pruning when sync is automated
       --config-management-plugin string            Config management plugin name
       --dest-name string                           K8s cluster Name (e.g. minikube)

--- a/docs/user-guide/commands/argocd_app_create.md
+++ b/docs/user-guide/commands/argocd_app_create.md
@@ -34,6 +34,7 @@ argocd app create APPNAME [flags]
 
 ```
       --allow-empty                                Set allow zero live resources when sync is automated
+      --annotations stringArray                    Set metadata annotations
       --auto-prune                                 Set automatic pruning when sync is automated
       --config-management-plugin string            Config management plugin name
       --dest-name string                           K8s cluster Name (e.g. minikube)

--- a/docs/user-guide/commands/argocd_app_create.md
+++ b/docs/user-guide/commands/argocd_app_create.md
@@ -34,7 +34,7 @@ argocd app create APPNAME [flags]
 
 ```
       --allow-empty                                Set allow zero live resources when sync is automated
-      --annotations stringArray                    Set metadata annotations
+      --annotations stringArray                    Set metadata annotations (e.g. example=value)
       --auto-prune                                 Set automatic pruning when sync is automated
       --config-management-plugin string            Config management plugin name
       --dest-name string                           K8s cluster Name (e.g. minikube)


### PR DESCRIPTION
Hello!

Added support for set metadata annotations with the `argocd-util app generate-spec` command.
My use case is to generate Annotations for use with the ArgoCD Image Updater.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

