### PR TITLE
chore: stop publishing documentation to github pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,10 +21,3 @@ jobs:
         run: |
           pip install -r docs/requirements.txt
           mkdocs build
-      - name: deploy
-        if: ${{ github.event_name == 'push' }}
-        uses: peaceiris/actions-gh-pages@v2.5.0
-        env:
-          PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./site


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #5535 

PR removes step that publishes documentation to github pages. Will replace gh-pages branch content with redirect to readthedocs once this PR is merged.