### PR TITLE
fix: allow cli/ui to follow logs

### DIFF
--- a/pkg/apis/application/v1alpha1/cluster_constants.go
+++ b/pkg/apis/application/v1alpha1/cluster_constants.go
@@ -48,17 +48,17 @@ var (
 	K8sMaxIdleConnections = env.ParseNumFromEnv(EnvK8sClientMaxIdleConnections, 500, 0, math.MaxInt32)
 
 	// K8sTLSHandshakeTimeout defines the maximum duration to wait for a TLS handshake to complete
-	K8sTLSHandshakeTimeout = env.ParseDurationFromEnv(EnvK8sTLSHandshakeTimeout, 10*time.Second, 0, math.MaxInt32)
+	K8sTLSHandshakeTimeout = env.ParseDurationFromEnv(EnvK8sTLSHandshakeTimeout, 10*time.Second, 0, math.MaxInt32*time.Second)
 
 	// K8sTCPTimeout defines the TCP timeout to use when performing K8s API requests
-	K8sTCPTimeout = env.ParseDurationFromEnv(EnvK8sTCPTimeout, 30*time.Second, 0, math.MaxInt32)
+	K8sTCPTimeout = env.ParseDurationFromEnv(EnvK8sTCPTimeout, 30*time.Second, 0, math.MaxInt32*time.Second)
 
 	// K8sTCPKeepAlive defines the interval for sending TCP keep alive to K8s API server
-	K8sTCPKeepAlive = env.ParseDurationFromEnv(EnvK8sTCPKeepAlive, 30*time.Second, 0, math.MaxInt32)
+	K8sTCPKeepAlive = env.ParseDurationFromEnv(EnvK8sTCPKeepAlive, 30*time.Second, 0, math.MaxInt32*time.Second)
 
 	// K8sTCPIdleConnTimeout defines the duration for keeping idle TCP connections to the K8s API server
-	K8sTCPIdleConnTimeout = env.ParseDurationFromEnv(EnvK8sTCPIdleConnTimeout, 5*time.Minute, 0, math.MaxInt32)
+	K8sTCPIdleConnTimeout = env.ParseDurationFromEnv(EnvK8sTCPIdleConnTimeout, 5*time.Minute, 0, math.MaxInt32*time.Second)
 
 	// K8sServerSideTimeout defines which server side timeout to send with each API request
-	K8sServerSideTimeout = env.ParseDurationFromEnv(EnvK8sTCPTimeout, 32*time.Second, 0, math.MaxInt32)
+	K8sServerSideTimeout = env.ParseDurationFromEnv(EnvK8sTCPTimeout, 0, 0, math.MaxInt32*time.Second)
 )


### PR DESCRIPTION
Closes #8947 

#8404 introduced a new environment var (`ARGOCD_K8S_TCP_TIMEOUT`) with a default of 32 seconds. This is causing requests for logs with `follow` configured to be timed out. Maybe the default should be no timeout and should be explicitly configured by the user if requested. 

For any user looking to configure these values, we should consider including these logging considerations in documentation for these env vars. There is an issue open for documenting these vars: #8527.

Additionally, the `max` param for using `env.ParseDurationFromEnv` func is being passed as arg math.MaxInt32, which is converted to `2.147483647s` as a time.Duration. This then only allows users to configure a value between 0 and 2.147483647s. This pr also updates parse duration funcs using math.MaxInt32 as a max to math.MaxInt32*time.Second to fix this issue.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

