### PR TITLE
Fix Kubernetes labels normalization for Prometheus 

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -49,6 +49,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [END.](https://www.endclothing.com/)
 1. [Energisme](https://energisme.com/)
 1. [Fave](https://myfave.com)
+1. [Fonoa](https://www.fonoa.com/)
 1. [Future PLC](https://www.futureplc.com/)
 1. [Garner](https://www.garnercorp.com)
 1. [G DATA CyberDefense AG](https://www.gdata-software.com/)

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -196,6 +196,7 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFil
 	}, nil
 }
 
+// Prometheus invalid labels, more info: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels.
 var invalidPromLabelChars = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 func normalizeLabels(prefix string, appLabels []string) []string {

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -196,11 +196,13 @@ func NewMetricsServer(addr string, appLister applister.ApplicationLister, appFil
 	}, nil
 }
 
+var invalidPromLabelChars = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
 func normalizeLabels(prefix string, appLabels []string) []string {
 	results := []string{}
 	for _, label := range appLabels {
 		//prometheus labels don't accept dash in their name
-		curr := strings.ReplaceAll(label, "-", "_")
+		curr := invalidPromLabelChars.ReplaceAllString(label, "_")
 		result := fmt.Sprintf("%s_%s", prefix, curr)
 		results = append(results, result)
 	}

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -33,6 +33,7 @@ metadata:
   labels:
     team-name: my-team
     team-bu: bu-id
+    argoproj.io/cluster: test-cluster
 spec:
   destination:
     namespace: dummy-namespace
@@ -57,6 +58,7 @@ metadata:
   labels:
     team-name: my-team
     team-bu: bu-id
+    argoproj.io/cluster: test-cluster
 spec:
   destination:
     namespace: dummy-namespace
@@ -87,6 +89,7 @@ metadata:
   labels:
     team-name: my-team
     team-bu: bu-id
+    argoproj.io/cluster: test-cluster
 spec:
   destination:
     namespace: dummy-namespace
@@ -254,14 +257,14 @@ func TestMetricLabels(t *testing.T) {
 	cases := []testCases{
 		{
 			description:  "will return the labels metrics successfully",
-			metricLabels: []string{"team-name", "team-bu"},
+			metricLabels: []string{"team-name", "team-bu", "argoproj.io/cluster"},
 			testCombination: testCombination{
 				applications: []string{fakeApp, fakeApp2, fakeApp3},
 				responseContains: `
 # TYPE argocd_app_labels gauge
-argocd_app_labels{label_team_bu="bu-id",label_team_name="my-team",name="my-app",namespace="argocd",project="important-project"} 1
-argocd_app_labels{label_team_bu="bu-id",label_team_name="my-team",name="my-app-2",namespace="argocd",project="important-project"} 1
-argocd_app_labels{label_team_bu="bu-id",label_team_name="my-team",name="my-app-3",namespace="argocd",project="important-project"} 1
+argocd_app_labels{label_argoproj_io_cluster="test-cluster",label_team_bu="bu-id",label_team_name="my-team",name="my-app",namespace="argocd",project="important-project"} 1
+argocd_app_labels{label_argoproj_io_cluster="test-cluster",label_team_bu="bu-id",label_team_name="my-team",name="my-app-2",namespace="argocd",project="important-project"} 1
+argocd_app_labels{label_argoproj_io_cluster="test-cluster",label_team_bu="bu-id",label_team_name="my-team",name="my-app-3",namespace="argocd",project="important-project"} 1
 `,
 			},
 		},


### PR DESCRIPTION
## PR info

Continues from #7374

When we were testing `v2.2.0-rc1` and added the label metrics, Argo panicked because of the type of labels we use (Valid in Kubernetes). We use `organization.fonoa.io/owner` style labels. This was the error:

```bash
panic: descriptor Desc{fqName: "argocd_app_labels", help: "Argo Application labels converted to Prometheus labels", constLabels: {}, variableLabels: [namespace name project l
abel_organization.fonoa.io/owner label_runtime.fonoa.io/cluster label_runtime.fonoa.io/environment label_runtime.fonoa.io/service label_runtime.fonoa.io/tier]} is invalid: "l
abel_organization.fonoa.io/owner" is not a valid label name for metric "argocd_app_labels"
```

This PR solves this by replacing all [non-valid Prometheus labels characters](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels) with a `_` character.

## Checklist

This PR is a small fix that 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

