### PR TITLE
fix: use deepMerge to populate partial user settings with default values

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -212,7 +212,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                                     )
                                 );
                             const {Tree, Pods, Network, List} = AppsDetailsViewKey;
-                            const zoomNum = ((pref.zoom || 1.0) * 100).toFixed(0);
+                            const zoomNum = (pref.zoom * 100).toFixed(0);
                             const setZoom = (s: number) => {
                                 let targetZoom: number = pref.zoom + s;
                                 if (targetZoom <= 0.05) {
@@ -321,7 +321,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                                                         useNetworkingHierarchy={pref.view === 'network'}
                                                         onClearFilter={clearFilter}
                                                         onGroupdNodeClick={groupdedNodeIds => openGroupNodeDetails(groupdedNodeIds)}
-                                                        zoom={pref.zoom || 1.0}
+                                                        zoom={pref.zoom}
                                                         filters={pref.resourceFilter}
                                                         setTreeFilterGraph={setFilterGraph}
                                                     />

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -1,4 +1,6 @@
+import * as deepMerge from 'deepmerge';
 import {BehaviorSubject, Observable} from 'rxjs';
+
 import {PodGroupType} from '../../applications/components/application-pod-view/pod-view';
 
 export type AppsDetailsViewType = 'tree' | 'network' | 'list' | 'pods';
@@ -24,7 +26,7 @@ export interface AppDetailsPreferences {
     hideFilters: boolean;
     wrapLines: boolean;
     groupNodes?: boolean;
-    zoom?: number;
+    zoom: number;
 }
 
 export interface PodViewPreferences {
@@ -172,6 +174,6 @@ export class ViewPreferencesService {
         } else {
             preferences = DEFAULT_PREFERENCES;
         }
-        return Object.assign({}, DEFAULT_PREFERENCES, preferences);
+        return deepMerge(DEFAULT_PREFERENCES, preferences);
     }
 }


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR ensures that UI correctly handles the addition of new view preferences settings when user already have preferences populated by previous versions. Currently the following use case is not working well:

1. User has the following settings 

```
{
  "appDetails":{
      "view":"tree"
    }
}
```

2. New release introduces `appDetails.zoom` with default value `1.0`

Currently view preference service returns `undefined` value for zoom which is might cause JS crash. Once PR is merge the default value will be used even if user have view preferences populated by previous argocd UI version.