### PR TITLE
fix: controller fails to connect to cluster using exec auth provider

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2347,9 +2347,10 @@ func (c *Cluster) RawRestConfig() *rest.Config {
 				Host:            c.Server,
 				TLSClientConfig: tlsClientConfig,
 				ExecProvider: &api.ExecConfig{
-					APIVersion: "client.authentication.k8s.io/v1alpha1",
-					Command:    "aws",
-					Args:       args,
+					APIVersion:      "client.authentication.k8s.io/v1alpha1",
+					Command:         "aws",
+					Args:            args,
+					InteractiveMode: api.NeverExecInteractiveMode,
 				},
 			}
 		} else if c.Config.ExecProviderConfig != nil {
@@ -2366,11 +2367,12 @@ func (c *Cluster) RawRestConfig() *rest.Config {
 				Host:            c.Server,
 				TLSClientConfig: tlsClientConfig,
 				ExecProvider: &api.ExecConfig{
-					APIVersion:  c.Config.ExecProviderConfig.APIVersion,
-					Command:     c.Config.ExecProviderConfig.Command,
-					Args:        c.Config.ExecProviderConfig.Args,
-					Env:         env,
-					InstallHint: c.Config.ExecProviderConfig.InstallHint,
+					APIVersion:      c.Config.ExecProviderConfig.APIVersion,
+					Command:         c.Config.ExecProviderConfig.Command,
+					Args:            c.Config.ExecProviderConfig.Args,
+					Env:             env,
+					InstallHint:     c.Config.ExecProviderConfig.InstallHint,
+					InteractiveMode: api.NeverExecInteractiveMode,
 				},
 			}
 		} else {


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Exec based K8S auth is failing after upgrading to k8s client v1.22 without explicitly disabling interative mode