### PR TITLE
Correct the ALB ingress example so that it is a valid spec Kubernetes

### DIFF
--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -379,7 +379,7 @@ spec:
 Once we create this service, we can configure the Ingress to conditionally route all `application/grpc` traffic to the new HTTP2 backend, using the `alb.ingress.kubernetes.io/conditions` annotation, as seen below. Note: The value after the . in the condition annotation _must_ be the same name as the service that you want traffic to route to - and will be applied on any path with a matching serviceName. 
 
 ```yaml
-  apiVersion: networking.k8s.io/v1 # Use extensions/v1beta1 for Kubernetes 1.18 and older
+  apiVersion: networking.k8s.io/v1 # Use extensions/v1beta1 and adjust the specification accordingly for Kubernetes 1.18 and older
   kind: Ingress
   metadata:
     annotations:
@@ -396,12 +396,16 @@ Once we create this service, we can configure the Ingress to conditionally route
       http:
         paths:
         - backend:
-            serviceName: argogrpc
-            servicePort: 443
+            service:
+              name: argogrpc
+              port:
+                number: 443
           pathType: ImplementationSpecific
         - backend:
-            serviceName: argocd-server
-            servicePort: 443
+            service:
+              name: argocd-server
+              port:
+                number: 443
           pathType: ImplementationSpecific
     tls:
     - hosts:


### PR DESCRIPTION
spec was wrong for the given API version of networking.k8s.io/v1

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

