### PR TITLE
fix: Prevent possible nil-pointer deref in normalizer

### DIFF
--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -152,6 +152,9 @@ func NewIgnoreNormalizer(ignore []v1alpha1.ResourceIgnoreDifferences, overrides 
 
 // Normalize removes fields from supplied resource using json paths from matching items of specified resources ignored differences list
 func (n *ignoreNormalizer) Normalize(un *unstructured.Unstructured) error {
+	if un == nil {
+		return fmt.Errorf("invalid argument: unstructured is nil")
+	}
 	matched := make([]normalizerPatch, 0)
 	for _, patch := range n.patches {
 		groupKind := un.GroupVersionKind().GroupKind()

--- a/util/argo/normalizers/diff_normalizer_test.go
+++ b/util/argo/normalizers/diff_normalizer_test.go
@@ -31,6 +31,9 @@ func TestNormalizeObjectWithMatchedGroupKind(t *testing.T) {
 	_, has, err = unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
 	assert.Nil(t, err)
 	assert.False(t, has)
+
+	err = normalizer.Normalize(nil)
+	assert.Error(t, err)
 }
 
 func TestNormalizeNoMatchedGroupKinds(t *testing.T) {


### PR DESCRIPTION
Fix a possible nil-pointer deref in diff normalizer.

Ref: https://oss-fuzz.com/testcase-detail/6263347908050944

/cc @terrytangyuan @hblixt @AdamKorcz 

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

