### PR TITLE
fix: Correctly calculate diffs for CRDs with ignore overrides

### DIFF
--- a/util/argo/diff/ignore.go
+++ b/util/argo/diff/ignore.go
@@ -40,30 +40,34 @@ func NewIgnoreDiffConfig(ignores []v1alpha1.ResourceIgnoreDifferences, overrides
 // will be returned taking precedence over Application specific ignore difference
 // configurations.
 func (i *IgnoreDiffConfig) HasIgnoreDifference(group, kind, name, namespace string) (bool, *IgnoreDifference) {
+	result := &IgnoreDifference{}
+	found := false
 	ro, ok := i.overrides[fmt.Sprintf("%s/%s", group, kind)]
 	if ok {
-		return ok, overrideToIgnoreDifference(ro)
+		mergeIgnoreDifferences(overrideToIgnoreDifference(ro), result)
+		found = true
 	}
 	wildOverride, ok := i.overrides["*/*"]
 	if ok {
-		return ok, overrideToIgnoreDifference(wildOverride)
+		mergeIgnoreDifferences(overrideToIgnoreDifference(wildOverride), result)
+		found = true
 	}
 
-	ignoresFound := []v1alpha1.ResourceIgnoreDifferences{}
 	for _, ignore := range i.ignores {
 		if glob.Match(ignore.Group, group) &&
 			glob.Match(ignore.Kind, kind) &&
 			(ignore.Name == "" || ignore.Name == name) &&
 			(ignore.Namespace == "" || ignore.Namespace == namespace) {
 
-			ignoresFound = append(ignoresFound, ignore)
-
+			mergeIgnoreDifferences(resourceToIgnoreDifference(ignore), result)
+			found = true
 		}
 	}
-	if len(ignoresFound) == 0 {
-		return false, nil
+	if !found {
+		return found, nil
 	}
-	return true, mergeIgnoreDifferences(ignoresFound)
+
+	return found, result
 }
 
 func overrideToIgnoreDifference(override v1alpha1.ResourceOverride) *IgnoreDifference {
@@ -74,14 +78,39 @@ func overrideToIgnoreDifference(override v1alpha1.ResourceOverride) *IgnoreDiffe
 	}
 }
 
-// mergeIgnoreDifferences will merge all ignore differences configurations found for
-// a specific resource.
-func mergeIgnoreDifferences(ignores []v1alpha1.ResourceIgnoreDifferences) *IgnoreDifference {
-	result := &IgnoreDifference{}
-	for _, ignore := range ignores {
-		result.JQPathExpressions = append(result.JQPathExpressions, ignore.JQPathExpressions...)
-		result.JSONPointers = append(result.JSONPointers, ignore.JSONPointers...)
-		result.ManagedFieldsManagers = append(result.ManagedFieldsManagers, ignore.ManagedFieldsManagers...)
+func resourceToIgnoreDifference(resource v1alpha1.ResourceIgnoreDifferences) *IgnoreDifference {
+	return &IgnoreDifference{
+		JSONPointers:          resource.JSONPointers,
+		JQPathExpressions:     resource.JQPathExpressions,
+		ManagedFieldsManagers: resource.ManagedFieldsManagers,
 	}
-	return result
+}
+
+// mergeIgnoreDifferences will merge all ignores in the given from in target
+// skipping repeated configs.
+func mergeIgnoreDifferences(from *IgnoreDifference, target *IgnoreDifference) {
+	for _, jqPath := range from.JQPathExpressions {
+		if !contains(target.JQPathExpressions, jqPath) {
+			target.JQPathExpressions = append(target.JQPathExpressions, jqPath)
+		}
+	}
+	for _, jsonPointer := range from.JSONPointers {
+		if !contains(target.JSONPointers, jsonPointer) {
+			target.JSONPointers = append(target.JSONPointers, jsonPointer)
+		}
+	}
+	for _, manager := range from.ManagedFieldsManagers {
+		if !contains(target.ManagedFieldsManagers, manager) {
+			target.ManagedFieldsManagers = append(target.ManagedFieldsManagers, manager)
+		}
+	}
+}
+
+func contains(slice []string, e string) bool {
+	for _, s := range slice {
+		if s == e {
+			return true
+		}
+	}
+	return false
 }

--- a/util/argo/diff/ignore_test.go
+++ b/util/argo/diff/ignore_test.go
@@ -34,12 +34,15 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		}
 	}
 	t.Run("will return ignore diffs from resource override", func(t *testing.T) {
-		// given
+		// givenn
 		gk := "apps/Deployment"
 		override := getOverride(gk)
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "", "")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, override)
+		expectedManagedFields := append(override[gk].IgnoreDifferences.ManagedFieldsManagers, ignoreDiff.ManagedFieldsManagers...)
+		expectedJSONPointers := append(override[gk].IgnoreDifferences.JSONPointers, ignoreDiff.JSONPointers...)
+		expectedJQExpression := append(override[gk].IgnoreDifferences.JQPathExpressions, ignoreDiff.JQPathExpressions...)
 
 		// when
 		ok, actual := ignoreConfig.HasIgnoreDifference("apps", "Deployment", "app-name", "default")
@@ -47,18 +50,20 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		// then
 		assert.True(t, ok)
 		assert.NotNil(t, actual)
-		expected := override[gk].IgnoreDifferences
-		assert.Equal(t, expected.ManagedFieldsManagers, actual.ManagedFieldsManagers)
-		assert.Equal(t, expected.JSONPointers, actual.JSONPointers)
-		assert.Equal(t, expected.JQPathExpressions, actual.JQPathExpressions)
+		assert.Equal(t, expectedManagedFields, actual.ManagedFieldsManagers)
+		assert.Equal(t, expectedJSONPointers, actual.JSONPointers)
+		assert.Equal(t, expectedJQExpression, actual.JQPathExpressions)
 	})
 	t.Run("will return ignore diffs from resource override with wildcard", func(t *testing.T) {
-		// given
+		// givenn
 		gk := "*/*"
 		override := getOverride(gk)
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "", "")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, override)
+		expectedManagedFields := append(override[gk].IgnoreDifferences.ManagedFieldsManagers, ignoreDiff.ManagedFieldsManagers...)
+		expectedJSONPointers := append(override[gk].IgnoreDifferences.JSONPointers, ignoreDiff.JSONPointers...)
+		expectedJQExpression := append(override[gk].IgnoreDifferences.JQPathExpressions, ignoreDiff.JQPathExpressions...)
 
 		// when
 		ok, actual := ignoreConfig.HasIgnoreDifference("apps", "Deployment", "app-name", "default")
