### PR TITLE
build: Pin Python to 3.9.8 to work with arch x64 on GitHub Actions

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9.7
+          python-version: 3.9.8
       - name: build
         run: |
           pip install -r docs/requirements.txt


### PR DESCRIPTION
Seeing failures for `Deploy` build. Example builds:
* https://github.com/argoproj/argo-cd/runs/4169914842?check_suite_focus=true
* https://github.com/argoproj/argo-cd/runs/4170223975?check_suite_focus=true

```
Error: Version 3.9.7 with arch x64 not found
Available versions:

2.7.18 (x64)
3.10.0 (x64)
3.5.10 (x64)
3.6.15 (x64)
3.7.12 (x64)
3.8.12 (x64)
3.9.8 (x64)

```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

