### PR TITLE
Revert "chore: Run dex reverse proxy only when dex is configured (#7999)"

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -772,7 +772,7 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 
 // registerDexHandlers will register dex HTTP handlers, creating the the OAuth client app
 func (a *ArgoCDServer) registerDexHandlers(mux *http.ServeMux) {
-	if !a.settings.IsDexConfigured() {
+	if !a.settings.IsSSOConfigured() {
 		return
 	}
 	// Run dex OpenID Connect Identity Provider behind a reverse proxy (served at /api/dex)


### PR DESCRIPTION
This reverts commit 303cc4613b488186fd221a72d38b32b825102080.

Closes https://github.com/argoproj/argo-cd/issues/8221

Due to changes of  https://github.com/argoproj/argo-cd/pull/7999 the `registerDexHandlers` method exists early. Hoverver this method registers handles for both Dex and OIDC login. Reverting this PR for now to restored OIDC functionality