### PR TITLE
fix: Add "Restarting MinIO" status to MiniO Tenant health check

### DIFF
--- a/resource_customizations/minio.min.io/Tenant/health.lua
+++ b/resource_customizations/minio.min.io/Tenant/health.lua
@@ -21,6 +21,11 @@ if obj.status ~= nil then
             health_status.message = obj.status.currentState
             return health_status
         end
+        if obj.status.currentState == "Restarting MinIO" then
+            health_status.status = "Progressing"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
         if obj.status.currentState == "Statefulset not controlled by operator" then
             health_status.status = "Degraded"
             health_status.message = obj.status.currentState

--- a/resource_customizations/minio.min.io/Tenant/testdata/restarting_minio.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/restarting_minio.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Restarting MinIO


### PR DESCRIPTION
The PR explicitly adds support for [Restarting MinIO](https://github.com/minio/operator/blob/774af325fd0586f5d8f945ea5a6eda949869189f/pkg/controller/cluster/main-controller.go#L123) status to MinIO Tenant health check


Signed-off-by: dnskr <dnskrv88@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
