### PR TITLE
fix: application card tooltip zindex overwrite toolbar

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-tiles.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-tiles.tsx
@@ -131,6 +131,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                             </div>
                                             <div className='columns small-9'>
                                                 <Tooltip
+                                                    zIndex={4}
                                                     content={
                                                         <div>
                                                             {Object.keys(app.metadata.labels || {})
@@ -167,7 +168,7 @@ export const ApplicationTiles = ({applications, syncApplication, refreshApplicat
                                                 Repository:
                                             </div>
                                             <div className='columns small-9'>
-                                                <Tooltip content={app.spec.source.repoURL}>
+                                                <Tooltip content={app.spec.source.repoURL} zIndex={4}>
                                                     <span>{app.spec.source.repoURL}</span>
                                                 </Tooltip>
                                             </div>


### PR DESCRIPTION
Closes #7146

* Changed:
  - As tooltip has default zIndex to 9999 which overwrite the topbar zindex (5). I reduced application title zIndex to 4
 
* Screenshot:
<img width="509" alt="Screen Shot 2021-09-15 at 1 00 59 AM" src="https://user-images.githubusercontent.com/4967217/133396618-38c81c19-d103-4fe0-825f-3ad03f14056a.png">


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

