### PR TITLE
fix: Health status bar button does not re-render properly. Fixes #8569

### DIFF
--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -293,7 +293,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
     const [isAppCreatePending, setAppCreatePending] = React.useState(false);
     const loaderRef = React.useRef<DataLoader>();
     const {List, Summary, Tiles} = AppsListViewKey;
-    const [isStatusBarShown, showStatusBar] = React.useState(true);
+    const [isStatusBarShown, setStatusBarShown] = React.useState(true);
 
     function refreshApp(appName: string) {
         // app refreshing might be done too quickly so that UI might miss it due to event batching
@@ -376,7 +376,6 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                             }`}
                                                                             style={{border: 'none'}}
                                                                             onClick={() => {
-                                                                                showStatusBar(!isStatusBarShown);
                                                                                 services.viewPreferences.updatePreferences({
                                                                                     appList: {
                                                                                         ...pref,
@@ -386,6 +385,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                                         }
                                                                                     }
                                                                                 });
+                                                                                setStatusBarShown(!isStatusBarShown);
                                                                             }}>
                                                                             <i className={`fas fa-ruler-horizontal`} />
                                                                         </button>
@@ -457,7 +457,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                 {(pref.view === 'summary' && <ApplicationsSummary applications={filteredApps} />) || (
                                                                     <Paginate
                                                                         header={filteredApps.length > 1 && <ApplicationsStatusBar applications={filteredApps} />}
-                                                                        showHeader={healthBarPrefs.showHealthStatusBar}
+                                                                        showHeader={isStatusBarShown}
                                                                         preferencesKey='applications-list'
                                                                         page={pref.page}
                                                                         emptyState={() => (

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -293,7 +293,6 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
     const [isAppCreatePending, setAppCreatePending] = React.useState(false);
     const loaderRef = React.useRef<DataLoader>();
     const {List, Summary, Tiles} = AppsListViewKey;
-    const [isStatusBarShown, setStatusBarShown] = React.useState(true);
 
     function refreshApp(appName: string) {
         // app refreshing might be done too quickly so that UI might miss it due to event batching
@@ -381,11 +380,11 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                                         ...pref,
                                                                                         statusBarView: {
                                                                                             ...healthBarPrefs,
-                                                                                            showHealthStatusBar: isStatusBarShown
+                                                                                            showHealthStatusBar: !healthBarPrefs.showHealthStatusBar
                                                                                         }
                                                                                     }
                                                                                 });
-                                                                                setStatusBarShown(!isStatusBarShown);
+                                                                                healthBarPrefs.showHealthStatusBar = !healthBarPrefs.showHealthStatusBar;
                                                                             }}>
                                                                             <i className={`fas fa-ruler-horizontal`} />
                                                                         </button>
@@ -457,7 +456,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                 {(pref.view === 'summary' && <ApplicationsSummary applications={filteredApps} />) || (
                                                                     <Paginate
                                                                         header={filteredApps.length > 1 && <ApplicationsStatusBar applications={filteredApps} />}
-                                                                        showHeader={isStatusBarShown}
+                                                                        showHeader={healthBarPrefs.showHealthStatusBar}
                                                                         preferencesKey='applications-list'
                                                                         page={pref.page}
                                                                         emptyState={() => (

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -293,6 +293,7 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
     const [isAppCreatePending, setAppCreatePending] = React.useState(false);
     const loaderRef = React.useRef<DataLoader>();
     const {List, Summary, Tiles} = AppsListViewKey;
+    const [isStatusBarShown, showStatusBar] = React.useState(true);
 
     function refreshApp(appName: string) {
         // app refreshing might be done too quickly so that UI might miss it due to event batching
@@ -374,17 +375,18 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                                 healthBarPrefs.showHealthStatusBar ? '-o' : ''
                                                                             }`}
                                                                             style={{border: 'none'}}
-                                                                            onClick={() =>
+                                                                            onClick={() => {
+                                                                                showStatusBar(!isStatusBarShown);
                                                                                 services.viewPreferences.updatePreferences({
                                                                                     appList: {
                                                                                         ...pref,
                                                                                         statusBarView: {
                                                                                             ...healthBarPrefs,
-                                                                                            showHealthStatusBar: !healthBarPrefs.showHealthStatusBar
+                                                                                            showHealthStatusBar: isStatusBarShown
                                                                                         }
                                                                                     }
-                                                                                })
-                                                                            }>
+                                                                                });
+                                                                            }}>
                                                                             <i className={`fas fa-ruler-horizontal`} />
                                                                         </button>
                                                                     </Tooltip>

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -375,16 +375,16 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                             }`}
                                                                             style={{border: 'none'}}
                                                                             onClick={() => {
+                                                                                healthBarPrefs.showHealthStatusBar = !healthBarPrefs.showHealthStatusBar;
                                                                                 services.viewPreferences.updatePreferences({
                                                                                     appList: {
                                                                                         ...pref,
                                                                                         statusBarView: {
                                                                                             ...healthBarPrefs,
-                                                                                            showHealthStatusBar: !healthBarPrefs.showHealthStatusBar
+                                                                                            showHealthStatusBar: healthBarPrefs.showHealthStatusBar
                                                                                         }
                                                                                     }
                                                                                 });
-                                                                                healthBarPrefs.showHealthStatusBar = !healthBarPrefs.showHealthStatusBar;
                                                                             }}>
                                                                             <i className={`fas fa-ruler-horizontal`} />
                                                                         </button>


### PR DESCRIPTION
Fixes #8569. The health status bar on the applications page can only be clicked once and then it will be hidden. However, when I click it again, the status bar does not appear, which is unexpected.

It turns out that the state of this should be persisted in order to re-render properly.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

