### PR TITLE
docs: fix yaml indent

### DIFF
--- a/docs/operator-manual/notifications/services/slack.md
+++ b/docs/operator-manual/notifications/services/slack.md
@@ -29,36 +29,37 @@ The Slack notification service configuration includes following settings:
 1. Invite your slack bot to this channel **otherwise slack bot won't be able to deliver notifications to this channel**
 1. Store Oauth access token in `argocd-notifications-secret` secret
 
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: <secret-name>
-    stringData:
-      slack-token: <Oauth-access-token>
-    ```
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  slack-token: <Oauth-access-token>
+```
 
 1. Define service type slack in data section of `argocd-notifications-cm` configmap:
 service
-    ```yaml
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: <config-map-name>
-    data:
-      service.slack: |
-        token: $slack-token
-    ```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.slack: |
+    token: $slack-token
+```
 
 1. Add annotation in application yaml file to enable notifications for specific argocd app
 
-    ```yaml
-    apiVersion: argoproj.io/v1alpha1
-    kind: Application
-    metadata:
-      annotations:
-        notifications.argoproj.io/subscribe.on-sync-succeeded.slack: my_channel
-    ```
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: my_channel
+```
 
 ## Templates
 


### PR DESCRIPTION
Fix rendering yaml manifests in [Notifications Services/slack](https://argo-cd.readthedocs.io/en/latest/operator-manual/notifications/services/slack/).

<img width="663" alt="screenshot1" src="https://user-images.githubusercontent.com/1947929/144573111-e8624593-1ece-4f8f-8d47-0adc7737f06f.png">

Signed-off-by: makocchi-git <makocchi@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

