### PR TITLE
chore: improve image build speed

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -45,6 +45,26 @@ jobs:
       # build
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
+
+      - name: Setup cache for argocd-ui docker layer
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
+
+      - name: Build cache for argocd-ui stage
+        uses: docker/build-push-action@v2
+        with:
+          context: ./src/github.com/argoproj/argo-cd
+          platforms: linux/amd64,linux/arm64
+          target: argocd-ui
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        if: github.event_name == 'push'
+
       - run: |
           IMAGE_PLATFORMS=linux/amd64
           if [[ "${{ github.event_name }}" == "push" || "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]
@@ -53,10 +73,19 @@ jobs:
           fi
           echo "Building image for platforms: $IMAGE_PLATFORMS"
           docker buildx build --platform $IMAGE_PLATFORMS --push="${{ github.event_name == 'push' }}" \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
             -t ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} \
             -t quay.io/argoproj/argocd:latest .
         working-directory: ./src/github.com/argoproj/argo-cd
 
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Clean up build cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        if: github.event_name == 'push'
 
       # deploy
       - run: git clone "https://$TOKEN@github.com/argoproj/argoproj-deployments"

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -63,7 +63,7 @@ jobs:
           push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-arm-image')
 
       - run: |
           IMAGE_PLATFORMS=linux/amd64
@@ -85,7 +85,7 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-arm-image')
 
       # deploy
       - run: git clone "https://$TOKEN@github.com/argoproj/argoproj-deployments"


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Adding only a caching layer of argocd-ui stage seems to cut off 38-39minutes of build time for linux/amd64/linux/arm64 builds. Please note adding the `test-arm-image` label will not create this cache during a pull request.  Caching will not be saved until it is ran from a feature branch or the default branch.

I created a repository for testing and provided documentation. Let me know if you have any questions.
https://github.com/34fathombelow/argocd_image_speedup#argo-cd-image-build-speedup-test

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

