### PR TITLE
chore: add imaware to users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -79,6 +79,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [IBM](https://www.ibm.com/)
 1. [Ibotta](https://home.ibotta.com)
 1. [IITS-Consulting](https://iits-consulting.de)
+1. [imaware](https://imaware.health)
 1. [Index Exchange](https://www.indexexchange.com/)
 1. [InsideBoard](https://www.insideboard.com)
 1. [Intuit](https://www.intuit.com/)


### PR DESCRIPTION
We use argo extensively in production, appsets, notif controller, and now multi cluster, so figured add our name to the list

