### PR TITLE
Remove Kubernetes External Secret from docs

### DIFF
--- a/docs/operator-manual/secret-management.md
+++ b/docs/operator-manual/secret-management.md
@@ -3,7 +3,6 @@
 Argo CD is un-opinionated about how secrets are managed. There's many ways to do it and there's no one-size-fits-all solution. Here's some ways people are doing GitOps secrets:
 
 * [Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
-* [GoDaddy Kubernetes External Secrets](https://github.com/godaddy/kubernetes-external-secrets)
 * [External Secrets Operator](https://github.com/external-secrets/external-secrets)
 * [Hashicorp Vault](https://www.vaultproject.io)
 * [Banzai Cloud Bank-Vaults](https://github.com/banzaicloud/bank-vaults)


### PR DESCRIPTION
It seems to be deprecated.
https://github.com/external-secrets/kubernetes-external-secrets

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

