### PR TITLE
fix: Retry with exponential backoff result in time to wait of zero(#7173)

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -766,11 +766,12 @@ func (r *RetryStrategy) NextRetryAt(lastAttempt time.Time, retryCounts int64) (t
 	}
 	// Formula: timeToWait = duration * factor^retry_number
 	// Note that timeToWait should equal to duration for the first retry attempt.
-	timeToWait := duration * time.Duration(math.Pow(float64(factor), float64(retryCounts)))
+	// When timeToWait is more than maxDuration retry should be performed at maxDuration.
+	timeToWait := float64(duration) * float64((math.Pow(float64(factor), float64(retryCounts))))
 	if maxDuration > 0 {
-		timeToWait = time.Duration(math.Min(float64(maxDuration), float64(timeToWait)))
+		timeToWait = math.Min(float64(maxDuration), timeToWait)
 	}
-	return lastAttempt.Add(timeToWait), nil
+	return lastAttempt.Add(time.Duration(timeToWait)), nil
 }
 
 // Backoff is the backoff strategy to use on subsequent retries for failing syncs

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -767,7 +767,7 @@ func (r *RetryStrategy) NextRetryAt(lastAttempt time.Time, retryCounts int64) (t
 	// Formula: timeToWait = duration * factor^retry_number
 	// Note that timeToWait should equal to duration for the first retry attempt.
 	// When timeToWait is more than maxDuration retry should be performed at maxDuration.
-	timeToWait := float64(duration) * float64((math.Pow(float64(factor), float64(retryCounts))))
+	timeToWait := float64(duration) * (math.Pow(float64(factor), float64(retryCounts)))
 	if maxDuration > 0 {
 		timeToWait = math.Min(float64(maxDuration), timeToWait)
 	}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2109,12 +2109,14 @@ func TestProjectNormalize(t *testing.T) {
 func TestRetryStrategy_NextRetryAtDefaultBackoff(t *testing.T) {
 	retry := RetryStrategy{}
 	now := time.Now()
-	expectedTimes := []time.Time{
-		now.Add(5 * time.Second),
-		now.Add(10 * time.Second),
-		now.Add(20 * time.Second),
-		now.Add(40 * time.Second),
-		now.Add(80 * time.Second),
+	expectedTimes := map[int]time.Time{
+		0:   now.Add(5 * time.Second),
+		1:   now.Add(10 * time.Second),
+		2:   now.Add(20 * time.Second),
+		3:   now.Add(40 * time.Second),
+		4:   now.Add(80 * time.Second),
+		80:  now.Add(DefaultSyncRetryMaxDuration),
+		100: now.Add(DefaultSyncRetryMaxDuration),
 	}
 
 	for i, expected := range expectedTimes {
@@ -2122,6 +2124,7 @@ func TestRetryStrategy_NextRetryAtDefaultBackoff(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected.Format(time.RFC850), retryAt.Format(time.RFC850))
 	}
+
 }
 
 func TestRetryStrategy_NextRetryAtCustomBackoff(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Fixes #7173 