### PR TITLE
build!: Remove non-Linux binaries from the image and fix image building on Mac ARM

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -264,6 +264,7 @@ jobs:
         env:
           NODE_ENV: production
           NODE_ONLINE_ENV: online
+          HOST_ARCH: amd64
         working-directory: ui/
       - name: Run ESLint
         run: yarn lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,8 +183,6 @@ jobs:
           git tag ${RELEASE_TAG}
 
       - name: Build Docker image for release
-        env:
-          BUILD_ALL_CLIS: true
         run: |
           set -ue
           git clean -fd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,6 +183,8 @@ jobs:
           git tag ${RELEASE_TAG}
 
       - name: Build Docker image for release
+        env:
+          BUILD_ALL_CLIS: true
         run: |
           set -ue
           git clean -fd

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN make argocd-all
 
 ARG BUILD_ALL_CLIS=true
 RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
-    make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all && \
+    make BIN_NAME=argocd-darwin-$(go env GOARCH) GOOS=darwin argocd-all && \
     make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all \
     ; fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,12 +115,6 @@ COPY . .
 COPY --from=argocd-ui /src/dist/app /go/src/github.com/argoproj/argo-cd/ui/dist/app
 RUN make argocd-all
 
-ENV BUILD_ALL_CLIS=false
-RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
-    make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all && \
-    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all \
-    ; fi
-
 ####################################################################################################
 # Final image
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ ADD ["ui/", "."]
 
 ARG ARGO_VERSION=latest
 ENV ARGO_VERSION=$ARGO_VERSION
-RUN NODE_ENV='production' NODE_ONLINE_ENV='online' yarn build
+RUN NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
 
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
@@ -117,8 +117,8 @@ RUN make argocd-all
 
 ARG BUILD_ALL_CLIS=true
 RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
-    make BIN_NAME=argocd-darwin-$(go env GOARCH) GOOS=darwin argocd-all && \
-    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all \
+    make BIN_NAME=argocd-darwin-$(go env GOARCH) GOOS=darwin GOARCH=$(go env GOARCH) argocd-all && \
+    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows GOARCH=amd64 argocd-all \
     ; fi
 
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,12 +115,6 @@ COPY . .
 COPY --from=argocd-ui /src/dist/app /go/src/github.com/argoproj/argo-cd/ui/dist/app
 RUN make argocd-all
 
-ARG BUILD_ALL_CLIS=true
-RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
-    make BIN_NAME=argocd-darwin-$(go env GOARCH) GOOS=darwin GOARCH=$(go env GOARCH) argocd-all && \
-    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows GOARCH=amd64 argocd-all \
-    ; fi
-
 ####################################################################################################
 # Final image
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,12 @@ COPY . .
 COPY --from=argocd-ui /src/dist/app /go/src/github.com/argoproj/argo-cd/ui/dist/app
 RUN make argocd-all
 
+ENV BUILD_ALL_CLIS=false
+RUN if [ "$BUILD_ALL_CLIS" = "true" ] ; then \
+    make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all && \
+    make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all \
+    ; fi
+
 ####################################################################################################
 # Final image
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ ADD ["ui/", "."]
 
 ARG ARGO_VERSION=latest
 ENV ARGO_VERSION=$ARGO_VERSION
-RUN NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
+RUN HOST_ARCH='amd64' NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
 
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,8 +3,6 @@
 ####################################################################################################
 FROM argocd-base
 COPY argocd /usr/local/bin/
-COPY argocd-darwin-$(go env GOARCH) /usr/local/bin/
-COPY argocd-windows-amd64.exe /usr/local/bin/
 
 USER root
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@
 ####################################################################################################
 FROM argocd-base
 COPY argocd /usr/local/bin/
-COPY argocd-darwin-amd64 /usr/local/bin/
+COPY argocd-darwin-$(go env GOARCH) /usr/local/bin/
 COPY argocd-windows-amd64.exe /usr/local/bin/
 
 USER root

