### PR TITLE
fix: throw better error if default branch is missing in gitea

### DIFF
--- a/applicationset/services/scm_provider/gitea.go
+++ b/applicationset/services/scm_provider/gitea.go
@@ -48,13 +48,7 @@ func (g *GiteaProvider) GetBranches(ctx context.Context, repo *Repository) ([]*R
 	if !g.allBranches {
 		branch, status, err := g.client.GetRepoBranch(g.owner, repo.Repository, repo.Branch)
 		if status.StatusCode == 404 {
-			// The gitea API sometimes specifies a non-existing branch as the default. Try to fall back to a reasonable
-			// default.
-			var branches []*gitea.Branch
-			branches, _, err = g.client.ListRepoBranches(g.owner, repo.Repository, gitea.ListRepoBranchesOptions{})
-			if err == nil && len(branches) == 1 {
-				branch = branches[0]
-			}
+			return nil, fmt.Errorf("got 404 while getting default branch %q for repo %q - check your repo config: %w", repo.Branch, repo.Repository, err)
 		}
 		if err != nil {
 			return nil, err

--- a/applicationset/services/scm_provider/gitea_test.go
+++ b/applicationset/services/scm_provider/gitea_test.go
@@ -19,20 +19,20 @@ func TestGiteaListRepos(t *testing.T) {
 		{
 			name:     "blank protocol",
 			allBranches: false,
-			url:      "git@gitea.com:gitea/go-sdk.git",
-			branches: []string{"master"},
+			url:      "git@gitea.com:test-argocd/pr-test.git",
+			branches: []string{"main"},
 		},
 		{
 			name:  "ssh protocol",
 			allBranches: false,
 			proto: "ssh",
-			url:   "git@gitea.com:gitea/go-sdk.git",
+			url:   "git@gitea.com:test-argocd/pr-test.git",
 		},
 		{
 			name:  "https protocol",
 			allBranches: false,
 			proto: "https",
-			url:   "https://gitea.com/gitea/go-sdk",
+			url:   "https://gitea.com/test-argocd/pr-test",
 		},
 		{
 			name:     "other protocol",
@@ -43,14 +43,14 @@ func TestGiteaListRepos(t *testing.T) {
 		{
 			name:        "all branches",
 			allBranches: true,
-			url:         "git@gitea.com:gitea/go-sdk.git",
-			branches:    []string{"master", "release/v0.11", "release/v0.12", "release/v0.13", "release/v0.14", "release/v0.15"},
+			url:         "git@gitea.com:test-argocd/pr-test.git",
+			branches:    []string{"main"},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			provider, _ := NewGiteaProvider(context.Background(), "gitea", "", "https://gitea.com/", c.allBranches, false)
+			provider, _ := NewGiteaProvider(context.Background(), "test-argocd", "", "https://gitea.com/", c.allBranches, false)
 			rawRepos, err := ListRepos(context.Background(), provider, c.filters, c.proto)
 			if c.hasError {
 				assert.NotNil(t, err)
@@ -61,7 +61,7 @@ func TestGiteaListRepos(t *testing.T) {
 				repos := []*Repository{}
 				branches := []string{}
 				for _, r := range rawRepos {
-					if r.Repository == "go-sdk" {
+					if r.Repository == "pr-test" {
 						repos = append(repos, r)
 						branches = append(branches, r.Branch)
 					}


### PR DESCRIPTION
A gitea unit test is failing because the gitea API is returning `main` as the default branch for https://gitea.com/gitea/test-openldap when the only existing branch is `master`.

I've modified the "get branch" logic to fall back to the only branch if the default branch is missing.