### PR TITLE
docs: Fix bullet point formatting in roadmap.md

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,6 +107,7 @@ The feature allows specifying dependencies between applications that allow orche
 ### Multi-tenancy improvements
 
 The multi-tenancy improvements that allow end-users to create Argo CD applications using Kubernetes directly without accessing Argo CD API.
+
 * [Applications outside argocd namespace](https://github.com/argoproj/argo-cd/pull/6409)
 * [AppSource](https://github.com/argoproj-labs/appsource)
 


### PR DESCRIPTION
This adds an empty line below the paragraph of *Multi-tenancy improvements* to generate the bullet points after it correctly.