### PR TITLE
fix: reload ArgoCD config if OIDC config changes

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/golang-jwt/jwt/v4"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,7 @@ import (
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v2/util/rbac"
+	settings_util "github.com/argoproj/argo-cd/v2/util/settings"
 )
 
 func fakeServer() (*ArgoCDServer, func()) {
@@ -544,4 +546,129 @@ func TestInitializeDefaultProject_ProjectAlreadyInitialized(t *testing.T) {
 	}
 
 	assert.Equal(t, proj.Spec, existingDefaultProject.Spec)
+}
+
+func TestOIDCConfigChangeDetection_SecretsChanged(t *testing.T) {
+	//Given
+	rawOIDCConfig, err := yaml.Marshal(&settings_util.OIDCConfig{
+		ClientID:     "$k8ssecret:clientid",
+		ClientSecret: "$k8ssecret:clientsecret"})
+	assert.NoError(t, err, "no error expected when marshalling OIDC config")
+
+	originalSecrets := map[string]string{"k8ssecret:clientid": "argocd", "k8ssecret:clientsecret": "sharedargooauthsecret"}
+
+	argoSettings := settings_util.ArgoCDSettings{OIDCConfigRAW: string(rawOIDCConfig), Secrets: originalSecrets}
+
+	originalOIDCConfig := argoSettings.OIDCConfig()
+
+	assert.Equal(t, originalOIDCConfig.ClientID, originalSecrets["k8ssecret:clientid"], "expected ClientID be replaced by secret value")
+	assert.Equal(t, originalOIDCConfig.ClientSecret, originalSecrets["k8ssecret:clientsecret"], "expected ClientSecret be replaced by secret value")
+
+	//When
+	newSecrets := map[string]string{"k8ssecret:clientid": "argocd", "k8ssecret:clientsecret": "a!Better!Secret"}
+	argoSettings.Secrets = newSecrets
+	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
+
+	//Then
+	assert.Equal(t, result, true, "secrets have changed, expect interpolated OIDCConfig to change")
+}
+
+func TestOIDCConfigChangeDetection_ConfigChanged(t *testing.T) {
+	//Given
+	rawOIDCConfig, err := yaml.Marshal(&settings_util.OIDCConfig{
+		Name:         "argocd",
+		ClientID:     "$k8ssecret:clientid",
+		ClientSecret: "$k8ssecret:clientsecret"})
+
+	assert.NoError(t, err, "no error expected when marshalling OIDC config")
+
+	originalSecrets := map[string]string{"k8ssecret:clientid": "argocd", "k8ssecret:clientsecret": "sharedargooauthsecret"}
+
+	argoSettings := settings_util.ArgoCDSettings{OIDCConfigRAW: string(rawOIDCConfig), Secrets: originalSecrets}
+
+	originalOIDCConfig := argoSettings.OIDCConfig()
+
+	assert.Equal(t, originalOIDCConfig.ClientID, originalSecrets["k8ssecret:clientid"], "expected ClientID be replaced by secret value")
+	assert.Equal(t, originalOIDCConfig.ClientSecret, originalSecrets["k8ssecret:clientsecret"], "expected ClientSecret be replaced by secret value")
+
+	//When
+	newRawOICDConfig, err := yaml.Marshal(&settings_util.OIDCConfig{
+		Name:         "cat",
+		ClientID:     "$k8ssecret:clientid",
+		ClientSecret: "$k8ssecret:clientsecret"})
+
+	assert.NoError(t, err, "no error expected when marshalling OIDC config")
+	argoSettings.OIDCConfigRAW = string(newRawOICDConfig)
+	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
+
+	//Then
+	assert.Equal(t, result, true, "no error expected since OICD config created")
+}
+
+func TestOIDCConfigChangeDetection_ConfigCreated(t *testing.T) {
+	//Given
+	argoSettings := settings_util.ArgoCDSettings{OIDCConfigRAW: ""}
+	originalOIDCConfig := argoSettings.OIDCConfig()
+
+	//When
+	newRawOICDConfig, err := yaml.Marshal(&settings_util.OIDCConfig{
+		Name:         "cat",
+		ClientID:     "$k8ssecret:clientid",
+		ClientSecret: "$k8ssecret:clientsecret"})
+	assert.NoError(t, err, "no error expected when marshalling OIDC config")
+	newSecrets := map[string]string{"k8ssecret:clientid": "argocd", "k8ssecret:clientsecret": "sharedargooauthsecret"}
+	argoSettings.OIDCConfigRAW = string(newRawOICDConfig)
+	argoSettings.Secrets = newSecrets
+	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
+
+	//Then
+	assert.Equal(t, result, true, "no error expected since new OICD config created")
+}
+
+func TestOIDCConfigChangeDetection_ConfigDeleted(t *testing.T) {
+	//Given
+	rawOIDCConfig, err := yaml.Marshal(&settings_util.OIDCConfig{
+		ClientID:     "$k8ssecret:clientid",
+		ClientSecret: "$k8ssecret:clientsecret"})
+	assert.NoError(t, err, "no error expected when marshalling OIDC config")
+
+	originalSecrets := map[string]string{"k8ssecret:clientid": "argocd", "k8ssecret:clientsecret": "sharedargooauthsecret"}
+
+	argoSettings := settings_util.ArgoCDSettings{OIDCConfigRAW: string(rawOIDCConfig), Secrets: originalSecrets}
+
+	originalOIDCConfig := argoSettings.OIDCConfig()
+
+	assert.Equal(t, originalOIDCConfig.ClientID, originalSecrets["k8ssecret:clientid"], "expected ClientID be replaced by secret value")
+	assert.Equal(t, originalOIDCConfig.ClientSecret, originalSecrets["k8ssecret:clientsecret"], "expected ClientSecret be replaced by secret value")
+
+	//When
+	argoSettings.OIDCConfigRAW = ""
+	argoSettings.Secrets = make(map[string]string)
+	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
+
+	//Then
+	assert.Equal(t, result, true, "no error expected since OICD config deleted")
+}
+
+func TestOIDCConfigChangeDetection_NoChange(t *testing.T) {
+	//Given
+	rawOIDCConfig, err := yaml.Marshal(&settings_util.OIDCConfig{
+		ClientID:     "$k8ssecret:clientid",
+		ClientSecret: "$k8ssecret:clientsecret"})
+	assert.NoError(t, err, "no error expected when marshalling OIDC config")
+
+	originalSecrets := map[string]string{"k8ssecret:clientid": "argocd", "k8ssecret:clientsecret": "sharedargooauthsecret"}
+
+	argoSettings := settings_util.ArgoCDSettings{OIDCConfigRAW: string(rawOIDCConfig), Secrets: originalSecrets}
+
+	originalOIDCConfig := argoSettings.OIDCConfig()
+
+	assert.Equal(t, originalOIDCConfig.ClientID, originalSecrets["k8ssecret:clientid"], "expected ClientID be replaced by secret value")
+	assert.Equal(t, originalOIDCConfig.ClientSecret, originalSecrets["k8ssecret:clientsecret"], "expected ClientSecret be replaced by secret value")
+
+	//When
+	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
+
+	//Then
+	assert.Equal(t, result, false, "no error since no config change")
 }


### PR DESCRIPTION
An OIDC config may refer to some secrets (e.g. `odic.config={client_secret='$k8s_secret_name:$k8s_secret_key'}) and if the value of these secrets are changed, ArgoCD should be restarted. This is currently not happening because the raw/non-interpolated OIDC config is tested for change only.

This PR fixes that.

Signed-off-by: Frederic Francois <frederic.francois@digital.cabinet-office.gov.uk>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [N/A] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [N/A] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [N/A ] Does this PR require documentation updates?
* [N/A] I've updated documentation as required by this PR.
* [N/A] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

