### PR TITLE
docs: Add argocd-vault-replacer

### DIFF
--- a/docs/operator-manual/secret-management.md
+++ b/docs/operator-manual/secret-management.md
@@ -12,6 +12,6 @@ Argo CD is un-opinionated about how secrets are managed. There's many ways to do
 * [aws-secret-operator](https://github.com/mumoshu/aws-secret-operator)
 * [KSOPS](https://github.com/viaduct-ai/kustomize-sops#argo-cd-integration)
 * [argocd-vault-plugin](https://github.com/IBM/argocd-vault-plugin)
-
+* [argocd-vault-replacer](https://github.com/crumbhole/argocd-vault-replacer)
 
 For discussion, see [#1364](https://github.com/argoproj/argo-cd/issues/1364)


### PR DESCRIPTION
This is a self explanatory documentation update that doesn't need to go in the release notes.

Adding argocd-vault-replacer as another hashicorp vault tool with different abilities from the IBM version. Primary differences:
* Ability to use kubernetes authentication
* Textual replacement rather than understanding the YAML so secrets can be anywhere, not just in limited locations.
* Ability to process the secrets into other forms (e.g. base64 encode)

Signed-off-by: Alan Clucas <alan@clucas.org>