### PR TITLE
chore: Log application name for invalid application spec

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -843,7 +843,7 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 	}
 
 	if err := argo.ValidateDestination(ctx, &app.Spec.Destination, s.db); err != nil {
-		return status.Errorf(codes.InvalidArgument, "application destination spec is invalid: %s", err.Error())
+		return status.Errorf(codes.InvalidArgument, "application destination spec for %s is invalid: %s", app.Name, err.Error())
 	}
 
 	var conditions []appv1.ApplicationCondition
@@ -853,7 +853,7 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 			return err
 		}
 		if len(conditions) > 0 {
-			return status.Errorf(codes.InvalidArgument, "application spec is invalid: %s", argo.FormatAppConditions(conditions))
+			return status.Errorf(codes.InvalidArgument, "application spec for %s is invalid: %s", app.Name, argo.FormatAppConditions(conditions))
 		}
 	}
 
@@ -862,7 +862,7 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 		return err
 	}
 	if len(conditions) > 0 {
-		return status.Errorf(codes.InvalidArgument, "application spec is invalid: %s", argo.FormatAppConditions(conditions))
+		return status.Errorf(codes.InvalidArgument, "application spec for %s is invalid: %s", app.Name, argo.FormatAppConditions(conditions))
 	}
 
 	app.Spec = *argo.NormalizeApplicationSpec(&app.Spec)


### PR DESCRIPTION
When creating an application directly through the CLI or a `kubectlapply`, it's relatively obvious which application is invalid (provided you aren't applying several at once) as you're there creating it interactively.

It's less clear when applications are generated by the application set controller. When that happens, you need to go looking in the controller logs, where you'll find something like:

> time="2021-08-10T11:36:02Z" level=error msg="application spec is invalid: InvalidSpecError: application destination {https://kubernetes.default.svc default} is not permitted in project 'my-project'"

which doesn't have any connection back to the application being generated. This is particularly tricky to track down if you're searching your logs via some sort of aggregator rather than watching `kubectl logs -f`.

After this change, the log produced would be:

> time="2021-08-10T11:36:02Z" level=error msg="application spec for guestbook is invalid: InvalidSpecError: application destination {https://kubernetes.default.svc default} is not permitted in project 'my-project'"

There's probably fancier ways this information could be presented (e.g. if application sets were represented in the UI and knew about failures to apply their generated applications), but this logging change seems like a cheap way to make this situation more debuggable.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

