### PR TITLE
fix: basehref not set correctly

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -848,7 +848,11 @@ func uiAssetExists(filename string) bool {
 		return false
 	}
 	defer io.Close(f)
-	return true
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return !stat.IsDir()
 }
 
 // newStaticAssetsHandler returns an HTTP handler to serve UI static assets


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #6919 

The server was incorrectly assuming that GET `http://<domain>/` requesting a file and was not performing href replacement. PR fixes the issue