### PR TITLE
docs: Add missing links to 1.8-2.1 upgrading guides

### DIFF
--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -37,6 +37,8 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
+* [v2.0 to v2.1](./2.0-2.1.md)
+* [v1.8 to v2.0](./1.8-2.0.md)
 * [v1.7 to v1.8](./1.7-1.8.md) 
 * [v1.6 to v1.7](./1.6-1.7.md) 
 * [v1.5 to v1.6](./1.5-1.6.md) 


### PR DESCRIPTION
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
