### PR TITLE
fix: Allow all resources to add external links

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -30,25 +30,20 @@ func populateNodeInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 		switch gvk.Kind {
 		case kube.PodKind:
 			populatePodInfo(un, res)
-			return
 		case kube.ServiceKind:
 			populateServiceInfo(un, res)
-			return
 		case "Node":
 			populateHostNodeInfo(un, res)
-			return
 		}
 	case "extensions", "networking.k8s.io":
 		switch gvk.Kind {
 		case kube.IngressKind:
 			populateIngressInfo(un, res)
-			return
 		}
 	case "networking.istio.io":
 		switch gvk.Kind {
 		case "VirtualService":
 			populateIstioVirtualServiceInfo(un, res)
-			return
 		}
 	}
 

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -43,6 +43,25 @@ var (
       ingress:
       - hostname: localhost`)
 
+	testLinkAnnotatedService = strToUnstructured(`
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: helm-guestbook
+    namespace: default
+    resourceVersion: "123"
+    uid: "4"
+    annotations:
+      link.argocd.argoproj.io/external-link: http://my-grafana.com/pre-generated-link
+  spec:
+    selector:
+      app: guestbook
+    type: LoadBalancer
+  status:
+    loadBalancer:
+      ingress:
+      - hostname: localhost`)
+
 	testIngress = strToUnstructured(`
   apiVersion: extensions/v1beta1
   kind: Ingress
@@ -50,6 +69,39 @@ var (
     name: helm-guestbook
     namespace: default
     uid: "4"
+  spec:
+    backend:
+      serviceName: not-found-service
+      servicePort: 443
+    rules:
+    - host: helm-guestbook.com
+      http:
+        paths:
+        - backend:
+            serviceName: helm-guestbook
+            servicePort: 443
+          path: /
+        - backend:
+            serviceName: helm-guestbook
+            servicePort: https
+          path: /
+    tls:
+    - host: helm-guestbook.com
+    secretName: my-tls-secret
+  status:
+    loadBalancer:
+      ingress:
+      - ip: 107.178.210.11`)
+
+	testLinkAnnotatedIngress = strToUnstructured(`
+  apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    name: helm-guestbook
+    namespace: default
+    uid: "4"
+    annotations:
+      link.argocd.argoproj.io/external-link: http://my-grafana.com/ingress-link
   spec:
     backend:
       serviceName: not-found-service
@@ -268,6 +320,17 @@ func TestGetServiceInfo(t *testing.T) {
 	}, info.NetworkingInfo)
 }
 
+func TestGetLinkAnnotatedServiceInfo(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testLinkAnnotatedService, info)
+	assert.Equal(t, 0, len(info.Info))
+	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
+		TargetLabels: map[string]string{"app": "guestbook"},
+		Ingress:      []v1.LoadBalancerIngress{{Hostname: "localhost"}},
+		ExternalURLs: []string{"http://my-grafana.com/pre-generated-link"},
+	}, info.NetworkingInfo)
+}
+
 func TestGetIstioVirtualServiceInfo(t *testing.T) {
 	info := &ResourceInfo{}
 	populateNodeInfo(testIstioVirtualService, info)
@@ -321,6 +384,30 @@ func TestGetIngressInfo(t *testing.T) {
 			ExternalURLs: []string{"https://helm-guestbook.com/"},
 		}, info.NetworkingInfo)
 	}
+}
+
+func TestGetLinkAnnotatedIngressInfo(t *testing.T) {
+	info := &ResourceInfo{}
+	populateNodeInfo(testLinkAnnotatedIngress, info)
+	assert.Equal(t, 0, len(info.Info))
+	sort.Slice(info.NetworkingInfo.TargetRefs, func(i, j int) bool {
+		return strings.Compare(info.NetworkingInfo.TargetRefs[j].Name, info.NetworkingInfo.TargetRefs[i].Name) < 0
+	})
+	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
+		Ingress: []v1.LoadBalancerIngress{{IP: "107.178.210.11"}},
+		TargetRefs: []v1alpha1.ResourceRef{{
+			Namespace: "default",
+			Group:     "",
+			Kind:      kube.ServiceKind,
+			Name:      "not-found-service",
+		}, {
+			Namespace: "default",
+			Group:     "",
+			Kind:      kube.ServiceKind,
+			Name:      "helm-guestbook",
+		}},
+		ExternalURLs: []string{"https://helm-guestbook.com/", "http://my-grafana.com/ingress-link"},
+	}, info.NetworkingInfo)
 }
 
 func TestGetIngressInfoWildCardPath(t *testing.T) {


### PR DESCRIPTION
Improves the phase 1 implementation of #3487 to allow adding links via annotations to all resource types, including ingresses/pods/services that previously skipped looking for annotations.

* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

