### PR TITLE
refactor: enhance application resources filter panels

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/foundation-sites/scss/util/util';
 
 $header: 120px;
 
@@ -188,5 +189,18 @@ $header: 120px;
 
     &__commit-message {
         line-height: 1.5em;
+    }
+
+    @include breakpoint(xxlarge up) {
+        .filters-group {
+            position: fixed;
+            padding-right: 1.5em;
+            max-height: calc(100vh - 200px);
+            overflow: hidden;
+        }
+    
+        .filters-group:hover {
+            overflow-y: auto;
+        }
     }
 }

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -1,11 +1,11 @@
-import {ActionButton, useData} from 'argo-ui/v2';
+import {useData} from 'argo-ui/v2';
 import * as minimatch from 'minimatch';
 import * as React from 'react';
 import {Application, ApplicationDestination, Cluster, HealthStatusCode, HealthStatuses, SyncStatusCode, SyncStatuses} from '../../../shared/models';
 import {AppsListPreferences, services} from '../../../shared/services';
-import {Filter} from '../filter/filter';
+import {Filter, FiltersGroup} from '../filter/filter';
 import * as LabelSelector from '../label-selector';
-import {ComparisonStatusIcon, HealthStatusIcon, useActionOnLargeWindow} from '../utils';
+import {ComparisonStatusIcon, HealthStatusIcon} from '../utils';
 
 export interface FilterResult {
     projects: boolean;
@@ -208,36 +208,20 @@ const NamespaceFilter = (props: AppFilterProps) => {
 };
 
 export const ApplicationsFilter = (props: AppFilterProps) => {
-    const hidden = props.pref.hideFilters;
-    const setHidden = (val: boolean) => {
-        services.viewPreferences.updatePreferences({appList: {...props.pref, hideFilters: val}});
+    const setShown = (val: boolean) => {
+        services.viewPreferences.updatePreferences({appList: {...props.pref, hideFilters: !val}});
     };
 
-    useActionOnLargeWindow(() => setHidden(false));
     return (
-        <React.Fragment>
-            <div className='applications-list__filters__title'>
-                FILTERS <i className='fa fa-filter' />
-                <ActionButton
-                    label={hidden ? 'SHOW' : 'HIDE'}
-                    action={() => setHidden(!hidden)}
-                    style={{marginLeft: 'auto', fontSize: '12px', lineHeight: '5px', display: hidden && 'block'}}
-                />
+        <FiltersGroup setShown={setShown} shown={!props.pref.hideFilters}>
+            <SyncFilter {...props} />
+            <HealthFilter {...props} />
+            <div className='filters-container__subgroup'>
+                <LabelsFilter {...props} />
+                <ProjectFilter {...props} />
+                <ClusterFilter {...props} />
+                <NamespaceFilter {...props} />
             </div>
-            <div className='applications-list__filters'>
-                {!hidden && (
-                    <React.Fragment>
-                        <SyncFilter {...props} />
-                        <HealthFilter {...props} />
-                        <div className='applications-list__filters__text-filters'>
-                            <LabelsFilter {...props} />
-                            <ProjectFilter {...props} />
-                            <ClusterFilter {...props} />
-                            <NamespaceFilter {...props} />
-                        </div>
-                    </React.Fragment>
-                )}
-            </div>
-        </React.Fragment>
+        </FiltersGroup>
     );
 };

--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -67,50 +67,6 @@
         }
     }
 
