### PR TITLE
fix: cleanup argocd unknown flag errors (#8625)

### DIFF
--- a/cmd/argocd/commands/root.go
+++ b/cmd/argocd/commands/root.go
@@ -37,6 +37,7 @@ func NewCommand() *cobra.Command {
 			c.HelpFunc()(c, args)
 		},
 		DisableAutoGenTag: true,
+		SilenceUsage:      true,
 	}
 
 	command.AddCommand(NewCompletionCommand())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -50,7 +49,6 @@ func main() {
 	}
 
 	if err := command.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Closes #8625 

This pull request makes errors from unknown flags easier to locate and removes a duplicate display of the error message.

Not sure if there are further considerations around removing the print of the error from `main.go`, but this can definitely be amended to make this skipping of the additional error print specific to the argocd cli.

Signed-off-by: Daniel Helfand <helfand.4@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

