### PR TITLE
refactor: allow using own config maps to register the cmp plugins instead of 'argocd-cmp-cm'

### DIFF
--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -31,15 +31,20 @@ type PluginConfigSpec struct {
 
 //Discover holds find and fileName
 type Discover struct {
-	Find     Command `json:"find"`
-	FileName string  `json:"fileName"`
+	Find     Find   `json:"find"`
+	FileName string `json:"fileName"`
 }
 
 // Command holds binary path and arguments list
 type Command struct {
 	Command []string `json:"command,omitempty"`
 	Args    []string `json:"args,omitempty"`
-	Glob    string   `json:"glob"`
+}
+
+// Find holds find command or glob pattern
+type Find struct {
+	Command
+	Glob string `json:"glob"`
 }
 
 func ReadPluginConfig(filePath string) (*PluginConfig, error) {
@@ -68,7 +73,7 @@ func ValidatePluginConfig(config PluginConfig) error {
 	if len(config.Spec.Generate.Command) == 0 {
 		return fmt.Errorf("invalid plugin configuration file. spec.generate command should be non-empty")
 	}
-	if config.Spec.Discover.Find.Glob == "" && len(config.Spec.Discover.Find.Command) == 0 && config.Spec.Discover.FileName == "" {
+	if config.Spec.Discover.Find.Glob == "" && len(config.Spec.Discover.Find.Command.Command) == 0 && config.Spec.Discover.FileName == "" {
 		return fmt.Errorf("invalid plugin configuration file. atleast one of discover.find.command or discover.find.glob or discover.fineName should be non-empty")
 	}
 	return nil

--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -113,7 +113,7 @@ func (s *Service) MatchRepository(ctx context.Context, q *apiclient.RepositoryRe
 	}
 
 	log.Debugf("Going to try runCommand.")
-	find, err := runCommand(config.Spec.Discover.Find, q.Path, os.Environ())
+	find, err := runCommand(config.Spec.Discover.Find.Command, q.Path, os.Environ())
 	if err != nil {
 		return &repoResponse, err
 	}

--- a/manifests/base/config/argocd-cmp-cm.yaml
+++ b/manifests/base/config/argocd-cmp-cm.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: argocd-cmp-cm
-  labels:
-    app.kubernetes.io/name: argocd-cmp-cm
-    app.kubernetes.io/part-of: argocd

--- a/manifests/base/config/kustomization.yaml
+++ b/manifests/base/config/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
 - argocd-cm.yaml
-- argocd-cmp-cm.yaml
 - argocd-cmd-params-cm.yaml
 - argocd-secret.yaml
 - argocd-rbac-cm.yaml

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -186,9 +186,6 @@ spec:
           name: var-files
         - emptyDir: {}
           name: plugins
-        - name: config-files
-          configMap:
-            name: argocd-cmp-cm
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -2749,14 +2749,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: argocd-cmp-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cmp-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-gpg-keys-cm
@@ -3109,9 +3101,6 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
-      - configMap:
-          name: argocd-cmp-cm
-        name: config-files
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -2918,14 +2918,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: argocd-cmp-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cmp-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-gpg-keys-cm
@@ -4017,9 +4009,6 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
-      - configMap:
-          name: argocd-cmp-cm
-        name: config-files
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -277,14 +277,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: argocd-cmp-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cmp-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-gpg-keys-cm
@@ -1376,9 +1368,6 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
-      - configMap:
-          name: argocd-cmp-cm
-        name: config-files
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -2861,14 +2861,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: argocd-cmp-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cmp-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-gpg-keys-cm
@@ -3351,9 +3343,6 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
-      - configMap:
-          name: argocd-cmp-cm
-        name: config-files
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -220,14 +220,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: argocd-cmp-cm
-    app.kubernetes.io/part-of: argocd
-  name: argocd-cmp-cm
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-gpg-keys-cm
@@ -710,9 +702,6 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
-      - configMap:
-          name: argocd-cmp-cm
-        name: config-files
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -132,7 +132,7 @@ func TestGenerateYamlManifestInDir(t *testing.T) {
 	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src}
 
 	// update this value if we add/remove manifests
-	const countOfManifests = 35
+	const countOfManifests = 34
 
 	res1, err := service.GenerateManifest(context.Background(), &q)
 


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The `argocd-cmp-cm` was added to allow users adding `plugin.yaml` content and volume mount it into the plugin sidecar container. It is not good to force everyone to use the `argocd-cmp-cm`: for example it will be impossible to package `plugin.yaml` content using Kustomize config map generator feature. Instead it is better to let use any config map.

PR removes empty 'argocd-cmp-cm'  and updates documentation accordingly. 