### PR TITLE
fix: project filter (#9651)

### DIFF
--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -143,7 +143,7 @@ export class ApplicationsService {
             const searchOptions = optionsToSearch(options);
             search.set('fields', searchOptions.fields);
             search.set('selector', searchOptions.selector);
-            query?.projects?.forEach(project => search.append('project', project));
+            query?.projects?.forEach(project => search.append('projects', project));
         }
         const searchStr = search.toString();
         const url = `/stream/applications${(searchStr && '?' + searchStr) || ''}`;


### PR DESCRIPTION
Fixes #9651

The query param for the initial list was correct. But the subsequent watch was not, so server-side filtering wasn't applied.

The break occurred when the field name changed in the gRPC upgrade: https://github.com/argoproj/argo-cd/pull/8929/files#diff-3305434591ea185f5c784bb266fe01e0500e99e0ee76952a566d7f1f8b8b6489R46

Thanks to @keithchong for pointing out that it looked like server-side filtering wasn't working!