### PR TITLE
fix: improve timeout.reconciliation error handling

### DIFF
--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -63,7 +63,7 @@ performance. For performance reasons controller monitors and caches only preferr
 preferred version into a version of the resource stored in Git. If `kubectl convert` fails because conversion is not supported then controller falls back to Kubernetes API query which slows down
 reconciliation. In this case advice user-preferred resource version in Git.
 
-* The controller polls Git every 3m by default. You can increase this duration using `timeout.reconciliation` setting in the `argocd-cm` ConfigMap.
+* The controller polls Git every 3m by default. You can increase this duration using `timeout.reconciliation` setting in the `argocd-cm` ConfigMap. The value of `timeout.reconciliation` is a duration string e.g `60s`, `1m`, `1h` or `1d`.
 
 * If the controller is managing too many clusters and uses too much memory then you can shard clusters across multiple
 controller replicas. To enable sharding increase the number of replicas in `argocd-application-controller` `StatefulSet`

--- a/docs/operator-manual/upgrading/2.0-2.1.md
+++ b/docs/operator-manual/upgrading/2.0-2.1.md
@@ -9,7 +9,7 @@ For example flag name `load_restrictor` is changed in Kustomize v4+. It is chang
 
 The`--app-resync` flag allows controlling how frequently Argo CD application controller checks resolve the target
 application revision of each application. In order to allow caching resolved revision per repository as opposed to per
-application, the `--app-resync` flag has been deprecated. Please use `timeout.reconciliation` setting in `argocd-cm` ConfigMap instead.
+application, the `--app-resync` flag has been deprecated. Please use `timeout.reconciliation` setting in `argocd-cm` ConfigMap instead. The value of `timeout.reconciliation` is a duration string e.g `60s`, `1m`, `1h` or `1d`.
 See example in [argocd-cm.yaml](../argocd-cm.yaml).
 
 From here on you can follow the [regular upgrade process](./overview.md).

--- a/util/env/env.go
+++ b/util/env/env.go
@@ -103,7 +103,7 @@ func ParseDurationFromEnv(env string, defaultValue, min, max time.Duration) time
 	}
 	durPtr, err := timeutil.ParseDuration(str)
 	if err != nil {
-		log.Warnf("Could not parse '%s' as a number from environment %s", str, env)
+		log.Warnf("Could not parse '%s' as a duration string from environment %s", str, env)
 		return defaultValue
 	}
 


### PR DESCRIPTION
- Improve error handling of invalid input for `timeout.reconciliation`.
- Update docs for expected format of `timeout.reconciliation`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

