### PR TITLE
fix: switch to promauto and fix repo server grpc metrics registration

### DIFF
--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -92,15 +92,15 @@ func NewCommand() *cobra.Command {
 
 			metricsServer := metrics.NewMetricsServer()
 			cacheutil.CollectMetrics(redisClient, metricsServer)
-			server, err := reposerver.NewServer(metricsServer, cache, tlsConfigCustomizer, repository.RepoServerInitConstants{
+			server := reposerver.NewServer(metricsServer, cache, repository.RepoServerInitConstants{
 				ParallelismLimit: parallelismLimit,
 				PauseGenerationAfterFailedGenerationAttempts: getPauseGenerationAfterFailedGenerationAttempts(),
 				PauseGenerationOnFailureForMinutes:           getPauseGenerationOnFailureForMinutes(),
 				PauseGenerationOnFailureForRequests:          getPauseGenerationOnFailureForRequests(),
 			})
-			errors.CheckError(err)
 
-			grpc := server.CreateGRPC()
+			grpc, err := server.CreateGRPC(tlsConfigCustomizer)
+			errors.CheckError(err)
 			listener, err := net.Listen("tcp", fmt.Sprintf(":%d", listenPort))
 			errors.CheckError(err)
 

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/argoproj/pkg/sync"
 	"github.com/go-redis/redis/v8"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/handlers"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"

--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/argoproj/pkg/sync"
 	"github.com/go-redis/redis/v8"
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/handlers"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

This pr mainly fix the problem that repo server cannot get the grpc server metrics. 
The reason of that is grpc server metrics by default are registered to the default global prometheus registry so that the default gatherer needs to be added for rendering those metrics.  Besides, line https://github.com/argoproj/argo-cd/pull/8245/files#diff-be7b600fde443a933e46d01013410637a279932444ab6e96e2652e8712af88e4R102 has been added.

Besides those changes, other changes are mainly refactoring for the metrics registration. Now metric definitions are initialized as global variables. This is not a good practise so I use `promauto` library to make metrics non-global and register them to the registry at the same time of definition.



Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

