### PR TITLE
feat: Allow escaping dollar in Envsubst

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -12,3 +12,13 @@
 * `ARGOCD_APP_SOURCE_TARGET_REVISION` - the target revision from the spec, e.g. `master`.
 * `KUBE_VERSION` - the version of kubernetes
 * `KUBE_API_VERSIONS` = the version of kubernetes API
+
+In case you don't want a variable to be interpolated, `$` can be escaped via `$$`.
+
+```
+command:
+  - sh
+  - -c
+  - |
+    echo $$FOO
+```

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -141,7 +141,12 @@ func (e Env) Envsubst(s string) string {
 		valByEnv[item.Name] = item.Value
 	}
 	return os.Expand(s, func(s string) string {
-		return valByEnv[s]
+		// allow escaping $ with $$
+		if s == "$" {
+			return "$"
+		} else {
+			return valByEnv[s]
+		}
 	})
 }
 

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2587,3 +2587,12 @@ func Test_validatePolicy_ValidResource(t *testing.T) {
 	err = validatePolicy("some-project", "org-admin", "p, proj:some-project:org-admin, clusters, *, some-project/*, allow")
 	assert.NoError(t, err)
 }
+
+func TestEnvsubst(t *testing.T) {
+	env := Env{
+		&EnvEntry{"foo", "bar"},
+	}
+
+	assert.Equal(t, "bar", env.Envsubst("$foo"))
+	assert.Equal(t, "$foo", env.Envsubst("$$foo"))
+}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/6176 and fixes https://github.com/argoproj/argo-cd/issues/6878

This allows escaping environment variables with `$$`. I've made the change as minimal as possible but if we're willing to break more things, we could also do:

 * make undefined variables error out (and force them to be escaped)
 * retain undefined variables as-is, `$foo` would remain `$foo`. However, this isn't fool-proof as `${foo}` will not retain the braces due to limitations with `os.Expand`

The current behavior for undefined variables is they get replaced by empty string.

I'm also not sure which parts of the documentation to update here. Is https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/ enough, or should all the individual pages be updated (helm, custom plugins, etc)

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

