### PR TITLE
chore: update Kex-Algorithms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/whilp/git-urls v0.0.0-20191001220047-6db9661140c0
 	github.com/xanzy/go-gitlab v0.60.0
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -1230,8 +1230,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/util/git/ssh.go
+++ b/util/git/ssh.go
@@ -11,13 +11,14 @@ import (
 // Unfortunately, crypto/ssh does not offer public constants or list for
 // this.
 var SupportedSSHKeyExchangeAlgorithms = []string{
-	"diffie-hellman-group14-sha1",
-	"diffie-hellman-group14-sha256",
+	"curve25519-sha256",
+	"curve25519-sha256@libssh.org",
 	"ecdh-sha2-nistp256",
 	"ecdh-sha2-nistp384",
 	"ecdh-sha2-nistp521",
-	"curve25519-sha256@libssh.org",
 	"diffie-hellman-group-exchange-sha256",
+	"diffie-hellman-group14-sha256",
+	"diffie-hellman-group14-sha1",
 }
 
 // List of default key exchange algorithms to use. We use those that are

--- a/util/git/ssh.go
+++ b/util/git/ssh.go
@@ -11,13 +11,12 @@ import (
 // Unfortunately, crypto/ssh does not offer public constants or list for
 // this.
 var SupportedSSHKeyExchangeAlgorithms = []string{
-	"diffie-hellman-group1-sha1",
 	"diffie-hellman-group14-sha1",
+	"diffie-hellman-group14-sha256",
 	"ecdh-sha2-nistp256",
 	"ecdh-sha2-nistp384",
 	"ecdh-sha2-nistp521",
 	"curve25519-sha256@libssh.org",
-	"diffie-hellman-group-exchange-sha1",
 	"diffie-hellman-group-exchange-sha256",
 }
 


### PR DESCRIPTION
Signed-off-by: douhunt <douhunt@protonmail.com>

Part 1 of 3 to upgrade base image to Ubuntu:22.04
This **must** be merged before #9551 and cherry-picked into 2.4

Upgraded golang.org/x/crypto libraries to support diffie-hellman-group14-sha256. I also removed two Kex-Algorithms which should no longer be used for security reasons. This may cause some breakage for a very very small group of users. I would also recommend removing diffie-hellman-group14-sha1 in the very near future (v2.5) and give users plenty of warning.
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

