### PR TITLE
fix: keep uid_entrypoint.sh for backward compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ COPY --from=builder /usr/local/bin/helm2 /usr/local/bin/helm2
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+# keep uid_entrypoint.sh for backward compatibility
+RUN ln -s /usr/local/bin/entrypoint.sh /usr/local/bin/uid_entrypoint.sh
 
 # support for mounting configuration from a configmap
 RUN mkdir -p /app/config/ssh && \

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -74,7 +74,7 @@ COPY --from=node /usr/local/bin/node /usr/local/bin
 COPY --from=node /opt/yarn-v1.22.4 /opt/yarn-v1.22.4
 
 # Entrypoint is required for container's user management
-COPY ./test/container/uid_entrypoint.sh /usr/local/bin
+COPY ./test/container/entrypoint.sh /usr/local/bin
 
 ARG UID
 
@@ -104,4 +104,4 @@ RUN useradd -l -u ${UID} -d /home/user -s /bin/bash user && \
     ln -s /opt/yarn-v1.22.4/bin/yarnpkg /usr/local/bin/yarnpkg && \
     mkdir -p /var/lib/registry && chmod -R 777 /var/lib/registry
 
-ENTRYPOINT ["/usr/local/bin/uid_entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/test/remote/Dockerfile
+++ b/test/remote/Dockerfile
@@ -36,7 +36,7 @@ COPY ./test/fixture/certs/argocd-e2e-server.key /etc/certs/argocd-test-server.ke
 COPY ./test/fixture/certs/argocd-test-ca.crt /etc/certs/argocd-test-ca.crt
 
 # Entrypoint is required for container's user management
-COPY ./test/remote/uid_entrypoint.sh /usr/local/bin
+COPY ./test/remote/entrypoint.sh /usr/local/bin
 COPY ./test/remote/Procfile /Procfile
 
 # We need goreman
@@ -83,4 +83,4 @@ RUN echo "[http]" >> /tmp/argo-e2e/submodule.git/config && \
 RUN echo "[http]" >> /tmp/argo-e2e/submoduleParent.git/config && \
     echo "  receivepack = true" >> /tmp/argo-e2e/submoduleParent.git/config 
 
-ENTRYPOINT ["/usr/local/bin/uid_entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-helm/issues/882 
Closes https://github.com/argoproj/argo-cd/issues/7044


I think renaming of uid_entrypoint.sh to entrypoint.sh should be considered a backward-incompatible change. To make it easier to migrate let's create `uid_entrypoint.sh` symlink and delete it in next release. 