### PR TITLE
docs: Add -s to sign off empty commits that retriggers CI

### DIFF
--- a/docs/developer-guide/ci.md
+++ b/docs/developer-guide/ci.md
@@ -15,7 +15,7 @@ Since the CI pipeline is triggered on Git commits, there is currently no (known)
 If you are absolutely sure that the failure was due to a failure in the pipeline, and not an error within the changes you committed, you can push an empty commit to your branch, thus retriggering the pipeline without any code changes. To do so, issue
 
 ```bash
-git commit --allow-empty -m "Retrigger CI pipeline"
+git commit -s --allow-empty -m "Retrigger CI pipeline"
 git push origin <yourbranch>
 ```
 


### PR DESCRIPTION
This will be more friendly to new contributors (often the ones who read this file to help debug CI failures). Otherwise `git commit -s --amend` or rebase is needed for DCO check when CI is passing.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

