### PR TITLE
fix: core-install.yaml always refers to latest argocd image

### DIFF
--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -31,6 +31,7 @@ $KUSTOMIZE version
 
 cd ${SRCROOT}/manifests/base && $KUSTOMIZE edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
 cd ${SRCROOT}/manifests/ha/base && $KUSTOMIZE edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
+cd ${SRCROOT}/manifests/core-install && $KUSTOMIZE edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
 
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install.yaml"
 $KUSTOMIZE build "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifests/install.yaml"

--- a/manifests/core-install/kustomization.yaml
+++ b/manifests/core-install/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
 - ../base/application-controller
 - ../base/repo-server
 - ../base/redis
+images:
+- name: quay.io/argoproj/argocd
+  newName: quay.io/argoproj/argocd
+  newTag: latest


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #7278