### PR TITLE
fix: client input arguments are ignored with equal sign #6822

### DIFF
--- a/util/config/env.go
+++ b/util/config/env.go
@@ -43,6 +43,17 @@ func loadFlags() error {
 	if key != "" {
 		flags[key] = "true"
 	}
+	// pkg shellquota doesn't recognize `=` so that the opts in format `foo=bar` could not work.
+	// issue ref: https://github.com/argoproj/argo-cd/issues/6822
+	for k, v := range flags {
+		if strings.Contains(k, "=") && strings.Count(k, "=") == 1 && v == "true" {
+			kv := strings.Split(k, "=")
+			actualKey, actualValue := kv[0], kv[1]
+			if _, ok := flags[actualKey]; !ok {
+				flags[actualKey] = actualValue
+			}
+		}
+	}
 	return nil
 }
 

--- a/util/config/env_test.go
+++ b/util/config/env_test.go
@@ -81,3 +81,9 @@ func TestFlagWithDoubleQuotes(t *testing.T) {
 
 	assert.Equal(t, "bar baz", GetFlag("foo", ""))
 }
+
+func TestFlagWithEqualSign(t *testing.T) {
+	loadOpts(t, "--foo=bar")
+
+	assert.Equal(t, "bar", GetFlag("foo", ""))
+}


### PR DESCRIPTION
Fix: #6822 
Signed-off-by: Charles Cai <charles.cai@sap.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

