### PR TITLE
feat: add quick-start buttons to parent/top-level resources #7208

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -244,6 +244,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                                                                 this.getApplicationActionMenu(application, false)
                                                             )
                                                         }
+                                                        quickStarts={node => AppUtils.renderResourceButtons(node, application, tree, this.appContext, this.appChanged)}
                                                     />
                                                 )) || (
                                                     <div>

--- a/ui/src/app/applications/components/application-pod-view/pod-view.scss
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.scss
@@ -197,6 +197,17 @@ $num-stats: 2;
                 }
             }
         }
+
+        &__quick-start-actions {
+            display: flex;
+            padding-top: 1em;
+            justify-content: center;
+
+            &.disabled {
+                cursor: default !important;
+                color: $argo-color-gray-3 !important;
+            }
+        }
     }
 
     @media screen and (max-width: map-get($breakpoints, large)) {

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -20,6 +20,7 @@ interface PodViewProps {
     onItemClick: (fullName: string) => void;
     app: Application;
     nodeMenu?: (node: ResourceNode) => React.ReactNode;
+    quickStarts?: (node: ResourceNode) => React.ReactNode;
 }
 
 export type PodGroupType = 'topLevelResource' | 'parentResource' | 'node';
@@ -31,6 +32,7 @@ interface PodGroup extends Partial<ResourceNode> {
     hostResourcesInfo?: HostResourceInfo[];
     resourceStatus?: Partial<ResourceStatus>;
     renderMenu?: () => React.ReactNode;
+    renderQuickStarts?: () => React.ReactNode;
     fullName?: string;
 }
 
@@ -41,6 +43,34 @@ export class PodView extends React.Component<PodViewProps> {
 
     public static contextTypes = {
         apis: PropTypes.object
+    };
+
+    deleteAction = async (pod: Pod) => {
+        this.appContext.apis.popup.prompt(
+            'Delete pod',
+            () => (
+                <div>
+                    <p>Are you sure you want to delete Pod '{pod.name}'?</p>
+                    <div className='argo-form-row' style={{paddingLeft: '30px'}}>
+                        <CheckboxField id='force-delete-checkbox' field='force' />
+                        <label htmlFor='force-delete-checkbox'>Force delete</label>
+                    </div>
+                </div>
+            ),
+            {
+                submit: async (vals, _, close) => {
+                    try {
+                        await services.applications.deleteResource(this.props.app.metadata.name, pod, !!vals.force, false);
+                        close();
+                    } catch (e) {
+                        this.appContext.apis.notifications.show({
+                            content: <ErrorNotification title='Unable to delete resource' e={e} />,
+                            type: NotificationType.Error
+                        });
+                    }
+                }
+            }
+        );
     };
 
     public render() {
@@ -205,40 +235,11 @@ export class PodView extends React.Component<PodViewProps> {
                                                                         {
                                                                             title: (
                                                                                 <React.Fragment>
-                                                                                    <i className='fa fa-trash' /> Delete
+                                                                                    <i className='fa fa-times-circle' /> Delete
                                                                                 </React.Fragment>
                                                                             ),
-                                                                            action: async () => {
-                                                                                this.appContext.apis.popup.prompt(
-                                                                                    'Delete pod',
-                                                                                    () => (
-                                                                                        <div>
-                                                                                            <p>Are your sure you want to delete Pod '{pod.name}'?</p>
-                                                                                            <div className='argo-form-row' style={{paddingLeft: '30px'}}>
-                                                                                                <CheckboxField id='force-delete-checkbox' field='force' />
-                                                                                                <label htmlFor='force-delete-checkbox'>Force delete</label>
-                                                                                            </div>
-                                                                                        </div>
-                                                                                    ),
-                                                                                    {
-                                                                                        submit: async (vals, _, close) => {
-                                                                                            try {
-                                                                                                await services.applications.deleteResource(
-                                                                                                    this.props.app.metadata.name,
-                                                                                                    pod,
-                                                                                                    !!vals.force,
-                                                                                                    false
-                                                                                                );
-                                                                                                close();
-                                                                                            } catch (e) {
-                                                                                                this.appContext.apis.notifications.show({
-                                                                                                    content: <ErrorNotification title='Unable to delete resource' e={e} />,
-                                                                                                    type: NotificationType.Error
-                                                                                                });
-                                                                                            }
-                                                                                        }
-                                                                                    }
-                                                                                );
+                                                                            action: () => {
+                                                                                this.deleteAction(pod);
                                                                             }
                                                                         }
                                                                     ]}
@@ -246,6 +247,9 @@ export class PodView extends React.Component<PodViewProps> {
                                                             ))}
                                                         </div>
                                                         <div className='pod-view__node__label'>PODS</div>
+                                                        {(podPrefs.sortMode === 'parentResource' || podPrefs.sortMode === 'topLevelResource') && (
+                                                            <div key={group.uid}>{group.renderQuickStarts()}</div>
+                                                        )}
                                                     </div>
                                                 </div>
                                             </div>
@@ -326,7 +330,8 @@ export class PodView extends React.Component<PodViewProps> {
                     info: (rnode.info || []).filter(i => !i.name.includes('Resource.')),
                     createdAt: rnode.createdAt,
                     resourceStatus: {health: rnode.health, status: status ? status.status : null},
-                    renderMenu: () => this.props.nodeMenu(rnode)
+                    renderMenu: () => this.props.nodeMenu(rnode),
+                    renderQuickStarts: () => this.props.quickStarts(rnode)
                 };
             }
         });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1,4 +1,5 @@
 import {DataLoader, FormField, MenuItem, NotificationType, Tooltip} from 'argo-ui';
