### PR TITLE
fix: Set header to OIDC requests

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -47,6 +47,7 @@ import (
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/env"
 	grpc_util "github.com/argoproj/argo-cd/v2/util/grpc"
+	http_util "github.com/argoproj/argo-cd/v2/util/http"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/kube"
 	"github.com/argoproj/argo-cd/v2/util/localconfig"
@@ -354,16 +355,29 @@ func (c *client) HTTPClient() (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	headers, err := parseHeaders(c.Headers)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.UserAgent != "" {
+		headers.Set("User-Agent", c.UserAgent)
+	}
+
 	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-			Proxy:           http.ProxyFromEnvironment,
-			Dial: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
+		Transport: &http_util.TransportWithHeader{
+			RoundTripper: &http.Transport{
+				TLSClientConfig: tlsConfig,
+				Proxy:           http.ProxyFromEnvironment,
+				Dial: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+			Header: headers,
 		},
 	}, nil
 }
@@ -508,11 +522,14 @@ func (c *client) newConn() (*grpc.ClientConn, io.Closer, error) {
 
 	ctx := context.Background()
 
-	for _, kv := range c.Headers {
-		if len(strings.Split(kv, ":"))%2 == 1 {
-			return nil, nil, fmt.Errorf("additional headers must be colon(:)-separated: %s", kv)
+	headers, err := parseHeaders(c.Headers)
+	if err != nil {
+		return nil, nil, err
+	}
+	for k, vs := range headers {
+		for _, v := range vs {
+			ctx = metadata.AppendToOutgoingContext(ctx, k, v)
 		}
-		ctx = metadata.AppendToOutgoingContext(ctx, strings.Split(kv, ":")[0], strings.Split(kv, ":")[1])
 	}
 
 	if c.UserAgent != "" {
@@ -795,4 +812,16 @@ func isCanceledContextErr(err error) bool {
 		}
 	}
 	return false
+}
+
+func parseHeaders(headerStrings []string) (http.Header, error) {
+	headers := http.Header{}
+	for _, kv := range headerStrings {
+		items := strings.Split(kv, ":")
+		if len(items)%2 == 1 {
+			return nil, fmt.Errorf("additional headers must be colon(:)-separated: %s", kv)
+		}
+		headers.Add(items[0], items[1])
+	}
+	return headers, nil
 }

--- a/util/http/http.go
+++ b/util/http/http.go
@@ -136,3 +136,22 @@ func (d DebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	log.Printf("%s", respDump)
 	return resp, nil
 }
+
+// TransportWithHeader is a HTTP Client Transport with default headers.
+type TransportWithHeader struct {
+	RoundTripper http.RoundTripper
+	Header       http.Header
+}
+
+func (rt *TransportWithHeader) RoundTrip(r *http.Request) (*http.Response, error) {
+	if rt.Header != nil {
+		headers := rt.Header.Clone()
+		for k, vs := range r.Header {
+			for _, v := range vs {
+				headers.Add(k, v)
+			}
+		}
+		r.Header = headers
+	}
+	return rt.RoundTripper.RoundTrip(r)
+}

--- a/util/http/http_test.go
+++ b/util/http/http_test.go
@@ -39,3 +39,49 @@ func TestSplitCookie(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cookieValue, token)
 }
+
+// TestRoundTripper just copy request headers to the resposne.
+type TestRoundTripper struct{}
+
+func (rt TestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp := http.Response{}
+	resp.Header = http.Header{}
+	for k, vs := range req.Header {
+		for _, v := range vs {
+			resp.Header.Add(k, v)
+		}
+	}
+	return &resp, nil
+}
+
+func TestTransportWithHeader(t *testing.T) {
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req.Header.Set("Bar", "req_1")
+	req.Header.Set("Foo", "req_1")
+
+	// No default headers.
+	client.Transport = &TransportWithHeader{
+		RoundTripper: &TestRoundTripper{},
+	}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Header, http.Header{
+		"Bar": []string{"req_1"},
+		"Foo": []string{"req_1"},
+	})
+
+	// with default headers.
+	client.Transport = &TransportWithHeader{
+		RoundTripper: &TestRoundTripper{},
+		Header: http.Header{
+			"Foo": []string{"default_1", "default_2"},
+		},
+	}
+	resp, err = client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Header, http.Header{
+		"Bar": []string{"req_1"},
+		"Foo": []string{"default_1", "default_2", "req_1"},
+	})
+}


### PR DESCRIPTION
Fixes #6614 

I fixed the CLI code so it sets given headers to OIDC requests as well.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
