### PR TITLE
feat: Add plugin call variables to sidecar plugin discovery (#9273)

### DIFF
--- a/cmpserver/plugin/plugin_test.go
+++ b/cmpserver/plugin/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/argoproj/argo-cd/v2/cmpserver/apiclient"
 	"github.com/argoproj/argo-cd/v2/test"
 )
 
@@ -62,6 +63,7 @@ func TestMatchRepository(t *testing.T) {
 	type fixture struct {
 		service *Service
 		path    string
+		env     []*apiclient.EnvEntry
 	}
 	setup := func(t *testing.T, opts ...pluginOpt) *fixture {
 		t.Helper()
@@ -71,6 +73,7 @@ func TestMatchRepository(t *testing.T) {
 		return &fixture{
 			service: s,
 			path:    path,
+			env:     []*apiclient.EnvEntry{{Name: "ENV_VAR", Value: "1"}},
 		}
 	}
 	t.Run("will match plugin by filename", func(t *testing.T) {
@@ -81,7 +84,7 @@ func TestMatchRepository(t *testing.T) {
 		f := setup(t, withDiscover(d))
 
 		// when
-		match, err := f.service.matchRepository(context.Background(), f.path)
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
 
 		// then
 		assert.NoError(t, err)
@@ -95,7 +98,7 @@ func TestMatchRepository(t *testing.T) {
 		f := setup(t, withDiscover(d))
 
 		// when
-		match, err := f.service.matchRepository(context.Background(), f.path)
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
 
 		// then
 		assert.NoError(t, err)
@@ -111,7 +114,7 @@ func TestMatchRepository(t *testing.T) {
 		f := setup(t, withDiscover(d))
 
 		// when
-		match, err := f.service.matchRepository(context.Background(), f.path)
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
 
 		// then
 		assert.NoError(t, err)
@@ -127,7 +130,7 @@ func TestMatchRepository(t *testing.T) {
 		f := setup(t, withDiscover(d))
 
 		// when
-		match, err := f.service.matchRepository(context.Background(), f.path)
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
 
 		// then
 		assert.NoError(t, err)
@@ -145,7 +148,7 @@ func TestMatchRepository(t *testing.T) {
 		f := setup(t, withDiscover(d))
 
 		// when
-		match, err := f.service.matchRepository(context.Background(), f.path)
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
 
 		// then
 		assert.NoError(t, err)
@@ -163,7 +166,43 @@ func TestMatchRepository(t *testing.T) {
 		f := setup(t, withDiscover(d))
 
 		// when
-		match, err := f.service.matchRepository(context.Background(), f.path)
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
+
+		// then
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+	t.Run("will match plugin because env var defined", func(t *testing.T) {
+		// given
+		d := Discover{
+			Find: Find{
+				Command: Command{
+					Command: []string{"sh", "-c", "echo -n $ENV_VAR"},
+				},
+			},
+		}
+		f := setup(t, withDiscover(d))
+
+		// when
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
+
+		// then
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+	t.Run("will not match plugin because no env var defined", func(t *testing.T) {
+		// given
+		d := Discover{
+			Find: Find{
+				Command: Command{
+					Command: []string{"sh", "-c", "echo -n $ENV_NO_VAR"},
+				},
+			},
+		}
+		f := setup(t, withDiscover(d))
+
+		// when
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
 
 		// then
 		assert.NoError(t, err)
@@ -181,7 +220,7 @@ func TestMatchRepository(t *testing.T) {
 		f := setup(t, withDiscover(d))
 
 		// when
-		match, err := f.service.matchRepository(context.Background(), f.path)
+		match, err := f.service.matchRepository(context.Background(), f.path, f.env)
 
 		// then
 		assert.Error(t, err)

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1031,7 +1031,7 @@ func TestRunCustomTool(t *testing.T) {
 			Name: "test",
 			Generate: argoappv1.Command{
 				Command: []string{"sh", "-c"},
-				Args:    []string{`echo "{\"kind\": \"FakeObject\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GIT_ASKPASS\": \"$GIT_ASKPASS\", \"GIT_USERNAME\": \"$GIT_USERNAME\", \"GIT_PASSWORD\": \"$GIT_PASSWORD\"}, \"labels\": {\"revision\": \"$TEST_REVISION\"}}}"`},
+				Args:    []string{`echo "{\"kind\": \"FakeObject\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"GIT_ASKPASS\": \"$GIT_ASKPASS\", \"GIT_USERNAME\": \"$GIT_USERNAME\", \"GIT_PASSWORD\": \"$GIT_PASSWORD\"}, \"labels\": {\"revision\": \"$ARGOCD_ENV_TEST_REVISION\"}}}"`},
 			},
 		}},
 		Repo: &argoappv1.Repository{

--- a/test/e2e/custom_tool_test.go
+++ b/test/e2e/custom_tool_test.go
@@ -102,7 +102,7 @@ func TestCustomToolWithEnv(t *testing.T) {
 				Name: Name(),
 				Generate: Command{
 					Command: []string{"sh", "-c"},
-					Args:    []string{`echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"`},
+					Args:    []string{`echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$ARGOCD_ENV_FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"`},
 				},
 			},
 		).
@@ -162,7 +162,7 @@ func TestCustomToolSyncAndDiffLocal(t *testing.T) {
 				Name: Name(),
 				Generate: Command{
 					Command: []string{"sh", "-c"},
-					Args:    []string{`echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"`},
+					Args:    []string{`echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$ARGOCD_ENV_FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"`},
 				},
 			},
 		).

--- a/util/app/discovery/discovery.go
+++ b/util/app/discovery/discovery.go
@@ -33,7 +33,7 @@ func Discover(ctx context.Context, repoPath string, enableGenerateManifests map[
 	apps := make(map[string]string)
 
 	// Check if it is CMP
-	conn, _, err := DetectConfigManagementPlugin(ctx, repoPath)
+	conn, _, err := DetectConfigManagementPlugin(ctx, repoPath, []string{})
 	if err == nil {
 		// Found CMP
 		io.Close(conn)
@@ -82,7 +82,7 @@ func AppType(ctx context.Context, path string, enableGenerateManifests map[strin
 // 3. check isSupported(path)?
 // 4.a if no then close connection
 // 4.b if yes then return conn for detected plugin
-func DetectConfigManagementPlugin(ctx context.Context, repoPath string) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, error) {
+func DetectConfigManagementPlugin(ctx context.Context, repoPath string, env []string) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, error) {
 	var conn io.Closer
 	var cmpClient pluginclient.ConfigManagementPluginServiceClient
 
@@ -106,7 +106,7 @@ func DetectConfigManagementPlugin(ctx context.Context, repoPath string) (io.Clos
 				continue
 			}
 
-			isSupported, err := matchRepositoryCMP(ctx, repoPath, cmpClient)
+			isSupported, err := matchRepositoryCMP(ctx, repoPath, cmpClient, env)
 			if err != nil {
 				log.Errorf("repository %s is not the match because %v", repoPath, err)
 				continue
@@ -131,13 +131,13 @@ func DetectConfigManagementPlugin(ctx context.Context, repoPath string) (io.Clos
 // matchRepositoryCMP will send the repoPath to the cmp-server. The cmp-server will
 // inspect the files and return true if the repo is supported for manifest generation.
 // Will return false otherwise.
-func matchRepositoryCMP(ctx context.Context, repoPath string, client pluginclient.ConfigManagementPluginServiceClient) (bool, error) {
+func matchRepositoryCMP(ctx context.Context, repoPath string, client pluginclient.ConfigManagementPluginServiceClient, env []string) (bool, error) {
 	matchRepoStream, err := client.MatchRepository(ctx, grpc_retry.Disable())
 	if err != nil {
 		return false, fmt.Errorf("error getting stream client: %s", err)
 	}
 
-	err = cmp.SendRepoStream(ctx, repoPath, repoPath, matchRepoStream, []string{})
+	err = cmp.SendRepoStream(ctx, repoPath, repoPath, matchRepoStream, env)
 	if err != nil {
 		return false, fmt.Errorf("error sending stream: %s", err)
 	}


### PR DESCRIPTION
Gives access to variables declared in the call of the plugin in the application
manifest to the discover command run on the CMP server.

Variables are prefixed with ENV_ to avoid security issues (plugin call
overiding important variables).
Modified variable names are also given to the generate command but the variables
with unmodified names are also defined to preserve the old behavior until it is
deprecated.

Fixes #9273
Fixes https://github.com/argoproj/argo-cd/issues/8986

Signed-off-by: Pierre Crégut <pierre.cregut@orange.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

