### PR TITLE
fix: Correct applicationset binary name aftermerge

### DIFF
--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - command:
             - entrypoint.sh
-            - applicationset-controller
+            - argocd-applicationset-controller
           image: quay.io/argoproj/argocd:latest
           imagePullPolicy: Always
           name: argocd-applicationset-controller

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -8998,7 +8998,7 @@ spec:
       containers:
       - command:
         - entrypoint.sh
-        - applicationset-controller
+        - argocd-applicationset-controller
         env:
         - name: NAMESPACE
           valueFrom:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9935,7 +9935,7 @@ spec:
       containers:
       - command:
         - entrypoint.sh
-        - applicationset-controller
+        - argocd-applicationset-controller
         env:
         - name: NAMESPACE
           valueFrom:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1222,7 +1222,7 @@ spec:
       containers:
       - command:
         - entrypoint.sh
-        - applicationset-controller
+        - argocd-applicationset-controller
         env:
         - name: NAMESPACE
           valueFrom:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9305,7 +9305,7 @@ spec:
       containers:
       - command:
         - entrypoint.sh
-        - applicationset-controller
+        - argocd-applicationset-controller
         env:
         - name: NAMESPACE
           valueFrom:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -592,7 +592,7 @@ spec:
       containers:
       - command:
         - entrypoint.sh
-        - applicationset-controller
+        - argocd-applicationset-controller
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

related #8864
Correcting binary name in argocd applicationset controller manifests