### PR TITLE
chore: remove final uses of repo List

### DIFF
--- a/test/e2e/fixture/repos/consequences.go
+++ b/test/e2e/fixture/repos/consequences.go
@@ -39,7 +39,7 @@ func (c *Consequences) repo() (*v1alpha1.Repository, error) {
 func (c *Consequences) get() (*v1alpha1.Repository, error) {
 	_, repoClient, _ := fixture.ArgoCDClientset.NewRepoClient()
 
-	repo, _ := repoClient.List(context.Background(), &repositorypkg.RepoQuery{})
+	repo, _ := repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
 	for i := range repo.Items {
 		if repo.Items[i].Repo == c.context.path {
 			return repo.Items[i], nil

--- a/test/e2e/repo_management_test.go
+++ b/test/e2e/repo_management_test.go
@@ -24,7 +24,7 @@ func TestAddRemovePublicRepo(t *testing.T) {
 		assert.NoError(t, err)
 		defer argoio.Close(conn)
 
-		repo, err := repoClient.List(context.Background(), &repositorypkg.RepoQuery{})
+		repo, err := repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
 
 		assert.Nil(t, err)
 		exists := false
@@ -39,7 +39,7 @@ func TestAddRemovePublicRepo(t *testing.T) {
 		_, err = fixture.RunCli("repo", "rm", repoUrl)
 		assert.NoError(t, err)
 
-		repo, err = repoClient.List(context.Background(), &repositorypkg.RepoQuery{})
+		repo, err = repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
 		assert.NoError(t, err)
 		exists = false
 		for i := range repo.Items {
@@ -82,7 +82,7 @@ func TestAddRemoveHelmRepo(t *testing.T) {
 		assert.NoError(t, err)
 		defer argoio.Close(conn)
 
-		repo, err := repoClient.List(context.Background(), &repositorypkg.RepoQuery{})
+		repo, err := repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
 
 		assert.NoError(t, err)
 		exists := false
@@ -97,7 +97,7 @@ func TestAddRemoveHelmRepo(t *testing.T) {
 		_, err = fixture.RunCli("repo", "rm", fixture.RepoURL(fixture.RepoURLTypeHelm))
 		assert.NoError(t, err)
 
-		repo, err = repoClient.List(context.Background(), &repositorypkg.RepoQuery{})
+		repo, err = repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
 		assert.NoError(t, err)
 		exists = false
 		for i := range repo.Items {
@@ -133,7 +133,7 @@ func TestAddHelmRepoInsecureSkipVerify(t *testing.T) {
 
 		defer argoio.Close(conn)
 
-		repo, err := repoClient.List(context.Background(), &repositorypkg.RepoQuery{})
+		repo, err := repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
 
 		if !assert.NoError(t, err) {
 			return


### PR DESCRIPTION
Part of #9258 

Removing final uses of List for repo client in argo-cd codebase. Replacing with non-deprecated ListRepositories. 

Signed-off-by: Daniel Helfand <helfand.4@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

