### PR TITLE
fix: resource details page crashes when resource is not deployed and hide managed fields is selected

### DIFF
--- a/ui/src/app/applications/components/application-node-info/application-node-info.tsx
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.tsx
@@ -97,7 +97,7 @@ export const ApplicationNodeInfo = (props: {
                 <DataLoader load={() => services.viewPreferences.getPreferences()}>
                     {pref => {
                         const live = deepMerge(props.live, {}) as any;
-                        if (live && pref.appDetails.hideManagedFields) {
+                        if (live?.metadata?.managedFields && pref.appDetails.hideManagedFields) {
                             delete live.metadata.managedFields;
                         }
                         return (


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR fixes the Javascript crash when resource is not deployed and hide managed fields is selected