### PR TITLE
fix: argocd core commands should not drop existing persistent flags

### DIFF
--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -49,7 +49,7 @@ func addKubectlFlagsToCmd(cmd *cobra.Command) clientcmd.ClientConfig {
 	overrides := clientcmd.ConfigOverrides{}
 	kflags := clientcmd.RecommendedConfigOverrideFlags("")
 	cmd.Flags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
-	clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), kflags)
+	clientcmd.BindOverrideFlags(&overrides, cmd.Flags(), kflags)
 	return clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
 }
 

--- a/docs/user-guide/commands/argocd_account_can-i.md
+++ b/docs/user-guide/commands/argocd_account_can-i.md
@@ -33,38 +33,23 @@ Resources: [clusters projects applications repositories certificates]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_account_delete-token.md
+++ b/docs/user-guide/commands/argocd_account_delete-token.md
@@ -26,38 +26,23 @@ argocd account delete-token --account <account-name> ID
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_account_generate-token.md
+++ b/docs/user-guide/commands/argocd_account_generate-token.md
@@ -28,38 +28,23 @@ argocd account generate-token --account <account-name>
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_account_get-user-info.md
+++ b/docs/user-guide/commands/argocd_account_get-user-info.md
@@ -16,38 +16,23 @@ argocd account get-user-info [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_account_get.md
+++ b/docs/user-guide/commands/argocd_account_get.md
@@ -27,38 +27,23 @@ argocd account get --account <account-name>
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_account_list.md
+++ b/docs/user-guide/commands/argocd_account_list.md
@@ -22,38 +22,23 @@ argocd account list
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_account_update-password.md
+++ b/docs/user-guide/commands/argocd_account_update-password.md
@@ -18,38 +18,23 @@ argocd account update-password [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_actions.md
+++ b/docs/user-guide/commands/argocd_app_actions.md
@@ -15,38 +15,23 @@ argocd app actions [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_actions_list.md
+++ b/docs/user-guide/commands/argocd_app_actions_list.md
@@ -12,6 +12,7 @@ argocd app actions list APPNAME [flags]
       --group string           Group
   -h, --help                   help for list
       --kind string            Kind
+      --namespace string       Namespace
   -o, --out string             Output format. One of: yaml, json
       --resource-name string   Name of resource
 ```
@@ -19,38 +20,23 @@ argocd app actions list APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_actions_run.md
+++ b/docs/user-guide/commands/argocd_app_actions_run.md
@@ -13,44 +13,30 @@ argocd app actions run APPNAME ACTION [flags]
       --group string           Group
   -h, --help                   help for run
       --kind string            Kind
+      --namespace string       Namespace
       --resource-name string   Name of resource
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_create.md
+++ b/docs/user-guide/commands/argocd_app_create.md
@@ -90,38 +90,23 @@ argocd app create APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_delete.md
+++ b/docs/user-guide/commands/argocd_app_delete.md
@@ -18,38 +18,23 @@ argocd app delete APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -27,38 +27,23 @@ argocd app diff APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_edit.md
+++ b/docs/user-guide/commands/argocd_app_edit.md
@@ -15,38 +15,23 @@ argocd app edit APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_get.md
+++ b/docs/user-guide/commands/argocd_app_get.md
@@ -20,38 +20,23 @@ argocd app get APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_history.md
+++ b/docs/user-guide/commands/argocd_app_history.md
@@ -16,38 +16,23 @@ argocd app history APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_list.md
+++ b/docs/user-guide/commands/argocd_app_list.md
@@ -29,38 +29,23 @@ argocd app list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_logs.md
+++ b/docs/user-guide/commands/argocd_app_logs.md
@@ -16,6 +16,7 @@ argocd app logs APPNAME [flags]
   -h, --help                help for logs
       --kind string         Resource kind
       --name string         Resource name
+      --namespace string    Resource namespace
       --since-seconds int   A relative time in seconds before the current time from which to show logs
       --tail int            The number of lines from the end of the logs to show
       --until-time string   Show logs until this time
@@ -24,38 +25,23 @@ argocd app logs APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_manifests.md
+++ b/docs/user-guide/commands/argocd_app_manifests.md
@@ -17,38 +17,23 @@ argocd app manifests APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_patch-resource.md
+++ b/docs/user-guide/commands/argocd_app_patch-resource.md
@@ -13,6 +13,7 @@ argocd app patch-resource APPNAME [flags]
       --group string           Group
   -h, --help                   help for patch-resource
       --kind string            Kind
+      --namespace string       Namespace
       --patch string           Patch
       --patch-type string      Which Patching strategy to use: 'application/json-patch+json', 'application/merge-patch+json', or 'application/strategic-merge-patch+json'. Defaults to 'application/merge-patch+json' (default "application/merge-patch+json")
       --resource-name string   Name of resource
@@ -21,38 +22,23 @@ argocd app patch-resource APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_patch.md
+++ b/docs/user-guide/commands/argocd_app_patch.md
@@ -26,38 +26,23 @@ argocd app patch APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_resources.md
+++ b/docs/user-guide/commands/argocd_app_resources.md
@@ -16,38 +16,23 @@ argocd app resources APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_rollback.md
+++ b/docs/user-guide/commands/argocd_app_rollback.md
@@ -17,38 +17,23 @@ argocd app rollback APPNAME [ID] [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -61,38 +61,23 @@ argocd app set APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -52,38 +52,23 @@ argocd app sync [APPNAME... | -l selector] [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_terminate-op.md
+++ b/docs/user-guide/commands/argocd_app_terminate-op.md
@@ -15,38 +15,23 @@ argocd app terminate-op APPNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_unset.md
+++ b/docs/user-guide/commands/argocd_app_unset.md
@@ -36,38 +36,23 @@ argocd app unset APPNAME parameters [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -35,38 +35,23 @@ argocd app wait [APPNAME.. | -l selector] [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cert_add-ssh.md
+++ b/docs/user-guide/commands/argocd_cert_add-ssh.md
@@ -18,38 +18,23 @@ argocd cert add-ssh --batch [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cert_add-tls.md
+++ b/docs/user-guide/commands/argocd_cert_add-tls.md
@@ -17,38 +17,23 @@ argocd cert add-tls SERVERNAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cert_list.md
+++ b/docs/user-guide/commands/argocd_cert_list.md
@@ -19,38 +19,23 @@ argocd cert list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cert_rm.md
+++ b/docs/user-guide/commands/argocd_cert_rm.md
@@ -17,38 +17,23 @@ argocd cert rm REPOSERVER [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cluster_add.md
+++ b/docs/user-guide/commands/argocd_cluster_add.md
@@ -21,6 +21,7 @@ argocd cluster add CONTEXT [flags]
       --in-cluster                         Indicates Argo CD resides inside this cluster and should connect using the internal k8s hostname (kubernetes.default.svc)
       --kubeconfig string                  use a particular kubeconfig file
       --name string                        Overwrite the cluster name
+      --namespace stringArray              List of namespaces which are allowed to manage
       --service-account string             System namespace service account to use for kubernetes resource management. If not set then default "argocd-manager" SA will be created
       --shard int                          Cluster shard number; inferred from hostname if not set (default -1)
       --system-namespace string            Use different system namespace (default "kube-system")
@@ -31,38 +32,23 @@ argocd cluster add CONTEXT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cluster_get.md
+++ b/docs/user-guide/commands/argocd_cluster_get.md
@@ -23,38 +23,23 @@ argocd cluster get in-cluster
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cluster_list.md
+++ b/docs/user-guide/commands/argocd_cluster_list.md
@@ -16,38 +16,23 @@ argocd cluster list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cluster_rm.md
+++ b/docs/user-guide/commands/argocd_cluster_rm.md
@@ -21,38 +21,23 @@ argocd cluster rm https://12.34.567.89
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_cluster_rotate-auth.md
+++ b/docs/user-guide/commands/argocd_cluster_rotate-auth.md
@@ -21,38 +21,23 @@ argocd cluster rotate-auth https://12.34.567.89
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_gpg_add.md
+++ b/docs/user-guide/commands/argocd_gpg_add.md
@@ -16,38 +16,23 @@ argocd gpg add [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_gpg_get.md
+++ b/docs/user-guide/commands/argocd_gpg_get.md
@@ -16,38 +16,23 @@ argocd gpg get KEYID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_gpg_list.md
+++ b/docs/user-guide/commands/argocd_gpg_list.md
@@ -16,38 +16,23 @@ argocd gpg list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_gpg_rm.md
+++ b/docs/user-guide/commands/argocd_gpg_rm.md
@@ -15,38 +15,23 @@ argocd gpg rm KEYID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_add-destination.md
+++ b/docs/user-guide/commands/argocd_proj_add-destination.md
@@ -15,38 +15,23 @@ argocd proj add-destination PROJECT SERVER NAMESPACE [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_add-orphaned-ignore.md
+++ b/docs/user-guide/commands/argocd_proj_add-orphaned-ignore.md
@@ -16,38 +16,23 @@ argocd proj add-orphaned-ignore PROJECT GROUP KIND [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_add-signature-key.md
+++ b/docs/user-guide/commands/argocd_proj_add-signature-key.md
@@ -15,38 +15,23 @@ argocd proj add-signature-key PROJECT KEY-ID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_add-source.md
+++ b/docs/user-guide/commands/argocd_proj_add-source.md
@@ -15,38 +15,23 @@ argocd proj add-source PROJECT URL [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_allow-cluster-resource.md
+++ b/docs/user-guide/commands/argocd_proj_allow-cluster-resource.md
@@ -16,38 +16,23 @@ argocd proj allow-cluster-resource PROJECT GROUP KIND [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_allow-namespace-resource.md
+++ b/docs/user-guide/commands/argocd_proj_allow-namespace-resource.md
@@ -16,38 +16,23 @@ argocd proj allow-namespace-resource PROJECT GROUP KIND [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_create.md
+++ b/docs/user-guide/commands/argocd_proj_create.md
@@ -27,38 +27,23 @@ argocd proj create PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_delete.md
+++ b/docs/user-guide/commands/argocd_proj_delete.md
@@ -15,38 +15,23 @@ argocd proj delete PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_deny-cluster-resource.md
+++ b/docs/user-guide/commands/argocd_proj_deny-cluster-resource.md
@@ -16,38 +16,23 @@ argocd proj deny-cluster-resource PROJECT GROUP KIND [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_deny-namespace-resource.md
+++ b/docs/user-guide/commands/argocd_proj_deny-namespace-resource.md
@@ -16,38 +16,23 @@ argocd proj deny-namespace-resource PROJECT GROUP KIND [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_edit.md
+++ b/docs/user-guide/commands/argocd_proj_edit.md
@@ -15,38 +15,23 @@ argocd proj edit PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_get.md
+++ b/docs/user-guide/commands/argocd_proj_get.md
@@ -16,38 +16,23 @@ argocd proj get PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_list.md
+++ b/docs/user-guide/commands/argocd_proj_list.md
@@ -16,38 +16,23 @@ argocd proj list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_remove-destination.md
+++ b/docs/user-guide/commands/argocd_proj_remove-destination.md
@@ -15,38 +15,23 @@ argocd proj remove-destination PROJECT SERVER NAMESPACE [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_remove-orphaned-ignore.md
+++ b/docs/user-guide/commands/argocd_proj_remove-orphaned-ignore.md
@@ -16,38 +16,23 @@ argocd proj remove-orphaned-ignore PROJECT GROUP KIND NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_remove-signature-key.md
+++ b/docs/user-guide/commands/argocd_proj_remove-signature-key.md
@@ -15,38 +15,23 @@ argocd proj remove-signature-key PROJECT KEY-ID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_remove-source.md
+++ b/docs/user-guide/commands/argocd_proj_remove-source.md
@@ -15,38 +15,23 @@ argocd proj remove-source PROJECT URL [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role.md
+++ b/docs/user-guide/commands/argocd_proj_role.md
@@ -15,38 +15,23 @@ argocd proj role [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_add-group.md
+++ b/docs/user-guide/commands/argocd_proj_role_add-group.md
@@ -15,38 +15,23 @@ argocd proj role add-group PROJECT ROLE-NAME GROUP-CLAIM [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_add-policy.md
+++ b/docs/user-guide/commands/argocd_proj_role_add-policy.md
@@ -18,38 +18,23 @@ argocd proj role add-policy PROJECT ROLE-NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_create-token.md
+++ b/docs/user-guide/commands/argocd_proj_role_create-token.md
@@ -18,38 +18,23 @@ argocd proj role create-token PROJECT ROLE-NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_create.md
+++ b/docs/user-guide/commands/argocd_proj_role_create.md
@@ -16,38 +16,23 @@ argocd proj role create PROJECT ROLE-NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_delete-token.md
+++ b/docs/user-guide/commands/argocd_proj_role_delete-token.md
@@ -15,38 +15,23 @@ argocd proj role delete-token PROJECT ROLE-NAME ISSUED-AT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_delete.md
+++ b/docs/user-guide/commands/argocd_proj_role_delete.md
@@ -15,38 +15,23 @@ argocd proj role delete PROJECT ROLE-NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_get.md
+++ b/docs/user-guide/commands/argocd_proj_role_get.md
@@ -15,38 +15,23 @@ argocd proj role get PROJECT ROLE-NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_list-tokens.md
+++ b/docs/user-guide/commands/argocd_proj_role_list-tokens.md
@@ -16,38 +16,23 @@ argocd proj role list-tokens PROJECT ROLE-NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_list.md
+++ b/docs/user-guide/commands/argocd_proj_role_list.md
@@ -16,38 +16,23 @@ argocd proj role list PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_remove-group.md
+++ b/docs/user-guide/commands/argocd_proj_role_remove-group.md
@@ -15,38 +15,23 @@ argocd proj role remove-group PROJECT ROLE-NAME GROUP-CLAIM [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_role_remove-policy.md
+++ b/docs/user-guide/commands/argocd_proj_role_remove-policy.md
@@ -18,38 +18,23 @@ argocd proj role remove-policy PROJECT ROLE-NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_set.md
+++ b/docs/user-guide/commands/argocd_proj_set.md
@@ -25,38 +25,23 @@ argocd proj set PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_windows.md
+++ b/docs/user-guide/commands/argocd_proj_windows.md
@@ -15,38 +15,23 @@ argocd proj windows [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_windows_add.md
+++ b/docs/user-guide/commands/argocd_proj_windows_add.md
@@ -22,38 +22,23 @@ argocd proj windows add PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_windows_delete.md
+++ b/docs/user-guide/commands/argocd_proj_windows_delete.md
@@ -15,38 +15,23 @@ argocd proj windows delete PROJECT ID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_windows_disable-manual-sync.md
+++ b/docs/user-guide/commands/argocd_proj_windows_disable-manual-sync.md
@@ -19,38 +19,23 @@ argocd proj windows disable-manual-sync PROJECT ID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_windows_enable-manual-sync.md
+++ b/docs/user-guide/commands/argocd_proj_windows_enable-manual-sync.md
@@ -19,38 +19,23 @@ argocd proj windows enable-manual-sync PROJECT ID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_windows_list.md
+++ b/docs/user-guide/commands/argocd_proj_windows_list.md
@@ -16,38 +16,23 @@ argocd proj windows list PROJECT [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_proj_windows_update.md
+++ b/docs/user-guide/commands/argocd_proj_windows_update.md
@@ -24,38 +24,23 @@ argocd proj windows update PROJECT ID [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_repo_add.md
+++ b/docs/user-guide/commands/argocd_repo_add.md
@@ -51,49 +51,36 @@ argocd repo add REPOURL [flags]
       --insecure-ignore-host-key                disables SSH strict host key checking (deprecated, use --insecure-skip-server-verification instead)
       --insecure-skip-server-verification       disables server certificate and host key checks
       --name string                             name of the repository, mandatory for repositories of type helm
+      --password string                         password to the repository
       --proxy string                            use proxy to access repository
       --ssh-private-key-path string             path to the private ssh key (e.g. ~/.ssh/id_rsa)
       --tls-client-cert-key-path string         path to the TLS client cert's key path (must be PEM format)
       --tls-client-cert-path string             path to the TLS client cert (must be PEM format)
       --type string                             type of the repository, "git" or "helm" (default "git")
       --upsert                                  Override an existing repository with the same name even if the spec differs
+      --username string                         username to the repository
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_repo_get.md
+++ b/docs/user-guide/commands/argocd_repo_get.md
@@ -17,38 +17,23 @@ argocd repo get [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_repo_list.md
+++ b/docs/user-guide/commands/argocd_repo_list.md
@@ -17,38 +17,23 @@ argocd repo list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_repo_rm.md
+++ b/docs/user-guide/commands/argocd_repo_rm.md
@@ -15,38 +15,23 @@ argocd repo rm REPO [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_repocreds_add.md
+++ b/docs/user-guide/commands/argocd_repocreds_add.md
@@ -35,48 +35,35 @@ argocd repocreds add REPOURL [flags]
       --github-app-installation-id int          installation id of the GitHub Application
       --github-app-private-key-path string      private key of the GitHub Application
   -h, --help                                    help for add
+      --password string                         password to the repository
       --ssh-private-key-path string             path to the private ssh key (e.g. ~/.ssh/id_rsa)
       --tls-client-cert-key-path string         path to the TLS client cert's key path (must be PEM format)
       --tls-client-cert-path string             path to the TLS client cert (must be PEM format)
       --type string                             type of the repository, "git" or "helm" (default "git")
       --upsert                                  Override an existing repository with the same name even if the spec differs
+      --username string                         username to the repository
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_repocreds_list.md
+++ b/docs/user-guide/commands/argocd_repocreds_list.md
@@ -16,38 +16,23 @@ argocd repocreds list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_repocreds_rm.md
+++ b/docs/user-guide/commands/argocd_repocreds_rm.md
@@ -15,38 +15,23 @@ argocd repocreds rm CREDSURL [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                       Username to impersonate for the operation
-      --as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --auth-token string               Authentication token
-      --certificate-authority string    Path to a cert file for the certificate authority
-      --client-certificate string       Path to a client certificate file for TLS
       --client-crt string               Client certificate file
       --client-crt-key string           Client certificate key file
-      --client-key string               Path to a client key file for TLS
-      --cluster string                  The name of the kubeconfig cluster to use
       --config string                   Path to Argo CD config (default "/home/user/.argocd/config")
-      --context string                  The name of the kubeconfig context to use
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
       --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
       --insecure                        Skip server certificate and domain verification
-      --insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --logformat string                Set the logging format. One of: text|json (default "text")
       --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
-  -n, --namespace string                If present, the namespace scope for this CLI request
-      --password string                 Password for basic authentication to the API server
       --plaintext                       Disable TLS
       --port-forward                    Connect to a random argocd-server port using port forwarding
       --port-forward-namespace string   Namespace name which should be used for port forwarding
-      --request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --server string                   The address and port of the Kubernetes API server
+      --server string                   Argo CD server address
       --server-crt string               Server certificate file
-      --tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                    Bearer token for authentication to the API server
-      --user string                     The name of the kubeconfig user to use
-      --username string                 Username for basic authentication to the API server
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>
