### PR TITLE
chore: simplify test tempdir

### DIFF
--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2623,6 +2623,7 @@ func TestGetCAPath(t *testing.T) {
 		"../another/invalid/thing",
 		"./also/invalid",
 		"$invalid/as/well",
+		"..",
 	}
 
 	for _, str := range validcert {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2599,10 +2599,7 @@ func Test_validateGroupName(t *testing.T) {
 
 func TestGetCAPath(t *testing.T) {
 
-	temppath, err := ioutil.TempDir("", "argocd-cert-test")
-	if err != nil {
-		panic(err)
-	}
+	temppath := t.TempDir()
 	cert, err := ioutil.ReadFile("../../../../test/fixture/certs/argocd-test-server.crt")
 	if err != nil {
 		panic(err)
@@ -2611,7 +2608,6 @@ func TestGetCAPath(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(temppath)
 	os.Setenv(argocdcommon.EnvVarTLSDataPath, temppath)
 	validcert := []string{
 		"https://foo.example.com",


### PR DESCRIPTION
Follow-up to simplify this test: https://github.com/argoproj/argo-cd/pull/8508#discussion_r845167818

I also added a test to make sure we hit this error:

```go
	if !strings.HasPrefix(certPath, dataPath) {
		return nil, fmt.Errorf("could not get certificate for host %s", serverName)
	}
```

In other words, check for a directory traversal.