### PR TITLE
chore: setup go 1.17 before lint

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           version: v1.38.0
           args: --timeout 10m --exclude SA5011
+          skip-go-installation: true  # Because we need a specific version
 
   test-go:
     name: Run unit tests for Go packages

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -60,6 +60,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:


### PR DESCRIPTION
golangci-lint has an implicit step to install golang. This morning it started installing golang 1.18 instead of 1.17. 

This change disables the implicit install step and explicitly installs whatever version of go we're currently targetting.