### PR TITLE
chore: upgrade base image to ubuntu:21.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=docker.io/library/ubuntu:21.04
+ARG BASE_IMAGE=docker.io/library/ubuntu:21.10
 ####################################################################################################
 # Builder image
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.17.6 as golang
 
 FROM registry:2.7.1 as registry
 
-FROM ubuntu:21.04
+FROM ubuntu:21.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN  apt-get update && apt-get install --fix-missing -y \

--- a/test/remote/Dockerfile
+++ b/test/remote/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.17.6 AS go
 RUN go get github.com/mattn/goreman && \
     go get github.com/kisielk/godepgraph 
 
-FROM ubuntu:21.04
+FROM ubuntu:21.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN  apt-get update && apt-get install -y \


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/8075

PR upgrades base ubuntu image to v21.10 