### PR TITLE
feat: add visual indicator for newly created pods (Issue #5587)

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.scss
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.scss
@@ -145,7 +145,15 @@ $num-stats: 2;
                     background-color: $argo-color-gray-6;
                 }
             }
-
+            &__star-icon {
+                background: none;
+                color: #ffce25;
+                display: block;
+                left: 20px;
+                margin: 0px;
+                position: absolute;
+                top: -5px;
+            }
             &__stat-tooltip {
                 text-align: left;
 

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -11,7 +11,7 @@ import {PodViewPreferences, services, ViewPreferences} from '../../../shared/ser
 import {ResourceTreeNode} from '../application-resource-tree/application-resource-tree';
 import {ResourceIcon} from '../resource-icon';
 import {ResourceLabel} from '../resource-label';
-import {ComparisonStatusIcon, HealthStatusIcon, nodeKey, PodHealthIcon} from '../utils';
+import {ComparisonStatusIcon, isYoungerThanXMinutes, HealthStatusIcon, nodeKey, PodHealthIcon} from '../utils';
 
 import './pod-view.scss';
 
@@ -192,6 +192,15 @@ export class PodView extends React.Component<PodViewProps> {
                                                                                 <div>
                                                                                     {pod.metadata.name}
                                                                                     <div>Health: {pod.health}</div>
+                                                                                    {pod.createdAt && (
+                                                                                        <span>
+                                                                                            <span>Created: </span>
+                                                                                            <Moment fromNow={true} ago={true}>
+                                                                                                {pod.createdAt}
+                                                                                            </Moment>
+                                                                                            <span> ago ({<Moment local={true}>{pod.createdAt}</Moment>})</span>
+                                                                                        </span>
+                                                                                    )}
                                                                                 </div>
                                                                             }
                                                                             popperOptions={{
@@ -208,8 +217,13 @@ export class PodView extends React.Component<PodViewProps> {
                                                                                 }
                                                                             }}
                                                                             key={pod.metadata.name}>
-                                                                            <div className={`pod-view__node__pod pod-view__node__pod--${pod.health.toLowerCase()}`}>
-                                                                                <PodHealthIcon state={{status: pod.health, message: ''}} />
+                                                                            <div style={{position: 'relative'}}>
+                                                                                {isYoungerThanXMinutes(pod, 30) && (
+                                                                                    <i className='fas fa-star pod-view__node__pod pod-view__node__pod__star-icon' />
+                                                                                )}
+                                                                                <div className={`pod-view__node__pod pod-view__node__pod--${pod.health.toLowerCase()}`}>
+                                                                                    <PodHealthIcon state={{status: pod.health, message: ''}} />
+                                                                                </div>
                                                                             </div>
                                                                         </Tooltip>
                                                                     )}

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -4,6 +4,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactForm from 'react-form';
 import {Text} from 'react-form';
+import * as moment from 'moment';
 import {BehaviorSubject, from, fromEvent, merge, Observable, Observer, Subscription} from 'rxjs';
 import {debounceTime} from 'rxjs/operators';
 import {AppContext, Context, ContextApis} from '../../shared/context';
@@ -966,6 +967,12 @@ export function getContainerName(pod: any, containerIndex: number): string {
     const containers = (pod.spec.containers || []).concat(pod.spec.initContainers || []);
     const container = containers[containerIndex];
     return container.name;
+}
+
+export function isYoungerThanXMinutes(pod: any, x: number): boolean {
+    const createdAt = moment(pod.createdAt, 'YYYY-MM-DDTHH:mm:ssZ');
+    const xMinutesAgo = moment().subtract(x, 'minutes');
+    return createdAt.isAfter(xMinutesAgo);
 }
 
 export const BASE_COLORS = [


### PR DESCRIPTION
Fixes #5587 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 


This PR will add a visual indicator for when pods are under 30 minutes old. It will also add additional information about the pod creation time in the tooltip for each pod. 

Under 30 minutes old will have a small star: 
![AgeStatusBadge-1](https://user-images.githubusercontent.com/50851526/147030080-374a0f88-a54e-4043-8d1f-850714abc719.png)

Over 30 minutes old will appear as normal: 
![ageStatusBadge-2](https://user-images.githubusercontent.com/50851526/147030088-0c28423a-be8a-4d12-a906-5ae5cb93ebe1.png)

Tooltip with createdAt information:
![ageStatusBadge-3](https://user-images.githubusercontent.com/50851526/147030092-0e8be1f3-b19b-4deb-b859-968d54c653c0.png)

