### PR TITLE
fix: Remove defaulty added offline_access scope in cli login when it is not supported by oidc provider

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -333,14 +333,10 @@ func (c *client) OIDCConfig(ctx context.Context, set *settingspkg.Settings) (*oa
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to query provider %q: %v", issuerURL, err)
 	}
-	oidcConf, err := oidcutil.ParseConfig(provider)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to parse provider config: %v", err)
 	}
 	scopes = oidcutil.GetScopesOrDefault(scopes)
-	if oidcutil.OfflineAccess(oidcConf.ScopesSupported) {
-		scopes = append(scopes, oidc.ScopeOfflineAccess)
-	}
 	oauth2conf := oauth2.Config{
 		ClientID: clientID,
 		Scopes:   scopes,

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -396,23 +396,6 @@ func ImplicitFlowURL(c *oauth2.Config, state string, opts ...oauth2.AuthCodeOpti
 	return c.AuthCodeURL(state, opts...)
 }
 
-// OfflineAccess returns whether or not 'offline_access' is a supported scope
-func OfflineAccess(scopes []string) bool {
-	if len(scopes) == 0 {
-		// scopes_supported is a "RECOMMENDED" discovery claim, not a required
-		// one. If missing, assume that the provider follows the spec and has
-		// an "offline_access" scope.
-		return true
-	}
-	// See if scopes_supported has the "offline_access" scope.
-	for _, scope := range scopes {
-		if scope == gooidc.ScopeOfflineAccess {
-			return true
-		}
-	}
-	return false
-}
-
 // InferGrantType infers the proper grant flow depending on the OAuth2 client config and OIDC configuration.
 // Returns either: "authorization_code" or "implicit"
 func InferGrantType(oidcConf *OIDCConfiguration) string {


### PR DESCRIPTION
Description:
When using the CLI to login with SSO option, even if the offline_access scope is not supported by the oidc provider, it was automatically added into the requested scopes, which actually lead to an unsuccessful authentication stating the scope is not supported.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. => This is a fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. => No open issue
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. => No API updates
* [x] Does this PR require documentation updates? => No
* [x] I've updated documentation as required by this PR. => Documentation was already fine!
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo) => Should be done auto?
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. => This cornet case was not tested
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). => It is locally but it seems I'm not allowed to have the CI running in this PR

