### PR TITLE
docs: minor formatting change in the docs

### DIFF
--- a/docs/operator-manual/user-management/keycloak.md
+++ b/docs/operator-manual/user-management/keycloak.md
@@ -57,17 +57,19 @@ Let's start by storing the client secret you generated earlier in the argocd sec
 
 1. First you'll need to encode the client secret in base64: `$ echo -n '83083958-8ec6-47b0-a411-a8c55381fbd2' | base64`
 2. Then you can edit the secret and add the base64 value to a new key called _oidc.keycloak.clientSecret_ using `$ kubectl edit secret argocd-secret`.
-   Your Secret should look something like this:
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: argocd-secret
-    data:
-      ...
-      oidc.keycloak.clientSecret: ODMwODM5NTgtOGVjNi00N2IwLWE0MTEtYThjNTUzODFmYmQy   
-      ...
-    ```
+   
+Your Secret should look something like this:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
+data:
+  ...
+  oidc.keycloak.clientSecret: ODMwODM5NTgtOGVjNi00N2IwLWE0MTEtYThjNTUzODFmYmQy   
+  ...
+```
 
 Now we can configure the config map and add the oidc configuration to enable our keycloak authentication.
 You can use `$ kubectl edit configmap argocd-cm`.


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 


I have noticed a minor formatting issue in the keycloak docs. Adding the screenshots of how it used to look before and what this PR updates.
![Screenshot 2021-09-28 at 5 35 22 PM](https://user-images.githubusercontent.com/43399466/135083880-8766bb1b-ab34-449e-8d5d-66862c994315.png)

**What this PR updates**
![Screenshot 2021-09-28 at 5 34 38 PM](https://user-images.githubusercontent.com/43399466/135083930-77c7d442-94d2-41b9-945f-e9e22f269a8b.png)


