### PR TITLE
fix: return a `codes.NotFound` error when trying to get a non-existent repository

### DIFF
--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -111,6 +111,11 @@ func (s *Server) List(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.
 
 // Get return the requested configured repository by URL and the state of its connections.
 func (s *Server) Get(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.Repository, error) {
+	exists, err := s.db.RepositoryExists(ctx, q.Repo)
+	if !exists {
+		return nil, status.Errorf(codes.NotFound, "repo '%s' not found", q.Repo)
+	}
+
 	repo, err := s.getRepo(ctx, q.Repo)
 	if err != nil {
 		return nil, err

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -122,6 +122,9 @@ func (s *Server) Get(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.R
 
 	// getRepo does not return an error for unconfigured repositories, so we are checking here
 	exists, err := s.db.RepositoryExists(ctx, q.Repo)
+	if err != nil {
+		return nil, err
+	}
 	if !exists {
 		return nil, status.Errorf(codes.NotFound, "repo '%s' not found", q.Repo)
 	}

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -102,8 +102,12 @@ func TestRepositoryServer(t *testing.T) {
 		repoServerClient.On("TestRepository", mock.Anything, mock.Anything).Return(&apiclient.TestRepositoryResponse{}, nil)
 		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
 
-		s := NewServer(&repoServerClientset, argoDB, enforcer, newFixtures().Cache, settingsMgr)
 		url := "https://test"
+		db := &dbmocks.ArgoDB{}
+		db.On("GetRepository", context.TODO(), url).Return(&v1alpha1.Repository{Repo: url}, nil)
+		db.On("RepositoryExists", context.TODO(), url).Return(true, nil)
+
+		s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, settingsMgr)
 		repo, err := s.Get(context.TODO(), &repository.RepoQuery{
 			Repo: url,
 		})
@@ -111,19 +115,38 @@ func TestRepositoryServer(t *testing.T) {
 		assert.Equal(t, repo.Repo, url)
 	})
 
-	t.Run("Test_GetWithNotExistRepoShouldReturn403", func(t *testing.T) {
+	t.Run("Test_GetWithErrorShouldReturn403", func(t *testing.T) {
 		repoServerClient := mocks.RepoServerServiceClient{}
 		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
 
+		url := "https://test"
 		db := &dbmocks.ArgoDB{}
-		db.On("GetRepository", context.TODO(), "test").Return(nil, errors.New("not found"))
+		db.On("GetRepository", context.TODO(), url).Return(nil, errors.New("some error"))
+		db.On("RepositoryExists", context.TODO(), url).Return(true, nil)
 
 		s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, settingsMgr)
 		repo, err := s.Get(context.TODO(), &repository.RepoQuery{
-			Repo: "test",
+			Repo: url,
 		})
 		assert.Nil(t, repo)
 		assert.Equal(t, err.Error(), "rpc error: code = PermissionDenied desc = permission denied")
+	})
+
+	t.Run("Test_GetWithNotExistRepoShouldReturn404", func(t *testing.T) {
+		repoServerClient := mocks.RepoServerServiceClient{}
+		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
+
+		url := "https://test"
+		db := &dbmocks.ArgoDB{}
+		db.On("GetRepository", context.TODO(), url).Return(&v1alpha1.Repository{Repo: url}, nil)
+		db.On("RepositoryExists", context.TODO(), url).Return(false, nil)
+
+		s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, settingsMgr)
+		repo, err := s.Get(context.TODO(), &repository.RepoQuery{
+			Repo: url,
+		})
+		assert.Nil(t, repo)
+		assert.Equal(t, err.Error(), "rpc error: code = NotFound desc = repo 'https://test' not found")
 	})
 
 	t.Run("Test_CreateRepositoryWithoutUpsert", func(t *testing.T) {

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -41,6 +41,8 @@ type ArgoDB interface {
 	CreateRepository(ctx context.Context, r *appv1.Repository) (*appv1.Repository, error)
 	// GetRepository returns a repository by URL
 	GetRepository(ctx context.Context, url string) (*appv1.Repository, error)
+	// RepositoryExists returns whether a repository is configured for the given URL
+	RepositoryExists(ctx context.Context, repoURL string) (bool, error)
 	// UpdateRepository updates a repository
 	UpdateRepository(ctx context.Context, r *appv1.Repository) (*appv1.Repository, error)
 	// DeleteRepository deletes a repository from config

--- a/util/db/mocks/ArgoDB.go
+++ b/util/db/mocks/ArgoDB.go
@@ -265,6 +265,29 @@ func (_m *ArgoDB) GetRepository(ctx context.Context, url string) (*v1alpha1.Repo
 	return r0, r1
 }
 
+// RepositoryExists provides a mock function with given fields: ctx, url
+func (_m *ArgoDB) RepositoryExists(ctx context.Context, url string) (bool, error) {
+	ret := _m.Called(ctx, url)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, url)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(bool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, url)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetRepositoryCredentials provides a mock function with given fields: ctx, name
 func (_m *ArgoDB) GetRepositoryCredentials(ctx context.Context, name string) (*v1alpha1.RepoCreds, error) {
 	ret := _m.Called(ctx, name)

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -84,6 +84,17 @@ func (db *db) GetRepository(ctx context.Context, repoURL string) (*appsv1.Reposi
 	return repository, err
 }
 
+func (db *db) RepositoryExists(ctx context.Context, repoURL string) (bool, error) {
+	secretsBackend := db.repoBackend()
+	exists, err := secretsBackend.RepositoryExists(ctx, repoURL)
+	if exists || err != nil {
+		return exists, err
+	}
+
+	legacyBackend := db.legacyRepoBackend()
+	return legacyBackend.RepositoryExists(ctx, repoURL)
+}
+
 func (db *db) getRepository(ctx context.Context, repoURL string) (*appsv1.Repository, error) {
 	secretsBackend := db.repoBackend()
 	exists, err := secretsBackend.RepositoryExists(ctx, repoURL)


### PR DESCRIPTION
### Context
Addressing #5951. More details can be found in the issue discussion, but as a quick summary:
- `argo repo get <repo>` and `/api/v1/repositories/{repo}` are documented as `Get a **configured** repository by URL`.
- However, `Get() Repository` does not return an error when querying a repo that is not configured in Argo.
- Instead, it initializes an empty repository object, and tests the connectivity: errors returned to the user only come from the connectivity test.

In particular, `Get() Repository` relies on this [db.getRepository](https://github.com/argoproj/argo-cd/blob/master/util/db/repository.go#L87-L105).  However, this function [returns a valid repository object when no configured repository is found](https://github.com/argoproj/argo-cd/blob/master/util/db/repository.go#L104), rather than nil with an error. This contrasts with `db.DeleteRepository` that does [return an error for unconfigured repositories](https://github.com/argoproj/argo-cd/blob/master/util/db/repository.go#L171)

### Change
`db.GetRepository` is called in different places, so I decided to avoid touching it, and instead implement a new `db.RepositoryExists` function that returns whether a repository matching the query is configured in Argo.

I then called this function from `Get() Repository` and propagated a `codes.NotFound` error as appropriate.

### Alternatives
I thought about a couple of alternative implementations, let me know if an approach is preferred:
- Modifying `db.GetRepository` to return an error when a repository is not found, rather than an empty repository object. This would need to be done carefully to avoid breaking things for logic that relies on that current behavior of `db.GetRepository`. A few approaches I can think about:
  - Adding a `default` parameter to `db.GetRepository` that would be the default return value if no repository is found
  - Moving the default empty repository initialization outside of `db.GetRepository` to every call site when `repo == nil && err == nil`
 - Keep the existing logic, but add a new field in the repository object to identify whether a repository is configured in Argo
 - Keep the existing logic without any change, but update the documentation to correctly reflect the expectation (basically, change the `Get a **configured** repository by URL`).

### Testing
#### Manual Testing
Configured Repo (API):

```bash
$ curl -s -H "Authorization: Bearer $ARGOCD_TOKEN" -k http://localhost:8080/api/v1/repositories/https%3A%2F%2Fgithub.com%2Fcylix%2Fcpp_redis | jq

{
  "repo": "https://github.com/cylix/cpp_redis",
  "connectionState": {
    "status": "Successful",
    "message": "",
    "attemptedAt": "2021-10-26T05:41:17Z"
  },
  "type": "git",
  "project": "default"
}
```

Configured Repo (CLI):

```bash
$ argocd --server localhost:8080 --plaintext --grpc-web repo get https://github.com/cylix/cpp_redis
TYPE  NAME  REPO                                INSECURE  OCI    LFS    CREDS  STATUS      MESSAGE
git         https://github.com/cylix/cpp_redis  false     false  false  false  Successful
```

Unconfigured Repo (API):

```bash
$ curl -s -H "Authorization: Bearer $ARGOCD_TOKEN" -k http://localhost:8080/api/v1/repositories/https%3A%2F%2Fgithub.com%2Ffoo%2Fexample-project.git | jq

{
  "error": "repo 'https://github.com/foo/example-project.git' not found",
  "code": 5,
  "message": "repo 'https://github.com/foo/example-project.git' not found"
}
```

```bash
$ curl -s -H "Authorization: Bearer $ARGOCD_TOKEN" -k http://localhost:8080/api/v1/repositories/https%3A%2F%2Fgitlab.com%2Ffoo%2Fexample-project.git | jq

{
  "error": "repo 'https://gitlab.com/foo/example-project.git' not found",
  "code": 5,
  "message": "repo 'https://gitlab.com/foo/example-project.git' not found"
}
```

```bash
curl -s -H "Authorization: Bearer $ARGOCD_TOKEN" -k http://localhost:8080/api/v1/repositories/git%40gitlab.com%3Afoo%2Fexample-project.git | jq

{
  "error": "repo 'git@gitlab.com:foo/example-project.git' not found",
  "code": 5,
  "message": "repo 'git@gitlab.com:foo/example-project.git' not found"
}
```

Unconfigured Repo (CLI):

```bash
$ argocd --server localhost:8080 --plaintext --grpc-web repo get https://github.com/foo/example-project.git
FATA[0000] rpc error: code = NotFound desc = repo 'https://github.com/foo/example-project.git' not found
```


#### Unit Tests
Added unit tests coverage ✅ 

### Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

### Misc.
Fixes #5951 