### PR TITLE
fix: downgrade normalize-url to avoid crash in safari

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -80,7 +80,8 @@
   },
   "resolutions": {
     "@types/react": "16.9.3",
-    "@types/react-dom": "16.9.3"
+    "@types/react-dom": "16.9.3",
+    "normalize-url": "4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6316,10 +6316,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-normalize-url@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
-  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+normalize-url@4.3.0, normalize-url@^6.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.3.0.tgz#9c49e10fc1876aeb76dba88bf1b2b5d9fa57b2ee"
+  integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
 
 npm-run-path@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #6701 

Safari cannot render Argo CD UI due to https://github.com/sindresorhus/normalize-url/issues/105 . The normalize-url version was upgraded to resolve security vulnerability. According to https://snyk.io/vuln/npm:normalize-url we can as well downgrade to 4.3.0 . Argo CD does not really need features of never version and we can safely downgrade and remove vulnerability as well.