### PR TITLE
chore: add timeout for argocd sync command in TestCustomToolWithSSHGitCreds

### DIFF
--- a/test/e2e/custom_tool_test.go
+++ b/test/e2e/custom_tool_test.go
@@ -116,7 +116,6 @@ func TestCustomToolWithSSHGitCreds(t *testing.T) {
 		CreateApp().
 		Sync().
 		Then().
-		Timeout(30).
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -286,6 +286,11 @@ func (a *Actions) Sync(args ...string) *Actions {
 
 	a.runCli(args...)
 
+	// Adding to see if any failures from sync timeout
+	if a.lastError != nil {
+		a.context.t.Log("logging last sync err: " + a.lastError.Error())
+	}
+
 	return a
 }
 


### PR DESCRIPTION
Seeing if test failures for TestCustomToolWithSSHGitCreds are related to argocd app sync timeout

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

