### PR TITLE
feat: Resources should be normalized in order to prevent our of sync during migration

### DIFF
--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
@@ -368,7 +368,7 @@ func reconcileApplications(
 	)
 
 	appStateManager := controller.NewAppStateManager(
-		argoDB, appClientset, repoServerClient, namespace, kubeutil.NewKubectl(), settingsMgr, stateCache, projInformer, server, cache, time.Second, argo.NewResourceTracking())
+		argoDB, appClientset, repoServerClient, namespace, kubeutil.NewKubectl(), settingsMgr, stateCache, projInformer, server, cache, time.Second, resource_tracking.NewResourceTracking())
 
 	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(context.Background(), v1.ListOptions{LabelSelector: selector})
 	if err != nil {
@@ -410,5 +410,5 @@ func reconcileApplications(
 }
 
 func newLiveStateCache(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) cache.LiveStateCache {
-	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, kubeutil.NewKubectl(), server, func(managedByApp map[string]bool, ref apiv1.ObjectReference) {}, nil, argo.NewResourceTracking())
+	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, kubeutil.NewKubectl(), server, func(managedByApp map[string]bool, ref apiv1.ObjectReference) {}, nil, resource_tracking.NewResourceTracking())
 }

--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -411,7 +411,7 @@ argocd admin settings resource-overrides ignore-differences ./deploy.yaml --argo
 
 				normalizedRes := res.DeepCopy()
 				logs := collectLogs(func() {
-					errors.CheckError(normalizer.Normalize(normalizedRes))
+					errors.CheckError(normalizer.Normalize(normalizedRes, nil, nil))
 				})
 				if logs != "" {
 					_, _ = fmt.Println(logs)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -885,7 +885,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 					val := argoSettings.ResourceOverrides[k]
 					overrides[k] = *val
 				}
-				normalizer, err := argo.NewDiffNormalizer(app.Spec.IgnoreDifferences, overrides)
+				normalizer, err := argo.NewDiffNormalizer(app.Spec.IgnoreDifferences, overrides, argoSettings.GetTrackingMethod())
 				errors.CheckError(err)
 
 				diffRes, err := diff.Diff(item.target, item.live, diff.WithNormalizer(normalizer))

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
+
 	clustercache "github.com/argoproj/gitops-engine/pkg/cache"
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -195,8 +197,8 @@ func NewApplicationController(
 			return nil, err
 		}
 	}
-	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, kubectl, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterFilter, argo.NewResourceTracking())
-	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.settingsMgr, stateCache, projInformer, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, argo.NewResourceTracking())
+	stateCache := statecache.NewLiveStateCache(db, appInformer, ctrl.settingsMgr, kubectl, ctrl.metricsServer, ctrl.handleObjectUpdated, clusterFilter, resource_tracking.NewResourceTracking())
+	appStateManager := NewAppStateManager(db, applicationClientset, repoClientset, namespace, kubectl, ctrl.settingsMgr, stateCache, projInformer, ctrl.metricsServer, argoCache, ctrl.statusRefreshTimeout, resource_tracking.NewResourceTracking())
 	ctrl.appInformer = appInformer
 	ctrl.appLister = appLister
 	ctrl.projInformer = projInformer

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
+
 	clustercache "github.com/argoproj/gitops-engine/pkg/cache"
 	"github.com/argoproj/gitops-engine/pkg/health"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
