### PR TITLE
docs: The commands are executed in `path`

### DIFF
--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -32,7 +32,7 @@ The following changes are required to configure a new plugin:
                 args: ["sample args"]
               lockRepo: true                 # Defaults to false. See below.
     
-    The `generate` command must print a valid YAML or JSON stream to stdout. Both `init` and `generate` commands are executed inside the application source directory.
+    The `generate` command must print a valid YAML or JSON stream to stdout. Both `init` and `generate` commands are executed inside the application source directory or in `path` when specified for the app.
 
 3. [Create an Application which uses your new CMP](#using-a-cmp).
 


### PR DESCRIPTION
Context: 

* <https://cloud-native.slack.com/archives/C01TSERG0KZ/p1646758764264269>
* I ran into an issue with my custom plugin failing with `kustomize build $ARGOCD_APP_SOURCE_PATH` as I was unaware that the command was executed in the `path` specified by the app.

Checklist:

* [x] Either ~~(a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or~~ (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

