### PR TITLE
fix: refactor delete dialog with propagation policies

### DIFF
--- a/ui/src/app/applications/components/utils.scss
+++ b/ui/src/app/applications/components/utils.scss
@@ -8,9 +8,14 @@
     align-items: center;
     padding-right: 2em;
 
+    input {
+        margin-right: 5px;
+    }
+    
     label {
         color: #6D7F8B;
         font-size: 15px;
+        padding-right: 30px;
     }
 }
 

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -88,7 +88,8 @@ export async function deleteApplication(appName: string, apis: ContextApis): Pro
                                 componentProps={{
                                     policyName: policy.name,
                                     policyID: policy.id,
-                                    policyMessage: policy.message
+                                    policyMessage: policy.message,
+                                    isDefaultPolicy: policy.id === 'foreground'
                                 }}
                             />
                         );
@@ -120,28 +121,30 @@ export async function deleteApplication(appName: string, apis: ContextApis): Pro
     return confirmed;
 }
 
-const PropagationPolicyOption = ReactForm.FormField((props: {fieldApi: ReactForm.FieldApi; policyName: string; policyID: string; policyMessage: string}) => {
-    const {
-        fieldApi: {setValue}
-    } = props;
-    return (
-        <div className='propagation-policy-option'>
-            <input
-                className='radio-button'
-                key={props.policyID}
-                type='radio'
-                name='propagation-policy'
-                value={props.policyID}
-                id={props.policyID}
-                defaultChecked={props.policyID === 'foreground'}
-                onChange={() => setValue(props.policyID)}
-            />
-            <label htmlFor={props.policyID}>
-                {props.policyName} {helpTip(props.policyMessage)}
-            </label>
-        </div>
-    );
-});
+const PropagationPolicyOption = ReactForm.FormField(
+    (props: {fieldApi: ReactForm.FieldApi; policyName: string; policyID: string; policyMessage: string; isDefaultPolicy: boolean}) => {
+        const {
+            fieldApi: {setValue}
+        } = props;
+        return (
+            <div className='propagation-policy-option'>
+                <input
+                    className='radio-button'
+                    key={props.policyID}
+                    type='radio'
+                    name='propagation-policy'
+                    value={props.policyID}
+                    id={props.policyID}
+                    defaultChecked={props.isDefaultPolicy}
+                    onChange={() => setValue(props.policyID)}
+                />
+                <label htmlFor={props.policyID}>
+                    {props.policyName} {helpTip(props.policyMessage)}
+                </label>
+            </div>
+        );
+    }
+);
 
 export const OperationPhaseIcon = ({app}: {app: appModels.Application}) => {
     const operationState = getAppOperationState(app);
@@ -246,10 +249,11 @@ export function findChildPod(node: appModels.ResourceNode, tree: appModels.Appli
 
 export const deletePopup = async (ctx: ContextApis, resource: ResourceTreeNode, application: appModels.Application, appChanged?: BehaviorSubject<appModels.Application>) => {
     const isManaged = !!resource.status;
+    const resourceDeleteForeground = 'resourceDeleteForeground';
     const propagationPolicies: {name: string; id: string; message: string}[] = [
         {
             name: 'Foreground',
-            id: 'foreground',
+            id: resourceDeleteForeground,
             message: `Deletes the resource and dependent resources using the cascading policy in the foreground`
         },
         {
@@ -289,7 +293,8 @@ export const deletePopup = async (ctx: ContextApis, resource: ResourceTreeNode, 
                                 componentProps={{
                                     policyName: policy.name,
                                     policyID: policy.id,
-                                    policyMessage: policy.message
+                                    policyMessage: policy.message,
+                                    isDefaultPolicy: policy.id === resourceDeleteForeground
                                 }}
                             />
                         );
@@ -321,7 +326,7 @@ export const deletePopup = async (ctx: ContextApis, resource: ResourceTreeNode, 
         },
         {name: 'argo-icon-warning', color: 'warning'},
         'yellow',
-        {propagationPolicy: 'foreground'}
+        {propagationPolicy: resourceDeleteForeground}
     );
 };
 


### PR DESCRIPTION
Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Fixes: #8289 

Refactor the resource deletion dialog box and reuse the existing propagation policy functionality. This change will also enable clicking text next to radio buttons in delete resource dialog