### PR TITLE
fix: cluster API should not drop system labels and annotations

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-	math "math"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/argoproj/argo-cd/v2/util/collections"
 	"github.com/argoproj/argo-cd/v2/util/helm"
 )
 
@@ -1308,11 +1309,11 @@ func (c *Cluster) Equals(other *Cluster) bool {
 		return false
 	}
 
-	if !reflect.DeepEqual(c.Annotations, other.Annotations) {
+	if !collections.StringMapsEqual(c.Annotations, other.Annotations) {
 		return false
 	}
 
-	if !reflect.DeepEqual(c.Labels, other.Labels) {
+	if !collections.StringMapsEqual(c.Labels, other.Labels) {
 		return false
 	}
 

--- a/util/collections/maps.go
+++ b/util/collections/maps.go
@@ -1,0 +1,23 @@
+package collections
+
+import "reflect"
+
+// CopyStringMap creates copy of a string map
+func CopyStringMap(in map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// StringMapsEqual compares two string maps assuming that nil and empty map are considered equal
+func StringMapsEqual(first map[string]string, second map[string]string) bool {
+	if first == nil {
+		first = map[string]string{}
+	}
+	if second == nil {
+		second = map[string]string{}
+	}
+	return reflect.DeepEqual(first, second)
+}

--- a/util/collections/maps_test.go
+++ b/util/collections/maps_test.go
@@ -1,0 +1,21 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyStringMap(t *testing.T) {
+	out := CopyStringMap(map[string]string{"foo": "bar"})
+	assert.Equal(t, map[string]string{"foo": "bar"}, out)
+}
+
+func TestStringMapsEqual(t *testing.T) {
+	assert.True(t, StringMapsEqual(nil, nil))
+	assert.True(t, StringMapsEqual(nil, map[string]string{}))
+	assert.True(t, StringMapsEqual(map[string]string{}, nil))
+	assert.True(t, StringMapsEqual(map[string]string{"foo": "bar"}, map[string]string{"foo": "bar"}))
+	assert.False(t, StringMapsEqual(map[string]string{"foo": "bar"}, nil))
+	assert.False(t, StringMapsEqual(map[string]string{"foo": "bar"}, map[string]string{"foo": "bar1"}))
+}

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -56,6 +56,28 @@ func Test_secretToCluster(t *testing.T) {
 	})
 }
 
+func TestClusterToSecret(t *testing.T) {
+	cluster := &appv1.Cluster{
+		Server:      "server",
+		Labels:      map[string]string{"test": "label"},
+		Annotations: map[string]string{"test": "annotation"},
+		Name:        "test",
+		Config:      v1alpha1.ClusterConfig{},
+		Project:     "project",
+		Namespaces:  []string{"default"},
+	}
+	s := &v1.Secret{}
+	err := clusterToSecret(cluster, s)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []byte(cluster.Server), s.Data["server"])
+	assert.Equal(t, []byte(cluster.Name), s.Data["name"])
+	assert.Equal(t, []byte(cluster.Project), s.Data["project"])
+	assert.Equal(t, []byte("default"), s.Data["namespaces"])
+	assert.Equal(t, cluster.Annotations, s.Annotations)
+	assert.Equal(t, cluster.Labels, s.Labels)
+}
+
 func Test_secretToCluster_NoConfig(t *testing.T) {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -70,8 +92,10 @@ func Test_secretToCluster_NoConfig(t *testing.T) {
 	cluster, err := secretToCluster(secret)
 	assert.NoError(t, err)
 	assert.Equal(t, *cluster, v1alpha1.Cluster{
-		Name:   "test",
-		Server: "http://mycluster",
+		Name:        "test",
+		Server:      "http://mycluster",
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
 	})
 }
 

--- a/util/db/repository_secrets_test.go
+++ b/util/db/repository_secrets_test.go
@@ -623,3 +623,36 @@ func TestSecretsRepositoryBackend_GetAllHelmRepoCreds(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, repoCreds, 1)
 }
