### PR TITLE
fix: issue with ql check

### DIFF
--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -90,7 +90,7 @@ func (c *client) executeRequest(fullMethodName string, msg []byte, md metadata.M
 		if err != nil {
 			code = codes.Unknown
 		} else {
-			code = codes.Code(statusInt)
+			code = codes.Code(int32(statusInt))
 		}
 		if code != codes.OK {
 			return nil, status.Error(code, resp.Header.Get("Grpc-Message"))


### PR DESCRIPTION
We have few failures in check  like 
https://github.com/argoproj/argo-cd/pull/7398/checks?check_run_id=5560866581

According to https://codeql.github.com/codeql-query-help/go/go-incorrect-integer-conversion/