### PR TITLE
build: Bump up network timeout during yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ FROM docker.io/library/node:12.18.4 as argocd-ui
 WORKDIR /src
 ADD ["ui/package.json", "ui/yarn.lock", "./"]
 
-RUN yarn install --network-timeout 100000
+RUN yarn install --network-timeout 200000
 
 ADD ["ui/", "."]
 


### PR DESCRIPTION
This PR bumps up network timeout to reduce the risk of failures of the image release workflow. This should fix the build on master branch.

```
#52 [linux/arm64 argocd-ui 4/6] RUN yarn install --network-timeout 100000
#52 953.0 error An unexpected error occurred: "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz: ESOCKETTIMEDOUT".
#52 953.0 info If you think this is a bug, please open a bug report with the information provided in "/src/yarn-error.log".
```

```
 > [linux/arm64 argocd-ui 4/6] RUN yarn install --network-timeout 100000:
#102 376.6 info There appears to be trouble with your network connection. Retrying...
#102 480.1 info There appears to be trouble with your network connection. Retrying...
#102 538.5 info There appears to be trouble with your network connection. Retrying...
#102 567.4 error An unexpected error occurred: "https://registry.yarnpkg.com/antd/-/antd-4.18.3.tgz: unexpected end of file".
```

Examples:
* https://github.com/argoproj/argo-cd/runs/5311582740?check_suite_focus=true
* https://github.com/argoproj/argo-cd/runs/5293225886?check_suite_focus=true
* https://github.com/argoproj/argo-cd/runs/5293846323?check_suite_focus=true

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

