### PR TITLE
chore: refactor Dockerfiles to reduce the build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ ARG BASE_IMAGE=docker.io/library/ubuntu:21.10
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM docker.io/library/golang:1.18 as builder
+FROM docker.io/library/golang:1.18 AS builder
 
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     openssh-server \
     nginx \
+    unzip \
     fcgiwrap \
     git \
     git-lfs \
@@ -24,18 +25,17 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /tmp
 
-ADD hack/install.sh .
-ADD hack/installers installers
-ADD hack/tool-versions.sh .
+COPY hack/install.sh hack/tool-versions.sh ./
+COPY hack/installers installers
 
-RUN ./install.sh helm-linux
-RUN INSTALL_PATH=/usr/local/bin ./install.sh kustomize
-RUN ./install.sh awscli-linux
+RUN ./install.sh helm-linux && \
+    INSTALL_PATH=/usr/local/bin ./install.sh kustomize && \
+    ./install.sh awscli-linux
 
 ####################################################################################################
 # Argo CD Base - used as the base for both the release and dev argocd images
 ####################################################################################################
-FROM $BASE_IMAGE as argocd-base
+FROM $BASE_IMAGE AS argocd-base
 
 USER root
 
@@ -48,7 +48,8 @@ RUN groupadd -g 999 argocd && \
     chmod g=u /home/argocd && \
     apt-get update && \
     apt-get dist-upgrade -y && \
-    apt-get install -y git git-lfs tini gpg tzdata && \
+    apt-get install -y \
+    git git-lfs tini gpg tzdata && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -59,19 +60,20 @@ COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=builder /usr/local/aws-cli/v2/current/dist /usr/local/aws-cli/v2/current/dist
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 # keep uid_entrypoint.sh for backward compatibility
-RUN ln -s /usr/local/bin/entrypoint.sh /usr/local/bin/uid_entrypoint.sh
-RUN ln -s /usr/local/aws-cli/v2/current/dist/aws /usr/local/bin/aws
+RUN ln -s /usr/local/bin/entrypoint.sh /usr/local/bin/uid_entrypoint.sh && \
+    ln -s /usr/local/aws-cli/v2/current/dist/aws /usr/local/bin/aws
 
 # support for mounting configuration from a configmap
-RUN mkdir -p /app/config/ssh && \
-    touch /app/config/ssh/ssh_known_hosts && \
-    ln -s /app/config/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts 
+WORKDIR /app/config/ssh
+RUN touch ssh_known_hosts && \
+    ln -s ssh_known_hosts /etc/ssh/ssh_known_hosts 
 
-RUN mkdir -p /app/config/tls
-RUN mkdir -p /app/config/gpg/source && \
-    mkdir -p /app/config/gpg/keys && \
-    chown argocd /app/config/gpg/keys && \
-    chmod 0700 /app/config/gpg/keys
+WORKDIR /app/config
+RUN mkdir -p tls && \
+    mkdir -p gpg/source && \
+    mkdir -p gpg/keys && \
+    chown argocd gpg/keys && \
+    chmod 0700 gpg/keys
 
 ENV USER=argocd
 
@@ -81,14 +83,15 @@ WORKDIR /home/argocd
 ####################################################################################################
 # Argo CD UI stage
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:12.18.4 as argocd-ui
+FROM --platform=$BUILDPLATFORM docker.io/library/node:12.18.4 AS argocd-ui
 
 WORKDIR /src
-ADD ["ui/package.json", "ui/yarn.lock", "./"]
+COPY ["ui/package.json", "ui/yarn.lock", "./"]
 
-RUN yarn install --network-timeout 200000
+RUN yarn install --network-timeout 200000 && \
+    yarn cache clean
 
-ADD ["ui/", "."]
+COPY ["ui/", "."]
 
 ARG ARGO_VERSION=latest
 ENV ARGO_VERSION=$ARGO_VERSION
@@ -97,13 +100,11 @@ RUN HOST_ARCH='amd64' NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTION
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM  docker.io/library/golang:1.18 as argocd-build
+FROM --platform=$BUILDPLATFORM  docker.io/library/golang:1.18 AS argocd-build
 
 WORKDIR /go/src/github.com/argoproj/argo-cd
 
