### PR TITLE
chore: Update haproxy for redis-ha to 2.0.25

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -770,7 +770,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: haproxy:2.0.22-alpine
+        image: haproxy:2.0.25-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -790,7 +790,7 @@ spec:
         runAsUser: 1000
       containers:
       - name: haproxy
-        image: haproxy:2.0.22-alpine
+        image: haproxy:2.0.25-alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -9,7 +9,7 @@ redis-ha:
   haproxy:
     enabled: true
     image:
-      tag: 2.0.22-alpine
+      tag: 2.0.25-alpine
     timeout:
       server: 6m
       client: 6m

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3731,7 +3731,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.0.22-alpine
+      - image: haproxy:2.0.25-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -3760,7 +3760,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.0.22-alpine
+        image: haproxy:2.0.25-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1118,7 +1118,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.0.22-alpine
+      - image: haproxy:2.0.25-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -1147,7 +1147,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.0.22-alpine
+        image: haproxy:2.0.25-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:


### PR DESCRIPTION
Update haproxy to 2.0.25, which fixes a recently discovered vulnerability allowing HTTP request smuggling ([CVE-2021-40346](https://nvd.nist.gov/vuln/detail/CVE-2021-40346))

Note: This has no immediate impact on Argo CD's security as far as I can tell, but we should upgrade anyway.

Candidate for cherry-picking into release-2.0 and release-2.1 branches.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

