### PR TITLE
refactor: avoid loading project in frequently executed controller methods

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -284,12 +284,8 @@ func (ctrl *ApplicationController) handleObjectUpdated(managedByApp map[string]b
 				if !ok {
 					continue
 				}
-				// exclude resource unless it is permitted in the app project. If project is not permitted then it is not controlled by the user and there is no point showing the warning.
-				if proj, err := ctrl.getAppProj(app); err == nil && proj.IsGroupKindPermitted(ref.GroupVersionKind().GroupKind(), true) &&
-					!isKnownOrphanedResourceExclusion(kube.NewResourceKey(ref.GroupVersionKind().Group, ref.GroupVersionKind().Kind, ref.Namespace, ref.Name), proj) {
 
-					managedByApp[app.Name] = false
-				}
+				managedByApp[app.Name] = true
 			}
 		}
 	}
@@ -1638,7 +1634,7 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 					return nil, nil
 				}
 
-				proj, err := ctrl.getAppProj(app)
+				proj, err := applisters.NewAppProjectLister(ctrl.projInformer.GetIndexer()).AppProjects(ctrl.namespace).Get(app.Spec.GetProject())
 				if err != nil {
 					return nil, nil
 				}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -785,11 +785,11 @@ func TestHandleOrphanedResourceUpdated(t *testing.T) {
 
 	isRequested, level := ctrl.isRefreshRequested(app1.Name)
 	assert.True(t, isRequested)
-	assert.Equal(t, ComparisonWithNothing, level)
+	assert.Equal(t, CompareWithRecent, level)
 
 	isRequested, level = ctrl.isRefreshRequested(app2.Name)
 	assert.True(t, isRequested)
-	assert.Equal(t, ComparisonWithNothing, level)
+	assert.Equal(t, CompareWithRecent, level)
 }
 
 func TestGetResourceTree_HasOrphanedResources(t *testing.T) {


### PR DESCRIPTION
PR fixes performance degradation introduced in v2.2 changes:

* Stops loading project in `handleObjectUpdated` method. Project is loaded to avoid reconciling app if not-permitted orphaned resource changed. It is cheaper to just reconcile app instead of loading project on every resource change
* Stops loading "global" project settings just to get orphaned resources settings in application indexer since orphaned resources are not inherited from global project.

Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>
