### PR TITLE
feat: add a new `--degraded` flag to `argocd app wait` command (#8496)

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -134,6 +134,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Orbital Insight](https://orbitalinsight.com/)
 1. [p3r](https://www.p3r.one/)
 1. [Packlink](https://www.packlink.com/)
+1. [PagerDuty](https://www.pagerduty.com/)
 1. [PayPay](https://paypay.ne.jp/)
 1. [Peloton Interactive](https://www.onepeloton.com/)
 1. [Pipefy](https://www.pipefy.com/)

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -22,14 +22,13 @@ argocd app wait [APPNAME.. | -l selector] [flags]
 ### Options
 
 ```
-      --health                 Wait for health
-  -h, --help                   help for wait
-      --operation              Wait for pending operations
-      --resource stringArray   Sync only specific resources as GROUP:KIND:NAME. Fields may be blank. This option may be specified repeatedly
-  -l, --selector string        Wait for apps by label
-      --suspended              Wait for suspended
-      --sync                   Wait for sync
-      --timeout uint           Time out after this many seconds
+      --health-status stringArray   Wait for health status. Healthy, Degraded, Suspended, Missing, Progressing, or Unknown. This option may be specified repeatedly to wait for different statuses
+  -h, --help                        help for wait
+      --operation                   Wait for pending operations
+      --resource stringArray        Sync only specific resources as GROUP:KIND:NAME. Fields may be blank. This option may be specified repeatedly
+  -l, --selector string             Wait for apps by label
+      --sync                        Wait for sync
+      --timeout uint                Time out after this many seconds
 ```
 
 ### Options inherited from parent commands

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1960,7 +1960,7 @@ func TestAppWaitOperationInProgress(t *testing.T) {
 		Expect(OperationPhaseIs(OperationRunning)).
 		When().
 		And(func() {
-			_, err := RunCli("app", "wait", Name(), "--suspended")
+			_, err := RunCli("app", "wait", Name(), "--health-status", "Suspended")
 			errors.CheckError(err)
 		})
 }


### PR DESCRIPTION
## Context
Closes https://github.com/argoproj/argo-cd/issues/8496

## Testing
* Unit tests for `checkResourceStatus`
* Manual testing on our own applications to verify it works in our deployment scenarios:
  * successful deployment
  * failed deployment due to crashloopbackoff
  * failed deployment due to failed canaries
  * ...

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

