### PR TITLE
chore: build UI assets before creating CLI binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ cli: test-tools-image
 	$(call run-in-test-client, GOOS=${HOST_OS} GOARCH=${HOST_ARCH} make cli-local)
 
 .PHONY: cli-local
-cli-local: clean-debug
+cli-local: clean-debug build-ui-local
 	CGO_ENABLED=0 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${CLI_NAME} ./cmd
 
 .PHONY: gen-resources-cli-local
@@ -341,6 +341,10 @@ lint-ui: test-tools-image
 .PHONY: lint-ui-local
 lint-ui-local:
 	cd ui && yarn lint
+
+.PHONY: build-ui-local
+build-ui-local:
+	cd ui && yarn build
 
 # Build all Go code
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ gen-resources-cli-local: clean-debug
 	CGO_ENABLED=0 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${GEN_RESOURCES_CLI_NAME} ./hack/gen-resources/cmd
 
 .PHONY: release-cli
-release-cli: clean-debug
+release-cli: clean-debug build-ui-local
 	make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all
 	make BIN_NAME=argocd-darwin-arm64 GOOS=darwin GOARCH=arm64 argocd-all
 	make BIN_NAME=argocd-linux-amd64 GOOS=linux argocd-all


### PR DESCRIPTION
We can embed the static UI assets during compile time. The "argocd admin dashboard" command relies on these assets and throws the following error when they are absent

```
open dist/app/index.html: file does not exist
```

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
