### PR TITLE
docs: Using Dex with OIDC needs the `config` element in yaml

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -222,9 +222,10 @@ data:
       - type: OIDC
         id: oidc
         name: OIDC
-        issuer: https://example-OIDC-provider.com
-        clientID: aaaabbbbccccddddeee
-        clientSecret: $dex.oidc.clientSecret
+        config:
+          issuer: https://example-OIDC-provider.com
+          clientID: aaaabbbbccccddddeee
+          clientSecret: $dex.oidc.clientSecret
 ```
 
 ### Requesting additional ID token claims
@@ -243,14 +244,15 @@ data:
       - type: OIDC
         id: oidc
         name: OIDC
-        issuer: https://example-OIDC-provider.com
-        clientID: aaaabbbbccccddddeee
-        clientSecret: $dex.oidc.clientSecret
-        insecureEnableGroups: true
-        scopes:
-        - profile
-        - email
-        - groups
+        config:
+          issuer: https://example-OIDC-provider.com
+          clientID: aaaabbbbccccddddeee
+          clientSecret: $dex.oidc.clientSecret
+          insecureEnableGroups: true
+          scopes:
+          - profile
+          - email
+          - groups
 ```
 
 !!! warning
@@ -272,15 +274,16 @@ data:
       - type: OIDC
         id: oidc
         name: OIDC
-        issuer: https://example-OIDC-provider.com
-        clientID: aaaabbbbccccddddeee
-        clientSecret: $dex.oidc.clientSecret
-        insecureEnableGroups: true
-        scopes:
-        - profile
-        - email
-        - groups
-        getUserInfo: true
+        config:
+          issuer: https://example-OIDC-provider.com
+          clientID: aaaabbbbccccddddeee
+          clientSecret: $dex.oidc.clientSecret
+          insecureEnableGroups: true
+          scopes:
+          - profile
+          - email
+          - groups
+          getUserInfo: true
 ```
 
 ## Existing OIDC Provider


### PR DESCRIPTION
In order to get Dex working with an OIDC provider, I had to structure the Dex config according to the [Dex Documentation](https://dexidp.io/docs/connectors/oidc/#configuration).
This means placing the OIDC configuration within their own `config` element in the `dex.config`, rather than listing them on the same level as the generic connector settings.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

