### PR TITLE
fix: add sh256 hashes for arm on osx for m1 cpus

### DIFF
--- a/hack/installers/checksums/kustomize_4.2.0_darwin_arm64.tar.gz.sha256
+++ b/hack/installers/checksums/kustomize_4.2.0_darwin_arm64.tar.gz.sha256
@@ -1,0 +1,1 @@
+7ad70475fe5684f7150f7f1825df5f17652ec812fa65129b756000e9a6b49fff  kustomize_4.2.0_darwin_arm64.tar.gz

--- a/hack/installers/checksums/kustomize_4.4.1_darwin_arm64.tar.gz.sha256
+++ b/hack/installers/checksums/kustomize_4.4.1_darwin_arm64.tar.gz.sha256
@@ -1,0 +1,1 @@
+689d873b30dc052a51e737eaf20a416e1a72a6d8f85e5d9c4969515fa2ad578c  kustomize_4.4.1_darwin_arm64.tar.gz


### PR DESCRIPTION
This adds arm sha256 hashes for osx for m1 cpus

Signed-off-by: zachaller <zachaller@hotmail.com>