### PR TITLE
chore: Pull in recent kubectl to test container

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,10 +1,12 @@
-FROM redis:7.0.0 as redis
+FROM docker.io/library/redis:7.0.0 as redis
 
-FROM node:12.18.4-buster as node
+FROM docker.io/library/node:12.18.4-buster as node
 
-FROM golang:1.18 as golang
+FROM docker.io/library/golang:1.18 as golang
 
-FROM registry:2.8 as registry
+FROM docker.io/library/registry:2.8 as registry
+
+FROM docker.io/bitnami/kubectl:1.23.6 as kubectl
 
 FROM ubuntu:21.10
 
@@ -31,6 +33,8 @@ RUN  apt-get update && apt-get install --fix-missing -y \
 
 COPY --from=golang /usr/local/go /usr/local/go
 
+COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+
 ENV PATH /dist:/go/bin:/usr/local/go/bin:$PATH
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
@@ -40,7 +44,6 @@ COPY hack/install.sh hack/tool-versions.sh go.* ./
 COPY hack/installers installers
 
 RUN ./install.sh helm-linux && \
-    ./install.sh kubectl-linux && \
     ./install.sh kustomize && \
     ./install.sh codegen-tools && \
     ./install.sh codegen-go-tools && \


### PR DESCRIPTION
PR pulls in latest kubectl from Bitnami's kubectl image to be used in the test container.

Also, fully qualify other image references.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

