### PR TITLE
fix: resource custom actions are not visible in resource actions dropdown

### DIFF
--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -357,7 +357,7 @@ function getActionItems(
     const resourceActions = services.applications
         .getResourceActions(application.metadata.name, resource)
         .then(actions => {
-            items.concat(
+            return items.concat(
                 actions.map(action => ({
                     title: action.name,
                     disabled: !!action.disabled,
@@ -376,7 +376,6 @@ function getActionItems(
                     }
                 }))
             );
-            return items;
         })
         .catch(() => items);
     menuItems = merge(from([items]), from(resourceActions));


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Minor UI bug fixe: resources custom actions are loaded but not rendered 