### PR TITLE
docs: mention alternatives to using ttl properites with Jobs/Workflows

### DIFF
--- a/docs/user-guide/resource_hooks.md
+++ b/docs/user-guide/resource_hooks.md
@@ -69,14 +69,18 @@ The following policies define when the hook will be deleted.
 | `HookFailed` | The hook resource is deleted after the hook failed. |
 | `BeforeHookCreation` | Any existing hook resource is deleted before the new one is created (since v1.3). It is meant to be used with `/metadata/name`. This is the default deletion policy. |
 
-As an alternative to hook deletion policies, both Jobs and Argo Workflows support the
-[`ttlSecondsAfterFinished`](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
-field in the spec, which let their respective controllers delete the Job/Workflow after it completes.
+### Sync Status with Jobs/Workflows with Time to Live (ttl)
 
-```yaml
-spec:
-  ttlSecondsAfterFinished: 600
-```
+Jobs support the [`ttlSecondsAfterFinished`](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
+field in the spec, which let their respective controllers delete the Job after it completes. Argo Workflows support a 
+[`ttlStrategy`](https://argoproj.github.io/argo-workflows/fields/#ttlstrategy) property that also allow a Workflow to be 
+cleaned up depending on the ttl strategy chosen.
+
+Using either of the properties above can lead to Applications being OutOfSync. This is because Argo CD will detect a difference 
+between the Job or Workflow defined in the git repository and what's on the cluster since the ttl properties cause deletion of the resource after completion.
+
+However, using deletion hooks instead of the ttl approaches mentioned above will prevent Applications from having a status of 
+OutOfSync even though the Job or Workflow was deleted after completion.
 
 ## Using A Hook To Send A Slack Message
 


### PR DESCRIPTION
Resource Hooks help prevent Applications from being labeled OutOfSync after Jobs/Workflows deleted. This may help with issues like #8586 and discussions like #8247.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

