### PR TITLE
feat: allow hiding managed fields in resource manifest viewer

### DIFF
--- a/ui/src/app/applications/components/application-node-info/application-node-info.scss
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.scss
@@ -31,4 +31,11 @@
         margin-right: 2px;
         line-height: 14px;
     }
+
+    &__checkboxes {
+        text-align: right;
+        label {
+            padding-right: 2em;
+        }
+    }
 }

--- a/ui/src/app/applications/components/application-node-info/application-node-info.tsx
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.tsx
@@ -1,4 +1,5 @@
-import {DataLoader, Tab, Tabs} from 'argo-ui';
+import {Checkbox, DataLoader, Tab, Tabs} from 'argo-ui';
+import * as deepMerge from 'deepmerge';
 import * as moment from 'moment';
 import * as React from 'react';
 
@@ -93,11 +94,38 @@ export const ApplicationNodeInfo = (props: {
             key: 'manifest',
             title: 'Live Manifest',
             content: (
-                <YamlEditor
-                    input={props.live}
-                    hideModeButtons={!props.live}
-                    onSave={(patch, patchType) => services.applications.patchResource(props.application.metadata.name, props.node, patch, patchType)}
-                />
+                <DataLoader load={() => services.viewPreferences.getPreferences()}>
+                    {pref => {
+                        const live = deepMerge(props.live, {}) as any;
+                        if (live && pref.appDetails.hideManagedFields) {
+                            delete live.metadata.managedFields;
+                        }
+                        return (
+                            <>
+                                <div className='application-node-info__checkboxes'>
+                                    <Checkbox
+                                        id='hideManagedFields'
+                                        checked={!!pref.appDetails.hideManagedFields}
+                                        onChange={() =>
+                                            services.viewPreferences.updatePreferences({
+                                                appDetails: {
+                                                    ...pref.appDetails,
+                                                    hideManagedFields: !pref.appDetails.hideManagedFields
+                                                }
+                                            })
+                                        }
+                                    />
+                                    <label htmlFor='hideManagedFields'>Hide Managed Fields</label>
+                                </div>
+                                <YamlEditor
+                                    input={live}
+                                    hideModeButtons={!live}
+                                    onSave={(patch, patchType) => services.applications.patchResource(props.application.metadata.name, props.node, patch, patchType)}
+                                />
+                            </>
+                        );
+                    }}
+                </DataLoader>
             )
         }
     ];

--- a/ui/src/app/shared/components/monaco-editor.tsx
+++ b/ui/src/app/shared/components/monaco-editor.tsx
@@ -31,7 +31,10 @@ const MonacoEditorLazy = React.lazy(() =>
 
             return (
                 <div
-                    style={{height: `${Math.max(props.minHeight || 0, height)}px`}}
+                    style={{
+                        height: `${Math.max(props.minHeight || 0, height + 100)}px`,
+                        overflowY: 'hidden'
+                    }}
                     ref={el => {
                         if (el) {
                             const container = el as {
@@ -40,7 +43,16 @@ const MonacoEditorLazy = React.lazy(() =>
                             };
                             if (props.editor) {
                                 if (!container.editorApi) {
-                                    container.editorApi = monaco.editor.create(el, props.editor.options);
+                                    const editor = monaco.editor.create(el, {
+                                        ...props.editor.options,
+                                        scrollBeyondLastLine: false,
+                                        scrollbar: {
+                                            alwaysConsumeMouseWheel: false,
+                                            vertical: 'hidden'
+                                        }
+                                    });
+
+                                    container.editorApi = editor;
                                 }
 
                                 const model = monaco.editor.createModel(props.editor.input.text, props.editor.input.language);

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -9,6 +9,7 @@ export interface AppDetailsPreferences {
     resourceView: 'manifest' | 'diff' | 'desiredManifest';
     inlineDiff: boolean;
     compactDiff: boolean;
+    hideManagedFields?: boolean;
     orphanedResources: boolean;
     podView: PodViewPreferences;
     darkMode: boolean;


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/6089 

PR improves the usability of resource manifest viewer. Following changes are implemented:

* Added "Hide Managed Fields" checkbox. The button allows the user to hide `metadata.managedFields` field:

https://user-images.githubusercontent.com/426437/144672502-14e21afe-c468-4c91-a436-fbab4a7ecc0a.mov

* Removes duplicate scroll within the editor. This makes it easier to navigate to the required part of a manifest and scroll no longer jump back and forth then manifest changes:

https://user-images.githubusercontent.com/426437/144672899-78ee70a5-0e93-4238-af52-c46f3ffec1c2.mov



