### PR TITLE
chore: make TestClusterDelete use current context

### DIFF
--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
@@ -234,8 +235,17 @@ func TestClusterDeleteDenied(t *testing.T) {
 }
 
 func TestClusterDelete(t *testing.T) {
+	// Use current context for test.
+	// Needed for RBAC cleanup.
+	pathOpts := clientcmd.NewDefaultPathOptions()
+	config, err := pathOpts.GetStartingConfig()
+	if err != nil {
+		t.Errorf("retrieving context: %v", err)
+	}
+	ctxName := config.CurrentContext
+
 	accountFixture.Given(t).
-		Name("default").
+		Name(ctxName).
 		When().
 		Create().
 		Login().
@@ -259,7 +269,7 @@ func TestClusterDelete(t *testing.T) {
 
 	clstAction := clusterFixture.
 		GivenWithSameState(t).
-		Name("default").
+		Name(ctxName).
 		Project(ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
@@ -267,7 +277,7 @@ func TestClusterDelete(t *testing.T) {
 		CreateWithRBAC()
 
 	// Check that RBAC is created
-	_, err := fixture.Run("", "kubectl", "get", "serviceaccount", "argocd-manager", "-n", "kube-system")
+	_, err = fixture.Run("", "kubectl", "get", "serviceaccount", "argocd-manager", "-n", "kube-system")
 	if err != nil {
 		t.Errorf("Expected no error from not finding serviceaccount argocd-manager but got:\n%s", err.Error())
 	}


### PR DESCRIPTION
TestClusterDelete requires use of a context named default, which is specific to k3s. To run this test locally, a user should be able to specify what context to use.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

