### PR TITLE
fix: fix repo server metrics registration

### DIFF
--- a/cmpserver/server.go
+++ b/cmpserver/server.go
@@ -95,6 +95,7 @@ func (a *ArgoCDCMPServer) CreateGRPC() *grpc.Server {
 
 	// Register reflection service on gRPC server.
 	reflection.Register(server)
+	grpc_prometheus.Register(server)
 
 	return server
 }

--- a/reposerver/metrics/metrics.go
+++ b/reposerver/metrics/metrics.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -29,9 +28,6 @@ const (
 // NewMetricsServer returns a new prometheus server which collects application metrics.
 func NewMetricsServer() *MetricsServer {
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	registry.MustRegister(collectors.NewGoCollector())
-
 	gitRequestCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "argocd_git_request_total",
@@ -80,7 +76,7 @@ func NewMetricsServer() *MetricsServer {
 	registry.MustRegister(redisRequestHistogram)
 
 	return &MetricsServer{
-		handler:                  promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+		handler:                  promhttp.HandlerFor(prometheus.Gatherers{registry, prometheus.DefaultGatherer}, promhttp.HandlerOpts{}),
 		gitRequestCounter:        gitRequestCounter,
 		gitRequestHistogram:      gitRequestHistogram,
 		repoPendingRequestsGauge: repoPendingRequestsGauge,

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -102,6 +102,7 @@ func (a *ArgoCDRepoServer) CreateGRPC() *grpc.Server {
 
 	// Register reflection service on gRPC server.
 	reflection.Register(server)
+	grpc_prometheus.Register(server)
 
 	return server
 }


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

This pr fixes the grpc server metrics of repo server. It replaces #8245.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

