### PR TITLE
chore: fix broken TestValidatePermissions unit test

### DIFF
--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -604,14 +604,7 @@ func TestValidatePermissions(t *testing.T) {
 			},
 		}
 		db := &dbmocks.ArgoDB{}
-		db.On("ListClusters", context.Background()).Return(&argoappv1.ClusterList{
-			Items: []argoappv1.Cluster{
-				{
-					Name:   "dind",
-					Server: "https://127.0.0.1:6443",
-				},
-			},
-		}, nil)
+		db.On("GetClusterServersByName", context.Background(), "does-not-exist").Return(nil, nil)
 		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		assert.NoError(t, err)
 		assert.Len(t, conditions, 1)
@@ -677,9 +670,7 @@ func TestValidatePermissions(t *testing.T) {
 			Name:   "does-exist",
 			Server: "https://127.0.0.1:6443",
 		}
-		db.On("ListClusters", context.Background()).Return(&argoappv1.ClusterList{
-			Items: []argoappv1.Cluster{cluster},
-		}, nil)
+		db.On("GetClusterServersByName", context.Background(), "does-exist").Return([]string{"https://127.0.0.1:6443"}, nil)
 		db.On("GetCluster", context.Background(), "https://127.0.0.1:6443").Return(&cluster, nil)
 		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

We've merged two PRs one after another: https://github.com/argoproj/argo-cd/pull/8133 and https://github.com/argoproj/argo-cd/pull/7976 

The second PR introduced a test that is incompatible with changes in the first PR which broke TestValidatePermissions test. PR fixes the broken test.