### PR TITLE
feat: Expose ARGOCD_APP_NAME to the `kustomize build` command (#8098)

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -1,8 +1,6 @@
 # Build Environment
 
-> v1.4
-
-[Custom tools](config-management-plugins.md), [Helm](helm.md), and [Jsonnet](jsonnet.md) support the following build env vars:
+[Custom tools](config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md), and [Kustomize](kustomize.md) support the following build env vars:
 
 * `ARGOCD_APP_NAME` - name of application
 * `ARGOCD_APP_NAMESPACE` - destination application namespace.

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -757,7 +757,7 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 			kustomizeBinary = q.KustomizeOptions.BinaryPath
 		}
 		k := kustomize.NewKustomizeApp(appPath, q.Repo.GetGitCreds(), repoURL, kustomizeBinary)
-		targetObjs, _, err = k.Build(q.ApplicationSource.Kustomize, q.KustomizeOptions)
+		targetObjs, _, err = k.Build(q.ApplicationSource.Kustomize, q.KustomizeOptions, env)
 	case v1alpha1.ApplicationSourceTypePlugin:
 		if q.ApplicationSource.Plugin != nil && q.ApplicationSource.Plugin.Name != "" {
 			targetObjs, err = runConfigManagementPlugin(appPath, repoRoot, env, q, q.Repo.GetGitCreds())
@@ -1276,7 +1276,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 				return err
 			}
 		case v1alpha1.ApplicationSourceTypeKustomize:
-			if err := populateKustomizeAppDetails(res, q, opContext.appPath); err != nil {
+			if err := populateKustomizeAppDetails(res, q, opContext.appPath, commitSHA); err != nil {
 				return err
 			}
 		}
@@ -1423,14 +1423,21 @@ func findHelmValueFilesInPath(path string) ([]string, error) {
 	return result, nil
 }
 
-func populateKustomizeAppDetails(res *apiclient.RepoAppDetailsResponse, q *apiclient.RepoServerAppDetailsQuery, appPath string) error {
+func populateKustomizeAppDetails(res *apiclient.RepoAppDetailsResponse, q *apiclient.RepoServerAppDetailsQuery, appPath string, reversion string) error {
 	res.Kustomize = &apiclient.KustomizeAppSpec{}
 	kustomizeBinary := ""
 	if q.KustomizeOptions != nil {
 		kustomizeBinary = q.KustomizeOptions.BinaryPath
 	}
 	k := kustomize.NewKustomizeApp(appPath, q.Repo.GetGitCreds(), q.Repo.Repo, kustomizeBinary)
-	_, images, err := k.Build(q.Source.Kustomize, q.KustomizeOptions)
+	fakeManifestRequest := apiclient.ManifestRequest{
+		AppName:           q.AppName,
+		Namespace:         "", // FIXME: omit it for now
+		Repo:              q.Repo,
+		ApplicationSource: q.Source,
+	}
+	env := newEnv(&fakeManifestRequest, reversion)
+	_, images, err := k.Build(q.Source.Kustomize, q.KustomizeOptions, env)
 	if err != nil {
 		return err
 	}

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -30,7 +30,7 @@ type Image = string
 // Kustomize provides wrapper functionality around the `kustomize` command.
 type Kustomize interface {
 	// Build returns a list of unstructured objects from a `kustomize build` command and extract supported parameters
-	Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOptions *v1alpha1.KustomizeOptions) ([]*unstructured.Unstructured, []Image, error)
+	Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOptions *v1alpha1.KustomizeOptions, envVars *v1alpha1.Env) ([]*unstructured.Unstructured, []Image, error)
 }
 
 // NewKustomizeApp create a new wrapper to run commands on the `kustomize` command-line tool.
@@ -84,7 +84,7 @@ func mapToEditAddArgs(val map[string]string) []string {
 	return args
 }
 