-    &__filters {
-        display: flex;
-        &__title {
-            margin-bottom: 1em;
-            font-size: 13px;
-            color: $argo-color-gray-6;
-            display: flex;
-            align-items: center;
-        }
-
-        .filter {
-            margin-right: 15px;
-            height: max-content;
-            min-width: 200px;
-            max-width: 200px;
-        }
-
-        &__text-filters {
-            align-self: start;
-            display: flex;
-            flex-wrap: wrap;
-        }
-    }
-
-    @include breakpoint(xxlarge up) {
-        .filter {
-            width: 100%;
-            margin-right: 0;
-        }
-
-        &__filters {
-            flex-wrap: wrap;
-            padding-bottom: 6em;
-
-            &__title .action-button {
-                display: none;
-            }
-
-            &__text-filters {
-                width: 100%;
-            }
-        }
-    }
-
     &__view-type {
         white-space: nowrap;
         i {

--- a/ui/src/app/applications/components/filter/filter.scss
+++ b/ui/src/app/applications/components/filter/filter.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/foundation-sites/scss/util/util';
 
 .filter {
     background-color: white;
@@ -41,5 +42,71 @@
     &__error,
     &__loading {
         text-align: center;
+    }
+
+    &--wrap {
+        overflow: auto;
+        .checkbox__item {
+            min-width: 4.5em;
+            float: left;
+        }
+    }
+}
+
+.filters-group {
+    &__container {
+        display: flex;
+        &__title {
+            margin-bottom: 1em;
+            font-size: 13px;
+            color: $argo-color-gray-6;
+            display: flex;
+            align-items: center;
+            width: 260px;
+        }
+
+        .filter {
+            margin-right: 15px;
+            height: max-content;
+            min-width: 260px;
+            max-width: 260px;
+        }
+
+        &__subgroup {
+            align-self: start;
+            display: flex;
+            flex-wrap: wrap;
+        }
+    }
+
+    &__container--hidden {
+        display: none;
+    }
+}
+
+@include breakpoint(xxlarge up) {
+    .filter {
+        width: 100%;
+        margin-right: 0;
+    }
+
+    .filters-group {
+        &__container {
+            width: 260px;
+            flex-wrap: wrap;
+            padding-bottom: 6em;
+
+            &__title .action-button {
+                display: none;
+            }
+
+            &__text-filters {
+                width: 100%;
+            }
+        }
+
+        &__container--hidden {
+            display: flex;
+        }
     }
 }

--- a/ui/src/app/applications/components/filter/filter.tsx
+++ b/ui/src/app/applications/components/filter/filter.tsx
@@ -1,4 +1,5 @@
-import {Autocomplete, CheckboxOption, CheckboxRow} from 'argo-ui/v2';
+import {ActionButton, Autocomplete, CheckboxOption, CheckboxRow} from 'argo-ui/v2';
+import classNames from 'classnames';
 import * as React from 'react';
 
 import './filter.scss';
@@ -14,7 +15,27 @@ interface FilterProps {
     retry?: () => void;
     loading?: boolean;
     radio?: boolean;
+    wrap?: boolean;
 }
+
+export const FiltersGroup = (props: {children?: React.ReactNode; appliedFilter?: string[]; shown: boolean; setShown: (val: boolean) => void; onClearFilter?: () => void}) => {
+    return (
+        <div className='filters-group'>
+            <div className='filters-group__container__title'>
+                FILTERS <i className='fa fa-filter' />
+                {props.appliedFilter?.length > 0 && props.onClearFilter && (
+                    <ActionButton label={'CLEAR ALL'} action={() => props.onClearFilter()} style={{marginLeft: 'auto', fontSize: '12px', lineHeight: '5px', display: 'block'}} />
+                )}
+                <ActionButton
+                    label={!props.shown ? 'SHOW' : 'HIDE'}
+                    action={() => props.setShown(!props.shown)}
+                    style={{marginLeft: props.appliedFilter?.length > 0 ? '5px' : 'auto', fontSize: '12px', lineHeight: '5px'}}
+                />
+            </div>
+            <div className={classNames('filters-group__container', {'filters-group__container--hidden': !props.shown})}>{props.children}</div>
+        </div>
+    );
+};
 
 export const Filter = (props: FilterProps) => {
     const init = {} as {[label: string]: boolean};
@@ -40,7 +61,7 @@ export const Filter = (props: FilterProps) => {
     }, [values]);
 
     return (
-        <div className='filter'>
+        <div className={classNames('filter', {'filter--wrap': props.wrap})}>
             <div className='filter__header'>
                 {props.label || 'FILTER'}
                 {(props.selected || []).length > 0 || (props.field && Object.keys(values).length > 0) ? (

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -12,7 +12,6 @@ import {COLORS, ErrorNotification, Revision} from '../../shared/components';
 import {ContextApis} from '../../shared/context';
 import * as appModels from '../../shared/models';
 import {services} from '../../shared/services';
-import {debounce} from 'argo-ui/v2/utils';
 
 require('./utils.scss');
 
@@ -912,16 +911,3 @@ export const BASE_COLORS = [
     '#4B0082', // purple
     '#964B00' // brown
 ];
-
-export const useActionOnLargeWindow = (action: () => void) => {
-    React.useEffect(() => {
-        const handleResize = () => {
-            if (window.innerWidth >= 1440) {
-                action();
-            }
-        };
-
-        window.addEventListener('resize', debounce(handleResize, 1000));
-        return () => window.removeEventListener('resize', handleResize);
-    });
-};


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR implements the following changes:

* changes resource filter position to fixed
* add icons to health, sync status filter panels on app details page
![image](https://user-images.githubusercontent.com/426437/126730708-1fe85efd-a2f9-488d-b0e6-0ac187e4c2f0.png)

* ownership and age filter checkboxes are rendered more compact

![image](https://user-images.githubusercontent.com/426437/126730835-c5b32ee9-4049-4c30-89b1-d224abc2cca9.png)

* filter panels are grouped together (similarly to app list page filters)
![image](https://user-images.githubusercontent.com/426437/126730904-0ef0bf0d-f666-453c-b997-c2bf32ab549a.png)

* duplicated code is moved into `FiltersGroup` component