### PR TITLE
fix: Add secrets protocol to allowedHelmRemoteProtocols 

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -8,6 +8,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [3Rein](https://www.3rein.com/)
 1. [7shifts](https://www.7shifts.com/)
 1. [Adevinta](https://www.adevinta.com/)
+1. [adorsys](https://www.adorsys.com/)
 1. [Adventure](https://jp.adventurekk.com/)
 1. [Akuity](https://akuity.io/)
 1. [Alibaba Group](https://www.alibabagroup.com/)

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -66,7 +66,7 @@ const (
 )
 
 // List of protocol schemes allowed for fetching remote value files
-var allowedHelmRemoteProtocols = []string{"http", "https"}
+var allowedHelmRemoteProtocols = []string{"http", "https", "secrets"}
 
 // Service implements ManifestService interface
 type Service struct {


### PR DESCRIPTION
Fixes #8397 

The secrets:// protocol is used by the helm-secrets project. It uses the helm [downloader plugin](https://helm.sh/docs/topics/plugins/#downloader-plugins) functionality to unencrypt value files without any additional helm wrapper secrets.

See: https://github.com/jkroepke/helm-secrets/wiki/ArgoCD-Integration

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

