### PR TITLE
refactor: move project filtering to server side

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-filter.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-filter.tsx
@@ -8,7 +8,6 @@ import * as LabelSelector from '../label-selector';
 import {ComparisonStatusIcon, HealthStatusIcon} from '../utils';
 
 export interface FilterResult {
-    projects: boolean;
     repos: boolean;
     sync: boolean;
     health: boolean;
@@ -25,7 +24,6 @@ export function getFilterResults(applications: Application[], pref: AppsListPref
     return applications.map(app => ({
         ...app,
         filterResult: {
-            projects: pref.projectsFilter.length === 0 || pref.projectsFilter.includes(app.spec.project),
             repos: pref.reposFilter.length === 0 || pref.reposFilter.includes(app.spec.source.repoURL),
             sync: pref.syncFilter.length === 0 || pref.syncFilter.includes(app.status.sync.status),
             health: pref.healthFilter.length === 0 || pref.healthFilter.includes(app.status.health.status),

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -42,14 +42,14 @@ const APP_FIELDS = [
 const APP_LIST_FIELDS = ['metadata.resourceVersion', ...APP_FIELDS.map(field => `items.${field}`)];
 const APP_WATCH_FIELDS = ['result.type', ...APP_FIELDS.map(field => `result.application.${field}`)];
 
-function loadApplications(): Observable<models.Application[]> {
-    return from(services.applications.list([], {fields: APP_LIST_FIELDS})).pipe(
+function loadApplications(projects: string[]): Observable<models.Application[]> {
+    return from(services.applications.list(projects, {fields: APP_LIST_FIELDS})).pipe(
         mergeMap(applicationsList => {
             const applications = applicationsList.items;
             return merge(
                 from([applications]),
                 services.applications
-                    .watch({resourceVersion: applicationsList.metadata.resourceVersion}, {fields: APP_WATCH_FIELDS})
+                    .watch({projects, resourceVersion: applicationsList.metadata.resourceVersion}, {fields: APP_WATCH_FIELDS})
                     .pipe(repeat())
                     .pipe(retryWhen(errors => errors.pipe(delay(WATCH_RETRY_TIMEOUT))))
                     // batch events to avoid constant re-rendering and improve UI performance
@@ -324,259 +324,241 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                 <Consumer>
                     {ctx => (
                         <Page title='Applications' toolbar={{breadcrumbs: [{title: 'Applications', path: '/applications'}]}} hideAuth={true}>
-                            <DataLoader
-                                ref={loaderRef}
-                                load={() => AppUtils.handlePageVisibility(() => loadApplications())}
-                                loadingRenderer={() => (
-                                    <div className='argo-container'>
-                                        <MockupList height={100} marginTop={30} />
-                                    </div>
-                                )}>
-                                {(applications: models.Application[]) => (
-                                    <React.Fragment>
-                                        <FlexTopBar
-                                            toolbar={services.viewPreferences.getPreferences().pipe(
-                                                map(pref => {
-                                                    const healthBarPrefs = pref.appList.statusBarView || ({} as HealthStatusBarPreferences);
-                                                    return {
-                                                        tools: (
-                                                            <React.Fragment key='app-list-tools'>
-                                                                <Query>{q => <SearchBar content={q.get('search')} apps={applications} ctx={ctx} />}</Query>
-                                                                <Tooltip content='Toggle Health Status Bar'>
-                                                                    <button
-                                                                        className={`applications-list__accordion argo-button argo-button--base${
-                                                                            healthBarPrefs.showHealthStatusBar ? '-o' : ''
-                                                                        }`}
-                                                                        style={{border: 'none'}}
-                                                                        onClick={() =>
-                                                                            services.viewPreferences.updatePreferences({
-                                                                                appList: {
-                                                                                    ...pref.appList,
-                                                                                    statusBarView: {...healthBarPrefs, showHealthStatusBar: !healthBarPrefs.showHealthStatusBar}
-                                                                                }
-                                                                            })
-                                                                        }>
-                                                                        <i className={`fas fa-ruler-horizontal`} />
-                                                                    </button>
-                                                                </Tooltip>
-                                                                <div className='applications-list__view-type' style={{marginLeft: 'auto'}}>
-                                                                    <i
-                                                                        className={classNames('fa fa-th', {selected: pref.appList.view === 'tiles'}, 'menu_icon')}
-                                                                        title='Tiles'
-                                                                        onClick={() => {
-                                                                            ctx.navigation.goto('.', {view: 'tiles'}, {replace: true});
-                                                                            services.viewPreferences.updatePreferences({appList: {...pref.appList, view: 'tiles'}});
-                                                                        }}
-                                                                    />
-                                                                    <i
-                                                                        className={classNames('fa fa-th-list', {selected: pref.appList.view === 'list'}, 'menu_icon')}
-                                                                        title='List'
-                                                                        onClick={() => {
-                                                                            ctx.navigation.goto('.', {view: 'list'}, {replace: true});
-                                                                            services.viewPreferences.updatePreferences({appList: {...pref.appList, view: 'list'}});
-                                                                        }}
-                                                                    />
-                                                                    <i
-                                                                        className={classNames('fa fa-chart-pie', {selected: pref.appList.view === 'summary'}, 'menu_icon')}
-                                                                        title='Summary'
-                                                                        onClick={() => {
-                                                                            ctx.navigation.goto('.', {view: 'summary'}, {replace: true});
-                                                                            services.viewPreferences.updatePreferences({appList: {...pref.appList, view: 'summary'}});
-                                                                        }}
-                                                                    />
-                                                                </div>
-                                                            </React.Fragment>
-                                                        ),
-                                                        actionMenu: {
-                                                            items: [
-                                                                {
-                                                                    title: 'New App',
-                                                                    iconClassName: 'fa fa-plus',
-                                                                    qeId: 'applications-list-button-new-app',
-                                                                    action: () => ctx.navigation.goto('.', {new: '{}'}, {replace: true})
-                                                                },
-                                                                {
-                                                                    title: 'Sync Apps',
-                                                                    iconClassName: 'fa fa-sync',
-                                                                    action: () => ctx.navigation.goto('.', {syncApps: true}, {replace: true})
-                                                                },
-                                                                {
-                                                                    title: 'Refresh Apps',
-                                                                    iconClassName: 'fa fa-redo',
-                                                                    action: () => ctx.navigation.goto('.', {refreshApps: true}, {replace: true})
-                                                                }
-                                                            ]
-                                                        }
-                                                    };
-                                                })
-                                            )}
-                                        />
-                                        <div className='applications-list'>
-                                            <DataLoader load={() => services.viewPreferences.getPreferences()}>
-                                                {prefs => {
-                                                    const healthBarPrefs = prefs.appList.statusBarView || ({} as HealthStatusBarPreferences);
-                                                    return (
-                                                        <ViewPref>
-                                                            {pref => {
-                                                                const {filteredApps, filterResults} = filterApps(applications, pref, pref.search);
-                                                                const appsView =
-                                                                    applications.length === 0 && (pref.labelsFilter || []).length === 0 ? (
-                                                                        <EmptyState icon='argo-icon-application'>
-                                                                            <h4>No applications yet</h4>
-                                                                            <h5>Create new application to start managing resources in your cluster</h5>
-                                                                            <button
-                                                                                qe-id='applications-list-button-create-application'
-                                                                                className='argo-button argo-button--base'
-                                                                                onClick={() => ctx.navigation.goto('.', {new: JSON.stringify({})}, {replace: true})}>
-                                                                                Create application
-                                                                            </button>
-                                                                        </EmptyState>
-                                                                    ) : (
-                                                                        <ApplicationsFilter
-                                                                            apps={filterResults}
-                                                                            onChange={newPrefs => onFilterPrefChanged(ctx, newPrefs)}
-                                                                            pref={pref}>
-                                                                            {(pref.view === 'summary' && <ApplicationsSummary applications={filteredApps} />) || (
-                                                                                <Paginate
-                                                                                    header={filteredApps.length > 1 && <ApplicationsStatusBar applications={filteredApps} />}
-                                                                                    showHeader={healthBarPrefs.showHealthStatusBar}
-                                                                                    preferencesKey='applications-list'
-                                                                                    page={pref.page}
-                                                                                    emptyState={() => (
-                                                                                        <EmptyState icon='fa fa-search'>
-                                                                                            <h4>No matching applications found</h4>
-                                                                                            <h5>
-                                                                                                Change filter criteria or&nbsp;
-                                                                                                <a
-                                                                                                    onClick={() => {
-                                                                                                        AppsListPreferences.clearFilters(pref);
-                                                                                                        onFilterPrefChanged(ctx, pref);
-                                                                                                    }}>
-                                                                                                    clear filters
-                                                                                                </a>
-                                                                                            </h5>
-                                                                                        </EmptyState>
-                                                                                    )}
-                                                                                    data={filteredApps}
-                                                                                    onPageChange={page => ctx.navigation.goto('.', {page})}>
-                                                                                    {data =>
-                                                                                        (pref.view === 'tiles' && (
-                                                                                            <ApplicationTiles
-                                                                                                applications={data}
-                                                                                                syncApplication={appName =>
-                                                                                                    ctx.navigation.goto('.', {syncApp: appName}, {replace: true})
-                                                                                                }
-                                                                                                refreshApplication={refreshApp}
-                                                                                                deleteApplication={appName => AppUtils.deleteApplication(appName, ctx)}
-                                                                                            />
-                                                                                        )) || (
-                                                                                            <ApplicationsTable
-                                                                                                applications={data}
-                                                                                                syncApplication={appName =>
-                                                                                                    ctx.navigation.goto('.', {syncApp: appName}, {replace: true})
-                                                                                                }
-                                                                                                refreshApplication={refreshApp}
-                                                                                                deleteApplication={appName => AppUtils.deleteApplication(appName, ctx)}
-                                                                                            />
-                                                                                        )
+                            <ViewPref>
+                                {pref => (
+                                    <DataLoader
+                                        input={pref.projectsFilter?.join(',')}
+                                        ref={loaderRef}
+                                        load={() => AppUtils.handlePageVisibility(() => loadApplications(pref.projectsFilter))}
+                                        loadingRenderer={() => (
+                                            <div className='argo-container'>
+                                                <MockupList height={100} marginTop={30} />
+                                            </div>
+                                        )}>
+                                        {(applications: models.Application[]) => {
+                                            const healthBarPrefs = pref.statusBarView || ({} as HealthStatusBarPreferences);
+                                            const {filteredApps, filterResults} = filterApps(applications, pref, pref.search);
+                                            return (
+                                                <React.Fragment>
+                                                    <FlexTopBar
+                                                        toolbar={{
+                                                            tools: (
+                                                                <React.Fragment key='app-list-tools'>
+                                                                    <Query>{q => <SearchBar content={q.get('search')} apps={applications} ctx={ctx} />}</Query>
+                                                                    <Tooltip content='Toggle Health Status Bar'>
+                                                                        <button
+                                                                            className={`applications-list__accordion argo-button argo-button--base${
+                                                                                healthBarPrefs.showHealthStatusBar ? '-o' : ''
+                                                                            }`}
+                                                                            style={{border: 'none'}}
+                                                                            onClick={() =>
+                                                                                services.viewPreferences.updatePreferences({
+                                                                                    appList: {
+                                                                                        ...pref,
+                                                                                        statusBarView: {
+                                                                                            ...healthBarPrefs,
+                                                                                            showHealthStatusBar: !healthBarPrefs.showHealthStatusBar
+                                                                                        }
                                                                                     }
-                                                                                </Paginate>
-                                                                            )}
-                                                                        </ApplicationsFilter>
-                                                                    );
-                                                                return (
-                                                                    <>
-                                                                        {appsView}
-                                                                        <ApplicationsSyncPanel
-                                                                            key='syncsPanel'
-                                                                            show={syncAppsInput}
-                                                                            hide={() => ctx.navigation.goto('.', {syncApps: null}, {replace: true})}
-                                                                            apps={filteredApps}
+                                                                                })
+                                                                            }>
+                                                                            <i className={`fas fa-ruler-horizontal`} />
+                                                                        </button>
+                                                                    </Tooltip>
+                                                                    <div className='applications-list__view-type' style={{marginLeft: 'auto'}}>
+                                                                        <i
+                                                                            className={classNames('fa fa-th', {selected: pref.view === 'tiles'}, 'menu_icon')}
+                                                                            title='Tiles'
+                                                                            onClick={() => {
+                                                                                ctx.navigation.goto('.', {view: 'tiles'}, {replace: true});
+                                                                                services.viewPreferences.updatePreferences({appList: {...pref, view: 'tiles'}});
+                                                                            }}
                                                                         />
-                                                                        <ApplicationsRefreshPanel
-                                                                            key='refreshPanel'
-                                                                            show={refreshAppsInput}
-                                                                            hide={() => ctx.navigation.goto('.', {refreshApps: null}, {replace: true})}
-                                                                            apps={filteredApps}
+                                                                        <i
+                                                                            className={classNames('fa fa-th-list', {selected: pref.view === 'list'}, 'menu_icon')}
+                                                                            title='List'
+                                                                            onClick={() => {
+                                                                                ctx.navigation.goto('.', {view: 'list'}, {replace: true});
+                                                                                services.viewPreferences.updatePreferences({appList: {...pref, view: 'list'}});
+                                                                            }}
                                                                         />
-                                                                    </>
-                                                                );
-                                                            }}
-                                                        </ViewPref>
-                                                    );
-                                                }}
-                                            </DataLoader>
-                                        </div>
-                                        <ObservableQuery>
-                                            {q => (
-                                                <DataLoader
-                                                    load={() =>
-                                                        q.pipe(
-                                                            mergeMap(params => {
-                                                                const syncApp = params.get('syncApp');
-                                                                return (syncApp && from(services.applications.get(syncApp))) || from([null]);
-                                                            })
-                                                        )
-                                                    }>
-                                                    {app => (
-                                                        <ApplicationSyncPanel
-                                                            key='syncPanel'
-                                                            application={app}
-                                                            selectedResource={'all'}
-                                                            hide={() => ctx.navigation.goto('.', {syncApp: null}, {replace: true})}
+                                                                        <i
+                                                                            className={classNames('fa fa-chart-pie', {selected: pref.view === 'summary'}, 'menu_icon')}
+                                                                            title='Summary'
+                                                                            onClick={() => {
+                                                                                ctx.navigation.goto('.', {view: 'summary'}, {replace: true});
+                                                                                services.viewPreferences.updatePreferences({appList: {...pref, view: 'summary'}});
+                                                                            }}
+                                                                        />
+                                                                    </div>
+                                                                </React.Fragment>
+                                                            ),
+                                                            actionMenu: {
+                                                                items: [
+                                                                    {
+                                                                        title: 'New App',
+                                                                        iconClassName: 'fa fa-plus',
+                                                                        qeId: 'applications-list-button-new-app',
+                                                                        action: () => ctx.navigation.goto('.', {new: '{}'}, {replace: true})
+                                                                    },
+                                                                    {
+                                                                        title: 'Sync Apps',
+                                                                        iconClassName: 'fa fa-sync',
+                                                                        action: () => ctx.navigation.goto('.', {syncApps: true}, {replace: true})
+                                                                    },
+                                                                    {
+                                                                        title: 'Refresh Apps',
+                                                                        iconClassName: 'fa fa-redo',
+                                                                        action: () => ctx.navigation.goto('.', {refreshApps: true}, {replace: true})
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }}
+                                                    />
+                                                    <div className='applications-list'>
+                                                        {applications.length === 0 && pref.projectsFilter?.length === 0 && (pref.labelsFilter || []).length === 0 ? (
+                                                            <EmptyState icon='argo-icon-application'>
+                                                                <h4>No applications yet</h4>
+                                                                <h5>Create new application to start managing resources in your cluster</h5>
+                                                                <button
+                                                                    qe-id='applications-list-button-create-application'
+                                                                    className='argo-button argo-button--base'
+                                                                    onClick={() => ctx.navigation.goto('.', {new: JSON.stringify({})}, {replace: true})}>
+                                                                    Create application
+                                                                </button>
+                                                            </EmptyState>
+                                                        ) : (
+                                                            <ApplicationsFilter apps={filterResults} onChange={newPrefs => onFilterPrefChanged(ctx, newPrefs)} pref={pref}>
+                                                                {(pref.view === 'summary' && <ApplicationsSummary applications={filteredApps} />) || (
+                                                                    <Paginate
+                                                                        header={filteredApps.length > 1 && <ApplicationsStatusBar applications={filteredApps} />}
+                                                                        showHeader={healthBarPrefs.showHealthStatusBar}
+                                                                        preferencesKey='applications-list'
+                                                                        page={pref.page}
+                                                                        emptyState={() => (
+                                                                            <EmptyState icon='fa fa-search'>
+                                                                                <h4>No matching applications found</h4>
+                                                                                <h5>
+                                                                                    Change filter criteria or&nbsp;
+                                                                                    <a
+                                                                                        onClick={() => {
+                                                                                            AppsListPreferences.clearFilters(pref);
+                                                                                            onFilterPrefChanged(ctx, pref);
+                                                                                        }}>
+                                                                                        clear filters
+                                                                                    </a>
+                                                                                </h5>
+                                                                            </EmptyState>
+                                                                        )}
+                                                                        data={filteredApps}
+                                                                        onPageChange={page => ctx.navigation.goto('.', {page})}>
+                                                                        {data =>
+                                                                            (pref.view === 'tiles' && (
+                                                                                <ApplicationTiles
+                                                                                    applications={data}
+                                                                                    syncApplication={appName => ctx.navigation.goto('.', {syncApp: appName}, {replace: true})}
+                                                                                    refreshApplication={refreshApp}
+                                                                                    deleteApplication={appName => AppUtils.deleteApplication(appName, ctx)}
+                                                                                />
+                                                                            )) || (
+                                                                                <ApplicationsTable
+                                                                                    applications={data}
+                                                                                    syncApplication={appName => ctx.navigation.goto('.', {syncApp: appName}, {replace: true})}
+                                                                                    refreshApplication={refreshApp}
+                                                                                    deleteApplication={appName => AppUtils.deleteApplication(appName, ctx)}
+                                                                                />
+                                                                            )
+                                                                        }
+                                                                    </Paginate>
+                                                                )}
+                                                            </ApplicationsFilter>
+                                                        )}
+                                                        <ApplicationsSyncPanel
+                                                            key='syncsPanel'
+                                                            show={syncAppsInput}
+                                                            hide={() => ctx.navigation.goto('.', {syncApps: null}, {replace: true})}
+                                                            apps={filteredApps}
                                                         />
-                                                    )}
-                                                </DataLoader>
-                                            )}
-                                        </ObservableQuery>
-                                        <SlidingPanel
-                                            isShown={!!appInput}
-                                            onClose={() => ctx.navigation.goto('.', {new: null}, {replace: true})}
-                                            header={
-                                                <div>
-                                                    <button
-                                                        qe-id='applications-list-button-create'
-                                                        className='argo-button argo-button--base'
-                                                        disabled={isAppCreatePending}
-                                                        onClick={() => createApi && createApi.submitForm(null)}>
-                                                        <Spinner show={isAppCreatePending} style={{marginRight: '5px'}} />
-                                                        Create
-                                                    </button>{' '}
-                                                    <button
-                                                        qe-id='applications-list-button-cancel'
-                                                        onClick={() => ctx.navigation.goto('.', {new: null}, {replace: true})}
-                                                        className='argo-button argo-button--base-o'>
-                                                        Cancel
-                                                    </button>
-                                                </div>
-                                            }>
-                                            {appInput && (
-                                                <ApplicationCreatePanel
-                                                    getFormApi={api => {
-                                                        setCreateApi(api);
-                                                    }}
-                                                    createApp={async app => {
-                                                        setAppCreatePending(true);
-                                                        try {
-                                                            await services.applications.create(app);
-                                                            ctx.navigation.goto('.', {new: null}, {replace: true});
-                                                        } catch (e) {
-                                                            ctx.notifications.show({
-                                                                content: <ErrorNotification title='Unable to create application' e={e} />,
-                                                                type: NotificationType.Error
-                                                            });
-                                                        } finally {
-                                                            setAppCreatePending(false);
-                                                        }
-                                                    }}
-                                                    app={appInput}
-                                                    onAppChanged={app => ctx.navigation.goto('.', {new: JSON.stringify(app)}, {replace: true})}
-                                                />
-                                            )}
-                                        </SlidingPanel>
-                                    </React.Fragment>
+                                                        <ApplicationsRefreshPanel
+                                                            key='refreshPanel'
+                                                            show={refreshAppsInput}
+                                                            hide={() => ctx.navigation.goto('.', {refreshApps: null}, {replace: true})}
+                                                            apps={filteredApps}
+                                                        />
+                                                    </div>
+                                                    <ObservableQuery>
+                                                        {q => (
+                                                            <DataLoader
+                                                                load={() =>
+                                                                    q.pipe(
+                                                                        mergeMap(params => {
+                                                                            const syncApp = params.get('syncApp');
+                                                                            return (syncApp && from(services.applications.get(syncApp))) || from([null]);
+                                                                        })
+                                                                    )
+                                                                }>
+                                                                {app => (
+                                                                    <ApplicationSyncPanel
+                                                                        key='syncPanel'
+                                                                        application={app}
+                                                                        selectedResource={'all'}
+                                                                        hide={() => ctx.navigation.goto('.', {syncApp: null}, {replace: true})}
+                                                                    />
+                                                                )}
+                                                            </DataLoader>
+                                                        )}
+                                                    </ObservableQuery>
+                                                    <SlidingPanel
+                                                        isShown={!!appInput}
+                                                        onClose={() => ctx.navigation.goto('.', {new: null}, {replace: true})}
+                                                        header={
+                                                            <div>
+                                                                <button
+                                                                    qe-id='applications-list-button-create'
+                                                                    className='argo-button argo-button--base'
+                                                                    disabled={isAppCreatePending}
+                                                                    onClick={() => createApi && createApi.submitForm(null)}>
+                                                                    <Spinner show={isAppCreatePending} style={{marginRight: '5px'}} />
+                                                                    Create
+                                                                </button>{' '}
+                                                                <button
+                                                                    qe-id='applications-list-button-cancel'
+                                                                    onClick={() => ctx.navigation.goto('.', {new: null}, {replace: true})}
+                                                                    className='argo-button argo-button--base-o'>
+                                                                    Cancel
+                                                                </button>
+                                                            </div>
+                                                        }>
+                                                        {appInput && (
+                                                            <ApplicationCreatePanel
+                                                                getFormApi={api => {
+                                                                    setCreateApi(api);
+                                                                }}
+                                                                createApp={async app => {
+                                                                    setAppCreatePending(true);
+                                                                    try {
+                                                                        await services.applications.create(app);
+                                                                        ctx.navigation.goto('.', {new: null}, {replace: true});
+                                                                    } catch (e) {
+                                                                        ctx.notifications.show({
+                                                                            content: <ErrorNotification title='Unable to create application' e={e} />,
+                                                                            type: NotificationType.Error
+                                                                        });
+                                                                    } finally {
+                                                                        setAppCreatePending(false);
+                                                                    }
+                                                                }}
+                                                                app={appInput}
+                                                                onAppChanged={app => ctx.navigation.goto('.', {new: JSON.stringify(app)}, {replace: true})}
+                                                            />
+                                                        )}
+                                                    </SlidingPanel>
+                                                </React.Fragment>
+                                            );
+                                        }}
+                                    </DataLoader>
                                 )}
-                            </DataLoader>
+                            </ViewPref>
                         </Page>
                     )}
                 </Consumer>

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -129,7 +129,7 @@ export class ApplicationsService {
             .then(() => true);
     }
 
-    public watch(query?: {name?: string; resourceVersion?: string}, options?: QueryOptions): Observable<models.ApplicationWatchEvent> {
+    public watch(query?: {name?: string; resourceVersion?: string; projects?: string[]}, options?: QueryOptions): Observable<models.ApplicationWatchEvent> {
         const search = new URLSearchParams();
         if (query) {
             if (query.name) {
@@ -143,6 +143,7 @@ export class ApplicationsService {
             const searchOptions = optionsToSearch(options);
             search.set('fields', searchOptions.fields);
             search.set('selector', searchOptions.selector);
+            query?.projects?.forEach(project => search.append('project', project));
         }
         const searchStr = search.toString();
         const url = `/stream/applications${(searchStr && '?' + searchStr) || ''}`;


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR moves improve applications list page performance by moving project filtering to server-side. When a user adds the project filter then both list and stream API will reduce only project-related applications which significantly reduce browser CPU usage. The disadvantage is that use will see a loading indicator after changing project filter:

https://user-images.githubusercontent.com/426437/148299532-0f7f9d54-923e-4ec0-84b8-e31e8512f68e.mov

I believe the loading indicator is acceptable in this case because typically end-users select the required project once and don't change it very frequently. 