### PR TITLE
fix: add missing download CLI tool link for ppc64le, s390x

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -39,6 +39,8 @@ data:
   # The URLs to download additional ArgoCD binaries (besides the Linux amd64 binary included by default)
   # for different OS architectures. If provided, additional download buttons will be displayed on the help page.
   help.download.linux-arm64: "path-or-url-to-download"
+  help.download.linux-ppc64le: "path-or-url-to-download"
+  help.download.linux-s390x: "path-or-url-to-download"
   help.download.darwin-amd64: "path-or-url-to-download"
   help.download.darwin-arm64: "path-or-url-to-download"
   help.download.windows-amd64: "path-or-url-to-download"

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -43,7 +43,7 @@ export const Help = () => {
                                             &nbsp;
                                             {Object.keys(binaryUrls || {}).map(binaryName => {
                                                 const url = binaryUrls[binaryName];
-                                                const match = binaryName.match(/.*(darwin|windows|linux)-(amd64|arm64)/);
+                                                const match = binaryName.match(/.*(darwin|windows|linux)-(amd64|arm64|ppc64le|s390x)/);
                                                 const [platform, arch] = match ? match.slice(1) : ['', ''];
                                                 return (
                                                     <>


### PR DESCRIPTION
Follow up of #7755, for ppc64le and s390x.

QUESTION: the above part has not matched href(`download/argocd-linux-${process.env.HOST_ARCH}`) and button name("Linux (amd64)"). Could I unify this to `${process.env.HOST_ARCH}`?

https://github.com/argoproj/argo-cd/blob/f219888d9672c6e4779bd1d6001146a91b675d57/ui/src/app/help/components/help.tsx#L40-L41

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

