### PR TITLE
Fix example `ServiceMonitor` for argocd-repo-server

### DIFF
--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -65,7 +65,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: argocd-repo-server-metrics
+      app.kubernetes.io/name: argocd-repo-server
   endpoints:
   - port: metrics
 ```


### PR DESCRIPTION
The Operator Manual suggests three nearly identical `ServiceMonitor`s (<https://argoproj.github.io/argo-cd/operator-manual/metrics/#prometheus-operator>). `argocd-metrics` and `argocd-server-metrics` are correct, but not `argocd-repo-server-metrics`, as the argocd-repo-server metrics are exposed on the main `Service`, not a separate one:

https://github.com/argoproj/argo-cd/blob/f613fab6f33cf03dd2a708085e1e45a041a04bcd/manifests/install.yaml#L2949-L2958

This patch corrects the `matchLabels`.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] ~I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.~
* [ ] ~I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~
* [ ] ~Does this PR require documentation updates?~
* [x] I've updated documentation as required by this PR.
* [ ] ~Optional. My organization is added to USERS.md.~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] ~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~
* [ ] ~My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).~