### PR TITLE
fix: high number of cluster sharding collisions

### DIFF
--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -26,7 +26,7 @@ func InferShard() (int, error) {
 	return shard, nil
 }
 
-// GetShardByID calculates cluster shard as `clusterSecret.UID % replicas count`
+// GetShardByID calculates cluster shard as `shardNumber % replicas count`
 func GetShardByID(id string, replicas int) int {
 	if id == "" {
 		return 0
@@ -45,7 +45,7 @@ func GetClusterFilter(replicas int, shard int) func(c *v1alpha1.Cluster) bool {
 			if c.Shard != nil {
 				clusterShard = int(*c.Shard)
 			} else {
-				clusterShard = GetShardByID(c.ID, replicas)
+				clusterShard = GetShardByID(strconv.Itoa(shard), replicas)
 			}
 		}
 		return clusterShard == shard


### PR DESCRIPTION
We have 2 clusters & 2 applications controller. It seems like the sharding put both clusters in argocd-application-controller-1 & none in argocd-application-0.

By using the code & testing with our secret cluster ID, we found that the algorithm generated both `1` for the 2 clusters instead of spreading them. It seems easier to just use the shard number instead of a secret cluster ID that could have a high risk of collision (lots of different values, but modulo is very short, 2 in our case).


How to reproduce? Quick extract (based on the code):

```go
package main

import (
	"fmt"
	"hash/fnv"
)

func main() {
	replicas := 2
	idSecret1 := "11ddd915-9d42-4bd3-83dd-1e922087720a"
	idSecret2 := "f605b122-034f-4f4d-8fe4-eadddfaa4905"
	h := fnv.New64a()
	_, _ = h.Write([]byte(idSecret1))
	h2 := fnv.New64a()
	_, _ = h.Write([]byte(idSecret2))
	fmt.Println("shard 1: %d", int(h.Sum64()%uint64(replicas)))
	fmt.Println("shard 2: %d", int(h2.Sum64()%uint64(replicas)))
}
```

The shard ID is also what is present in the [tests](https://github.com/argoproj/argo-cd/blob/master/controller/sharding/sharding_test.go#L25)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