+
+func TestRepoCredsToSecret(t *testing.T) {
+	s := &corev1.Secret{}
+	creds := &appsv1.RepoCreds{
+		URL:                        "URL",
+		Username:                   "Username",
+		Password:                   "Password",
+		SSHPrivateKey:              "SSHPrivateKey",
+		EnableOCI:                  true,
+		TLSClientCertData:          "TLSClientCertData",
+		TLSClientCertKey:           "TLSClientCertKey",
+		Type:                       "Type",
+		GithubAppPrivateKey:        "GithubAppPrivateKey",
+		GithubAppId:                123,
+		GithubAppInstallationId:    456,
+		GitHubAppEnterpriseBaseURL: "GitHubAppEnterpriseBaseURL",
+	}
+	repoCredsToSecret(creds, s)
+	assert.Equal(t, []byte(creds.URL), s.Data["url"])
+	assert.Equal(t, []byte(creds.Username), s.Data["username"])
+	assert.Equal(t, []byte(creds.Password), s.Data["password"])
+	assert.Equal(t, []byte(creds.SSHPrivateKey), s.Data["sshPrivateKey"])
+	assert.Equal(t, []byte(strconv.FormatBool(creds.EnableOCI)), s.Data["enableOCI"])
+	assert.Equal(t, []byte(creds.TLSClientCertData), s.Data["tlsClientCertData"])
+	assert.Equal(t, []byte(creds.TLSClientCertKey), s.Data["tlsClientCertKey"])
+	assert.Equal(t, []byte(creds.Type), s.Data["type"])
+	assert.Equal(t, []byte(creds.GithubAppPrivateKey), s.Data["githubAppPrivateKey"])
+	assert.Equal(t, []byte(strconv.FormatInt(creds.GithubAppId, 10)), s.Data["githubAppID"])
+	assert.Equal(t, []byte(strconv.FormatInt(creds.GithubAppInstallationId, 10)), s.Data["githubAppInstallationID"])
+	assert.Equal(t, []byte(creds.GitHubAppEnterpriseBaseURL), s.Data["githubAppEnterpriseBaseUrl"])
+	assert.Equal(t, map[string]string{common.AnnotationKeyManagedBy: common.AnnotationValueManagedByArgoCD}, s.Annotations)
+	assert.Equal(t, map[string]string{common.LabelKeySecretType: common.LabelValueSecretTypeRepoCreds}, s.Labels)
+}

--- a/util/db/secrets.go
+++ b/util/db/secrets.go
@@ -76,7 +76,11 @@ func updateSecretString(secret *apiv1.Secret, key, value string) {
 	}
 }
 
-func (db *db) createSecret(ctx context.Context, secretType string, secret *apiv1.Secret) (*apiv1.Secret, error) {
+func (db *db) createSecret(ctx context.Context, secret *apiv1.Secret) (*apiv1.Secret, error) {
+	return db.kubeclientset.CoreV1().Secrets(db.ns).Create(ctx, secret, metav1.CreateOptions{})
+}
+
+func addSecretMetadata(secret *apiv1.Secret, secretType string) {
 	if secret.Annotations == nil {
 		secret.Annotations = map[string]string{}
 	}
@@ -86,9 +90,6 @@ func (db *db) createSecret(ctx context.Context, secretType string, secret *apiv1
 		secret.Labels = map[string]string{}
 	}
 	secret.Labels[common.LabelKeySecretType] = secretType
-
-	secret, err := db.kubeclientset.CoreV1().Secrets(db.ns).Create(ctx, secret, metav1.CreateOptions{})
-	return secret, err
 }
 
 func (db *db) deleteSecret(ctx context.Context, secret *apiv1.Secret) error {


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Followup PR for https://github.com/argoproj/argo-cd/pull/7139: cluster API should allow users to modify labels/annotations but should preserve system labels and annotations.