### PR TITLE
fix: env vars to tune cluster cache were broken

### DIFF
--- a/pkg/apis/application/v1alpha1/cluster_constants.go
+++ b/pkg/apis/application/v1alpha1/cluster_constants.go
@@ -36,12 +36,12 @@ var (
 
 func init() {
 	if envQPS := os.Getenv(EnvK8sClientQPS); envQPS != "" {
-		if qps, err := strconv.ParseFloat(envQPS, 32); err != nil {
+		if qps, err := strconv.ParseFloat(envQPS, 32); err == nil {
 			K8sClientConfigQPS = float32(qps)
 		}
 	}
 	if envBurst := os.Getenv(EnvK8sClientBurst); envBurst != "" {
-		if burst, err := strconv.Atoi(envBurst); err != nil {
+		if burst, err := strconv.Atoi(envBurst); err == nil {
 			K8sClientConfigBurst = burst
 		}
 	} else {
@@ -49,7 +49,7 @@ func init() {
 	}
 
 	if envMaxConn := os.Getenv(EnvK8sClientMaxIdleConnections); envMaxConn != "" {
-		if maxConn, err := strconv.Atoi(envMaxConn); err != nil {
+		if maxConn, err := strconv.Atoi(envMaxConn); err == nil {
 			K8sMaxIdleConnections = maxConn
 		}
 	}


### PR DESCRIPTION
The following env vars to tune the cluster cache never worked because we were checking for error when parsing the env var, we should have been checking for success:
* `ARGOCD_K8S_CLIENT_QPS`
* `ARGOCD_K8S_CLIENT_BURST`
* `ARGOCD_K8S_CLIENT_MAX_IDLE_CONNECTIONS`

Signed-off-by: Jesse Suen <jesse@akuity.io>
