### PR TITLE
docs: Helm plugins via initContainers

### DIFF
--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -253,7 +253,7 @@ repoServer:
       args:
         - apk --no-cache add curl;
           helm plugin install https://github.com/hayorov/helm-gcs.git;
-          helm repo add bulder-shared gs://my-private-helm-gcs-repository;
+          helm repo add my-gcs-repo gs://my-private-helm-gcs-repository;
           chmod -R 777 $HELM_DATA_HOME;
 ```
 

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -207,6 +207,7 @@ Some users find this pattern preferable to maintaining their own version of the 
 
 Below is an example of how to add Helm plugins when installing ArgoCD with the [official ArgoCD helm chart](https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd):
 
+```
 # helm-gcs plugin
 repoServer:
   volumes:
@@ -254,6 +255,7 @@ repoServer:
           helm plugin install https://github.com/hayorov/helm-gcs.git;
           helm repo add bulder-shared gs://my-private-helm-gcs-repository;
           chmod -R 777 $HELM_DATA_HOME;
+```
 
 ## Helm Version
 

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -169,9 +169,11 @@ Or via declarative syntax:
 
 Argo CD is un-opinionated on what cloud provider you use and what kind of Helm plugins you are using, that's why there are no plugins delivered with the ArgoCD image.
 
-But sometimes it happens you would like to use a custom plugin. One of the cases is that you would like to use Google Cloud Storage or Amazon S3 storage to save the Helm charts, for example: https://github.com/hayorov/helm-gcs where you can use `gs://` protocol for Helm chart repository access.
+But sometimes you want to use a custom plugin. Perhaps you would like to use Google Cloud Storage or Amazon S3 storage to save the Helm charts, for example: https://github.com/hayorov/helm-gcs where you can use `gs://` protocol for Helm chart repository access.
+There are two ways to install custom plugins; you can modify the ArgoCD container image, or you can use a Kubernetes `initContainer`.
 
-In order to do that you have to prepare your own ArgoCD image with installed plugins.
+### Modifying the ArgoCD container image
+One way to use this plugin is to prepare your own ArgoCD image where it is included.
 
 Example `Dockerfile`:
 
@@ -198,6 +200,60 @@ ENV HELM_PLUGINS="/home/argocd/.local/share/helm/plugins/"
 You have to remember about `HELM_PLUGINS` environment property - this is required for plugins to work correctly.
 
 After that you have to use your custom image for ArgoCD installation.
+
+### Using `initContainers`
+Another option is to install Helm plugins via Kubernetes `initContainers`.
+Some users find this pattern preferable to maintaining their own version of the ArgoCD container image.
+
+Below is an example of how to add Helm plugins when installing ArgoCD with the [official ArgoCD helm chart](https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd):
+
+# helm-gcs plugin
+repoServer:
+  volumes:
+    - name: helm
+      emptyDir: {}
+    - name: gcloud
+      secret:
+        secretName: helm-credentials
+  volumeMounts:
+    - mountPath: /helm
+      name: helm
+    - mountPath: /gcloud
+      name: gcloud
+  env:
+    - name: HELM_DATA_HOME
+      value: /helm
+    - name: HELM_CACHE_HOME
+      value: /helm/cache
+    - name: HELM_CONFIG_HOME
+      value: /helm/config
+    - name: HELM_PLUGINS
+      value: /helm/plugins/
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /gcloud/key.json
+  initContainers:
+    - name: install-helm-plugins
+      image: alpine/helm:3.6.3
+      volumeMounts:
+        - mountPath: /helm
+          name: helm
+        - mountPath: /gcloud
+          name: gcloud
+      env:
+        - name: HELM_DATA_HOME
+          value: /helm
+        - name: HELM_CACHE_HOME
+          value: /helm/cache
+        - name: HELM_CONFIG_HOME
+          value: /helm/config
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /gcloud/key.json
+      command: ["/bin/sh", "-c"]
+      args:
+        - apk --no-cache add curl;
+          helm plugin install https://github.com/hayorov/helm-gcs.git;
+          helm repo add bulder-shared gs://my-private-helm-gcs-repository;
+          chmod -R 777 $HELM_DATA_HOME;
 
 ## Helm Version
 


### PR DESCRIPTION
Related: #7066

Include an alternative method for installing Helm plugins that don't require users to maintain their own version of the ArgoCD container image.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

