### PR TITLE
feat: Treat connection reset as a retryable error

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -354,7 +354,8 @@ func isTransientNetworkErr(err error) bool {
 	}
 	if strings.Contains(errorString, "net/http: TLS handshake timeout") ||
 		strings.Contains(errorString, "i/o timeout") ||
-		strings.Contains(errorString, "connection timed out") {
+		strings.Contains(errorString, "connection timed out") ||
+		strings.Contains(errorString, "connection reset by peer") {
 		return true
 	}
 	return false

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -111,6 +111,7 @@ func TestIsRetryableError(t *testing.T) {
 		tlsHandshakeTimeoutErr net.Error = netError("net/http: TLS handshake timeout")
 		ioTimeoutErr           net.Error = netError("i/o timeout")
 		connectionTimedout     net.Error = netError("connection timed out")
+		connectionReset        net.Error = netError("connection reset by peer")
 	)
 	t.Run("Nil", func(t *testing.T) {
 		assert.False(t, isRetryableError(nil))
@@ -147,5 +148,8 @@ func TestIsRetryableError(t *testing.T) {
 	})
 	t.Run("ConnectionTimeout", func(t *testing.T) {
 		assert.True(t, isRetryableError(connectionTimedout))
+	})
+	t.Run("ConnectionReset", func(t *testing.T) {
+		assert.True(t, isRetryableError(connectionReset))
 	})
 }


### PR DESCRIPTION
We recently have users reporting this in Argo Workflows so I felt that we should treat it in the same way in Argo CD as well.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

