### PR TITLE
build: Disable non-testing CI builds on forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   CodeQL-Build:
+    if: github.repository == 'argoproj/argo-cd'
 
     # CodeQL runs on ubuntu-latest and windows-latest
     runs-on: ubuntu-latest

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   publish:
+    if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-latest
     env:
       GOPATH: /home/runner/work/argo-cd/argo-cd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   prepare-release:
     name: Perform automatic release on trigger ${{ github.ref }}
+    if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-latest
     env:
       # The name of the tag as supplied by the GitHub event


### PR DESCRIPTION
These jobs require docker registry credentials or run on a schedule even on ArgoCD forks, which is a waste of GitHub Actions resources for fork owners. We currently disabled these for Workflows and I think ArgoCD would benefit from it as well.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

