### PR TITLE
Update ingress.md

### DIFF
--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -411,8 +411,7 @@ Once we create this service, we can configure the Ingress to conditionally route
     annotations:
       alb.ingress.kubernetes.io/backend-protocol: HTTPS
       # Use this annotation (which must match a service name) to route traffic to HTTP2 backends.
-      alb.ingress.kubernetes.io/conditions.argogrpc: |
-        [{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]
+      alb.ingress.kubernetes.io/conditions.argogrpc: '[{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]'
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     name: argocd
     namespace: argocd


### PR DESCRIPTION
original annotation new line shift produces the following error ouptut 

```markdown
Failed build model due to ingress: argocd/ingress-argocd-stage: failed to parse json annotation, alb.ingress.kubernetes.io/conditions.argogrpc: '[{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]' : invalid character '\'' looking for beginning of value
```
upon the changes introduced in this PR the alb for argocd works as expected