### PR TITLE
fix: ListResourceActions() returns duplicate actions

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1687,8 +1687,8 @@ func (s *Server) ListResourceActions(ctx context.Context, q *application.Applica
 		return nil, err
 	}
 	actionsPtr := []*appv1.ResourceAction{}
-	for _, action := range availableActions {
-		actionsPtr = append(actionsPtr, &action)
+	for i := range availableActions {
+		actionsPtr = append(actionsPtr, &availableActions[i])
 	}
 
 	return &application.ResourceActionsListResponse{Actions: actionsPtr}, nil


### PR DESCRIPTION
`ListResourceActions()` API is returning duplicate actions. The issue is because of appending the pointer of the range variable instead of the actual element of the slice.

```
{"actions":[{"name":"resume","disabled":true},{"name":"resume","disabled":true}]}
```

Fixes: #9334 

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

