### PR TITLE
chore: don't give applicationset write access to projects

### DIFF
--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
@@ -11,7 +11,6 @@ rules:
       - argoproj.io
     resources:
       - applications
-      - appprojects
       - applicationsets
       - applicationsets/finalizers
     verbs:
@@ -22,6 +21,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - appprojects
+    verbs:
+      - get
   - apiGroups:
       - argoproj.io
     resources:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9057,7 +9057,6 @@ rules:
   - argoproj.io
   resources:
   - applications
-  - appprojects
   - applicationsets
   - applicationsets/finalizers
   verbs:
@@ -9068,6 +9067,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9089,7 +9089,6 @@ rules:
   - argoproj.io
   resources:
   - applications
-  - appprojects
   - applicationsets
   - applicationsets/finalizers
   verbs:
@@ -9100,6 +9099,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -110,7 +110,6 @@ rules:
   - argoproj.io
   resources:
   - applications
-  - appprojects
   - applicationsets
   - applicationsets/finalizers
   verbs:
@@ -121,6 +120,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9080,7 +9080,6 @@ rules:
   - argoproj.io
   resources:
   - applications
-  - appprojects
   - applicationsets
   - applicationsets/finalizers
   verbs:
@@ -9091,6 +9090,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -101,7 +101,6 @@ rules:
   - argoproj.io
   resources:
   - applications
-  - appprojects
   - applicationsets
   - applicationsets/finalizers
   verbs:
@@ -112,6 +111,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - argoproj.io
   resources:


### PR DESCRIPTION
As far as I can tell, the applicationset controller only needs `get` on appprojects.