### PR TITLE
fix: Make zoom level a user preference (#7183)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -34,7 +34,6 @@ interface ApplicationDetailsState {
     revision?: string;
     groupedResources?: ResourceStatus[];
     slidingPanelPage?: number;
-    zoom?: number;
     filteredGraph?: any[];
 }
 
@@ -70,7 +69,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
 
     constructor(props: RouteComponentProps<{name: string}>) {
         super(props);
-        this.state = {page: 0, groupedResources: [], slidingPanelPage: 0, zoom: 1.0, filteredGraph: []};
+        this.state = {page: 0, groupedResources: [], slidingPanelPage: 0, filteredGraph: []};
     }
 
     private get showOperationState() {
@@ -213,15 +212,15 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                                     )
                                 );
                             const {Tree, Pods, Network, List} = AppsDetailsViewKey;
-                            const zoomNum = (this.state.zoom * 100).toFixed(0);
+                            const zoomNum = ((pref.zoom || 1.0) * 100).toFixed(0);
                             const setZoom = (s: number) => {
-                                let targetZoom: number = this.state.zoom + s;
+                                let targetZoom: number = pref.zoom + s;
                                 if (targetZoom <= 0.05) {
                                     targetZoom = 0.1;
                                 } else if (targetZoom > 2.0) {
                                     targetZoom = 2.0;
                                 }
-                                this.setState({zoom: targetZoom});
+                                services.viewPreferences.updatePreferences({appDetails: {...pref, zoom: targetZoom}});
                             };
                             const setFilterGraph = (filterGraph: any[]) => {
                                 this.setState({filteredGraph: filterGraph});
@@ -322,7 +321,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                                                         useNetworkingHierarchy={pref.view === 'network'}
                                                         onClearFilter={clearFilter}
                                                         onGroupdNodeClick={groupdedNodeIds => openGroupNodeDetails(groupdedNodeIds)}
-                                                        zoom={this.state.zoom}
+                                                        zoom={pref.zoom || 1.0}
                                                         filters={pref.resourceFilter}
                                                         setTreeFilterGraph={setFilterGraph}
                                                     />

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -24,6 +24,7 @@ export interface AppDetailsPreferences {
     hideFilters: boolean;
     wrapLines: boolean;
     groupNodes?: boolean;
+    zoom?: number;
 }
 
 export interface PodViewPreferences {
@@ -110,7 +111,8 @@ const DEFAULT_PREFERENCES: ViewPreferences = {
         },
         darkMode: false,
         followLogs: false,
-        wrapLines: false
+        wrapLines: false,
+        zoom: 1.0
     },
     appList: {
         view: 'tiles' as AppsListViewType,


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

No specific issue for this PR, but is a follow-up change to address Alex's comment made here:

https://github.com/argoproj/argo-cd/pull/8290#pullrequestreview-865564568

So, with this change, each browser tab Argo CD UI instance will have the same zoom level. 
See bullet point 2 from here: https://github.com/argoproj/argo-cd/pull/8290#issue-1115669298
and matches the behavior of the grouped nodes button.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