@@ -106,7 +108,7 @@ func NewLiveStateCache(
 	metricsServer *metrics.MetricsServer,
 	onObjectUpdated ObjectUpdatedHandler,
 	clusterFilter func(cluster *appv1.Cluster) bool,
-	resourceTracking argo.ResourceTracking) LiveStateCache {
+	resourceTracking resource_tracking.ResourceTracking) LiveStateCache {
 
 	return &liveStateCache{
 		appInformer:     appInformer,
@@ -136,7 +138,7 @@ type liveStateCache struct {
 	settingsMgr      *settings.SettingsManager
 	metricsServer    *metrics.MetricsServer
 	clusterFilter    func(cluster *appv1.Cluster) bool
-	resourceTracking argo.ResourceTracking
+	resourceTracking resource_tracking.ResourceTracking
 
 	// listSemaphore is used to limit the number of concurrent memory consuming operations on the
 	// k8s list queries results across all clusters to avoid memory spikes during cache initialization.
@@ -288,7 +290,7 @@ func (c *liveStateCache) getCluster(server string) (clustercache.ClusterCache, e
 		return nil, fmt.Errorf("controller is configured to ignore cluster %s", cluster.Server)
 	}
 
-	trackingMethod := argo.GetTrackingMethod(c.settingsMgr)
+	trackingMethod := resource_tracking.GetTrackingMethod(c.settingsMgr)
 	clusterCache = clustercache.NewClusterCache(cluster.RESTConfig(),
 		clustercache.SetListSemaphore(c.listSemaphore),
 		clustercache.SetResyncTimeout(K8SClusterResyncDuration),

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-redis/redis/v8"
@@ -194,7 +194,7 @@ func (c *Cache) DeleteManifests(revision string, appSrc *appv1.ApplicationSource
 
 func appDetailsCacheKey(revision string, appSrc *appv1.ApplicationSource, trackingMethod appv1.TrackingMethod) string {
 	if trackingMethod == "" {
-		trackingMethod = argo.TrackingMethodLabel
+		trackingMethod = resource_tracking.TrackingMethodLabel
 	}
 	return fmt.Sprintf("appdetails|%s|%d|%s", revision, appSourceKey(appSrc), trackingMethod)
 }

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
 
 	"github.com/Masterminds/semver"
 	"github.com/TomOnTime/utfutil"
@@ -69,7 +69,7 @@ type Service struct {
 	cache                     *reposervercache.Cache
 	parallelismLimitSemaphore *semaphore.Weighted
 	metricsServer             *metrics.MetricsServer
-	resourceTracking          argo.ResourceTracking
+	resourceTracking          resource_tracking.ResourceTracking
 	newGitClient              func(rawRepoURL string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (git.Client, error)
 	newHelmClient             func(repoURL string, creds helm.Creds, enableOci bool, proxy string, opts ...helm.ClientOpts) helm.Client
 	initConstants             RepoServerInitConstants
@@ -85,7 +85,7 @@ type RepoServerInitConstants struct {
 }
 
 // NewService returns a new instance of the Manifest service
-func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cache, initConstants RepoServerInitConstants, resourceTracking argo.ResourceTracking) *Service {
+func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cache, initConstants RepoServerInitConstants, resourceTracking resource_tracking.ResourceTracking) *Service {
 	var parallelismLimitSemaphore *semaphore.Weighted
 	if initConstants.ParallelismLimit > 0 {
 		parallelismLimitSemaphore = semaphore.NewWeighted(initConstants.ParallelismLimit)
@@ -715,7 +715,7 @@ func GenerateManifests(appPath, repoRoot, revision string, q *apiclient.Manifest
 	var targetObjs []*unstructured.Unstructured
 	var dest *v1alpha1.ApplicationDestination
 
-	resourceTracking := argo.NewResourceTracking()
+	resourceTracking := resource_tracking.NewResourceTracking()
 	appSourceType, err := GetAppSourceType(q.ApplicationSource, appPath, q.AppName)
 	if err != nil {
 		return nil, err

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +72,7 @@ func newServiceWithOpt(cf clientFunc) (*Service, *gitmocks.Client) {
 		cacheutil.NewCache(cacheutil.NewInMemoryCache(1*time.Minute)),
 		1*time.Minute,
 		1*time.Minute,
-	), RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking())
+	), RepoServerInitConstants{ParallelismLimit: 1}, resource_tracking.NewResourceTracking())
 
 	chart := "my-chart"
 	version := "1.1.0"

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
@@ -94,7 +94,7 @@ func (a *ArgoCDRepoServer) CreateGRPC() *grpc.Server {
 	versionpkg.RegisterVersionServiceServer(server, version.NewServer(nil, func() (bool, error) {
 		return true, nil
 	}))
-	manifestService := repository.NewService(a.metricsServer, a.cache, a.initConstants, argo.NewResourceTracking())
+	manifestService := repository.NewService(a.metricsServer, a.cache, a.initConstants, resource_tracking.NewResourceTracking())
 	apiclient.RegisterRepoServerServiceServer(server, manifestService)
 
 	healthService := health.NewServer()

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
+
 	"github.com/Masterminds/semver"
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
@@ -331,7 +333,7 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 			KubeVersion:       serverVersion,
 			ApiVersions:       argo.APIGroupsToVersions(apiGroups),
 			HelmRepoCreds:     helmCreds,
-			TrackingMethod:    string(argoutil.GetTrackingMethod(s.settingsMgr)),
+			TrackingMethod:    string(resource_tracking.GetTrackingMethod(s.settingsMgr)),
 		})
 		return err
 	})
@@ -415,7 +417,7 @@ func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*app
 				KustomizeOptions: kustomizeOptions,
 				Repos:            helmRepos,
 				NoCache:          true,
-				TrackingMethod:   string(argoutil.GetTrackingMethod(s.settingsMgr)),
+				TrackingMethod:   string(resource_tracking.GetTrackingMethod(s.settingsMgr)),
 			})
 			return err
 		}); err != nil {

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
 
-	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
@@ -41,7 +41,7 @@ func TestDeployment(t *testing.T) {
 func TestDeploymentWithAnnotationTrackingMode(t *testing.T) {
 	ctx := Given(t)
 
-	SetTrackingMethod(string(argo.TrackingMethodAnnotation))
+	SetTrackingMethod(string(resource_tracking.TrackingMethodAnnotation))
 	ctx.
 		Path("deployment").
 		When().
@@ -64,7 +64,7 @@ func TestDeploymentWithAnnotationTrackingMode(t *testing.T) {
 
 func TestDeploymentWithLabelTrackingMode(t *testing.T) {
 	ctx := Given(t)
-	SetTrackingMethod(string(argo.TrackingMethodLabel))
+	SetTrackingMethod(string(resource_tracking.TrackingMethodLabel))
 	ctx.
 		Path("deployment").
 		When().

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
+
 	"github.com/r3labs/diff"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
@@ -245,7 +247,7 @@ func ValidateRepo(
 		KustomizeOptions: kustomizeOptions,
 		// don't use case during application change to make sure to fetch latest git/helm revisions
 		NoRevisionCache: true,
-		TrackingMethod:  string(GetTrackingMethod(settingsMgr)),
+		TrackingMethod:  string(resource_tracking.GetTrackingMethod(settingsMgr)),
 	})
 	if err != nil {
 		conditions = append(conditions, argoappv1.ApplicationCondition{
@@ -499,7 +501,7 @@ func verifyGenerateManifests(
 		KubeVersion:       kubeVersion,
 		ApiVersions:       apiVersions,
 		HelmRepoCreds:     repositoryCredentials,
-		TrackingMethod:    string(GetTrackingMethod(settingsMgr)),
+		TrackingMethod:    string(resource_tracking.GetTrackingMethod(settingsMgr)),
 	}
 	req.Repo.CopyCredentialsFromRepo(repoRes)
 	req.Repo.CopySettingsFrom(repoRes)

--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -151,7 +151,7 @@ func NewIgnoreNormalizer(ignore []v1alpha1.ResourceIgnoreDifferences, overrides 
 }
 
 // Normalize removes fields from supplied resource using json paths from matching items of specified resources ignored differences list
-func (n *ignoreNormalizer) Normalize(un *unstructured.Unstructured) error {
+func (n *ignoreNormalizer) Normalize(un, config, live *unstructured.Unstructured) error {
 	matched := make([]normalizerPatch, 0)
 	for _, patch := range n.patches {
 		groupKind := un.GroupVersionKind().GroupKind()

--- a/util/argo/normalizers/diff_normalizer_test.go
+++ b/util/argo/normalizers/diff_normalizer_test.go
@@ -26,7 +26,7 @@ func TestNormalizeObjectWithMatchedGroupKind(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, has)
 
-	err = normalizer.Normalize(deployment)
+	err = normalizer.Normalize(deployment, nil, nil)
 	assert.Nil(t, err)
 	_, has, err = unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
 	assert.Nil(t, err)
@@ -44,7 +44,7 @@ func TestNormalizeNoMatchedGroupKinds(t *testing.T) {
 
 	deployment := test.NewDeployment()
 
-	err = normalizer.Normalize(deployment)
+	err = normalizer.Normalize(deployment, nil, nil)
 	assert.Nil(t, err)
 
 	_, hasSpec, err := unstructured.NestedMap(deployment.Object, "spec")
@@ -67,7 +67,7 @@ func TestNormalizeMatchedResourceOverrides(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, has)
 
-	err = normalizer.Normalize(deployment)
+	err = normalizer.Normalize(deployment, nil, nil)
 	assert.Nil(t, err)
 	_, has, err = unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
 	assert.Nil(t, err)
@@ -105,14 +105,14 @@ func TestNormalizeMissingJsonPointer(t *testing.T) {
 
 	deployment := test.NewDeployment()
 
-	err = normalizer.Normalize(deployment)
+	err = normalizer.Normalize(deployment, nil, nil)
 	assert.NoError(t, err)
 
 	crd := unstructured.Unstructured{}
 	err = yaml.Unmarshal([]byte(testCRDYAML), &crd)
 	assert.NoError(t, err)
 
-	err = normalizer.Normalize(&crd)
+	err = normalizer.Normalize(&crd, nil, nil)
 	assert.NoError(t, err)
 }
 
@@ -131,7 +131,7 @@ func TestNormalizeGlobMatch(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, has)
 
-	err = normalizer.Normalize(deployment)
+	err = normalizer.Normalize(deployment, nil, nil)
 	assert.Nil(t, err)
 	_, has, err = unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
 	assert.Nil(t, err)
@@ -160,7 +160,7 @@ func TestNormalizeJQPathExpression(t *testing.T) {
 	assert.True(t, has)
 	assert.Len(t, actualInitContainers, 2)
 
-	err = normalizer.Normalize(deployment)
+	err = normalizer.Normalize(deployment, nil, nil)
 	assert.Nil(t, err)
 	actualInitContainers, has, err = unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "initContainers")
 	assert.Nil(t, err)
@@ -197,7 +197,7 @@ func TestNormalizeJQPathExpressionWithError(t *testing.T) {
 	originalDeployment, err := deployment.MarshalJSON()
 	assert.Nil(t, err)
 
-	err = normalizer.Normalize(deployment)
+	err = normalizer.Normalize(deployment, nil, nil)
 	assert.Nil(t, err)
 
 	normalizedDeployment, err := deployment.MarshalJSON()

--- a/util/argo/normalizers/knowntypes_normalizer.go
+++ b/util/argo/normalizers/knowntypes_normalizer.go
@@ -145,7 +145,7 @@ func remarshal(fieldVal interface{}, field knownTypeField) (interface{}, error) 
 
 // Normalize re-format custom resource fields using built-in Kubernetes types JSON marshaler.
 // This technique allows avoiding false drift detections in CRDs that import data structures from Kubernetes codebase.
-func (n *knownTypesNormalizer) Normalize(un *unstructured.Unstructured) error {
+func (n *knownTypesNormalizer) Normalize(un, config, live *unstructured.Unstructured) error {
 	if fields, ok := n.typeFields[un.GroupVersionKind().GroupKind()]; ok {
 		for _, field := range fields {
 			err := normalize(un.Object, field, field.fieldPath)

--- a/util/argo/normalizers/knowntypes_normalizer_test.go
+++ b/util/argo/normalizers/knowntypes_normalizer_test.go
@@ -82,7 +82,7 @@ func TestNormalize_MapField(t *testing.T) {
 
 	rollout := mustUnmarshalYAML(someCRDYaml)
 
-	err = normalizer.Normalize(rollout)
+	err = normalizer.Normalize(rollout, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -123,7 +123,7 @@ func TestNormalize_FieldInNestedSlice(t *testing.T) {
 		return
 	}
 
-	err = normalizer.Normalize(rollout)
+	err = normalizer.Normalize(rollout, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -175,7 +175,7 @@ spec:
 		return
 	}
 
-	err = normalizer.Normalize(rollout)
+	err = normalizer.Normalize(rollout, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -216,7 +216,7 @@ spec:
 		return
 	}
 
-	err = normalizer.Normalize(rollout)
+	err = normalizer.Normalize(rollout, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -242,7 +242,7 @@ func TestFieldDoesNotExist(t *testing.T) {
 		return
 	}
 
-	err = normalizer.Normalize(rollout)
+	err = normalizer.Normalize(rollout, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/util/argo/normalizers/resource_id_normalizer.go
+++ b/util/argo/normalizers/resource_id_normalizer.go
@@ -1,0 +1,75 @@
+package normalizers
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/argoproj/argo-cd/v2/util/kube"
+)
+
+type resourceIdNormalizer struct {
+	trackingMethod string
+}
+
+func init() {
+
+}
+
+// NewResourceIdNormalizer
+func NewResourceIdNormalizer(trackingMethod string) (*resourceIdNormalizer, error) {
+	normalizer := resourceIdNormalizer{trackingMethod: trackingMethod}
+	return &normalizer, nil
+}
+
+// Normalize re-format custom resource fields using built-in Kubernetes types JSON marshaler.
+// This technique allows avoiding false drift detections in CRDs that import data structures from Kubernetes codebase.
+func (n *resourceIdNormalizer) Normalize(origin, config, live *unstructured.Unstructured) error {
+	if resource_tracking.IsOldTrackingMethod(n.trackingMethod) {
+		return nil
+	}
+
+	if live == nil {
+		return nil
+	}
+
+	if n.trackingMethod == string(resource_tracking.TrackingMethodAnnotation) {
+		annotation := kube.GetAppInstanceAnnotation(origin, common.AnnotationKeyAppInstance)
+		_ = kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
+		if config != nil {
+			_ = kube.SetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance, annotation)
+			_ = kube.SetAppInstanceLabel(config, common.LabelKeyAppInstance, kube.GetAppInstanceLabel(live, common.LabelKeyAppInstance))
+		}
+	}
+
+	if n.trackingMethod == string(resource_tracking.TrackingMethodAnnotationAndLabel) {
+		annotation := kube.GetAppInstanceAnnotation(origin, common.AnnotationKeyAppInstance)
+		_ = kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
+		if config != nil {
+			_ = kube.SetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance, annotation)
+		}
+	}
+
+	//
+	//label := kube.GetAppInstanceLabel(origin, common.LabelKeyAppInstance)
+	//
+	//lannotation := kube.GetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance)
+	//llabel := kube.GetAppInstanceLabel(live, common.LabelKeyAppInstance)
+	//
+	//if annotation != "" {
+	//}
+	//
+	//if label != "" {
+	//	_ = kube.SetAppInstanceLabel(live, common.LabelKeyAppInstance, label)
+	//}
+	//
+	//if lannotation != "" {
+	//	_ = kube.SetAppInstanceAnnotation(origin, common.AnnotationKeyAppInstance, lannotation)
+	//}
+	//
+	//if llabel != "" {
+	//	_ = kube.SetAppInstanceLabel(origin, common.LabelKeyAppInstance, llabel)
+	//}
+	return nil
+}

--- a/util/argo/normalizers/resource_id_normalizer.go
+++ b/util/argo/normalizers/resource_id_normalizer.go
@@ -3,10 +3,10 @@ package normalizers
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
-
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/util/kube"
+
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
 )
 
 type resourceIdNormalizer struct {
@@ -34,42 +34,21 @@ func (n *resourceIdNormalizer) Normalize(origin, config, live *unstructured.Unst
 		return nil
 	}
 
-	if n.trackingMethod == string(resource_tracking.TrackingMethodAnnotation) {
-		annotation := kube.GetAppInstanceAnnotation(origin, common.AnnotationKeyAppInstance)
-		_ = kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
-		if config != nil {
-			_ = kube.SetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance, annotation)
-			_ = kube.SetAppInstanceLabel(config, common.LabelKeyAppInstance, kube.GetAppInstanceLabel(live, common.LabelKeyAppInstance))
+	annotation := kube.GetAppInstanceAnnotation(origin, common.AnnotationKeyAppInstance)
+	err := kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
+	if err != nil {
+		return err
+	}
+	if config != nil {
+		err = kube.SetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance, annotation)
+		if err != nil {
+			return err
+		}
+		err = kube.SetAppInstanceLabel(config, common.LabelKeyAppInstance, kube.GetAppInstanceLabel(live, common.LabelKeyAppInstance))
+		if err != nil {
+			return err
 		}
 	}
 
-	if n.trackingMethod == string(resource_tracking.TrackingMethodAnnotationAndLabel) {
-		annotation := kube.GetAppInstanceAnnotation(origin, common.AnnotationKeyAppInstance)
-		_ = kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
-		if config != nil {
-			_ = kube.SetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance, annotation)
-		}
-	}
-
-	//
-	//label := kube.GetAppInstanceLabel(origin, common.LabelKeyAppInstance)
-	//
-	//lannotation := kube.GetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance)
-	//llabel := kube.GetAppInstanceLabel(live, common.LabelKeyAppInstance)
-	//
-	//if annotation != "" {
-	//}
-	//
-	//if label != "" {
-	//	_ = kube.SetAppInstanceLabel(live, common.LabelKeyAppInstance, label)
-	//}
-	//
-	//if lannotation != "" {
-	//	_ = kube.SetAppInstanceAnnotation(origin, common.AnnotationKeyAppInstance, lannotation)
-	//}
-	//
-	//if llabel != "" {
-	//	_ = kube.SetAppInstanceLabel(origin, common.LabelKeyAppInstance, llabel)
-	//}
 	return nil
 }

--- a/util/argo/normalizers/resource_id_normalizer_test.go
+++ b/util/argo/normalizers/resource_id_normalizer_test.go
@@ -1,0 +1,44 @@
+package normalizers
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v2/util/kube"
+
+	"github.com/argoproj/argo-cd/v2/util/resource_tracking"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/argoproj/argo-cd/v2/common"
+)
+
+func TestResourceIdNormalizer_Normalize(t *testing.T) {
+	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	assert.Nil(t, err)
+	var obj *unstructured.Unstructured
+	err = yaml.Unmarshal(yamlBytes, &obj)
+	assert.Nil(t, err)
+
+	resourceTracking := resource_tracking.NewResourceTracking()
+
+	err = resourceTracking.SetAppInstance(obj, common.LabelKeyAppInstance, "my-app", "", resource_tracking.TrackingMethodLabel)
+
+	yamlBytes, err = ioutil.ReadFile("testdata/svc.yaml")
+	assert.Nil(t, err)
+	var obj2 *unstructured.Unstructured
+	err = yaml.Unmarshal(yamlBytes, &obj2)
+	assert.Nil(t, err)
+
+	err = resourceTracking.SetAppInstance(obj2, common.AnnotationKeyAppInstance, "my-app2", "", resource_tracking.TrackingMethodAnnotation)
+
+	normalizer, _ := NewResourceIdNormalizer("annotation")
+
+	_ = normalizer.Normalize(obj2, nil, obj)
+
+	annotation := kube.GetAppInstanceAnnotation(obj2, common.AnnotationKeyAppInstance)
+
+	assert.Equal(t, obj.GetAnnotations()[common.AnnotationKeyAppInstance], annotation)
+}

--- a/util/argo/normalizers/testdata/svc.yaml
+++ b/util/argo/normalizers/testdata/svc.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376

--- a/util/resource_tracking/resource_tracking.go
+++ b/util/resource_tracking/resource_tracking.go
@@ -1,4 +1,4 @@
-package argo
+package resource_tracking
 
 import (
 	"fmt"
@@ -55,6 +55,10 @@ func GetTrackingMethod(settingsMgr *settings.SettingsManager) v1alpha1.TrackingM
 		return TrackingMethodLabel
 	}
 	return v1alpha1.TrackingMethod(tm)
+}
+
+func IsOldTrackingMethod(trackingMethod string) bool {
+	return trackingMethod == "" || trackingMethod == string(TrackingMethodLabel)
 }
 
 // GetAppName retrieve application name base on tracking method

--- a/util/resource_tracking/resource_tracking_test.go
+++ b/util/resource_tracking/resource_tracking_test.go
@@ -21,9 +21,9 @@ func TestSetAppInstanceLabel(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	err = SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodLabel)
+	err = resourceTracking.SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodLabel)
 	assert.Nil(t, err)
-	app := GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodLabel)
+	app := resourceTracking.GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodLabel)
 	assert.Equal(t, "my-app", app)
 }
 
@@ -37,10 +37,10 @@ func TestSetAppInstanceAnnotation(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	err = SetAppInstance(&obj, common.AnnotationKeyAppInstance, "my-app", "", TrackingMethodAnnotation)
+	err = resourceTracking.SetAppInstance(&obj, common.AnnotationKeyAppInstance, "my-app", "", TrackingMethodAnnotation)
 	assert.Nil(t, err)
 
-	app := GetAppName(&obj, common.AnnotationKeyAppInstance, TrackingMethodAnnotation)
+	app := resourceTracking.GetAppName(&obj, common.AnnotationKeyAppInstance, TrackingMethodAnnotation)
 	assert.Equal(t, "my-app", app)
 }
 
@@ -53,10 +53,10 @@ func TestSetAppInstanceAnnotationAndLabel(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	err = SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodAnnotationAndLabel)
+	err = resourceTracking.SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodAnnotationAndLabel)
 	assert.Nil(t, err)
 
-	app := GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotationAndLabel)
+	app := resourceTracking.GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotationAndLabel)
 	assert.Equal(t, "my-app", app)
 }
 
@@ -70,13 +70,13 @@ func TestSetAppInstanceAnnotationNotFound(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	app := GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotation)
+	app := resourceTracking.GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotation)
 	assert.Equal(t, "", app)
 }
 
 func TestParseAppInstanceValue(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	appInstanceValue, err := ParseAppInstanceValue("app:<group>/<kind>:<namespace>/<name>")
+	appInstanceValue, err := resourceTracking.ParseAppInstanceValue("app:<group>/<kind>:<namespace>/<name>")
 	if !assert.NoError(t, err) {
 		t.Fatal()
 	}
@@ -89,18 +89,18 @@ func TestParseAppInstanceValue(t *testing.T) {
 
 func TestParseAppInstanceValueWrongFormat1(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	_, err := ParseAppInstanceValue("app")
+	_, err := resourceTracking.ParseAppInstanceValue("app")
 	assert.Error(t, err, WrongResourceTrackingFormat)
 }
 
 func TestParseAppInstanceValueWrongFormat2(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	_, err := ParseAppInstanceValue("app;group/kind/ns")
+	_, err := resourceTracking.ParseAppInstanceValue("app;group/kind/ns")
 	assert.Error(t, err, WrongResourceTrackingFormat)
 }
 
 func TestParseAppInstanceValueCorrectFormat(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	_, err := ParseAppInstanceValue("app:group/kind:test/ns")
+	_, err := resourceTracking.ParseAppInstanceValue("app:group/kind:test/ns")
 	assert.NoError(t, err)
 }

--- a/util/resource_tracking/resource_tracking_test.go
+++ b/util/resource_tracking/resource_tracking_test.go
@@ -1,4 +1,4 @@
-package argo
+package resource_tracking
 
 import (
 	"io/ioutil"
@@ -21,9 +21,9 @@ func TestSetAppInstanceLabel(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	err = resourceTracking.SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodLabel)
+	err = SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodLabel)
 	assert.Nil(t, err)
-	app := resourceTracking.GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodLabel)
+	app := GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodLabel)
 	assert.Equal(t, "my-app", app)
 }
 
@@ -37,10 +37,10 @@ func TestSetAppInstanceAnnotation(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	err = resourceTracking.SetAppInstance(&obj, common.AnnotationKeyAppInstance, "my-app", "", TrackingMethodAnnotation)
+	err = SetAppInstance(&obj, common.AnnotationKeyAppInstance, "my-app", "", TrackingMethodAnnotation)
 	assert.Nil(t, err)
 
-	app := resourceTracking.GetAppName(&obj, common.AnnotationKeyAppInstance, TrackingMethodAnnotation)
+	app := GetAppName(&obj, common.AnnotationKeyAppInstance, TrackingMethodAnnotation)
 	assert.Equal(t, "my-app", app)
 }
 
@@ -53,10 +53,10 @@ func TestSetAppInstanceAnnotationAndLabel(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	err = resourceTracking.SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodAnnotationAndLabel)
+	err = SetAppInstance(&obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodAnnotationAndLabel)
 	assert.Nil(t, err)
 
-	app := resourceTracking.GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotationAndLabel)
+	app := GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotationAndLabel)
 	assert.Equal(t, "my-app", app)
 }
 
