### PR TITLE
docs: Clarify that kustomize build environment is not support

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -1,6 +1,6 @@
 # Build Environment
 
-[Custom tools](config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md), and [Kustomize](kustomize.md) support the following build env vars:
+[Custom tools](config-management-plugins.md), [Helm](helm.md), and [Jsonnet](jsonnet.md) support the following build env vars:
 
 * `ARGOCD_APP_NAME` - name of application
 * `ARGOCD_APP_NAMESPACE` - destination application namespace.

--- a/docs/user-guide/kustomize.md
+++ b/docs/user-guide/kustomize.md
@@ -84,4 +84,4 @@ argocd app set <appName> --kustomize-version v3.5.4
 
 ## Build Environment
 
-Kustomize does not support parameters and therefore cannot support the standard [build environment](build-environment.md).
+Kustomize **does not support** parameters and therefore cannot support the standard [build environment](build-environment.md).


### PR DESCRIPTION
Kustomize does not support the standard build environment.

- Remove Kustomize from build-environment.md page
- Emphasize that build environment is not support in kustomize.md page

Fixes #8848

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

