### PR TITLE
docs,ingress.md: update ambassador mappings to avoid --grpc-web-root-path

### DIFF
--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -32,15 +32,19 @@ metadata:
   name: argocd-server-cli
   namespace: argocd
 spec:
+  # NOTE: the port must be ignored if you have strip_matching_host_port enabled on envoy
   host: argocd.example.com:443
   prefix: /
-  service: argocd-server:443
+  service: argocd-server:80
+  regex_headers:
+    Content-Type: "^application/grpc.*$"
+  grpc: true
 ```
 
-Login with the `argocd` CLI using the extra `--grpc-web-root-path` flag for gRPC-web.
+Login with the `argocd` CLI:
 
 ```shell
-argocd login <host>:<port> --grpc-web-root-path /
+argocd login <host>
 ```
 
 ### Option 2: Mapping CRD for Path-based Routing


### PR DESCRIPTION
I found it non-intuitive to have to tell our users to use `--grpc-web-root-path /` when logging in when the defaults should have just worked.

This commit updates the Host-based ambassador mappings to avoid that, making plain `argocd login <host>` calls work.

---

Weirdly enough, `service: argocd-server:443` in both the original CLI mapping and the one proposed in this patch does not work at all, and yields the following error:

```
$ argocd login argocd.example.com
FATA[0002] rpc error: code = Internal desc = transport: received the unexpected content-type "text/plain; charset=utf-8"
```

Using `service: argocd-server:80` instead works as expected.
