### PR TITLE
fix: Cluster API does not support updating labels and annotations

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -181,6 +181,12 @@ var clusterFieldsByPath = map[string]func(updated *appv1.Cluster, existing *appv
 	"clusterResources": func(updated *appv1.Cluster, existing *appv1.Cluster) {
 		updated.ClusterResources = existing.ClusterResources
 	},
+	"labels": func(updated *appv1.Cluster, existing *appv1.Cluster) {
+		updated.Labels = existing.Labels
+	},
+	"annotations": func(updated *appv1.Cluster, existing *appv1.Cluster) {
+		updated.Annotations = existing.Annotations
+	},
 }
 
 // Update updates a cluster

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -109,4 +109,38 @@ func TestUpdateCluster_FieldsPathSet(t *testing.T) {
 	assert.Equal(t, updated.Name, "minikube")
 	assert.Equal(t, updated.Namespaces, []string{"default", "kube-system"})
 	assert.Equal(t, *updated.Shard, int64(1))
+
+	labelEnv := map[string]string{
+		"env": "qa",
+	}
+	_, err = server.Update(context.Background(), &clusterapi.ClusterUpdateRequest{
+		Cluster: &v1alpha1.Cluster{
+			Server: "https://127.0.0.1",
+			Labels: labelEnv,
+		},
+		UpdatedFields: []string{"labels"},
+	})
+
+	require.NoError(t, err)
+
+	assert.Equal(t, updated.Name, "minikube")
+	assert.Equal(t, updated.Namespaces, []string{"default", "kube-system"})
+	assert.Equal(t, updated.Labels, labelEnv)
+
+	annotationEnv := map[string]string{
+		"env": "qa",
+	}
+	_, err = server.Update(context.Background(), &clusterapi.ClusterUpdateRequest{
+		Cluster: &v1alpha1.Cluster{
+			Server:      "https://127.0.0.1",
+			Annotations: annotationEnv,
+		},
+		UpdatedFields: []string{"annotations"},
+	})
+
+	require.NoError(t, err)
+
+	assert.Equal(t, updated.Name, "minikube")
+	assert.Equal(t, updated.Namespaces, []string{"default", "kube-system"})
+	assert.Equal(t, updated.Annotations, annotationEnv)
 }


### PR DESCRIPTION
Signed-off-by: May Zhang <may_zhang@intuit.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

fixes: #7897