### PR TITLE
Unique repo path and permissions

### DIFF
--- a/reposerver/repository/lock_test.go
+++ b/reposerver/repository/lock_test.go
@@ -26,10 +26,10 @@ func lockQuickly(action func() (io.Closer, error)) (io.Closer, bool) {
 	}
 }
 
-func numberOfInits(initializedTimes *int) func() error {
-	return func() error {
+func numberOfInits(initializedTimes *int) func() (io.Closer, error) {
+	return func() (io.Closer, error) {
 		*initializedTimes++
-		return nil
+		return util.NopCloser, nil
 	}
 }
 
@@ -120,8 +120,8 @@ func TestLock_FailedInitialization(t *testing.T) {
 	lock := NewRepositoryLock()
 
 	closer1, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, func() error {
-			return errors.New("failed")
+		return lock.Lock("myRepo", "1", true, func() (io.Closer, error) {
+			return util.NopCloser, errors.New("failed")
 		})
 	})
 
@@ -132,8 +132,8 @@ func TestLock_FailedInitialization(t *testing.T) {
 	assert.Nil(t, closer1)
 
 	closer2, done := lockQuickly(func() (io.Closer, error) {
-		return lock.Lock("myRepo", "1", true, func() error {
-			return nil
+		return lock.Lock("myRepo", "1", true, func() (io.Closer, error) {
+			return util.NopCloser, nil
 		})
 	})
 

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -123,6 +123,9 @@ func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cac
 
 func (s *Service) Init() error {
 	_, err := os.Stat(s.rootDir)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(s.rootDir, 0300)
+	}
 	if err == nil {
 		// give itself read permissions to list previously written directories
 		err = os.Chmod(s.rootDir, 0700)
@@ -130,8 +133,6 @@ func (s *Service) Init() error {
 	var files []fs.FileInfo
 	if err == nil {
 		files, err = ioutil.ReadDir(s.rootDir)
-	} else if !os.IsNotExist(err) {
-		return os.MkdirAll(s.rootDir, 0300)
 	}
 	if err != nil {
 		log.Warnf("Failed to restore cloned repositories paths: %v", err)

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -16,10 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-jsonnet"
-
-	"github.com/argoproj/argo-cd/v2/util/argo"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/TomOnTime/utfutil"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
@@ -27,6 +23,7 @@ import (
 	"github.com/argoproj/pkg/sync"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/ghodss/yaml"
+	"github.com/google/go-jsonnet"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
@@ -44,6 +41,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/reposerver/metrics"
 	"github.com/argoproj/argo-cd/v2/util/app/discovery"
 	argopath "github.com/argoproj/argo-cd/v2/util/app/path"
+	"github.com/argoproj/argo-cd/v2/util/argo"
 	executil "github.com/argoproj/argo-cd/v2/util/exec"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/glob"
@@ -68,12 +66,14 @@ const (
 // Service implements ManifestService interface
 type Service struct {
 	gitCredsStore             git.CredsStore
+	gitRepoPaths              *io.TempPaths
+	chartPaths                *io.TempPaths
 	repoLock                  *repositoryLock
 	cache                     *reposervercache.Cache
 	parallelismLimitSemaphore *semaphore.Weighted
 	metricsServer             *metrics.MetricsServer
 	resourceTracking          argo.ResourceTracking
-	newGitClient              func(rawRepoURL string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (git.Client, error)
+	newGitClient              func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (git.Client, error)
 	newHelmClient             func(repoURL string, creds helm.Creds, enableOci bool, proxy string, opts ...helm.ClientOpts) helm.Client
 	initConstants             RepoServerInitConstants
 	// now is usually just time.Now, but may be replaced by unit tests for testing purposes
@@ -100,7 +100,7 @@ func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cac
 		repoLock:                  repoLock,
 		cache:                     cache,
 		metricsServer:             metricsServer,
-		newGitClient:              git.NewClient,
+		newGitClient:              git.NewClientExt,
 		resourceTracking:          resourceTracking,
 		newHelmClient: func(repoURL string, creds helm.Creds, enableOci bool, proxy string, opts ...helm.ClientOpts) helm.Client {
 			return helm.NewClientWithLock(repoURL, creds, sync.NewKeyLock(), enableOci, proxy, opts...)
@@ -108,6 +108,8 @@ func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cac
 		initConstants: initConstants,
 		now:           time.Now,
 		gitCredsStore: gitCredsStore,
+		gitRepoPaths:  io.NewTempPaths(),
+		chartPaths:    io.NewTempPaths(),
 	}
 }
 
@@ -1675,8 +1677,12 @@ func fileParameters(q *apiclient.RepoServerAppDetailsQuery) []v1alpha1.HelmFileP
 }
 
 func (s *Service) newClient(repo *v1alpha1.Repository, opts ...git.ClientOpts) (git.Client, error) {
+	repoPath, err := s.gitRepoPaths.GetPath(git.NormalizeGitURL(repo.Repo))
+	if err != nil {
+		return nil, err
+	}
 	opts = append(opts, git.WithEventHandlers(metrics.NewGitClientEventHandlers(s.metricsServer)))
-	return s.newGitClient(repo.Repo, repo.GetGitCreds(s.gitCredsStore), repo.IsInsecure(), repo.EnableLFS, repo.Proxy, opts...)
+	return s.newGitClient(repo.Repo, repoPath, repo.GetGitCreds(s.gitCredsStore), repo.IsInsecure(), repo.EnableLFS, repo.Proxy, opts...)
 }
 
 // newClientResolveRevision is a helper to perform the common task of instantiating a git client
@@ -1695,7 +1701,7 @@ func (s *Service) newClientResolveRevision(repo *v1alpha1.Repository, revision s
 
 func (s *Service) newHelmClientResolveRevision(repo *v1alpha1.Repository, revision string, chart string, noRevisionCache bool) (helm.Client, string, error) {
 	enableOCI := repo.EnableOCI || helm.IsHelmOciRepo(repo.Repo)
-	helmClient := s.newHelmClient(repo.Repo, repo.GetHelmCreds(), enableOCI, repo.Proxy, helm.WithIndexCache(s.cache))
+	helmClient := s.newHelmClient(repo.Repo, repo.GetHelmCreds(), enableOCI, repo.Proxy, helm.WithIndexCache(s.cache), helm.WithChartPaths(s.chartPaths))
 	// OCI helm registers don't support semver ranges. Assuming that given revision is exact version
 	if helm.IsVersion(revision) || enableOCI {
 		return helmClient, revision, nil
@@ -1753,7 +1759,7 @@ func checkoutRevision(gitClient git.Client, revision string, submoduleEnabled bo
 }
 
 func (s *Service) GetHelmCharts(ctx context.Context, q *apiclient.HelmChartsRequest) (*apiclient.HelmChartsResponse, error) {
-	index, err := s.newHelmClient(q.Repo.Repo, q.Repo.GetHelmCreds(), q.Repo.EnableOCI, q.Repo.Proxy).GetIndex(true)
+	index, err := s.newHelmClient(q.Repo.Repo, q.Repo.GetHelmCreds(), q.Repo.EnableOCI, q.Repo.Proxy, helm.WithChartPaths(s.chartPaths)).GetIndex(true)
 	if err != nil {
 		return nil, err
 	}
@@ -1814,7 +1820,7 @@ func (s *Service) ResolveRevision(ctx context.Context, q *apiclient.ResolveRevis
 		if helm.IsVersion(ambiguousRevision) {
 			return &apiclient.ResolveRevisionResponse{Revision: ambiguousRevision, AmbiguousRevision: ambiguousRevision}, nil
 		}
-		client := helm.NewClient(repo.Repo, repo.GetHelmCreds(), repo.EnableOCI || app.Spec.Source.IsHelmOci(), repo.Proxy)
+		client := helm.NewClient(repo.Repo, repo.GetHelmCreds(), repo.EnableOCI || app.Spec.Source.IsHelmOci(), repo.Proxy, helm.WithChartPaths(s.chartPaths))
 		index, err := client.GetIndex(false)
 		if err != nil {
 			return &apiclient.ResolveRevisionResponse{Revision: "", AmbiguousRevision: ""}, err

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj/pkg/sync"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/ghodss/yaml"
+	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-jsonnet"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
@@ -47,6 +48,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/glob"
 	"github.com/argoproj/argo-cd/v2/util/gpg"
+	"github.com/argoproj/argo-cd/v2/util/grpc"
 	"github.com/argoproj/argo-cd/v2/util/helm"
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/ksonnet"
@@ -67,6 +69,7 @@ const (
 // Service implements ManifestService interface
 type Service struct {
 	gitCredsStore             git.CredsStore
+	rootDir                   string
 	gitRepoPaths              *io.TempPaths
 	chartPaths                *io.TempPaths
 	gitRepoInitializer        func(rootPath string) goio.Closer
@@ -91,7 +94,7 @@ type RepoServerInitConstants struct {
 }
 
 // NewService returns a new instance of the Manifest service
-func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cache, initConstants RepoServerInitConstants, resourceTracking argo.ResourceTracking, gitCredsStore git.CredsStore) *Service {
+func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cache, initConstants RepoServerInitConstants, resourceTracking argo.ResourceTracking, gitCredsStore git.CredsStore, rootDir string) *Service {
 	var parallelismLimitSemaphore *semaphore.Weighted
 	if initConstants.ParallelismLimit > 0 {
 		parallelismLimitSemaphore = semaphore.NewWeighted(initConstants.ParallelismLimit)
@@ -110,15 +113,37 @@ func NewService(metricsServer *metrics.MetricsServer, cache *reposervercache.Cac
 		initConstants:      initConstants,
 		now:                time.Now,
 		gitCredsStore:      gitCredsStore,
-		gitRepoPaths:       io.NewTempPaths(),
-		chartPaths:         io.NewTempPaths(),
+		gitRepoPaths:       io.NewTempPaths(rootDir),
+		chartPaths:         io.NewTempPaths(rootDir),
 		gitRepoInitializer: directoryPermissionInitializer,
+		rootDir:            rootDir,
 	}
+}
+
+func (s *Service) Init() error {
+	files, err := ioutil.ReadDir(s.rootDir)
+	if err != nil && !os.IsNotExist(err) {
+		log.Warnf("Failed to restore cloned repositories paths: %v", err)
+	}
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+		fullPath := filepath.Join(s.rootDir, file.Name())
+		closer := s.gitRepoInitializer(fullPath)
+		if repo, err := gogit.PlainOpen(fullPath); err == nil {
+			if remotes, err := repo.Remotes(); err == nil && len(remotes) > 0 && len(remotes[0].Config().URLs) > 0 {
+				s.gitRepoPaths.Add(git.NormalizeGitURL(remotes[0].Config().URLs[0]), fullPath)
+			}
+		}
+		io.Close(closer)
+	}
+	return nil
 }
 
 // List a subset of the refs (currently, branches and tags) of a git repo
 func (s *Service) ListRefs(ctx context.Context, q *apiclient.ListRefsRequest) (*apiclient.Refs, error) {
-	gitClient, err := s.newClient(q.Repo)
+	gitClient, err := s.newClient(ctx, q.Repo)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +166,7 @@ func (s *Service) ListRefs(ctx context.Context, q *apiclient.ListRefsRequest) (*
 
 // ListApps lists the contents of a GitHub repo
 func (s *Service) ListApps(ctx context.Context, q *apiclient.ListAppsRequest) (*apiclient.AppList, error) {
-	gitClient, commitSHA, err := s.newClientResolveRevision(q.Repo, q.Revision)
+	gitClient, commitSHA, err := s.newClientResolveRevision(ctx, q.Repo, q.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +247,7 @@ func (s *Service) runRepoOperation(
 			return err
 		}
 	} else {
-		gitClient, revision, err = s.newClientResolveRevision(repo, revision, git.WithCache(s.cache, !settings.noRevisionCache && !settings.noCache))
+		gitClient, revision, err = s.newClientResolveRevision(ctx, repo, revision, git.WithCache(s.cache, !settings.noRevisionCache && !settings.noCache))
 		if err != nil {
 			return err
 		}
@@ -1623,7 +1648,7 @@ func (s *Service) GetRevisionMetadata(ctx context.Context, q *apiclient.RepoServ
 		}
 	}
 
-	gitClient, _, err := s.newClientResolveRevision(q.Repo, q.Revision)
+	gitClient, _, err := s.newClientResolveRevision(ctx, q.Repo, q.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -1679,10 +1704,14 @@ func fileParameters(q *apiclient.RepoServerAppDetailsQuery) []v1alpha1.HelmFileP
 	return q.Source.Helm.FileParameters
 }
 
-func (s *Service) newClient(repo *v1alpha1.Repository, opts ...git.ClientOpts) (git.Client, error) {
+func (s *Service) newClient(ctx context.Context, repo *v1alpha1.Repository, opts ...git.ClientOpts) (git.Client, error) {
 	repoPath, err := s.gitRepoPaths.GetPath(git.NormalizeGitURL(repo.Repo))
 	if err != nil {
 		return nil, err
+	}
+	if sanitizer, ok := grpc.SanitizerFromContext(ctx); ok {
+		// make sure randomized path replaced with '.' in the error message
+		sanitizer.AddReplacement(repoPath, ".")
 	}
 	opts = append(opts, git.WithEventHandlers(metrics.NewGitClientEventHandlers(s.metricsServer)))
 	return s.newGitClient(repo.Repo, repoPath, repo.GetGitCreds(s.gitCredsStore), repo.IsInsecure(), repo.EnableLFS, repo.Proxy, opts...)
@@ -1690,8 +1719,8 @@ func (s *Service) newClient(repo *v1alpha1.Repository, opts ...git.ClientOpts) (
 
 // newClientResolveRevision is a helper to perform the common task of instantiating a git client
 // and resolving a revision to a commit SHA
-func (s *Service) newClientResolveRevision(repo *v1alpha1.Repository, revision string, opts ...git.ClientOpts) (git.Client, string, error) {
-	gitClient, err := s.newClient(repo, opts...)
+func (s *Service) newClientResolveRevision(ctx context.Context, repo *v1alpha1.Repository, revision string, opts ...git.ClientOpts) (git.Client, string, error) {
+	gitClient, err := s.newClient(ctx, repo, opts...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -82,7 +82,7 @@ func newServiceWithOpt(cf clientFunc) (*Service, *gitmocks.Client) {
 	helmClient.On("ExtractChart", chart, version).Return("./testdata/my-chart", io.NopCloser, nil)
 	helmClient.On("CleanChartCache", chart, version).Return(nil)
 
-	service.newGitClient = func(rawRepoURL string, creds git.Creds, insecure bool, enableLfs bool, prosy string, opts ...git.ClientOpts) (client git.Client, e error) {
+	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, prosy string, opts ...git.ClientOpts) (client git.Client, e error) {
 		return gitClient, nil
 	}
 	service.newHelmClient = func(repoURL string, creds helm.Creds, enableOci bool, proxy string, opts ...helm.ClientOpts) helm.Client {
@@ -118,7 +118,7 @@ func newServiceWithCommitSHA(root, revision string) *Service {
 		gitClient.On("Root").Return(root)
 	})
 
-	service.newGitClient = func(rawRepoURL string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (client git.Client, e error) {
+	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (client git.Client, e error) {
 		return gitClient, nil
 	}
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	goio "io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -13,8 +14,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/argoproj/argo-cd/v2/util/argo"
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +28,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/reposerver/cache"
 	"github.com/argoproj/argo-cd/v2/reposerver/metrics"
 	fileutil "github.com/argoproj/argo-cd/v2/test/fixture/path"
+	"github.com/argoproj/argo-cd/v2/util/argo"
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	gitmocks "github.com/argoproj/argo-cd/v2/util/git/mocks"
@@ -87,6 +87,9 @@ func newServiceWithOpt(cf clientFunc) (*Service, *gitmocks.Client) {
 	}
 	service.newHelmClient = func(repoURL string, creds helm.Creds, enableOci bool, proxy string, opts ...helm.ClientOpts) helm.Client {
 		return helmClient
+	}
+	service.gitRepoInitializer = func(rootPath string) goio.Closer {
+		return io.NopCloser
 	}
 	return service, gitClient
 }

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -73,11 +73,7 @@ func newServiceWithOpt(cf clientFunc) (*Service, *gitmocks.Client) {
 		cacheutil.NewCache(cacheutil.NewInMemoryCache(1*time.Minute)),
 		1*time.Minute,
 		1*time.Minute,
-<<<<<<< HEAD
-	), RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{})
-=======
-	), RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), os.TempDir())
->>>>>>> afe616a79 (support restoring URLs from file system; sanitize error messages)
+	), RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, os.TempDir())
 
 	chart := "my-chart"
 	version := "1.1.0"

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1971,4 +1971,8 @@ func TestInit(t *testing.T) {
 	repo1Path, err := service.gitRepoPaths.GetPath(git.NormalizeGitURL("https://github.com/argo-cd/test-repo1"))
 	assert.NoError(t, err)
 	assert.Equal(t, repoPath, repo1Path)
+
+	_, err = ioutil.ReadDir(dir)
+	require.Error(t, err)
+	require.NoError(t, initGitRepo(path.Join(dir, "repo2"), "https://github.com/argo-cd/test-repo2"))
 }

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -69,7 +69,8 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 	streamInterceptors := []grpc.StreamServerInterceptor{grpc_logrus.StreamServerInterceptor(serverLog), grpc_prometheus.StreamServerInterceptor, grpc_util.PanicLoggerStreamServerInterceptor(serverLog)}
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		grpc_logrus.UnaryServerInterceptor(serverLog),
-		grpc_prometheus.UnaryServerInterceptor, grpc_util.PanicLoggerUnaryServerInterceptor(serverLog),
+		grpc_prometheus.UnaryServerInterceptor,
+		grpc_util.PanicLoggerUnaryServerInterceptor(serverLog),
 		grpc_util.ErrorSanitizerUnaryServerInterceptor(),
 	}
 

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -86,7 +86,7 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 	if tlsConfig != nil {
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}
-	repoService := repository.NewService(metricsServer, cache, initConstants, argo.NewResourceTracking(), filepath.Join(os.TempDir(), "_argocd-repo"))
+	repoService := repository.NewService(metricsServer, cache, initConstants, argo.NewResourceTracking(), gitCredsStore, filepath.Join(os.TempDir(), "_argocd-repo"))
 	if err := repoService.Init(); err != nil {
 		return nil, err
 	}
@@ -97,11 +97,8 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 		cache:         cache,
 		initConstants: initConstants,
 		opts:          serverOpts,
-<<<<<<< HEAD
 		gitCredsStore: gitCredsStore,
-=======
 		repoService:   repoService,
->>>>>>> afe616a79 (support restoring URLs from file system; sanitize error messages)
 	}, nil
 }
 
@@ -111,12 +108,7 @@ func (a *ArgoCDRepoServer) CreateGRPC() *grpc.Server {
 	versionpkg.RegisterVersionServiceServer(server, version.NewServer(nil, func() (bool, error) {
 		return true, nil
 	}))
-<<<<<<< HEAD
-	manifestService := repository.NewService(a.metricsServer, a.cache, a.initConstants, argo.NewResourceTracking(), a.gitCredsStore)
-	apiclient.RegisterRepoServerServiceServer(server, manifestService)
-=======
 	apiclient.RegisterRepoServerServiceServer(server, a.repoService)
->>>>>>> afe616a79 (support restoring URLs from file system; sanitize error messages)
 
 	healthService := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(server, healthService)

--- a/reposerver/server.go
+++ b/reposerver/server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
@@ -32,6 +33,7 @@ import (
 // ArgoCDRepoServer is the repo server implementation
 type ArgoCDRepoServer struct {
 	log           *log.Entry
+	repoService   *repository.Service
 	metricsServer *metrics.MetricsServer
 	gitCredsStore git.CredsStore
 	cache         *reposervercache.Cache
@@ -65,7 +67,11 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 
 	serverLog := log.NewEntry(log.StandardLogger())
 	streamInterceptors := []grpc.StreamServerInterceptor{grpc_logrus.StreamServerInterceptor(serverLog), grpc_prometheus.StreamServerInterceptor, grpc_util.PanicLoggerStreamServerInterceptor(serverLog)}
-	unaryInterceptors := []grpc.UnaryServerInterceptor{grpc_logrus.UnaryServerInterceptor(serverLog), grpc_prometheus.UnaryServerInterceptor, grpc_util.PanicLoggerUnaryServerInterceptor(serverLog)}
+	unaryInterceptors := []grpc.UnaryServerInterceptor{
+		grpc_logrus.UnaryServerInterceptor(serverLog),
+		grpc_prometheus.UnaryServerInterceptor, grpc_util.PanicLoggerUnaryServerInterceptor(serverLog),
+		grpc_util.ErrorSanitizerUnaryServerInterceptor(),
+	}
 
 	serverOpts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)),
@@ -79,6 +85,10 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 	if tlsConfig != nil {
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}
+	repoService := repository.NewService(metricsServer, cache, initConstants, argo.NewResourceTracking(), filepath.Join(os.TempDir(), "_argocd-repo"))
+	if err := repoService.Init(); err != nil {
+		return nil, err
+	}
 
 	return &ArgoCDRepoServer{
 		log:           serverLog,
@@ -86,7 +96,11 @@ func NewServer(metricsServer *metrics.MetricsServer, cache *reposervercache.Cach
 		cache:         cache,
 		initConstants: initConstants,
 		opts:          serverOpts,
+<<<<<<< HEAD
 		gitCredsStore: gitCredsStore,
+=======
+		repoService:   repoService,
+>>>>>>> afe616a79 (support restoring URLs from file system; sanitize error messages)
 	}, nil
 }
 
@@ -96,8 +110,12 @@ func (a *ArgoCDRepoServer) CreateGRPC() *grpc.Server {
 	versionpkg.RegisterVersionServiceServer(server, version.NewServer(nil, func() (bool, error) {
 		return true, nil
 	}))
+<<<<<<< HEAD
 	manifestService := repository.NewService(a.metricsServer, a.cache, a.initConstants, argo.NewResourceTracking(), a.gitCredsStore)
 	apiclient.RegisterRepoServerServiceServer(server, manifestService)
+=======
+	apiclient.RegisterRepoServerServiceServer(server, a.repoService)
+>>>>>>> afe616a79 (support restoring URLs from file system; sanitize error messages)
 
 	healthService := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(server, healthService)

--- a/util/grpc/sanitizer.go
+++ b/util/grpc/sanitizer.go
@@ -1,0 +1,73 @@
+package grpc
+
+import (
+	"errors"
+	"strings"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	contextKey = "sanitizer"
+)
+
+// ErrorSanitizerUnaryServerInterceptor returns a new unary server interceptor that sanitizes error messages
+// and provides Sanitizer to define replacements.
+func ErrorSanitizerUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		sanitizer := NewSanitizer()
+		resp, err = handler(ContextWithSanitizer(ctx, sanitizer), req)
+		if err == nil {
+			return resp, nil
+		}
+
+		if se, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
+			return resp, status.Error(se.GRPCStatus().Code(), sanitizer.Replace(se.GRPCStatus().Message()))
+		}
+
+		return resp, errors.New(sanitizer.Replace(err.Error()))
+	}
+}
+
+// ContextWithSanitizer returns a new context with sanitizer set.
+func ContextWithSanitizer(ctx context.Context, sanitizer Sanitizer) context.Context {
+	return context.WithValue(ctx, contextKey, sanitizer)
+}
+
+// SanitizerFromContext returns sanitizer from context.
+func SanitizerFromContext(ctx context.Context) (Sanitizer, bool) {
+	res, ok := ctx.Value(contextKey).(Sanitizer)
+	return res, ok
+}
+
+// Sanitizer provides methods to define list of strings and replacements
+type Sanitizer interface {
+	Replace(s string) string
+	AddReplacement(val string, replacement string)
+}
+
+type sanitizer struct {
+	replacements map[string]string
+}
+
+// NewSanitizer returns a new Sanitizer instance
+func NewSanitizer() *sanitizer {
+	return &sanitizer{
+		replacements: map[string]string{},
+	}
+}
+
+// AddReplacement adds a replacement to the Sanitizer
+func (s *sanitizer) AddReplacement(val string, replacement string) {
+	s.replacements[val] = replacement
+}
+
+// Replace replaces all occurrences of the configured values in the sanitizer with the replacements
+func (s *sanitizer) Replace(val string) string {
+	for k, v := range s.replacements {
+		val = strings.Replace(val, k, v, -1)
+	}
+	return val
+}

--- a/util/grpc/sanitizer_test.go
+++ b/util/grpc/sanitizer_test.go
@@ -1,0 +1,37 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestSanitizer(t *testing.T) {
+	s := NewSanitizer()
+
+	ctx := ContextWithSanitizer(context.TODO(), s)
+
+	sanitizer, ok := SanitizerFromContext(ctx)
+	require.True(t, ok)
+	sanitizer.AddReplacement("/my-random/path", ".")
+
+	res := s.Replace("error at /my-random/path/sub-dir: something went wrong")
+	assert.Equal(t, "error at ./sub-dir: something went wrong", res)
+}
+
+func TestErrorSanitizerUnaryServerInterceptor(t *testing.T) {
+	interceptor := ErrorSanitizerUnaryServerInterceptor()
+
+	_, err := interceptor(context.Background(), nil, nil, func(ctx context.Context, req interface{}) (interface{}, error) {
+		sanitizer, ok := SanitizerFromContext(ctx)
+		require.True(t, ok)
+		sanitizer.AddReplacement("/my-random/path", ".")
+		return nil, status.Error(codes.Internal, "error at /my-random/path/sub-dir: something went wrong")
+	})
+
+	assert.Equal(t, "rpc error: code = Internal desc = error at ./sub-dir: something went wrong", err.Error())
+}

--- a/util/grpc/sanitizer_test.go
+++ b/util/grpc/sanitizer_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,19 @@ func TestSanitizer(t *testing.T) {
 
 	res := s.Replace("error at /my-random/path/sub-dir: something went wrong")
 	assert.Equal(t, "error at ./sub-dir: something went wrong", res)
+}
+
+func TestSanitizer_RegexReplacement(t *testing.T) {
+	s := NewSanitizer()
+
+	ctx := ContextWithSanitizer(context.TODO(), s)
+
+	sanitizer, ok := SanitizerFromContext(ctx)
+	require.True(t, ok)
+
+	sanitizer.AddRegexReplacement(regexp.MustCompile("(/my-random/path)"), ".")
+	res := s.Replace("error at /my-random/path/something: something went wrong")
+	assert.Equal(t, "error at ./something: something went wrong", res)
 }
 
 func TestErrorSanitizerUnaryServerInterceptor(t *testing.T) {

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -77,7 +77,7 @@ func NewClientWithLock(repoURL string, creds Creds, repoLock sync.KeyLock, enabl
 		repoLock:        repoLock,
 		enableOci:       enableOci,
 		proxy:           proxy,
-		chartCachePaths: io.NewTempPaths(),
+		chartCachePaths: io.NewTempPaths(os.TempDir()),
 	}
 	for i := range opts {
 		opts[i](c)

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/argoproj/pkg/sync"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
@@ -152,8 +153,8 @@ func (c *nativeHelmChart) ExtractChart(chart string, version string, passCredent
 
 	if !exists {
 		// create empty temp directory to extract chart from the registry
-		tempDest, err := ioutil.TempDir("", "helm")
-		if err != nil {
+		tempDest := path.Join(os.TempDir(), uuid.New().String())
+		if err := os.Mkdir(tempDest, 0755); err != nil {
 			return "", nil, err
 		}
 		defer func() { _ = os.RemoveAll(tempDest) }()
@@ -353,7 +354,7 @@ func normalizeChartName(chart string) string {
 }
 
 func (c *nativeHelmChart) getCachedChartPath(chart string, version string) (string, error) {
-	return c.chartCachePaths.GetPath(fmt.Sprintf("%s/%s-%s", c.repoURL, strings.ReplaceAll(chart, "/", "_"), version))
+	return c.chartCachePaths.GetPath(fmt.Sprintf("%s/%s:%s", c.repoURL, strings.ReplaceAll(chart, "/", "_"), version))
 }
 
 // Ensures that given OCI registries URL does not have protocol

--- a/util/io/paths.go
+++ b/util/io/paths.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// TempPaths allows generating and memoizing random paths for a given URL.
+// TempPaths allows generating and memoizing random paths, each path being mapped to a specific key.
 type TempPaths struct {
 	root  string
 	paths map[string]string
@@ -27,7 +27,7 @@ func (p *TempPaths) Add(key string, value string) {
 	p.paths[key] = value
 }
 
-// GetPath generates a path for the given URL or returns previously generated one.
+// GetPath generates a path for the given key or returns previously generated one.
 func (p *TempPaths) GetPath(key string) (string, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/util/io/paths.go
+++ b/util/io/paths.go
@@ -1,0 +1,37 @@
+package io
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// TempPaths allows generating and memorizing random paths for a given URL.
+type TempPaths struct {
+	paths map[string]string
+	lock  sync.Mutex
+}
+
+func NewTempPaths() *TempPaths {
+	return &TempPaths{
+		paths: make(map[string]string),
+	}
+}
+
+// GetPath generates a path for the given URL or returns previously generated one.
+func (p *TempPaths) GetPath(url string) (string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if val, ok := p.paths[url]; ok {
+		return val, nil
+	}
+	uniqueId, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+	repoPath := filepath.Join(os.TempDir(), uniqueId.String())
+	p.paths[url] = repoPath
+	return repoPath, nil
+}

--- a/util/io/paths.go
+++ b/util/io/paths.go
@@ -1,37 +1,44 @@
 package io
 
 import (
-	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/google/uuid"
 )
 
-// TempPaths allows generating and memorizing random paths for a given URL.
+// TempPaths allows generating and memoizing random paths for a given URL.
 type TempPaths struct {
+	root  string
 	paths map[string]string
 	lock  sync.Mutex
 }
 
-func NewTempPaths() *TempPaths {
+func NewTempPaths(root string) *TempPaths {
 	return &TempPaths{
-		paths: make(map[string]string),
+		root:  root,
+		paths: map[string]string{},
 	}
 }
 
-// GetPath generates a path for the given URL or returns previously generated one.
-func (p *TempPaths) GetPath(url string) (string, error) {
+func (p *TempPaths) Add(key string, value string) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	if val, ok := p.paths[url]; ok {
+	p.paths[key] = value
+}
+
+// GetPath generates a path for the given URL or returns previously generated one.
+func (p *TempPaths) GetPath(key string) (string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if val, ok := p.paths[key]; ok {
 		return val, nil
 	}
 	uniqueId, err := uuid.NewRandom()
 	if err != nil {
 		return "", err
 	}
-	repoPath := filepath.Join(os.TempDir(), uniqueId.String())
-	p.paths[url] = repoPath
+	repoPath := filepath.Join(p.root, uniqueId.String())
+	p.paths[key] = repoPath
 	return repoPath, nil
 }

--- a/util/io/paths_test.go
+++ b/util/io/paths_test.go
@@ -1,0 +1,36 @@
+package io
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPath_SameURLs(t *testing.T) {
+	paths := NewTempPaths()
+	res1, err := paths.GetPath("https://localhost/test.txt")
+	require.NoError(t, err)
+	res2, err := paths.GetPath("https://localhost/test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, res1, res2)
+}
+
+func TestGetPath_DifferentURLs(t *testing.T) {
+	paths := NewTempPaths()
+	res1, err := paths.GetPath("https://localhost/test1.txt")
+	require.NoError(t, err)
+	res2, err := paths.GetPath("https://localhost/test2txt")
+	require.NoError(t, err)
+	assert.NotEqual(t, res1, res2)
+}
+
+func TestGetPath_SameURLsDifferentInstances(t *testing.T) {
+	paths1 := NewTempPaths()
+	res1, err := paths1.GetPath("https://localhost/test.txt")
+	require.NoError(t, err)
+	paths2 := NewTempPaths()
+	res2, err := paths2.GetPath("https://localhost/test.txt")
+	require.NoError(t, err)
+	assert.NotEqual(t, res1, res2)
+}

--- a/util/io/paths_test.go
+++ b/util/io/paths_test.go
@@ -21,7 +21,7 @@ func TestGetPath_DifferentURLs(t *testing.T) {
 	paths := NewTempPaths(os.TempDir())
 	res1, err := paths.GetPath("https://localhost/test1.txt")
 	require.NoError(t, err)
-	res2, err := paths.GetPath("https://localhost/test2txt")
+	res2, err := paths.GetPath("https://localhost/test2.txt")
 	require.NoError(t, err)
 	assert.NotEqual(t, res1, res2)
 }

--- a/util/io/paths_test.go
+++ b/util/io/paths_test.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,7 @@ import (
 )
 
 func TestGetPath_SameURLs(t *testing.T) {
-	paths := NewTempPaths()
+	paths := NewTempPaths(os.TempDir())
 	res1, err := paths.GetPath("https://localhost/test.txt")
 	require.NoError(t, err)
 	res2, err := paths.GetPath("https://localhost/test.txt")
@@ -17,7 +18,7 @@ func TestGetPath_SameURLs(t *testing.T) {
 }
 
 func TestGetPath_DifferentURLs(t *testing.T) {
-	paths := NewTempPaths()
+	paths := NewTempPaths(os.TempDir())
 	res1, err := paths.GetPath("https://localhost/test1.txt")
 	require.NoError(t, err)
 	res2, err := paths.GetPath("https://localhost/test2txt")
@@ -26,10 +27,10 @@ func TestGetPath_DifferentURLs(t *testing.T) {
 }
 
 func TestGetPath_SameURLsDifferentInstances(t *testing.T) {
-	paths1 := NewTempPaths()
+	paths1 := NewTempPaths(os.TempDir())
 	res1, err := paths1.GetPath("https://localhost/test.txt")
 	require.NoError(t, err)
-	paths2 := NewTempPaths()
+	paths2 := NewTempPaths(os.TempDir())
 	res2, err := paths2.GetPath("https://localhost/test.txt")
 	require.NoError(t, err)
 	assert.NotEqual(t, res1, res2)


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev [AMatyushentsev@gmail.com](mailto:AMatyushentsev@gmail.com)

PR implements two changes:

* Git and Helm repositories are cloned/fetched into random/non-predicable local directory
* Repo server remove read permissions from Git repos when not using it for manifest generation