### PR TITLE
chore: fix typo in godoc string

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -368,7 +368,7 @@ const (
 	kustomizePathPrefixKey = "kustomize.path"
 	// anonymousUserEnabledKey is the key which enables or disables anonymous user
 	anonymousUserEnabledKey = "users.anonymous.enabled"
-	// anonymousUserEnabledKey is the key which specifies token expiration duration
+	// userSessionDurationKey is the key which specifies token expiration duration
 	userSessionDurationKey = "users.session.duration"
 	// diffOptions is the key where diff options are configured
 	resourceCompareOptionsKey = "resource.compareoptions"


### PR DESCRIPTION
While investigating how to disable the new terminal feature introduced in version 2.4, came across this accidental copy/paste.

Figured would boyscout it in.