### PR TITLE
fix: long banner messages get cut off

### DIFF
--- a/ui/src/app/ui-banner/ui-banner.scss
+++ b/ui/src/app/ui-banner/ui-banner.scss
@@ -15,6 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 5px 10px 5px 70px;
 
     a {
         text-decoration: underline;
@@ -27,4 +28,14 @@
             top: $banner-height;
         }
     }
+}
+
+.ui-banner-text {
+    margin-right: 15px;
+    overflow-y: auto;
+    max-height: 50px;
+}
+
+.ui-banner-button {
+    line-height: 1.1;
 }

--- a/ui/src/app/ui-banner/ui-banner.tsx
+++ b/ui/src/app/ui-banner/ui-banner.tsx
@@ -32,7 +32,7 @@ export const Banner = (props: React.Props<any>) => {
                 return (
                     <React.Fragment>
                         <div className='ui-banner' style={{visibility: show ? 'visible' : 'hidden'}}>
-                            <div style={{marginRight: '15px'}}>
+                            <div className='ui-banner-text'>
                                 {url !== undefined ? (
                                     <a href={url} target='_blank' rel='noopener noreferrer'>
                                         {content}
@@ -41,10 +41,12 @@ export const Banner = (props: React.Props<any>) => {
                                     <React.Fragment>{content}</React.Fragment>
                                 )}
                             </div>
-                            <button className='argo-button argo-button--base' style={{marginRight: '5px'}} onClick={() => setVisible(false)}>
+                            <button className='ui-banner-button argo-button argo-button--base' style={{marginRight: '5px'}} onClick={() => setVisible(false)}>
                                 Dismiss for now
                             </button>
-                            <button className='argo-button argo-button--base' onClick={() => services.viewPreferences.updatePreferences({...prefs, hideBannerContent: content})}>
+                            <button
+                                className='ui-banner-button argo-button argo-button--base'
+                                onClick={() => services.viewPreferences.updatePreferences({...prefs, hideBannerContent: content})}>
                                 Don't show again
                             </button>
                         </div>


### PR DESCRIPTION
Closes #7056 

Previously, a longer banner notification message would look like this: 

![banner-before](https://user-images.githubusercontent.com/50851526/134225207-2764b1a3-9f09-4b8f-b34f-b3390fa336e9.png)

Now, it would look like this:

https://user-images.githubusercontent.com/50851526/134225045-d9cbffa5-ef80-4572-9b44-2cf781cbd6a0.mp4

cc: @rbreeze 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

