### PR TITLE
fix: refreshing label toast

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -39,13 +39,14 @@ $header: 120px;
     }
 
     &__refreshing-label {
+        color: $white-color;
         position: fixed;
         top: $header + 100px;
-        left: 310px;
-        background-color: $argo-color-gray-4;
+        left: 50%;
+        background-color: $argo-color-gray-7;
         border: 1px solid $argo-color-gray-5;
         border-radius: 5px;
-        padding: 0 5px;
+        padding: 5px 5px;
         font-size: 0.6em;
     }
 


### PR DESCRIPTION
Signed-off-by: saumeya <saumeyakatyal@gmail.com>
closes #7487 
Adding the `refreshing` (should I add ... to the label)label in the Status Panel esp under Health according to me would make it lose the context that the app is being refreshed, however I agree that currently it is not visible at all - I have moved the label to the center and changed the color to make it look like usual toasts on screens. Let me know your feedback @jsoref   

**Current behaviour**
![before](https://user-images.githubusercontent.com/17771352/146545906-1b54af06-ed47-435d-96b8-17fc24e9696e.jpeg)

**After CSS changes**
![after](https://user-images.githubusercontent.com/17771352/146545914-32a6e1cd-e6e1-429d-b318-ac2a5aefd3d0.jpeg)

Note on DCO:
If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

