### PR TITLE
fix: Use the matchMode specified in the rbac configmap

### DIFF
--- a/cmd/argocd/commands/admin/settings_rbac_test.go
+++ b/cmd/argocd/commands/admin/settings_rbac_test.go
@@ -50,7 +50,7 @@ func Test_PolicyFromYAML(t *testing.T) {
 	uPol, dRole, matchMode := getPolicy("testdata/rbac/argocd-rbac-cm.yaml", nil, "")
 	require.NotEmpty(t, uPol)
 	require.Equal(t, "role:unknown", dRole)
-	require.Equal(t, "regex", matchMode)
+	require.Empty(t, matchMode)
 }
 
 func Test_PolicyFromK8s(t *testing.T) {
@@ -62,15 +62,14 @@ func Test_PolicyFromK8s(t *testing.T) {
 			Namespace: "argocd",
 		},
 		Data: map[string]string{
-			"policy.csv":       string(data),
-			"policy.default":   "role:unknown",
-			"policy.matchMode": "regex",
+			"policy.csv":     string(data),
+			"policy.default": "role:unknown",
 		},
 	})
 	uPol, dRole, matchMode := getPolicy("", kubeclientset, "argocd")
 	require.NotEmpty(t, uPol)
 	require.Equal(t, "role:unknown", dRole)
-	require.Equal(t, "regex", matchMode)
+	require.Equal(t, "", matchMode)
 
 	t.Run("get applications", func(t *testing.T) {
 		ok := checkPolicy("role:user", "get", "applications", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
@@ -89,7 +88,64 @@ func Test_PolicyFromK8s(t *testing.T) {
 		require.True(t, ok)
 	})
 	t.Run("get certificates by default role without builtin policy", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", "*", "", uPol, "role:readonly", "regex", true)
+		ok := checkPolicy("role:user", "get", "certificates", "*", "", uPol, "role:readonly", "glob", true)
+		require.False(t, ok)
+	})
+	t.Run("use regex match mode instead of glob", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", ".*", assets.BuiltinPolicyCSV, uPol, "role:readonly", "regex", true)
+		require.False(t, ok)
+	})
+}
+
+func Test_PolicyFromK8sUsingRegex(t *testing.T) {
+	policy := `
+p, role:user, clusters, get, .+, allow
+p, role:user, clusters, get, https://kubernetes.*, deny
+p, role:user, applications, get, .*, allow
+p, role:user, applications, create, .*/.*, allow`
+
+	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-rbac-cm",
+			Namespace: "argocd",
+		},
+		Data: map[string]string{
+			"policy.csv":       policy,
+			"policy.default":   "role:unknown",
+			"policy.matchMode": "regex",
+		},
+	})
+	uPol, dRole, matchMode := getPolicy("", kubeclientset, "argocd")
+	require.NotEmpty(t, uPol)
+	require.Equal(t, "role:unknown", dRole)
+	require.Equal(t, "regex", matchMode)
+
+	builtInPolicy := `
+p, role:readonly, certificates, get, .*, allow
+p, role:, certificates, get, .*, allow`
+
+	t.Run("get applications", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "applications", ".*/.*", builtInPolicy, uPol, dRole, "regex", true)
+		require.True(t, ok)
+	})
+	t.Run("get clusters", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "clusters", ".*", builtInPolicy, uPol, dRole, "regex", true)
+		require.True(t, ok)
+	})
+	t.Run("get certificates", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", ".*", builtInPolicy, uPol, dRole, "regex", true)
+		require.False(t, ok)
+	})
+	t.Run("get certificates by default role", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", ".*", builtInPolicy, uPol, "role:readonly", "regex", true)
+		require.True(t, ok)
+	})
+	t.Run("get certificates by default role without builtin policy", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", ".*", "", uPol, "role:readonly", "regex", true)
+		require.False(t, ok)
+	})
+	t.Run("use glob match mode instead of regex", func(t *testing.T) {
+		ok := checkPolicy("role:user", "get", "certificates", ".+", builtInPolicy, uPol, dRole, "glob", true)
 		require.False(t, ok)
 	})
 }

--- a/cmd/argocd/commands/admin/testdata/rbac/argocd-rbac-cm.yaml
+++ b/cmd/argocd/commands/admin/testdata/rbac/argocd-rbac-cm.yaml
@@ -11,7 +11,6 @@ data:
     p, role:user, logs, get, */*, allow
     g, test, role:user
   policy.default: role:unknown
-  policy.matchMode: regex
 kind: ConfigMap
 metadata:
   labels:

--- a/cmd/argocd/commands/admin/testdata/rbac/argocd-rbac-cm.yaml
+++ b/cmd/argocd/commands/admin/testdata/rbac/argocd-rbac-cm.yaml
@@ -11,6 +11,7 @@ data:
     p, role:user, logs, get, */*, allow
     g, test, role:user
   policy.default: role:unknown
+  policy.matchMode: regex
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
Read the `matchMode` field from the argocd-rbac-cm before checking the policy

Closes: #9363 

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

