### PR TITLE
Clarify key/cert encoding in docs for cluster credentials #7544

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -506,13 +506,13 @@ execProviderConfig:
     installHint: string
 # Transport layer security configuration settings
 tlsClientConfig:
-    # PEM-encoded bytes (typically read from a client certificate file).
+    # Base64 encoded PEM-encoded bytes (typically read from a client certificate file).
     caData: string
-    # PEM-encoded bytes (typically read from a client certificate file).
+    # Base64 encoded PEM-encoded bytes (typically read from a client certificate file).
     certData: string
     # Server should be accessed without verifying the TLS certificate
     insecure: boolean
-    # PEM-encoded bytes (typically read from a client certificate key file).
+    # Base64 encoded PEM-encoded bytes (typically read from a client certificate key file).
     keyData: string
     # ServerName is passed to the server for SNI and is used in the client to check server
     # certificates against. If ServerName is empty, the hostname used to contact the


### PR DESCRIPTION
I just stumbled across a piece of documentation that IMO is slightly unclear. The comments for the key material in cluster credentials in the example don't state clearly that the PEM encoded keys/certs must additionally be base64 encoded - I consequently did it wrong the first time around.

I suggest adding some clarifying additional info in the example's comment.

Fixes #7544 