### PR TITLE
feat: Add Redis SSL support. Fixes #4688

### DIFF
--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -37,6 +37,7 @@ permits access to the API request.
 All network communication is performed over TLS including service-to-service communication between
 the three components (argocd-server, argocd-repo-server, argocd-application-controller). The Argo CD
 API server can enforce the use of TLS 1.2 using the flag: `--tlsminversion 1.2`.
+Communication with Redis is performed over plain HTTP by default. TLS can be setup with command line arguments.
 
 ## Sensitive Information
 

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -36,6 +36,11 @@ argocd-application-controller [flags]
       --operation-processors int              Number of application operation processors (default 10)
       --password string                       Password for basic authentication to the API server
       --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
+      --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.
       --repo-server string                    Repo server address. (default "argocd-repo-server:8081")
       --repo-server-plaintext                 Disable TLS on connections to repo server

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -22,6 +22,11 @@ argocd-repo-server [flags]
       --parallelismlimit int                 Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit.
       --port int                             Listen on given port for incoming connections (default 8081)
       --redis string                         Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string          Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string      Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string              Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-insecure-skip-tls-verify       Skip Redis server certificate validation.
+      --redis-use-tls                        Use TLS when connecting to Redis. 
       --redisdb int                          Redis database.
       --repo-cache-expiration duration       Cache expiration for repo state, incl. app lists, app details, manifest generation, revision meta-data (default 24h0m0s)
       --revision-cache-expiration duration   Cache expiration for cached revision (default 3m0s)

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -41,6 +41,11 @@ argocd-server [flags]
       --password string                               Password for basic authentication to the API server
       --port int                                      Listen on given port (default 8080)
       --redis string                                  Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string                   Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string               Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string                       Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-insecure-skip-tls-verify                Skip Redis server certificate validation.
+      --redis-use-tls                                 Use TLS when connecting to Redis. 
       --redisdb int                                   Redis database.
       --repo-server string                            Repo server address (default "argocd-repo-server:8081")
       --repo-server-plaintext                         Use a plaintext client (non-TLS) to connect to repository server

--- a/docs/operator-manual/server-commands/argocd-util_cluster_shards.md
+++ b/docs/operator-manual/server-commands/argocd-util_cluster_shards.md
@@ -25,6 +25,11 @@ argocd-util cluster shards [flags]
       --password string                       Password for basic authentication to the API server
       --port-forward-redis                    Automatically port-forward ha proxy redis from current namespace? (default true)
       --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
+      --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.
       --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified
       --request-timeout string                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")

--- a/docs/operator-manual/server-commands/argocd-util_cluster_stats.md
+++ b/docs/operator-manual/server-commands/argocd-util_cluster_stats.md
@@ -25,6 +25,11 @@ argocd-util cluster stats [flags]
       --password string                       Password for basic authentication to the API server
       --port-forward-redis                    Automatically port-forward ha proxy redis from current namespace? (default true)
       --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
+      --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.
       --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified
       --request-timeout string                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -7,14 +7,15 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-redis/redis/v8"
-	"github.com/spf13/cobra"
 	"crypto/tls"
 	"crypto/x509"
 
+	"github.com/go-redis/redis/v8"
+	"github.com/spf13/cobra"
+
 	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/util/env"
 	certutil "github.com/argoproj/argo-cd/v2/util/cert"
