### PR TITLE
chore: upgrade golangci-lint to v1.46.2

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.46.2
           args: --timeout 10m --exclude SA5011 --verbose
 
   test-go:

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2

--- a/server/server.go
+++ b/server/server.go
@@ -1003,6 +1003,7 @@ func (a *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, error
 		if !argoCDSettings.AnonymousUserEnabled {
 			return ctx, claimsErr
 		} else {
+			// nolint:staticcheck
 			ctx = context.WithValue(ctx, "claims", "")
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -508,7 +508,7 @@ func getTestServer(t *testing.T, anonymousEnabled bool, withFakeSSO bool) (argoc
 		cm.Data["users.anonymous.enabled"] = "true"
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		return  // Start with a placeholder. We need the server URL before setting up the real handler.
+		// Start with a placeholder. We need the server URL before setting up the real handler.
 	}))
 	ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dexMockHandler(t, ts.URL)(w, r)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -594,6 +594,8 @@ func TestAuthenticate_3rd_party_JWTs(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, testData := range tests {
 		testDataCopy := testData
 
@@ -601,7 +603,6 @@ func TestAuthenticate_3rd_party_JWTs(t *testing.T) {
 			t.Parallel()
 
 			argocd, dexURL := getTestServer(t, testDataCopy.anonymousEnabled, true)
-			ctx := context.Background()
 			testDataCopy.claims.Issuer = fmt.Sprintf("%s/api/dex", dexURL)
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, testDataCopy.claims)
 			tokenString, err := token.SignedString([]byte("key"))
@@ -689,6 +690,8 @@ func TestAuthenticate_no_SSO(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, testData := range tests {
 		testDataCopy := testData
 
@@ -696,7 +699,6 @@ func TestAuthenticate_no_SSO(t *testing.T) {
 			t.Parallel()
 
 			argocd, dexURL := getTestServer(t, testDataCopy.anonymousEnabled, false)
-			ctx := context.Background()
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{Issuer: fmt.Sprintf("%s/api/dex", dexURL)})
 			tokenString, err := token.SignedString([]byte("key"))
 			require.NoError(t, err)
@@ -795,6 +797,8 @@ func TestAuthenticate_bad_request_metadata(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, testData := range tests {
 		testDataCopy := testData
 
@@ -802,7 +806,6 @@ func TestAuthenticate_bad_request_metadata(t *testing.T) {
 			t.Parallel()
 
 			argocd, _ := getTestServer(t, testDataCopy.anonymousEnabled, true)
-			ctx := context.Background()
 			ctx = metadata.NewIncomingContext(context.Background(), testDataCopy.metadata)
 
 			ctx, err := argocd.Authenticate(ctx)


### PR DESCRIPTION
Because:

* Installation of golangci-lint v1.45.2 is currently broken and fails
  silently due to a redacted dependency
  (https://github.com/blizzy78/varnamelen/issues/13)

This commit:

* Upgrades golangci-lint to v1.46.2

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

