### PR TITLE
fix: TestFailedConversion and turn back on in e2e

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k3s-version: [v1.23.3, v1.22.6, v1.21.2]
+        k3s-version: [v1.22.6, v1.21.2]
     needs: 
       - build-go
     env:

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -851,9 +851,6 @@ func TestConfigMap(t *testing.T) {
 }
 
 func TestFailedConversion(t *testing.T) {
-	if os.Getenv("ARGOCD_E2E_K3S") == "true" {
-		t.SkipNow()
-	}
 	defer func() {
 		FailOnErr(Run("", "kubectl", "delete", "apiservice", "v1beta1.metrics.k8s.io"))
 	}()

--- a/test/e2e/testdata/failed-conversion/apiservice.yaml
+++ b/test/e2e/testdata/failed-conversion/apiservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io


### PR DESCRIPTION
This fixes the TestFailedConversion test that was broken due to
v1beta1 being deprecated in k8s 1.22 https://kubernetes.io/docs/reference/using-api/deprecation-guide/#apiservice-v122

Signed-off-by: zachaller <zachaller@hotmail.com>
