### PR TITLE
docs: remove mention of ksonnet in basics

### DIFF
--- a/docs/understand_the_basics.md
+++ b/docs/understand_the_basics.md
@@ -12,6 +12,5 @@ Before effectively using Argo CD, it is necessary to understand the underlying t
 * Depending on how you plan to template your applications:
     * [Kustomize](https://kustomize.io) 
     * [Helm](https://helm.sh)
-    * [Ksonnet](https://ksonnet.io) 
 * If you're integrating with Jenkins:
 	* [Jenkins User Guide](https://jenkins.io)


### PR DESCRIPTION
As announced [here](https://tanzu.vmware.com/content/blog/welcoming-heptio-open-source-projects-to-vmware), the ksonnet project is being sunset. I suggest removing the link from the basics documentation page.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

