### PR TITLE
fix: don't include exec as part of the default read-only role

### DIFF
--- a/assets/builtin-policy.csv
+++ b/assets/builtin-policy.csv
@@ -14,7 +14,6 @@ p, role:readonly, projects, get, *, allow
 p, role:readonly, accounts, get, *, allow
 p, role:readonly, gpgkeys, get, *, allow
 p, role:readonly, logs, get, */*, allow
-p, role:readonly, exec, get, */*, allow
 
 p, role:admin, applications, create, */*, allow
 p, role:admin, applications, update, */*, allow


### PR DESCRIPTION
exec seems a bit too powerful to be treated as "read-only". Especially since service account tokens are mounted in pods by default.