### PR TITLE
docs: rename credit agricole to credit agricole CIB.

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -30,7 +30,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Codefresh](https://www.codefresh.io/)
 1. [Codility](https://www.codility.com/)
 1. [Commonbond](https://commonbond.co/)
-1. [Crédit Agricole CIB](https://www.ca-cib.com) 
+1. [Crédit Agricole CIB](https://www.ca-cib.com)
 1. [CROZ d.o.o.](https://croz.net/)
 1. [CyberAgent](https://www.cyberagent.co.jp/en/)
 1. [Cybozu](https://cybozu-global.com)

--- a/USERS.md
+++ b/USERS.md
@@ -30,7 +30,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Codefresh](https://www.codefresh.io/)
 1. [Codility](https://www.codility.com/)
 1. [Commonbond](https://commonbond.co/)
-1. [Crédit Agricole](https://www.ca-cib.com) 
+1. [Crédit Agricole CIB](https://www.ca-cib.com) 
 1. [CROZ d.o.o.](https://croz.net/)
 1. [CyberAgent](https://www.cyberagent.co.jp/en/)
 1. [Cybozu](https://cybozu-global.com)


### PR DESCRIPTION
Simple rename of Credit Agricole to Credit Agricole CIB in the list of production users.