### PR TITLE
fix: resource tracking normalization shuold drop empty labels

### DIFF
--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -131,7 +131,11 @@ func RemoveLabel(un *unstructured.Unstructured, key string) {
 	for k := range labels {
 		if k == key {
 			delete(labels, k)
-			un.SetLabels(labels)
+			if len(labels) == 0 {
+				un.SetLabels(nil)
+			} else {
+				un.SetLabels(labels)
+			}
 			break
 		}
 	}

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -217,5 +217,5 @@ func TestRemoveLabel(t *testing.T) {
 
 	RemoveLabel(&obj, "test")
 
-	assert.Len(t, obj.GetLabels(), 0)
+	assert.Nil(t, obj.GetLabels())
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Followup fix for https://github.com/argoproj/argo-cd/pull/7899 . To avoid the reporting diff after switching to new tracking method the normalization process drops expected label from live resource. If it is last label the normalization should drop `label` field altogether.