### PR TITLE
refactor: Update notification engine 

### DIFF
--- a/docs/operator-manual/notifications/services/pagerduty.md
+++ b/docs/operator-manual/notifications/services/pagerduty.md
@@ -1,0 +1,66 @@
+# Pagerduty
+
+## Parameters
+
+The Pagerduty notification service is used to create pagerduty incidents and requires specifying the following settings:
+
+* `pagerdutyToken` - the pagerduty auth token
+* `from` - email address of a valid user associated with the account making the request.
+* `serviceID` - The ID of the resource.
+
+
+## Example
+
+The following snippet contains sample Pagerduty service configuration:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  pagerdutyToken: <pd-api-token>
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.pagerduty: |
+    token: $pagerdutyToken
+    from: <emailid>
+```
+
+## Template
+
+Notification templates support specifying subject for pagerduty notifications:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  template.rollout-aborted: |
+    message: Rollout {{.rollout.metadata.name}} is aborted.
+    pagerduty:
+      title: "Rollout {{.rollout.metadata.name}}"
+      urgency: "high"
+      body: "Rollout {{.rollout.metadata.name}} aborted "
+      priorityID: "<priorityID of incident>"
+```
+
+NOTE: A Priority is a label representing the importance and impact of an incident. This is only available on Standard and Enterprise plans of pagerduty.
+
+## Annotation
+
+Annotation sample for pagerduty notifications:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerduty: "<serviceID for Pagerduty>"
+```

--- a/docs/operator-manual/notifications/services/slack.md
+++ b/docs/operator-manual/notifications/services/slack.md
@@ -54,6 +54,26 @@ The Slack notification service configuration includes following settings:
         annotations:
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: my_channel
 
+1. Annotation with more than one trigger multiple of destinations and recipients
+
+      ```yaml
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+      annotations:
+        notifications.argoproj.io/subscriptions: |
+          - trigger: [on-scaling-replica-set, on-rollout-updated, on-rollout-step-completed]
+            destinations:
+              - service: slack
+                recipients: [my-channel-1, my-channel-2]
+              - service: email
+                recipients: [recipient-1, recipient-2, recipient-3 ]
+          - trigger: [on-rollout-aborted, on-analysis-run-failed, on-analysis-run-error]
+            destinations:
+              - service: slack
+                recipients: [my-channel-21, my-channel-22]
+      ```
+
 ## Templates
 
 Notification templates can be customized to leverage slack message blocks and attachments

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/alicebob/miniredis/v2 v2.14.2
 	github.com/argoproj/gitops-engine v0.6.1-0.20220328190556-73bcea9c8c8f
-	github.com/argoproj/notifications-engine v0.3.1-0.20220322174744-ac18ca10234c
+	github.com/argoproj/notifications-engine v0.3.1-0.20220430155844-567361917320
 	github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0
 	github.com/aws/aws-sdk-go v1.38.49
 	github.com/bombsimon/logrusr/v2 v2.0.1
@@ -237,6 +237,7 @@ require (
 )
 
 require (
+	github.com/PagerDuty/go-pagerduty v1.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/Microsoft/hcsshim v0.8.22/go.mod h1:91uVCVzvX2QD16sMCenoxxXo6L1wJnLMX
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PagerDuty/go-pagerduty v1.5.0 h1:/p8FGD32G8HGm7MQIjlTPTGXRJ62Qkm8Lmt5BcUVJOo=
+github.com/PagerDuty/go-pagerduty v1.5.0/go.mod h1:txr8VbObXdk2RkqF+C2an4qWssdGY99fK26XYUDjh+4=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -146,8 +148,8 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/appscode/go v0.0.0-20190808133642-1d4ef1f1c1e0/go.mod h1:iy07dV61Z7QQdCKJCIvUoDL21u6AIceRhZzyleh2ymc=
 github.com/argoproj/gitops-engine v0.6.1-0.20220328190556-73bcea9c8c8f h1:3x8pG690gbZtGK2G/dlL7b243t/WyyeDT7OUs2n76Nk=
 github.com/argoproj/gitops-engine v0.6.1-0.20220328190556-73bcea9c8c8f/go.mod h1:pRgVpLW7pZqf7n3COJ7UcDepk4cI61LAcJd64Q3Jq/c=
-github.com/argoproj/notifications-engine v0.3.1-0.20220322174744-ac18ca10234c h1:n/5BIocdWYtp1qC8/GFgUUV62I+gln54KFZZLgczwDc=
-github.com/argoproj/notifications-engine v0.3.1-0.20220322174744-ac18ca10234c/go.mod h1:QF4tr3wfWOnhkKSaRpx7k/KEErQAh8iwKQ2pYFu/SfA=
+github.com/argoproj/notifications-engine v0.3.1-0.20220430155844-567361917320 h1:XDjtTfccs4rSOT1n+i1zV9RpxQdKky1b4YBic16E0qY=
+github.com/argoproj/notifications-engine v0.3.1-0.20220430155844-567361917320/go.mod h1:R3zlopt+/juYlebQc9Jarn9vBQ2xZruWOWjUNkfGY9M=
 github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0 h1:Cfp7rO/HpVxnwlRqJe0jHiBbZ77ZgXhB6HWlYD02Xdc=
 github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0/go.mod h1:ra+bQPmbVAoEL+gYSKesuigt4m49i3Qa3mE/xQcjCiA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - operator-manual/notifications/services/mattermost.md
       - operator-manual/notifications/services/opsgenie.md
       - operator-manual/notifications/services/overview.md
+      - operator-manual/notifications/services/pagerduty.md
       - operator-manual/notifications/services/pushover.md
       - operator-manual/notifications/services/rocketchat.md
       - operator-manual/notifications/services/slack.md


### PR DESCRIPTION
Signed-off-by: todaywasawesome <dan@codefresh.io>

Notification Engine is several months behind and includes several bug fixes and two additional features.

- https://github.com/argoproj/notifications-engine/issues/90
- https://github.com/argoproj/notifications-engine/issues/78 and https://github.com/argoproj/notifications-engine/issues/64
- https://github.com/argoproj/notifications-engine/pull/85 similar to https://github.com/argoproj/argo-rollouts/pull/1958


@crenshaw-dev @alexmt There is an open question if we should cherrypick this into 2.4. Given how far behind the current package is, my instinct is that we should include it. Argo Rollouts is using a version from Jan '22 while CD is using one from Nov '21.

CC @kevinchen-verkada who is advocating for these changes. 