### PR TITLE
docs: Kustomize load_restrictor -> load-restrictor

### DIFF
--- a/docs/user-guide/kustomize.md
+++ b/docs/user-guide/kustomize.md
@@ -35,8 +35,8 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
-    kustomize.buildOptions: --load_restrictor LoadRestrictionsNone
-    kustomize.buildOptions.v3.9.1: --output /tmp
+    kustomize.buildOptions: --load-restrictor LoadRestrictionsNone
+    kustomize.buildOptions.v4.4.0: --output /tmp
 ```
 ## Custom Kustomize versions
 


### PR DESCRIPTION
In Kustomize 4, they renamed the parameter.


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

