### PR TITLE
fix: build ui as part of 'make release-cli' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ gen-resources-cli-local: clean-debug
 	CGO_ENABLED=0 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${GEN_RESOURCES_CLI_NAME} ./hack/gen-resources/cmd
 
 .PHONY: release-cli
-release-cli: clean-debug
+release-cli: clean-debug build-ui
 	make BIN_NAME=argocd-darwin-amd64 GOOS=darwin argocd-all
 	make BIN_NAME=argocd-darwin-arm64 GOOS=darwin GOARCH=arm64 argocd-all
 	make BIN_NAME=argocd-linux-amd64 GOOS=linux argocd-all
@@ -266,17 +266,20 @@ repo-server:
 controller:
 	CGO_ENABLED=0 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd-application-controller ./cmd
 
+.PHONY: build-ui
+build-ui:
+	docker build -t argocd-ui --target argocd-ui .
+	find ./ui/dist -type f -not -name gitkeep -delete
+	docker run -v ${CURRENT_DIR}/ui/dist/app:/tmp/app --rm -t argocd-ui sh -c 'cp -r ./dist/app/* /tmp/app/'
+
 .PHONY: image
 ifeq ($(DEV_IMAGE), true)
 # The "dev" image builds the binaries from the users desktop environment (instead of in Docker)
 # which speeds up builds. Dockerfile.dev needs to be copied into dist to perform the build, since
 # the dist directory is under .dockerignore.
 IMAGE_TAG="dev-$(shell git describe --always --dirty)"
-image:
+image: build-ui
 	docker build -t argocd-base --target argocd-base .
-	docker build -t argocd-ui --target argocd-ui .
-	find ./ui/dist -type f -not -name gitkeep -delete
-	docker run -v ${CURRENT_DIR}/ui/dist/app:/tmp/app --rm -t argocd-ui sh -c 'cp -r ./dist/app/* /tmp/app/'
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags '${LDFLAGS}' -o ${DIST_DIR}/argocd ./cmd
 	ln -sfn ${DIST_DIR}/argocd ${DIST_DIR}/argocd-server
 	ln -sfn ${DIST_DIR}/argocd ${DIST_DIR}/argocd-application-controller


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #8486 

During introducing ARM image support we've accidentally lost UI assets required for CLI. PR fixes the issue.