### PR TITLE
fix: remove misleading Helm labels from Redis resources in HA mode

### DIFF
--- a/manifests/ha/base/redis-ha/kustomization.yaml
+++ b/manifests/ha/base/redis-ha/kustomization.yaml
@@ -118,6 +118,12 @@ patchesJson6902:
     version: v1
     group: ""
     kind: ConfigMap
+    name: argocd-redis-ha-health-configmap
+  path: overlays/modify-labels.yaml
+- target:
+    version: v1
+    group: ""
+    kind: ConfigMap
     name: argocd-redis-ha-configmap
   path: overlays/modify-labels.yaml
 - target:
@@ -165,8 +171,20 @@ patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io
     version: v1
+    kind: Role
+    name: argocd-redis-ha-haproxy
+  path: overlays/modify-labels.yaml
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
     kind: RoleBinding
     name: argocd-redis-ha
+  path: overlays/modify-labels.yaml
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: RoleBinding
+    name: argocd-redis-ha-haproxy
   path: overlays/modify-labels.yaml
 - target:
     version: v1

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2650,11 +2650,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: redis-ha
-    chart: redis-ha-4.12.15
-    component: argocd-redis-ha-haproxy
-    heritage: Helm
-    release: argocd
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
   name: argocd-redis-ha-haproxy
 rules:
 - apiGroups:
@@ -2810,11 +2808,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: redis-ha
-    chart: redis-ha-4.12.15
-    component: argocd-redis-ha-haproxy
-    heritage: Helm
-    release: argocd
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
   name: argocd-redis-ha-haproxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3369,10 +3365,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: argocd-redis-ha
-    chart: redis-ha-4.12.15
-    heritage: Helm
-    release: argocd
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
   name: argocd-redis-ha-health-configmap
 ---
 apiVersion: v1

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -122,11 +122,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: redis-ha
-    chart: redis-ha-4.12.15
-    component: argocd-redis-ha-haproxy
-    heritage: Helm
-    release: argocd
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
   name: argocd-redis-ha-haproxy
 rules:
 - apiGroups:
@@ -231,11 +229,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: redis-ha
-    chart: redis-ha-4.12.15
-    component: argocd-redis-ha-haproxy
-    heritage: Helm
-    release: argocd
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
   name: argocd-redis-ha-haproxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -756,10 +752,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: argocd-redis-ha
-    chart: redis-ha-4.12.15
-    heritage: Helm
-    release: argocd
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis-ha
+    app.kubernetes.io/part-of: argocd
   name: argocd-redis-ha-health-configmap
 ---
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Adding Kustomization patches to remove the misleading Helm labels from certain Redis resources in HA mode 

Closes: #6570 

