### PR TITLE
chore: add GOPKGINYAMLV2-2840885 to snyk ignore list

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -24,5 +24,9 @@ ignore:
           Argo CD uses go-restful as a transitive dependency of kube-openapi. kube-openapi is used to generate openapi
           specs. We do not use go-restul at runtime and are therefore not vulnerable to this CORS misconfiguration
           issue in go-restful.
+  SNYK-GOLANG-GOPKGINYAMLV2-2840885:
+    - '*':
+        reason: >-
+          The package is used to parse configuration provided by the administrator and hence cannot cause DoS.
 patch: {}
 


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The CVE reported in https://security.snyk.io/vuln/SNYK-GOLANG-GOPKGINYAMLV2-2840885 is not applicable to Argo CD since the affected package is used to parse admin provided configuration. Admins already have full access to Argo CD so DoS is not a treat here.