### PR TITLE
fix: update deprecated helm2 installation URL

### DIFF
--- a/hack/installers/install-helm2-linux.sh
+++ b/hack/installers/install-helm2-linux.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 
 export TARGET_FILE=helm-v${helm2_version}-linux-${ARCHITECTURE}.tar.gz
 
-[ -e ${DOWNLOADS}/${TARGET_FILE} ] || curl -sLf --retry 3 -o ${DOWNLOADS}/${TARGET_FILE} https://storage.googleapis.com/kubernetes-helm/helm-v${helm2_version}-linux-$ARCHITECTURE.tar.gz
+[ -e ${DOWNLOADS}/${TARGET_FILE} ] || curl -sLf --retry 3 -o ${DOWNLOADS}/${TARGET_FILE} https://get.helm.sh/helm-v${helm2_version}-linux-$ARCHITECTURE.tar.gz
 $(dirname $0)/compare-chksum.sh
 mkdir -p /tmp/helm2 && tar -C /tmp/helm2 -xf $DOWNLOADS/${TARGET_FILE}
 sudo install -m 0755 /tmp/helm2/linux-$ARCHITECTURE/helm $BIN/helm2


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The https://storage.googleapis.com/kubernetes-helm/helm-v2.17.0-linux-amd64.tar.gz is not longer working. Switching installation to https://get.helm.sh