### PR TITLE
chore: make timeout configurable for Expect func

### DIFF
--- a/test/e2e/custom_tool_test.go
+++ b/test/e2e/custom_tool_test.go
@@ -116,6 +116,7 @@ func TestCustomToolWithSSHGitCreds(t *testing.T) {
 		CreateApp().
 		Sync().
 		Then().
+		Timeout(30).
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -326,7 +326,7 @@ func (a *Actions) And(block func()) *Actions {
 
 func (a *Actions) Then() *Consequences {
 	a.context.t.Helper()
-	return &Consequences{a.context, a}
+	return &Consequences{a.context, a, 15}
 }
 
 func (a *Actions) runCli(args ...string) {

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -17,6 +17,7 @@ import (
 type Consequences struct {
 	context *Context
 	actions *Actions
+	timeout int
 }
 
 func (c *Consequences) Expect(e Expectation) *Consequences {
@@ -24,7 +25,7 @@ func (c *Consequences) Expect(e Expectation) *Consequences {
 	c.context.t.Helper()
 	var message string
 	var state state
-	timeout := time.Duration(15) * time.Second
+	timeout := time.Duration(c.timeout) * time.Second
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(3 * time.Second) {
 		state, message = e(c)
 		switch state {
@@ -83,4 +84,9 @@ func (c *Consequences) resource(kind, name, namespace string) ResourceStatus {
 			Message: "not found",
 		},
 	}
+}
+
+func (c *Consequences) Timeout(timeout int) *Consequences {
+	c.timeout = timeout
+	return c
 }


### PR DESCRIPTION
This was motivated by the TestCustomToolWithSSHGitCreds being flakey with timeouts. Open to suggestion on timeout for test. Choice of 30s was arbitrary. 

See the following test failure logs:
* https://github.com/argoproj/argo-cd/runs/5952025679?check_suite_focus=true
* https://github.com/argoproj/argo-cd/runs/5951901836?check_suite_focus=true
* https://github.com/argoproj/argo-cd/runs/5893419995?check_suite_focus=true

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

