### PR TITLE
fix: correct jsonnet paths resolution

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1100,7 +1100,8 @@ func makeJsonnetVm(appPath string, repoRoot string, sourceJsonnet v1alpha1.Appli
 	// Jsonnet Imports relative to the repository path
 	jpaths := []string{appPath}
 	for _, p := range sourceJsonnet.Libs {
-		jpath, _, err := pathutil.ResolveFilePath(appPath, repoRoot, p, nil)
+		// the jsonnet library path is relative to the repository root, not application path
+		jpath, _, err := pathutil.ResolveFilePath(repoRoot, repoRoot, p, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -254,7 +254,7 @@ func TestGenerateJsonnetManifestInDir(t *testing.T) {
 				Jsonnet: argoappv1.ApplicationSourceJsonnet{
 					ExtVars: []argoappv1.JsonnetVar{{Name: "extVarString", Value: "extVarString"}, {Name: "extVarCode", Value: "\"extVarCode\"", Code: true}},
 					TLAs:    []argoappv1.JsonnetVar{{Name: "tlaString", Value: "tlaString"}, {Name: "tlaCode", Value: "\"tlaCode\"", Code: true}},
-					Libs:    []string{"./vendor"},
+					Libs:    []string{"testdata/jsonnet/vendor"},
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes #8719

The https://github.com/argoproj/argo-cd/pull/8606/ unintentionally changed how `directory.jsonnet.libs` are interpreted: relative to app directory instead of repo directory. This PR revert it back to repo directory.