--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,6 @@ image:
 	find ./ui/dist -type f -not -name gitkeep -delete
 	docker run -v ${CURRENT_DIR}/ui/dist/app:/tmp/app --rm -t argocd-ui sh -c 'cp -r ./dist/app/* /tmp/app/'
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd ./cmd
-	CGO_ENABLED=0 GOOS=darwin GOARCH=${HOST_ARCH} go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-darwin-${HOST_ARCH} ./cmd
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-windows-amd64.exe ./cmd
 	ln -sfn ${DIST_DIR}/argocd ${DIST_DIR}/argocd-server
 	ln -sfn ${DIST_DIR}/argocd ${DIST_DIR}/argocd-application-controller
 	ln -sfn ${DIST_DIR}/argocd ${DIST_DIR}/argocd-repo-server
@@ -277,10 +275,8 @@ endif
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argocd:$(IMAGE_TAG) ; fi
 
 .PHONY: armimage
-# The "BUILD_ALL_CLIS" argument is to skip building the CLIs for darwin and windows
-# which would take a really long time.
 armimage:
-	docker build -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG)-arm . --build-arg BUILD_ALL_CLIS="false"
+	docker build -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG)-arm .
 
 .PHONY: builder-image
 builder-image:

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ manifests: test-tools-image
 # consolidated binary for cli, util, server, repo-server, controller
 .PHONY: argocd-all
 argocd-all: clean-debug
-	CGO_ENABLED=0 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${BIN_NAME} ./cmd
+	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${BIN_NAME} ./cmd
 
 .PHONY: server
 server: clean-debug

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ image:
 	find ./ui/dist -type f -not -name gitkeep -delete
 	docker run -v ${CURRENT_DIR}/ui/dist/app:/tmp/app --rm -t argocd-ui sh -c 'cp -r ./dist/app/* /tmp/app/'
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd ./cmd
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-darwin-amd64 ./cmd
+	CGO_ENABLED=0 GOOS=darwin GOARCH=${HOST_ARCH} go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-darwin-${HOST_ARCH} ./cmd
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-windows-amd64.exe ./cmd
 	ln -sfn ${DIST_DIR}/argocd ${DIST_DIR}/argocd-server
 	ln -sfn ${DIST_DIR}/argocd ${DIST_DIR}/argocd-application-controller

--- a/Makefile
+++ b/Makefile
@@ -214,9 +214,9 @@ cli-local: clean-debug
 .PHONY: release-cli
 release-cli: clean-debug image
 	docker create --name tmp-argocd-linux $(IMAGE_PREFIX)argocd:$(IMAGE_TAG)
+	make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all
+	make BIN_NAME=argocd-windows-amd64.exe GOOS=windows argocd-all
 	docker cp tmp-argocd-linux:/usr/local/bin/argocd ${DIST_DIR}/argocd-linux-amd64
-	docker cp tmp-argocd-linux:/usr/local/bin/argocd-darwin-amd64 ${DIST_DIR}/argocd-darwin-amd64
-	docker cp tmp-argocd-linux:/usr/local/bin/argocd-windows-amd64.exe ${DIST_DIR}/argocd-windows-amd64.exe
 	docker rm tmp-argocd-linux
 
 .PHONY: test-tools-image

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	gosync "sync"
 	"time"
+	go_runtime "runtime"
 
 	// nolint:staticcheck
 	golang_proto "github.com/golang/protobuf/proto"
