### PR TITLE
docs: refresh before calling sync

### DIFF
--- a/docs/user-guide/ci_automation.md
+++ b/docs/user-guide/ci_automation.md
@@ -5,7 +5,7 @@ pushed to Git, and the cluster state then syncs to the desired state in git. Thi
 from imperative pipelines which do not traditionally use Git repositories to hold application
 config.
 
-To push new container images into to a cluster managed by Argo CD, the following workflow (or 
+To push new container images into to a cluster managed by Argo CD, the following workflow (or
 variations), might be used:
 
 ## Build And Publish A New Container Image
@@ -46,6 +46,7 @@ that is always compatible with the Argo CD API server.
 export ARGOCD_SERVER=argocd.mycompany.com
 export ARGOCD_AUTH_TOKEN=<JWT token generated from project>
 curl -sSL -o /usr/local/bin/argocd https://${ARGOCD_SERVER}/download/argocd-linux-amd64
+argocd app get --refresh guestbook
 argocd app sync guestbook
 argocd app wait guestbook
 ```


### PR DESCRIPTION
Context:

- https://cloud-native.slack.com/archives/C01TSERG0KZ/p1646908096836719
- Before calling sync the repo needs to be refreshed

Checklist:

* [x] Either ~~(a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or~~ (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

