### PR TITLE
chore: Publish latest build to quay instead of Docker Hub

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -34,13 +34,13 @@ jobs:
       # login
       - run: |
           docker login ghcr.io --username $USERNAME --password $PASSWORD
-          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
+          docker login quay.io --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
         if: github.event_name == 'push'
         env:
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}
-          DOCKER_TOKEN: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.RELEASE_QUAY_USERNAME }}
+          DOCKER_TOKEN: ${{ secrets.RELEASE_QUAY_TOKEN }}
 
       # build
       - uses: docker/setup-qemu-action@v1
@@ -54,7 +54,7 @@ jobs:
           echo "Building image for platforms: $IMAGE_PLATFORMS"
           docker buildx build --platform $IMAGE_PLATFORMS --push="${{ github.event_name == 'push' }}" \
             -t ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} \
-            -t argoproj/argocd:latest .
+            -t quay.io/argoproj/argocd:latest .
         working-directory: ./src/github.com/argoproj/argo-cd
 
 


### PR DESCRIPTION
We deprecated Docker Hub. Currently, we use quay.io to build `latest` image, but since we now have multi-arch images from our build pipeline, we should push them to quay.io and disable the automated builds there.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

