### PR TITLE
docs: Update 2.3 notes - mention helm chart

### DIFF
--- a/docs/operator-manual/upgrading/2.2-2.3.md
+++ b/docs/operator-manual/upgrading/2.2-2.3.md
@@ -6,8 +6,11 @@ The Argo CD Notifications and ApplicationSet are part of Argo CD now. You no lon
 The Notifications and ApplicationSet components are bundled into default Argo CD installation manifests.
 
 The bundled manifests are drop-in replacements for the previous versions. If you are using Kustomize to bundle the manifests together then just
-remove references to https://github.com/argoproj-labs/argocd-notifications and https://github.com/argoproj-labs/applicationset. No action is required
-if you are using `kubectl apply`.
+remove references to https://github.com/argoproj-labs/argocd-notifications and https://github.com/argoproj-labs/applicationset.
+
+If you are using [the argocd-notifications helm chart](https://github.com/argoproj/argo-helm/tree/argocd-notifications-1.8.1/charts/argocd-notifications), you can move the chart [values](https://github.com/argoproj/argo-helm/blob/argocd-notifications-1.8.1/charts/argocd-notifications/values.yaml) to the `notifications` section of the argo-cd chart [values](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml#L2152). Although most values remain as is, for details please look up the values that are relevant to you.
+
+No action is required if you are using `kubectl apply`.
 
 ## Configure Additional Argo CD Binaries
 


### PR DESCRIPTION
Spent some time looking this up, as we use the helm chart. I believe values should be copied as-is into the `notifications` section of the argo-cd chart. Please correct me if I'm wrong in this assumption

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

