### PR TITLE
fix: fix deployment config health status

### DIFF
--- a/resource_customizations/apps.openshift.io/DeploymentConfig/health.lua
+++ b/resource_customizations/apps.openshift.io/DeploymentConfig/health.lua
@@ -1,13 +1,13 @@
 health_check = {}
 if obj.status ~= nil then
-  if obj.status.conditions ~= nil then
+  if obj.status.conditions ~= nil and obj.status.replicas ~= nil then
     numTrue = 0
     for i, condition in pairs(obj.status.conditions) do
       if (condition.type == "Available" or condition.type == "Progressing") and condition.status == "True" then
         numTrue = numTrue + 1
       end
     end
-    if numTrue == 2 then
+    if numTrue == 2 or obj.status.replicas == 0 then
       health_check.status = "Healthy"
       health_check.message = "replication controller successfully rolled out"
       return health_check

--- a/resource_customizations/apps.openshift.io/DeploymentConfig/health_test.yaml
+++ b/resource_customizations/apps.openshift.io/DeploymentConfig/health_test.yaml
@@ -11,3 +11,7 @@ tests:
     status: Healthy
     message: "replication controller successfully rolled out"
   inputPath: testdata/healthy.yaml
+- healthStatus:
+    status: Healthy
+    message: "replication controller successfully rolled out"
+  inputPath: testdata/healthy_zero_replicas.yaml

--- a/resource_customizations/apps.openshift.io/DeploymentConfig/testdata/degraded.yaml
+++ b/resource_customizations/apps.openshift.io/DeploymentConfig/testdata/degraded.yaml
@@ -133,10 +133,10 @@ spec:
 status:
   latestVersion: 1
   observedGeneration: 1
-  replicas: 0
-  updatedReplicas: 0
+  replicas: 10
+  updatedReplicas: 10
   availableReplicas: 0
-  unavailableReplicas: 0
+  unavailableReplicas: 10
   details:
     message: config change
     causes:

--- a/resource_customizations/apps.openshift.io/DeploymentConfig/testdata/healthy_zero_replicas.yaml
+++ b/resource_customizations/apps.openshift.io/DeploymentConfig/testdata/healthy_zero_replicas.yaml
@@ -1,0 +1,68 @@
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example
+  namespace: default
+spec:
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      maxUnavailable: 25%
+      maxSurge: 25%
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ConfigChange
+  replicas: 3
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    app: httpd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: httpd
+    spec:
+      containers:
+        - name: httpd
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+status:
+  availableReplicas: 0
+  conditions:
+    - lastTransitionTime: '2022-02-02T12:22:22Z'
+      lastUpdateTime: '2022-02-02T12:23:53Z'
+      message: replication controller "jenkins-1" successfully rolled out
+      reason: NewReplicationControllerAvailable
+      status: 'True'
+      type: Progressing
+    - lastTransitionTime: '2022-02-02T14:11:11Z'
+      lastUpdateTime: '2022-02-02T14:11:11Z'
+      message: Deployment config does not have minimum availability.
+      status: 'False'
+      type: Available
+  details:
+    causes:
+      - type: ConfigChange
+    message: config change
+  latestVersion: 1
+  observedGeneration: 5
+  replicas: 0
+  unavailableReplicas: 0
+  updatedReplicas: 0


### PR DESCRIPTION
Signed-off-by: ishitasequeira <isequeir@redhat.com>

Currently, when a DeploymentConfig is scaled to 0 ArgoCD puts in it progressing state forever with health status message as `replication controller is waiting for pods to run`. This PR fixes this edge case scenario for health check of DeploymentConfig.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

