### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -460,8 +460,7 @@ func TestHelm3CRD(t *testing.T) {
 
 func TestHelmRepoDiffLocal(t *testing.T) {
 	SkipOnEnv(t, "HELM")
-	helmTmp, err := ioutil.TempDir("", "argocd-helm-repo-diff-local-test")
-	assert.NoError(t, err)
+	helmTmp := t.TempDir()
 	Given(t).
 		CustomCACertAdded().
 		HelmRepoAdded("custom-repo").

--- a/util/cert/cert_test.go
+++ b/util/cert/cert_test.go
@@ -472,10 +472,7 @@ func TestGetSSHKnownHostsDataPath(t *testing.T) {
 
 func TestGetCertificateForConnect(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		temppath, err := ioutil.TempDir("", "argocd-cert-test")
-		if err != nil {
-			panic(err)
-		}
+		temppath := t.TempDir()
 		cert, err := ioutil.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
 		if err != nil {
 			panic(err)
@@ -484,7 +481,6 @@ func TestGetCertificateForConnect(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		defer os.RemoveAll(temppath)
 		os.Setenv(common.EnvVarTLSDataPath, temppath)
 		certs, err := GetCertificateForConnect("127.0.0.1")
 		assert.NoError(t, err)
@@ -492,11 +488,7 @@ func TestGetCertificateForConnect(t *testing.T) {
 	})
 
 	t.Run("No cert found", func(t *testing.T) {
-		temppath, err := ioutil.TempDir("", "argocd-cert-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(temppath)
+		temppath := t.TempDir()
 		os.Setenv(common.EnvVarTLSDataPath, temppath)
 		certs, err := GetCertificateForConnect("127.0.0.1")
 		assert.NoError(t, err)
@@ -504,15 +496,11 @@ func TestGetCertificateForConnect(t *testing.T) {
 	})
 
 	t.Run("No valid cert in file", func(t *testing.T) {
-		temppath, err := ioutil.TempDir("", "argocd-cert-test")
+		temppath := t.TempDir()
+		err := ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
 		if err != nil {
 			panic(err)
 		}
-		err = ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(temppath)
 		os.Setenv(common.EnvVarTLSDataPath, temppath)
 		certs, err := GetCertificateForConnect("127.0.0.1")
 		assert.Error(t, err)
@@ -524,10 +512,7 @@ func TestGetCertificateForConnect(t *testing.T) {
 
 func TestGetCertBundlePathForRepository(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		temppath, err := ioutil.TempDir("", "argocd-cert-test")
-		if err != nil {
-			panic(err)
-		}
+		temppath := t.TempDir()
 		cert, err := ioutil.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
 		if err != nil {
 			panic(err)
@@ -536,7 +521,6 @@ func TestGetCertBundlePathForRepository(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		defer os.RemoveAll(temppath)
 		os.Setenv(common.EnvVarTLSDataPath, temppath)
 		certpath, err := GetCertBundlePathForRepository("127.0.0.1")
 		assert.NoError(t, err)
@@ -544,11 +528,7 @@ func TestGetCertBundlePathForRepository(t *testing.T) {
 	})
 
 	t.Run("No cert found", func(t *testing.T) {
-		temppath, err := ioutil.TempDir("", "argocd-cert-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(temppath)
+		temppath := t.TempDir()
 		os.Setenv(common.EnvVarTLSDataPath, temppath)
 		certpath, err := GetCertBundlePathForRepository("127.0.0.1")
 		assert.NoError(t, err)
@@ -556,15 +536,11 @@ func TestGetCertBundlePathForRepository(t *testing.T) {
 	})
 
 	t.Run("No valid cert in file", func(t *testing.T) {
-		temppath, err := ioutil.TempDir("", "argocd-cert-test")
+		temppath := t.TempDir()
+		err := ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
 		if err != nil {
 			panic(err)
 		}
-		err = ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(temppath)
 		os.Setenv(common.EnvVarTLSDataPath, temppath)
 		certpath, err := GetCertBundlePathForRepository("127.0.0.1")
 		assert.NoError(t, err)

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -245,11 +245,7 @@ func TestLFSClient(t *testing.T) {
 	// TODO(alexmt): dockerize tests in and enabled it
 	t.Skip()
 
-	tempDir, err := ioutil.TempDir("", "git-client-lfs-test-")
-	assert.NoError(t, err)
-	if err == nil {
-		defer func() { _ = os.RemoveAll(tempDir) }()
-	}
+	tempDir := t.TempDir()
 
 	client, err := NewClientExt("https://github.com/argoproj-labs/argocd-testrepo-lfs", tempDir, NopCreds{}, false, true, "")
 	assert.NoError(t, err)
@@ -284,11 +280,7 @@ func TestLFSClient(t *testing.T) {
 }
 
 func TestVerifyCommitSignature(t *testing.T) {
-	p, err := ioutil.TempDir("", "test-verify-commit-sig")
-	if err != nil {
-		panic(err.Error())
-	}
-	defer os.RemoveAll(p)
+	p := t.TempDir()
 
 	client, err := NewClientExt("https://github.com/argoproj/argo-cd.git", p, NopCreds{}, false, false, "")
 	assert.NoError(t, err)
@@ -343,9 +335,7 @@ func TestNewFactory(t *testing.T) {
 			test.Flaky(t)
 		}
 
-		dirName, err := ioutil.TempDir("", "git-client-test-")
-		assert.NoError(t, err)
-		defer func() { _ = os.RemoveAll(dirName) }()
+		dirName := t.TempDir()
 
 		client, err := NewClientExt(tt.args.url, dirName, NopCreds{}, tt.args.insecureIgnoreHostKey, false, "")
 		assert.NoError(t, err)
@@ -381,11 +371,7 @@ func TestNewFactory(t *testing.T) {
 }
 
 func TestListRevisions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-list-revisions")
-	if err != nil {
-		panic(err.Error())
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	repoURL := "https://github.com/argoproj/argo-cd.git"
 	client, err := NewClientExt(repoURL, dir, NopCreds{}, false, false, "")

--- a/util/gpg/gpg_test.go
+++ b/util/gpg/gpg_test.go
@@ -28,12 +28,8 @@ var syncTestSources = map[string]string{
 }
 
 // Helper function to create temporary GNUPGHOME
-func initTempDir() string {
-	p, err := ioutil.TempDir("", "gpg-test")
-	if err != nil {
-		// makes no sense to continue test without temp dir
-		panic(err.Error())
-	}
+func initTempDir(tb testing.TB) string {
+	p := tb.TempDir()
 	fmt.Printf("-> Using %s as GNUPGHOME\n", p)
 	os.Setenv(common.EnvGnuPGHome, p)
 	return p
@@ -49,8 +45,7 @@ func Test_IsGPGEnabled(t *testing.T) {
 }
 
 func Test_GPG_InitializeGnuPG(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	p := initTempDir(t)
 
 	// First run should initialize fine
 	err := InitializeGnuPG()
@@ -88,8 +83,7 @@ func Test_GPG_InitializeGnuPG(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not point to a directory")
 
 	// Unaccessible GNUPGHOME
-	p = initTempDir()
-	defer os.RemoveAll(p)
+	p = initTempDir(t)
 	fp := fmt.Sprintf("%s/gpg", p)
 	err = os.Mkdir(fp, 0000)
 	if err != nil {
@@ -110,8 +104,7 @@ func Test_GPG_InitializeGnuPG(t *testing.T) {
 	// GNUPGHOME with too wide permissions
 	// We do not expect an error here, because of openshift's random UIDs that
 	// forced us to use an emptyDir mount (#4127)
-	p = initTempDir()
-	defer os.RemoveAll(p)
+	p = initTempDir(t)
 	err = os.Chmod(p, 0777)
 	if err != nil {
 		panic(err.Error())
@@ -122,8 +115,7 @@ func Test_GPG_InitializeGnuPG(t *testing.T) {
 }
 
 func Test_GPG_KeyManagement(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	initTempDir(t)
 
 	err := InitializeGnuPG()
 	assert.NoError(t, err)
@@ -218,8 +210,7 @@ func Test_GPG_KeyManagement(t *testing.T) {
 }
 
 func Test_ImportPGPKeysFromString(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	initTempDir(t)
 
 	err := InitializeGnuPG()
 	assert.NoError(t, err)
@@ -236,8 +227,7 @@ func Test_ImportPGPKeysFromString(t *testing.T) {
 }
 
 func Test_ValidateGPGKeysFromString(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	initTempDir(t)
 
 	err := InitializeGnuPG()
 	assert.NoError(t, err)
@@ -259,8 +249,7 @@ func Test_ValidateGPGKeysFromString(t *testing.T) {
 }
 
 func Test_ValidateGPGKeys(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	initTempDir(t)
 
 	err := InitializeGnuPG()
 	assert.NoError(t, err)
@@ -289,8 +278,7 @@ func Test_ValidateGPGKeys(t *testing.T) {
 }
 
 func Test_GPG_ParseGitCommitVerification(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	initTempDir(t)
 
 	err := InitializeGnuPG()
 	assert.NoError(t, err)
@@ -506,8 +494,7 @@ func Test_isHexString(t *testing.T) {
 }
 
 func Test_IsSecretKey(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	initTempDir(t)
 
 	// First run should initialize fine
 	err := InitializeGnuPG()
@@ -534,18 +521,13 @@ func Test_IsSecretKey(t *testing.T) {
 }
 
 func Test_SyncKeyRingFromDirectory(t *testing.T) {
-	p := initTempDir()
-	defer os.RemoveAll(p)
+	initTempDir(t)
 
 	// First run should initialize fine
 	err := InitializeGnuPG()
 	assert.NoError(t, err)
 
-	tempDir, err := ioutil.TempDir("", "gpg-sync-test")
-	if err != nil {
-		panic(err.Error())
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	{
 		new, removed, err := SyncKeyRingFromDirectory(tempDir)

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -2,7 +2,6 @@ package kustomize
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -21,12 +20,9 @@ const kustomization2b = "Kustomization"
 const kustomization3 = "force_common"
 const kustomization4 = "custom_version"
 
-func testDataDir(testData string) (string, error) {
-	res, err := ioutil.TempDir("", "kustomize-test")
-	if err != nil {
-		return "", err
-	}
-	_, err = exec.RunCommand("cp", exec.CmdOpts{}, "-r", "./testdata/"+testData, filepath.Join(res, "testdata"))
+func testDataDir(tb testing.TB, testData string) (string, error) {
+	res := tb.TempDir()
+	_, err := exec.RunCommand("cp", exec.CmdOpts{}, "-r", "./testdata/"+testData, filepath.Join(res, "testdata"))
 	if err != nil {
 		return "", err
 	}
@@ -34,7 +30,7 @@ func testDataDir(testData string) (string, error) {
 }
 
 func TestKustomizeBuild(t *testing.T) {
-	appPath, err := testDataDir(kustomization1)
+	appPath, err := testDataDir(t, kustomization1)
 	assert.Nil(t, err)
 	namePrefix := "namePrefix-"
 	nameSuffix := "-nameSuffix"
@@ -162,7 +158,7 @@ func TestKustomizeBuildForceCommonLabels(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		appPath, err := testDataDir(tc.TestData)
+		appPath, err := testDataDir(t, tc.TestData)
 		assert.Nil(t, err)
 		kustomize := NewKustomizeApp(appPath, git.NopCreds{}, "", "")
 		objs, _, err := kustomize.Build(&tc.KustomizeSource, nil, nil)
@@ -211,7 +207,7 @@ func TestKustomizeBuildForceCommonAnnotations(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		appPath, err := testDataDir(tc.TestData)
+		appPath, err := testDataDir(t, tc.TestData)
 		assert.Nil(t, err)
 		kustomize := NewKustomizeApp(appPath, git.NopCreds{}, "", "")
 		objs, _, err := kustomize.Build(&tc.KustomizeSource, nil, nil)
@@ -228,9 +224,9 @@ func TestKustomizeBuildForceCommonAnnotations(t *testing.T) {
 }
 
 func TestKustomizeCustomVersion(t *testing.T) {
-	appPath, err := testDataDir(kustomization1)
+	appPath, err := testDataDir(t, kustomization1)
 	assert.Nil(t, err)
-	kustomizePath, err := testDataDir(kustomization4)
+	kustomizePath, err := testDataDir(t, kustomization4)
 	assert.Nil(t, err)
 	envOutputFile := kustomizePath + "/env_output"
 	kustomize := NewKustomizeApp(appPath, git.NopCreds{}, "", kustomizePath+"/kustomize.special")


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer require.NoError(os.RemoveAll(tmpDir))

	// now
	tmpDir := t.TempDir()
}
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

