### PR TITLE
feat!: remove rbac when using argocd cluster rm (#8958)

### DIFF
--- a/cmd/argocd/commands/cluster_test.go
+++ b/cmd/argocd/commands/cluster_test.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func Test_getQueryBySelector(t *testing.T) {
@@ -43,4 +45,64 @@ func Test_printClusterTable(t *testing.T) {
 			ServerVersion: "my-version",
 		},
 	})
+}
+
+func Test_getRestConfig(t *testing.T) {
+	type args struct {
+		pathOpts *clientcmd.PathOptions
+		ctxName  string
+	}
+	pathOpts := &clientcmd.PathOptions{
+		GlobalFile:   "./testdata/config",
+		LoadingRules: clientcmd.NewDefaultClientConfigLoadingRules(),
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expected    *rest.Config
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			"Load config for context successfully",
+			args{
+				pathOpts,
+				"argocd2.example.com:443",
+			},
+			&rest.Config{Host: "argocd2.example.com:443"},
+			false,
+			"",
+		},
+		{
+			"Load config for current-context successfully",
+			args{
+				pathOpts,
+				"localhost:8080",
+			},
+			&rest.Config{Host: "localhost:8080"},
+			false,
+			"",
+		},
+		{
+			"Context not found",
+			args{
+				pathOpts,
+				"not-exist",
+			},
+			nil,
+			true,
+			"Context not-exist does not exist in kubeconfig",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := getRestConfig(tt.args.pathOpts, tt.args.ctxName); err == nil {
+				require.Equal(t, got, tt.expected)
+			} else if tt.wantErr {
+				require.Equal(t, err.Error(), tt.expectedErr)
+			} else {
+				t.Errorf("An unexpected error occurred during test %s:\n%s", tt.name, err.Error())
+			}
+		})
+	}
 }

--- a/cmd/argocd/commands/testdata/config
+++ b/cmd/argocd/commands/testdata/config
@@ -1,25 +1,31 @@
-contexts:
-- name: argocd1.example.com:443
-  server: argocd1.example.com:443
-  user: argocd1.example.com:443
-- name: argocd2.example.com:443
-  server: argocd2.example.com:443
-  user: argocd2.example.com:443
-- name: localhost:8080
-  server: localhost:8080
-  user: localhost:8080
-current-context: localhost:8080
-servers:
-- server: argocd1.example.com:443
-- server: argocd2.example.com:443
-- plain-text: true
-  server: localhost:8080
-users:
-- auth-token: vErrYS3c3tReFRe$hToken
+clusters:
+- cluster:
+    server: argocd1.example.com:443
   name: argocd1.example.com:443
-  refresh-token: vErrYS3c3tReFRe$hToken
-- auth-token: vErrYS3c3tReFRe$hToken
+- cluster:
+    server: argocd2.example.com:443
   name: argocd2.example.com:443
-  refresh-token: vErrYS3c3tReFRe$hToken
-- auth-token: vErrYS3c3tReFRe$hToken
+- cluster:
+    server: localhost:8080
   name: localhost:8080
+contexts:
+- context:
+    server: argocd1.example.com:443
+    user: argocd1.example.com:443
+    cluster: argocd1.example.com:443
+  name: argocd1.example.com:443
+- context:
+    server: argocd2.example.com:443
+    user: argocd2.example.com:443
+    cluster: argocd2.example.com:443
+  name: argocd2.example.com:443
+- context:
+    server: localhost:8080
+    user: localhost:8080
+    cluster: localhost:8080
+  name: localhost:8080
+current-context: localhost:8080
+users:
+- name:  argocd1.example.com:443
+- name:  argocd2.example.com:443
+- name:  localhost:8080

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -197,6 +197,11 @@ func TestClusterDeleteDenied(t *testing.T) {
 				Action:   "create",
 				Scope:    ProjectName + "/*",
 			},
+			{
+				Resource: "clusters",
+				Action:   "get",
+				Scope:    ProjectName + "/*",
+			},
 		}, "org-admin")
 
 	// Attempt to remove cluster creds by name