+import {ActionButton} from 'argo-ui/v2';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactForm from 'react-form';
@@ -309,6 +310,80 @@ export const deletePopup = async (ctx: ContextApis, resource: ResourceTreeNode, 
     );
 };
 
+function getActionItems(
+    resource: ResourceTreeNode,
+    application: appModels.Application,
+    tree: appModels.ApplicationTree,
+    appContext: AppContext,
+    appChanged: BehaviorSubject<appModels.Application>,
+    isQuickStart: boolean
+): Observable<ActionMenuItem[]> {
+    let menuItems: Observable<ActionMenuItem[]>;
+    const isRoot = resource.root && nodeKey(resource.root) === nodeKey(resource);
+    const items: MenuItem[] = [
+        ...((isRoot && [
+            {
+                title: 'Sync',
+                iconClassName: 'fa fa-sync',
+                action: () => showDeploy(nodeKey(resource), appContext)
+            }
+        ]) ||
+            []),
+        {
+            title: 'Delete',
+            iconClassName: 'fa fa-times-circle',
+            action: async () => {
+                return deletePopup(appContext.apis, resource, application, appChanged);
+            }
+        }
+    ];
+    if (!isQuickStart) {
+        items.unshift({
+            title: 'Details',
+            iconClassName: 'fa fa-info-circle',
+            action: () => appContext.apis.navigation.goto('.', {node: nodeKey(resource)})
+        });
+    }
+
+    if (findChildPod(resource, tree)) {
+        items.push({
+            title: 'Logs',
+            iconClassName: 'fa fa-align-left',
+            action: () => appContext.apis.navigation.goto('.', {node: nodeKey(resource), tab: 'logs'}, {replace: true})
+        });
+    }
+    if (isQuickStart) {
+        return from([items]);
+    }
+    const resourceActions = services.applications
+        .getResourceActions(application.metadata.name, resource)
+        .then(actions => {
+            items.concat(
+                actions.map(action => ({
+                    title: action.name,
+                    disabled: !!action.disabled,
+                    action: async () => {
+                        try {
+                            const confirmed = await appContext.apis.popup.confirm(`Execute '${action.name}' action?`, `Are you sure you want to execute '${action.name}' action?`);
+                            if (confirmed) {
+                                await services.applications.runResourceAction(application.metadata.name, resource, action.name);
+                            }
+                        } catch (e) {
+                            appContext.apis.notifications.show({
+                                content: <ErrorNotification title='Unable to execute resource action' e={e} />,
+                                type: NotificationType.Error
+                            });
+                        }
+                    }
+                }))
+            );
+            return items;
+        })
+        .catch(() => items);
+    menuItems = merge(from([items]), from(resourceActions));
+    return menuItems;
+}
+
 export function renderResourceMenu(
     resource: ResourceTreeNode,
     application: appModels.Application,
@@ -322,60 +397,7 @@ export function renderResourceMenu(
     if (isAppNode(resource) && resource.name === application.metadata.name) {
         menuItems = from([getApplicationActionMenu()]);
     } else {
-        const isRoot = resource.root && nodeKey(resource.root) === nodeKey(resource);
-        const items: MenuItem[] = [
-            {
-                title: 'Details',
-                action: () => appContext.apis.navigation.goto('.', {node: nodeKey(resource)}, {replace: true})
-            },
-            ...((isRoot && [
-                {
-                    title: 'Sync',
-                    action: () => showDeploy(nodeKey(resource), appContext)
-                }
-            ]) ||
-                []),
-            {
-                title: 'Delete',
-                action: async () => {
-                    return deletePopup(appContext.apis, resource, application, appChanged);
-                }
-            }
-        ];
-        if (findChildPod(resource, tree)) {
-            items.push({
-                title: 'Logs',
-                action: () => appContext.apis.navigation.goto('.', {node: nodeKey(resource), tab: 'logs'}, {replace: true})
-            });
-        }
-        const resourceActions = services.applications
-            .getResourceActions(application.metadata.name, resource)
-            .then(actions =>
-                items.concat(
-                    actions.map(action => ({
-                        title: action.name,
-                        disabled: !!action.disabled,
-                        action: async () => {
-                            try {
-                                const confirmed = await appContext.apis.popup.confirm(
-                                    `Execute '${action.name}' action?`,
-                                    `Are you sure you want to execute '${action.name}' action?`
-                                );
-                                if (confirmed) {
-                                    await services.applications.runResourceAction(application.metadata.name, resource, action.name);
-                                }
-                            } catch (e) {
-                                appContext.apis.notifications.show({
-                                    content: <ErrorNotification title='Unable to execute resource action' e={e} />,
-                                    type: NotificationType.Error
-                                });
-                            }
-                        }
-                    }))
-                )
-            )
-            .catch(() => items);
-        menuItems = merge(from([items]), from(resourceActions));
+        menuItems = getActionItems(resource, application, tree, appContext, appChanged, false);
     }
     return (
         <DataLoader load={() => menuItems}>
@@ -396,6 +418,45 @@ export function renderResourceMenu(
                         </li>
                     ))}
                 </ul>
+            )}
+        </DataLoader>
+    );
+}
+
+export function renderResourceButtons(
+    resource: ResourceTreeNode,
+    application: appModels.Application,
+    tree: appModels.ApplicationTree,
+    appContext: AppContext,
+    appChanged: BehaviorSubject<appModels.Application>
+): React.ReactNode {
+    let menuItems: Observable<ActionMenuItem[]>;
+    menuItems = getActionItems(resource, application, tree, appContext, appChanged, true);
+    return (
+        <DataLoader load={() => menuItems}>
+            {items => (
+                <div className='pod-view__node__quick-start-actions'>
+                    {items.map((item, i) => (
+                        <ActionButton
+                            disabled={item.disabled}
+                            key={i}
+                            action={(e: React.MouseEvent) => {
+                                e.stopPropagation();
+                                if (!item.disabled) {
+                                    item.action();
+                                    document.body.click();
+                                }
+                            }}
+                            icon={item.iconClassName}
+                            tooltip={
+                                item.title
+                                    .toString()
+                                    .charAt(0)
+                                    .toUpperCase() + item.title.toString().slice(1)
+                            }
+                        />
+                    ))}
+                </div>
             )}
         </DataLoader>
     );


### PR DESCRIPTION
Closes #7208 
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

This PR will adds quick-start buttons, like so: 

https://user-images.githubusercontent.com/50851526/134728680-55df83be-fc68-4564-8125-7e5a04bcebda.mp4

Note: The "Details" option that is included in the dropdown options is not included in the quick start options since clicking on the card name already brings you to the details. 



