### PR TITLE
fix: do not unset passCredentials when it's not specified (#9102)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -563,20 +563,24 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 	return command
 }
 
+// unsetOpts describe what to unset in an Application.
+type unsetOpts struct {
+	namePrefix bool
+	nameSuffix bool
+	kustomizeVersion bool
+	kustomizeImages []string
+	parameters []string
+	valuesFiles []string
+	valuesLiteral bool
+	ignoreMissingValueFiles bool
+	pluginEnvs []string
+	passCredentials bool
+}
+
 // NewApplicationUnsetCommand returns a new instance of an `argocd app unset` command
 func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var (
-		parameters              []string
-		valuesLiteral           bool
-		valuesFiles             []string
-		ignoreMissingValueFiles bool
-		nameSuffix              bool
-		namePrefix              bool
-		kustomizeVersion        bool
-		kustomizeImages         []string
-		pluginEnvs              []string
-		appOpts                 cmdutil.AppOptions
-	)
+	appOpts := cmdutil.AppOptions{}
+	opts := unsetOpts{}
 	var command = &cobra.Command{
 		Use:   "unset APPNAME parameters",
 		Short: "Unset application parameters",
@@ -600,89 +604,11 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 			app, err := appIf.Get(context.Background(), &applicationpkg.ApplicationQuery{Name: &appName})
 			errors.CheckError(err)
 
-			updated := false
-			if app.Spec.Source.Kustomize != nil {
-				if namePrefix {
-					updated = true
-					app.Spec.Source.Kustomize.NamePrefix = ""
-				}
-
-				if nameSuffix {
-					updated = true
-					app.Spec.Source.Kustomize.NameSuffix = ""
-				}
-
-				if kustomizeVersion {
-					updated = true
-					app.Spec.Source.Kustomize.Version = ""
-				}
-
-				for _, kustomizeImage := range kustomizeImages {
-					for i, item := range app.Spec.Source.Kustomize.Images {
-						if argoappv1.KustomizeImage(kustomizeImage).Match(item) {
-							updated = true
-							//remove i
-							a := app.Spec.Source.Kustomize.Images
-							copy(a[i:], a[i+1:]) // Shift a[i+1:] left one index.
-							a[len(a)-1] = ""     // Erase last element (write zero value).
-							a = a[:len(a)-1]     // Truncate slice.
-							app.Spec.Source.Kustomize.Images = a
-						}
-					}
-				}
+			updated, nothingToUnset := unset(&app.Spec.Source, opts)
+			if nothingToUnset {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
 			}
-			if app.Spec.Source.Helm != nil {
-				if len(parameters) == 0 && len(valuesFiles) == 0 && !valuesLiteral && !ignoreMissingValueFiles {
-					c.HelpFunc()(c, args)
-					os.Exit(1)
-				}
-				for _, paramStr := range parameters {
-					helmParams := app.Spec.Source.Helm.Parameters
-					for i, p := range helmParams {
-						if p.Name == paramStr {
-							app.Spec.Source.Helm.Parameters = append(helmParams[0:i], helmParams[i+1:]...)
-							updated = true
-							break
-						}
-					}
-				}
-				if valuesLiteral {
-					app.Spec.Source.Helm.Values = ""
-					updated = true
-				}
-				for _, valuesFile := range valuesFiles {
-					specValueFiles := app.Spec.Source.Helm.ValueFiles
-					for i, vf := range specValueFiles {
-						if vf == valuesFile {
-							app.Spec.Source.Helm.ValueFiles = append(specValueFiles[0:i], specValueFiles[i+1:]...)
-							updated = true
-							break
-						}
-					}
-				}
-				if ignoreMissingValueFiles {
-					app.Spec.Source.Helm.IgnoreMissingValueFiles = false
-					updated = true
-				}
-				if app.Spec.Source.Helm.PassCredentials {
-					app.Spec.Source.Helm.PassCredentials = false
-					updated = true
-				}
-			}
-
-			if app.Spec.Source.Plugin != nil {
-				if len(pluginEnvs) == 0 {
-					c.HelpFunc()(c, args)
-					os.Exit(1)
-				}
-				for _, env := range pluginEnvs {
-					err = app.Spec.Source.Plugin.RemoveEnvEntry(env)
-					if err == nil {
-						updated = true
-					}
-				}
-			}
-
 			if !updated {
 				return
 			}
@@ -696,16 +622,99 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().StringArrayVarP(&parameters, "parameter", "p", []string{}, "Unset a parameter override (e.g. -p guestbook=image)")
-	command.Flags().StringArrayVar(&valuesFiles, "values", []string{}, "Unset one or more Helm values files")
-	command.Flags().BoolVar(&valuesLiteral, "values-literal", false, "Unset literal Helm values block")
-	command.Flags().BoolVar(&ignoreMissingValueFiles, "ignore-missing-value-files", false, "Unset the helm ignore-missing-value-files option (revert to false)")
-	command.Flags().BoolVar(&nameSuffix, "namesuffix", false, "Kustomize namesuffix")
-	command.Flags().BoolVar(&namePrefix, "nameprefix", false, "Kustomize nameprefix")
-	command.Flags().BoolVar(&kustomizeVersion, "kustomize-version", false, "Kustomize version")
-	command.Flags().StringArrayVar(&kustomizeImages, "kustomize-image", []string{}, "Kustomize images name (e.g. --kustomize-image node --kustomize-image mysql)")
-	command.Flags().StringArrayVar(&pluginEnvs, "plugin-env", []string{}, "Unset plugin env variables (e.g --plugin-env name)")
+	command.Flags().StringArrayVarP(&opts.parameters, "parameter", "p", []string{}, "Unset a parameter override (e.g. -p guestbook=image)")
+	command.Flags().StringArrayVar(&opts.valuesFiles, "values", []string{}, "Unset one or more Helm values files")
+	command.Flags().BoolVar(&opts.valuesLiteral, "values-literal", false, "Unset literal Helm values block")
+	command.Flags().BoolVar(&opts.ignoreMissingValueFiles, "ignore-missing-value-files", false, "Unset the helm ignore-missing-value-files option (revert to false)")
+	command.Flags().BoolVar(&opts.nameSuffix, "namesuffix", false, "Kustomize namesuffix")
+	command.Flags().BoolVar(&opts.namePrefix, "nameprefix", false, "Kustomize nameprefix")
+	command.Flags().BoolVar(&opts.kustomizeVersion, "kustomize-version", false, "Kustomize version")
+	command.Flags().StringArrayVar(&opts.kustomizeImages, "kustomize-image", []string{}, "Kustomize images name (e.g. --kustomize-image node --kustomize-image mysql)")
+	command.Flags().StringArrayVar(&opts.pluginEnvs, "plugin-env", []string{}, "Unset plugin env variables (e.g --plugin-env name)")
+	command.Flags().BoolVar(&opts.passCredentials, "pass-credentials", false, "Unset passCredentials")
 	return command
+}
+
+func unset(source *argoappv1.ApplicationSource, opts unsetOpts) (updated bool, nothingToUnset bool) {
+	if source.Kustomize != nil {
+		if opts.namePrefix && source.Kustomize.NamePrefix != "" {
+			updated = true
+			source.Kustomize.NamePrefix = ""
+		}
+
+		if opts.nameSuffix && source.Kustomize.NameSuffix != "" {
+			updated = true
+			source.Kustomize.NameSuffix = ""
+		}
+
+		if opts.kustomizeVersion && source.Kustomize.Version != "" {
+			updated = true
+			source.Kustomize.Version = ""
+		}
+
+		for _, kustomizeImage := range opts.kustomizeImages {
+			for i, item := range source.Kustomize.Images {
+				if argoappv1.KustomizeImage(kustomizeImage).Match(item) {
+					updated = true
+					//remove i
+					a := source.Kustomize.Images
+					copy(a[i:], a[i+1:]) // Shift a[i+1:] left one index.
+					a[len(a)-1] = ""     // Erase last element (write zero value).
+					a = a[:len(a)-1]     // Truncate slice.
+					source.Kustomize.Images = a
+				}
+			}
+		}
+	}
+	if source.Helm != nil {
+		if len(opts.parameters) == 0 && len(opts.valuesFiles) == 0 && !opts.valuesLiteral && !opts.ignoreMissingValueFiles && !opts.passCredentials {
+			return false, true
+		}
+		for _, paramStr := range opts.parameters {
+			helmParams := source.Helm.Parameters
+			for i, p := range helmParams {
+				if p.Name == paramStr {
+					source.Helm.Parameters = append(helmParams[0:i], helmParams[i+1:]...)
+					updated = true
+					break
+				}
+			}
+		}
+		if opts.valuesLiteral && source.Helm.Values != "" {
+			source.Helm.Values = ""
+			updated = true
+		}
+		for _, valuesFile := range opts.valuesFiles {
+			specValueFiles := source.Helm.ValueFiles
+			for i, vf := range specValueFiles {
+				if vf == valuesFile {
+					source.Helm.ValueFiles = append(specValueFiles[0:i], specValueFiles[i+1:]...)
+					updated = true
+					break
+				}
+			}
+		}
+		if opts.ignoreMissingValueFiles && source.Helm.IgnoreMissingValueFiles {
+			source.Helm.IgnoreMissingValueFiles = false
+			updated = true
+		}
+		if opts.passCredentials && source.Helm.PassCredentials {
+			source.Helm.PassCredentials = false
+			updated = true
+		}
+	}
+	if source.Plugin != nil {
+		if len(opts.pluginEnvs) == 0 {
+			return false, true
+		}
+		for _, env := range opts.pluginEnvs {
+			err := source.Plugin.RemoveEnvEntry(env)
+			if err == nil {
+				updated = true
+			}
+		}
+	}
+	return updated, false
 }
 
 // targetObjects deserializes the list of target states into unstructured objects

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -637,6 +637,10 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 
 func unset(source *argoappv1.ApplicationSource, opts unsetOpts) (updated bool, nothingToUnset bool) {
 	if source.Kustomize != nil {
+		if !opts.namePrefix && !opts.nameSuffix && !opts.kustomizeVersion && len(opts.kustomizeImages) == 0 {
+			return false, true
+		}
+
 		if opts.namePrefix && source.Kustomize.NamePrefix != "" {
 			updated = true
 			source.Kustomize.NamePrefix = ""

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -779,3 +779,26 @@ func Test_unset(t *testing.T) {
 	assert.False(t, updated)
 	assert.False(t, nothingToUnset)
 }
+
+func Test_unset_nothingToUnset(t *testing.T) {
+	testCases := []struct{
+		name string
+		source v1alpha1.ApplicationSource
+	}{
+		{"kustomize", v1alpha1.ApplicationSource{Kustomize: &v1alpha1.ApplicationSourceKustomize{}}},
+		{"helm", v1alpha1.ApplicationSource{Helm: &v1alpha1.ApplicationSourceHelm{}}},
+		{"plugin", v1alpha1.ApplicationSource{Plugin: &v1alpha1.ApplicationSourcePlugin{}}},
+	}
+
+	for _, testCase := range testCases {
+		testCaseCopy := testCase
+
+		t.Run(testCaseCopy.name, func(t *testing.T) {
+			t.Parallel()
+
+			updated, nothingToUnset := unset(&testCaseCopy.source, unsetOpts{})
+			assert.False(t, updated)
+			assert.True(t, nothingToUnset)
+		})
+	}
+}

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -730,7 +730,7 @@ func Test_unset(t *testing.T) {
 	assert.Equal(t, 1, len(helmSource.Helm.Parameters))
 	assert.True(t, updated)
 	assert.False(t, nothingToUnset)
-	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{parameters: []string{"name-1"}})
+	updated, nothingToUnset = unset(helmSource, unsetOpts{parameters: []string{"name-1"}})
 	assert.False(t, updated)
 	assert.False(t, nothingToUnset)
 

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -638,3 +638,144 @@ func TestPrintApplicationNames(t *testing.T) {
 		t.Fatalf("Incorrect print params output %q, should be %q", output, expectation)
 	}
 }
+
+func Test_unset(t *testing.T) {
+	kustomizeSource := &v1alpha1.ApplicationSource{
+		Kustomize: &v1alpha1.ApplicationSourceKustomize{
+			NamePrefix: "some-prefix",
+			NameSuffix: "some-suffix",
+			Version:    "123",
+			Images: v1alpha1.KustomizeImages{
+				"old1=new:tag",
+				"old2=new:tag",
+			},
+		},
+	}
+
+	helmSource := &v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{
+			IgnoreMissingValueFiles: true,
+			Parameters: []v1alpha1.HelmParameter{
+				{
+					Name:  "name-1",
+					Value: "value-1",
+				},
+				{
+					Name:  "name-2",
+					Value: "value-2",
+				},
+			},
+			PassCredentials: true,
+			Values:          "some: yaml",
+			ValueFiles: []string{
+				"values-1.yaml",
+				"values-2.yaml",
+			},
+		},
+	}
+
+	pluginSource := &v1alpha1.ApplicationSource{
+		Plugin: &v1alpha1.ApplicationSourcePlugin{
+			Env: v1alpha1.Env{
+				{
+					Name: "env-1",
+					Value: "env-value-1",
+				},
+				{
+					Name: "env-2",
+					Value: "env-value-2",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "some-prefix", kustomizeSource.Kustomize.NamePrefix)
+	updated, nothingToUnset := unset(kustomizeSource, unsetOpts{namePrefix: true})
+	assert.Equal(t, "", kustomizeSource.Kustomize.NamePrefix)
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{namePrefix: true})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, "some-suffix", kustomizeSource.Kustomize.NameSuffix)
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{nameSuffix: true})
+	assert.Equal(t, "", kustomizeSource.Kustomize.NameSuffix)
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{nameSuffix: true})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, "123", kustomizeSource.Kustomize.Version)
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{kustomizeVersion: true})
+	assert.Equal(t, "", kustomizeSource.Kustomize.Version)
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{kustomizeVersion: true})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, 2, len(kustomizeSource.Kustomize.Images))
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{kustomizeImages: []string{"old1=new:tag"}})
+	assert.Equal(t, 1, len(kustomizeSource.Kustomize.Images))
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{kustomizeImages: []string{"old1=new:tag"}})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, 2, len(helmSource.Helm.Parameters))
+	updated, nothingToUnset = unset(helmSource, unsetOpts{parameters: []string{"name-1"}})
+	assert.Equal(t, 1, len(helmSource.Helm.Parameters))
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(kustomizeSource, unsetOpts{parameters: []string{"name-1"}})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, 2, len(helmSource.Helm.ValueFiles))
+	updated, nothingToUnset = unset(helmSource, unsetOpts{valuesFiles: []string{"values-1.yaml"}})
+	assert.Equal(t, 1, len(helmSource.Helm.ValueFiles))
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(helmSource, unsetOpts{valuesFiles: []string{"values-1.yaml"}})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, "some: yaml", helmSource.Helm.Values)
+	updated, nothingToUnset = unset(helmSource, unsetOpts{valuesLiteral: true})
+	assert.Equal(t, "", helmSource.Helm.Values)
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(helmSource, unsetOpts{valuesLiteral: true})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, true, helmSource.Helm.IgnoreMissingValueFiles)
+	updated, nothingToUnset = unset(helmSource, unsetOpts{ignoreMissingValueFiles: true})
+	assert.Equal(t, false, helmSource.Helm.IgnoreMissingValueFiles)
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(helmSource, unsetOpts{ignoreMissingValueFiles: true})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, true, helmSource.Helm.PassCredentials)
+	updated, nothingToUnset = unset(helmSource, unsetOpts{passCredentials: true})
+	assert.Equal(t, false, helmSource.Helm.PassCredentials)
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(helmSource, unsetOpts{passCredentials: true})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+
+	assert.Equal(t, 2, len(pluginSource.Plugin.Env))
+	updated, nothingToUnset = unset(pluginSource, unsetOpts{pluginEnvs: []string{"env-1"}})
+	assert.Equal(t, 1, len(pluginSource.Plugin.Env))
+	assert.True(t, updated)
+	assert.False(t, nothingToUnset)
+	updated, nothingToUnset = unset(pluginSource, unsetOpts{pluginEnvs: []string{"env-1"}})
+	assert.False(t, updated)
+	assert.False(t, nothingToUnset)
+}

--- a/docs/user-guide/commands/argocd_app_unset.md
+++ b/docs/user-guide/commands/argocd_app_unset.md
@@ -29,6 +29,7 @@ argocd app unset APPNAME parameters [flags]
       --nameprefix                    Kustomize nameprefix
       --namesuffix                    Kustomize namesuffix
   -p, --parameter stringArray         Unset a parameter override (e.g. -p guestbook=image)
+      --pass-credentials              Unset passCredentials
       --plugin-env stringArray        Unset plugin env variables (e.g --plugin-env name)
       --values stringArray            Unset one or more Helm values files
       --values-literal                Unset literal Helm values block


### PR DESCRIPTION
Fixes #9102

The main issue was that passCredentials was always unset.

The other issue was that some fields were being unset even if we didn't first check if they _needed_ to be unset. So we were making an unnecessary API call.