### PR TITLE
feat: Use encrypted cookie to store OAuth2 state nonce (instead of redis)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -78,6 +78,8 @@ const (
 	AuthCookieName = "argocd.token"
 	// StateCookieName is the HTTP cookie name that holds temporary nonce tokens for CSRF protection
 	StateCookieName = "argocd.oauthstate"
+	// StateCookieMaxAge is the maximum age of the oauth state cookie
+	StateCookieMaxAge = time.Minute * 5
 
 	// ChangePasswordSSOTokenMaxAge is the max token age for password change operation
 	ChangePasswordSSOTokenMaxAge = time.Minute * 5

--- a/common/common.go
+++ b/common/common.go
@@ -76,6 +76,8 @@ const (
 	ArgoCDUserAgentName = "argocd-client"
 	// AuthCookieName is the HTTP cookie name where we store our auth token
 	AuthCookieName = "argocd.token"
+	// StateCookieName is the HTTP cookie name that holds temporary nonce tokens for CSRF protection
+	StateCookieName = "argocd.oauthstate"
 
 	// ChangePasswordSSOTokenMaxAge is the max token age for password change operation
 	ChangePasswordSSOTokenMaxAge = time.Minute * 5

--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -13,7 +13,6 @@ import (
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v2/util/env"
-	"github.com/argoproj/argo-cd/v2/util/oidc"
 )
 
 var ErrCacheMiss = appstatecache.ErrCacheMiss
@@ -24,8 +23,6 @@ type Cache struct {
 	oidcCacheExpiration             time.Duration
 	loginAttemptsExpiration         time.Duration
 }
-
-var _ oidc.OIDCStateStorage = &Cache{}
 
 func NewCache(
 	cache *appstatecache.Cache,
@@ -89,20 +86,6 @@ func (c *Cache) GetClusterInfo(server string, res *appv1.ClusterInfo) error {
 
 func (c *Cache) SetClusterInfo(server string, res *appv1.ClusterInfo) error {
 	return c.cache.SetClusterInfo(server, res)
-}
-
-func oidcStateKey(key string) string {
-	return fmt.Sprintf("oidc|%s", key)
-}
-
-func (c *Cache) GetOIDCState(key string) (*oidc.OIDCState, error) {
-	res := oidc.OIDCState{}
-	err := c.cache.GetItem(oidcStateKey(key), &res)
-	return &res, err
-}
-
-func (c *Cache) SetOIDCState(key string, state *oidc.OIDCState) error {
-	return c.cache.SetItem(oidcStateKey(key), state, c.oidcCacheExpiration, state == nil)
 }
 
 func (c *Cache) GetCache() *cacheutil.Cache {

--- a/server/cache/cache_test.go
+++ b/server/cache/cache_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
-	"github.com/argoproj/argo-cd/v2/util/oidc"
 )
 
 type fixtures struct {
@@ -44,23 +43,6 @@ func TestCache_GetRepoConnectionState(t *testing.T) {
 	value, err := cache.GetRepoConnectionState("my-repo")
 	assert.NoError(t, err)
 	assert.Equal(t, ConnectionState{Status: "my-state"}, value)
-}
-
-func TestCache_GetOIDCState(t *testing.T) {
-	cache := newFixtures().Cache
-	// cache miss
-	_, err := cache.GetOIDCState("my-key")
-	assert.Equal(t, ErrCacheMiss, err)
-	// populate cache
-	err = cache.SetOIDCState("my-key", &oidc.OIDCState{ReturnURL: "my-return-url"})
-	assert.NoError(t, err)
-	//cache miss
-	_, err = cache.GetOIDCState("other-key")
-	assert.Equal(t, ErrCacheMiss, err)
-	// cache hit
-	value, err := cache.GetOIDCState("my-key")
-	assert.NoError(t, err)
-	assert.Equal(t, &oidc.OIDCState{ReturnURL: "my-return-url"}, value)
 }
 
 func TestAddCacheFlagsToCmd(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -782,7 +782,7 @@ func (a *ArgoCDServer) registerDexHandlers(mux *http.ServeMux) {
 		tlsConfig := a.settings.TLSConfig()
 		tlsConfig.InsecureSkipVerify = true
 	}
-	a.ssoClientApp, err = oidc.NewClientApp(a.settings, a.Cache, a.DexServerAddr, a.BaseHRef)
+	a.ssoClientApp, err = oidc.NewClientApp(a.settings, a.DexServerAddr, a.BaseHRef)
 	errors.CheckError(err)
 	mux.HandleFunc(common.LoginEndpoint, a.ssoClientApp.HandleLogin)
 	mux.HandleFunc(common.CallbackEndpoint, a.ssoClientApp.HandleCallback)

--- a/util/crypto/crypto.go
+++ b/util/crypto/crypto.go
@@ -4,9 +4,22 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
 	"errors"
 	"io"
+
+	"golang.org/x/crypto/scrypt"
 )
+
+// KeyFromPassphrase generates 32 byte key from the passphrase
+func KeyFromPassphrase(passphrase string) ([]byte, error) {
+	// salt is just a hash of a passphrase (effectively no salt)
+	salt := sha256.Sum256([]byte(passphrase))
+	// These defaults will consume approximately 16MB of memory (128 * r * N)
+	const N = 16384
+	const r = 8
+	return scrypt.Key([]byte(passphrase), salt[:], N, r, 1, 32)
+}
 
 // Encrypt encrypts the given data with the given passphrase.
 func Encrypt(data []byte, key []byte) ([]byte, error) {

--- a/util/crypto/crypto.go
+++ b/util/crypto/crypto.go
@@ -4,21 +4,13 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
 	"errors"
 	"io"
 )
 
-func passphraseToKey(passphrase string) []byte {
-	hasher := sha256.New()
-	hasher.Write([]byte(passphrase))
-	key := hasher.Sum(nil)
-	return key
-}
-
 // Encrypt encrypts the given data with the given passphrase.
-func Encrypt(data []byte, passphrase string) ([]byte, error) {
-	block, err := aes.NewCipher(passphraseToKey(passphrase))
+func Encrypt(data []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}
@@ -28,15 +20,15 @@ func Encrypt(data []byte, passphrase string) ([]byte, error) {
 	}
 	nonce := make([]byte, gcm.NonceSize())
 	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
-		panic(err.Error())
+		return nil, err
 	}
 	ciphertext := gcm.Seal(nonce, nonce, data, nil)
 	return ciphertext, nil
 }
 
 // Decrypt decrypts the given data using the given passphrase.
-func Decrypt(data []byte, passphrase string) ([]byte, error) {
-	block, err := aes.NewCipher(passphraseToKey(passphrase))
+func Decrypt(data []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}

--- a/util/crypto/crypto.go
+++ b/util/crypto/crypto.go
@@ -1,0 +1,53 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"io"
+)
+
+func getKey(passphrase string) []byte {
+	hasher := sha256.New()
+	hasher.Write([]byte(passphrase))
+	key := hasher.Sum(nil)
+	return key
+}
+
+// Encrypt encrypts the given data with the given passphrase.
+func Encrypt(data []byte, passphrase string) ([]byte, error) {
+	block, err := aes.NewCipher(getKey(passphrase))
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		panic(err.Error())
+	}
+	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+	return ciphertext, nil
+}
+
+// Decrypt decrypts the given data using the given passphrase.
+func Decrypt(data []byte, passphrase string) ([]byte, error) {
+	block, err := aes.NewCipher(getKey(passphrase))
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize()
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plaintext, nil
+}

--- a/util/crypto/crypto_test.go
+++ b/util/crypto/crypto_test.go
@@ -1,0 +1,26 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecrypt_Successful(t *testing.T) {
+	encrypted, err := Encrypt([]byte("test"), "sample-password")
+	require.NoError(t, err)
+
+	decrypted, err := Decrypt(encrypted, "sample-password")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", string(decrypted))
+}
+
+func TestEncryptDecrypt_Failed(t *testing.T) {
+	encrypted, err := Encrypt([]byte("test"), "sample-password")
+	require.NoError(t, err)
+
+	_, err = Decrypt(encrypted, "wrong-password")
+	assert.Error(t, err)
+}

--- a/util/crypto/crypto_test.go
+++ b/util/crypto/crypto_test.go
@@ -1,26 +1,43 @@
 package crypto
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func newKey() ([]byte, error) {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	if err != nil {
+		b = nil
+	}
+	return b, err
+}
+
 func TestEncryptDecrypt_Successful(t *testing.T) {
-	encrypted, err := Encrypt([]byte("test"), "sample-password")
+	key, err := newKey()
+	require.NoError(t, err)
+	encrypted, err := Encrypt([]byte("test"), key)
 	require.NoError(t, err)
 
-	decrypted, err := Decrypt(encrypted, "sample-password")
+	decrypted, err := Decrypt(encrypted, key)
 	require.NoError(t, err)
 
 	assert.Equal(t, "test", string(decrypted))
 }
 
 func TestEncryptDecrypt_Failed(t *testing.T) {
-	encrypted, err := Encrypt([]byte("test"), "sample-password")
+	key, err := newKey()
+	require.NoError(t, err)
+	encrypted, err := Encrypt([]byte("test"), key)
 	require.NoError(t, err)
 
-	_, err = Decrypt(encrypted, "wrong-password")
+	wrongKey, err := newKey()
+	require.NoError(t, err)
+
+	_, err = Decrypt(encrypted, wrongKey)
 	assert.Error(t, err)
 }

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -151,7 +151,7 @@ func (a *ClientApp) generateAppState(returnURL string, w http.ResponseWriter) (s
 	http.SetCookie(w, &http.Cookie{
 		Name:     common.StateCookieName,
 		Value:    cookieValue,
-		Expires:  time.Now().Add(3 * time.Minute),
+		Expires:  time.Now().Add(common.StateCookieMaxAge),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 		Secure:   a.secureCookie,
@@ -173,14 +173,15 @@ func (a *ClientApp) verifyAppState(r *http.Request, w http.ResponseWriter, state
 		return "", err
 	}
 	cookieVal := string(val)
-	returnURL := ""
+	returnURL := a.baseHRef
 	parts := strings.SplitN(cookieVal, ":", 2)
-	if len(parts) > 1 {
+	if len(parts) == 2 && parts[1] != "" {
 		returnURL = parts[1]
 	}
 	if parts[0] != state {
 		return "", fmt.Errorf("invalid state in '%s' cookie", common.AuthCookieName)
 	}
+	// set empty cookie to clear it
 	http.SetCookie(w, &http.Cookie{
 		Name:     common.StateCookieName,
 		Value:    "",

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -142,7 +142,11 @@ func (a *ClientApp) generateAppState(returnURL string, w http.ResponseWriter) (s
 		returnURL = a.baseHRef
 	}
 	cookieValue := fmt.Sprintf("%s:%s", randStr, returnURL)
-	if encrypted, err := crypto.Encrypt([]byte(cookieValue), string(a.settings.ServerSignature)); err != nil {
+	key, err := a.settings.GetServerSignatureKey()
+	if err != nil {
+		return "", err
+	}
+	if encrypted, err := crypto.Encrypt([]byte(cookieValue), key); err != nil {
 		return "", err
 	} else {
 		cookieValue = hex.EncodeToString(encrypted)
@@ -168,7 +172,11 @@ func (a *ClientApp) verifyAppState(r *http.Request, w http.ResponseWriter, state
 	if err != nil {
 		return "", err
 	}
-	val, err = crypto.Decrypt(val, string(a.settings.ServerSignature))
+	key, err := a.settings.GetServerSignatureKey()
+	if err != nil {
+		return "", err
+	}
+	val, err = crypto.Decrypt(val, key)
 	if err != nil {
 		return "", err
 	}

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -223,7 +223,7 @@ func TestGenerateAppState_NoReturnURL(t *testing.T) {
 	signature, err := util.MakeSignature(32)
 	require.NoError(t, err)
 	cdSettings := &settings.ArgoCDSettings{ServerSignature: signature}
-	key, err := cdSettings.GetServerSignatureKey()
+	key, err := cdSettings.GetServerEncryptionKey()
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "/", nil)

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -35,6 +35,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/server/settings/oidc"
 	"github.com/argoproj/argo-cd/v2/util"
+	"github.com/argoproj/argo-cd/v2/util/crypto"
 	"github.com/argoproj/argo-cd/v2/util/kube"
 	"github.com/argoproj/argo-cd/v2/util/password"
 	tlsutil "github.com/argoproj/argo-cd/v2/util/tls"
@@ -1481,8 +1482,9 @@ func (a *ArgoCDSettings) IsDexConfigured() bool {
 	return len(dexCfg) > 0
 }
 
-func (a *ArgoCDSettings) GetServerSignatureKey() ([]byte, error) {
-	return base64.StdEncoding.DecodeString(string(a.ServerSignature))
+// GetServerEncryptionKey generates a new server encryption key using the server signature as a passphrase
+func (a *ArgoCDSettings) GetServerEncryptionKey() ([]byte, error) {
+	return crypto.KeyFromPassphrase(string(a.ServerSignature))
 }
 
 func UnmarshalDexConfig(config string) (map[string]interface{}, error) {

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -1481,6 +1481,10 @@ func (a *ArgoCDSettings) IsDexConfigured() bool {
 	return len(dexCfg) > 0
 }
 
+func (a *ArgoCDSettings) GetServerSignatureKey() ([]byte, error) {
+	return base64.StdEncoding.DecodeString(string(a.ServerSignature))
+}
+
 func UnmarshalDexConfig(config string) (map[string]interface{}, error) {
 	var dexCfg map[string]interface{}
 	err := yaml.Unmarshal([]byte(config), &dexCfg)


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/5873

PR changes SSO auth flow to store temporary nonce tokens in an encrypted cookie instead of redis