### PR TITLE
chore: add snyk scan to image build

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -13,6 +13,11 @@ env:
   GOLANG_VERSION: '1.17.6'
 
 jobs:
+  snyk:
+    name: Run Snyk scans
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
   publish:
     if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-latest
@@ -72,15 +77,34 @@ jobs:
             IMAGE_PLATFORMS=linux/amd64,linux/arm64
           fi
           echo "Building image for platforms: $IMAGE_PLATFORMS"
-          docker buildx build --platform $IMAGE_PLATFORMS --push="${{ github.event_name == 'push' }}" \
+          docker buildx build --platform $IMAGE_PLATFORMS \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             -t ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} \
             -t quay.io/argoproj/argocd:latest .
         working-directory: ./src/github.com/argoproj/argo-cd
 
+      - name: Run Snyk scans
+        if: github.event_name == 'push'
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          npm install -g snyk
+
+          # Run with high threshold to fail build.
+          snyk test --org=argoproj --all-projects --exclude=docs,site --severity-threshold=high --policy-path=.snyk
+          snyk iac test manifests/install.yaml --org=argoproj --severity-threshold=high --policy-path=.snyk
+          snyk container test quay.io/argoproj/argocd:latest --org=argoproj --file=Dockerfile --severity-threshold=high
+
+      - name: Push the image
+        if: github.event_name == 'push'
+        run: |
+          docker push ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }}
+          docker push quay.io/argoproj/argocd:latest
+
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
+
       - name: Clean up build cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -13,11 +13,6 @@ env:
   GOLANG_VERSION: '1.17.6'
 
 jobs:
-  snyk:
-    name: Run Snyk scans
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
   publish:
     if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-latest

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -96,12 +96,6 @@ jobs:
         run: |
           snyk container test quay.io/argoproj/argocd:latest --org=argoproj --file=Dockerfile --severity-threshold=high
 
-      - name: Push the image
-        if: github.event_name == 'push'
-        run: |
-          docker push ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }}
-          docker push quay.io/argoproj/argocd:latest
-
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -99,7 +99,6 @@ jobs:
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
-
       - name: Clean up build cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -65,20 +65,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
         if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-arm-image')
 
-      - run: |
-          IMAGE_PLATFORMS=linux/amd64
-          if [[ "${{ github.event_name }}" == "push" || "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]
-          then
-            IMAGE_PLATFORMS=linux/amd64,linux/arm64
-          fi
-          echo "Building image for platforms: $IMAGE_PLATFORMS"
-          docker buildx build --platform $IMAGE_PLATFORMS \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            -t ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} \
-            -t quay.io/argoproj/argocd:latest .
-        working-directory: ./src/github.com/argoproj/argo-cd
-
-      - name: Run Snyk scans
+      - name: Run non-container Snyk scans
         if: github.event_name == 'push'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -88,6 +75,25 @@ jobs:
           # Run with high threshold to fail build.
           snyk test --org=argoproj --all-projects --exclude=docs,site --severity-threshold=high --policy-path=.snyk
           snyk iac test manifests/install.yaml --org=argoproj --severity-threshold=high --policy-path=.snyk
+
+      - run: |
+          IMAGE_PLATFORMS=linux/amd64
+          if [[ "${{ github.event_name }}" == "push" || "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]
+          then
+            IMAGE_PLATFORMS=linux/amd64,linux/arm64
+          fi
+          echo "Building image for platforms: $IMAGE_PLATFORMS"
+          docker buildx build --platform $IMAGE_PLATFORMS --push="${{ github.event_name == 'push' }}" \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            -t ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} \
+            -t quay.io/argoproj/argocd:latest .
+        working-directory: ./src/github.com/argoproj/argo-cd
+
+      - name: Run container Snyk scan
+        if: github.event_name == 'push'
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
           snyk container test quay.io/argoproj/argocd:latest --org=argoproj --file=Dockerfile --severity-threshold=high
 
       - name: Push the image


### PR DESCRIPTION
This is part of https://github.com/argoproj/argo-cd/issues/8657

It's basically just a safety-check to make sure we don't push images which have "high" or more severe vulnerabilities.

Unfortunately, we can't do this in PRs because the Snyk secret is not available to those workflows. But the Snyk GitHub integration should find most issues on PRs anyway.

This provides benefits in addition to what the Snyk GitHub integration does: specifically it scans for IaC and container issues.