### PR TITLE
feat: add new sync option to fail if finds shared resources

### DIFF
--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -21,7 +21,7 @@ The sync-status panel shows that pruning was skipped, and why:
 
 ![sync option no prune](../assets/sync-option-no-prune-sync-status.png)
 
-The app will be out of sync if Argo CD expects a resource to be pruned. You may wish to use this along with [compare options](compare-options.md).
+The app will be out of sync if ArgoCD expects a resource to be pruned. You may wish to use this along with [compare options](compare-options.md).
 
 ## Disable Kubectl Validation
 
@@ -114,7 +114,7 @@ metadata:
 
 ## Replace Resource Instead Of Applying Changes
 
-By default, Argo CD executes `kubectl apply` operation to apply the configuration stored in Git. In some cases
+By default, ArgoCD executes `kubectl apply` operation to apply the configuration stored in Git. In some cases
 `kubectl apply` is not suitable. For example, resource spec might be too big and won't fit into
 `kubectl.kubernetes.io/last-applied-configuration` annotation that is added by `kubectl apply`. In such cases you
 might use `Replace=true` sync option:
@@ -125,7 +125,7 @@ syncOptions:
 - Replace=true
 ```
 
-If the `Replace=true` sync option is set the Argo CD will use `kubectl replace` or `kubectl create` command to apply changes.
+If the `Replace=true` sync option is set the ArgoCD will use `kubectl replace` or `kubectl create` command to apply changes.
 
 This can also be configured at individual resource level.
 ```yaml
@@ -133,3 +133,15 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 ```
+
+## Fail the sync if a shared resource is found
+
+By default, ArgoCD will apply all manifests found in the git path configured in the Application regardless if the resources
+defined in the yamls are already applied by another Application. If the `FailOnSharedResource` sync option is set, ArgoCD will
+fail the sync whenever it finds a resource in the current Application that is already applied in the cluster by another Application.
+
+```yaml
+syncOptions:
+- FailOnSharedResource=true
+```
+


### PR DESCRIPTION
Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

Fixes https://github.com/argoproj/argo-cd/issues/7156

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

