### PR TITLE
fix: Return early on error when updating clusters

### DIFF
--- a/controller/clusterinfoupdater.go
+++ b/controller/clusterinfoupdater.go
@@ -64,6 +64,7 @@ func (c *clusterInfoUpdater) updateClusters() {
 	clusters, err := c.db.ListClusters(context.Background())
 	if err != nil {
 		log.Warnf("Failed to save clusters info: %v", err)
+		return
 	}
 	var clustersFiltered []appv1.Cluster
 	if c.clusterFilter == nil {


### PR DESCRIPTION
There is a race condition when the controller starts up with empty configuration, that can lead to a crash due to nil pointer dereference. This can be observed while running the end-to-end tests from the CI, which are always executed on a clean environment (sorry for the color codes, c&p'ed from the e2e log artifacts):

```
10:43:45    controller | [mINFO[0000] Starting secretInformer forcluster           
10:43:45    controller | [mWARN[0000] Failed to save clusters info: server.secretkey is missing 
10:43:45    controller | [mpanic: runtime error: invalid memory address or nil pointer dereference
10:43:45    controller | [m[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x3281517]
10:43:45    controller | [mgoroutine 66 [running]:
10:43:45    controller | [mgithub.com/argoproj/argo-cd/v2/controller.(*clusterInfoUpdater).updateClusters(0xc0007fed40)
10:43:45    controller | [m	/home/runner/work/argo-cd/argo-cd/controller/clusterinfoupdater.go:70 +0x1f7
10:43:45    controller | [mgithub.com/argoproj/argo-cd/v2/controller.(*clusterInfoUpdater).Run(0xc00011cc60, {0x45aebf0, 0xc0007fe700})
10:43:45    controller | [m	/home/runner/work/argo-cd/argo-cd/controller/clusterinfoupdater.go:44 +0x32
10:43:45    controller | [mcreated by github.com/argoproj/argo-cd/v2/controller.(*ApplicationController).RegisterClusterSecretUpdater
10:43:45    controller | [m	/home/runner/work/argo-cd/argo-cd/controller/appcontroller.go:1744 +0x1ef
10:43:45    controller | [mexit status 2
```

This is a simple fix that returns early from `updateClusters` when the config DB's `listClusters()` method fails (e.g. due to yet incomplete configuration).

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

