### PR TITLE
fix: css warning icon color change

### DIFF
--- a/ui/src/app/applications/components/application-conditions/application-conditions.scss
+++ b/ui/src/app/applications/components/application-conditions/application-conditions.scss
@@ -10,7 +10,7 @@
         }
 
         &--warning {
-            border-left-color: $argo-failed-color-light;
+            border-left-color: $argo-status-warning-color;
         }
 
         &--info {

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.scss
@@ -99,7 +99,7 @@
         }
         & {
             a.warning {
-                color: $argo-failed-color-light;
+                color: $argo-status-warning-color;
             }
         }
         & {


### PR DESCRIPTION
Signed-off-by: saumeya <saumeyakatyal@gmail.com>

closes #6132 
![warning1](https://user-images.githubusercontent.com/17771352/145547209-618fc818-4b50-44d7-ad7b-f2a5b291cb96.png)
![warning2](https://user-images.githubusercontent.com/17771352/145547234-49d18e3b-ff0d-40ca-ba2c-84d567512be5.png)


Note on DCO:
If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

