### PR TITLE
fix: Argo CD server address unspecified with Argo CD CLI v2.1.x

### DIFF
--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/shlex"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	terminal "golang.org/x/term"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/clientcmd"
@@ -58,15 +59,21 @@ func NewVersionCmd(cliName string) *cobra.Command {
 	return &versionCmd
 }
 
-// AddKubectlFlagsToCmd adds kubectl like flags to a command and returns the ClientConfig interface
+// AddKubectlFlagsToCmd adds kubectl like flags to a persistent flags of a command and returns the ClientConfig interface
 // for retrieving the values.
 func AddKubectlFlagsToCmd(cmd *cobra.Command) clientcmd.ClientConfig {
+	return AddKubectlFlagsToSet(cmd.PersistentFlags())
+}
+
+// AddKubectlFlagsToSet adds kubectl like flags to a provided flag set and returns the ClientConfig interface
+// for retrieving the values.
+func AddKubectlFlagsToSet(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	overrides := clientcmd.ConfigOverrides{}
 	kflags := clientcmd.RecommendedConfigOverrideFlags("")
-	cmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
-	clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), kflags)
+	flags.StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
+	clientcmd.BindOverrideFlags(&overrides, flags, kflags)
 	return clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Fixes https://github.com/argoproj/argo-cd/issues/7227

The `headless.InitCommand` method inject K8S flags into each command.  This is ok for all flags except `--server` flag since it is shadow Argo CD's `--server` flag. PR changes to logic to skip adding K8S `--server` flag.