### PR TITLE
fix: pass repo-server arguments by `args` field

### DIFF
--- a/docs/operator-manual/applicationset/Controlling-Resource-Modification.md
+++ b/docs/operator-manual/applicationset/Controlling-Resource-Modification.md
@@ -83,6 +83,7 @@ spec:
       containers:
       - command:
         - entrypoint.sh
+        args:
         - argocd-applicationset-controller
         # Insert new parameters here, for example:
         # --policy create-only

--- a/docs/operator-manual/applicationset/Getting-Started.md
+++ b/docs/operator-manual/applicationset/Getting-Started.md
@@ -83,6 +83,7 @@ do following changes in manifests/install.yaml
       containers:
       - command:
         - entrypoint.sh
+      - args:  
         - argocd-applicationset-controller
         - --enable-leader-election=true
 ```

--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - command:
             - entrypoint.sh
+          args:
             - argocd-applicationset-controller
           image: quay.io/argoproj/argocd:latest
           imagePullPolicy: Always

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -21,7 +21,11 @@ spec:
       - name: argocd-repo-server
         image: quay.io/argoproj/argocd:latest
         imagePullPolicy: Always
-        command: [ "sh", "-c", "entrypoint.sh argocd-repo-server --redis $(ARGOCD_REDIS_SERVICE):6379"]
+        command: ["entrypoint.sh"]
+        args:
+          - "argocd-repo-server"
+          - "--redis"
+          - "$(ARGOCD_REDIS_SERVICE):6379"
         env:
           - name: ARGOCD_RECONCILIATION_TIMEOUT
             valueFrom:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9527,9 +9527,10 @@ spec:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
       containers:
-      - command:
-        - entrypoint.sh
+      - args:
         - argocd-applicationset-controller
+        command:
+        - entrypoint.sh
         env:
         - name: NAMESPACE
           valueFrom:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9664,10 +9664,12 @@ spec:
             weight: 5
       automountServiceAccountToken: false
       containers:
-      - command:
-        - sh
-        - -c
-        - entrypoint.sh argocd-repo-server --redis argocd-redis:6379
+      - args:
+        - argocd-repo-server
+        - --redis
+        - argocd-redis:6379
+        command:
+        - entrypoint.sh
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/manifests/ha/base/overlays/argocd-repo-server-deployment.yaml
+++ b/manifests/ha/base/overlays/argocd-repo-server-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       - name: argocd-repo-server
         command:
         - entrypoint.sh
+        args:
         - argocd-repo-server
         - --redis
         - "argocd-redis-ha-haproxy:6379"

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10766,7 +10766,11 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - command:
+      - args:
+        - argocd-repo-server
+        - --redis
+        - $(ARGOCD_REDIS_SERVICE):6379
+        command:
         - entrypoint.sh
         - argocd-repo-server
         - --redis

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10466,9 +10466,10 @@ spec:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
       containers:
-      - command:
-        - entrypoint.sh
+      - args:
         - argocd-applicationset-controller
+        command:
+        - entrypoint.sh
         env:
         - name: NAMESPACE
           valueFrom:
@@ -10769,12 +10770,9 @@ spec:
       - args:
         - argocd-repo-server
         - --redis
-        - $(ARGOCD_REDIS_SERVICE):6379
+        - argocd-redis-ha-haproxy:6379
         command:
         - entrypoint.sh
-        - argocd-repo-server
-        - --redis
-        - argocd-redis-ha-haproxy:6379
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1540,7 +1540,11 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - command:
+      - args:
+        - argocd-repo-server
+        - --redis
+        - $(ARGOCD_REDIS_SERVICE):6379
+        command:
         - entrypoint.sh
         - argocd-repo-server
         - --redis

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1240,9 +1240,10 @@ spec:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
       containers:
-      - command:
-        - entrypoint.sh
+      - args:
         - argocd-applicationset-controller
+        command:
+        - entrypoint.sh
         env:
         - name: NAMESPACE
           valueFrom:
@@ -1543,12 +1544,9 @@ spec:
       - args:
         - argocd-repo-server
         - --redis
-        - $(ARGOCD_REDIS_SERVICE):6379
+        - argocd-redis-ha-haproxy:6379
         command:
         - entrypoint.sh
-        - argocd-repo-server
-        - --redis
-        - argocd-redis-ha-haproxy:6379
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10107,10 +10107,12 @@ spec:
             weight: 5
       automountServiceAccountToken: false
       containers:
-      - command:
-        - sh
-        - -c
-        - entrypoint.sh argocd-repo-server --redis argocd-redis:6379
+      - args:
+        - argocd-repo-server
+        - --redis
+        - argocd-redis:6379
+        command:
+        - entrypoint.sh
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9838,9 +9838,10 @@ spec:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
       containers:
-      - command:
-        - entrypoint.sh
+      - args:
         - argocd-applicationset-controller
+        command:
+        - entrypoint.sh
         env:
         - name: NAMESPACE
           valueFrom:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -881,10 +881,12 @@ spec:
             weight: 5
       automountServiceAccountToken: false
       containers:
-      - command:
-        - sh
-        - -c
-        - entrypoint.sh argocd-repo-server --redis argocd-redis:6379
+      - args:
+        - argocd-repo-server
+        - --redis
+        - argocd-redis:6379
+        command:
+        - entrypoint.sh
         env:
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -612,9 +612,10 @@ spec:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
       containers:
-      - command:
-        - entrypoint.sh
+      - args:
         - argocd-applicationset-controller
+        command:
+        - entrypoint.sh
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
## Background

https://github.com/argoproj/argo-cd/pull/9628 resolved the environment variable interpolation issue for the non-HA repo-server. However, it might not pass signals (including SIGTERM) to the repo-server because the command is executed in a shell. It may cause repo-server unable to shutdown gracefully.

### AS-IS

```sh
argocd@test:~$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
argocd       1  0.0  0.0   2308   832 ?        Ss   20:31   0:00 sh -c entrypoint.sh argocd-repo-server --redis test:6379
argocd       7  1.1  0.8 800248 67896 ?        Sl   20:31   0:00 argocd-repo-server --redis test:6379
```

### TO-BE

> Note that tini is a PID1

```
argocd@test:~$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
argocd       1  0.0  0.0   2204   784 ?        Ss   20:35   0:00 tini -- argocd-repo-server --redis test:6379
argocd       7  0.6  0.8 800248 65604 ?        Sl   20:35   0:00 argocd-repo-server --redis test:6379
```

## Changes

- Use entrypoint.sh directly to make `tini` to handle signal properly
- Pass argument by `args` field.

Signed-off-by: Sunghoon Kang <hoon@akuity.io>

### Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? > No
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 