### PR TITLE
Expose ARGO_INGRESS_LINK_PROTO variable for Ingress links

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -17,6 +18,11 @@ import (
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/resource"
+)
+
+const (
+	// EnvIngressLinkProto is the env variable that tells ArgoCD to generate Ingress resource links using the specified protocol
+	EnvIngressLinkProto = "ARGO_INGRESS_LINK_PROTO"
 )
 
 func populateNodeInfo(un *unstructured.Unstructured, res *ResourceInfo) {
@@ -160,25 +166,28 @@ func populateIngressInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 				if host == nil || host == "" {
 					continue
 				}
-				stringPort := "http"
-				if tls, ok, err := unstructured.NestedSlice(un.Object, "spec", "tls"); ok && err == nil {
-					for i := range tls {
-						tlsline, ok := tls[i].(map[string]interface{})
-						secretName := tlsline["secretName"]
-						if ok && secretName != nil {
-							stringPort = "https"
-						}
-						tlshost := tlsline["host"]
-						if tlshost == host {
-							stringPort = "https"
-							continue
-						}
-						if hosts := tlsline["hosts"]; hosts != nil {
-							tlshosts, ok := tlsline["hosts"].(map[string]interface{})
-							if ok {
-								for j := range tlshosts {
-									if tlshosts[j] == host {
-										stringPort = "https"
+				stringPort := os.Getenv(EnvIngressLinkProto)
+				if stringPort == "" {
+					stringPort = "http"
+					if tls, ok, err := unstructured.NestedSlice(un.Object, "spec", "tls"); ok && err == nil {
+						for i := range tls {
+							tlsline, ok := tls[i].(map[string]interface{})
+							secretName := tlsline["secretName"]
+							if ok && secretName != nil {
+								stringPort = "https"
+							}
+							tlshost := tlsline["host"]
+							if tlshost == host {
+								stringPort = "https"
+								continue
+							}
+							if hosts := tlsline["hosts"]; hosts != nil {
+								tlshosts, ok := tlsline["hosts"].(map[string]interface{})
+								if ok {
+									for j := range tlshosts {
+										if tlshosts[j] == host {
+											stringPort = "https"
+										}
 									}
 								}
 							}


### PR DESCRIPTION
Closes #8021.

Expose ARGO_INGRESS_LINK_PROTO environment variable to explicitly
tell controller to generate links of a certain protocol for
Ingress resources.

Example:

    ARGO_INGRESS_LINK_PROTO=https
    ARGO_INGRESS_LINK_PROTO=http

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

