### PR TITLE
chore: Implement a retry in aws auth command

### DIFF
--- a/cmd/argocd-k8s-auth/commands/aws.go
+++ b/cmd/argocd-k8s-auth/commands/aws.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -40,16 +41,7 @@ func newAWSCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use: "aws",
 		Run: func(c *cobra.Command, args []string) {
-			sess, err := session.NewSession()
-			errors.CheckError(err)
-			stsAPI := sts.New(sess)
-			if roleARN != "" {
-				creds := stscreds.NewCredentials(sess, roleARN)
-				stsAPI = sts.New(sess, &aws.Config{Credentials: creds})
-			}
-			request, _ := stsAPI.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
-			request.HTTPRequest.Header.Add(clusterIDHeader, clusterName)
-			presignedURLString, err := request.Presign(requestPresignParam)
+			presignedURLString, err := getSignedRequestWithRetry(time.Minute, clusterName, roleARN)
 			errors.CheckError(err)
 			token := v1Prefix + base64.RawURLEncoding.EncodeToString([]byte(presignedURLString))
 			// Set token expiration to 1 minute before the presigned URL expires for some cushion
@@ -60,6 +52,41 @@ func newAWSCommand() *cobra.Command {
 	command.Flags().StringVar(&clusterName, "cluster-name", "", "AWS Cluster name")
 	command.Flags().StringVar(&roleARN, "role-arn", "", "AWS Role ARN")
 	return command
+}
+
+func getSignedRequestWithRetry(timeout time.Duration, clusterName, roleARN string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		signed, err := getSignedRequest(clusterName, roleARN)
+		if err == nil {
+			return signed, nil
+		}
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("timeout while trying to get signed aws request: last error: %s", err)
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+func getSignedRequest(clusterName, roleARN string) (string, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("error creating new AWS session: %s", err)
+	}
+	stsAPI := sts.New(sess)
+	if roleARN != "" {
+		creds := stscreds.NewCredentials(sess, roleARN)
+		stsAPI = sts.New(sess, &aws.Config{Credentials: creds})
+	}
+	request, _ := stsAPI.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
+	request.HTTPRequest.Header.Add(clusterIDHeader, clusterName)
+	signed, err := request.Presign(requestPresignParam)
+	if err != nil {
+		return "", fmt.Errorf("error presigning AWS request: %s", err)
+	}
+	return signed, nil
 }
 
 func formatJSON(token string, expiration time.Time) string {


### PR DESCRIPTION
This PR implements a simple retry with timeout around the `argocd-k8s-auth aws` command.

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

