### PR TITLE
feat: add gke auth command to argocd-k8s-auth (#5958)

### DIFF
--- a/cmd/argocd-k8s-auth/commands/argocd_k8s_auth.go
+++ b/cmd/argocd-k8s-auth/commands/argocd_k8s_auth.go
@@ -19,6 +19,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	command.AddCommand(newAWSCommand())
+	command.AddCommand(newGCPCommand())
 
 	return command
 }

--- a/cmd/argocd-k8s-auth/commands/gcp.go
+++ b/cmd/argocd-k8s-auth/commands/gcp.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2/google"
+
+	"github.com/argoproj/argo-cd/v2/util/errors"
+)
+
+var (
+	// defaultGCPScopes:
+	// - cloud-platform is the base scope to authenticate to GCP.
+	// - userinfo.email is used to authenticate to GKE APIs with gserviceaccount
+	//   email instead of numeric uniqueID.
+	// https://github.com/kubernetes/client-go/blob/be758edd136e61a1bffadf1c0235fceb8aee8e9e/plugin/pkg/client/auth/gcp/gcp.go#L59
+	defaultGCPScopes = []string{
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/userinfo.email",
+	}
+)
+
+func newGCPCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use: "gcp",
+		Run: func(c *cobra.Command, args []string) {
+			// Preferred way to retrieve GCP credentials
+			// https://github.com/golang/oauth2/blob/9780585627b5122c8cc9c6a378ac9861507e7551/google/doc.go#L54-L68
+			cred, err := google.FindDefaultCredentials(context.Background(), defaultGCPScopes...)
+			errors.CheckError(err)
+			token, err := cred.TokenSource.Token()
+			errors.CheckError(err)
+			_, _ = fmt.Fprint(os.Stdout, formatJSON(token.AccessToken, token.Expiry))
+		},
+	}
+	return command
+}

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -554,6 +554,35 @@ stringData:
     }
 ```
 
+GKE cluster secret example using argocd-k8s-auth and [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mycluster-secret
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+type: Opaque
+stringData:
+  name: mycluster.com
+  server: https://mycluster.com
+  config: |
+    {
+      "execProviderConfig": {
+        "command": "argocd-k8s-auth",
+        "args": ["gcp"],
+        "apiVersion": "client.authentication.k8s.io/v1beta1"
+      },
+      "tlsClientConfig": {
+        "insecure": false,
+        "caData": "<base64 encoded certificate>"
+      }
+    }
+```
+
+Note that you must enable Workload Identity on your GKE cluster, create GCP service account with appropriate IAM role and bind it to Kubernetes service account for argocd-application-controller and argocd-server (showing Pod logs on UI). See [Use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) and [Authenticating to the Kubernetes API server](https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication).
+
 ## Helm Chart Repositories
 
 Non standard Helm Chart repositories have to be registered explicitly.


### PR DESCRIPTION
This PR adds support for GKE authentication to argocd-k8s-auth CLI introduced by #8032.

AWS (EKS) has first-class support for managing external clusters with IAM authentication since #588 but other cloud providers don't have such an easy configuration option.

Previously, with regard to GKE, we had to build custom image following the instruction described in [BYOI (Build Your Own Image)](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#byoi-build-your-own-image) and manually install [gke-gcloud-auth-plugin](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke) (~~currently not open sourced?~~ [gke-gcloud-auth-plugin](https://github.com/kubernetes/cloud-provider-gcp/tree/master/cmd/gke-gcloud-auth-plugin)) or third party tools like [sl1pm4t/gcp-exec-creds](https://github.com/sl1pm4t/gcp-exec-creds). Then register cluster using `execProviderConfig` to specify the command for thoese auth plugins.

Recently, #8032 introduced the mechanism to extend support for more cloud providers to add their own auth methods, so I added built-in support for GKE clusters. This PR requires neither extra dependencies nor complicated logic so I think it's easy to maintain like aws auth feature.

```sh
❯ CGO_ENABLED=0 go build -v -o $(pwd)/dist/argocd-k8s-auth ./cmd
❯ ./dist/argocd-k8s-auth gcp | jq
{
  "kind": "ExecCredential",
  "apiVersion": "client.authentication.k8s.io/v1beta1",
  "spec": {
    "interactive": false
  },
  "status": {
    "expirationTimestamp": "2022-04-24T03:30:58Z",
    "token": "**redacted**"
  }
}
```

Use this feature to manage external clusters with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity):

1. Create GKE cluster and enable Workload Identity
1. Create GCP service account for ArgoCD
1. Add appropriate role to GCP service account and optionally restrict access to the K8s resources using K8s RBAC. See [Authenticating services](https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#authenticating_services).
1. Bind GCP service account to K8s service account and set annotation to K8s service account for argocd-application-controller and argocd-server. See [Configure applications to use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
1. Edit cluster `config` field on existing Secret and replace `execProviderConfig` to use built-in `argocd-k8s-auth` binary described in updated doc. Don't forget to Base64 encode value in case of using data with Secret.

    ```yaml
    apiVersion: v1
    kind: Secret
    metadata:
      name: mycluster-secret
      labels:
        argocd.argoproj.io/secret-type: cluster
    type: Opaque
    data:
      name: bXljbHVzdGVyLmNvbQ==
      server: aHR0cHM6Ly9teWNsdXN0ZXIuY29t
      config: ewogICJleGVjUHJvdmlkZXJDb25maWciOiB7CiAgICAiY29tbWFuZCI6ICJhcmdvY2QtazhzLWF1dGgiLAogICAgImFyZ3MiOiBbImdjcCJdLAogICAgImFwaVZlcnNpb24iOiAiY2xpZW50LmF1dGhlbnRpY2F0aW9uLms4cy5pby92MWJldGExIgogIH0sCiAgInRsc0NsaWVudENvbmZpZyI6IHsKICAgICJpbnNlY3VyZSI6IGZhbHNlLAogICAgImNhRGF0YSI6ICI8YmFzZTY0IGVuY29kZWQgY2VydGlmaWNhdGU+IgogIH0KfQ==
    ```

Closes #5958

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
~~* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~~
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
~~* [ ] Optional. My organization is added to USERS.md.~~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
~~* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~~
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
