### PR TITLE
fix(ui): Add State to props passed to Extensions

### DIFF
--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -120,7 +120,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 key: 'extension',
                 content: (
                     <div>
-                        <ExtensionComponent node={node} tree={tree} state={state} />
+                        <ExtensionComponent tree={tree} state={state} />
                     </div>
                 )
             });

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -120,7 +120,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 key: 'extension',
                 content: (
                     <div>
-                        <ExtensionComponent tree={tree} state={state} />
+                        <ExtensionComponent tree={tree} resource={state} />
                     </div>
                 )
             });

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -114,7 +114,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 }
             ]);
         }
-        if (ExtensionComponent) {
+        if (ExtensionComponent && state) {
             tabs.push({
                 title: 'More',
                 key: 'extension',

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -120,7 +120,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 key: 'extension',
                 content: (
                     <div>
-                        <ExtensionComponent node={node} tree={tree} />
+                        <ExtensionComponent node={node} tree={tree} state={state} />
                     </div>
                 )
             });

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {ApplicationTree, ResourceNode} from '../models';
+import {ApplicationTree, ResourceNode, State} from '../models';
 
 const extensions: {[key: string]: Extension} = {};
 const cache = new Map<string, Promise<Extension>>();
@@ -11,6 +11,7 @@ export interface Extension {
 export interface ExtensionComponentProps {
     node: ResourceNode;
     tree: ApplicationTree;
+    state: {spec: State}
 }
 
 export class ExtensionsService {

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -11,7 +11,7 @@ export interface Extension {
 export interface ExtensionComponentProps {
     node: ResourceNode;
     tree: ApplicationTree;
-    state: {spec: State}
+    state: {spec: State};
 }
 
 export class ExtensionsService {

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {ApplicationTree, ResourceNode, State} from '../models';
+import {ApplicationTree, State} from '../models';
 
 const extensions: {[key: string]: Extension} = {};
 const cache = new Map<string, Promise<Extension>>();
@@ -9,9 +9,8 @@ export interface Extension {
 }
 
 export interface ExtensionComponentProps {
-    node: ResourceNode;
+    resource: State;
     tree: ApplicationTree;
-    state: {spec: State};
 }
 
 export class ExtensionsService {


### PR DESCRIPTION
The Rollouts Extension, and likely other Extensions, need more data about the node (namely `spec` and `status`) to render useful info:

```
export const Extension = (props: {
  tree: ApplicationResourceTree;
  resource: Rollout;
  state: any;
}) => {
  const { resource, state, tree } = props as any;
  const { spec, status } = state;
```

Signed-off-by: Remington Breeze <remington@breeze.software>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

