### PR TITLE
fix: argocd-dex now merges existing dex.config.oauth2 block instead of overwriting

### DIFF
--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -35,8 +35,17 @@ func GenerateDexConfigYAML(settings *settings.ArgoCDSettings) ([]byte, error) {
 	dexCfg["telemetry"] = map[string]interface{}{
 		"http": "0.0.0.0:5558",
 	}
-	dexCfg["oauth2"] = map[string]interface{}{
-		"skipApprovalScreen": true,
+
+	oauth2Cfg, ok := dexCfg["oauth2"].(map[string]interface{})
+	if ok {
+		_ , ok := oauth2Cfg["skipApprovalScreen"].(bool)
+		if !ok {
+			oauth2Cfg["skipApprovalScreen"] = true
+		}
+	}else {
+		dexCfg["oauth2"] = map[string]interface{}{
+			"skipApprovalScreen": true,
+		}
 	}
 
 	argoCDStaticClient := map[string]interface{}{

--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -36,13 +36,11 @@ func GenerateDexConfigYAML(settings *settings.ArgoCDSettings) ([]byte, error) {
 		"http": "0.0.0.0:5558",
 	}
 
-	oauth2Cfg, ok := dexCfg["oauth2"].(map[string]interface{})
-	if ok {
-		_ , ok := oauth2Cfg["skipApprovalScreen"].(bool)
-		if !ok {
+	if oauth2Cfg, found := dexCfg["oauth2"].(map[string]interface{}); found {
+		if _, found := oauth2Cfg["skipApprovalScreen"].(bool); !found {
 			oauth2Cfg["skipApprovalScreen"] = true
 		}
-	}else {
+	} else {
 		dexCfg["oauth2"] = map[string]interface{}{
 			"skipApprovalScreen": true,
 		}


### PR DESCRIPTION
Fixes #7275 

Signed-off-by: Joshua Helton <jdoghelton@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

