### PR TITLE
test: Make context tests idempodent

### DIFF
--- a/cmd/argocd/commands/context_test.go
+++ b/cmd/argocd/commands/context_test.go
@@ -36,13 +36,13 @@ users:
 - auth-token: vErrYS3c3tReFRe$hToken
   name: localhost:8080`
 
-const testConfigFilePath = "./testdata/config"
+const testConfigFilePath = "./testdata/local.config"
 
 func TestContextDelete(t *testing.T) {
-
 	// Write the test config file
 	err := ioutil.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	assert.NoError(t, err)
+	defer os.Remove(testConfigFilePath)
 
 	err = os.Chmod(testConfigFilePath, 0600)
 	require.NoError(t, err, "Could not change the file permission to 0600 %v", err)
@@ -75,9 +75,4 @@ func TestContextDelete(t *testing.T) {
 	assert.NotContains(t, localConfig.Servers, localconfig.Server{PlainText: true, Server: "localhost:8080"})
 	assert.NotContains(t, localConfig.Users, localconfig.User{AuthToken: "vErrYS3c3tReFRe$hToken", Name: "localhost:8080"})
 	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd2.example.com:443", Server: "argocd2.example.com:443", User: "argocd2.example.com:443"})
-
-	// Write the file again so that no conflicts are made in git
-	err = ioutil.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
-	assert.NoError(t, err)
-
 }

--- a/cmd/argocd/commands/logout_test.go
+++ b/cmd/argocd/commands/logout_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/util/localconfig"
@@ -16,6 +17,10 @@ func TestLogout(t *testing.T) {
 	// Write the test config file
 	err := ioutil.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
 	assert.NoError(t, err)
+	defer os.Remove(testConfigFilePath)
+
+	err = os.Chmod(testConfigFilePath, 0600)
+	require.NoError(t, err)
 
 	localConfig, err := localconfig.ReadLocalConfig(testConfigFilePath)
 	assert.NoError(t, err)
@@ -32,9 +37,4 @@ func TestLogout(t *testing.T) {
 	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd1.example.com:443", Server: "argocd1.example.com:443", User: "argocd1.example.com:443"})
 	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "argocd2.example.com:443", Server: "argocd2.example.com:443", User: "argocd2.example.com:443"})
 	assert.Contains(t, localConfig.Contexts, localconfig.ContextRef{Name: "localhost:8080", Server: "localhost:8080", User: "localhost:8080"})
-
-	// Write the file again so that no conflicts are made in git
-	err = ioutil.WriteFile(testConfigFilePath, []byte(testConfig), os.ModePerm)
-	assert.NoError(t, err)
-
 }


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

