### PR TITLE
feat: Resources should be normalized in order to prevent our of sync during migration

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -48,7 +48,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
-	argokube "github.com/argoproj/argo-cd/v2/util/kube"
 	"github.com/argoproj/argo-cd/v2/util/templates"
 	"github.com/argoproj/argo-cd/v2/util/text/label"
 )
@@ -925,6 +924,8 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 }
 
 func groupObjsForDiff(resources *application.ManagedResourcesResponse, objs map[kube.ResourceKey]*unstructured.Unstructured, items []objKeyLiveTarget, argoSettings *settings.Settings, appName string) []objKeyLiveTarget {
+	resourceTracking := argo.NewResourceTracking()
+
 	for _, res := range resources.Items {
 		var live = &unstructured.Unstructured{}
 		err := json.Unmarshal([]byte(res.NormalizedLiveState), &live)
@@ -938,7 +939,7 @@ func groupObjsForDiff(resources *application.ManagedResourcesResponse, objs map[
 		}
 		if local, ok := objs[key]; ok || live != nil {
 			if local != nil && !kube.IsCRD(local) {
-				err = argokube.SetAppInstanceLabel(local, argoSettings.AppLabelKey, appName)
+				err = resourceTracking.SetAppInstance(local, argoSettings.AppLabelKey, appName, "", argoappv1.TrackingMethod(argoSettings.GetTrackingMethod()))
 				errors.CheckError(err)
 			}
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -503,7 +503,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *ap
 	noCache = noCache || refreshRequested || app.Status.Expired(m.statusRefreshTimeout)
 
 	for i := range reconciliation.Target {
-		_ = m.resourceTracking.Normalize(reconciliation.Target[i], reconciliation.Live[i], string(trackingMethod))
+		_ = m.resourceTracking.Normalize(reconciliation.Target[i], reconciliation.Live[i], appLabelKey, string(trackingMethod))
 	}
 
 	if noCache || specChanged || revisionChanged || m.cache.GetAppManagedResources(app.Name, &cachedDiff) != nil {

--- a/controller/state.go
+++ b/controller/state.go
@@ -502,6 +502,10 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *ap
 	_, refreshRequested := app.IsRefreshRequested()
 	noCache = noCache || refreshRequested || app.Status.Expired(m.statusRefreshTimeout)
 
+	for i := range reconciliation.Target {
+		_ = m.resourceTracking.Normalize(reconciliation.Target[i], reconciliation.Live[i], string(trackingMethod))
+	}
+
 	if noCache || specChanged || revisionChanged || m.cache.GetAppManagedResources(app.Name, &cachedDiff) != nil {
 		// (rare) cache miss
 		diffResults, err = diff.DiffArray(reconciliation.Target, reconciliation.Live, diffOpts...)

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+
 	"github.com/argoproj/argo-cd/v2/common"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,6 +32,7 @@ type ResourceTracking interface {
 	SetAppInstance(un *unstructured.Unstructured, key, val, namespace string, trackingMethod v1alpha1.TrackingMethod) error
 	BuildAppInstanceValue(value AppInstanceValue) string
 	ParseAppInstanceValue(value string) (*AppInstanceValue, error)
+	Normalize(config, live *unstructured.Unstructured, trackingMethod string) error
 }
 
 //AppInstanceValue store information about resource tracking info
@@ -55,6 +58,10 @@ func GetTrackingMethod(settingsMgr *settings.SettingsManager) v1alpha1.TrackingM
 		return TrackingMethodLabel
 	}
 	return v1alpha1.TrackingMethod(tm)
+}
+
+func IsOldTrackingMethod(trackingMethod string) bool {
+	return trackingMethod == "" || trackingMethod == string(TrackingMethodLabel)
 }
 
 // GetAppName retrieve application name base on tracking method
@@ -141,4 +148,31 @@ func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceVal
 	appInstanceValue.Namespace = nsParts[0]
 	appInstanceValue.Name = nsParts[1]
 	return &appInstanceValue, nil
+}
+
+func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, trackingMethod string) error {
+	if IsOldTrackingMethod(trackingMethod) {
+		return nil
+	}
+
+	if live == nil || config == nil {
+		return nil
+	}
+
+	label := kube.GetAppInstanceLabel(live, common.LabelKeyAppInstance)
+	if label == "" {
+		return nil
+	}
+	annotation := argokube.GetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance)
+	err := argokube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
+	if err != nil {
+		return err
+	}
+
+	err = argokube.SetAppInstanceLabel(config, common.LabelKeyAppInstance, label)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -163,6 +163,7 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, l
 	if label == "" {
 		return nil
 	}
+
 	annotation := argokube.GetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance)
 	err := argokube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
 	if err != nil {

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -32,7 +32,7 @@ type ResourceTracking interface {
 	SetAppInstance(un *unstructured.Unstructured, key, val, namespace string, trackingMethod v1alpha1.TrackingMethod) error
 	BuildAppInstanceValue(value AppInstanceValue) string
 	ParseAppInstanceValue(value string) (*AppInstanceValue, error)
-	Normalize(config, live *unstructured.Unstructured, trackingMethod string) error
+	Normalize(config, live *unstructured.Unstructured, labelKey, trackingMethod string) error
 }
 
 //AppInstanceValue store information about resource tracking info
@@ -150,7 +150,7 @@ func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceVal
 	return &appInstanceValue, nil
 }
 
-func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, trackingMethod string) error {
+func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, labelKey, trackingMethod string) error {
 	if IsOldTrackingMethod(trackingMethod) {
 		return nil
 	}
@@ -159,7 +159,7 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, t
 		return nil
 	}
 
