### PR TITLE
docs: Clarify sync wave precedence by kind and add note on delay between waves

### DIFF
--- a/docs/user-guide/sync-waves.md
+++ b/docs/user-guide/sync-waves.md
@@ -38,7 +38,7 @@ When Argo CD starts a sync, it orders the resources in the following precedence:
 
 * The phase
 * The wave they are in (lower values first)
-* By kind (e.g. namespaces first)
+* By kind (e.g. [namespaces first and then other Kubernetes resources, followed by custom resources](https://github.com/argoproj/gitops-engine/blob/bc9ce5764fa306f58cf59199a94f6c968c775a2d/pkg/sync/sync_tasks.go#L27-L66))
 * By name 
 
 It then determines the number of the next wave to apply. This is the first number where any resource is out-of-sync or unhealthy.
@@ -48,3 +48,8 @@ It applies resources in that wave.
 It repeats this process until all phases and waves are in-sync and healthy.
 
 Because an application can have resources that are unhealthy in the first wave, it may be that the app can never get to healthy.
+
+Note that there's currently a delay between each sync wave in order give other controllers a chance to react to the spec change
+that we just applied. This also prevent Argo CD from assessing resource health too quickly (against the stale object), causing
+hooks to fire prematurely. The current delay between each sync wave is 2 seconds and can be configured via environment
+variable `ARGOCD_SYNC_WAVE_DELAY`.


### PR DESCRIPTION
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

