### PR TITLE
chore: disable webpack dev-server compression

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -96,6 +96,7 @@ const config = {
         })
     ],
     devServer: {
+        compress: false,
         historyApiFallback: {
             disableDotRule: true
         },


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR disables compression of webpack dev server to fix SSE calls. The SSE response cannot be gzipped because content is delivered in chunks.