@@ -66,13 +71,12 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		// then
 		assert.True(t, ok)
 		assert.NotNil(t, actual)
-		expected := override[gk].IgnoreDifferences
-		assert.Equal(t, expected.ManagedFieldsManagers, actual.ManagedFieldsManagers)
-		assert.Equal(t, expected.JSONPointers, actual.JSONPointers)
-		assert.Equal(t, expected.JQPathExpressions, actual.JQPathExpressions)
+		assert.Equal(t, expectedManagedFields, actual.ManagedFieldsManagers)
+		assert.Equal(t, expectedJSONPointers, actual.JSONPointers)
+		assert.Equal(t, expectedJQExpression, actual.JQPathExpressions)
 	})
 	t.Run("will return ignore diffs from application resource", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "app-name", "default")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -88,7 +92,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		assert.Equal(t, ignoreDiff.JQPathExpressions, actual.JQPathExpressions)
 	})
 	t.Run("will return ignore diffs from application resource with no app name and namespace configured", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "", "")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -104,7 +108,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		assert.Equal(t, ignoreDiff.JQPathExpressions, actual.JQPathExpressions)
 	})
 	t.Run("will return ignore diffs for all resources from group", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("apps", "*", "", "")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -120,7 +124,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		assert.Equal(t, ignoreDiff.JQPathExpressions, actual.JQPathExpressions)
 	})
 	t.Run("will return ignore diffs for all resources", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("*", "*", "", "")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -136,7 +140,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		assert.Equal(t, ignoreDiff.JQPathExpressions, actual.JQPathExpressions)
 	})
 	t.Run("no ignore diffs if namespace do not match", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "app-name", "default")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -149,7 +153,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		require.Nil(t, actual)
 	})
 	t.Run("no ignore diffs if name do not match", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "app-name", "default")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -162,7 +166,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		require.Nil(t, actual)
 	})
 	t.Run("no ignore diffs if resource do not match", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "app-name", "default")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -175,7 +179,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		require.Nil(t, actual)
 	})
 	t.Run("no ignore diffs if group do not match", func(t *testing.T) {
-		// give
+		// given
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "app-name", "default")
 		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
 		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, nil)
@@ -186,6 +190,30 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		// then
 		assert.False(t, ok)
 		require.Nil(t, actual)
