### PR TITLE
feat: goreman option to exclude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,11 @@ start-local: mod-vendor-local dep-ui-local
 	ARGOCD_E2E_TEST=false \
 		goreman -f $(ARGOCD_PROCFILE) start ${ARGOCD_START}
 
+.PHONY: goreman-start
+goreman-start:
+	bash ./hack/goreman-start.sh
+
+
 # Runs pre-commit validation with the virtualized toolchain
 .PHONY: pre-commit
 pre-commit: codegen build lint test

--- a/Makefile
+++ b/Makefile
@@ -452,8 +452,8 @@ start-local: mod-vendor-local dep-ui-local
 		goreman -f $(ARGOCD_PROCFILE) start ${ARGOCD_START}
 
 # Run goreman start with exclude option , provide exclude env variable with list of services
-.PHONY: goreman-start
-goreman-start:
+.PHONY: run
+start:
 	bash ./hack/goreman-start.sh
 
 

--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,7 @@ start-local: mod-vendor-local dep-ui-local
 	ARGOCD_E2E_TEST=false \
 		goreman -f $(ARGOCD_PROCFILE) start ${ARGOCD_START}
 
+# Run goreman start with exclude option , provide exclude env variable with list of services
 .PHONY: goreman-start
 goreman-start:
 	bash ./hack/goreman-start.sh

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ start-local: mod-vendor-local dep-ui-local
 
 # Run goreman start with exclude option , provide exclude env variable with list of services
 .PHONY: run
-start:
+run:
 	bash ./hack/goreman-start.sh
 
 

--- a/hack/goreman-start.sh
+++ b/hack/goreman-start.sh
@@ -24,7 +24,6 @@ if [ "$EXCLUDE" != "" ]; then
           servicesToRun+=($element)
         fi
     done
-
 fi
 
 command="goreman start "

--- a/hack/goreman-start.sh
+++ b/hack/goreman-start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+declare -a services=("controller" "api-server" "redis" "repo-server" "ui")
+
+EXCLUDE=$exclude
+
+declare -a servicesToRun=()
+
+if [ "$EXCLUDE" != "" ]; then
+    servicesToExclude=($(echo "$EXCLUDE" | tr ',' '\n'))
+
+    for element in "${services[@]}"
+    do
+        found=false
+        for excludedSvc in "${servicesToExclude[@]}"
+        do
+          if [[ "$excludedSvc" == "$element" ]]; then
+            found=true
+          fi
+        done
+        if [[ "$found" == false ]]; then
+          servicesToRun+=($element)
+        fi
+    done
+
+fi
+
+command="goreman start "
+
+for element in "${servicesToRun[@]}"
+do
+  command+=$element
+  command+=" "
+done
+
+eval $command

--- a/hack/goreman-start.sh
+++ b/hack/goreman-start.sh
@@ -7,8 +7,10 @@ EXCLUDE=$exclude
 declare -a servicesToRun=()
 
 if [ "$EXCLUDE" != "" ]; then
+    # Parse services list by ',' character
     servicesToExclude=($(echo "$EXCLUDE" | tr ',' '\n'))
 
+    # Find subset of items from services array that not include servicesToExclude items
     for element in "${services[@]}"
     do
         found=false


### PR DESCRIPTION
Ability to run goreman start with exclude option. 

Example: 
make goreman-start exclude=ui,redis

In most cases developers just write one service ( API, UI , so on ) and they need define whole list of services instead just skip some specific service. I recommend provide such option to run local env. Actually old way working as before

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

