### PR TITLE
fix: util.cli.SetLogLevel should update global log level

### DIFF
--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -162,6 +162,7 @@ func SetLogLevel(logLevel string) {
 	level, err := log.ParseLevel(text.FirstNonEmpty(logLevel, log.InfoLevel.String()))
 	errors.CheckError(err)
 	os.Setenv(common.EnvLogLevel, level.String())
+	log.SetLevel(level)
 }
 
 // SetGLogLevel set the glog level for the k8s go-client


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #6850 

The https://github.com/argoproj/argo-cd/commit/e44fa434abcfd622f13cf8a0107bc84752184f36 accidentally dropped code that updates global logger log level. Adding this line back.