### PR TITLE
chore: escape proj in regex

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1588,7 +1588,7 @@ func validatePolicy(proj string, role string, policy string) error {
 	}
 	// object
 	object := strings.Trim(policyComponents[4], " ")
-	objectRegexp, err := regexp.Compile(fmt.Sprintf(`^%s/[*\w-.]+$`, proj))
+	objectRegexp, err := regexp.Compile(fmt.Sprintf(`^%s/[*\w-.]+$`, regexp.QuoteMeta(proj)))
 	if err != nil || !objectRegexp.MatchString(object) {
 		return status.Errorf(codes.InvalidArgument, "invalid policy rule '%s': object must be of form '%s/*' or '%s/<APPNAME>', not '%s'", policy, proj, proj, object)
 	}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2577,6 +2577,6 @@ func Test_validatePolicy_projIsNotRegex(t *testing.T) {
 	err = validatePolicy("some.project", "org-admin", "p, proj:some.project:org-admin, applications, *, some.project/*, allow")
 	assert.NoError(t, err)
 
-	err = validatePolicy("some-project", "org-admin", "p, proj:some.project:org-admin, applications, *, some-project/*, allow")
+	err = validatePolicy("some-project", "org-admin", "p, proj:some-project:org-admin, applications, *, some-project/*, allow")
 	assert.NoError(t, err)
 }

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2573,4 +2573,10 @@ func Test_validatePolicy_projIsNotRegex(t *testing.T) {
 	// Make sure the "." in "some.project" isn't treated as the regex wildcard.
 	err := validatePolicy("some.project", "org-admin", "p, proj:some.project:org-admin, applications, *, some-project/*, allow")
 	assert.Error(t, err)
+
+	err = validatePolicy("some.project", "org-admin", "p, proj:some.project:org-admin, applications, *, some.project/*, allow")
+	assert.NoError(t, err)
+
+	err = validatePolicy("some-project", "org-admin", "p, proj:some.project:org-admin, applications, *, some-project/*, allow")
+	assert.NoError(t, err)
 }

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2568,3 +2568,9 @@ func TestOrphanedResourcesMonitorSettings_IsWarn(t *testing.T) {
 	settings.Warn = pointer.BoolPtr(true)
 	assert.True(t, settings.IsWarn())
 }
+
+func Test_validatePolicy_projIsNotRegex(t *testing.T) {
+	// Make sure the "." in "some.project" isn't treated as the regex wildcard.
+	err := validatePolicy("some.project", "org-admin", "p, proj:some.project:org-admin, applications, *, some-project/*, allow")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
The only regex control character that's allowed in a project name is `.`. But still, best practice is to escape. Plus code gets copy/pasted, so good to have a solid example.