### PR TITLE
fix: update account.proto annotaion for gen grpc gateway

### DIFF
--- a/server/account/account.proto
+++ b/server/account/account.proto
@@ -78,7 +78,7 @@ service AccountService {
 
 	// CanI checks if the current account has permission to perform an action
 	rpc CanI(CanIRequest) returns (CanIResponse) {
-		option (google.api.http).get = "/api/v1/account/can-i/{resource}/{action}/{subresource}";
+		option (google.api.http).get = "/api/v1/account/can-i/{resource}/{action}/{subresource=**}";
 	}
 
 	// UpdatePassword updates an account's password to a new value


### PR DESCRIPTION
For /api/v1/account/can-i/{resource}/{action}/{subresource}
the subresource in path parm may have slash, so it need be a wildcard
ex: /api/v1/account/can-i/{resource}/{action}/{subresource}
may be /api/v1/account/can-i/projects/create/abc/abc-123
for now it will return 404