### PR TITLE
fix: built-in admin should has exec permission

### DIFF
--- a/assets/builtin-policy.csv
+++ b/assets/builtin-policy.csv
@@ -36,6 +36,7 @@ p, role:admin, projects, delete, *, allow
 p, role:admin, accounts, update, *, allow
 p, role:admin, gpgkeys, create, *, allow
 p, role:admin, gpgkeys, delete, *, allow
+p, role:admin, exec, create, */*, allow
 
 g, role:admin, role:readonly
 g, admin, role:admin

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -287,4 +287,4 @@ data:
   server.rbac.log.enforce.enable: "false"
 
   # exec.enabled indicates whether the UI exec feature is enabled. It is disabled by default.
-  exec.enabled: false
+  exec.enabled: "false"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Built-in `admin` is supposed to have full permissions so it should have `exec` permissions as well.