### PR TITLE
fix: use markdown include to fix broken docs (#8913)

### DIFF
--- a/docs/operator-manual/notifications/templates.md
+++ b/docs/operator-manual/notifications/templates.md
@@ -90,4 +90,4 @@ data:
     message: "Author: {{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}"
 ```
 
-{!functions.md!}
+{!docs/operator-manual/notifications/functions.md!}

--- a/docs/operator-manual/notifications/triggers.md
+++ b/docs/operator-manual/notifications/triggers.md
@@ -122,4 +122,4 @@ Example:
 when: time.Now().Sub(time.Parse(app.status.operationState.startedAt)).Minutes() >= 5
 ```
 
-{!functions.md!}
+{!docs/operator-manual/notifications/functions.md!}

--- a/docs/operator-manual/notifications/troubleshooting.md
+++ b/docs/operator-manual/notifications/troubleshooting.md
@@ -72,8 +72,8 @@ kubectl exec -it argocd-notifications-controller-<pod-hash> \
 
 ## Commands
 
-{!troubleshooting-commands.md!}
+{!docs/operator-manual/notifications/troubleshooting-commands.md!}
 
 ## Errors
 
-{!troubleshooting-errors.md!}
+{!docs/operator-manual/notifications/troubleshooting-errors.md!}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ google_analytics:
 - UA-105170809-2
 - auto
 markdown_extensions:
+- markdown_include.include
 - codehilite
 - admonition
 - toc:


### PR DESCRIPTION
Fixes #8913

For some reason `markdown_include` was in requirements.txt but was never actually used.