### PR TITLE
chore: make lint-docs less flakey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ serve-docs:
 .PHONY: lint-docs
 lint-docs:
 	#  https://github.com/dkhamsing/awesome_bot
-	find docs -name '*.md' -exec grep -l http {} + | xargs docker run --rm -v $(PWD):/mnt:ro dkhamsing/awesome_bot -t 3 --allow-dupe --allow-redirect --white-list `cat docs/url-allow-list | grep -v "#" | tr "\n" ','` --skip-save-results --
+	find docs -name '*.md' -exec grep -l http {} + | xargs docker run --rm -v $(PWD):/mnt:ro dkhamsing/awesome_bot -t 3 --allow-dupe --allow-redirect --allow-timeout --allow-ssl --allow 502,500,429,400 --white-list `cat docs/url-allow-list | grep -v "#" | tr "\n" ','` --skip-save-results --
 
 # Verify that kubectl can connect to your K8s cluster from Docker
 .PHONY: verify-kube-connect

--- a/docs/url-allow-list
+++ b/docs/url-allow-list
@@ -67,3 +67,4 @@ ghe.example.com
 github.com/yourghuser/argo-cd
 github.com/argoproj/argo-cd/releases/download/
 https://github.com/hayorov/helm-gcs.git;
+grafana.apps.argoproj.io


### PR DESCRIPTION
Decisions based on the most common spurious errors in the last 14 days.

- 12: Connection refused from grafana.apps.argoproj.io
- 7: 429 (too many requests) from github.com
- 4: 502 (bad gateway)
  - 3: from dexidp.io
  - 1: from github.com
- 2: Net::OpenTimeout
    - 1: from getambassador.io
    - 1: from docs.microsoft.com
- 1: 500 from golang.org
- 1: 400 (invalid request) from storybook.js.org
- 1: getaddrinfo: Try again from tools.ietf.org