### PR TITLE
refactor: Make gRPC user agent enforcer testable

### DIFF
--- a/util/grpc/useragent.go
+++ b/util/grpc/useragent.go
@@ -14,9 +14,12 @@ import (
 // UserAgentUnaryServerInterceptor returns a UnaryServerInterceptor which enforces a minimum client
 // version in the user agent
 func UserAgentUnaryServerInterceptor(clientName, constraintStr string) grpc.UnaryServerInterceptor {
-	userAgentEnforcer := newUserAgentEnforcer(clientName, constraintStr)
+	semVerConstraint, err := semver.NewConstraint(constraintStr)
+	if err != nil {
+		panic(err)
+	}
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if err := userAgentEnforcer(ctx); err != nil {
+		if err := userAgentEnforcer(ctx, clientName, constraintStr, semVerConstraint); err != nil {
 			return nil, err
 		}
 		return handler(ctx, req)
@@ -26,57 +29,54 @@ func UserAgentUnaryServerInterceptor(clientName, constraintStr string) grpc.Unar
 // UserAgentStreamServerInterceptor returns a StreamServerInterceptor which enforces a minimum client
 // version in the user agent
 func UserAgentStreamServerInterceptor(clientName, constraintStr string) grpc.StreamServerInterceptor {
-	userAgentEnforcer := newUserAgentEnforcer(clientName, constraintStr)
+	semVerConstraint, err := semver.NewConstraint(constraintStr)
+	if err != nil {
+		panic(err)
+	}
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if err := userAgentEnforcer(stream.Context()); err != nil {
+		if err := userAgentEnforcer(stream.Context(), clientName, constraintStr, semVerConstraint); err != nil {
 			return err
 		}
 		return handler(srv, stream)
 	}
 }
 
-func newUserAgentEnforcer(clientName, constraintStr string) func(context.Context) error {
-	semVerConstraint, err := semver.NewConstraint(constraintStr)
-	if err != nil {
-		panic(err)
+func userAgentEnforcer(ctx context.Context, clientName, constraintStr string, semVerConstraint *semver.Constraints) error {
+	var userAgents []string
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		for _, ua := range md["user-agent"] {
+			// ua is a string like "argocd-client/v0.11.0+cde040e grpc-go/1.15.0"
+			userAgents = append(userAgents, strings.Fields(ua)...)
+			break
+		}
 	}
-	return func(ctx context.Context) error {
-		var userAgents []string
-		if md, ok := metadata.FromIncomingContext(ctx); ok {
-			for _, ua := range md["user-agent"] {
-				// ua is a string like "argocd-client/v0.11.0+cde040e grpc-go/1.15.0"
-				userAgents = append(userAgents, strings.Fields(ua)...)
-				break
-			}
-		}
-		if isLegacyClient(userAgents) {
-			return status.Errorf(codes.FailedPrecondition, "unsatisfied client version constraint: %s", constraintStr)
-		}
+	if isLegacyClient(userAgents) {
+		return status.Errorf(codes.FailedPrecondition, "unsatisfied client version constraint: %s", constraintStr)
+	}
 
-		for _, userAgent := range userAgents {
-			uaSplit := strings.Split(userAgent, "/")
-			if len(uaSplit) != 2 || uaSplit[0] != clientName {
-				// User-agent was supplied, but client/format is not one we care about (e.g. grpc-go)
-				continue
-			}
-			// remove pre-release part
-			versionStr := strings.Split(uaSplit[1], "-")[0]
-			// We have matched the client name to the one we care about
-			uaVers, err := semver.NewVersion(versionStr)
-			if err != nil {
-				return status.Errorf(codes.InvalidArgument, "could not parse version from user-agent: %s", userAgent)
-			}
-			if ok, errs := semVerConstraint.Validate(uaVers); !ok {
-				return status.Errorf(codes.FailedPrecondition, "unsatisfied client version constraint: %s", errs[0].Error())
-			}
-			return nil
+	for _, userAgent := range userAgents {
+		uaSplit := strings.Split(userAgent, "/")
+		if len(uaSplit) != 2 || uaSplit[0] != clientName {
+			// User-agent was supplied, but client/format is not one we care about (e.g. grpc-go)
+			continue
 		}
-		// If we get here, the caller either did not supply user-agent, supplied one which we don't
-		// care about. This implies it is a from a custom generated client, so we permit the request.
-		// We really only want to enforce user-agent version constraints for clients under our
-		// control which we know to have compatibility issues
+		// remove pre-release part
+		versionStr := strings.Split(uaSplit[1], "-")[0]
+		// We have matched the client name to the one we care about
+		uaVers, err := semver.NewVersion(versionStr)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "could not parse version from user-agent: %s", userAgent)
+		}
+		if ok, errs := semVerConstraint.Validate(uaVers); !ok {
+			return status.Errorf(codes.FailedPrecondition, "unsatisfied client version constraint: %s", errs[0].Error())
+		}
 		return nil
 	}
+	// If we get here, the caller either did not supply user-agent, supplied one which we don't
+	// care about. This implies it is a from a custom generated client, so we permit the request.
+	// We really only want to enforce user-agent version constraints for clients under our
+	// control which we know to have compatibility issues
+	return nil
 }
 
 // isLegacyClient checks if the request was made from a legacy Argo CD client (i.e. v0.10 CLI).

--- a/util/grpc/useragent_test.go
+++ b/util/grpc/useragent_test.go
@@ -1,0 +1,61 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func Test_UserAgentEnforcer(t *testing.T) {
+	t.Run("Test enforcing valid user-agent", func(t *testing.T) {
+		clientName := "argo-cd"
+		constraintStr := "^1"
+		semverConstraint, _ := semver.NewConstraint(constraintStr)
+		md := metadata.New(map[string]string{"user-agent": "argo-cd/1.0"})
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		err := userAgentEnforcer(ctx, clientName, constraintStr, semverConstraint)
+		require.NoError(t, err)
+	})
+	t.Run("Test enforcing ignored user-agent", func(t *testing.T) {
+		clientName := "argo-cd"
+		constraintStr := "^1"
+		semverConstraint, _ := semver.NewConstraint(constraintStr)
+		md := metadata.New(map[string]string{"user-agent": "flux/3.0"})
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		err := userAgentEnforcer(ctx, clientName, constraintStr, semverConstraint)
+		require.NoError(t, err)
+	})
+	t.Run("Test enforcing user-agent with version not matching constraint", func(t *testing.T) {
+		clientName := "argo-cd"
+		constraintStr := "^1"
+		semverConstraint, _ := semver.NewConstraint(constraintStr)
+		md := metadata.New(map[string]string{"user-agent": "argo-cd/3.0"})
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		err := userAgentEnforcer(ctx, clientName, constraintStr, semverConstraint)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsatisfied client version constraint")
+	})
+	t.Run("Test legacy user-agent", func(t *testing.T) {
+		clientName := "argo-cd"
+		constraintStr := "^1"
+		semverConstraint, _ := semver.NewConstraint(constraintStr)
+		md := metadata.New(map[string]string{"user-agent": "grpc-go/1.15.0"})
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		err := userAgentEnforcer(ctx, clientName, constraintStr, semverConstraint)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsatisfied client version constraint")
+	})
+	t.Run("Test invalid version", func(t *testing.T) {
+		clientName := "argo-cd"
+		constraintStr := "^1"
+		semverConstraint, _ := semver.NewConstraint(constraintStr)
+		md := metadata.New(map[string]string{"user-agent": "argo-cd/super"})
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		err := userAgentEnforcer(ctx, clientName, constraintStr, semverConstraint)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not parse version")
+	})
+}


### PR DESCRIPTION
This refactors `util/grpc/useragent.go` so that it becomes better testable. Also adds proper tests.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

