### PR TITLE
fix: notifications controller manifests shuold use argocd image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,5 +127,6 @@ RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-repo-server
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-cmp-server
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-application-controller
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-dex
+RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-notifications
 
 USER 999

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 		command = cmpserver.NewCommand()
 	case "argocd-dex":
 		command = dex.NewCommand()
-	case "argocd-notification":
+	case "argocd-notifications":
 		command = notification.NewCommand()
 	default:
 		command = cli.NewCommand()

--- a/manifests/base/notification/argocd-notifications-controller-deployment.yaml
+++ b/manifests/base/notification/argocd-notifications-controller-deployment.yaml
@@ -30,13 +30,12 @@ spec:
               path: ca.crt
       containers:
         - command:
-            - /app/argocd-notifications-backend
-            - controller
+            - argocd-notifications
           workingDir: /app
           livenessProbe:
             tcpSocket:
               port: 9001
-          image: argoprojlabs/argocd-notifications:latest
+          image: quay.io/argoproj/argocd:latest
           imagePullPolicy: Always
           name: argocd-notifications-controller
           volumeMounts:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -3834,9 +3834,8 @@ spec:
     spec:
       containers:
       - command:
-        - /app/argocd-notifications-backend
-        - controller
-        image: argoprojlabs/argocd-notifications:latest
+        - argocd-notifications
+        image: quay.io/argoproj/argocd:latest
         imagePullPolicy: Always
         livenessProbe:
           tcpSocket:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1185,9 +1185,8 @@ spec:
     spec:
       containers:
       - command:
-        - /app/argocd-notifications-backend
-        - controller
-        image: argoprojlabs/argocd-notifications:latest
+        - argocd-notifications
+        image: quay.io/argoproj/argocd:latest
         imagePullPolicy: Always
         livenessProbe:
           tcpSocket:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3204,9 +3204,8 @@ spec:
     spec:
       containers:
       - command:
-        - /app/argocd-notifications-backend
-        - controller
-        image: argoprojlabs/argocd-notifications:latest
+        - argocd-notifications
+        image: quay.io/argoproj/argocd:latest
         imagePullPolicy: Always
         livenessProbe:
           tcpSocket:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -555,9 +555,8 @@ spec:
     spec:
       containers:
       - command:
-        - /app/argocd-notifications-backend
-        - controller
-        image: argoprojlabs/argocd-notifications:latest
+        - argocd-notifications
+        image: quay.io/argoproj/argocd:latest
         imagePullPolicy: Always
         livenessProbe:
           tcpSocket:


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR contains the last bit required to merge argocd notifications into argocd