### PR TITLE
feat: add git url cache to keep normalized git url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-retryablehttp v0.7.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/improbable-eng/grpc-web v0.0.0-20181111100011-16092bd1d58a
 	github.com/itchyny/gojq v0.12.3
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -495,6 +495,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	lru "github.com/hashicorp/golang-lru"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -81,14 +82,19 @@ type db struct {
 	ns            string
 	kubeclientset kubernetes.Interface
 	settingsMgr   *settings.SettingsManager
+	reposCache    *lru.Cache
 }
 
 // NewDB returns a new instance of the argo database
 func NewDB(namespace string, settingsMgr *settings.SettingsManager, kubeclientset kubernetes.Interface) ArgoDB {
+	// We ignore the error here as this only happens if size < 0.
+	cache, _ := lru.New(2048)
+
 	return &db{
 		settingsMgr:   settingsMgr,
 		ns:            namespace,
 		kubeclientset: kubeclientset,
+		reposCache:    cache,
 	}
 }
 

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -302,11 +302,11 @@ func (db *db) enrichCredsToRepos(ctx context.Context, repositories []*appsv1.Rep
 }
 
 func (db *db) repoBackend() repositoryBackend {
-	return &secretsRepositoryBackend{db: db}
+	return &secretsRepositoryBackend{db: db, cache: db.reposCache}
 }
 
 func (db *db) legacyRepoBackend() repositoryBackend {
-	return &legacyRepositoryBackend{db: db}
+	return &legacyRepositoryBackend{db: db, cache: db.reposCache}
 }
 
 func (db *db) enrichCredsToRepo(ctx context.Context, repository *appsv1.Repository) error {

--- a/util/db/repository_legacy_test.go
+++ b/util/db/repository_legacy_test.go
@@ -3,10 +3,13 @@ package db
 import (
 	"testing"
 
+	lru "github.com/hashicorp/golang-lru"
+
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
 func Test_getRepositoryCredentialIndex(t *testing.T) {
+	cache, _ := lru.New(100)
 	repositoryCredentials := []settings.RepositoryCredentials{
 		{URL: "http://known"},
 		{URL: "http://known/repos"},
@@ -27,7 +30,7 @@ func Test_getRepositoryCredentialIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getRepositoryCredentialIndex(repositoryCredentials, tt.repoURL); got != tt.want {
+			if got := getRepositoryCredentialIndex(cache, repositoryCredentials, tt.repoURL); got != tt.want {
 				t.Errorf("getRepositoryCredentialIndex() = %v, want %v", got, tt.want)
 			}
 		})

--- a/util/db/repository_secrets_test.go
+++ b/util/db/repository_secrets_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -16,12 +17,13 @@ import (
 )
 
 func TestSecretsRepositoryBackend_CreateRepository(t *testing.T) {
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{})
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	input := &appsv1.Repository{
 		Name:                  "ArgoCD",
@@ -86,12 +88,13 @@ func TestSecretsRepositoryBackend_GetRepository(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	repository, err := testee.GetRepository(context.TODO(), "git@github.com:argoproj/argo-cd.git")
 	assert.NoError(t, err)
@@ -141,12 +144,13 @@ func TestSecretsRepositoryBackend_ListRepositories(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	repositories, err := testee.ListRepositories(context.TODO(), nil)
 	assert.NoError(t, err)
@@ -219,12 +223,13 @@ func TestSecretsRepositoryBackend_UpdateRepository(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	managedRepository.Username = "newUsername"
 	updateRepository, err := testee.UpdateRepository(context.TODO(), managedRepository)
@@ -290,12 +295,13 @@ func TestSecretsRepositoryBackend_DeleteRepository(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	err := testee.DeleteRepository(context.TODO(), "git@github.com:argoproj/argo-cd.git")
 	assert.NoError(t, err)
@@ -313,12 +319,13 @@ func TestSecretsRepositoryBackend_DeleteRepository(t *testing.T) {
 }
 
 func TestSecretsRepositoryBackend_CreateRepoCreds(t *testing.T) {
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{})
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	input := &appsv1.RepoCreds{
 		URL:       "git@github.com:argoproj",
@@ -377,12 +384,13 @@ func TestSecretsRepositoryBackend_GetRepoCreds(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoCredSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	repoCred, err := testee.GetRepoCreds(context.TODO(), "git@github.com:argoproj")
 	assert.NoError(t, err)
@@ -428,12 +436,13 @@ func TestSecretsRepositoryBackend_ListRepoCreds(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoCredSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	repoCreds, err := testee.ListRepoCreds(context.TODO())
 	assert.NoError(t, err)
@@ -489,12 +498,13 @@ func TestSecretsRepositoryBackend_UpdateRepoCreds(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoCredSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	managedCreds.Username = "newUsername"
 	updateRepoCreds, err := testee.UpdateRepoCreds(context.TODO(), managedCreds)
@@ -558,12 +568,13 @@ func TestSecretsRepositoryBackend_DeleteRepoCreds(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	err := testee.DeleteRepoCreds(context.TODO(), "git@github.com:argoproj")
 	assert.NoError(t, err)
@@ -612,12 +623,13 @@ func TestSecretsRepositoryBackend_GetAllHelmRepoCreds(t *testing.T) {
 		},
 	}
 
+	cache, _ := lru.New(100)
 	clientset := getClientset(map[string]string{}, repoCredSecrets...)
 	testee := &secretsRepositoryBackend{db: &db{
 		ns:            testNamespace,
 		kubeclientset: clientset,
 		settingsMgr:   settings.NewSettingsManager(context.TODO(), clientset, testNamespace),
-	}}
+	}, cache: cache}
 
 	repoCreds, err := testee.GetAllHelmRepoCreds(context.TODO())
 	assert.NoError(t, err)

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -51,11 +51,7 @@ var (
 func TestDb_CreateRepository(t *testing.T) {
 	clientset := getClientset(map[string]string{})
 	settingsManager := settings.NewSettingsManager(context.TODO(), clientset, testNamespace)
-	testee := &db{
-		ns:            testNamespace,
-		kubeclientset: clientset,
-		settingsMgr:   settingsManager,
-	}
+	testee := NewDB(testNamespace, settingsManager, clientset)
 
 	input := &appsv1.Repository{
 		Name:     "TestRepo",
@@ -87,11 +83,7 @@ func TestDb_CreateRepository(t *testing.T) {
 func TestDb_GetRepository(t *testing.T) {
 	clientset := getClientset(map[string]string{"repositories": repoArgoProj}, newManagedSecret(), repoArgoCD)
 	settingsManager := settings.NewSettingsManager(context.TODO(), clientset, testNamespace)
-	testee := &db{
-		ns:            testNamespace,
-		kubeclientset: clientset,
-		settingsMgr:   settingsManager,
-	}
+	testee := NewDB(testNamespace, settingsManager, clientset)
 
 	repository, err := testee.GetRepository(context.TODO(), "git@github.com:argoproj/argoproj.git")
 	assert.NoError(t, err)
@@ -112,11 +104,7 @@ func TestDb_GetRepository(t *testing.T) {
 func TestDb_ListRepositories(t *testing.T) {
 	clientset := getClientset(map[string]string{"repositories": repoArgoProj}, newManagedSecret(), repoArgoCD)
 	settingsManager := settings.NewSettingsManager(context.TODO(), clientset, testNamespace)
-	testee := &db{
-		ns:            testNamespace,
-		kubeclientset: clientset,
-		settingsMgr:   settingsManager,
-	}
+	testee := NewDB(testNamespace, settingsManager, clientset)
 
 	repositories, err := testee.ListRepositories(context.TODO())
 	assert.NoError(t, err)
@@ -141,11 +129,7 @@ func TestDb_UpdateRepository(t *testing.T) {
 
 	clientset := getClientset(map[string]string{"repositories": repoArgoProj}, newManagedSecret(), repoArgoCD)
 	settingsManager := settings.NewSettingsManager(context.TODO(), clientset, testNamespace)
-	testee := &db{
-		ns:            testNamespace,
-		kubeclientset: clientset,
-		settingsMgr:   settingsManager,
-	}
+	testee := NewDB(testNamespace, settingsManager, clientset)
 
 	// Verify that legacy repository can still be updated
 	settingRepository.Username = "OtherUpdatedUsername"
@@ -183,11 +167,7 @@ func TestDb_UpdateRepository(t *testing.T) {
 func TestDb_DeleteRepository(t *testing.T) {
 	clientset := getClientset(map[string]string{"repositories": repoArgoProj}, newManagedSecret(), repoArgoCD)
 	settingsManager := settings.NewSettingsManager(context.TODO(), clientset, testNamespace)
-	testee := &db{
-		ns:            testNamespace,
-		kubeclientset: clientset,
-		settingsMgr:   settingsManager,
-	}
+	testee := NewDB(testNamespace, settingsManager, clientset)
 
 	err := testee.DeleteRepository(context.TODO(), "git@github.com:argoproj/argoproj.git")
 	assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Why is this needed?

![same-url](https://user-images.githubusercontent.com/25150124/138614159-72c80cb0-6635-419b-9d15-854d8445873a.png)

From the profiling graph, you can find out that most of the time are spent on the `SameURL` function. Basically, it is calculating the normalized URL multiple times and there are duplications. Besides, the normalized url results are static so we can use a thread safe map to save them.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

