### PR TITLE
fix: Increase y-margin in resource tree view (#7183)

### DIFF
--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -445,7 +445,7 @@ function findNetworkTargets(nodes: ResourceTreeNode[], networkingInfo: models.Re
 }
 export const ApplicationResourceTree = (props: ApplicationResourceTreeProps) => {
     const graph = new dagre.graphlib.Graph();
-    graph.setGraph({nodesep: 15, rankdir: 'LR', marginx: -100});
+    graph.setGraph({nodesep: 15, rankdir: 'LR', marginy: 45, marginx: -100});
     graph.setDefaultEdgeLabel(() => ({}));
     const overridesCount = getAppOverridesCount(props.app);
     const appNode = {


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

This is a follow up issue to the zoom support added via https://github.com/argoproj/argo-cd/pull/8290

When the tree structure consists of one long horizontal branch, the floating bar is in the way.  In a lot of cases, the floating toolbar is fine to float above the tree contents, because the tree is scrollable.  But in this case, the tree structure is not scrollable vertically, so the toolbar is in the way.  We should increase the Y-margin.

Problem

<img width="1575" alt="Screen Shot 2022-02-23 at 2 22 58 PM" src="https://user-images.githubusercontent.com/7726022/155394716-a9399ea9-ef70-44ed-8b59-87395c227326.png">

With Fix:

<img width="1577" alt="Screen Shot 2022-02-23 at 2 24 33 PM" src="https://user-images.githubusercontent.com/7726022/155394734-3f527221-f155-49d2-8e49-b0b5dd153326.png">


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

