### PR TITLE
fix: resource tracking normalization should not always drop old label

### DIFF
--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -150,6 +150,8 @@ func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceVal
 	return &appInstanceValue, nil
 }
 
+// Normalize updates live resource and removes diff caused but missing annotation or extra tracking label.
+// The normalization is required to ensure smooth transition to new tracking method.
 func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, labelKey, trackingMethod string) error {
 	if IsOldTrackingMethod(trackingMethod) {
 		return nil
@@ -170,7 +172,9 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, l
 		return err
 	}
 
-	argokube.RemoveLabel(live, labelKey)
+	if argokube.GetAppInstanceLabel(config, labelKey) == "" {
+		argokube.RemoveLabel(live, labelKey)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR fixes one more edge case in resource tracking normalization (see https://github.com/argoproj/argo-cd/pull/7909 and https://github.com/argoproj/argo-cd/pull/7899).

The resource manifest in git might have `app.kubernetes.io/instance` label. In this case, normalization should not keep that label untouched. 