### PR TITLE
fix: always call ValidateDestination

### DIFF
--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -276,7 +276,7 @@ func ValidateRepo(
 		return nil, err
 	}
 	conditions = append(conditions, verifyGenerateManifests(
-		ctx, repo, permittedHelmRepos, app, repoClient, kustomizeOptions, plugins, cluster.ServerVersion, APIResourcesToStrings(apiGroups, true), permittedHelmCredentials, settingsMgr, db)...)
+		ctx, repo, permittedHelmRepos, app, repoClient, kustomizeOptions, plugins, cluster.ServerVersion, APIResourcesToStrings(apiGroups, true), permittedHelmCredentials, settingsMgr)...)
 
 	return conditions, nil
 }
@@ -381,7 +381,6 @@ func ValidatePermissions(ctx context.Context, spec *argoappv1.ApplicationSpec, p
 	} else if spec.Destination.Server == "" {
 		conditions = append(conditions, argoappv1.ApplicationCondition{Type: argoappv1.ApplicationConditionInvalidSpecError, Message: errDestinationMissing})
 	}
-
 	return conditions, nil
 }
 
@@ -479,11 +478,9 @@ func verifyGenerateManifests(
 	apiVersions []string,
 	repositoryCredentials []*argoappv1.RepoCreds,
 	settingsMgr *settings.SettingsManager,
-	db db.ArgoDB,
 ) []argoappv1.ApplicationCondition {
 	spec := &app.Spec
 	var conditions []argoappv1.ApplicationCondition
-
 	if spec.Destination.Server == "" {
 		conditions = append(conditions, argoappv1.ApplicationCondition{
 			Type:    argoappv1.ApplicationConditionInvalidSpecError,

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -579,6 +579,45 @@ func TestValidatePermissions(t *testing.T) {
 		assert.Contains(t, conditions[0].Message, "has not been configured")
 	})
 
+	t.Run("Destination cluster name does not exist", func(t *testing.T) {
+		spec := argoappv1.ApplicationSpec{
+			Source: argoappv1.ApplicationSource{
+				RepoURL:        "http://some/where",
+				Path:           "",
+				Chart:          "somechart",
+				TargetRevision: "1.4.1",
+			},
+			Destination: argoappv1.ApplicationDestination{
+				Name:      "does-not-exist",
+				Namespace: "default",
+			},
+		}
+		proj := argoappv1.AppProject{
+			Spec: argoappv1.AppProjectSpec{
+				Destinations: []argoappv1.ApplicationDestination{
+					{
+						Server:    "*",
+						Namespace: "default",
+					},
+				},
+				SourceRepos: []string{"http://some/where"},
+			},
+		}
+		db := &dbmocks.ArgoDB{}
+		db.On("ListClusters", context.Background()).Return(&argoappv1.ClusterList{
+			Items: []argoappv1.Cluster{
+				{
+					Name:   "dind",
+					Server: "https://127.0.0.1:6443",
+				},
+			},
+		}, nil)
+		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
+		assert.NoError(t, err)
+		assert.Len(t, conditions, 1)
+		assert.Contains(t, conditions[0].Message, "unable to find destination server: there are no clusters with this name: does-not-exist")
+	})
+
 	t.Run("Cannot get cluster info from DB", func(t *testing.T) {
 		spec := argoappv1.ApplicationSpec{
 			Source: argoappv1.ApplicationSource{
@@ -607,6 +646,44 @@ func TestValidatePermissions(t *testing.T) {
 		db.On("GetCluster", context.Background(), spec.Destination.Server).Return(nil, fmt.Errorf("Unknown error occurred"))
 		_, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		assert.Error(t, err)
+	})
+
+	t.Run("Destination cluster name resolves to valid server", func(t *testing.T) {
+		spec := argoappv1.ApplicationSpec{
+			Source: argoappv1.ApplicationSource{
+				RepoURL:        "http://some/where",
+				Path:           "",
+				Chart:          "somechart",
+				TargetRevision: "1.4.1",
+			},
+			Destination: argoappv1.ApplicationDestination{
+				Name:      "does-exist",
+				Namespace: "default",
+			},
+		}
+		proj := argoappv1.AppProject{
+			Spec: argoappv1.AppProjectSpec{
+				Destinations: []argoappv1.ApplicationDestination{
+					{
+						Server:    "*",
+						Namespace: "default",
+					},
+				},
+				SourceRepos: []string{"http://some/where"},
+			},
+		}
+		db := &dbmocks.ArgoDB{}
+		cluster := argoappv1.Cluster{
+			Name:   "does-exist",
+			Server: "https://127.0.0.1:6443",
+		}
+		db.On("ListClusters", context.Background()).Return(&argoappv1.ClusterList{
+			Items: []argoappv1.Cluster{cluster},
+		}, nil)
+		db.On("GetCluster", context.Background(), "https://127.0.0.1:6443").Return(&cluster, nil)
+		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
+		assert.NoError(t, err)
+		assert.Len(t, conditions, 0)
 	})
 }
 
@@ -704,16 +781,6 @@ func TestValidateDestination(t *testing.T) {
 
 		err := ValidateDestination(context.Background(), &dest, nil)
 		assert.Equal(t, "application destination can't have both name and server defined: minikube https://127.0.0.1:6443", err.Error())
-		assert.False(t, dest.IsServerInferred())
-	})
-
-	t.Run("Error when having neither server url nor name", func(t *testing.T) {
-		dest := argoappv1.ApplicationDestination{
-			Namespace: "default",
-		}
-
-		err := ValidateDestination(context.Background(), &dest, nil)
-		assert.Equal(t, "Destination server missing from app spec", err.Error())
 		assert.False(t, dest.IsServerInferred())
 	})
 

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -707,6 +707,16 @@ func TestValidateDestination(t *testing.T) {
 		assert.False(t, dest.IsServerInferred())
 	})
 
+	t.Run("Error when having neither server url nor name", func(t *testing.T) {
+		dest := argoappv1.ApplicationDestination{
+			Namespace: "default",
+		}
+
+		err := ValidateDestination(context.Background(), &dest, nil)
+		assert.Equal(t, "Destination server missing from app spec", err.Error())
+		assert.False(t, dest.IsServerInferred())
+	})
+
 	t.Run("List clusters fails", func(t *testing.T) {
 		dest := argoappv1.ApplicationDestination{
 			Name: "minikube",


### PR DESCRIPTION
Signed-off-by: Mark Pim <j.mark.pim@gmail.com>

fixes #7828 

Using this example, badly configured app (with a destination cluster name that doesn't exist):
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: test-broken
  namespace: argocd
spec:
  destination:
    namespace: default
    name: i-dont-exist
  project: default
  source:
    helm:
      parameters:
      - name: ingress.enabled
        value: "true"
    path: helm-guestbook
    repoURL: https://github.com/argoproj/argocd-example-apps
    targetRevision: HEAD
```

Before this fix results in a constantly flipping status condition, and ever increasing resourceVersion and generation:

```shell
% for i in {1..10}; do; kubectl get application test-broken -o yaml | yq e '(.metadata.resourceVersion, .metadata.generation, .status.conditions)' -; sleep 1; done;
5497392
201
- lastTransitionTime: "2021-12-17T11:11:20Z"
  message: Destination server missing from app spec
  type: InvalidSpecError
5497441
248
- lastTransitionTime: "2021-12-17T11:11:21Z"
  message: Destination server missing from app spec
  type: InvalidSpecError
5497489
293
- lastTransitionTime: "2021-12-17T11:11:22Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5497537
338
- lastTransitionTime: "2021-12-17T11:11:23Z"
  message: Destination server missing from app spec
  type: InvalidSpecError
5497587
382
- lastTransitionTime: "2021-12-17T11:11:24Z"
  message: Destination server missing from app spec
  type: InvalidSpecError
5497638
431
- lastTransitionTime: "2021-12-17T11:11:25Z"
  message: Destination server missing from app spec
  type: InvalidSpecError
5497688
478
- lastTransitionTime: "2021-12-17T11:11:27Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5497736
524
- lastTransitionTime: "2021-12-17T11:11:28Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5497788
573
- lastTransitionTime: "2021-12-17T11:11:29Z"
  message: Destination server missing from app spec
  type: InvalidSpecError
5497834
617
- lastTransitionTime: "2021-12-17T11:11:30Z"
  message: Destination server missing from app spec
  type: InvalidSpecError
```

Note, this doesn't only cause needless churn on the Kubernetes API. Browsing the application in the UI is unusable because the react DOM is constantly rebuilding as it gets all the new version updates from the server.

After this fix, the resource is stable:

```shell
% for i in {1..10}; do; kubectl get application test-broken -o yaml | yq e '(.metadata.resourceVersion, .metadata.generation, .status.conditions)' -; sleep 1; done;
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
5499629
3
- lastTransitionTime: "2021-12-17T11:20:56Z"
  message: 'unable to find destination server: there are no clusters with this name: i-dont-exist'
  type: InvalidSpecError
```



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

