### PR TITLE
fix: change repo-server command to expand 'ARGOCD_REDIS_SERVICE' env variable

### DIFF
--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -21,11 +21,7 @@ spec:
       - name: argocd-repo-server
         image: quay.io/argoproj/argocd:latest
         imagePullPolicy: Always
-        command:
-        - entrypoint.sh
-        - argocd-repo-server
-        - --redis
-        - $(ARGOCD_REDIS_SERVICE):6379
+        command: [ "sh", "-c", "entrypoint.sh argocd-repo-server --redis $(ARGOCD_REDIS_SERVICE):6379"]
         env:
           - name: ARGOCD_RECONCILIATION_TIMEOUT
             valueFrom:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9590,10 +9590,9 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
-        - entrypoint.sh
-        - argocd-repo-server
-        - --redis
-        - argocd-redis:6379
+        - sh
+        - -c
+        - entrypoint.sh argocd-repo-server --redis argocd-redis:6379
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10033,10 +10033,9 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
-        - entrypoint.sh
-        - argocd-repo-server
-        - --redis
-        - argocd-redis:6379
+        - sh
+        - -c
+        - entrypoint.sh argocd-repo-server --redis argocd-redis:6379
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -882,10 +882,9 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
-        - entrypoint.sh
-        - argocd-repo-server
-        - --redis
-        - argocd-redis:6379
+        - sh
+        - -c
+        - entrypoint.sh argocd-repo-server --redis argocd-redis:6379
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Repo server deployment command in non HA manifest uses env variable to control redis but does not use shell. So repo server just trying to connect to `$(ARGOCD_REDIS_SERVICE)` and never able to cache manifests. PR fixes this issue.