### PR TITLE
feat(cli): Allow to view previously terminated container logs

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -282,6 +282,7 @@ func NewApplicationLogsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		untilTime    string
 		filter       string
 		container    string
+		previous     bool
 	)
 	var command = &cobra.Command{
 		Use:   "logs APPNAME",
@@ -311,6 +312,7 @@ func NewApplicationLogsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 					UntilTime:    &untilTime,
 					Filter:       &filter,
 					Container:    container,
+					Previous:     previous,
 				})
 				if err != nil {
 					log.Fatalf("failed to get pod logs: %v", err)
@@ -352,6 +354,7 @@ func NewApplicationLogsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringVar(&untilTime, "until-time", "", "Show logs until this time")
 	command.Flags().StringVar(&filter, "filter", "", "Show logs contain this string")
 	command.Flags().StringVar(&container, "container", "", "Optional container name")
+	command.Flags().BoolVarP(&previous, "previous", "p", false, "Specify if the previously terminated container logs should be returned")
 
 	return command
 }

--- a/docs/user-guide/commands/argocd_app_logs.md
+++ b/docs/user-guide/commands/argocd_app_logs.md
@@ -17,6 +17,7 @@ argocd app logs APPNAME [flags]
       --kind string         Resource kind
       --name string         Resource name
       --namespace string    Resource namespace
+  -p, --previous            Specify if the previously terminated container logs should be returned
       --since-seconds int   A relative time in seconds before the current time from which to show logs
       --tail int            The number of lines from the end of the logs to show
       --until-time string   Show logs until this time


### PR DESCRIPTION
This is useful when we want to see the snapshot of previously terminated container logs.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