+	"github.com/argoproj/argo-cd/v2/util/env"
 )
 
 const (
@@ -54,8 +55,8 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	cmd.Flags().BoolVar(&insecureRedis, "redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
 	cmd.Flags().StringVar(&redisCACerticate, "redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
 	return func() (*Cache, error) {
-		var tlsConfig *tls.Config = nil;
-		if (redisUseTLS) {
+		var tlsConfig *tls.Config = nil
+		if redisUseTLS {
 			tlsConfig = &tls.Config{}
 			if redisClientCertificate != "" {
 				clientCert, err := tls.LoadX509KeyPair(redisClientCertificate, redisClientKey)

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/spf13/cobra"
+	"crypto/tls"
+	"crypto/x509"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/util/env"
+	certutil "github.com/argoproj/argo-cd/v2/util/cert"
 )
 
 const (
@@ -33,6 +36,11 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	sentinelAddresses := make([]string, 0)
 	sentinelMaster := ""
 	redisDB := 0
+	redisCACerticate := ""
+	redisClientCertificate := ""
+	redisClientKey := ""
+	redisUseTLS := false
+	insecureRedis := false
 	var defaultCacheExpiration time.Duration
 
 	cmd.Flags().StringVar(&redisAddress, "redis", env.StringFromEnv("REDIS_SERVER", ""), "Redis server hostname and port (e.g. argocd-redis:6379). ")
@@ -40,7 +48,38 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	cmd.Flags().StringArrayVar(&sentinelAddresses, "sentinel", []string{}, "Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). ")
 	cmd.Flags().StringVar(&sentinelMaster, "sentinelmaster", "master", "Redis sentinel master group name.")
 	cmd.Flags().DurationVar(&defaultCacheExpiration, "default-cache-expiration", env.ParseDurationFromEnv("ARGOCD_DEFAULT_CACHE_EXPIRATION", 24*time.Hour, 0, math.MaxInt32), "Cache expiration default")
+	cmd.Flags().BoolVar(&redisUseTLS, "redis-use-tls", false, "Use TLS when connecting to Redis. ")
+	cmd.Flags().StringVar(&redisClientCertificate, "redis-client-certificate", "", "Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).")
+	cmd.Flags().StringVar(&redisClientKey, "redis-client-key", "", "Path to Redis client key (e.g. /etc/certs/redis/client.crt).")
+	cmd.Flags().BoolVar(&insecureRedis, "redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
+	cmd.Flags().StringVar(&redisCACerticate, "redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
 	return func() (*Cache, error) {
+		var tlsConfig *tls.Config = nil;
+		if (redisUseTLS) {
+			tlsConfig = &tls.Config{}
+			if redisClientCertificate != "" {
+				clientCert, err := tls.LoadX509KeyPair(redisClientCertificate, redisClientKey)
+				if err != nil {
+					return nil, err
+				}
+				tlsConfig.Certificates = []tls.Certificate{clientCert}
+			}
+			if insecureRedis {
+				tlsConfig.InsecureSkipVerify = true
+			} else if redisCACerticate != "" {
+				redisCA, err := certutil.ParseTLSCertificatesFromPath(redisCACerticate)
+				if err != nil {
+					return nil, err
+				}
+				tlsConfig.RootCAs = certutil.GetCertPoolFromPEMData(redisCA)
+			} else {
+				var err error
+				tlsConfig.RootCAs, err = x509.SystemCertPool()
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
 		password := os.Getenv(envRedisPassword)
 		maxRetries := env.ParseNumFromEnv(envRedisRetryCount, defaultRedisRetryCount, 0, math.MaxInt32)
 		if len(sentinelAddresses) > 0 {
@@ -50,21 +89,23 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 				DB:            redisDB,
 				Password:      password,
 				MaxRetries:    maxRetries,
+				TLSConfig:     tlsConfig,
 			})
 			for i := range opts {
 				opts[i](client)
 			}
 			return NewCache(NewRedisCache(client, defaultCacheExpiration)), nil
 		}
-
 		if redisAddress == "" {
 			redisAddress = common.DefaultRedisAddr
 		}
+
 		client := redis.NewClient(&redis.Options{
 			Addr:       redisAddress,
 			Password:   password,
 			DB:         redisDB,
 			MaxRetries: maxRetries,
+			TLSConfig:  tlsConfig,
 		})
 		for i := range opts {
 			opts[i](client)


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

This is similar to https://github.com/argoproj/argo-cd/pull/4689, but adds more options to support various scenarios menitioned in the original PR:
1. insecure tls:
`--redis argocd-redis:6379 --redis-use-tls --redis-insecure-skip-tls-verify`

2. self-signed cert on redis server
`--redis argocd-redis:6379 --redis-use-tls --redis-ca-certificate /home/argocd/redis-tls/tls.crt --redis-client-certificate /home/argocd/redis-client-tls/tls.crt --redis-client-key /home/argocd/redis-client-tls/tls.key`

3. private ca:
`--redis argocd-redis:6379 --redis-use-tls --redis-ca-certificate /home/argocd/ca/tls.crt --redis-client-certificate /home/argocd/redis-client-tls/tls.crt --redis-client-key /home/argocd/redis-client-tls/tls.key`

4. system ca:
`--redis argocd-redis:6379 --redis-use-tls --redis-client-certificate /home/argocd/redis-client-tls/tls.crt --redis-client-key /home/argocd/redis-client-tls/tls.key`

Looking into updating tests ~~and the docs~~