### PR TITLE
docs: Update archlinux install with official package

### DIFF
--- a/docs/cli_installation.md
+++ b/docs/cli_installation.md
@@ -4,10 +4,10 @@ You can download the latest Argo CD version from [the latest release page of thi
 
 ## Linux and WSL
 
-### ArchLinux User Repository ([AUR](https://aur.archlinux.org/packages/))
+### ArchLinux
 
 ```bash
-yay -Sy argocd-bin
+pacman -S argocd
 ```
 
 ### Homebrew


### PR DESCRIPTION
Signed-off-by: Paulo Coelho <prscoelho@protonmail.com>

I noticed that the docs for cli installation on archlinux weren't updated. Sometimes the arch maintainers move things out of the AUR once something becomes popular enough. So argocd-bin is no longer in the AUR, but now it's in the official packages.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 


