### PR TITLE
feat: support loading extensions in Argo CD UI

### DIFF
--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   collectCoverage: true,
   transformIgnorePatterns: ['node_modules/(?!(argo-ui)/)'],
   globals: {
+    'window': {},
     'ts-jest': {
       isolatedModules: true,
     },

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -1,9 +1,11 @@
 import {DataLoader, Tab, Tabs} from 'argo-ui';
+import {useData} from 'argo-ui/v2';
 import * as React from 'react';
 import {EventsList, YamlEditor} from '../../../shared/components';
 import {Context} from '../../../shared/context';
 import {Application, ApplicationTree, AppSourceType, Event, RepoAppDetails, ResourceNode, State, SyncStatuses} from '../../../shared/models';
 import {services} from '../../../shared/services';
+import {ExtensionComponentProps} from '../../../shared/services/extensions-service';
 import {NodeInfo, SelectNode} from '../application-details/application-details';
 import {ApplicationNodeInfo} from '../application-node-info/application-node-info';
 import {ApplicationParameters} from '../application-parameters/application-parameters';
@@ -38,7 +40,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
     const page = parseInt(new URLSearchParams(appContext.history.location.search).get('page'), 10) || 0;
     const untilTimes = (new URLSearchParams(appContext.history.location.search).get('untilTimes') || '').split(',') || [];
 
-    const getResourceTabs = (node: ResourceNode, state: State, podState: State, events: Event[], tabs: Tab[]) => {
+    const getResourceTabs = (node: ResourceNode, state: State, podState: State, events: Event[], ExtensionComponent: React.ComponentType<ExtensionComponentProps>, tabs: Tab[]) => {
         if (!node || node === undefined) {
             return [];
         }
@@ -112,6 +114,17 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 }
             ]);
         }
+        if (ExtensionComponent) {
+            tabs.push({
+                title: 'More',
+                key: 'extension',
+                content: (
+                    <div>
+                        <ExtensionComponent node={node} tree={tree} />
+                    </div>
+                )
+            });
+        }
         return tabs;
     };
 
@@ -182,6 +195,8 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
 
         return tabs;
     };
+
+    const [extension] = useData(() => services.extensions.loadResourceExtension(selectedNode.group, selectedNode.kind));
 
     return (
         <div style={{width: '100%', height: '100%'}}>
@@ -254,7 +269,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                             </div>
                             <Tabs
                                 navTransparent={true}
-                                tabs={getResourceTabs(selectedNode, data.liveState, data.podState, data.events, [
+                                tabs={getResourceTabs(selectedNode, data.liveState, data.podState, data.events, extension.component, [
                                     {
                                         title: 'SUMMARY',
                                         icon: 'fa fa-file-alt',

--- a/ui/src/app/index.tsx
+++ b/ui/src/app/index.tsx
@@ -11,3 +11,5 @@ if (mdl.hot) {
         ReactDOM.render(<UpdatedApp />, document.getElementById('app'));
     });
 }
+
+(window as any).React = React;

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {ApplicationTree, ResourceNode} from '../models';
+
+const extensions: {[key: string]: Extension} = {};
+const cache = new Map<string, Promise<Extension>>();
+
+export interface Extension {
+    component: React.ComponentType<ExtensionComponentProps>;
+}
+
+export interface ExtensionComponentProps {
+    node: ResourceNode;
+    tree: ApplicationTree;
+}
+
+export class ExtensionsService {
+    public async loadResourceExtension(group: string, kind: string): Promise<Extension> {
+        const key = `${group}-${kind}`;
+        const res =
+            cache.get(key) ||
+            new Promise<Extension>((resolve, reject) => {
+                const script = document.createElement('script');
+                script.src = `extensions/${group}/${kind}/ui/extensions.js`;
+                script.onload = () => {
+                    const ext = extensions[key];
+                    if (!ext) {
+                        reject(`Failed to load extension for ${group}/${kind}`);
+                    } else {
+                        resolve(ext);
+                    }
+                };
+                script.onerror = reject;
+                document.body.appendChild(script);
+            });
+        cache.set(key, res);
+        return res;
+    }
+}
+
+(window as any).extensions = extensions;

--- a/ui/src/app/shared/services/index.ts
+++ b/ui/src/app/shared/services/index.ts
@@ -3,6 +3,7 @@ import {ApplicationsService} from './applications-service';
 import {AuthService} from './auth-service';
 import {CertificatesService} from './cert-service';
 import {ClustersService} from './clusters-service';
+import {ExtensionsService} from './extensions-service';
 import {GnuPGPublicKeyService} from './gpgkey-service';
 import {ProjectsService} from './projects-service';
 import {RepositoriesService} from './repo-service';
@@ -23,6 +24,7 @@ export interface Services {
     version: VersionService;
     accounts: AccountsService;
     gpgkeys: GnuPGPublicKeyService;
+    extensions: ExtensionsService;
 }
 
 export const services: Services = {
@@ -37,7 +39,8 @@ export const services: Services = {
     viewPreferences: new ViewPreferencesService(),
     version: new VersionService(),
     accounts: new AccountsService(),
-    gpgkeys: new GnuPGPublicKeyService()
+    gpgkeys: new GnuPGPublicKeyService(),
+    extensions: new ExtensionsService()
 };
 
 export {ProjectRoleParams, CreateJWTTokenParams, DeleteJWTTokenParams, JWTTokenResponse} from './projects-service';

--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -115,6 +115,7 @@ const config = {
         port: 4000,
         host: process.env.ARGOCD_E2E_YARN_HOST || 'localhost',
         proxy: {
+            '/extensions': proxyConf,
             '/api': proxyConf,
             '/auth': proxyConf,
             '/swagger-ui': proxyConf,


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR introduces the ability to load CRD UI extensions on the resource details page.  The resource details page attempt to load `/extensions/<group>/<kind>/ui/extensions.js` URL (once per group/kind). The extension JS is supposed to inject extension info key `<group>-<kind>` of a `extensions` global variable. 

To test locally create `/tmp/extensions/argoproj.io/Rollout/ui/extensions.js` with the following content:

```js
window.extensions['argoproj.io-Rollout'] = {
    component: function (props) {
        return React.createElement('div', null, 'hello ' + props.node.name);
    }
};
```

Navigate to Argo Rollouts resource

![image](https://user-images.githubusercontent.com/426437/129958415-1b775b42-4151-43d6-b128-95766ac6d938.png)

