### PR TITLE
fix: applications/resources filter improvement and bug fixes

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -44,7 +44,7 @@ $header: 120px;
     &__refreshing-label {
         position: fixed;
         top: $header + 100px;
-        left: 60px;
+        left: 310px;
         background-color: $argo-color-gray-4;
         border: 1px solid $argo-color-gray-5;
         border-radius: 5px;
@@ -192,16 +192,12 @@ $header: 120px;
         line-height: 1.5em;
     }
 
-    @include breakpoint(xxlarge up) {
-        .filters-group {
-            position: fixed;
-            padding-right: 1.5em;
-            max-height: calc(100vh - 200px);
-            overflow: hidden;
-        }
-    
-        .filters-group:hover {
-            overflow-y: auto;
+    .filters-group__panel {
+        top: 230px;
+    }
+    @include breakpoint(large down) {
+        .filters-group__panel {
+            top: 280px;
         }
     }
 }

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -216,28 +216,23 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                                                 </div>
                                             )}
                                             {((pref.view === 'tree' || pref.view === 'network') && (
-                                                <div className='row'>
-                                                    <div className='columns small-12 xxlarge-2'>
-                                                        <Filters pref={pref} tree={tree} onSetFilter={setFilter} onClearFilter={clearFilter} />
-                                                    </div>
-                                                    <div className='columns small-12 xxlarge-10'>
-                                                        <ApplicationResourceTree
-                                                            nodeFilter={node => this.filterTreeNode(node, treeFilter)}
-                                                            selectedNodeFullName={this.selectedNodeKey}
-                                                            onNodeClick={fullName => this.selectNode(fullName)}
-                                                            nodeMenu={node =>
-                                                                AppUtils.renderResourceMenu(node, application, tree, this.appContext, this.appChanged, () =>
-                                                                    this.getApplicationActionMenu(application, false)
-                                                                )
-                                                            }
-                                                            tree={tree}
-                                                            app={application}
-                                                            showOrphanedResources={pref.orphanedResources}
-                                                            useNetworkingHierarchy={pref.view === 'network'}
-                                                            onClearFilter={clearFilter}
-                                                        />
-                                                    </div>
-                                                </div>
+                                                <Filters pref={pref} tree={tree} onSetFilter={setFilter} onClearFilter={clearFilter}>
+                                                    <ApplicationResourceTree
+                                                        nodeFilter={node => this.filterTreeNode(node, treeFilter)}
+                                                        selectedNodeFullName={this.selectedNodeKey}
+                                                        onNodeClick={fullName => this.selectNode(fullName)}
+                                                        nodeMenu={node =>
+                                                            AppUtils.renderResourceMenu(node, application, tree, this.appContext, this.appChanged, () =>
+                                                                this.getApplicationActionMenu(application, false)
+                                                            )
+                                                        }
+                                                        tree={tree}
+                                                        app={application}
+                                                        showOrphanedResources={pref.orphanedResources}
+                                                        useNetworkingHierarchy={pref.view === 'network'}
+                                                        onClearFilter={clearFilter}
+                                                    />
+                                                </Filters>
                                             )) ||
                                                 (pref.view === 'pods' && (
                                                     <PodView

--- a/ui/src/app/applications/components/application-details/application-resource-filter.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.tsx
@@ -78,6 +78,7 @@ export const Filters = (props: {pref: AppDetailsPreferences; tree: ApplicationTr
         .sort();
     const namespaces = tree.nodes
         .map(x => x.namespace)
+        .filter(x => !!x)
         .concat(alreadyFilteredOn('namespace'))
         .filter(uniq)
         .sort();
@@ -88,17 +89,15 @@ export const Filters = (props: {pref: AppDetailsPreferences; tree: ApplicationTr
 
     return (
         <FiltersGroup appliedFilter={pref.resourceFilter} onClearFilter={onClearFilter} setShown={setShown} shown={shown}>
-            <div className='filters-container__text-filters'>
-                {ResourceFilter({label: 'KINDS', prefix: 'kind', options: kinds.map(toOption), field: true})}
-                {ResourceFilter({
-                    label: 'SYNC STATUS',
-                    prefix: 'sync',
-                    options: ['Synced', 'OutOfSync'].map(label => ({
-                        label,
-                        icon: <ComparisonStatusIcon status={label as SyncStatusCode} noSpin={true} />
-                    }))
-                })}
-            </div>
+            {ResourceFilter({label: 'KINDS', prefix: 'kind', options: kinds.map(toOption), field: true})}
+            {ResourceFilter({
+                label: 'SYNC STATUS',
+                prefix: 'sync',
+                options: ['Synced', 'OutOfSync'].map(label => ({
+                    label,
+                    icon: <ComparisonStatusIcon status={label as SyncStatusCode} noSpin={true} />
+                }))
+            })}
             {ResourceFilter({
                 label: 'HEALTH STATUS',
                 prefix: 'health',
@@ -107,12 +106,7 @@ export const Filters = (props: {pref: AppDetailsPreferences; tree: ApplicationTr
                     icon: <HealthStatusIcon state={{status: label as HealthStatusCode, message: ''}} noSpin={true} />
                 }))
             })}
-            <div className='filters-container__subgroup'>
-                {namespaces.length > 1 &&
-                    ResourceFilter({label: 'NAMESPACES', prefix: 'namespace', options: (namespaces || []).filter(l => l && l !== '').map(toOption), field: true})}
-                {ResourceFilter({label: 'OWNERSHIP', prefix: 'ownership', wrap: true, options: ['Owners', 'Owned'].map(toOption)})}
-                {ResourceFilter({label: 'AGE', prefix: 'createdWithin', options: ['1m', '3m', '5m', '15m', '60m'].map(toOption), radio: true, wrap: true})}
-            </div>
+            {namespaces.length > 1 && ResourceFilter({label: 'NAMESPACES', prefix: 'namespace', options: (namespaces || []).filter(l => l && l !== '').map(toOption), field: true})}
         </FiltersGroup>
     );
 };

--- a/ui/src/app/applications/components/application-details/application-resource-filter.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-filter.tsx
@@ -10,7 +10,13 @@ function toOption(label: string) {
     return {label};
 }
 
-export const Filters = (props: {pref: AppDetailsPreferences; tree: ApplicationTree; onSetFilter: (items: string[]) => void; onClearFilter: () => void}) => {
+export const Filters = (props: {
+    children?: React.ReactNode;
+    pref: AppDetailsPreferences;
+    tree: ApplicationTree;
+    onSetFilter: (items: string[]) => void;
+    onClearFilter: () => void;
+}) => {
     const {pref, tree, onSetFilter} = props;
 
     const onClearFilter = () => {
@@ -51,19 +57,11 @@ export const Filters = (props: {pref: AppDetailsPreferences; tree: ApplicationTr
         onSetFilter(strings);
     };
 
-    const ResourceFilter = (p: {label: string; prefix: string; options: {label: string}[]; field?: boolean; radio?: boolean; wrap?: boolean}) => {
+    const ResourceFilter = (p: {label: string; prefix: string; options: {label: string}[]; field?: boolean; radio?: boolean}) => {
         return loading ? (
             <div>Loading...</div>
         ) : (
-            <Filter
-                label={p.label}
-                selected={selectedFor(p.prefix)}
-                setSelected={v => setFilters(p.prefix, v)}
-                options={p.options}
-                field={!!p.field}
-                radio={!!p.radio}
-                wrap={!!p.wrap}
-            />
+            <Filter label={p.label} selected={selectedFor(p.prefix)} setSelected={v => setFilters(p.prefix, v)} options={p.options} field={!!p.field} radio={!!p.radio} />
         );
     };
 
@@ -88,7 +86,7 @@ export const Filters = (props: {pref: AppDetailsPreferences; tree: ApplicationTr
     };
 
     return (
-        <FiltersGroup appliedFilter={pref.resourceFilter} onClearFilter={onClearFilter} setShown={setShown} shown={shown}>
+        <FiltersGroup content={props.children} appliedFilter={pref.resourceFilter} onClearFilter={onClearFilter} setShown={setShown} expanded={shown}>
             {ResourceFilter({label: 'KINDS', prefix: 'kind', options: kinds.map(toOption), field: true})}
             {ResourceFilter({
                 label: 'SYNC STATUS',

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -433,12 +433,15 @@ export const ApplicationResourceTree = (props: ApplicationResourceTreeProps) => 
     } else {
         // Tree view
         const managedKeys = new Set(props.app.status.resources.map(nodeKey));
+        const orphanedKeys = new Set(props.tree.orphanedNodes?.map(nodeKey));
         const orphans: ResourceTreeNode[] = [];
         nodes.forEach(node => {
             if ((node.parentRefs || []).length === 0 || managedKeys.has(nodeKey(node))) {
                 roots.push(node);
             } else {
-                orphans.push(node);
+                if (orphanedKeys.has(nodeKey(node))) {
+                    orphans.push(node);
+                }
                 node.parentRefs.forEach(parent => {
                     const children = childrenByParentKey.get(treeNodeKey(parent)) || [];
                     children.push(node);

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -59,6 +59,7 @@ interface AppFilterProps {
     apps: FilteredApp[];
     pref: AppsListPreferences;
     onChange: (newPrefs: AppsListPreferences) => void;
+    children?: React.ReactNode;
 }
 
 const getCounts = (apps: FilteredApp[], filterType: keyof FilterResult, filter: (app: Application) => string, init?: string[]) => {
@@ -218,17 +219,13 @@ export const ApplicationsFilter = (props: AppFilterProps) => {
     };
 
     return (
-        <FiltersGroup setShown={setShown} shown={!props.pref.hideFilters}>
+        <FiltersGroup setShown={setShown} expanded={!props.pref.hideFilters} content={props.children}>
             <SyncFilter {...props} />
             <HealthFilter {...props} />
-            <div className='filters-container__subgroup'>
-                <LabelsFilter {...props} />
-                <ProjectFilter {...props} />
-            </div>
-            <div className='filters-container__subgroup'>
-                <ClusterFilter {...props} />
-                <NamespaceFilter {...props} />
-            </div>
+            <LabelsFilter {...props} />
+            <ProjectFilter {...props} />
+            <ClusterFilter {...props} />
+            <NamespaceFilter {...props} />
         </FiltersGroup>
     );
 };

--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -224,6 +224,8 @@ export const ApplicationsFilter = (props: AppFilterProps) => {
             <div className='filters-container__subgroup'>
                 <LabelsFilter {...props} />
                 <ProjectFilter {...props} />
+            </div>
+            <div className='filters-container__subgroup'>
                 <ClusterFilter {...props} />
                 <NamespaceFilter {...props} />
             </div>

--- a/ui/src/app/applications/components/applications-list/applications-list.scss
+++ b/ui/src/app/applications/components/applications-list/applications-list.scss
@@ -169,4 +169,13 @@
         display: inline-block;
         width: 28px;
     }
+
+    .filters-group__panel {
+        top: 120px;
+    }
+    @include breakpoint(medium down) {
+        .filters-group__panel {
+            top: 200px;
+        }
+    }
 }

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -378,31 +378,20 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                             <ViewPref>
                                                 {pref => {
                                                     const {filteredApps, filterResults} = filterApps(applications, pref, pref.search);
-                                                    return applications.length === 0 && (pref.labelsFilter || []).length === 0 ? (
-                                                        <EmptyState icon='argo-icon-application'>
-                                                            <h4>No applications yet</h4>
-                                                            <h5>Create new application to start managing resources in your cluster</h5>
-                                                            <button
-                                                                qe-id='applications-list-button-create-application'
-                                                                className='argo-button argo-button--base'
-                                                                onClick={() => ctx.navigation.goto('.', {new: JSON.stringify({})})}>
-                                                                Create application
-                                                            </button>
-                                                        </EmptyState>
-                                                    ) : (
-                                                        <div className='row'>
-                                                            <div className='columns small-12 xxlarge-2'>
-                                                                <ApplicationsFilter apps={filterResults} onChange={newPrefs => onFilterPrefChanged(ctx, newPrefs)} pref={pref} />
-                                                                {syncAppsInput && (
-                                                                    <ApplicationsSyncPanel
-                                                                        key='syncsPanel'
-                                                                        show={syncAppsInput}
-                                                                        hide={() => ctx.navigation.goto('.', {syncApps: null})}
-                                                                        apps={filteredApps}
-                                                                    />
-                                                                )}
-                                                            </div>
-                                                            <div className='columns small-12 xxlarge-10'>
+                                                    const appsView =
+                                                        applications.length === 0 && (pref.labelsFilter || []).length === 0 ? (
+                                                            <EmptyState icon='argo-icon-application'>
+                                                                <h4>No applications yet</h4>
+                                                                <h5>Create new application to start managing resources in your cluster</h5>
+                                                                <button
+                                                                    qe-id='applications-list-button-create-application'
+                                                                    className='argo-button argo-button--base'
+                                                                    onClick={() => ctx.navigation.goto('.', {new: JSON.stringify({})})}>
+                                                                    Create application
+                                                                </button>
+                                                            </EmptyState>
+                                                        ) : (
+                                                            <ApplicationsFilter apps={filterResults} onChange={newPrefs => onFilterPrefChanged(ctx, newPrefs)} pref={pref}>
                                                                 {(pref.view === 'summary' && <ApplicationsSummary applications={filteredApps} />) || (
                                                                     <Paginate
                                                                         header={filteredApps.length > 1 && <ApplicationsStatusBar applications={filteredApps} />}
@@ -444,8 +433,18 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                         }
                                                                     </Paginate>
                                                                 )}
-                                                            </div>
-                                                        </div>
+                                                            </ApplicationsFilter>
+                                                        );
+                                                    return (
+                                                        <>
+                                                            {appsView}
+                                                            <ApplicationsSyncPanel
+                                                                key='syncsPanel'
+                                                                show={syncAppsInput}
+                                                                hide={() => ctx.navigation.goto('.', {syncApps: null})}
+                                                                apps={filteredApps}
+                                                            />
+                                                        </>
                                                     );
                                                 }}
                                             </ViewPref>

--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -217,7 +217,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                                         refreshApplication(app.metadata.name);
                                                     }}>
                                                     <i className={classNames('fa fa-redo', {'status-icon--spin': AppUtils.isAppRefreshing(app)})} />{' '}
-                                                    <span className='show-for-xlarge'>Refresh</span>
+                                                    <span className='show-for-xxlarge'>Refresh</span>
                                                 </a>
                                                 &nbsp;
                                                 <a
@@ -227,7 +227,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                                         e.stopPropagation();
                                                         deleteApplication(app.metadata.name);
                                                     }}>
-                                                    <i className='fa fa-times-circle' /> Delete
+                                                    <i className='fa fa-times-circle' /> <span className='show-for-xxlarge'>Delete</span>
                                                 </a>
                                             </div>
                                         </div>

--- a/ui/src/app/applications/components/filter/filter.scss
+++ b/ui/src/app/applications/components/filter/filter.scss
@@ -54,6 +54,12 @@
 }
 
 .filters-group {
+    .action-button {
+        margin-left: 5px;
+        font-size: 12px;
+        line-height: 5px;
+    }
+
     &__container {
         display: flex;
         &__title {

--- a/ui/src/app/applications/components/filter/filter.scss
+++ b/ui/src/app/applications/components/filter/filter.scss
@@ -9,17 +9,17 @@
     margin-bottom: 1em;
 
     &__header {
-        display: flex;
-        align-items: center;
-        flex-wrap: wrap;
         font-size: 13px;
         color: $argo-color-gray-5;
         font-weight: 500;
         margin-bottom: 0.5em;
         height: 28px;
+        position: relative;
     }
 
     &__collapse {
+        position: absolute;
+        right: 0;
         cursor: pointer;
         margin-left: auto;
         color: $argo-color-gray-7;
@@ -43,76 +43,95 @@
     &__loading {
         text-align: center;
     }
-
-    &--wrap {
-        overflow: auto;
-        .checkbox__item {
-            min-width: 4.5em;
-            float: left;
-        }
-    }
 }
 
 .filters-group {
-    .action-button {
-        margin-left: 5px;
-        font-size: 12px;
-        line-height: 5px;
+    &__toggle {
+        display: none;
+        cursor: pointer;
+        position: absolute;
+        left: 16em;
+        color: $argo-color-gray-6;
     }
 
-    &__container {
-        display: flex;
+    .fa-filter {
+        float: left;
+        margin-right: 1em;
+    }
+
+    &__panel {
+        transition: width 0.2s ease-in-out;
+        background-color: $argo-color-gray-3;
+        box-shadow: 1px 1px 2px 0px rgba(0, 0, 0, 0.1);
+        padding: 10px;
+        overflow-y: hidden;
+        overflow-x: hidden;
+        z-index: 1;
+
+        position: fixed;
+        width: 240px;
+        margin-top: -18px;
+        left: 60px;
+        bottom: 0;
+
         &__title {
             margin-bottom: 1em;
             font-size: 13px;
             color: $argo-color-gray-6;
-            display: flex;
             align-items: center;
             width: 200px;
         }
 
-        .filter {
-            margin-right: 15px;
-            height: max-content;
-            min-width: 200px;
-            max-width: 200px;
+        &:hover {
+            overflow-y: auto;
         }
 
-        &__subgroup {
-            align-self: start;
-            display: flex;
-            flex-wrap: wrap;
+        .filter {
+            width: 205px;
+            transition: visibility 0.2s ease-in-out;
         }
     }
 
-    &__container--hidden {
-        display: none;
+    &__content {
+        padding-left: 230px;
     }
 }
 
-@include breakpoint(xxlarge up) {
-    .filter {
-        width: 100%;
-        margin-right: 0;
+
+@include breakpoint(xlarge down) {
+    .filters-group__toggle {
+        display: inline;
     }
 
-    .filters-group {
-        &__container {
-            width: 260px;
-            flex-wrap: wrap;
-            padding-bottom: 6em;
+    .filters-group--expanded {
+        .filters-group__toggle {
+            color: $argo-color-gray-8;
+        }
+    }
 
-            &__title .action-button {
+    .filters-group__toggle:hover {
+        color: $argo-color-gray-7;
+    }
+
+    .filters-group:not(.filters-group--expanded) {
+        .filters-group__panel:not(.filters-group__panel:hover) {
+            width: 30px;
+
+            .filters-group__toggle {
                 display: none;
             }
 
-            &__text-filters {
-                width: 100%;
+            &__title {
+                display: none;
+            }
+
+            .filter {
+                visibility: hidden;
             }
         }
 
-        &__container--hidden {
-            display: flex;
+        .filters-group__content {
+            padding-left: 30px;
         }
     }
 }

--- a/ui/src/app/applications/components/filter/filter.tsx
+++ b/ui/src/app/applications/components/filter/filter.tsx
@@ -1,5 +1,5 @@
-import {ActionButton, Autocomplete, CheckboxOption, CheckboxRow} from 'argo-ui/v2';
-import classNames from 'classnames';
+import {Autocomplete, CheckboxOption, CheckboxRow} from 'argo-ui/v2';
+import * as classNames from 'classnames';
 import * as React from 'react';
 
 import './filter.scss';
@@ -15,18 +15,32 @@ interface FilterProps {
     retry?: () => void;
     loading?: boolean;
     radio?: boolean;
-    wrap?: boolean;
 }
 
-export const FiltersGroup = (props: {children?: React.ReactNode; appliedFilter?: string[]; shown: boolean; setShown: (val: boolean) => void; onClearFilter?: () => void}) => {
+export const FiltersGroup = (props: {
+    children?: React.ReactNode;
+    content: React.ReactNode;
+    appliedFilter?: string[];
+    expanded: boolean;
+    setShown: (val: boolean) => void;
+    onClearFilter?: () => void;
+}) => {
     return (
-        <div className='filters-group'>
-            <div className='filters-group__container__title'>
-                FILTERS <i className='fa fa-filter' />
-                {props.appliedFilter?.length > 0 && props.onClearFilter && <ActionButton label={'CLEAR ALL'} action={() => props.onClearFilter()} />}
-                <ActionButton label={!props.shown ? 'SHOW' : 'HIDE'} action={() => props.setShown(!props.shown)} />
+        <div className={classNames('filters-group', {'filters-group--expanded': props.expanded})}>
+            <div className='filters-group__panel'>
+                <i className='fa fa-filter' />
+                <div className='filters-group__panel__title'>
+                    FILTERS{' '}
+                    {props.appliedFilter?.length > 0 && props.onClearFilter && (
+                        <button onClick={() => props.onClearFilter()} className='argo-button argo-button--base argo-button--sm'>
+                            CLEAR ALL
+                        </button>
+                    )}
+                    <i className='fa fa-thumbtack filters-group__toggle' onClick={() => props.setShown(!props.expanded)} />
+                </div>
+                <>{props.children}</>
             </div>
-            <div className={classNames('filters-group__container', {'filters-group__container--hidden': !props.shown})}>{props.children}</div>
+            <div className='filters-group__content'>{props.content}</div>
         </div>
     );
 };
@@ -62,11 +76,11 @@ export const Filter = (props: FilterProps) => {
     }, [props.selected.length]);
 
     return (
-        <div className={classNames('filter', {'filter--wrap': props.wrap})}>
+        <div className='filter'>
             <div className='filter__header'>
                 {props.label || 'FILTER'}
                 {(props.selected || []).length > 0 || (props.field && Object.keys(values).length > 0) ? (
-                    <div
+                    <button
                         className='argo-button argo-button--base argo-button--sm'
                         style={{marginLeft: 'auto'}}
                         onClick={() => {
@@ -74,7 +88,7 @@ export const Filter = (props: FilterProps) => {
                             setInput('');
                         }}>
                         <i className='fa fa-times-circle' /> CLEAR
-                    </div>
+                    </button>
                 ) : (
                     <i className={`fa fa-caret-${collapsed ? 'down' : 'up'} filter__collapse`} onClick={() => setCollapsed(!collapsed)} />
                 )}

--- a/ui/src/app/applications/components/filter/filter.tsx
+++ b/ui/src/app/applications/components/filter/filter.tsx
@@ -23,14 +23,8 @@ export const FiltersGroup = (props: {children?: React.ReactNode; appliedFilter?:
         <div className='filters-group'>
             <div className='filters-group__container__title'>
                 FILTERS <i className='fa fa-filter' />
-                {props.appliedFilter?.length > 0 && props.onClearFilter && (
-                    <ActionButton label={'CLEAR ALL'} action={() => props.onClearFilter()} style={{marginLeft: 'auto', fontSize: '12px', lineHeight: '5px', display: 'block'}} />
-                )}
-                <ActionButton
-                    label={!props.shown ? 'SHOW' : 'HIDE'}
-                    action={() => props.setShown(!props.shown)}
-                    style={{marginLeft: props.appliedFilter?.length > 0 ? '5px' : 'auto', fontSize: '12px', lineHeight: '5px'}}
-                />
+                {props.appliedFilter?.length > 0 && props.onClearFilter && <ActionButton label={'CLEAR ALL'} action={() => props.onClearFilter()} />}
+                <ActionButton label={!props.shown ? 'SHOW' : 'HIDE'} action={() => props.setShown(!props.shown)} />
             </div>
             <div className={classNames('filters-group__container', {'filters-group__container--hidden': !props.shown})}>{props.children}</div>
         </div>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1669,7 +1669,7 @@ are-we-there-yet@~1.1.2:
 
 "argo-ui@git+https://github.com/argoproj/argo-ui.git":
   version "1.0.0"
-  resolved "git+https://github.com/argoproj/argo-ui.git#672a3a329ec7f9e99304880555fc08aba692cc16"
+  resolved "git+https://github.com/argoproj/argo-ui.git#9ebea339e3ad8d81945c77257a16097af389d392"
   dependencies:
     "@fortawesome/fontawesome-free" "^5.8.1"
     "@tippy.js/react" "^2.1.2"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1669,7 +1669,7 @@ are-we-there-yet@~1.1.2:
 
 "argo-ui@git+https://github.com/argoproj/argo-ui.git":
   version "1.0.0"
-  resolved "git+https://github.com/argoproj/argo-ui.git#9ebea339e3ad8d81945c77257a16097af389d392"
+  resolved "git+https://github.com/argoproj/argo-ui.git#e81faeb971180151796ab5aeca8e8740ed4a3578"
   dependencies:
     "@fortawesome/fontawesome-free" "^5.8.1"
     "@tippy.js/react" "^2.1.2"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/6945

More fixes for applications and resource filters: 

* drops Age and Ownership filters from resources page: 
  * Age filter became unusable after 1 hr; additionally the intention was to find recently updated resources, not created but modification time is not available. 
  * Ownership filter is only useful in combination with a filter that is applied to nonroot resource. For example user could filter child pods by label and then find it's parents. But we don't have such filter
* fixes Sync and Health filter: element should be shown if it matches to the filter or it's root matches to the filter. E.g. In-Progress should show all in-progress deployments and replicas with pods of such deployments. 