### PR TITLE
fix: copy ui assets into correct dist directory during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN go mod download
 
 # Perform the build
 COPY . .
-COPY --from=argocd-ui ./src/dist/app ./src/ui/dist/app
+COPY --from=argocd-ui /src/dist/app /go/src/github.com/argoproj/argo-cd/ui/dist/app
 RUN make argocd-all
 
 ARG BUILD_ALL_CLIS=true


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

