### PR TITLE
docs: update ApplicationSet controller getting started link

### DIFF
--- a/docs/user-guide/application-set.md
+++ b/docs/user-guide/application-set.md
@@ -42,6 +42,6 @@ Likewise, changes made to the ApplicationSet `template` fields will automaticall
 
 Within ApplicationSet there exist other more powerful generators in addition to the List generator, including the Cluster generator (which automatically uses Argo CD-defined clusters to template Applications), and the Git generator (which uses the files/directories of a Git repository to template applications).
 
-To learn more about the ApplicationSet controller, check out [ApplicationSet documentation](https://argocd-applicationset.readthedocs.io/en/stable/) and [Getting Started](https://argocd-applicationset.readthedocs.io/en/stable/Geting-Started/) to install the ApplicationSet controller alongside Argo CD.
+To learn more about the ApplicationSet controller, check out [ApplicationSet documentation](https://argocd-applicationset.readthedocs.io/en/stable/) and [Getting Started](https://argocd-applicationset.readthedocs.io/en/stable/Getting-Started/) to install the ApplicationSet controller alongside Argo CD.
 
 **Note:** Starting `v2.3` of Argo CD, we don't need to install ApplicationSet Controller separately. It would be instead as part of Argo CD installation.


### PR DESCRIPTION
Saving users another click by updating the ApplicationSet getting started link. Currently, users end up [here](https://argocd-applicationset.readthedocs.io/en/stable/Geting-Started/). The link had a typo so was updated to [this](https://argocd-applicationset.readthedocs.io/en/stable/Getting-Started/).

The link typo update was Geting-Started -> Getting-Started. 

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

