### PR TITLE
fix: argocd build fails on windows

### DIFF
--- a/cmpserver/plugin/plugin_unix.go
+++ b/cmpserver/plugin/plugin_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+// +build !windows
+
+package plugin
+
+import (
+	"syscall"
+)
+
+func newSysProcAttr(setpgid bool) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: setpgid}
+}
+
+func sysCallKill(pid int) error {
+	return syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/cmpserver/plugin/plugin_windows.go
+++ b/cmpserver/plugin/plugin_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+// +build windows
+
+package plugin
+
+import (
+	"syscall"
+)
+
+func newSysProcAttr(setpgid bool) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func sysCallKill(pid int) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Argo CD fails on windows because plugin.go uses a couple of Linux-only functions. We don't need to support running CMP plugins functionality on windows but, because all argocd components are packaged into one binary, we have to be able to compile it on windows. PR uses platform build tags to provide stabs for windows binary.