### PR TITLE
fix: Improve user experience for update-password CLI command

### DIFF
--- a/docs/user-guide/commands/argocd_account.md
+++ b/docs/user-guide/commands/argocd_account.md
@@ -59,5 +59,5 @@ argocd account [flags]
 * [argocd account get](argocd_account_get.md)	 - Get account details
 * [argocd account get-user-info](argocd_account_get-user-info.md)	 - Get user info
 * [argocd account list](argocd_account_list.md)	 - List accounts
-* [argocd account update-password](argocd_account_update-password.md)	 - Update password
+* [argocd account update-password](argocd_account_update-password.md)	 - Update an account's password
 

--- a/docs/user-guide/commands/argocd_account_update-password.md
+++ b/docs/user-guide/commands/argocd_account_update-password.md
@@ -1,16 +1,36 @@
 ## argocd account update-password
 
-Update password
+Update an account's password
+
+### Synopsis
+
+
+This command can be used to update the password of the currently logged on
+user, or an arbitrary local user account when the currently logged on user
+has appropriate RBAC permissions to change other accounts.
+
 
 ```
 argocd account update-password [flags]
+```
+
+### Examples
+
+```
+
+	# Update the current user's password
+	argocd account update-password
+
+	# Update the password for user foobar
+	argocd account update-password --account foobar
+
 ```
 
 ### Options
 
 ```
       --account string            an account name that should be updated. Defaults to current user account
-      --current-password string   current password you wish to change
+      --current-password string   password of the currently logged on user
   -h, --help                      help for update-password
       --new-password string       new password you want to update to
 ```

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -129,15 +129,15 @@ func AskToProceed(message string) bool {
 }
 
 // ReadAndConfirmPassword is a helper to read and confirm a password from stdin
-func ReadAndConfirmPassword() (string, error) {
+func ReadAndConfirmPassword(username string) (string, error) {
 	for {
-		fmt.Print("*** Enter new password: ")
+		fmt.Printf("*** Enter new password for user %s: ", username)
 		password, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", err
 		}
 		fmt.Print("\n")
-		fmt.Print("*** Confirm new password: ")
+		fmt.Printf("*** Confirm new password for user %s: ", username)
 		confirmPassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This improves the user experience when using `argocd account update-password`

Addresses #7558 and a lot of discussions I had on Slack and other channels.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

