### PR TITLE
refactor: use cached project while calculating resource tree

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -360,7 +360,7 @@ func isKnownOrphanedResourceExclusion(key kube.ResourceKey, proj *appv1.AppProje
 func (ctrl *ApplicationController) getResourceTree(a *appv1.Application, managedResources []*appv1.ResourceDiff) (*appv1.ApplicationTree, error) {
 	nodes := make([]appv1.ResourceNode, 0)
 
-	proj, err := argo.GetAppProject(&a.Spec, applisters.NewAppProjectLister(ctrl.projInformer.GetIndexer()), ctrl.namespace, ctrl.settingsMgr, ctrl.db, context.TODO())
+	proj, err := ctrl.getAppProj(a)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>
 
The https://github.com/argoproj/argo-cd/pull/7274 reduced controller CPU usage by introducing project caching. This PR adds project cache uses in `getResourceTree` method - it was forgotten in #7274 
