### PR TITLE
fix(ui): pass getResource function to the extension component

### DIFF
--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -122,11 +122,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 key: 'extension',
                 content: (
                     <ErrorBoundary message={`Something went wrong with Extension for ${state.kind}`}>
-                        <ExtensionComponent
-                            tree={tree} 
-                            resource={state} 
-                            getResourceFunc={node => services.applications.getResource(application.metadata.name, node)}
-                        />
+                        <ExtensionComponent tree={tree} resource={state} getResourceFunc={resource => services.applications.getResource(application.metadata.name, resource)} />
                     </ErrorBoundary>
                 )
             });

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -122,7 +122,11 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 key: 'extension',
                 content: (
                     <ErrorBoundary message={`Something went wrong with Extension for ${state.kind}`}>
-                        <ExtensionComponent tree={tree} resource={state} />
+                        <ExtensionComponent
+                            tree={tree} 
+                            resource={state} 
+                            getResourceFunc={node => services.applications.getResource(application.metadata.name, node)}
+                        />
                     </ErrorBoundary>
                 )
             });

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {ApplicationTree, State} from '../models';
+import {ApplicationTree, ResourceNode, State} from '../models';
+import { ApplicationsService } from './applications-service';
 
 const extensions: {resources: {[key: string]: Extension}} = {resources: {}};
 const cache = new Map<string, Promise<Extension>>();
@@ -11,6 +12,7 @@ export interface Extension {
 export interface ExtensionComponentProps {
     resource: State;
     tree: ApplicationTree;
+    getResourceFunc: (name: string, resource: ResourceNode) => Promise<State>;
 }
 
 export class ExtensionsService {

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {ApplicationTree, ResourceNode, State} from '../models';
-import { ApplicationsService } from './applications-service';
 
 const extensions: {resources: {[key: string]: Extension}} = {resources: {}};
 const cache = new Map<string, Promise<Extension>>();
@@ -12,7 +11,7 @@ export interface Extension {
 export interface ExtensionComponentProps {
     resource: State;
     tree: ApplicationTree;
-    getResourceFunc: (name: string, resource: ResourceNode) => Promise<State>;
+    getResourceFunc: (resource: ResourceNode) => Promise<State>;
 }
 
 export class ExtensionsService {


### PR DESCRIPTION
This is an attempt to address https://github.com/argoproj-labs/argocd-extensions/issues/10

When `workloadRef` is used in `Rollout` resource, the extension is not able to access `spec.template` as it's defined in the `Deployment` resource. We need additional call to the api to fetch necessary information from `Deployment`.

The fix is to pass the `getResource()` function to the extension component.

I clearly miss a lot of contexts and background knowledge of the project, let me know if the attempt doesn't make sense and I'm happy to update the implementation.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

