### PR TITLE
chore: Bump stable version of application set addon

### DIFF
--- a/manifests/addons/applicationset/stable/kustomization.yaml
+++ b/manifests/addons/applicationset/stable/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/applicationset/v0.3.0/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/applicationset/v0.4.1/manifests/install.yaml


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR updates applicationset stable version to v0.4.1