### PR TITLE
chore: refactoring gpg test data embeding it in go code

### DIFF
--- a/util/gpg/testdata/data.go
+++ b/util/gpg/testdata/data.go
@@ -1,0 +1,59 @@
+package testdata
+
+import _ "embed"
+
+var (
+	//go:embed bad_signature_bad.txt
+	Bad_signature_bad_txt string
+
+	//go:embed bad_signature_badkeyid.txt
+	Bad_signature_badkeyid_txt string
+
+	//go:embed bad_signature_malformed1.txt
+	Bad_signature_malformed1_txt string
+
+	//go:embed bad_signature_malformed2.txt
+	Bad_signature_malformed2_txt string
+
+	//go:embed bad_signature_malformed3.txt
+	Bad_signature_malformed3_txt string
+
+	//go:embed bad_signature_manipulated.txt
+	Bad_signature_manipulated_txt string
+
+	//go:embed bad_signature_nodata.txt
+	Bad_signature_nodata_txt string
+
+	//go:embed bad_signature_preeof1.txt
+	Bad_signature_preeof1_txt string
+
+	//go:embed bad_signature_preeof2.txt
+	Bad_signature_preeof2_txt string
+
+	//go:embed garbage.asc
+	Garbage_asc string
+
+	//go:embed github.asc
+	Github_asc string
+
+	//go:embed good_signature.txt
+	Good_signature_txt string
+
+	//go:embed janedoe.asc
+	Janedoe_asc string
+
+	//go:embed johndoe.asc
+	Johndoe_asc string
+
+	//go:embed multi.asc
+	Multi_asc string
+
+	//go:embed multi2.asc
+	Multi2_asc string
+
+	//go:embed unknown_signature1.txt
+	Unknown_signature1_txt string
+
+	//go:embed unknown_signature2.txt
+	Unknown_signature2_txt string
+)


### PR DESCRIPTION
Current GPG test data is loaded in tests with relative path which forces the test and debug running to always CWD to the directory where the test is defined. Loading test data with relative path is also not refactoring friendly. This PR refactor that code to make usage of Go 1.16 embed functionality to address both problems.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

