### PR TITLE
refactor: corrected regexp usage

### DIFF
--- a/server/account/account.go
+++ b/server/account/account.go
@@ -88,7 +88,7 @@ func (s *Server) UpdatePassword(ctx context.Context, q *account.UpdatePasswordRe
 		return nil, err
 	}
 
-	if !validPasswordRegexp.Match([]byte(q.NewPassword)) {
+	if !validPasswordRegexp.MatchString(q.NewPassword) {
 		err := fmt.Errorf("New password does not match the following expression: %s.", passwordPattern)
 		return nil, err
 	}

--- a/util/cert/cert.go
+++ b/util/cert/cert.go
@@ -78,10 +78,9 @@ var validFQDNRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{
 // If fqdn is true, given string must also be a FQDN representation.
 func IsValidHostname(hostname string, fqdn bool) bool {
 	if !fqdn {
-		return validHostNameRegexp.Match([]byte(hostname)) || validIPv6Regexp.Match([]byte(hostname))
-	} else {
-		return validFQDNRegexp.Match([]byte(hostname))
+		return validHostNameRegexp.MatchString(hostname) || validIPv6Regexp.MatchString(hostname)
 	}
+	return validFQDNRegexp.MatchString(hostname)
 }
 
 // Get the configured path to where TLS certificates are stored on the local


### PR DESCRIPTION
This PR corrects `*regexp.Regexp` methods usage.

Switched to optimised version.
1) badge (more optimised and easy to read code)

Switch from bytes to strings to make fewer allocations
2) accounts - password validation
3) hostname validation

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

