### PR TITLE
fix: preventOverflow console warnings (#7297)

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -169,6 +169,9 @@ export class PodView extends React.Component<PodViewProps> {
                                                                                     preventOverflow: {
                                                                                         enabled: true
                                                                                     },
+                                                                                    hide: {
+                                                                                        enabled: false
+                                                                                    },
                                                                                     flip: {
                                                                                         enabled: false
                                                                                     }

--- a/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/revision-metadata-panel.tsx
@@ -16,6 +16,9 @@ export const RevisionMetadataPanel = (props: {appName: string; type: string; rev
                             preventOverflow: {
                                 enabled: false
                             },
+                            hide: {
+                                enabled: false
+                            },
                             flip: {
                                 enabled: false
                             }

--- a/ui/src/app/applications/components/applications-list/applications-labels.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-labels.tsx
@@ -20,6 +20,9 @@ export const ApplicationsLabels = ({app}: {app: Application}) => {
                 modifiers: {
                     preventOverflow: {
                         enabled: true
+                    },
+                    hide: {
+                        enabled: false
                     }
                 }
             }}


### PR DESCRIPTION
Closes #7297 

I saw this error, googled it, and saw this issue in the tippyjs github repo: https://github.com/atomiks/tippyjs/issues/105 
I guess you need the hide modified to be included, so I added it everywhere that had popperOptions and the console warnings no longer appear. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

