### PR TITLE
chore: Update Ingress apiVersion to networking.k8s.io/v1beta1

### DIFF
--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -44,7 +44,7 @@ var (
       - hostname: localhost`)
 
 	testIngress = strToUnstructured(`
-  apiVersion: networking.k8s.io/v1
+  apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -75,7 +75,7 @@ var (
       - ip: 107.178.210.11`)
 
 	testIngressWildCardPath = strToUnstructured(`
-  apiVersion: networking.k8s.io/v1
+  apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -106,7 +106,7 @@ var (
       - ip: 107.178.210.11`)
 
 	testIngressWithoutTls = strToUnstructured(`
-  apiVersion: networking.k8s.io/v1
+  apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -373,7 +373,7 @@ func TestGetIngressInfoWithoutTls(t *testing.T) {
 
 func TestGetIngressInfoWithHost(t *testing.T) {
 	ingress := strToUnstructured(`
-  apiVersion: networking.k8s.io/v1
+  apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -409,7 +409,7 @@ func TestGetIngressInfoWithHost(t *testing.T) {
 }
 func TestGetIngressInfoNoHost(t *testing.T) {
 	ingress := strToUnstructured(`
-  apiVersion: networking.k8s.io/v1
+  apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     name: helm-guestbook

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -44,7 +44,7 @@ var (
       - hostname: localhost`)
 
 	testIngress = strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -75,7 +75,7 @@ var (
       - ip: 107.178.210.11`)
 
 	testIngressWildCardPath = strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -106,7 +106,7 @@ var (
       - ip: 107.178.210.11`)
 
 	testIngressWithoutTls = strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -373,7 +373,7 @@ func TestGetIngressInfoWithoutTls(t *testing.T) {
 
 func TestGetIngressInfoWithHost(t *testing.T) {
 	ingress := strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -409,7 +409,7 @@ func TestGetIngressInfoWithHost(t *testing.T) {
 }
 func TestGetIngressInfoNoHost(t *testing.T) {
 	ingress := strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -441,7 +441,7 @@ func TestGetIngressInfoNoHost(t *testing.T) {
 }
 func TestExternalUrlWithSubPath(t *testing.T) {
 	ingress := strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -469,7 +469,7 @@ func TestExternalUrlWithSubPath(t *testing.T) {
 }
 func TestExternalUrlWithMultipleSubPaths(t *testing.T) {
 	ingress := strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook
@@ -508,7 +508,7 @@ func TestExternalUrlWithMultipleSubPaths(t *testing.T) {
 }
 func TestExternalUrlWithNoSubPath(t *testing.T) {
 	ingress := strToUnstructured(`
-  apiVersion: extensions/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: helm-guestbook

--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -79,7 +79,7 @@ Since Contour Ingress supports only a single protocol per Ingress object, define
 
 Internal HTTP/HTTPS Ingress:
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-http
@@ -102,7 +102,7 @@ spec:
 
 Internal gRPC Ingress:
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-grpc
@@ -124,7 +124,7 @@ spec:
 
 External HTTPS SSO Callback Ingress:
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-external-callback-http
@@ -178,7 +178,7 @@ In order to expose the Argo CD API server with a single ingress rule and hostnam
 must be used to passthrough TLS connections and terminate TLS at the Argo CD API server.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-ingress
@@ -244,7 +244,7 @@ way would be to define two Ingress objects. One for HTTP/HTTPS, and the other fo
 
 HTTP/HTTPS Ingress:
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-http-ingress
@@ -269,7 +269,7 @@ spec:
 
 gRPC Ingress:
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-grpc-ingress
@@ -379,7 +379,7 @@ spec:
 Once we create this service, we can configure the Ingress to conditionally route all `application/grpc` traffic to the new HTTP2 backend, using the `alb.ingress.kubernetes.io/conditions` annotation, as seen below. Note: The value after the . in the condition annotation _must_ be the same name as the service that you want traffic to route to - and will be applied on any path with a matching serviceName. 
 
 ```yaml
-  apiVersion: networking.k8s.io/v1 # Use extensions/v1beta1 for Kubernetes 1.18 and older
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     annotations:

--- a/test/e2e/testdata/deprecated-extensions/ingress.yaml
+++ b/test/e2e/testdata/deprecated-extensions/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: extensions-ingress

--- a/test/e2e/testdata/networking/guestbook-ui-svc-ingress.yaml
+++ b/test/e2e/testdata/networking/guestbook-ui-svc-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: guestbook-ui
@@ -17,7 +17,7 @@ spec:
           serviceName: guestbook-ui-internal
           servicePort: 80
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: guestbook-ui-2


### PR DESCRIPTION
This fixes the warning: `Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`.

Reference:
> The v1.22 release will stop serving the following deprecated API versions in favor of newer and more stable API versions:
Ingress in the extensions/v1beta1 API version will no longer be served
Migrate to use the networking.k8s.io/v1beta1 API version, available since v1.14. Existing persisted data can be retrieved/updated via the new version.


Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