@@ -70,13 +70,13 @@ func TestSetAppInstanceAnnotationNotFound(t *testing.T) {
 
 	resourceTracking := NewResourceTracking()
 
-	app := resourceTracking.GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotation)
+	app := GetAppName(&obj, common.LabelKeyAppInstance, TrackingMethodAnnotation)
 	assert.Equal(t, "", app)
 }
 
 func TestParseAppInstanceValue(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	appInstanceValue, err := resourceTracking.ParseAppInstanceValue("app:<group>/<kind>:<namespace>/<name>")
+	appInstanceValue, err := ParseAppInstanceValue("app:<group>/<kind>:<namespace>/<name>")
 	if !assert.NoError(t, err) {
 		t.Fatal()
 	}
@@ -89,18 +89,18 @@ func TestParseAppInstanceValue(t *testing.T) {
 
 func TestParseAppInstanceValueWrongFormat1(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	_, err := resourceTracking.ParseAppInstanceValue("app")
+	_, err := ParseAppInstanceValue("app")
 	assert.Error(t, err, WrongResourceTrackingFormat)
 }
 
 func TestParseAppInstanceValueWrongFormat2(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	_, err := resourceTracking.ParseAppInstanceValue("app;group/kind/ns")
+	_, err := ParseAppInstanceValue("app;group/kind/ns")
 	assert.Error(t, err, WrongResourceTrackingFormat)
 }
 
 func TestParseAppInstanceValueCorrectFormat(t *testing.T) {
 	resourceTracking := NewResourceTracking()
-	_, err := resourceTracking.ParseAppInstanceValue("app:group/kind:test/ns")
+	_, err := ParseAppInstanceValue("app:group/kind:test/ns")
 	assert.NoError(t, err)
 }

--- a/util/resource_tracking/testdata/svc.yaml
+++ b/util/resource_tracking/testdata/svc.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376


### PR DESCRIPTION
Continuation for https://github.com/argoproj/argo-cd/pull/7251

During migration we should normalize annotation with specific key as label for prevent our of sync status inside existing resources