### PR TITLE
docs: more appset security docs

### DIFF
--- a/docs/operator-manual/applicationset/Generators-Cluster.md
+++ b/docs/operator-manual/applicationset/Generators-Cluster.md
@@ -45,7 +45,7 @@ spec:
     metadata:
       name: '{{name}}-guestbook' # 'name' field of the Secret
     spec:
-      project: "default"
+      project: "my-project"
       source:
         repoURL: https://github.com/argoproj/argocd-example-apps/
         targetRevision: HEAD
@@ -144,7 +144,7 @@ spec:
     metadata:
       name: '{{name}}-guestbook'
     spec:
-      project: "default"
+      project: "my-project"
       source:
         repoURL: https://github.com/argoproj/argocd-example-apps/
         # The cluster values field for each generator will be substituted here:

--- a/docs/operator-manual/applicationset/Generators-Git.md
+++ b/docs/operator-manual/applicationset/Generators-Git.md
@@ -2,6 +2,12 @@
 
 The Git generator contains two subtypes: the Git directory generator, and Git file generator.
 
+!!! warning
+    Git generators are often used to make it easier for (non-admin) developers to create Applications.
+    If the `project` field in your ApplicationSet is templated, developers may be able to create Applications under Projects with excessive permissions.
+    For ApplicationSets with a templated `project` field, [the source of truth _must_ be controlled by admins](./Security.md#templated-project-field)
+    - in the case of git generators, PRs must require admin approval.
+
 ## Git Generator: Directories
 
 The Git directory generator, one of two subtypes of the Git generator, generates parameters using the directory structure of a specified Git repository.
@@ -41,7 +47,7 @@ spec:
     metadata:
       name: '{{path[0]}}'
     spec:
-      project: default
+      project: "my-project"
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
@@ -88,7 +94,7 @@ spec:
     metadata:
       name: '{{path.basename}}'
     spec:
-      project: default
+      project: "my-project"
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD

--- a/docs/operator-manual/applicationset/Generators-List.md
+++ b/docs/operator-manual/applicationset/Generators-List.md
@@ -20,7 +20,7 @@ spec:
     metadata:
       name: '{{cluster}}-guestbook'
     spec:
-      project: default
+      project: "my-project"
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD

--- a/docs/operator-manual/applicationset/Generators-Pull-Request.md
+++ b/docs/operator-manual/applicationset/Generators-Pull-Request.md
@@ -1,7 +1,6 @@
 # Pull Request Generator
 
-The Pull Request generator uses the API of an SCMaaS provider (eg GitHub/GitLab) to automatically discover open pull requests within an repository. This fits well with the style of building a test environment when you create a pull request.
-
+The Pull Request generator uses the API of an SCMaaS provider (e.g. GitHub/GitLab) to automatically discover open pull requests within a repository. This fits well with the style of building a test environment when you create a pull request.
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -16,9 +15,15 @@ spec:
         # ...
 ```
 
+!!! note
+    Know the security implications of PR generators in ApplicationSets. 
+    [Only admins may create ApplicationSets](./Security.md#only-admins-may-createupdatedelete-applicationsets) to avoid
+    leaking Secrets, and [only admins may create PRs](./Security.md#templated-project-field) if the `project` field of 
+    an ApplicationSet with a PR generator is templated, to avoid granting management of out-of-bounds resources.
+
 ## GitHub
 
-Specify the repository from which to fetch the Github Pull requests.
+Specify the repository from which to fetch the GitHub Pull requests.
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -48,7 +53,7 @@ spec:
 ```
 
 * `owner`: Required name of the GitHub organization or user.
-* `repo`: Required name of the Github repository.
+* `repo`: Required name of the GitHub repository.
 * `api`: If using GitHub Enterprise, the URL to access it. (Optional)
 * `tokenRef`: A `Secret` name and key containing the GitHub access token to use for requests. If not specified, will make anonymous requests which have a lower rate limit and can only see public repositories. (Optional)
 * `labels`: Labels is used to filter the PRs that you want to target. (Optional)
@@ -216,7 +221,7 @@ spec:
           parameters:
           - name: "image.tag"
             value: "pull-{{head_sha}}"
-      project: default
+      project: "my-project"
       destination:
         server: https://kubernetes.default.svc
         namespace: default
@@ -247,7 +252,7 @@ spec:
             app.kubernetes.io/instance: {{branch}}-{{number}}
           images:
           - ghcr.io/myorg/myrepo:{{head_sha}}
-      project: default
+      project: "my-project"
       destination:
         server: https://kubernetes.default.svc
         namespace: default

--- a/docs/operator-manual/applicationset/Generators-SCM-Provider.md
+++ b/docs/operator-manual/applicationset/Generators-SCM-Provider.md
@@ -19,6 +19,12 @@ spec:
 
 * `cloneProtocol`: Which protocol to use for the SCM URL. Default is provider-specific but ssh if possible. Not all providers necessarily support all protocols, see provider documentation below for available options.
 
+!!! note
+    Know the security implications of using SCM generators. [Only admins may create ApplicationSets](./Security.md#only-admins-may-createupdatedelete-applicationsets) 
+    to avoid leaking Secrets, and [only admins may create repos/branches](./Security.md#templated-project-field) if the 
+    `project` field of an ApplicationSet with an SCM generator is templated, to avoid granting management of 
+    out-of-bounds resources.
+
 ## GitHub
 
 The GitHub mode uses the GitHub API to scan and organization in either github.com or GitHub Enterprise.

--- a/docs/operator-manual/applicationset/Getting-Started.md
+++ b/docs/operator-manual/applicationset/Getting-Started.md
@@ -22,9 +22,9 @@ Follow the [Argo CD Getting Started](../../getting_started.md) instructions for 
 
 ### B) Install ApplicationSet into an existing Argo CD install (pre-Argo CD v2.3)
 
-**Note**: These instruction only apply to versions of Argo CD before v2.3.0.
+**Note**: These instructions only apply to versions of Argo CD before v2.3.0.
 
-The ApplicationSet controller *must* be installed into the same namespace as the Argo CD it is targetting.
+The ApplicationSet controller *must* be installed into the same namespace as the Argo CD it is targeting.
 
 Presuming that Argo CD is installed into the `argocd` namespace, run the following command:
 

--- a/docs/operator-manual/applicationset/Security.md
+++ b/docs/operator-manual/applicationset/Security.md
@@ -1,0 +1,38 @@
+# ApplicationSet Security
+
+ApplicationSet is a powerful tool, and it is crucial to understand its security implications before using it.
+
+## Only admins may create/update/delete ApplicationSets
+
+ApplicationSets can create Applications under arbitrary [Projects](../../user-guide/projects.md). Argo CD setups often
+include Projects (such as the `default`) with high levels of permissions, often including the ability to manage the 
+resources of Argo CD itself (like the RBAC ConfigMap).
+
+ApplicationSets can also quickly create an arbitrary number of Applications and just as quickly delete them.
+
+Finally, ApplicationSets can reveal privileged information. For example, the [git generator](./Generators-Git.md) can
+read Secrets in the Argo CD namespace and send them to arbitrary URLs as auth headers. (This functionality is intended
+for authorizing requests to SCM providers like GitHub, but it could be abused by a malicious user.)
+
+For these reasons, **only admins** may be given permission (via Kubernetes RBAC or any other mechanism) to create, 
+update, or delete ApplicationSets.
+
+## Admins must apply appropriate controls for ApplicationSets' sources of truth
+
+Even if non-admins can't create ApplicationSet resources, they may be able to affect the behavior of ApplicationSets.
+
+For example, if an ApplicationSet uses a [git generator](./Generators-Git.md), a malicious user with push access to the
+source git repository could generate an excessively high number of Applications, putting strain on the ApplicationSet
+and Application controllers. They could also cause the SCM provider's rate limiting to kick in, degrading ApplicationSet
+service.
+
+### Templated `project` field
+
+It's important to pay special attention to ApplicationSets where the `project` field is templated. A malicious user with
+write access to the generator's source of truth (for example, someone with push access to the git repo for a git
+generator) could create Applications under Projects with insufficient restrictions. A malicious user with the ability to
+create an Application under an unrestricted Project (like the `default` Project) could take control of Argo CD itself
+by, for example, modifying its RBAC ConfigMap.
+
+If the `project` field is not hard-coded in an ApplicationSet's template, then admins _must_ control all sources of 
+truth for the ApplicationSet's generators.

--- a/docs/operator-manual/applicationset/index.md
+++ b/docs/operator-manual/applicationset/index.md
@@ -15,6 +15,9 @@ The ApplicationSet controller, supplements Argo CD by adding additional features
 - Improved support for monorepos: in the context of Argo CD, a monorepo is multiple Argo CD Application resources defined within a single Git repository
 - Within multitenant clusters, improves the ability of individual cluster tenants to deploy applications using Argo CD (without needing to involve privileged cluster administrators in enabling the destination clusters/namespaces)
 
+!!! note
+    Be aware of the [security implications](./Security.md) of ApplicationSets before using them.
+
 ## The ApplicationSet resource
 
 This example defines a new `guestbook` resource of kind `ApplicationSet`:
@@ -37,6 +40,7 @@ spec:
     metadata:
       name: '{{cluster}}-guestbook'
     spec:
+      project: my-project
       source:
         repoURL: https://github.com/infra-team/cluster-deployments.git
         targetRevision: HEAD

--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -211,3 +211,8 @@ can be found in [server/server.go](https://github.com/argoproj/argo-cd/blob/abba
 
 Argo CD does not log IP addresses of clients requesting API endpoints, since the API server is typically behind a proxy. Instead, it is recommended
 to configure IP addresses logging in the proxy server that sits in front of the API server.
+
+## ApplicationSets
+
+Argo CD's ApplicationSets feature has its own [security considerations](./applicationset/Security.md). Be aware of those
+issues before using ApplicationSets.

--- a/docs/user-guide/application-set.md
+++ b/docs/user-guide/application-set.md
@@ -4,6 +4,10 @@ The [ApplicationSet controller](../operator-manual/applicationset/index.md) is a
 
 The set of tools provided by the ApplicationSet controller may also be used to allow developers (without access to the Argo CD namespace) to independently create Applications without cluster-administrator intervention.
 
+!!! warning
+    Be aware of the [security implications](../operator-manual/applicationset/Security.md) before allowing developers to
+    create Applications via ApplicationSets.
+
 The ApplicationSet controller is installed alongside Argo CD (within the same namespace), and the controller automatically generates Argo CD Applications based on the contents of a new `ApplicationSet` Custom Resource (CR).
 
 Here is an example of an `ApplicationSet` resource that can be used to target an Argo CD Application to multiple clusters:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
     - Introduction: operator-manual/applicationset/index.md
     - Installations: operator-manual/applicationset/Getting-Started.md
     - Use Cases: operator-manual/applicationset/Use-Cases.md
+    - Security: operator-manual/applicationset/Security.md
     - How ApplicationSet controller interacts with Argo CD: operator-manual/applicationset/Argo-CD-Integration.md
     - Generators:
       - operator-manual/applicationset/Generators.md


### PR DESCRIPTION
Most of the changes are self-explanatory.

I've changed several instances of using the `default` project in examples to using `my-example`. I want to encourage folks to consider which project they actually need to use for the appset, since the `default` project has full permissions by default.