### PR TITLE
fix: add missing await on cluster list page

### DIFF
--- a/ui/src/app/settings/components/clusters-list/clusters-list.tsx
+++ b/ui/src/app/settings/components/clusters-list/clusters-list.tsx
@@ -58,7 +58,7 @@ export const ClustersList = (props: RouteComponentProps<{}>) => {
                                                                                 );
                                                                                 if (confirmed) {
                                                                                     try {
-                                                                                        services.clusters.delete(cluster.server).finally(() => {
+                                                                                        await services.clusters.delete(cluster.server).finally(() => {
                                                                                             ctx.navigation.goto('.', {new: null}, {replace: true});
                                                                                             if (clustersLoaderRef.current) {
                                                                                                 clustersLoaderRef.current.reload();


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR adds missing await statement and fixes https://sonarcloud.io/project/issues?id=argoproj_argo-cd&open=AXziGYrxr-Q-4_QAFkPk&resolved=false&types=BUG