-	label := kube.GetAppInstanceLabel(live, common.LabelKeyAppInstance)
+	label := kube.GetAppInstanceLabel(live, labelKey)
 	if label == "" {
 		return nil
 	}
@@ -169,7 +169,7 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, t
 		return err
 	}
 
-	err = argokube.SetAppInstanceLabel(config, common.LabelKeyAppInstance, label)
+	err = argokube.SetAppInstanceLabel(config, labelKey, label)
 	if err != nil {
 		return err
 	}

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -126,9 +126,13 @@ func TestResourceIdNormalizer_Normalize(t *testing.T) {
 
 	err = resourceTracking.SetAppInstance(obj2, common.AnnotationKeyAppInstance, "my-app2", "", TrackingMethodAnnotation)
 
-	_ = resourceTracking.Normalize(obj2, obj, string(TrackingMethodAnnotation))
+	_ = resourceTracking.Normalize(obj2, obj, common.LabelKeyAppInstance, string(TrackingMethodAnnotation))
 
 	annotation := kube.GetAppInstanceAnnotation(obj2, common.AnnotationKeyAppInstance)
 
 	assert.Equal(t, obj.GetAnnotations()[common.AnnotationKeyAppInstance], annotation)
+}
+
+func TestIsOldTrackingMethod(t *testing.T) {
+	assert.Equal(t, true, IsOldTrackingMethod(string(TrackingMethodLabel)))
 }

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -114,9 +114,10 @@ func TestResourceIdNormalizer_Normalize(t *testing.T) {
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
 
-	resourceTracking := NewResourceTracking()
+	rt := NewResourceTracking()
 
-	err = resourceTracking.SetAppInstance(obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodLabel)
+	err = rt.SetAppInstance(obj, common.LabelKeyAppInstance, "my-app", "", TrackingMethodLabel)
+	assert.Nil(t, err)
 
 	yamlBytes, err = ioutil.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
@@ -124,12 +125,12 @@ func TestResourceIdNormalizer_Normalize(t *testing.T) {
 	err = yaml.Unmarshal(yamlBytes, &obj2)
 	assert.Nil(t, err)
 
-	err = resourceTracking.SetAppInstance(obj2, common.AnnotationKeyAppInstance, "my-app2", "", TrackingMethodAnnotation)
+	err = rt.SetAppInstance(obj2, common.AnnotationKeyAppInstance, "my-app2", "", TrackingMethodAnnotation)
+	assert.Nil(t, err)
 
-	_ = resourceTracking.Normalize(obj2, obj, common.LabelKeyAppInstance, string(TrackingMethodAnnotation))
+	_ = rt.Normalize(obj2, obj, common.LabelKeyAppInstance, string(TrackingMethodAnnotation))
 
 	annotation := kube.GetAppInstanceAnnotation(obj2, common.AnnotationKeyAppInstance)
-
 	assert.Equal(t, obj.GetAnnotations()[common.AnnotationKeyAppInstance], annotation)
 }
 

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -129,7 +129,6 @@ func TestResourceIdNormalizer_Normalize(t *testing.T) {
 	assert.Nil(t, err)
 
 	_ = rt.Normalize(obj2, obj, common.LabelKeyAppInstance, string(TrackingMethodAnnotation))
-
 	annotation := kube.GetAppInstanceAnnotation(obj2, common.AnnotationKeyAppInstance)
 	assert.Equal(t, obj.GetAnnotations()[common.AnnotationKeyAppInstance], annotation)
 }


### PR DESCRIPTION
Continuation for https://github.com/argoproj/argo-cd/pull/7251

During migration we should normalize annotation with specific key as label for prevent our of sync status inside existing resources