### PR TITLE
chore: Fix working directory for remote e2e test image

### DIFF
--- a/test/remote/Dockerfile
+++ b/test/remote/Dockerfile
@@ -23,8 +23,6 @@ RUN  apt-get update && apt-get install --no-install-recommends -y \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-WORKDIR /etc/certs
-
 # These are required for running end-to-end tests
 COPY ./test/fixture/testrepos/id_rsa.pub /root/.ssh/authorized_keys
 COPY ./test/fixture/testrepos/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Commit cc6c625401a5140240787f0184131fd73d9c4b55 changed a RUN mkdir command into a WORKDIR, which also affected the entrypoint.  This triggered an error in goreman which looks for Procfile (which is installed here in the root directory) in the working directory.

Since COPY creates any missing directories in the destination path, there is no need for a separate step to create it.  This change leaves WORKDIR as the default (the root directory) as before.

Please backport to release-2.4 branch which is also affected.

/cc @jannfis 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 