### PR TITLE
feat: Add filter pathdoesntexist in scm generator

### DIFF
--- a/applicationset/services/scm_provider/types.go
+++ b/applicationset/services/scm_provider/types.go
@@ -24,12 +24,12 @@ type SCMProviderService interface {
 
 // A compiled version of SCMProviderGeneratorFilter for performance.
 type Filter struct {
-	RepositoryMatch  *regexp.Regexp
-	PathsExist       []string
-	PathsDoesntExist []string
-	LabelMatch       *regexp.Regexp
-	BranchMatch      *regexp.Regexp
-	FilterType       FilterType
+	RepositoryMatch *regexp.Regexp
+	PathsExist      []string
+	PathsDoNotExist []string
+	LabelMatch      *regexp.Regexp
+	BranchMatch     *regexp.Regexp
+	FilterType      FilterType
 }
 
 // A convenience type for indicating where to apply a filter

--- a/applicationset/services/scm_provider/types.go
+++ b/applicationset/services/scm_provider/types.go
@@ -24,11 +24,12 @@ type SCMProviderService interface {
 
 // A compiled version of SCMProviderGeneratorFilter for performance.
 type Filter struct {
-	RepositoryMatch *regexp.Regexp
-	PathsExist      []string
-	LabelMatch      *regexp.Regexp
-	BranchMatch     *regexp.Regexp
-	FilterType      FilterType
+	RepositoryMatch  *regexp.Regexp
+	PathsExist       []string
+	PathsDoesntExist []string
+	LabelMatch       *regexp.Regexp
+	BranchMatch      *regexp.Regexp
+	FilterType       FilterType
 }
 
 // A convenience type for indicating where to apply a filter

--- a/applicationset/services/scm_provider/utils.go
+++ b/applicationset/services/scm_provider/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/applicationset/v1alpha1"
 )
@@ -31,8 +32,8 @@ func compileFilters(filters []argoprojiov1alpha1.SCMProviderGeneratorFilter) ([]
 			outFilter.PathsExist = filter.PathsExist
 			outFilter.FilterType = FilterTypeBranch
 		}
-		if filter.PathsDoesntExist != nil {
-			outFilter.PathsDoesntExist = filter.PathsDoesntExist
+		if filter.PathsDoNotExist != nil {
+			outFilter.PathsDoNotExist = filter.PathsDoNotExist
 			outFilter.FilterType = FilterTypeBranch
 		}
 		if filter.BranchMatch != nil {
@@ -71,6 +72,7 @@ func matchFilter(ctx context.Context, provider SCMProviderService, repo *Reposit
 
 	if len(filter.PathsExist) != 0 {
 		for _, path := range filter.PathsExist {
+			path = strings.TrimRight(path, "/")
 			hasPath, err := provider.RepoHasPath(ctx, repo, path)
 			if err != nil {
 				return false, err
@@ -80,8 +82,9 @@ func matchFilter(ctx context.Context, provider SCMProviderService, repo *Reposit
 			}
 		}
 	}
-	if len(filter.PathsDoesntExist) != 0 {
-		for _, path := range filter.PathsDoesntExist {
+	if len(filter.PathsDoNotExist) != 0 {
+		for _, path := range filter.PathsDoNotExist {
+			path = strings.TrimRight(path, "/")
 			hasPath, err := provider.RepoHasPath(ctx, repo, path)
 			if err != nil {
 				return false, err

--- a/applicationset/services/scm_provider/utils_test.go
+++ b/applicationset/services/scm_provider/utils_test.go
@@ -72,7 +72,7 @@ func TestFilterLabelMatch(t *testing.T) {
 	assert.Equal(t, "two", repos[1].Repository)
 }
 
-func TestFilterPatchExists(t *testing.T) {
+func TestFilterPathExists(t *testing.T) {
 	provider := &MockProvider{
 		Repos: []*Repository{
 			{
@@ -97,6 +97,29 @@ func TestFilterPatchExists(t *testing.T) {
 	assert.Equal(t, "two", repos[0].Repository)
 }
 
+func TestFilterPathDoesntExists(t *testing.T) {
+	provider := &MockProvider{
+		Repos: []*Repository{
+			{
+				Repository: "one",
+			},
+			{
+				Repository: "two",
+			},
+			{
+				Repository: "three",
+			},
+		},
+	}
+	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
+		{
+			PathsDoesntExist: []string{"two"},
+		},
+	}
+	repos, err := ListRepos(context.Background(), provider, filters, "")
+	assert.Nil(t, err)
+	assert.Len(t, repos, 2)
+}
 func TestFilterRepoMatchBadRegexp(t *testing.T) {
 	provider := &MockProvider{
 		Repos: []*Repository{
@@ -273,6 +296,10 @@ func TestApplicableFilterMap(t *testing.T) {
 		PathsExist: []string{"test"},
 		FilterType: FilterTypeBranch,
 	}
+	pathDoesntExistsFilter := Filter{
+		PathsDoesntExist: []string{"test"},
+		FilterType:       FilterTypeBranch,
+	}
 	labelMatchFilter := Filter{
 		LabelMatch: &regexp.Regexp{},
 		FilterType: FilterTypeRepo,
@@ -285,8 +312,8 @@ func TestApplicableFilterMap(t *testing.T) {
 		FilterType:  FilterTypeBranch,
 	}
 	filterMap := getApplicableFilters([]*Filter{&branchFilter, &repoFilter,
-		&pathExistsFilter, &labelMatchFilter, &unsetFilter, &additionalBranchFilter})
+		&pathExistsFilter, &labelMatchFilter, &unsetFilter, &additionalBranchFilter, &pathDoesntExistsFilter})
 
 	assert.Len(t, filterMap[FilterTypeRepo], 2)
-	assert.Len(t, filterMap[FilterTypeBranch], 3)
+	assert.Len(t, filterMap[FilterTypeBranch], 4)
 }

--- a/applicationset/services/scm_provider/utils_test.go
+++ b/applicationset/services/scm_provider/utils_test.go
@@ -113,7 +113,7 @@ func TestFilterPathDoesntExists(t *testing.T) {
 	}
 	filters := []argoprojiov1alpha1.SCMProviderGeneratorFilter{
 		{
-			PathsDoesntExist: []string{"two"},
+			PathsDoNotExist: []string{"two"},
 		},
 	}
 	repos, err := ListRepos(context.Background(), provider, filters, "")
@@ -297,8 +297,8 @@ func TestApplicableFilterMap(t *testing.T) {
 		FilterType: FilterTypeBranch,
 	}
 	pathDoesntExistsFilter := Filter{
-		PathsDoesntExist: []string{"test"},
-		FilterType:       FilterTypeBranch,
+		PathsDoNotExist: []string{"test"},
+		FilterType:      FilterTypeBranch,
 	}
 	labelMatchFilter := Filter{
 		LabelMatch: &regexp.Regexp{},

--- a/docs/operator-manual/applicationset/Generators-SCM-Provider.md
+++ b/docs/operator-manual/applicationset/Generators-SCM-Provider.md
@@ -188,11 +188,11 @@ spec:
       # Include any repository starting with "myapp" AND including a Kustomize config AND labeled with "deploy-ok" ...
       - repositoryMatch: ^myapp
         pathsExist: [kubernetes/kustomization.yaml]
-        pathsDoesntExist: [disabledrepo.txt]
         labelMatch: deploy-ok
-      # ... OR any repository starting with "otherapp" AND a Helm folder.
+      # ... OR include any repository starting with "otherapp" AND a Helm folder and doesn't have file disabledrepo.txt.
       - repositoryMatch: ^otherapp
         pathsExist: [helm]
+        pathsDoesntExist: [disabledrepo.txt]
   template:
   # ...
 ```

--- a/docs/operator-manual/applicationset/Generators-SCM-Provider.md
+++ b/docs/operator-manual/applicationset/Generators-SCM-Provider.md
@@ -188,6 +188,7 @@ spec:
       # Include any repository starting with "myapp" AND including a Kustomize config AND labeled with "deploy-ok" ...
       - repositoryMatch: ^myapp
         pathsExist: [kubernetes/kustomization.yaml]
+        pathsDoesntExist: [disabledrepo.txt]
         labelMatch: deploy-ok
       # ... OR any repository starting with "otherapp" AND a Helm folder.
       - repositoryMatch: ^otherapp
@@ -198,6 +199,7 @@ spec:
 
 * `repositoryMatch`: A regexp matched against the repository name.
 * `pathsExist`: An array of paths within the repository that must exist. Can be a file or directory, but do not include the trailing `/` for directories.
+* `pathsDoesntExist`: An array of paths within the repository that must not exist. Can be a file or directory, but do not include the trailing `/` for directories.
 * `labelMatch`: A regexp matched against repository labels. If any label matches, the repository is included.
 * `branchMatch`: A regexp matched against branch names.
 

--- a/docs/operator-manual/applicationset/Generators-SCM-Provider.md
+++ b/docs/operator-manual/applicationset/Generators-SCM-Provider.md
@@ -192,14 +192,14 @@ spec:
       # ... OR include any repository starting with "otherapp" AND a Helm folder and doesn't have file disabledrepo.txt.
       - repositoryMatch: ^otherapp
         pathsExist: [helm]
-        pathsDoesntExist: [disabledrepo.txt]
+        pathsDoNotExist: [disabledrepo.txt]
   template:
   # ...
 ```
 
 * `repositoryMatch`: A regexp matched against the repository name.
-* `pathsExist`: An array of paths within the repository that must exist. Can be a file or directory, but do not include the trailing `/` for directories.
-* `pathsDoesntExist`: An array of paths within the repository that must not exist. Can be a file or directory, but do not include the trailing `/` for directories.
+* `pathsExist`: An array of paths within the repository that must exist. Can be a file or directory.
+* `pathsDoNotExist`: An array of paths within the repository that must not exist. Can be a file or directory.
 * `labelMatch`: A regexp matched against repository labels. If any label matches, the repository is included.
 * `branchMatch`: A regexp matched against branch names.
 

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -4868,7 +4868,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -7021,7 +7021,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -8039,7 +8039,7 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
-                              pathsDoesntExist:
+                              pathsDoNotExist:
                                 items:
                                   type: string
                                 type: array

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -4868,6 +4868,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -7017,6 +7021,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -8031,6 +8039,10 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
+                              pathsDoesntExist:
+                                items:
+                                  type: string
+                                type: array
                               pathsExist:
                                 items:
                                   type: string

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -2716,6 +2716,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -4865,6 +4869,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -5879,6 +5887,10 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
+                              pathsDoesntExist:
+                                items:
+                                  type: string
+                                type: array
                               pathsExist:
                                 items:
                                   type: string

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -2716,7 +2716,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -4869,7 +4869,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -5887,7 +5887,7 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
-                              pathsDoesntExist:
+                              pathsDoNotExist:
                                 items:
                                   type: string
                                 type: array

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4868,7 +4868,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -7021,7 +7021,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -8039,7 +8039,7 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
-                              pathsDoesntExist:
+                              pathsDoNotExist:
                                 items:
                                   type: string
                                 type: array

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -4868,6 +4868,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -7017,6 +7021,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -8031,6 +8039,10 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
+                              pathsDoesntExist:
+                                items:
+                                  type: string
+                                type: array
                               pathsExist:
                                 items:
                                   type: string

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -4868,7 +4868,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -7021,7 +7021,7 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
-                                        pathsDoesntExist:
+                                        pathsDoNotExist:
                                           items:
                                             type: string
                                           type: array
@@ -8039,7 +8039,7 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
-                              pathsDoesntExist:
+                              pathsDoNotExist:
                                 items:
                                   type: string
                                 type: array

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -4868,6 +4868,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -7017,6 +7021,10 @@ spec:
                                           type: string
                                         labelMatch:
                                           type: string
+                                        pathsDoesntExist:
+                                          items:
+                                            type: string
+                                          type: array
                                         pathsExist:
                                           items:
                                             type: string
@@ -8031,6 +8039,10 @@ spec:
                                 type: string
                               labelMatch:
                                 type: string
+                              pathsDoesntExist:
+                                items:
+                                  type: string
+                                type: array
                               pathsExist:
                                 items:
                                   type: string

--- a/pkg/apis/applicationset/v1alpha1/applicationset_types.go
+++ b/pkg/apis/applicationset/v1alpha1/applicationset_types.go
@@ -381,7 +381,7 @@ type SCMProviderGeneratorFilter struct {
 	// An array of paths, all of which must exist.
 	PathsExist []string `json:"pathsExist,omitempty"`
 	// An array of paths, all of which must not exist.
-	PathsDoesntExist []string `json:"pathsDoesntExist,omitempty"`
+	PathsDoNotExist []string `json:"pathsDoNotExist,omitempty"`
 	// A regex which must match at least one label.
 	LabelMatch *string `json:"labelMatch,omitempty"`
 	// A regex which must match the branch name.

--- a/pkg/apis/applicationset/v1alpha1/applicationset_types.go
+++ b/pkg/apis/applicationset/v1alpha1/applicationset_types.go
@@ -380,6 +380,8 @@ type SCMProviderGeneratorFilter struct {
 	RepositoryMatch *string `json:"repositoryMatch,omitempty"`
 	// An array of paths, all of which must exist.
 	PathsExist []string `json:"pathsExist,omitempty"`
+	// An array of paths, all of which must not exist.
+	PathsDoesntExist []string `json:"pathsDoesntExist,omitempty"`
 	// A regex which must match at least one label.
 	LabelMatch *string `json:"labelMatch,omitempty"`
 	// A regex which must match the branch name.

--- a/pkg/apis/applicationset/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/applicationset/v1alpha1/zz_generated.deepcopy.go
@@ -906,8 +906,8 @@ func (in *SCMProviderGeneratorFilter) DeepCopyInto(out *SCMProviderGeneratorFilt
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.PathsDoesntExist != nil {
-		in, out := &in.PathsDoesntExist, &out.PathsDoesntExist
+	if in.PathsDoNotExist != nil {
+		in, out := &in.PathsDoNotExist, &out.PathsDoNotExist
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/apis/applicationset/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/applicationset/v1alpha1/zz_generated.deepcopy.go
@@ -906,6 +906,11 @@ func (in *SCMProviderGeneratorFilter) DeepCopyInto(out *SCMProviderGeneratorFilt
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PathsDoesntExist != nil {
+		in, out := &in.PathsDoesntExist, &out.PathsDoesntExist
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.LabelMatch != nil {
 		in, out := &in.LabelMatch, &out.LabelMatch
 		*out = new(string)


### PR DESCRIPTION
Fixes :- [#555](https://github.com/argoproj/applicationset/issues/555)
In a way can provide fix to [this](https://github.com/argoproj/argo-cd/issues/4808)
Repo with certain file if present in application will be ignored by applicationset
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

