### PR TITLE
docs: add @rbreeze as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ approvers:
 - jessesuen
 - jgwest
 - mayzhang2000
+- rbreeze
 
 reviewers:
 - dthomson25


### PR DESCRIPTION
@rbreeze has been nominated (sponsors: @alexmt, @jessesuen, @jannfis) and has been approved as an approver for his contributions to argo-cd, argo-workflows, and argo-rollouts. Welcome @rbreeze!

Signed-off-by: Jesse Suen <jessesuen@gmail.com>
