### PR TITLE
fix: refreshing label is hidden by resource tree

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -52,6 +52,7 @@ $header: 120px;
         border-radius: 5px;
         padding: 5px 5px;
         font-size: 0.6em;
+        z-index: 1;
     }
 
     &__tab-content-full-height {


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

before:

https://user-images.githubusercontent.com/426437/152619636-03def924-0310-4298-9f18-0aae9e89981b.mov

after

https://user-images.githubusercontent.com/426437/152619643-3a97fa82-8449-4a89-9752-f17112ecdb74.mov


