### PR TITLE
refactoring: upgrade casbin to latest stable version (v2.39.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/argoproj/argo-cd/v2
 go 1.16
 
 require (
+	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Masterminds/semver v1.5.0
 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
 	github.com/alicebob/miniredis v2.5.0+incompatible
@@ -12,7 +13,7 @@ require (
 	github.com/argoproj/pkg v0.9.1
 	github.com/bombsimon/logrusr v1.0.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.2
-	github.com/casbin/casbin v1.9.1
+	github.com/casbin/casbin/v2 v2.39.1
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1

--- a/go.sum
+++ b/go.sum
@@ -160,9 +160,9 @@ github.com/bradleyfalzon/ghinstallation v1.1.1/go.mod h1:vyCmHTciHx/uuyN82Zc3rXN
 github.com/bradleyfalzon/ghinstallation/v2 v2.0.2 h1:VdhctVU4Kag+Yo5iuvEvFx4HNpLEI99Cm41UnE7y1WE=
 github.com/bradleyfalzon/ghinstallation/v2 v2.0.2/go.mod h1:GhRUp70E+QFvNemlFd4unyHZ8ryBiMQkJm6KgdilpUo=
 github.com/bwmarrin/discordgo v0.19.0/go.mod h1:O9S4p+ofTFwB02em7jkpkV8M3R0/PUVOwN61zSZ0r4Q=
-github.com/casbin/casbin v1.9.1 h1:ucjbS5zTrmSLtH4XogqOG920Poe6QatdXtz1FEbApeM=
-github.com/casbin/casbin v1.9.1/go.mod h1:z8uPsfBJGUsnkagrt3G8QvjgTKFMBJ32UP8HpZllfog=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/casbin/casbin/v2 v2.39.1 h1:TatfPL1hByffzPs610HL8+gBjCisAtEhjVhpIsbZ+ws=
+github.com/casbin/casbin/v2 v2.39.1/go.mod h1:sEL80qBYTbd+BPeL4iyvwYzFT3qwLaESq5aFKVLbLfA=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -13,9 +13,10 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/glob"
 	jwtutil "github.com/argoproj/argo-cd/v2/util/jwt"
 
-	"github.com/casbin/casbin"
-	"github.com/casbin/casbin/model"
-	"github.com/casbin/casbin/util"
+	"github.com/Knetic/govaluate"
+	"github.com/casbin/casbin/v2"
+	"github.com/casbin/casbin/v2/model"
+	"github.com/casbin/casbin/v2/util"
 	jwt "github.com/dgrijalva/jwt-go/v4"
 	gocache "github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
@@ -44,10 +45,10 @@ const (
 // CasbinEnforcer represents methods that must be implemented by a Casbin enforces
 type CasbinEnforcer interface {
 	EnableLog(bool)
-	Enforce(rvals ...interface{}) bool
+	Enforce(rvals ...interface{}) (bool, error)
 	LoadPolicy() error
 	EnableEnforce(bool)
-	AddFunction(name string, function func(args ...interface{}) (interface{}, error))
+	AddFunction(name string, function govaluate.ExpressionFunction)
 	GetGroupingPolicy() [][]string
 }
 
@@ -110,25 +111,26 @@ func (e *Enforcer) tryGetCabinEnforcer(project string, policy string) (CasbinEnf
 	if cached != nil {
 		return cached.enforcer, nil
 	}
+	matchFunc := globMatchFunc
+	if e.matchMode == RegexMatchMode {
+		matchFunc = util.RegexMatchFunc
+	}
+
 	var err error
 	var enforcer CasbinEnforcer
 	if policy != "" {
-		if enforcer, err = newEnforcerSafe(e.model, newAdapter(e.adapter.builtinPolicy, e.adapter.userDefinedPolicy, policy)); err != nil {
+		if enforcer, err = newEnforcerSafe(matchFunc, e.model, newAdapter(e.adapter.builtinPolicy, e.adapter.userDefinedPolicy, policy)); err != nil {
 			// fallback to default policy if project policy is invalid
 			log.Errorf("Failed to load project '%s' policy", project)
-			enforcer, err = newEnforcerSafe(e.model, e.adapter)
+			enforcer, err = newEnforcerSafe(matchFunc, e.model, e.adapter)
 		}
 	} else {
-		enforcer, err = newEnforcerSafe(e.model, e.adapter)
+		enforcer, err = newEnforcerSafe(matchFunc, e.model, e.adapter)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	matchFunc := globMatchFunc
-	if e.matchMode == RegexMatchMode {
-		matchFunc = util.RegexMatchFunc
-	}
 	enforcer.AddFunction("globOrRegexMatch", matchFunc)
 	enforcer.EnableLog(e.enableLog)
 	enforcer.EnableEnforce(e.enabled)
@@ -139,19 +141,18 @@ func (e *Enforcer) tryGetCabinEnforcer(project string, policy string) (CasbinEnf
 // ClaimsEnforcerFunc is func template to enforce a JWT claims. The subject is replaced
 type ClaimsEnforcerFunc func(claims jwt.Claims, rvals ...interface{}) bool
 
-func newEnforcerSafe(params ...interface{}) (e CasbinEnforcer, err error) {
+func newEnforcerSafe(matchFunction govaluate.ExpressionFunction, params ...interface{}) (e CasbinEnforcer, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("%v", r)
 			e = nil
 		}
 	}()
-	enfs := casbin.NewCachedEnforcer(params...)
+	enfs, err := casbin.NewCachedEnforcer(params...)
 	if err != nil {
 		return nil, err
 	}
-	// Default glob match mode
-	enfs.AddFunction("globOrRegexMatch", globMatchFunc)
+	enfs.AddFunction("globOrRegexMatch", matchFunction)
 	return enfs, nil
 }
 
@@ -291,7 +292,7 @@ func (e *Enforcer) EnforceWithCustomEnforcer(enf CasbinEnforcer, rvals ...interf
 func enforce(enf CasbinEnforcer, defaultRole string, claimsEnforcerFunc ClaimsEnforcerFunc, rvals ...interface{}) bool {
 	// check the default role
 	if defaultRole != "" && len(rvals) >= 2 {
-		if enf.Enforce(append([]interface{}{defaultRole}, rvals[1:]...)...) {
+		if ok, err := enf.Enforce(append([]interface{}{defaultRole}, rvals[1:]...)...); ok && err == nil {
 			return true
 		}
 	}
@@ -312,7 +313,8 @@ func enforce(enf CasbinEnforcer, defaultRole string, claimsEnforcerFunc ClaimsEn
 	default:
 		rvals = append([]interface{}{""}, rvals[1:]...)
 	}
-	return enf.Enforce(rvals...)
+	ok, err := enf.Enforce(rvals...)
+	return ok && err == nil
 }
 
 // SetBuiltinPolicy sets a built-in policy, which augments any user defined policies
@@ -408,7 +410,7 @@ func (e *Enforcer) syncUpdate(cm *apiv1.ConfigMap, onUpdated func(cm *apiv1.Conf
 
 // ValidatePolicy verifies a policy string is acceptable to casbin
 func ValidatePolicy(policy string) error {
-	_, err := newEnforcerSafe(newBuiltInModel(), newAdapter("", "", policy))
+	_, err := newEnforcerSafe(globMatchFunc, newBuiltInModel(), newAdapter("", "", policy))
 	if err != nil {
 		return fmt.Errorf("policy syntax error: %s", policy)
 	}
@@ -419,7 +421,11 @@ func ValidatePolicy(policy string) error {
 // This is needed because it is not safe to re-use the same casbin Model when instantiating new
 // casbin enforcers.
 func newBuiltInModel() model.Model {
-	return casbin.NewModel(assets.ModelConf)
+	m, err := model.NewModelFromString(assets.ModelConf)
+	if err != nil {
+		panic(err)
+	}
+	return m
 }
 
 // Casbin adapter which satisfies persist.Adapter interface


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The PR is an attempt to resolve https://github.com/argoproj/argo-cd/issues/7801 . I've wasted a couple of days trying to find bug in Argo CD code but no luck.  Another option is that cached enforce of casbin itself has a bug. 

The PR upgrades casbin to most recent stable version which introduce 8 fixes for cached informer https://github.com/casbin/casbin/commits/master/enforcer_cached.go .  I suggest merging this PR, test next release candidate another week and either close #7801  or rollback both casbin upgrade and caching changes.