### PR TITLE
fix: controller should not create orphaned resources warning by default

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1607,7 +1607,7 @@ type OrphanedResourceKey struct {
 
 // IsWarn returns true if warnings are enabled for orphan resources monitoring
 func (s *OrphanedResourcesMonitorSettings) IsWarn() bool {
-	return s.Warn == nil || *s.Warn
+	return s.Warn != nil && *s.Warn
 }
 
 // SignatureKey is the specification of a key required to verify commit signatures with

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2228,3 +2228,14 @@ func TestRemoveEnvEntry(t *testing.T) {
 		assert.EqualError(t, err, `unable to find env variable with key "key" for plugin "test"`)
 	})
 }
+
+func TestOrphanedResourcesMonitorSettings_IsWarn(t *testing.T) {
+	settings := OrphanedResourcesMonitorSettings{}
+	assert.False(t, settings.IsWarn())
+
+	settings.Warn = pointer.BoolPtr(false)
+	assert.False(t, settings.IsWarn())
+
+	settings.Warn = pointer.BoolPtr(true)
+	assert.True(t, settings.IsWarn())
+}

--- a/test/e2e/project_management_test.go
+++ b/test/e2e/project_management_test.go
@@ -66,7 +66,7 @@ func TestProjectCreation(t *testing.T) {
 	assert.Equal(t, "https://github.com/argoproj/argo-cd.git", proj.Spec.SourceRepos[0])
 
 	assert.NotNil(t, proj.Spec.OrphanedResources)
-	assert.True(t, proj.Spec.OrphanedResources.IsWarn())
+	assert.False(t, proj.Spec.OrphanedResources.IsWarn())
 
 	assertProjHasEvent(t, proj, "create", argo.EventReasonResourceCreated)
 


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Minor bug fix: controller should create orphan resource warning only if the setting is explicitly enabled by user.