### PR TITLE
chore: upgrade moment to latest version to fix CVE

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -24,9 +24,9 @@
     "json-merge-patch": "^0.2.3",
     "lodash-es": "^4.17.21",
     "minimatch": "^3.0.4",
-    "moment": "^2.24.0",
+    "moment": "^2.29.2",
     "monaco-editor": "^0.27.0",
-    "path": "^0.12.7" ,
+    "path": "^0.12.7",
     "prop-types": "^15.6.0",
     "react": "^16.9.3",
     "react-autocomplete": "^1.8.1",
@@ -91,11 +91,11 @@
     "jest-junit": "^6.4.0",
     "jest-transform-css": "^2.0.0",
     "monaco-editor-webpack-plugin": "^6.0.0",
-    "sass": "^1.49.9",
     "postcss": "^8.2.13",
     "prettier": "1.19",
     "raw-loader": "^0.5.1",
     "react-test-renderer": "16.8.3",
+    "sass": "^1.49.9",
     "sass-loader": "^12.6.0",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.20.1",
@@ -108,8 +108,8 @@
     "tslint-react": "^3.4.0",
     "typescript": "^4.0.3",
     "webpack": "^5.70.0",
-    "yarn": "^1.22.10",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.7.4"
+    "webpack-dev-server": "^4.7.4",
+    "yarn": "^1.22.10"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6320,6 +6320,11 @@ moment-timezone@^0.5.33:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+moment@^2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+
 monaco-editor-webpack-plugin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-6.0.0.tgz#628956ce1851afa2a5f6c88d0ecbb24e9a444898"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR upgrades `moment` to latest version and fixes https://security.snyk.io/vuln/SNYK-JS-MOMENT-2440688 . Argo CD is not really affected since `moment` is used only on client side but good to fix it since it fails CI.