### PR TITLE
fix: applicationset, return revision from getGitGeneratorInfo

### DIFF
--- a/applicationset/utils/testdata/github-commit-branch-event.json 
+++ b/applicationset/utils/testdata/github-commit-branch-event.json 
@@ -1,0 +1,186 @@
+{
+    "ref": "refs/heads/master",
+    "before": "d5c1ffa8e294bc18c639bfb4e0df499251034414",
+    "after": "63738bb582c8b540af7bcfc18f87c575c3ed66e0",
+    "created": false,
+    "deleted": false,
+    "forced": true,
+    "base_ref": null,
+    "compare": "https://github.com/org/repo/compare/d5c1ffa8e294...63738bb582c8",
+    "commits": [
+      {
+        "id": "63738bb582c8b540af7bcfc18f87c575c3ed66e0",
+        "tree_id": "64897da445207e409ad05af93b1f349ad0a4ee19",
+        "distinct": true,
+        "message": "Add staging-argocd-demo environment",
+        "timestamp": "2018-05-04T15:40:02-07:00",
+        "url": "https://github.com/org/repo/commit/63738bb582c8b540af7bcfc18f87c575c3ed66e0",
+        "author": {
+          "name": "Jesse Suen",
+          "email": "Jesse_Suen@example.com",
+          "username": "org"
+        },
+        "committer": {
+          "name": "Jesse Suen",
+          "email": "Jesse_Suen@example.com",
+          "username": "org"
+        },
+        "added": [
+          "ksapps/test-app/environments/staging-argocd-demo/main.jsonnet",
+          "ksapps/test-app/environments/staging-argocd-demo/params.libsonnet"
+        ],
+        "removed": [
+  
+        ],
+        "modified": [
+          "ksapps/test-app/app.yaml"
+        ]
+      }
+    ],
+    "head_commit": {
+      "id": "63738bb582c8b540af7bcfc18f87c575c3ed66e0",
+      "tree_id": "64897da445207e409ad05af93b1f349ad0a4ee19",
+      "distinct": true,
+      "message": "Add staging-argocd-demo environment",
+      "timestamp": "2018-05-04T15:40:02-07:00",
+      "url": "https://github.com/org/repo/commit/63738bb582c8b540af7bcfc18f87c575c3ed66e0",
+      "author": {
+        "name": "Jesse Suen",
+        "email": "Jesse_Suen@example.com",
+        "username": "org"
+      },
+      "committer": {
+        "name": "Jesse Suen",
+        "email": "Jesse_Suen@example.com",
+        "username": "org"
+      },
+      "added": [
+        "ksapps/test-app/environments/staging-argocd-demo/main.jsonnet",
+        "ksapps/test-app/environments/staging-argocd-demo/params.libsonnet"
+      ],
+      "removed": [
+  
+      ],
+      "modified": [
+        "ksapps/test-app/app.yaml"
+      ]
+    },
+    "repository": {
+      "id": 123060978,
+      "name": "repo",
+      "full_name": "org/repo",
+      "owner": {
+        "name": "org",
+        "email": "org@users.noreply.github.com",
+        "login": "org",
+        "id": 12677113,
+        "avatar_url": "https://avatars0.githubusercontent.com/u/12677113?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/org",
+        "html_url": "https://github.com/org",
+        "followers_url": "https://api.github.com/users/org/followers",
+        "following_url": "https://api.github.com/users/org/following{/other_user}",
+        "gists_url": "https://api.github.com/users/org/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/org/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/org/subscriptions",
+        "organizations_url": "https://api.github.com/users/org/orgs",
+        "repos_url": "https://api.github.com/users/org/repos",
+        "events_url": "https://api.github.com/users/org/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/org/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "private": false,
+      "html_url": "https://github.com/org/repo",
+      "description": "Test Repository",
+      "fork": false,
+      "url": "https://github.com/org/repo",
+      "forks_url": "https://api.github.com/repos/org/repo/forks",
+      "keys_url": "https://api.github.com/repos/org/repo/keys{/key_id}",
+      "collaborators_url": "https://api.github.com/repos/org/repo/collaborators{/collaborator}",
+      "teams_url": "https://api.github.com/repos/org/repo/teams",
+      "hooks_url": "https://api.github.com/repos/org/repo/hooks",
+      "issue_events_url": "https://api.github.com/repos/org/repo/issues/events{/number}",
+      "events_url": "https://api.github.com/repos/org/repo/events",
+      "assignees_url": "https://api.github.com/repos/org/repo/assignees{/user}",
+      "branches_url": "https://api.github.com/repos/org/repo/branches{/branch}",
+      "tags_url": "https://api.github.com/repos/org/repo/tags",
+      "blobs_url": "https://api.github.com/repos/org/repo/git/blobs{/sha}",
+      "git_tags_url": "https://api.github.com/repos/org/repo/git/tags{/sha}",
+      "git_refs_url": "https://api.github.com/repos/org/repo/git/refs{/sha}",
+      "trees_url": "https://api.github.com/repos/org/repo/git/trees{/sha}",
+      "statuses_url": "https://api.github.com/repos/org/repo/statuses/{sha}",
+      "languages_url": "https://api.github.com/repos/org/repo/languages",
+      "stargazers_url": "https://api.github.com/repos/org/repo/stargazers",
+      "contributors_url": "https://api.github.com/repos/org/repo/contributors",
+      "subscribers_url": "https://api.github.com/repos/org/repo/subscribers",
+      "subscription_url": "https://api.github.com/repos/org/repo/subscription",
+      "commits_url": "https://api.github.com/repos/org/repo/commits{/sha}",
+      "git_commits_url": "https://api.github.com/repos/org/repo/git/commits{/sha}",
+      "comments_url": "https://api.github.com/repos/org/repo/comments{/number}",
+      "issue_comment_url": "https://api.github.com/repos/org/repo/issues/comments{/number}",
+      "contents_url": "https://api.github.com/repos/org/repo/contents/{+path}",
+      "compare_url": "https://api.github.com/repos/org/repo/compare/{base}...{head}",
+      "merges_url": "https://api.github.com/repos/org/repo/merges",
+      "archive_url": "https://api.github.com/repos/org/repo/{archive_format}{/ref}",
+      "downloads_url": "https://api.github.com/repos/org/repo/downloads",
+      "issues_url": "https://api.github.com/repos/org/repo/issues{/number}",
+      "pulls_url": "https://api.github.com/repos/org/repo/pulls{/number}",
+      "milestones_url": "https://api.github.com/repos/org/repo/milestones{/number}",
+      "notifications_url": "https://api.github.com/repos/org/repo/notifications{?since,all,participating}",
+      "labels_url": "https://api.github.com/repos/org/repo/labels{/name}",
+      "releases_url": "https://api.github.com/repos/org/repo/releases{/id}",
+      "deployments_url": "https://api.github.com/repos/org/repo/deployments",
+      "created_at": 1519698615,
+      "updated_at": "2018-05-04T22:37:55Z",
+      "pushed_at": 1525473610,
+      "git_url": "git://github.com/org/repo.git",
+      "ssh_url": "git@github.com:org/repo.git",
+      "clone_url": "https://github.com/org/repo.git",
+      "svn_url": "https://github.com/org/repo",
+      "homepage": null,
+      "size": 538,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "language": null,
+      "has_issues": true,
+      "has_projects": true,
+      "has_downloads": true,
+      "has_wiki": true,
+      "has_pages": false,
+      "forks_count": 1,
+      "mirror_url": null,
+      "archived": false,
+      "open_issues_count": 0,
+      "license": null,
+      "forks": 1,
+      "open_issues": 0,
+      "watchers": 0,
+      "default_branch": "main",
+      "stargazers": 0,
+      "master_branch": "main"
+    },
+    "pusher": {
+      "name": "org",
+      "email": "org@users.noreply.github.com"
+    },
+    "sender": {
+      "login": "org",
+      "id": 12677113,
+      "avatar_url": "https://avatars0.githubusercontent.com/u/12677113?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/org",
+      "html_url": "https://github.com/org",
+      "followers_url": "https://api.github.com/users/org/followers",
+      "following_url": "https://api.github.com/users/org/following{/other_user}",
+      "gists_url": "https://api.github.com/users/org/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/org/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/org/subscriptions",
+      "organizations_url": "https://api.github.com/users/org/orgs",
+      "repos_url": "https://api.github.com/users/org/repos",
+      "events_url": "https://api.github.com/users/org/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/org/received_events",
+      "type": "User",
+      "site_admin": false
+    }
+  }

--- a/applicationset/utils/webhook.go
+++ b/applicationset/utils/webhook.go
@@ -170,6 +170,7 @@ func getGitGeneratorInfo(payload interface{}) *gitGeneratorInfo {
 	return &gitGeneratorInfo{
 		RepoRegexp:  repoRegexp,
 		TouchedHead: touchedHead,
+		Revision:    revision,
 	}
 }
 

--- a/applicationset/utils/webhook_test.go
+++ b/applicationset/utils/webhook_test.go
@@ -44,6 +44,15 @@ func TestWebhookHandler(t *testing.T) {
 			expectedRefresh:    true,
 		},
 		{
+			desc:               "WebHook from a GitHub repository via Commit to branch",
+			headerKey:          "X-GitHub-Event",
+			headerValue:        "push",
+			payloadFile:        "github-commit-branch-event.json",
+			effectedAppSets:    []string{"git-github"},
+			expectedStatusCode: http.StatusOK,
+			expectedRefresh:    true,
+		},
+		{
 			desc:               "WebHook from a GitLab repository via Commit",
 			headerKey:          "X-Gitlab-Event",
 			headerValue:        "Push Hook",
@@ -159,7 +168,8 @@ func fakeAppWithGitGenerator(name, namespace, repo string) *argoprojiov1alpha1.A
 			Generators: []argoprojiov1alpha1.ApplicationSetGenerator{
 				{
 					Git: &argoprojiov1alpha1.GitGenerator{
-						RepoURL: repo,
+						RepoURL:  repo,
+						Revision: "master",
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: rishabh625 <rishabhmishra625@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

This PR is moved from [here](https://github.com/argoproj/applicationset/pull/520)
