### PR TITLE
chore: add k8s v1.24.1 to test matrix

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        k3s-version: [v1.23.3, v1.22.6, v1.21.2]
+        k3s-version: [v1.24.1, v1.23.3, v1.22.6, v1.21.2]
     needs: 
       - build-go
     env:

--- a/test/e2e/fixture/applicationsets/actions.go
+++ b/test/e2e/fixture/applicationsets/actions.go
@@ -69,7 +69,7 @@ func GetServiceAccountBearerToken(clientset kubernetes.Interface, ns string, sa 
 	var serviceAccount *corev1.ServiceAccount
 	var secret *corev1.Secret
 	var err error
-	err = wait.Poll(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+	err = wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
 		serviceAccount, err = clientset.CoreV1().ServiceAccounts(ns).Get(context.Background(), sa, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/fixture/applicationsets/actions.go
+++ b/test/e2e/fixture/applicationsets/actions.go
@@ -69,7 +69,7 @@ func GetServiceAccountBearerToken(clientset kubernetes.Interface, ns string, sa 
 	var serviceAccount *corev1.ServiceAccount
 	var secret *corev1.Secret
 	var err error
-	err = wait.Poll(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+	err = wait.Poll(500*time.Millisecond, 10*time.Second, func() (bool, error) {
 		serviceAccount, err = clientset.CoreV1().ServiceAccounts(ns).Get(context.Background(), sa, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Closes #9603

This pull requests adds 1.24.1 to the test matrix for running e2e tests. An original attempt to add it resulted in failing e2e tests so it was reverted. After further researching, it turned out some e2e tests were taking longer to run than in previous versions. This seems to be related to an e2e test helper function which is unable to find the bearer token for serviceaccounts since this is no longer automatically added in 1.24.1. Lowering how long to wait for the bearer token secret should help improve the time it takes these tests to run and prevent the test suite from timing out after 30m.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

