### PR TITLE
docs: Add cluster URL when creating an app to be consistent with the screenshot

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -150,7 +150,7 @@ Connect the [https://github.com/argoproj/argocd-example-apps.git](https://github
 
 ![connect repo](assets/connect-repo.png)
 
-For **Destination**, set cluster to `in-cluster` and namespace to `default`:
+For **Destination**, set cluster URL to `https://kubernetes.default.svc` (or `in-cluster` for cluster name) and namespace to `default`:
 
 ![destination](assets/destination.png)
 


### PR DESCRIPTION
See https://argo-cd.readthedocs.io/en/stable/getting_started/#creating-apps-via-ui. The screenshot uses the cluster URL instead cluster name. 

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

