### PR TITLE
fix: reset token-cookie on logout (oidc)

### DIFF
--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -20,12 +20,13 @@ import (
 )
 
 //NewHandler creates handler serving to do api/logout endpoint
-func NewHandler(appClientset versioned.Interface, settingsMrg *settings.SettingsManager, sessionMgr *session.SessionManager, rootPath, namespace string) *Handler {
+func NewHandler(appClientset versioned.Interface, settingsMrg *settings.SettingsManager, sessionMgr *session.SessionManager, rootPath, baseHRef, namespace string) *Handler {
 	return &Handler{
 		appClientset: appClientset,
 		namespace:    namespace,
 		settingsMgr:  settingsMrg,
 		rootPath:     rootPath,
+		baseHRef:     baseHRef,
 		verifyToken:  sessionMgr.VerifyToken,
 		revokeToken:  sessionMgr.RevokeToken,
 	}
@@ -38,6 +39,7 @@ type Handler struct {
 	rootPath     string
 	verifyToken  func(tokenString string) (jwt.Claims, string, error)
 	revokeToken  func(ctx context.Context, id string, expiringAt time.Duration) error
+	baseHRef     string
 }
 
 var (
@@ -85,11 +87,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(cookie.Name, common.AuthCookieName) {
 			continue
 		}
+
+		argocdCookiePath := h.rootPath
+		if argoCDSettings.IsSSOConfigured() {
+			argocdCookiePath = h.baseHRef
+		}
+
 		argocdCookie := http.Cookie{
 			Name:  cookie.Name,
 			Value: "",
 		}
-		argocdCookie.Path = fmt.Sprintf("/%s", strings.TrimRight(strings.TrimLeft(h.rootPath, "/"), "/"))
+
+		argocdCookie.Path = fmt.Sprintf("/%s", strings.TrimRight(strings.TrimLeft(argocdCookiePath, "/"), "/"))
 		w.Header().Add("Set-Cookie", argocdCookie.String())
 	}
 

--- a/server/logout/logout.go
+++ b/server/logout/logout.go
@@ -88,17 +88,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		argocdCookiePath := h.rootPath
-		if argoCDSettings.IsSSOConfigured() {
-			argocdCookiePath = h.baseHRef
-		}
-
 		argocdCookie := http.Cookie{
 			Name:  cookie.Name,
 			Value: "",
 		}
 
-		argocdCookie.Path = fmt.Sprintf("/%s", strings.TrimRight(strings.TrimLeft(argocdCookiePath, "/"), "/"))
+		argocdCookie.Path = fmt.Sprintf("/%s", strings.TrimRight(strings.TrimLeft(h.baseHRef, "/"), "/"))
 		w.Header().Add("Set-Cookie", argocdCookie.String())
 	}
 

--- a/server/logout/logout_test.go
+++ b/server/logout/logout_test.go
@@ -26,6 +26,7 @@ var (
 	validJWTPattern                      = regexp.MustCompile(`[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+`)
 	baseURL                              = "http://localhost:4000"
 	rootPath                             = "argocd"
+	baseHRef                             = "argocd"
 	baseLogoutURL                        = "http://localhost:4000/logout"
 	baseLogoutURLwithToken               = "http://localhost:4000/logout?id_token_hint={{token}}"
 	baseLogoutURLwithRedirectURL         = "http://localhost:4000/logout?post_logout_redirect_uri={{logoutRedirectURL}}"
@@ -214,21 +215,21 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 
 	sessionManager := session.NewSessionManager(settingsManagerWithOIDCConfig, test.NewFakeProjLister(), "", session.NewUserStateStorage(nil))
 
-	oidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfig, sessionManager, rootPath, "default")
+	oidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfig, sessionManager, rootPath, baseHRef, "default")
 	oidcHandler.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")
 		}
 		return &jwt.StandardClaims{Issuer: "okta"}, "", nil
 	}
-	nonoidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithoutOIDCConfig, sessionManager, "", "default")
+	nonoidcHandler := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithoutOIDCConfig, sessionManager, "", baseHRef, "default")
 	nonoidcHandler.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")
 		}
 		return &jwt.StandardClaims{Issuer: session.SessionManagerClaimsIssuer}, "", nil
 	}
-	oidcHandlerWithoutLogoutURL := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfigButNoLogoutURL, sessionManager, "", "default")
+	oidcHandlerWithoutLogoutURL := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfigButNoLogoutURL, sessionManager, "", baseHRef, "default")
 	oidcHandlerWithoutLogoutURL.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")
@@ -236,7 +237,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 		return &jwt.StandardClaims{Issuer: "okta"}, "", nil
 	}
 
-	oidcHandlerWithoutBaseURL := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfigButNoURL, sessionManager, "argocd", "default")
+	oidcHandlerWithoutBaseURL := NewHandler(appclientset.NewSimpleClientset(), settingsManagerWithOIDCConfigButNoURL, sessionManager, "argocd", baseHRef, "default")
 	oidcHandlerWithoutBaseURL.verifyToken = func(tokenString string) (jwt.Claims, string, error) {
 		if !validJWTPattern.MatchString(tokenString) {
 			return nil, "", errors.New("invalid jwt")

--- a/server/server.go
+++ b/server/server.go
@@ -681,7 +681,7 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 			handler: mux,
 			urlToHandler: map[string]http.Handler{
 				"/api/badge":          badge.NewHandler(a.AppClientset, a.settingsMgr, a.Namespace),
-				common.LogoutEndpoint: logout.NewHandler(a.AppClientset, a.settingsMgr, a.sessionMgr, a.ArgoCDServerOpts.RootPath, a.Namespace),
+				common.LogoutEndpoint: logout.NewHandler(a.AppClientset, a.settingsMgr, a.sessionMgr, a.ArgoCDServerOpts.RootPath, a.ArgoCDServerOpts.BaseHRef, a.Namespace),
 			},
 			contentTypeToHandler: map[string]http.Handler{
 				"application/grpc-web+proto": grpcWebHandler,


### PR DESCRIPTION
## Situation
We are running ArgoCD on a subpath (`/argo-cd`) and connected to OIDC.
`--basehref` is therefore set to `/argo-cd`, `--rootpath` is not set.

When logging out via UI, it's impossible to login again.

<img width="573" alt="cookies" src="https://user-images.githubusercontent.com/36745144/130967045-67d58cdc-6e2e-4038-b800-823631f5532c.png">

## Problem
On Logout, an empty-value cookie is sent, but the `path` does not match the `argocd.token` cookie that was saved on login. Therefore the saved token is not overwritten. Login is not possible anymore because the token from the cookie would be used and is already revoked.

## Solution

With OIDC-Logins, the `basehref` is used as cookie-path (https://github.com/argoproj/argo-cd/blob/master/util/oidc/oidc.go#L313).
With non-OIDC logins, the value of `--rootpath` is used as cookie-path (https://github.com/argoproj/argo-cd/blob/master/server/server.go#L635).
Therefore I added a check when sending the empty-value cookie, if it is oidc-login.

An option would be to set the cookie-paths from direct-logins to the `basehref` as well, but I'm not sure about that.


----

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

