### PR TITLE
fix: add permission check to argocd-cli

### DIFF
--- a/cmd/argocd/commands/context_test.go
+++ b/cmd/argocd/commands/context_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/argoproj/argo-cd/v2/util/localconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testConfig = `contexts:
@@ -44,6 +44,8 @@ func TestContextDelete(t *testing.T) {
 	err := ioutil.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	assert.NoError(t, err)
 
+	err = os.Chmod(testConfigFilePath, 0600)
+	require.NoError(t, err, "Could not change the file permission to 0600 %v", err)
 	localConfig, err := localconfig.ReadLocalConfig(testConfigFilePath)
 	assert.NoError(t, err)
 	assert.Equal(t, localConfig.CurrentContext, "localhost:8080")

--- a/util/localconfig/localconfig_test.go
+++ b/util/localconfig/localconfig_test.go
@@ -1,6 +1,11 @@
 package localconfig
 
 import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,4 +15,77 @@ func TestGetUsername(t *testing.T) {
 	assert.Equal(t, "admin", GetUsername("admin:login"))
 	assert.Equal(t, "admin", GetUsername("admin"))
 	assert.Equal(t, "", GetUsername(""))
+}
+
+func TestFilePermission(t *testing.T) {
+	dirPath := "testfolder/"
+
+	err := os.MkdirAll(path.Dir(dirPath), 0700)
+	require.NoError(t, err, "Could not create argocd folder with 0700 permission: %v", err)
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(dirPath)
+		require.NoError(t, err, "Could not remove directory")
+
+	})
+
+	for _, c := range []struct {
+		name          string
+		testfile      string
+		perm          os.FileMode
+		expectedError error
+	}{
+		{
+			name:          "Test config file with permission 0700",
+			testfile:      ".config_0700",
+			perm:          0700,
+			expectedError: fmt.Errorf("config file has incorrect permission flags:-rwx------.change the file permission either to 0400 or 0600."),
+		},
+		{
+			name:          "Test config file with permission 0777",
+			testfile:      ".config_0777",
+			perm:          0777,
+			expectedError: fmt.Errorf("config file has incorrect permission flags:-rwxrwxrwx.change the file permission either to 0400 or 0600."),
+		},
+		{
+			name:          "Test config file with permission 0600",
+			testfile:      ".config_0600",
+			perm:          0600,
+			expectedError: nil,
+		},
+		{
+			name:          "Test config file with permission 0400",
+			testfile:      ".config_0400",
+			perm:          0400,
+			expectedError: nil,
+		},
+		{
+			name:          "Test config file with permission 0300",
+			testfile:      ".config_0300",
+			perm:          0300,
+			expectedError: fmt.Errorf("config file has incorrect permission flags:--wx------.change the file permission either to 0400 or 0600."),
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+
+			filePath := filepath.Join(dirPath, c.testfile)
+
+			f, err := os.Create(filePath)
+			require.NoError(t, err, "Could not write  create config file: %v", err)
+			defer f.Close()
+
+			err = f.Chmod(c.perm)
+			require.NoError(t, err, "Could not change the file permission to %s: %v", c.perm, err)
+
+			fi, err := os.Stat(filePath)
+			require.NoError(t, err, "Could not access the fileinfo: %v", err)
+
+			if err := getFilePermission(fi); err != nil {
+				assert.EqualError(t, err, c.expectedError.Error())
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: [Ashutosh](<mail.ashutosh8@gmail.com>)

This is a fix for https://github.com/argoproj/argo-cd/issues/5780

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

