### PR TITLE
fix: fix invalid resource icons

### DIFF
--- a/ui/src/app/applications/components/resource-icon.tsx
+++ b/ui/src/app/applications/components/resource-icon.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import {resources} from './resources';
+import {resourceIcons} from './resources';
 
 export const ResourceIcon = ({kind, customStyle}: {kind: string; customStyle?: React.CSSProperties}) => {
     if (kind === 'node') {
         return <img src={'assets/images/infrastructure_components/' + kind + '.svg'} alt={kind} style={{padding: '2px', width: '40px', height: '32px', ...customStyle}} />;
     }
-    const i = resources.get(kind);
+    const i = resourceIcons.get(kind);
     if (i !== undefined) {
         return <img src={'assets/images/resources/' + i + '.svg'} alt={kind} style={{padding: '2px', width: '40px', height: '32px', ...customStyle}} />;
     }

--- a/ui/src/app/applications/components/resources.ts
+++ b/ui/src/app/applications/components/resources.ts
@@ -1,6 +1,40 @@
 // https://github.com/kubernetes/community/tree/master/icons
 // https://docs.google.com/presentation/d/15h_MHjR2fzXIiGZniUdHok_FP07u1L8MAX5cN1r0j4U/edit
 
+export const resourceIcons = new Map<string, string>([
+    ['ClusterRole', 'c-role'],
+    ['ConfigMap', 'cm'],
+    ['ClusterRoleBinding', 'crb'],
+    ['CustomResourceDefinition', 'crd'],
+    ['CronJob', 'cronjob'],
+    ['Deployment', 'deploy'],
+    ['DaemonSet', 'ds'],
+    ['Endpoint', 'ep'],
+    ['Endpoints', 'ep'],
+    ['Group', 'group'],
+    ['HorizontalPodAutoscaler', 'hpa'],
+    ['Ingress', 'ing'],
+    ['Job', 'job'],
+    ['LimitRange', 'limits'],
+    ['NetworkPolicy', 'netpol'],
+    ['Namespace', 'ns'],
+    ['Pod', 'pod'],
+    ['PodSecurityPolicy', 'psp'],
+    ['PersistentVolume', 'pv'],
+    ['PersistentVolumeClaim', 'pvc'],
+    ['Quote', 'quota'],
+    ['RoleBinding', 'rb'],
+    ['Role', 'role'],
+    ['ReplicaSet', 'rs'],
+    ['ServiceAccount', 'sa'],
+    ['StorageClass', 'sc'],
+    ['Secret', 'secret'],
+    ['StatefulSet', 'sts'],
+    ['Service', 'svc'],
+    ['User', 'user'],
+    ['Volume', 'vol']
+]);
+
 export const resources = new Map<string, string>([
     ['ClusterRole', 'c-role'],
     ['ComponentStatus', 'cs'],
@@ -22,7 +56,7 @@ export const resources = new Map<string, string>([
     ['NetworkPolicy', 'netpol'],
     ['Namespace', 'ns'],
     ['Node', 'no'],
-    ['Pod', 'po'],
+    ['Pod', 'pod'],
     ['PodSecurityPolicy', 'psp'],
     ['PersistentVolume', 'pv'],
     ['PersistentVolumeClaim', 'pvc'],


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR https://github.com/argoproj/argo-cd/pull/7466 introduced additional resource name abbreviations into `resources` map. It appears that the resources map is used as icons as well as abreviations. PR adds a separate map `resourceIcons` that is used only for icons.