-func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOptions *v1alpha1.KustomizeOptions) ([]*unstructured.Unstructured, []Image, error) {
+func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOptions *v1alpha1.KustomizeOptions, envVars *v1alpha1.Env) ([]*unstructured.Unstructured, []Image, error) {
 
 	if opts != nil {
 		if opts.NamePrefix != "" {
@@ -155,7 +155,11 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 		cmd = exec.Command(k.getBinaryPath(), "build", k.path)
 	}
 
-	cmd.Env = os.Environ()
+	env := os.Environ()
+	if envVars != nil {
+		env = append(env, envVars.Environ()...)
+	}
+	cmd.Env = env
 	closer, environ, err := k.creds.Environ()
 	if err != nil {
 		return nil, nil, err

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -3,6 +3,7 @@ package kustomize
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -18,6 +19,7 @@ const kustomization1 = "kustomization_yaml"
 const kustomization2a = "kustomization_yml"
 const kustomization2b = "Kustomization"
 const kustomization3 = "force_common"
+const kustomization4 = "custom_version"
 
 func testDataDir(testData string) (string, error) {
 	res, err := ioutil.TempDir("", "kustomize-test")
@@ -50,7 +52,7 @@ func TestKustomizeBuild(t *testing.T) {
 			"app.kubernetes.io/part-of":    "argo-cd-tests",
 		},
 	}
-	objs, images, err := kustomize.Build(&kustomizeSource, nil)
+	objs, images, err := kustomize.Build(&kustomizeSource, nil, nil)
 	assert.Nil(t, err)
 	if err != nil {
 		assert.Equal(t, len(objs), 2)
@@ -163,7 +165,7 @@ func TestKustomizeBuildForceCommonLabels(t *testing.T) {
 		appPath, err := testDataDir(tc.TestData)
 		assert.Nil(t, err)
 		kustomize := NewKustomizeApp(appPath, git.NopCreds{}, "", "")
-		objs, _, err := kustomize.Build(&tc.KustomizeSource, nil)
+		objs, _, err := kustomize.Build(&tc.KustomizeSource, nil, nil)
 		switch tc.ExpectErr {
 		case true:
 			assert.Error(t, err)
@@ -212,7 +214,7 @@ func TestKustomizeBuildForceCommonAnnotations(t *testing.T) {
 		appPath, err := testDataDir(tc.TestData)
 		assert.Nil(t, err)
 		kustomize := NewKustomizeApp(appPath, git.NopCreds{}, "", "")
-		objs, _, err := kustomize.Build(&tc.KustomizeSource, nil)
+		objs, _, err := kustomize.Build(&tc.KustomizeSource, nil, nil)
 		switch tc.ExpectErr {
 		case true:
 			assert.Error(t, err)
@@ -223,4 +225,29 @@ func TestKustomizeBuildForceCommonAnnotations(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestKustomizeCustomVersion(t *testing.T) {
+	appPath, err := testDataDir(kustomization1)
+	assert.Nil(t, err)
+	kustomizePath, err := testDataDir(kustomization4)
+	assert.Nil(t, err)
+	envOutputFile := kustomizePath + "/env_output"
+	kustomize := NewKustomizeApp(appPath, git.NopCreds{}, "", kustomizePath+"/kustomize.special")
+	kustomizeSource := v1alpha1.ApplicationSourceKustomize{
+		Version: "special",
+	}
+	env := &v1alpha1.Env{
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAME", Value: "argo-cd-tests"},
+	}
+	objs, images, err := kustomize.Build(&kustomizeSource, nil, env)
+	assert.Nil(t, err)
+	if err != nil {
+		assert.Equal(t, len(objs), 2)
+		assert.Equal(t, len(images), 2)
+	}
+
+	content, err := os.ReadFile(envOutputFile)
+	assert.Nil(t, err)
+	assert.Equal(t, "ARGOCD_APP_NAME=argo-cd-tests\n", string(content))
 }

--- a/util/kustomize/testdata/custom_version/kustomize.special
+++ b/util/kustomize/testdata/custom_version/kustomize.special
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+current_dir=$(dirname $0)
+output="$current_dir/env_output"
+
+env | grep "ARGOCD_APP_NAME" > $output
+
+kustomize $@


### PR DESCRIPTION
See the discussion at here: https://github.com/argoproj/argo-cd/issues/8098

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
