### PR TITLE
fix: upgrade to kustomize 4.2.0

### DIFF
--- a/docs/operator-manual/upgrading/2.0-2.1.md
+++ b/docs/operator-manual/upgrading/2.0-2.1.md
@@ -2,7 +2,7 @@
 
 ## Upgraded Kustomize Version
 
-Note that bundled Kustomize has been upgraded to v4.1.2. Some of the flags are changed in Kustomize V4. 
+Note that bundled Kustomize has been upgraded to v4.2.0. Some of the flags are changed in Kustomize V4. 
 For example flag name `load_restrictor` is changed in Kustomize v4+. It is changed from `--load_restrictor=none` to `--load-restrictor LoadRestrictionsNone`. 
 
 ## Replacing `--app-resync` flag with `timeout.reconciliation` setting

--- a/hack/installers/checksums/kustomize_4.1.2_linux_amd64.tar.gz.sha256
+++ b/hack/installers/checksums/kustomize_4.1.2_linux_amd64.tar.gz.sha256
@@ -1,1 +1,0 @@
-4efb7d0dadba7fab5191c680fcb342c2b6f252f230019cf9cffd5e4b0cad1d12  kustomize_4.1.2_linux_amd64.tar.gz

--- a/hack/installers/checksums/kustomize_4.1.2_linux_arm64.tar.gz.sha256
+++ b/hack/installers/checksums/kustomize_4.1.2_linux_arm64.tar.gz.sha256
@@ -1,1 +1,0 @@
-d4b0ababb06d7208b439c48c5dadf979433f062ee7131203f6a94ce1159c9d5e  kustomize_4.1.2_linux_arm64.tar.gz

--- a/hack/installers/checksums/kustomize_4.2.0_linux_amd64.tar.gz.sha256
+++ b/hack/installers/checksums/kustomize_4.2.0_linux_amd64.tar.gz.sha256
@@ -1,0 +1,1 @@
+220dd03dcda8e45dc50e4e42b2d71882cbc4c05e0ed863513e67930ecad939eb  kustomize_4.2.0_linux_amd64.tar.gz

--- a/hack/installers/checksums/kustomize_4.2.0_linux_arm64.tar.gz.sha256
+++ b/hack/installers/checksums/kustomize_4.2.0_linux_arm64.tar.gz.sha256
@@ -1,0 +1,1 @@
+33f2cf3b5db64c09560c187224e9d29452fde2b7f00f85941604fc75d9769e4a  kustomize_4.2.0_linux_arm64.tar.gz

--- a/hack/installers/install-codegen-tools.sh
+++ b/hack/installers/install-codegen-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-KUSTOMIZE_VERSION=4.1.2 "$(dirname $0)/../install.sh" helm2-linux jq-linux kustomize-linux protoc-linux swagger-linux
+KUSTOMIZE_VERSION=4.2.0 "$(dirname $0)/../install.sh" helm2-linux jq-linux kustomize-linux protoc-linux swagger-linux

--- a/hack/tool-versions.sh
+++ b/hack/tool-versions.sh
@@ -14,6 +14,6 @@ jq_version=1.6
 ksonnet_version=0.13.1
 kubectl_version=1.17.8
 kubectx_version=0.6.3
-kustomize4_version=4.1.2
+kustomize4_version=4.2.0
 protoc_version=3.7.1
 swagger_version=0.19.0


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Motivation for this PR

To bundle multiple resource into one ArgoCD Application, I'm mainly use kustomize, import helm charts like (kube-prometheus-stack) with [HelmChartInflationGenerator](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/builtins/#_helmchartinflationgenerator_) and enrich such release with additional resource like SealedSecret and oauth2-proxy.

kustomize 4.2.0 introduce the flag to import CRDs from helm charts. https://github.com/kubernetes-sigs/kustomize/pull/3898

I would like to use kustomize 4.2.0 to close the current gap with the CRD installation. Kustomize 4 is already present in the master, this change should not be consider as breaking change.

Workaround:

Provide kustomize 4.2.0 via [custom tooling](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/).