### PR TITLE
docs: dex type must be lower case

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -219,7 +219,7 @@ data:
   dex.config: |
     connectors:
       # OIDC
-      - type: OIDC
+      - type: oidc
         id: oidc
         name: OIDC
         config:


### PR DESCRIPTION
This took me way too long to figure out, dex doesn't support uppercase values of the type field so `OIDC` must be `oidc`

or you get the following error
```
time="2022-03-14T22:19:24Z" level=info msg="dex config modified. restarting dex"
error parse config file /tmp/dex.yaml: error unmarshaling JSON: unknown connector type "OIDC"
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

