### PR TITLE
feat: enable specifying root ca for oidc (#6712)

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -372,6 +372,21 @@ You are not required to specify a logoutRedirectURL as this is automatically gen
 !!! note
    The post logout redirect URI may need to be whitelisted against your OIDC provider's client settings for ArgoCD.
 
+### Configuring a custom root CA certificate for communicating with the OIDC provider
+
+If your OIDC provider is setup with a certificate which is not signed by one of the well known certificate authorities
+you can provide a custom certificate which will be used in verifying the OIDC provider's TLS certificate when
+communicating with it.  
+Add a `rootCA` to your `oidc.config` which contains the PEM encoded root certificate:
+
+```yaml
+  oidc.config: |
+    ...
+    rootCA: |
+      -----BEGIN CERTIFICATE-----
+      ... encoded certificate data here ...
+      -----END CERTIFICATE-----
+```
 
 
 ## SSO Further Reading

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -107,10 +107,7 @@ func NewClientApp(settings *settings.ArgoCDSettings, cache OIDCStateStorage, dex
 	if err != nil {
 		return nil, fmt.Errorf("parse redirect-uri: %v", err)
 	}
-	tlsConfig := settings.TLSConfig()
-	if tlsConfig != nil {
-		tlsConfig.InsecureSkipVerify = true
-	}
+	tlsConfig := settings.OIDCTLSConfig()
 	a.client = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -111,6 +111,7 @@ type OIDCConfig struct {
 	RequestedScopes        []string               `json:"requestedScopes,omitempty"`
 	RequestedIDTokenClaims map[string]*oidc.Claim `json:"requestedIDTokenClaims,omitempty"`
 	LogoutURL              string                 `json:"logoutURL,omitempty"`
+	RootCA                 string                 `json:"rootCA,omitempty"`
 }
 
 // DEPRECATED. Helm repository credentials are now managed using RepoCredentials
@@ -1390,6 +1391,27 @@ func (a *ArgoCDSettings) OAuth2ClientSecret() string {
 		return a.DexOAuth2ClientSecret()
 	}
 	return ""
+}
+
+func (a *ArgoCDSettings) OIDCTLSConfig() *tls.Config {
+	if oidcConfig := a.OIDCConfig(); oidcConfig != nil {
+		if oidcConfig.RootCA != "" {
+			certPool := x509.NewCertPool()
+			ok := certPool.AppendCertsFromPEM([]byte(oidcConfig.RootCA))
+			if !ok {
+				log.Warn("invalid oidc root ca cert - returning default tls.Config instead")
+				return &tls.Config{}
+			}
+			return &tls.Config{
+				RootCAs: certPool,
+			}
+		}
+	}
+	tlsConfig := a.TLSConfig()
+	if tlsConfig != nil {
+		tlsConfig.InsecureSkipVerify = true
+	}
+	return tlsConfig
 }
 
 func appendURLPath(inputURL string, inputPath string) (string, error) {


### PR DESCRIPTION
When configuring an external OIDC provider which uses a private PKI
for its certificates it was not possible to properly verify the certificate
being served. Also, when using ArgoCD in insecure mode, e.g. when running
behind istio for providing mTLS, this resulted in errors.

Closes [6713]

Issue: https://github.com/argoproj/argo-cd/issues/6713

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

