### PR TITLE
chore: use go install instead of deprecated go get

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -379,7 +379,7 @@ jobs:
       - name: Download Go dependencies
         run: |
           go mod download
-          go get github.com/mattn/goreman
+          go install github.com/mattn/goreman@latest
       - name: Install all tools required for building & testing
         run: |
           make install-test-tools-local

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L https://go.kubebuilder.io/dl/2.3.1/$(go env GOOS)/$(go env GOARCH) |
     tar -xz -C /tmp/ && mv /tmp/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH) /usr/local/kubebuilder
 
 RUN apt-get install redis-server -y
-RUN go get github.com/mattn/goreman
+RUN go install github.com/mattn/goreman@latest
 
 USER gitpod
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,5 +2,5 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: make mod-download-local dep-ui-local && GO111MODULE=off go get github.com/mattn/goreman
+  - init: make mod-download-local dep-ui-local && GO111MODULE=off go install github.com/mattn/goreman@latest
     command: make start-test-k8s

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
 
-which go-junit-report || go get github.com/jstemmer/go-junit-report
+which go-junit-report || go install github.com/jstemmer/go-junit-report@latest
 
 TEST_RESULTS=${TEST_RESULTS:-test-results}
 TEST_FLAGS=

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -49,9 +49,9 @@ RUN ./install.sh ksonnet-linux && \
     ./install.sh codegen-tools && \
     ./install.sh codegen-go-tools && \
     ./install.sh lint-tools && \
-    go get github.com/mattn/goreman && \
-    go get github.com/kisielk/godepgraph && \
-    go get github.com/jstemmer/go-junit-report && \
+    go install github.com/mattn/goreman@latest && \
+    go install github.com/kisielk/godepgraph@latest && \
+    go install github.com/jstemmer/go-junit-report@latest && \
     rm -rf /tmp/dl && \
     rm -rf /tmp/helm && \
     rm -rf /tmp/helm2 && \

--- a/test/remote/Dockerfile
+++ b/test/remote/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.17.6 AS go
 
-RUN go get github.com/mattn/goreman && \
-    go get github.com/kisielk/godepgraph 
+RUN go install github.com/mattn/goreman@latest && \
+    go install github.com/kisielk/godepgraph@latest
 
 FROM ubuntu:21.10
 

--- a/test/remote/README.md
+++ b/test/remote/README.md
@@ -54,7 +54,7 @@ To build it, run the following. Note that kustomize is required:
 
 ```shell
 cd test/remote
-export IMAGE_NAMESPACE=quay.io/youruser
+export IMAGE_NAMESPACE=quay.io/{YOUR USERNAME HERE}
 # builds & tags the image
 make image
 # pushes the image to your repository
@@ -65,6 +65,8 @@ make manifests > /tmp/e2e-repositories.yaml
 
 If you do not have kustomize installed, you need to manually edit the manifests
 at `test/remote/manifests/e2e_repositories.yaml` to point to the correct image.
+
+If you get `make: realpath: Command not found`, install coreutils.
 
 ### Deploy the test container and additional permissions
 
@@ -83,7 +85,7 @@ Then, apply the manifests for the E2E repositories workload:
 kubectl -n argocd-e2e apply -f /tmp/e2e-repositories.yaml
 ```
 
-Verify that the deployment was succesful:
+Verify that the deployment was successful:
 
 ```shell
 kubectl -n argocd-e2e rollout status deployment argocd-e2e-cluster
@@ -106,13 +108,13 @@ as the cluster, or the cluster IPs are routed to your host, you can use the
 following:
 
 ```shell
-export ARGOCD_SERVER=$(kubectl get svc argocd-server -o jsonpath='{.spec.clusterIP}')
+export ARGOCD_SERVER=$(kubectl -n argocd-e2e get svc argocd-server -o jsonpath='{.spec.clusterIP}')
 ```
 
 Set the admin password to use:
 
 ```shell
-export ARGOCD_E2E_ADMIN_PASSWORD=$(kubectl get secrets argocd-initial-admin-secret -o jsonpath='{.data.password}'|base64 -d)
+export ARGOCD_E2E_ADMIN_PASSWORD=$(kubectl -n argocd-e2e get secrets argocd-initial-admin-secret -o jsonpath='{.data.password}'|base64 -d)
 ```
 
 Run the tests
@@ -204,7 +206,7 @@ Some environment variables can control the behavior of the tests:
 
 Furthermore, you can skip various classes of tests by setting the following to true:
 
-```
+```shell
 # If you disabled GPG feature, set to true to skip related tests
 export ARGOCD_E2E_SKIP_GPG=${ARGOCD_E2E_SKIP_GPG:-false}
 # Some tests do not work OOTB with OpenShift
@@ -215,7 +217,6 @@ export ARGOCD_E2E_SKIP_HELM=${ARGOCD_E2E_SKIP_HELM:-false}
 export ARGOCD_E2E_SKIP_HELM2=${ARGOCD_E2E_SKIP_HELM2:-false}
 # Skip Ksonnet tests
 export ARGOCD_E2E_SKIP_KSONNET=${ARGOCD_E2E_SKIP_KSONNET:-false}
-
 ```
 
 ## Recording tests that ran successfully and restart at point of fail


### PR DESCRIPTION
Looks like [`go get` is deprecated for installing binaries](https://golang.org/doc/go-get-install-deprecation).

I've made these changes without 100% knowing the context in which these commands are run, so please review carefully. :-)