### PR TITLE
chore: ignore irrelevant go-restful vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -18,5 +18,11 @@ ignore:
     - '*':
         reason: >-
           Code is only run client-side. No risk of directory traversal.
+  SNYK-GOLANG-GITHUBCOMEMICKLEIGORESTFUL-2435653:
+    - '*':
+        reason: >-
+          Argo CD uses go-restful as a transitive dependency of kube-openapi. kube-openapi is used to generate openapi
+          specs. We do not use go-restul at runtime and are therefore not vulnerable to this CORS misconfiguration
+          issue in go-restful.
 patch: {}
 


### PR DESCRIPTION
Does anything actually use this file? https://github.com/argoproj/argo-cd/blob/master/pkg/apis/application/v1alpha1/openapi_generated.go

It uses kube-openapi, which depends on a module with a high-level vulnerability. https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMEMICKLEIGORESTFUL-2435653

I don’t think the vulnerability affects us, because I don’t think any Argo CD code actually uses this file. So one easy way to eliminate the Snyk failure would be to gitignore that file.

The other way to deal with the vulnerability is to ignore it in Snyk, which is what this PR does.