### PR TITLE
Update health.lua

### DIFF
--- a/resource_customizations/kubernetes-client.io/ExternalSecret/health.lua
+++ b/resource_customizations/kubernetes-client.io/ExternalSecret/health.lua
@@ -3,9 +3,9 @@ if obj.status ~= nil then
   if obj.status.status == "SUCCESS" then
     health_status.status = "Healthy"
     health_status.message = "Fetched ExternalSecret."
-  elseif obj.status.status:find('^ERROR') ~= nil then
+  elseif tostring(obj.status.status).find('^ERROR') ~= nil then
     health_status.status = "Degraded"
-    health_status.message = obj.status.status:gsub("ERROR, ", "")
+    health_status.message = tostring(obj.status.status).gsub("ERROR, ", "")
   else
     health_status.status = "Progressing"
     health_status.message = "Waiting for ExternalSecret."


### PR DESCRIPTION
To avoid getting the `<string>:6: attempt to index a non-table object(string) with key 'find' stack traceback: <string>:6: in main chunk [G]: ?` error everytime an external secret is in error we can cast the status to string and use  string functions

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

