### PR TITLE
fix: css change for clear button in filters

### DIFF
--- a/ui/src/app/applications/components/filter/filter.tsx
+++ b/ui/src/app/applications/components/filter/filter.tsx
@@ -116,8 +116,7 @@ export const Filter = (props: FilterProps) => {
                 {props.label || 'FILTER'}
                 {(props.selected || []).length > 0 || (props.field && Object.keys(values).length > 0) ? (
                     <button
-                        className='argo-button argo-button--base argo-button--sm'
-                        style={{marginLeft: 'auto'}}
+                        className='argo-button argo-button--base argo-button--sm argo-button--right'
                         onClick={() => {
                             setValues({} as {[label: string]: boolean});
                             setInput('');


### PR DESCRIPTION
Signed-off-by: saumeya <saumeyakatyal@gmail.com>

The current button has no spacing between the heading and looks like this - 
![clear-button-now](https://user-images.githubusercontent.com/17771352/144854699-8b539a38-8658-4ea2-9ba4-58861e95e7ad.png)
The PR implements the button towards the right
![clear-button-changed](https://user-images.githubusercontent.com/17771352/144854714-91bda934-c110-4c2f-b54d-c05e3ae538c1.png)



Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

