### PR TITLE
chore: ignore irrelevant moment vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -14,5 +14,9 @@ ignore:
     - 'manifests/install.yaml > *':
         reason: >-
           Argo CD needs wide permissions to manage resources.
+  SNYK-JS-MOMENT-2440688:
+    - '*':
+        reason: >-
+          Code is only run client-side. No rusk of directory traversal.
 patch: {}
 

--- a/.snyk
+++ b/.snyk
@@ -17,6 +17,6 @@ ignore:
   SNYK-JS-MOMENT-2440688:
     - '*':
         reason: >-
-          Code is only run client-side. No rusk of directory traversal.
+          Code is only run client-side. No risk of directory traversal.
 patch: {}
 


### PR DESCRIPTION
Transient dependencies prevent us from simply upgrading past this issue.

I've verified that this ignore rule works by running this locally:

```sh
snyk test --org=argoproj --all-projects --exclude=docs,site --severity-threshold=high --policy-path=.snyk
```