### PR TITLE
fix: fix broken image build and release workflows

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -31,6 +31,17 @@ jobs:
         working-directory: ./src/github.com/argoproj/argo-cd
         id: image
 
+      # login
+      - run: |
+          docker login ghcr.io --username $USERNAME --password $PASSWORD
+          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
+        if: github.event_name == 'push'
+        env:
+          USERNAME: ${{ secrets.USERNAME }}
+          PASSWORD: ${{ secrets.TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}
+          DOCKER_TOKEN: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+
       # build
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
@@ -41,23 +52,12 @@ jobs:
             IMAGE_PLATFORMS=linux/amd64,linux/arm64
           fi
           echo "Building image for platforms: $IMAGE_PLATFORMS"
-          make image DOCKER_PUSH=false IMAGE_NAMESPACE=ghcr.io/argoproj IMAGE_TAG=${{ steps.image.outputs.tag }} IMAGE_PLATFORMS=${IMAGE_PLATFORMS}
+          docker buildx build --platform $IMAGE_PLATFORMS --push="${{ github.event_name == 'push' }}" \
+            -t ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} \
+            -t argoproj/argocd:${{ steps.image.outputs.tag }} \
+            -t argoproj/argocd:latest .
         working-directory: ./src/github.com/argoproj/argo-cd
 
-      # publish
-      - run: |
-          docker login ghcr.io --username $USERNAME --password $PASSWORD
-          docker push ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }}
-
-          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
-          docker tag ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} argoproj/argocd:latest
-          docker push argoproj/argocd:latest
-        if: github.event_name == 'push'
-        env:
-          USERNAME: ${{ secrets.USERNAME }}
-          PASSWORD: ${{ secrets.TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}
-          DOCKER_TOKEN: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
 
       # deploy
       - run: git clone "https://$TOKEN@github.com/argoproj/argoproj-deployments"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,18 +183,7 @@ jobs:
           echo "Creating release ${RELEASE_TAG}"
           git tag ${RELEASE_TAG}
 
-      - name: Build Docker image for release
-        run: |
-          set -ue
-          git clean -fd
-          mkdir -p dist/
-          make image IMAGE_TAG="${TARGET_VERSION}" DOCKER_PUSH=false IMAGE_PLATFORMS=linux/amd64,linux/arm64
-          make release-cli
-          chmod +x ./dist/argocd-linux-amd64
-          ./dist/argocd-linux-amd64 version --client
-        if: ${{ env.DRY_RUN != 'true' }}
-
-      - name: Push docker image to repository
+      - name: Login to docker repositories
         env:
           DOCKER_USERNAME: ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}
           DOCKER_TOKEN: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
@@ -203,11 +192,20 @@ jobs:
         run: |
           set -ue
           docker login quay.io --username "${QUAY_USERNAME}" --password "${QUAY_TOKEN}"
-          docker push ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION}
           # Remove the following when Docker Hub is gone
           docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
-          docker tag ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION} argoproj/argocd:v${TARGET_VERSION}
-          docker push argoproj/argocd:v${TARGET_VERSION}
+        if: ${{ env.DRY_RUN != 'true' }}
+
+
+      - name: Build and push Docker image for release
+        run: |
+          set -ue
+          git clean -fd
+          mkdir -p dist/
+          docker buildx build --platform linux/amd64,linux/arm64 --push -t ${IMAGE_NAMESPACE}/argocd:${TARGET_VERSION} -t argoproj/argocd:${TARGET_VERSION} .
+          make release-cli
+          chmod +x ./dist/argocd-linux-amd64
+          ./dist/argocd-linux-amd64 version --client
         if: ${{ env.DRY_RUN != 'true' }}
 
       - name: Read release notes file

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ PATH:=$(PATH):$(PWD)/hack
 # docker image publishing options
 DOCKER_PUSH?=false
 IMAGE_NAMESPACE?=
-IMAGE_PLATFORMS?=linux/amd64
 # perform static compilation
 STATIC_BUILD?=true
 # build development images
@@ -282,7 +281,7 @@ image:
 	docker build -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG) -f dist/Dockerfile.dev dist
 else
 image:
-	docker buildx build --platform $(IMAGE_PLATFORMS) -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG) .
+	docker build -t $(IMAGE_PREFIX)argocd:$(IMAGE_TAG) .
 endif
 	@if [ "$(DOCKER_PUSH)" = "true" ] ; then docker push $(IMAGE_PREFIX)argocd:$(IMAGE_TAG) ; fi
 


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

It appears that multi-arch images cannot be stored in local registry and have to be pushed to remote registry by `docker buildx build` command. PR updates `image` and `release` workflows accordingly.