### PR TITLE
fix: add writable /tmp mount for the applicationset controller

### DIFF
--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
@@ -41,6 +41,8 @@ spec:
             name: gpg-keys
           - mountPath: /app/config/gpg/keys
             name: gpg-keyring
+          - mountPath: /tmp
+            name: tmp
           securityContext:
            capabilities:
              drop:
@@ -61,3 +63,5 @@ spec:
         name: gpg-keys
       - emptyDir: {}
         name: gpg-keyring
+      - emptyDir: {}
+        name: tmp

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9400,6 +9400,8 @@ spec:
           name: gpg-keys
         - mountPath: /app/config/gpg/keys
           name: gpg-keyring
+        - mountPath: /tmp
+          name: tmp
       serviceAccountName: argocd-applicationset-controller
       volumes:
       - configMap:
@@ -9413,6 +9415,8 @@ spec:
         name: gpg-keys
       - emptyDir: {}
         name: gpg-keyring
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10337,6 +10337,8 @@ spec:
           name: gpg-keys
         - mountPath: /app/config/gpg/keys
           name: gpg-keyring
+        - mountPath: /tmp
+          name: tmp
       serviceAccountName: argocd-applicationset-controller
       volumes:
       - configMap:
@@ -10350,6 +10352,8 @@ spec:
         name: gpg-keys
       - emptyDir: {}
         name: gpg-keyring
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1261,6 +1261,8 @@ spec:
           name: gpg-keys
         - mountPath: /app/config/gpg/keys
           name: gpg-keyring
+        - mountPath: /tmp
+          name: tmp
       serviceAccountName: argocd-applicationset-controller
       volumes:
       - configMap:
@@ -1274,6 +1276,8 @@ spec:
         name: gpg-keys
       - emptyDir: {}
         name: gpg-keyring
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9707,6 +9707,8 @@ spec:
           name: gpg-keys
         - mountPath: /app/config/gpg/keys
           name: gpg-keyring
+        - mountPath: /tmp
+          name: tmp
       serviceAccountName: argocd-applicationset-controller
       volumes:
       - configMap:
@@ -9720,6 +9722,8 @@ spec:
         name: gpg-keys
       - emptyDir: {}
         name: gpg-keyring
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -631,6 +631,8 @@ spec:
           name: gpg-keys
         - mountPath: /app/config/gpg/keys
           name: gpg-keyring
+        - mountPath: /tmp
+          name: tmp
       serviceAccountName: argocd-applicationset-controller
       volumes:
       - configMap:
@@ -644,6 +646,8 @@ spec:
         name: gpg-keys
       - emptyDir: {}
         name: gpg-keyring
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
The applicationset controller needs a writeable /tmp volume since it clones git repos.

Regression due to https://github.com/argoproj/argo-cd/pull/9087 but is not in any released version.

Another reason to do this: https://github.com/argoproj/argo-cd/issues/8948