### PR TITLE
docs(high availability): fix formating

### DIFF
--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -138,6 +138,7 @@ Installations that use a different repo for each app are **not** subject to this
 !!! note
     Application manifest paths annotation support depends on the git provider used for the Application. It is currently only supported for GitHub, GitLab, and Gogs based repos
 I'm using `.Second()` modifier to avoid distracting users who already rely on `--app-resync` flag.
+
 * **Relative path** The annotation might contains relative path. In this case the path is considered relative to the path specified in the application source:
 
 ```yaml


### PR DESCRIPTION
# Description

In the HA page the bullet point is not displayed
![image](https://user-images.githubusercontent.com/4170158/153373425-57c8e81f-38c0-4676-948f-c22ad3f8533c.png)

Tested with
```bash
docker run  --rm -it -p 8000:8000 -v /path/argo-cd:/docs squidfunk/mkdocs-material:4.1.1 serve -a 0.0.0.0:8000
```

![image](https://user-images.githubusercontent.com/4170158/153374290-a2f28f07-00a6-4492-9984-83525a991142.png)


# Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

# Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

