### PR TITLE
docs: add comment about current-user-password

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -77,6 +77,7 @@ argocd account get --account <username>
 
 * Set user password
 ```bash
+# if you are managing users as the admin user, <current-user-password> should be the current admin password.
 argocd account update-password \
   --account <name> \
   --current-password <current-user-password> \


### PR DESCRIPTION
It is not immediately clear what the `<current-user-password>` should be as shown by this issue: https://github.com/argoproj/argo-cd/issues/4096.
This comment should make it more clear that when users are setting passwords as the default `admin` user, they should be using the `admin` password here.

Fixes #4096