### PR TITLE
docs: document Python removal on upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.3.0 (Unreleased)
+## v2.3.0
 
 ### Argo CD ApplicationSet and Notifications are now part of Argo CD
 

--- a/docs/operator-manual/upgrading/2.2-2.3.md
+++ b/docs/operator-manual/upgrading/2.2-2.3.md
@@ -9,9 +9,9 @@ The bundled manifests are drop-in replacements for the previous versions. If you
 remove references to https://github.com/argoproj-labs/argocd-notifications and https://github.com/argoproj-labs/applicationset. No action is required
 if you are using `kubectl apply`.
 
-## Configure Additional ArgoCD Binaries
+## Configure Additional Argo CD Binaries
 
-We have removed non-Linux ArgoCD binaries (Darwin amd64 and Windows amd64) from the image ([#7668](https://github.com/argoproj/argo-cd/pull/7668)) and the associated download buttons in the help page in the UI.
+We have removed non-Linux Argo CD binaries (Darwin amd64 and Windows amd64) from the image ([#7668](https://github.com/argoproj/argo-cd/pull/7668)) and the associated download buttons in the help page in the UI.
 
 Those removed binaries will still be included in the release assets and we made those configurable in [#7755](https://github.com/argoproj/argo-cd/pull/7755). You can add download buttons for other OS architectures by adding the following to your `argocd-cm` ConfigMap:
 
@@ -31,10 +31,15 @@ data:
   help.download.windows-amd64: "path-or-url-to-download"
 ```
 
+## Removed Python from the base image
+
+If you are using a [Config Management Plugin](../../user-guide/config-management-plugins.md) that relies on Python, you
+will need to build a custom image on the Argo CD base to install Python.
+
 ## Upgraded Kustomize Version
 
 Note that bundled Kustomize version has been upgraded from 4.2.0 to 4.4.1.
 
-## Upgrade Helm Version
+## Upgraded Helm Version
 
 Note that bundled Helm version has been upgraded from 3.7.1 to 3.8.0.


### PR DESCRIPTION
Python was removed from the base image in 2.3. We should let folks know, in case their CMP depends on Python.

https://github.com/argoproj/argo-cd/discussions/8939