### PR TITLE
fix: Custom Styles feature is broken

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -63,6 +63,7 @@ func NewCommand() *cobra.Command {
 		frameOptions             string
 		repoServerPlaintext      bool
 		repoServerStrictTLS      bool
+		staticAssetsDir          string
 	)
 	var command = &cobra.Command{
 		Use:               cliName,
@@ -139,6 +140,7 @@ func NewCommand() *cobra.Command {
 				Cache:               cache,
 				XFrameOptions:       frameOptions,
 				RedisClient:         redisClient,
+				StaticAssetsDir:     staticAssetsDir,
 			}
 
 			stats.RegisterStackDumper()
@@ -157,9 +159,7 @@ func NewCommand() *cobra.Command {
 
 	clientConfig = cli.AddKubectlFlagsToCmd(command)
 	command.Flags().BoolVar(&insecure, "insecure", env.ParseBoolFromEnv("ARGOCD_SERVER_INSECURE", false), "Run server without TLS")
-	var staticAssetsDir string
-	command.Flags().StringVar(&staticAssetsDir, "staticassets", "", "Static assets directory path")
-	_ = command.Flags().MarkDeprecated("staticassets", "The --staticassets flag is not longer supported. Static assets are embedded into binary.")
+	command.Flags().StringVar(&staticAssetsDir, "staticassets", env.StringFromEnv("ARGOCD_SERVER_STATIC_ASSETS", "/shared/app"), "Directory path that contains additional static assets")
 	command.Flags().StringVar(&baseHRef, "basehref", env.StringFromEnv("ARGOCD_SERVER_BASEHREF", "/"), "Value for base href in index.html. Used if Argo CD is running behind reverse proxy under subpath different from /")
 	command.Flags().StringVar(&rootPath, "rootpath", env.StringFromEnv("ARGOCD_SERVER_ROOTPATH", ""), "Used if Argo CD is running behind reverse proxy under subpath different from /")
 	command.Flags().StringVar(&cmdutil.LogFormat, "logformat", env.StringFromEnv("ARGOCD_SERVER_LOGFORMAT", "text"), "Set the logging format. One of: text|json")

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -48,6 +48,8 @@ data:
   server.basehref: "/"
   # Used if Argo CD is running behind reverse proxy under subpath different from /
   server.rootpath: "/"
+  # Directory path that contains additional static assets
+  server.staticassets: "/shared/app"
 
   # Set the logging format. One of: text|json (default "text")
   server.log.format: "text"

--- a/docs/operator-manual/custom-styles.md
+++ b/docs/operator-manual/custom-styles.md
@@ -88,9 +88,10 @@ spec:
         name: styles
 ```
 
-Note that the CSS file should be mounted within a subdirectory of the existing "/shared/app" directory
+Note that the CSS file should be mounted within a subdirectory of the "/shared/app" directory
 (e.g. "/shared/app/custom").  Otherwise, the file will likely fail to be imported by the browser with an
-"incorrect MIME type" error.
+"incorrect MIME type" error. The subdirectory can be changed using `server.staticassets` key of the
+[argocd-cmd-params-cm.yaml](./argocd-cmd-params-cm.yaml) ConfigMap.
 
 ## Developing Style Overlays
 The styles specified in the injected CSS file should be specific to components and classes defined in [argo-ui](https://github.com/argoproj/argo-ui).

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -56,6 +56,7 @@ argocd-server [flags]
       --sentinel stringArray                          Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
       --sentinelmaster string                         Redis sentinel master group name. (default "master")
       --server string                                 The address and port of the Kubernetes API server
+      --staticassets string                           Directory path that contains additional static assets (default "/shared/app")
       --tls-server-name string                        If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --tlsciphers string                             The list of acceptable ciphers to be used when establishing TLS connections. Use 'list' to list available ciphers. (default "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_256_GCM_SHA384")
       --tlsmaxversion string                          The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.3")

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -136,6 +136,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: server.login.attempts.expiration
                 optional: true
+        - name: ARGOCD_SERVER_STATIC_ASSETS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: server.staticassets
+              optional: true
         - name: ARGOCD_APP_STATE_CACHE_EXPIRATION
           valueFrom:
               configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4114,6 +4114,12 @@ spec:
               key: server.login.attempts.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_STATIC_ASSETS
+          valueFrom:
+            configMapKeyRef:
+              key: server.staticassets
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APP_STATE_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1501,6 +1501,12 @@ spec:
               key: server.login.attempts.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_STATIC_ASSETS
+          valueFrom:
+            configMapKeyRef:
+              key: server.staticassets
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APP_STATE_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3439,6 +3439,12 @@ spec:
               key: server.login.attempts.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_STATIC_ASSETS
+          valueFrom:
+            configMapKeyRef:
+              key: server.staticassets
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APP_STATE_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -826,6 +826,12 @@ spec:
               key: server.login.attempts.expiration
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_SERVER_STATIC_ASSETS
+          valueFrom:
+            configMapKeyRef:
+              key: server.staticassets
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_APP_STATE_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:

--- a/util/io/bytereadseeker.go
+++ b/util/io/bytereadseeker.go
@@ -1,0 +1,38 @@
+package io
+
+import (
+	"io"
+	"io/fs"
+)
+
+func NewByteReadSeeker(data []byte) *byteReadSeeker {
+	return &byteReadSeeker{data: data}
+}
+
+type byteReadSeeker struct {
+	data   []byte
+	offset int64
+}
+
+func (f byteReadSeeker) Read(b []byte) (int, error) {
+	if f.offset >= int64(len(f.data)) {
+		return 0, io.EOF
+	}
+	n := copy(b, f.data[f.offset:])
+	f.offset += int64(n)
+	return n, nil
+}
+
+func (f byteReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case 1:
+		offset += f.offset
+	case 2:
+		offset += int64(len(f.data))
+	}
+	if offset < 0 || offset > int64(len(f.data)) {
+		return 0, &fs.PathError{Op: "seek", Err: fs.ErrInvalid}
+	}
+	f.offset = offset
+	return offset, nil
+}

--- a/util/io/componsablefs.go
+++ b/util/io/componsablefs.go
@@ -1,0 +1,23 @@
+package io
+
+import "io/fs"
+
+type composableFS struct {
+	innerFS []fs.FS
+}
+
+// NewComposableFS creates files system that attempts reading file from multiple wrapped file systems
+func NewComposableFS(innerFS ...fs.FS) *composableFS {
+	return &composableFS{innerFS: innerFS}
+}
+
+// Open attempts open file in wrapped file systems and returns first successful
+func (c composableFS) Open(name string) (f fs.File, err error) {
+	for i := range c.innerFS {
+		f, err = c.innerFS[i].Open(name)
+		if err == nil {
+			break
+		}
+	}
+	return
+}

--- a/util/io/subdirfs.go
+++ b/util/io/subdirfs.go
@@ -1,0 +1,20 @@
+package io
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+type subDirFs struct {
+	dir string
+	fs  fs.FS
+}
+
+func (s subDirFs) Open(name string) (fs.File, error) {
+	return s.fs.Open(filepath.Join(s.dir, name))
+}
+
+// NewSubDirFS returns file system that represents sub-directory in a wrapped file system
+func NewSubDirFS(dir string, fs fs.FS) *subDirFs {
+	return &subDirFs{dir: dir, fs: fs}
+}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/7065

PR re-introduces deprecated `--staticassets` flag to `argocd-server`. The flag allows users to serve additional static assets to enable [custom styling](https://argoproj.github.io/argo-cd/operator-manual/custom-styles/) feature. For backward compatibility the default flag value is `/shared/app` 