@@ -226,4 +231,76 @@ func TestClusterDeleteDenied(t *testing.T) {
 		AndCLIOutput(func(output string, err error) {
 			assert.True(t, strings.Contains(err.Error(), "PermissionDenied desc = permission denied: clusters, delete"))
 		})
+}
+
+func TestClusterDelete(t *testing.T) {
+	accountFixture.Given(t).
+		Name("default").
+		When().
+		Create().
+		Login().
+		SetPermissions([]fixture.ACL{
+			{
+				Resource: "clusters",
+				Action:   "create",
+				Scope:    ProjectName + "/*",
+			},
+			{
+				Resource: "clusters",
+				Action:   "get",
+				Scope:    ProjectName + "/*",
+			},
+			{
+				Resource: "clusters",
+				Action:   "delete",
+				Scope:    ProjectName + "/*",
+			},
+		}, "org-admin")
+
+	clstAction := clusterFixture.
+		GivenWithSameState(t).
+		Name("default").
+		Project(ProjectName).
+		Upsert(true).
+		Server(KubernetesInternalAPIServerAddr).
+		When().
+		CreateWithRBAC()
+
+	// Check that RBAC is created
+	_, err := fixture.Run("", "kubectl", "get", "serviceaccount", "argocd-manager", "-n", "kube-system")
+	if err != nil {
+		t.Errorf("Expected no error from not finding serviceaccount argocd-manager but got:\n%s", err.Error())
+	}
+
+	_, err = fixture.Run("", "kubectl", "get", "clusterrole", "argocd-manager-role")
+	if err != nil {
+		t.Errorf("Expected no error from not finding clusterrole argocd-manager-role but got:\n%s", err.Error())
+	}
+
+	_, err = fixture.Run("", "kubectl", "get", "clusterrolebinding", "argocd-manager-role-binding")
+	if err != nil {
+		t.Errorf("Expected no error from not finding clusterrole argocd-manager-role but got:\n%s", err.Error())
+	}
+
+	clstAction.DeleteByName().
+		Then().
+		AndCLIOutput(func(output string, err error) {
+			assert.Equal(t, "Cluster 'default' removed", output)
+		})
+
+	// Check that RBAC is removed after delete
+	output, err := fixture.Run("", "kubectl", "get", "serviceaccount", "argocd-manager", "-n", "kube-system")
+	if err == nil {
+		t.Errorf("Expected error from not finding serviceaccount argocd-manager but got:\n%s", output)
+	}
+
+	output, err = fixture.Run("", "kubectl", "get", "clusterrole", "argocd-manager-role")
+	if err == nil {
+		t.Errorf("Expected error from not finding clusterrole argocd-manager-role but got:\n%s", output)
+	}
+
+	output, err = fixture.Run("", "kubectl", "get", "clusterrolebinding", "argocd-manager-role-binding")
+	if err == nil {
+		t.Errorf("Expected error from not finding clusterrole argocd-manager-role but got:\n%s", output)
+	}
 }

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -24,7 +24,7 @@ func (c *Consequences) Expect(e Expectation) *Consequences {
 	c.context.t.Helper()
 	var message string
 	var state state
-	timeout := time.Duration(15) * time.Second
+	timeout := time.Duration(30) * time.Second
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(3 * time.Second) {
 		state, message = e(c)
 		switch state {

--- a/test/e2e/fixture/cluster/actions.go
+++ b/test/e2e/fixture/cluster/actions.go
@@ -7,6 +7,9 @@ import (
 	"log"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/clusterauth"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	clusterpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/cluster"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
@@ -61,6 +64,30 @@ func (a *Actions) Create(args ...string) *Actions {
 	}
 
 	return a
+}
+
+func (a *Actions) CreateWithRBAC(args ...string) *Actions {
+	pathOpts := clientcmd.NewDefaultPathOptions()
+	config, err := pathOpts.GetStartingConfig()
+	if err != nil {
+		a.lastError = err
+		return a
+	}
+	clientConfig := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{})
+	conf, err := clientConfig.ClientConfig()
+	if err != nil {
+		a.lastError = err
+		return a
+	}
+	client := kubernetes.NewForConfigOrDie(conf)
+
+	_, err = clusterauth.InstallClusterManagerRBAC(client, "kube-system", []string{})
+	if err != nil {
+		a.lastError = err
+		return a
+	}
+
+	return a.Create()
 }
 
 func (a *Actions) List() *Actions {


### PR DESCRIPTION
Closes #8958 

This change will remove rbac used by Argo CD for creating resources on external clusters once the cluster is removed. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