+	})
+	t.Run("will merge ignore differences correctly", func(t *testing.T) {
+		// given
+		gk := "*/*"
+		override := getOverride(gk)
+		ignoreDiff := getIgnoreDiff("*", "*", "", "")
+		expectedManagers := append(ignoreDiff.ManagedFieldsManagers, "repeated-manager")
+		expectedJSONPointers := append(ignoreDiff.JSONPointers, "repeated-jsonpointer")
+		expectedJQPath := append(ignoreDiff.JQPathExpressions, "repeated-jqpath")
+		ignoreDiff.ManagedFieldsManagers = append(ignoreDiff.ManagedFieldsManagers, []string{"repeated-manager", "repeated-manager"}...)
+		ignoreDiff.JSONPointers = append(ignoreDiff.JSONPointers, []string{"repeated-jsonpointer", "repeated-jsonpointer"}...)
+		ignoreDiff.JQPathExpressions = append(ignoreDiff.JQPathExpressions, []string{"repeated-jqpath", "repeated-jqpath"}...)
+		ignoreDiffs := []v1alpha1.ResourceIgnoreDifferences{ignoreDiff}
+		ignoreConfig := diff.NewIgnoreDiffConfig(ignoreDiffs, override)
+
+		// when
+		ok, actual := ignoreConfig.HasIgnoreDifference("apps", "Deployment", "app-name", "default")
+
+		// then
+		assert.True(t, ok)
+		require.NotNil(t, actual)
+		assert.Equal(t, expectedManagers, actual.ManagedFieldsManagers)
+		assert.Equal(t, expectedJSONPointers, actual.JSONPointers)
+		assert.Equal(t, expectedJQPath, actual.JQPathExpressions)
 	})
 
 }

--- a/util/argo/diff/ignore_test.go
+++ b/util/argo/diff/ignore_test.go
@@ -191,7 +191,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		assert.False(t, ok)
 		require.Nil(t, actual)
 	})
-	t.Run("will merge ignore differences correctly", func(t *testing.T) {
+	t.Run("will merge ignore differences correctly removing duplicated configs", func(t *testing.T) {
 		// given
 		gk := "*/*"
 		override := getOverride(gk)

--- a/util/argo/diff/ignore_test.go
+++ b/util/argo/diff/ignore_test.go
@@ -34,7 +34,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		}
 	}
 	t.Run("will return ignore diffs from resource override", func(t *testing.T) {
-		// givenn
+		// given
 		gk := "apps/Deployment"
 		override := getOverride(gk)
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "", "")
@@ -55,7 +55,7 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		assert.Equal(t, expectedJQExpression, actual.JQPathExpressions)
 	})
 	t.Run("will return ignore diffs from resource override with wildcard", func(t *testing.T) {
-		// givenn
+		// given
 		gk := "*/*"
 		override := getOverride(gk)
 		ignoreDiff := getIgnoreDiff("apps", "Deployment", "", "")

--- a/util/argo/diff/ignore_test.go
+++ b/util/argo/diff/ignore_test.go
@@ -197,8 +197,11 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		override := getOverride(gk)
 		ignoreDiff := getIgnoreDiff("*", "*", "", "")
 		expectedManagers := append(ignoreDiff.ManagedFieldsManagers, "repeated-manager")
+		expectedManagers = append(expectedManagers, override[gk].IgnoreDifferences.ManagedFieldsManagers...)
 		expectedJSONPointers := append(ignoreDiff.JSONPointers, "repeated-jsonpointer")
+		expectedJSONPointers = append(expectedJSONPointers, override[gk].IgnoreDifferences.JSONPointers...)
 		expectedJQPath := append(ignoreDiff.JQPathExpressions, "repeated-jqpath")
+		expectedJQPath = append(expectedJQPath, override[gk].IgnoreDifferences.JQPathExpressions...)
 		ignoreDiff.ManagedFieldsManagers = append(ignoreDiff.ManagedFieldsManagers, []string{"repeated-manager", "repeated-manager"}...)
 		ignoreDiff.JSONPointers = append(ignoreDiff.JSONPointers, []string{"repeated-jsonpointer", "repeated-jsonpointer"}...)
 		ignoreDiff.JQPathExpressions = append(ignoreDiff.JQPathExpressions, []string{"repeated-jqpath", "repeated-jqpath"}...)
@@ -211,9 +214,9 @@ func TestIgnoreDiffConfig_HasIgnoreDifference(t *testing.T) {
 		// then
 		assert.True(t, ok)
 		require.NotNil(t, actual)
-		assert.Equal(t, expectedManagers, actual.ManagedFieldsManagers)
-		assert.Equal(t, expectedJSONPointers, actual.JSONPointers)
-		assert.Equal(t, expectedJQPath, actual.JQPathExpressions)
+		assert.ElementsMatch(t, expectedManagers, actual.ManagedFieldsManagers)
+		assert.ElementsMatch(t, expectedJSONPointers, actual.JSONPointers)
+		assert.ElementsMatch(t, expectedJQPath, actual.JQPathExpressions)
 	})
 
 }


### PR DESCRIPTION
Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

There was a problem when checking the ignore difference configuration for CRDs manifests. The problem is related to the fact that all CRDs will [be automatically configured](https://github.com/argoproj/argo-cd/blob/fa46ac178f809577285d8b37480ef1e46e7cb4a4/util/settings/settings.go#L733-L737) with resource overrides and that configuration was making application diff configs to be discarded. This PR will, instead, merge all diff configs available in settings with the Application's ones and use that merged object to determine how to calculate diffs.

This PR partially addresses the issue reported in https://github.com/argoproj/argo-cd/issues/9071

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

