### PR TITLE
chore: Skip cluster e2e tests if already run

### DIFF
--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -11,12 +11,15 @@ import (
 )
 
 func TestClusterList(t *testing.T) {
+	SkipIfAlreadyRun(t)
 	output := FailOnErr(RunCli("cluster", "list")).(string)
 	assert.Equal(t, fmt.Sprintf(`SERVER                          NAME        VERSION  STATUS      MESSAGE
 https://kubernetes.default.svc  in-cluster  %v     Successful  `, GetVersions().ServerVersion), output)
+	RecordTestRun(t)
 }
 
 func TestClusterGet(t *testing.T) {
+	SkipIfAlreadyRun(t)
 	output := FailOnErr(RunCli("cluster", "get", "https://kubernetes.default.svc")).(string)
 
 	assert.Contains(t, output, fmt.Sprintf(`
@@ -29,4 +32,5 @@ serverVersion: "%v"`, GetVersions().ServerVersion))
     insecure: false`)
 
 	assert.Contains(t, output, `status: Successful`)
+	RecordTestRun(t)
 }

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -12,14 +12,15 @@ import (
 
 func TestClusterList(t *testing.T) {
 	SkipIfAlreadyRun(t)
+	defer RecordTestRun(t)
 	output := FailOnErr(RunCli("cluster", "list")).(string)
 	assert.Equal(t, fmt.Sprintf(`SERVER                          NAME        VERSION  STATUS      MESSAGE
 https://kubernetes.default.svc  in-cluster  %v     Successful  `, GetVersions().ServerVersion), output)
-	RecordTestRun(t)
 }
 
 func TestClusterGet(t *testing.T) {
 	SkipIfAlreadyRun(t)
+	defer RecordTestRun(t)
 	output := FailOnErr(RunCli("cluster", "get", "https://kubernetes.default.svc")).(string)
 
 	assert.Contains(t, output, fmt.Sprintf(`
@@ -32,5 +33,4 @@ serverVersion: "%v"`, GetVersions().ServerVersion))
     insecure: false`)
 
 	assert.Contains(t, output, `status: Successful`)
-	RecordTestRun(t)
 }


### PR DESCRIPTION
The `TestClusterList` and `TestClusterGet` e2e tests aren't skipped if already run (and requested to skip). They can't be run without another e2e having run before to ensure a clean state, so properly skip and record them when `ARGOCD_E2E_RECORD` is set.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

