### PR TITLE
fix: updated cli docs for windows

### DIFF
--- a/docs/cli_installation.md
+++ b/docs/cli_installation.md
@@ -81,7 +81,7 @@ $version = (Invoke-RestMethod https://api.github.com/repos/argoproj/argo-cd/rele
 Replace `$version` in the command below with the version of Argo CD you would like to download:
 
 ```powershell
-$url = "https://github.com/argoproj/argo-cd/releases/download/" + $version + "/argocd-windows-amd64.exe"
+$url = "https://github.com/argoproj/argo-cd/releases/download/" + '$version' + "/argocd-windows-amd64.exe"
 $output = "argocd.exe"
 
 Invoke-WebRequest -Uri $url -OutFile $output


### PR DESCRIPTION
Signed off: [adefemi171@gmail.com](mailto:adefemi171@gmail.com)
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 


The installation for ArgoCD on windows require quote around the version number, added that to the docs.

