### PR TITLE
refactor: cache virtual project calculation to improve performance

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -110,10 +110,14 @@ func NewCommand() *cobra.Command {
 			errors.CheckError(err)
 			cache.Cache.SetClient(cacheutil.NewTwoLevelClient(cache.Cache.GetClient(), 10*time.Minute))
 
-			settingsMgr := settings.NewSettingsManager(ctx, kubeClient, namespace)
+			var appController *controller.ApplicationController
+
+			settingsMgr := settings.NewSettingsManager(ctx, kubeClient, namespace, settings.WithRepoOrClusterChangedHandler(func() {
+				appController.InvalidateProjectsCache()
+			}))
 			kubectl := kubeutil.NewKubectl()
 			clusterFilter := getClusterFilter()
-			appController, err := controller.NewApplicationController(
+			appController, err = controller.NewApplicationController(
 				namespace,
 				settingsMgr,
 				kubeClient,


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Application controller uses `argo.GetAppProjectByName` method to get application project object that includes "global" project restrictions and project scoped repo/clusters. This logic might be CPU-consuming if Argo CD installation has a lot of repositories/clusters. Our internal dev Argo CD has ~300 repos and consumes 4.5 CPU. PR implements project caching (cache is reset every time when any repo/cluster or project changes). This reduces CPU usage in the same dev Argo CD instance to ~0.05 CPU