### PR TITLE
feat: Add a metric to express connection status to each cluster

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -74,6 +74,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Lytt](https://www.lytt.co/)
 1. [Major League Baseball](https://mlb.com)
 1. [Mambu](https://www.mambu.com/)
+1. [Mattermost](https://www.mattermost.com)
 1. [Max Kelsen](https://www.maxkelsen.com/)
 1. [MindSpore](https://mindspore.cn)
 1. [Mirantis](https://mirantis.com/)

--- a/controller/metrics/clustercollector.go
+++ b/controller/metrics/clustercollector.go
@@ -41,6 +41,12 @@ var (
 		descClusterDefaultLabels,
 		nil,
 	)
+	descClusterConnectionStatus = prometheus.NewDesc(
+		"argocd_cluster_connection_status",
+		"The k8s cluster current connection status.",
+		append(descClusterDefaultLabels, "k8s_version"),
+		nil,
+	)
 )
 
 type HasClustersInfo interface {
@@ -77,9 +83,11 @@ func (c *clusterCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descClusterCacheResources
 	ch <- descClusterAPIs
 	ch <- descClusterCacheAgeSeconds
+	ch <- descClusterConnectionStatus
 }
 
 func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
+
 	now := time.Now()
 	for _, c := range c.info {
 		defaultValues := []string{c.Server}
@@ -91,5 +99,6 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 			cacheAgeSeconds = int(now.Sub(*c.LastCacheSyncTime).Seconds())
 		}
 		ch <- prometheus.MustNewConstMetric(descClusterCacheAgeSeconds, prometheus.GaugeValue, float64(cacheAgeSeconds), defaultValues...)
+		ch <- prometheus.MustNewConstMetric(descClusterConnectionStatus, prometheus.GaugeValue, boolFloat64(c.SyncError != nil), append(defaultValues, c.K8SVersion)...)
 	}
 }


### PR DESCRIPTION
The cluster collector includes one more metric for kubernetes cluster connection
which rely on `SyncError`.

Closes [ISSUE #6855]

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