-COPY go.mod go.mod
-COPY go.sum go.sum
-
+COPY go.* ./
 RUN go mod download
 
 # Perform the build
@@ -120,12 +121,12 @@ FROM argocd-base
 COPY --from=argocd-build /go/src/github.com/argoproj/argo-cd/dist/argocd* /usr/local/bin/
 
 USER root
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-repo-server
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-cmp-server
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-application-controller
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-dex
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-notifications
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-applicationset-controller
+RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-repo-server && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-cmp-server && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-application-controller && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-dex && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-notifications && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-applicationset-controller 
 
 USER 999

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,11 +5,11 @@ FROM argocd-base
 COPY argocd /usr/local/bin/
 
 USER root
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-repo-server
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-application-controller
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-dex
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-notifications
-RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-applicationset-controller
+RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-repo-server && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-application-controller && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-dex && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-notifications && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-applicationset-controller
 
 USER 999

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -35,11 +35,8 @@ ENV GOROOT /usr/local/go
 ENV GOPATH /go
 
 # Install build and test dependencies
-ADD ./hack/tool-versions.sh .
-ADD ./hack/install.sh .
-ADD ./hack/installers installers
-ADD go.mod go.mod
-ADD go.sum go.sum
+COPY hack/install.sh hack/tool-versions.sh go.* ./
+COPY hack/installers installers
 
 RUN ./install.sh helm-linux && \
     ./install.sh kubectl-linux && \

--- a/test/remote/Dockerfile
+++ b/test/remote/Dockerfile
@@ -6,7 +6,7 @@ RUN go install github.com/mattn/goreman@latest && \
 FROM ubuntu:21.10
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN  apt-get update && apt-get install -y \
+RUN  apt-get update && apt-get install --no-install-recommends -y \
         ca-certificates \
         curl \
         openssh-server \
@@ -23,7 +23,7 @@ RUN  apt-get update && apt-get install -y \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN mkdir -p /etc/certs
+WORKDIR /etc/certs
 
 # These are required for running end-to-end tests
 COPY ./test/fixture/testrepos/id_rsa.pub /root/.ssh/authorized_keys

--- a/ui-test/Dockerfile
+++ b/ui-test/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:12.18.4 as node
+FROM node:12.18.4 AS node
 
-RUN apt-get update && apt-get install -y \
-    software-properties-common
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    software-properties-common 
 
 #Chrome browser to run the tests
 ARG CHROME_VERSION=86.0.4240.75
@@ -9,7 +9,7 @@ RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add \
     && wget https://www.slimjet.com/chrome/download-chrome.php?file=files%2F$CHROME_VERSION%2Fgoogle-chrome-stable_current_amd64.deb \
     && dpkg -i download-chrome*.deb || true
 
-RUN apt-get install -y -f \
+RUN apt-get install --no-install-recommends -y -f \
     && rm -rf /var/lib/apt/lists/*
 
 #Disable the SUID sandbox so that chrome can launch without being in a privileged container
@@ -20,6 +20,6 @@ RUN dpkg-divert --add --rename --divert /opt/google/chrome/google-chrome.real /o
 WORKDIR /usr/src/app
 COPY package*.json ./
 COPY yarn.lock ./
-RUN yarn install
+RUN yarn install && yarn cache clean
 COPY . .
 


### PR DESCRIPTION
Checklist:

* [c] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

## Summary
I managed to reduce build time by half with those changes. In addition I wanted to make a changes to Dockerfiles that follows the best practices, such as:
* Use **WORKDIR** instead of **RUN mkdir -p**
* Reduce number of layers
* Consolidate multiple **RUN** commands
* Add **yarn cache clean** -> https://github.com/hadolint/hadolint/issues/395
* Change **ADD** with **COPY** since you do not copy any *.tar files -> [nr 7](https://res.cloudinary.com/snyk/image/upload/v1551798390/Docker_Image_Security_Best_Practices_.pdf)
* Add [```--no-install-recommends```](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends)  