@@ -813,24 +814,8 @@ func registerDownloadHandlers(mux *http.ServeMux, base string) {
 	if err != nil {
 		log.Warnf("argocd not in PATH")
 	} else {
-		mux.HandleFunc(base+"/argocd-linux-amd64", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(base+"/argocd-linux-"+go_runtime.GOARCH, func(w http.ResponseWriter, r *http.Request) {
 			http.ServeFile(w, r, linuxPath)
-		})
-	}
-	darwinPath, err := exec.LookPath("argocd-darwin-amd64")
-	if err != nil {
-		log.Warnf("argocd-darwin-amd64 not in PATH")
-	} else {
-		mux.HandleFunc(base+"/argocd-darwin-amd64", func(w http.ResponseWriter, r *http.Request) {
-			http.ServeFile(w, r, darwinPath)
-		})
-	}
-	windowsPath, err := exec.LookPath("argocd-windows-amd64.exe")
-	if err != nil {
-		log.Warnf("argocd-windows-amd64.exe not in PATH")
-	} else {
-		mux.HandleFunc(base+"/argocd-windows-amd64.exe", func(w http.ResponseWriter, r *http.Request) {
-			http.ServeFile(w, r, windowsPath)
 		})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	go_runtime "runtime"
 	"strings"
 	gosync "sync"
 	"time"
-	go_runtime "runtime"
 
 	// nolint:staticcheck
 	golang_proto "github.com/golang/protobuf/proto"

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -20,7 +20,7 @@ export const Help = () => (
                     <div className='columns large-4 small-6'>
                         <div className='help-box'>
                             <p>Want to download the CLI tool?</p>
-                            <a href={`download/argocd-linux-amd64`} className='user-info-panel-buttons argo-button argo-button--base'>
+                            <a href={`download/argocd-linux-${process.env.HOST_ARCH}`} className='user-info-panel-buttons argo-button argo-button--base'>
                                 <i className='fab fa-linux ' /> Linux
                             </a>
                         </div>

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -23,14 +23,6 @@ export const Help = () => (
                             <a href={`download/argocd-linux-amd64`} className='user-info-panel-buttons argo-button argo-button--base'>
                                 <i className='fab fa-linux ' /> Linux
                             </a>
-                            &nbsp;
-                            <a href={`download/argocd-darwin-amd64`} className='user-info-panel-buttons argo-button argo-button--base'>
-                                <i className='fab fa-apple' /> macOS
-                            </a>
-                            &nbsp;
-                            <a href={`download/argocd-windows-amd64.exe`} className='user-info-panel-buttons argo-button argo-button--base'>
-                                <i className='fab fa-windows' /> Windows
-                            </a>
                         </div>
                     </div>
                     <div className='columns large-4 small-6'>

--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -59,6 +59,7 @@ const config = {
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
             'process.env.NODE_ONLINE_ENV': JSON.stringify(process.env.NODE_ONLINE_ENV || 'offline'),
+            'process.env.HOST_ARCH': JSON.stringify(process.env.HOST_ARCH || 'amd64'),
             'SYSTEM_INFO': JSON.stringify({
                 version: process.env.ARGO_VERSION || 'latest'
             })


### PR DESCRIPTION
Currently, this is hard-coded to work with `darwin-amd64` only.

This also fixes the error `#49 52.15 cmd/go: unsupported GOOS/GOARCH pair windows/arm64` as well as the following error when building the UI:

```
 > [argocd-ui 6/6] RUN NODE_ENV='production' NODE_ONLINE_ENV='online' yarn build:
#43 0.399 yarn run v1.22.4
#43 0.420 $ find ./dist -type f -not -name gitkeep -delete && webpack --config ./src/app/webpack.config.js
#43 1.086 Bundling in production...
#43 164.3 Killed
#43 164.7 error Command failed with exit code 137.
#43 164.7 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
executor failed running [/bin/sh -c NODE_ENV='production' NODE_ONLINE_ENV='online' yarn build]: exit code: 137
make: *** [image] Error 1
```

The root causes are:
* `GOOS`  and `GOARCH`  were not passed to `make argocd-all` explicitly and `windows + arm64` doesn't work. 
* `NODE_OPTIONS` is required to avoid out-of-memory issue `exit code: 137` when running `yarn build`.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

