### PR TITLE
fix: updated config file permission requirements for windows (#9666)

### DIFF
--- a/util/localconfig/file_perm_unix.go
+++ b/util/localconfig/file_perm_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package localconfig
+
+import (
+	"fmt"
+	"os"
+)
+
+func getFilePermission(fi os.FileInfo) error {
+	if fi.Mode().Perm() == 0600 || fi.Mode().Perm() == 0400 {
+		return nil
+	}
+	return fmt.Errorf("config file has incorrect permission flags:%s."+
+		"change the file permission either to 0400 or 0600.", fi.Mode().Perm().String())
+}

--- a/util/localconfig/file_perm_windows.go
+++ b/util/localconfig/file_perm_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package localconfig
+
+import (
+	"fmt"
+	"os"
+)
+
+func getFilePermission(fi os.FileInfo) error {
+	if fi.Mode().Perm() == 0666 || fi.Mode().Perm() == 0444 {
+		return nil
+	}
+	return fmt.Errorf("config file has incorrect permission flags:%s."+
+		"change the file permission either to 0444 or 0666.", fi.Mode().Perm().String())
+}

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -311,11 +311,3 @@ func GetUsername(subject string) string {
 	}
 	return subject
 }
-
-func getFilePermission(fi os.FileInfo) error {
-	if fi.Mode().Perm() == 0600 || fi.Mode().Perm() == 0400 {
-		return nil
-	}
-	return fmt.Errorf("config file has incorrect permission flags:%s."+
-		"change the file permission either to 0400 or 0600.", fi.Mode().Perm().String())
-}

--- a/util/localconfig/localconfig_test.go
+++ b/util/localconfig/localconfig_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package localconfig
 
 import (
@@ -83,7 +85,7 @@ func TestFilePermission(t *testing.T) {
 			if err := getFilePermission(fi); err != nil {
 				assert.EqualError(t, err, c.expectedError.Error())
 			} else {
-				require.Nil(t, err)
+				require.Nil(t, c.expectedError)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #9666 
Fixes #9702 

This PR updates the permission requirements for windows to 0444 or 0666 instead of 0400 and 0600. The config file produced by argocd cli on windows always appears to be having 0666 permission this is probably due to some limitations on windows acl, hence this PR updates the requirement specifically for windows for 0666 or 0444 permission instead of 0400/0600.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

