### PR TITLE
feat: Exposing Default Metric Port for ApplicationSet Controller in Manifest Files. #8999

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -202,3 +202,4 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Yubo](https://www.yubo.live/)
 1. [Zimpler](https://www.zimpler.com/)
 1. [ZOZO](https://corp.zozo.com/)
+1. [Trendyol](https://www.trendyol.com/)

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -131,6 +131,21 @@ spec:
   - port: metrics
 ```
 
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-applicationset-controller-metrics
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-applicationset-controller
+  endpoints:
+  - port: metrics
+```
+
 ## Dashboards
 
 You can find an example Grafana dashboard [here](https://github.com/argoproj/argo-cd/blob/master/examples/dashboard.json) or check demo instance

--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
@@ -25,6 +25,8 @@ spec:
           ports:
           - containerPort: 7000
             name: webhook
+          - containerPort: 8080
+            name: metrics
           env:
             - name: NAMESPACE
               valueFrom:

--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-service.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-service.yaml
@@ -12,5 +12,9 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -8921,6 +8921,10 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -9010,6 +9014,8 @@ spec:
         ports:
         - containerPort: 7000
           name: webhook
+        - containerPort: 8080
+          name: metrics
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9675,6 +9675,10 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -9947,6 +9951,8 @@ spec:
         ports:
         - containerPort: 7000
           name: webhook
+        - containerPort: 8080
+          name: metrics
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -962,6 +962,10 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -1234,6 +1238,8 @@ spec:
         ports:
         - containerPort: 7000
           name: webhook
+        - containerPort: 8080
+          name: metrics
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9150,6 +9150,10 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -9317,6 +9321,8 @@ spec:
         ports:
         - containerPort: 7000
           name: webhook
+        - containerPort: 8080
+          name: metrics
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -437,6 +437,10 @@ spec:
     port: 7000
     protocol: TCP
     targetPort: webhook
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-applicationset-controller
 ---
@@ -604,6 +608,8 @@ spec:
         ports:
         - containerPort: 7000
           name: webhook
+        - containerPort: 8080
+          name: metrics
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts


### PR DESCRIPTION
Fixes #8999

Out of the box, Applicationset presents some controller-runtime metrics on port 8080. However, the metric port is not defined as a container port in manifest files, therefore, they are not accessible. This
commit aims to make it accessible.

Co-authored-by: Erkan Zileli <erkan.zileli@trendyol.com>
Signed-off-by: Celal Öner <celal.oner@trendyol.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

