### PR TITLE
docs: upgrade notes for new RBAC resource in 2.4

### DIFF
--- a/docs/operator-manual/upgrading/2.3-2.4.md
+++ b/docs/operator-manual/upgrading/2.3-2.4.md
@@ -1,0 +1,27 @@
+# v2.3 to 2.4
+
+## Configure RBAC to account for new `exec` resource
+
+2.4 introduces a new `exec` [RBAC resource](https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#rbac-resources-and-actions).
+
+When you upgrade to 2.4, RBAC policies with `*` in the resource field will automatically apply to the `exec` privilege.
+
+To avoid granting the new privilege, replace the existing policy with a list of new policies explicitly listing the old resources.
+
+Old:
+
+```csv
+p, role:org-admin, *, get, my-proj/*, allow
+```
+
+New:
+
+```csv
+p, role: org-admin, get, get, my-proj/*, allow
+p, role: org-admin, create, get, my-proj/*, allow
+p, role: org-admin, update, get, my-proj/*, allow
+p, role: org-admin, delete, get, my-proj/*, allow
+p, role: org-admin, sync, get, my-proj/*, allow
+p, role: org-admin, override, get, my-proj/*, allow
+p, role: org-admin, action, get, my-proj/*, allow
+```

--- a/docs/operator-manual/upgrading/2.3-2.4.md
+++ b/docs/operator-manual/upgrading/2.3-2.4.md
@@ -4,7 +4,7 @@
 
 2.4 introduces a new `exec` [RBAC resource](https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#rbac-resources-and-actions).
 
-When you upgrade to 2.4, RBAC policies with `*` in the resource field will automatically apply to the `exec` privilege.
+When you upgrade to 2.4, RBAC policies with `*` in the resource field and `get` or `*` in the verb field will automatically grant the `exec` privilege.
 
 To avoid granting the new privilege, replace the existing policy with a list of new policies explicitly listing the old resources.
 

--- a/docs/operator-manual/upgrading/2.3-2.4.md
+++ b/docs/operator-manual/upgrading/2.3-2.4.md
@@ -8,6 +8,8 @@ When you upgrade to 2.4, RBAC policies with `*` in the resource field and `get` 
 
 To avoid granting the new privilege, replace the existing policy with a list of new policies explicitly listing the old resources.
 
+### Example
+
 Old:
 
 ```csv

--- a/docs/operator-manual/upgrading/2.3-2.4.md
+++ b/docs/operator-manual/upgrading/2.3-2.4.md
@@ -17,11 +17,11 @@ p, role:org-admin, *, get, my-proj/*, allow
 New:
 
 ```csv
-p, role: org-admin, get, get, my-proj/*, allow
-p, role: org-admin, create, get, my-proj/*, allow
-p, role: org-admin, update, get, my-proj/*, allow
-p, role: org-admin, delete, get, my-proj/*, allow
-p, role: org-admin, sync, get, my-proj/*, allow
-p, role: org-admin, override, get, my-proj/*, allow
-p, role: org-admin, action, get, my-proj/*, allow
+p, role: org-admin, clusters, get, my-proj/*, allow
+p, role: org-admin, projects, get, my-proj/*, allow
+p, role: org-admin, applications, get, my-proj/*, allow
+p, role: org-admin, repositories, get, my-proj/*, allow
+p, role: org-admin, certificates, get, my-proj/*, allow
+p, role: org-admin, accounts, get, my-proj/*, allow
+p, role: org-admin, gpgkeys, get, my-proj/*, allow
 ```

--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -37,6 +37,8 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
+* [v2.3 to v2.4](./2.3-2.4.md)
+* [v2.2 to v2.3](./2.2-2.3.md)
 * [v2.1 to v2.2](./2.1-2.2.md)
 * [v2.0 to v2.1](./2.0-2.1.md)
 * [v1.8 to v2.0](./1.8-2.0.md)


### PR DESCRIPTION
Just realized that old RBAC policies might need to be updated because of https://github.com/argoproj/argo-cd/pull/8905.