### PR TITLE
docs(users): add woolworths,wooliesx

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -137,6 +137,8 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Webstores](https://www.webstores.nl)
 1. [Whitehat Berlin](https://whitehat.berlin) by Guido Maria Serra +Fenaroli
 1. [Witick](https://witick.io/)
+1. [WooliesX](https://wooliesx.com.au/)
+1. [Woolworths Group](https://www.woolworthsgroup.com.au/)
 1. [WSpot](https://www.wspot.com.br/)
 1. [Yieldlab](https://www.yieldlab.de/)
 1. [Zimpler](https://www.zimpler.com/)


### PR DESCRIPTION
already using argo-workflow/events, now cd

I'm wondering how come the buttom of the users.md restarts the alphabetical list, seems odd to me

![image](https://user-images.githubusercontent.com/20961507/126726053-f3cf48aa-3a5e-49ca-9c08-d8e2e7fe5683.png)


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

