### PR TITLE
fix: allow argocd-notification ingress to repo-server

### DIFF
--- a/manifests/base/repo-server/argocd-repo-server-network-policy.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-network-policy.yaml
@@ -16,6 +16,9 @@ spec:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-application-controller
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: argocd-notifications-controller
       ports:
         - protocol: TCP
           port: 8081

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4629,6 +4629,9 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-application-controller
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-notifications-controller
     ports:
     - port: 8081
       protocol: TCP

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2016,6 +2016,9 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-application-controller
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-notifications-controller
     ports:
     - port: 8081
       protocol: TCP

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3781,6 +3781,9 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-application-controller
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-notifications-controller
     ports:
     - port: 8081
       protocol: TCP

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1168,6 +1168,9 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-application-controller
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-notifications-controller
     ports:
     - port: 8081
       protocol: TCP


### PR DESCRIPTION
This change allows an argocd-notification installation using the provided
manifests to ingress to the repo-server.

I am not sure if there is a prevailing opinion about how to manage a
cross project network policy for these related components so I thought
I would put up a PR to spark that discussion. This could live in a separate
NetworkPolicy object managed by the argocd-notifications manifests but I
thought it wuold be better for the possible ingresses for the argocd project
to all live in the argo-cd manifests. I know that notifications are an optional
component, so maybe this is better provided as a separate manifest that can
be strategic merged in? (I am a kustomize user).

Regardless, I think this policy is something that be maintained by argoproj
in some form to reduce release burden of users trying to hand maintain network
policies.

Fixes #argoproj-labs/argocd-notifications#294

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

