### PR TITLE
fix: fix broken monaco editor collapse icons

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -88,6 +88,10 @@ const config = {
                 {
                     from: 'node_modules/redoc/bundles/redoc.standalone.js',
                     to: 'assets/scripts/redoc.standalone.js'
+                },
+                {
+                    from: 'node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon',
+                    to: 'assets/fonts'
                 }
             ]
         }),

--- a/ui/src/assets/fonts.css
+++ b/ui/src/assets/fonts.css
@@ -1,3 +1,8 @@
+@font-face {
+	font-family: "codicon";
+	src: url("./fonts/codicon.ttf") format("truetype");
+}
+
 /* === Heebo - 300 */
 @font-face {
 	font-family: 'Heebo';


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Before:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/426437/157134465-136977a8-5fd8-4787-8f03-fd5ffe390137.png">


After:

<img width="552" alt="image" src="https://user-images.githubusercontent.com/426437/157134370-ee8ac042-4ac7-4a18-89cf-7d7dbc29b837.png">
