### PR TITLE
refactor: rename 'appclientset' to not collide with its pkg

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -96,7 +96,7 @@ func NewCommand() *cobra.Command {
 			if failureRetryCount > 0 {
 				appclientsetConfig = kube.AddFailureRetryWrapper(appclientsetConfig, failureRetryCount, failureRetryPeriodMilliSeconds)
 			}
-			appclientset := appclientset.NewForConfigOrDie(appclientsetConfig)
+			appClientSet := appclientset.NewForConfigOrDie(appclientsetConfig)
 			tlsConfig := apiclient.TLSConfiguration{
 				DisableTLS:       repoServerPlaintext,
 				StrictValidation: repoServerStrictTLS,
@@ -131,7 +131,7 @@ func NewCommand() *cobra.Command {
 				BaseHRef:            baseHRef,
 				RootPath:            rootPath,
 				KubeClientset:       kubeclientset,
-				AppClientset:        appclientset,
+				AppClientset:        appClientSet,
 				RepoClientset:       repoclientset,
 				DexServerAddr:       dexServerAddress,
 				DisableAuth:         disableAuth,


### PR DESCRIPTION
Very simple change, I've just renamed a local var because it was colliding with the imported package name. See:

```go
import servercache "github.com/argoproj/argo-cd/v2/server/cache"
[...]
appclientset := appclientset.NewForConfigOrDie(appclientsetConfig)
```
