### PR TITLE
chore: More informative error message when redirect URL is invalid

### DIFF
--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -246,9 +246,9 @@ func (a *ClientApp) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	returnURL := r.FormValue("return_url")
-	// Check if return_url is valid, otherwise abort processing (see #2707)
+	// Check if return_url is valid, otherwise abort processing (see https://github.com/argoproj/argo-cd/pull/4780)
 	if !isValidRedirectURL(returnURL, []string{a.settings.URL}) {
-		http.Error(w, "Invalid return_url", http.StatusBadRequest)
+		http.Error(w, "Invalid redirect URL: the protocol and host (including port) must match and the path must be within allowed URLs if provided", http.StatusBadRequest)
 		return
 	}
 	stateNonce := a.generateAppState(returnURL)


### PR DESCRIPTION
Came across the error `Invalid return_url` when developing locally and I had to dig the codebase and issues to figure out the root cause. 

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
