### PR TITLE
chore: pre filter groups before enforcing #4296

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -43,6 +43,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Fave](https://myfave.com)
 1. [Future PLC](https://www.futureplc.com/)
 1. [Garner](https://www.garnercorp.com)
+1. [G DATA CyberDefense AG](https://www.gdata-software.com/)
 1. [Generali Deutschland AG](https://www.generali.de/)
 1. [Glovo](https://www.glovoapp.com)
 1. [GMETRI](https://gmetri.com/)

--- a/util/jwt/jwt.go
+++ b/util/jwt/jwt.go
@@ -12,6 +12,9 @@ import (
 
 // MapClaims converts a jwt.Claims to a MapClaims
 func MapClaims(claims jwtgo.Claims) (jwtgo.MapClaims, error) {
+	if mapClaims, ok := claims.(*jwtgo.MapClaims); ok {
+		return *mapClaims, nil
+	}
 	claimsBytes, err := json.Marshal(claims)
 	if err != nil {
 		return nil, err

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -150,6 +150,11 @@ func (e *Enforcer) EnforceErr(rvals ...interface{}) error {
 // user-defined policy. This allows any explicit denies of the built-in, and user-defined policies
 // to override the run-time policy. Runs normal enforcement if run-time policy is empty.
 func (e *Enforcer) EnforceRuntimePolicy(policy string, rvals ...interface{}) bool {
+	enf := e.CreateEnforcerWithRuntimePolicy(policy)
+	return e.EnforceWithCustomEnforcer(enf, rvals...)
+}
+
+func (e *Enforcer) CreateEnforcerWithRuntimePolicy(policy string) *casbin.Enforcer {
 	var enf *casbin.Enforcer
 	var err error
 	if policy == "" {
@@ -161,6 +166,10 @@ func (e *Enforcer) EnforceRuntimePolicy(policy string, rvals ...interface{}) boo
 			enf = e.Enforcer
 		}
 	}
+	return enf
+}
+
+func (e *Enforcer) EnforceWithCustomEnforcer(enf *casbin.Enforcer, rvals ...interface{}) bool {
 	return enforce(enf, e.defaultRole, e.claimsEnforcerFunc, rvals...)
 }
 

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -154,6 +154,9 @@ func (e *Enforcer) EnforceRuntimePolicy(policy string, rvals ...interface{}) boo
 	return e.EnforceWithCustomEnforcer(enf, rvals...)
 }
 
+// CreateEnforcerWithRuntimePolicy creates an enforcer with a policy defined at run-time which augments the built-in and
+// user-defined policy. This allows any explicit denies of the built-in, and user-defined policies
+// to override the run-time policy. Runs normal enforcement if run-time policy is empty.
 func (e *Enforcer) CreateEnforcerWithRuntimePolicy(policy string) *casbin.Enforcer {
 	var enf *casbin.Enforcer
 	var err error
@@ -169,6 +172,7 @@ func (e *Enforcer) CreateEnforcerWithRuntimePolicy(policy string) *casbin.Enforc
 	return enf
 }
 
+// EnforceWithCustomEnforcer wraps enforce with an custom enforcer
 func (e *Enforcer) EnforceWithCustomEnforcer(enf *casbin.Enforcer, rvals ...interface{}) bool {
 	return enforce(enf, e.defaultRole, e.claimsEnforcerFunc, rvals...)
 }


### PR DESCRIPTION
Part of: #4296

Impact of my change for 10000 applications and a user with 50 groups. I reduced the hits of EnforceRuntimePolicy from 500000 below 30000.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

