### PR TITLE
docs: plugins need their own writeable tmp volume

### DIFF
--- a/docs/operator-manual/upgrading/2.3-2.4.md
+++ b/docs/operator-manual/upgrading/2.3-2.4.md
@@ -97,7 +97,7 @@ spec:
       - name: your-plugin-name
         volumeMounts:
         - mountPath: /tmp
-          name: tmp  # Replace this with a volume specific to your plugin, like your-plugin-name-tmp.
+          name: your-plugin-name-tmp
       volumes:
         # Add this volume.
         - name: your-plugin-name-tmp

--- a/docs/operator-manual/upgrading/2.3-2.4.md
+++ b/docs/operator-manual/upgrading/2.3-2.4.md
@@ -82,7 +82,8 @@ p, role:test-db-admins, logs, get, staging-db-admins/*, allow
 As a security enhancement, [sidecar plugins](../../user-guide/config-management-plugins.md#option-2-configure-plugin-via-sidecar)
 no longer share the /tmp directory with the repo-server.
 
-If you have one or more sidecar plugins enabled, remove the /tmp volume mount from the plugin container definition.
+If you have one or more sidecar plugins enabled, replace the /tmp volume mount for each sidecar to use a volume specific 
+to each plugin.
 
 ```yaml
 apiVersion: apps/v1
@@ -95,7 +96,10 @@ spec:
       containers:
       - name: your-plugin-name
         volumeMounts:
-        # Remove the next two lines:
         - mountPath: /tmp
-          name: tmp
+          name: tmp  # Replace this with a volume specific to your plugin, like your-plugin-name-tmp.
+      volumes:
+        # Add this volume.
+        - name: your-plugin-name-tmp
+          emptyDir: {}
 ```

--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -113,8 +113,7 @@ data:
       generate:
         command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"']
       discover:
-        find:
-          command: [echo, yes]
+        fileName: "./subdir/s*.yaml"
       allowConcurrency: true
       lockRepo: false
 ```
@@ -128,7 +127,7 @@ entrypoint. You can use either off-the-shelf or custom-built plugin image as sid
 containers:
 - name: cmp
   command: [/var/run/argocd/argocd-cmp-server] # Entrypoint should be Argo CD lightweight CMP server i.e. argocd-cmp-server
-  image: quay.io/argoproj/argo-cd:v2.3.3 # This can be off-the-shelf or custom-built image
+  image: busybox # This can be off-the-shelf or custom-built image
   securityContext:
     runAsNonRoot: true
     runAsUser: 999

--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -140,7 +140,7 @@ containers:
     - mountPath: /home/argocd/cmp-server/config/plugin.yaml
       subPath: plugin.yaml
       name: cmp-plugin
-    # Starting with v2.3, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps 
+    # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps 
     # mitigate path traversal attacks.
     - mountPath: /tmp
       name: cmp-tmp


### PR DESCRIPTION
Two fixes: indention in docs, and adding new temp volume needed by CMPs.