### PR TITLE
fix: webhook URL matching edge cases

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,7 +18,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/st
 This will create a new namespace, `argocd`, where Argo CD services and application resources will live.
 
 !!! warning
-    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you installing Argo CD into a different
+    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
     namespace then make sure to update the namespace reference.
 
 If you are not interested in UI, SSO, multi-cluster features then you can install [core](operator-manual/installation.md#core) Argo CD components only:

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -227,8 +227,9 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload interface{}) {
 	}
 
 	for _, webURL := range webURLs {
-		repoRegexp := getWebUrlRegex(webURL)
-		if repoRegexp == nil {
+		repoRegexp, err := getWebUrlRegex(webURL)
+		if err != nil {
+			log.Warnf("Failed to get repoRegexp: %s", err)
 			continue
 		}
 		for _, app := range apps.Items {
@@ -251,11 +252,10 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload interface{}) {
 
 // getWebUrlRegex compiles a regex that will match any targetRevision referring to the same repo as the given webURL.
 // webURL is expected to be a URL from an SCM webhook payload pointing to the web page for the repo.
-func getWebUrlRegex(webURL string) *regexp.Regexp {
+func getWebUrlRegex(webURL string) (*regexp.Regexp, error) {
 	urlObj, err := url.Parse(webURL)
 	if err != nil {
-		log.Warnf("Failed to parse repoURL '%s'", webURL)
-		return nil
+		return nil, fmt.Errorf("failed to parse repoURL '%s'", webURL)
 	}
 
 	regexEscapedHostname := regexp.QuoteMeta(urlObj.Hostname())
@@ -263,11 +263,10 @@ func getWebUrlRegex(webURL string) *regexp.Regexp {
 	regexpStr := fmt.Sprintf(`(?i)^(http://|https://|\w+@|ssh://(\w+@)?)%s(:[0-9]+|)[:/]%s(\.git)?$`, regexEscapedHostname, regexEscapedPath)
 	repoRegexp, err := regexp.Compile(regexpStr)
 	if err != nil {
-		log.Warnf("Failed to compile regexp for repoURL '%s'", webURL)
-		return nil
+		return nil, fmt.Errorf("failed to compile regexp for repoURL '%s'", webURL)
 	}
 
-	return repoRegexp
+	return repoRegexp, nil
 }
 
 func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Application, change changeInfo, trackingMethod string, appInstanceLabelKey string) error {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -249,6 +249,8 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload interface{}) {
 	}
 }
 
+// getWebUrlRegex compiles a regex that will match any targetRevision referring to the same repo as the given webURL.
+// webURL is expected to be a URL from an SCM webhook payload pointing to the web page for the repo.
 func getWebUrlRegex(webURL string) *regexp.Regexp {
 	urlObj, err := url.Parse(webURL)
 	if err != nil {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -291,7 +291,8 @@ func Test_getWebUrlRegex(t *testing.T) {
 		testCopy := testCase
 		t.Run(testCopy.name, func(t *testing.T) {
 			t.Parallel()
-			regexp := getWebUrlRegex(testCopy.webURL)
+			regexp, err := getWebUrlRegex(testCopy.webURL)
+			assert.NoError(t, err)
 			if matches := regexp.MatchString(testCopy.repo); matches != testCopy.shouldMatch {
 				t.Errorf("appRevisionHasChanged() = %v, want %v", matches, testCopy.shouldMatch)
 			}

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v2/util/cache/appstate"
-
 	"github.com/argoproj/argo-cd/v2/util/db/mocks"
 
 	servercache "github.com/argoproj/argo-cd/v2/server/cache"
@@ -263,4 +262,38 @@ func TestAppRevisionHasChanged(t *testing.T) {
 			TargetRevision: "refs/heads/env/test",
 		},
 	}}, "env/test", false))
+}
+
+func Test_getWebUrlRegex(t *testing.T) {
+	tests := []struct{
+		shouldMatch bool
+		webURL string
+		repo string
+		name string
+	}{
+		// Ensure input is regex-escaped.
+		{false, "https://example.com/org/a..d", "https://example.com/org/abcd", "dots in repo names should not be treated as wildcards"},
+		{false, "https://an.example.com/org/repo", "https://an-example.com/org/repo", "dots in domain names should not be treated as wildcards"},
+
+		// Standard cases.
+		{true, "https://example.com/org/repo", "https://example.com/org/repo", "exact match should match"},
+		{false, "https://example.com/org/repo", "https://example.com/org/repo-2", "partial match should not match"},
+		{true, "https://example.com/org/repo", "https://example.com/org/repo.git", "no .git should match with .git"},
+		{true, "https://example.com/org/repo", "git@example.com:org/repo", "git without protocol should match"},
+		{true, "https://example.com/org/repo", "user@example.com:org/repo", "git with non-git username shout match"},
+		{true, "https://example.com/org/repo", "ssh://git@example.com/org/repo", "git with protocol should match"},
+		{true, "https://example.com/org/repo", "ssh://git@example.com:22/org/repo", "git with port number should should match"},
+		{true, "https://example.com:443/org/repo", "ssh://git@example.com:22/org/repo", "https and ssh w/ different port numbers should match"},
+		{true, "https://example.com:443/org/repo", "GIT@EXAMPLE.COM:22:ORG/REPO", "matches aren't case-sensitive"},
+	}
+	for _, testCase := range tests {
+		testCopy := testCase
+		t.Run(testCopy.name, func(t *testing.T) {
+			t.Parallel()
+			regexp := getWebUrlRegex(testCopy.webURL)
+			if matches := regexp.MatchString(testCopy.repo); matches != testCopy.shouldMatch {
+				t.Errorf("appRevisionHasChanged() = %v, want %v", matches, testCopy.shouldMatch)
+			}
+		})
+	}
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v2/util/cache/appstate"
+
 	"github.com/argoproj/argo-cd/v2/util/db/mocks"
 
 	servercache "github.com/argoproj/argo-cd/v2/server/cache"
@@ -265,11 +266,11 @@ func TestAppRevisionHasChanged(t *testing.T) {
 }
 
 func Test_getWebUrlRegex(t *testing.T) {
-	tests := []struct{
+	tests := []struct {
 		shouldMatch bool
-		webURL string
-		repo string
-		name string
+		webURL      string
+		repo        string
+		name        string
 	}{
 		// Ensure input is regex-escaped.
 		{false, "https://example.com/org/a..d", "https://example.com/org/abcd", "dots in repo names should not be treated as wildcards"},


### PR DESCRIPTION
This fixes two edge cases when matching git hook payloads to targetRevisions.

1) Dots are now interpreted literally. Previously, `example.com:org/some.repo` would match targetRevision `example.com:org/some-repo`. 

   The current implementation would technically allow any regex pattern in the org or repo name. But practically speaking, dots are the only control characters that show up in org, repo, and domain names.
2) Partial matches no longer count. Previously `example.com:org/a` would match targetRevision `example.com:org/apple`.