### PR TITLE
fix: correctly handle project field during partial cluster update

### DIFF
--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -143,4 +143,18 @@ func TestUpdateCluster_FieldsPathSet(t *testing.T) {
 	assert.Equal(t, updated.Name, "minikube")
 	assert.Equal(t, updated.Namespaces, []string{"default", "kube-system"})
 	assert.Equal(t, updated.Annotations, annotationEnv)
+
+	_, err = server.Update(context.Background(), &clusterapi.ClusterUpdateRequest{
+		Cluster: &v1alpha1.Cluster{
+			Server:  "https://127.0.0.1",
+			Project: "new-project",
+		},
+		UpdatedFields: []string{"project"},
+	})
+
+	require.NoError(t, err)
+
+	assert.Equal(t, updated.Name, "minikube")
+	assert.Equal(t, updated.Namespaces, []string{"default", "kube-system"})
+	assert.Equal(t, updated.Project, "new-project")
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>


The https://github.com/argoproj/argo-cd/pull/7039 introduced project scoped clusters support and introduced access check that ensures that user has permissions to change project. We did not take partial cluster update (using `updatedFields` query parameter) . The permission check should be done only is "full" update is executed or request updates "project" field.