### PR TITLE
chore: Log out the resource triggering reconciliation

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -319,6 +319,13 @@ func (ctrl *ApplicationController) handleObjectUpdated(managedByApp map[string]b
 		if isManagedResource {
 			level = CompareWithRecent
 		}
+
+		// Additional check for debug level so we don't need to evaluate the
+		// format string in case of non-debug scenarios
+		if log.GetLevel() >= log.DebugLevel {
+			log.Debugf("Refreshing app %s for change in cluster of object %s/%s of type %s/%s", appName, ref.Namespace, ref.Name, ref.APIVersion, ref.Kind)
+		}
+
 		ctrl.requestAppRefresh(appName, &level, nil)
 	}
 }

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -323,7 +323,13 @@ func (ctrl *ApplicationController) handleObjectUpdated(managedByApp map[string]b
 		// Additional check for debug level so we don't need to evaluate the
 		// format string in case of non-debug scenarios
 		if log.GetLevel() >= log.DebugLevel {
-			log.Debugf("Refreshing app %s for change in cluster of object %s/%s of type %s/%s", appName, ref.Namespace, ref.Name, ref.APIVersion, ref.Kind)
+			var resKey string
+			if ref.Namespace != "" {
+				resKey = ref.Namespace + "/" + ref.Name
+			} else {
+				resKey = "(cluster-scoped)/" + ref.Name
+			}
+			log.Debugf("Refreshing app %s for change in cluster of object %s of type %s/%s", appName, resKey, ref.APIVersion, ref.Kind)
 		}
 
 		ctrl.requestAppRefresh(appName, &level, nil)


### PR DESCRIPTION
In case of a controller requested app refresh, it might be good to know which resource has triggered the controller to initiate the reconciliation.

This PR adds debugging information for that.

Related to #8100

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

