### PR TITLE
Update link to Helm secrets

### DIFF
--- a/docs/operator-manual/secret-management.md
+++ b/docs/operator-manual/secret-management.md
@@ -7,7 +7,7 @@ Argo CD is un-opinionated about how secrets are managed. There's many ways to do
 * [External Secrets Operator](https://github.com/ContainerSolutions/externalsecret-operator)
 * [Hashicorp Vault](https://www.vaultproject.io)
 * [Banzai Cloud Bank-Vaults](https://github.com/banzaicloud/bank-vaults)
-* [Helm Secrets](https://github.com/futuresimple/helm-secrets)
+* [Helm Secrets](https://github.com/jkroepke/helm-secrets)
 * [Kustomize secret generator plugins](https://github.com/kubernetes-sigs/kustomize/blob/fd7a353df6cece4629b8e8ad56b71e30636f38fc/examples/kvSourceGoPlugin.md#secret-values-from-anywhere)
 * [aws-secret-operator](https://github.com/mumoshu/aws-secret-operator)
 * [KSOPS](https://github.com/viaduct-ai/kustomize-sops#argo-cd-integration)


### PR DESCRIPTION
The helm secrets link (https://github.com/futuresimple/helm-secrets) is pointing to the deprecated version of the tool. In their Deprecation notice (https://github.com/zendesk/helm-secrets#deprecation-information) they recommend moving to the maintained fork https://github.com/jkroepke/helm-secrets

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

