### PR TITLE
fix: Pass context to resource tree (#5468)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -339,6 +339,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{nam
                                                         onClearFilter={clearFilter}
                                                         onGroupdNodeClick={groupdedNodeIds => openGroupNodeDetails(groupdedNodeIds)}
                                                         zoom={pref.zoom}
+                                                        appContext={this.appContext}
                                                         nameDirection={this.state.truncateNameOnRight}
                                                         filters={pref.resourceFilter}
                                                         setTreeFilterGraph={setFilterGraph}

--- a/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
+++ b/ui/src/app/applications/components/application-resource-tree/application-resource-tree.tsx
@@ -326,10 +326,8 @@ export const describeNode = (node: ResourceTreeNode) => {
 };
 
 function processPodGroup(targetPodGroup: ResourceTreeNode, child: ResourceTreeNode, props: ApplicationResourceTreeProps) {
-    const statusByKey = new Map<string, models.ResourceStatus>();
     if (!targetPodGroup.podGroup) {
         const fullName = nodeKey(targetPodGroup);
-        const status = statusByKey.get(fullName);
         if ((targetPodGroup.parentRefs || []).length === 0) {
             targetPodGroup.root = targetPodGroup;
         }
@@ -340,7 +338,6 @@ function processPodGroup(targetPodGroup: ResourceTreeNode, child: ResourceTreeNo
             ...targetPodGroup,
             info: (targetPodGroup.info || []).filter(i => !i.name.includes('Resource.')),
             createdAt: targetPodGroup.createdAt,
-            resourceStatus: {health: targetPodGroup.health, status: status ? status.status : null},
             renderMenu: () => props.nodeMenu(targetPodGroup),
             kind: targetPodGroup.kind,
             type: 'parentResource',


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

For the PR https://github.com/argoproj/argo-cd/pull/8996, the details page is supposed to pass the `context` to the resource tree.  This is needed otherwise the menu actions on the pod will not work. (It's missing perhaps when I rebased (?) or for some other reason. It's already defined in the `ApplicationResourceTreeProps` properties for this very purpose.) This fix also includes the change to fix the sonarcloud issue where the map is empty.

This is a bug fix with no open issue. It (the context) should have been part of the above PR to fix issue #5468.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.  

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

