### PR TITLE
feat: populate Server field with destination name when destination server is empty

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -362,7 +362,7 @@ func NewApplicationLogsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 func printAppSummaryTable(app *argoappv1.Application, appURL string, windows *argoappv1.SyncWindows) {
 	fmt.Printf(printOpFmtStr, "Name:", app.Name)
 	fmt.Printf(printOpFmtStr, "Project:", app.Spec.GetProject())
-	fmt.Printf(printOpFmtStr, "Server:", app.Spec.Destination.Server)
+	fmt.Printf(printOpFmtStr, "Server:", getServer(app))
 	fmt.Printf(printOpFmtStr, "Namespace:", app.Spec.Destination.Namespace)
 	fmt.Printf(printOpFmtStr, "URL:", appURL)
 	fmt.Printf(printOpFmtStr, "Repo:", app.Spec.Source.RepoURL)
@@ -516,6 +516,14 @@ func printParams(app *argoappv1.Application) {
 		}
 	}
 	_ = w.Flush()
+}
+
+func getServer(app *argoappv1.Application) string {
+	if app.Spec.Destination.Server == "" {
+		return app.Spec.Destination.Name
+	}
+
+	return app.Spec.Destination.Server
 }
 
 // NewApplicationSetCommand returns a new instance of an `argocd app set` command
@@ -1078,7 +1086,7 @@ func printApplicationTable(apps []argoappv1.Application, output *string) {
 	for _, app := range apps {
 		vals := []interface{}{
 			app.Name,
-			app.Spec.Destination.Server,
+			getServer(&app),
 			app.Spec.Destination.Namespace,
 			app.Spec.GetProject(),
 			app.Status.Sync.Status,


### PR DESCRIPTION
Closes #8576 

Updating the argocd CLI to display the server name if the destination cluster is not specified. This would affect the `argocd app get` and `argocd app list commands`. 

An alternative approach to this could be to use the destination name to get the cluster server details similar to how the `argocd cluster get` command works. I chose using the destination name since it is consistent with what's specific on the Application spec.