### PR TITLE
fix: Support podman and older version of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,8 @@ RUN go mod download
 # Perform the build
 COPY . .
 COPY --from=argocd-ui /src/dist/app /go/src/github.com/argoproj/argo-cd/ui/dist/app
-ARG TARGETOS TARGETARCH
+ARG TARGETOS
+ARG TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make argocd-all
 
 ####################################################################################################


### PR DESCRIPTION
Podman and older versions of docker do not support multiple args
on a single line. It was recently added to docker in this commit
https://github.com/moby/buildkit/pull/1692 and podman still dose not have support
for it.

Signed-off-by: zachaller <zachaller@hotmail.com>