### PR TITLE
fix: use serviceaccount name instead of struct

### DIFF
--- a/util/clusterauth/clusterauth.go
+++ b/util/clusterauth/clusterauth.go
@@ -297,13 +297,13 @@ func getOrCreateServiceAccountTokenSecret(clientset kubernetes.Interface, sa, ns
 	return createServiceAccountToken(clientset, serviceAccount)
 }
 
-func createServiceAccountToken(clientset kubernetes.Interface, sa *corev1.ServiceAccount) (string, error) {
+func createServiceAccountToken(clientset kubernetes.Interface, serviceAccount *corev1.ServiceAccount) (string, error) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: sa.Name + "-token-",
-			Namespace:    sa.Namespace,
+			GenerateName: serviceAccount.Name + "-token-",
+			Namespace:    serviceAccount.Namespace,
 			Annotations: map[string]string{
-				corev1.ServiceAccountNameKey: sa.Name,
+				corev1.ServiceAccountNameKey: serviceAccount.Name,
 			},
 		},
 		Type: corev1.SecretTypeServiceAccountToken,
@@ -311,24 +311,24 @@ func createServiceAccountToken(clientset kubernetes.Interface, sa *corev1.Servic
 
 	ctx, cancel := context.WithTimeout(context.Background(), common.ClusterAuthRequestTimeout)
 	defer cancel()
-	secret, err := clientset.CoreV1().Secrets(sa.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+	secret, err := clientset.CoreV1().Secrets(serviceAccount.Namespace).Create(ctx, secret, metav1.CreateOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to create secret for serviceaccount %q: %w", sa.Name, err)
+		return "", fmt.Errorf("failed to create secret for serviceaccount %q: %w", serviceAccount.Name, err)
 	}
 
-	log.Infof("Created bearer token secret for ServiceAccount %q", sa.Name)
-	sa.Secrets = []corev1.ObjectReference{{
+	log.Infof("Created bearer token secret for ServiceAccount %q", serviceAccount.Name)
+	serviceAccount.Secrets = []corev1.ObjectReference{{
 		Name:      secret.Name,
 		Namespace: secret.Namespace,
 	}}
-	patch, err := json.Marshal(sa)
+	patch, err := json.Marshal(serviceAccount)
 	if err != nil {
-		return "", fmt.Errorf("failed marshaling patch for serviceaccount %q: %w", sa.Name, err)
+		return "", fmt.Errorf("failed marshaling patch for serviceaccount %q: %w", serviceAccount.Name, err)
 	}
 
-	_, err = clientset.CoreV1().ServiceAccounts(sa.Namespace).Patch(ctx, sa.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.Namespace).Patch(ctx, serviceAccount.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to patch serviceaccount %q with bearer token secret: %w", sa.Name, err)
+		return "", fmt.Errorf("failed to patch serviceaccount %q with bearer token secret: %w", serviceAccount.Name, err)
 	}
 
 	return secret.Name, nil

--- a/util/clusterauth/clusterauth.go
+++ b/util/clusterauth/clusterauth.go
@@ -313,22 +313,22 @@ func createServiceAccountToken(clientset kubernetes.Interface, sa *corev1.Servic
 	defer cancel()
 	secret, err := clientset.CoreV1().Secrets(sa.Namespace).Create(ctx, secret, metav1.CreateOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to create secret for serviceaccount %q: %w", sa, err)
+		return "", fmt.Errorf("failed to create secret for serviceaccount %q: %w", sa.Name, err)
 	}
 
-	log.Infof("Created bearer token secret for ServiceAccount %q", sa)
+	log.Infof("Created bearer token secret for ServiceAccount %q", sa.Name)
 	sa.Secrets = []corev1.ObjectReference{{
 		Name:      secret.Name,
 		Namespace: secret.Namespace,
 	}}
 	patch, err := json.Marshal(sa)
 	if err != nil {
-		return "", fmt.Errorf("failed marshaling patch for serviceaccount %q: %w", sa, err)
+		return "", fmt.Errorf("failed marshaling patch for serviceaccount %q: %w", sa.Name, err)
 	}
 
 	_, err = clientset.CoreV1().ServiceAccounts(sa.Namespace).Patch(ctx, sa.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to patch serviceaccount %q with bearer token secret: %w", sa, err)
+		return "", fmt.Errorf("failed to patch serviceaccount %q with bearer token secret: %w", sa.Name, err)
 	}
 
 	return secret.Name, nil


### PR DESCRIPTION
Minor cleanup of #9546. Should use ServiceAccount name in error message instead of whole struct. Also changing name of param from sa to serviceAccount since other funcs have sa param as string to avoid confusion. Should be cherry-picked into 2.4.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

