### PR TITLE
fix: Horizontal Scrolling doesn't appear until page end (#8298)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -4,6 +4,7 @@
 $header: 120px;
 
 .application-details {
+    height: 100vh;
     &__status-panel {
         position: fixed;
         left: 60px;
@@ -27,7 +28,7 @@ $header: 120px;
         overflow-x: auto;
         overflow-y: auto;
         margin-top: 115px;
-        min-height: calc(100vh - 2 * 50px - 115px);
+        height: calc(100vh - 2 * 50px - 115px);
         @media screen and (max-width: map-get($breakpoints, xlarge)) {
             margin-top: 165px;
         }


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

Fixes https://github.com/argoproj/argo-cd/issues/8298

Limit the height of the parent to only the viewable area, but allow the inner contents to scroll.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

