### PR TITLE
fix: argocd admin repo generate-spec should convert secret data

### DIFF
--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -581,7 +581,6 @@ func NewGenClusterConfigCommand(pathOpts *clientcmd.PathOptions) *cobra.Command 
 			secret, err := kubeClientset.CoreV1().Secrets(ArgoCDNamespace).Get(context.Background(), secName, v1.GetOptions{})
 			errors.CheckError(err)
 
-			ConvertSecretData(secret)
 			errors.CheckError(PrintResources(outputFormat, os.Stdout, secret))
 		},
 	}

--- a/cmd/argocd/commands/admin/generatespec_utils.go
+++ b/cmd/argocd/commands/admin/generatespec_utils.go
@@ -38,6 +38,9 @@ func getOutWriter(inline bool, filePath string) (io.Writer, io.Closer, error) {
 // PrintResources prints a single resource in YAML or JSON format to stdout according to the output format
 func PrintResources(output string, out io.Writer, resources ...interface{}) error {
 	for i, resource := range resources {
+		if secret, ok := resource.(*v1.Secret); ok {
+			convertSecretData(secret)
+		}
 		filteredResource, err := omitFields(resource)
 		if err != nil {
 			return err
@@ -78,7 +81,7 @@ func omitFields(resource interface{}) (interface{}, error) {
 	}
 
 	toMap := make(map[string]interface{})
-	err = json.Unmarshal([]byte(string(jsonBytes)), &toMap)
+	err = json.Unmarshal(jsonBytes, &toMap)
 	if err != nil {
 		return nil, err
 	}
@@ -93,8 +96,8 @@ func omitFields(resource interface{}) (interface{}, error) {
 	return toMap, nil
 }
 
-// ConvertSecretData converts kubernetes secret's data to stringData
-func ConvertSecretData(secret *v1.Secret) {
+// convertSecretData converts kubernetes secret's data to stringData
+func convertSecretData(secret *v1.Secret) {
 	secret.Kind = kube.SecretKind
 	secret.APIVersion = "v1"
 	secret.StringData = map[string]string{}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The `argocd admin repo generate-spec` command is supposed to convert `data` fields of generated secret to `stringData` but not doing it. The PR fixes the error:

```
argocd admin repo generate-spec https://github.com/argoproj/argocd-example-apps --name stable --username my-username --password my-password
apiVersion: v1
kind: Secret
metadata:
  annotations:
    managed-by: argocd.argoproj.io
  labels:
    argocd.argoproj.io/secret-type: repository
  name: repo-1686952910
stringData:
  name: stable
  password: my-password
  type: git
  url: https://github.com/argoproj/argocd-example-apps
  username: my-username
```