### PR TITLE
fix: http headers contain colons in the field value

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -815,11 +815,12 @@ func isCanceledContextErr(err error) bool {
 func parseHeaders(headerStrings []string) (http.Header, error) {
 	headers := http.Header{}
 	for _, kv := range headerStrings {
-		items := strings.Split(kv, ":")
-		if len(items)%2 == 1 {
+		i := strings.IndexByte(kv, ':')
+		// zero means meaningless empty header name
+		if i <= 0 {
 			return nil, fmt.Errorf("additional headers must be colon(:)-separated: %s", kv)
 		}
-		headers.Add(items[0], items[1])
+		headers.Add(kv[0:i], kv[i+1:])
 	}
 	return headers, nil
 }

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -1,0 +1,16 @@
+package apiclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseHeaders(t *testing.T) {
+	headerString := []string{"foo:", "foo1:bar1", "foo2:bar2:bar2"}
+	headers, err := parseHeaders(headerString)
+	assert.NoError(t, err)
+	assert.Equal(t, headers.Get("foo"), "")
+	assert.Equal(t, headers.Get("foo1"), "bar1")
+	assert.Equal(t, headers.Get("foo2"), "bar2:bar2")
+}


### PR DESCRIPTION
 Signed-off-by: ls0f <lovedboy.tk@qq.com>

when use argocd cli specicify headers(eg `argocd app list -H foo:bar1:bar2`), it will fail cause by parseHeaders method
```
FATA[0000] Failed to establish connection to x.x.x.x:8080: additional headers must be colon(:)-separated: foo:bar1:bar2 
```
According to dodument [rfc7230](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6)
![image](https://user-images.githubusercontent.com/1734093/167987094-86cf6687-f38d-4e76-af24-6ca10c7b71a8.png)

**http headers value with colons is valid.**


[httpie](https://github.com/httpie/httpie) cli support headers contain colons in the field value, eg: 
```
http GET httpbin.org/headers User-Agent:mozila:4 foo:bar1:bar2
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 236
Content-Type: application/json
Date: Thu, 12 May 2022 03:43:26 GMT
Server: gunicorn/19.9.0

{
    "headers": {
        "Accept": "*/*",
        "Accept-Encoding": "gzip, deflate",
        "Foo": "bar1:bar2",
        "Host": "httpbin.org",
        "User-Agent": "mozila:4",
        "X-Amzn-Trace-Id": "Root=1-627c825e-4bf6905c04e828e70f85abb3"
    }
}
```

