### PR TITLE
chore: Improve image build speed by 8x

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -58,7 +58,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./src/github.com/argoproj/argo-cd
-          platforms: linux/amd64,linux/arm64
           target: argocd-ui
           push: false
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ WORKDIR /home/argocd
 ####################################################################################################
 # Argo CD UI stage
 ####################################################################################################
-FROM docker.io/library/node:12.18.4 as argocd-ui
+FROM --platform=$BUILDPLATFORM docker.io/library/node:12.18.4 as argocd-ui
 
 WORKDIR /src
 ADD ["ui/package.json", "ui/yarn.lock", "./"]
@@ -99,7 +99,7 @@ RUN HOST_ARCH='amd64' NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTION
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
 ####################################################################################################
-FROM docker.io/library/golang:1.17.6 as argocd-build
+FROM --platform=$BUILDPLATFORM  docker.io/library/golang:1.17.6 as argocd-build
 
 WORKDIR /go/src/github.com/argoproj/argo-cd
 
@@ -111,7 +111,8 @@ RUN go mod download
 # Perform the build
 COPY . .
 COPY --from=argocd-ui /src/dist/app /go/src/github.com/argoproj/argo-cd/ui/dist/app
-RUN make argocd-all
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make argocd-all
 
 ####################################################################################################
 # Final image


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

## "No, no, no, cache speed is too slow! We're gonna have to go right to... Ludicrous Speed!"

### tl;dr

Adding cache was helpful in speeding up image build times by 2x. These changes improve build times by a total of **8x** while maintaining backwards compatability. The flowchart below shows how the Dockerfile is processed using cross-compilation. Orange nodes are `x86_64` and opaque orange nodes are `arm64`  Using hardware emulation is to slow for  `argocd-ui` and `argocd-build` stages.

### Dockerfile improvements

We can leverage the build host architecture ($BUILDPLATFORM) to build the `argocd-ui` stage since it only produces artifacts which are platform independent, saving approx. 38 mins in build time.

The `argocd-build` stage can also be built on the build host architecture (\$BUILDPLATFORM) to cross compile the Argo binaries by passing in `ARG TARGETOS TARGETARCH`. These are the parameters used in `buildx --platform linux/amd64,linux/arm64` . Setting `RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make argocd-all` will instruct buildx to compile architectures listed with `--platforms` .  The binaries are then passed into the Final Image for each architecture.  With these changes build times have been 10-12 mins on github runners. Ref: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope

```mermaid
flowchart TB
id1([builder]) & id6([builder])
id1([builder]) --> id2([argo-base]) --> id3([argo-ui])--> id4([argocd-build])
id4([argocd-build]) --> id5([x86_64 Final Image]) & id8([ arm64 Final Image])
id6([builder]) --> id7([argo-base]) ---->  id8([arm64 Final Image])
id5 & id8 --> id9([Container Registry])

style id9 fill:#5C74C6,stroke:#333,stroke-width:2px,color:#ffffff
classDef x86 fill:#EF7B4D,stroke:#EF7B4D,stroke-width:2px,color:#ffffff
classDef arm64 fill:#FCE5DB,stroke:#EF7B4D,stroke-width:2px,color:#EF7B4D
class id1,id2,id3,id4,id5 x86
class id6,id7,id8 arm64

```

### Test Performed

- Built Images with github runners
- Built Images locally
- Pushed to a registry
- Verified binaries built properly inside container (podman & docker run ...)
- Ran on native arm64 cluster (Raspberry Pi Cluster)
- Ran on x86_64 cluster (Kind and Minikube)

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

images:
- name: quay.io/argoproj/argocd
  newName: ghcr.io/34fathombelow/argocd_image_speedup
  newTag: latest

namespace: argocd-test
resources:
- https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
