### PR TITLE
fix: don't run codeql for push events from dependabot

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,9 @@ name: "Code scanning - action"
 
 on:
   push:
+    # Secrets aren't available for dependabot on push. https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow#error-403-resource-not-accessible-by-integration-when-using-dependabot
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
   schedule:
     - cron: '0 19 * * 0'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,15 +16,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
There are two changes:
1) don't run the `push` codeql check for dependabot branches - it doesn't have access to the right secrets, and the check will fail like this: https://github.com/argoproj/argo-cd/pull/8919
   The check will still run for the `pull_request` event
2) run on the merge commit instead of HEAD^2, as recommended in a codeql warning: 
   > Warning: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
   
   https://github.com/argoproj/argo-cd/runs/5728019379?check_suite_focus=true