### PR TITLE
fix: respect the root CA configured in oidcConfig.rootCA (#9505)

### DIFF
--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -123,10 +123,7 @@ func NewSessionManager(settingsMgr *settings.SettingsManager, projectsLister v1a
 	if err != nil {
 		panic(err)
 	}
-	tlsConfig := settings.TLSConfig()
-	if tlsConfig != nil {
-		tlsConfig.InsecureSkipVerify = true
-	}
+	tlsConfig := settings.OIDCTLSConfig()
 	s.client = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -2,8 +2,12 @@ package session
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"strings"
@@ -455,4 +459,130 @@ func TestFailedAttemptsExpiry(t *testing.T) {
 	assert.Len(t, mgr.GetLoginFailures(), 1)
 
 	os.Setenv(envLoginFailureWindowSeconds, "")
+}
+func oidcMockHandler(t *testing.T, url string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.RequestURI {
+		case "/.well-known/openid-configuration":
+			_, err := io.WriteString(w, fmt.Sprintf(`
+{
+  "issuer": "%[1]s",
+  "authorization_endpoint": "%[1]s/auth",
+  "token_endpoint": "%[1]s/token",
+  "jwks_uri": "%[1]s/keys",
+  "userinfo_endpoint": "%[1]s/userinfo",
+  "device_authorization_endpoint": "%[1]s/device/code",
+  "grant_types_supported": ["authorization_code"],
+  "response_types_supported": ["code"],
+  "subject_types_supported": ["public"],
+  "id_token_signing_alg_values_supported": ["RS512"],
+  "code_challenge_methods_supported": ["S256", "plain"],
+  "scopes_supported": ["openid"],
+  "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+  "claims_supported": ["sub", "aud", "exp"]
+}`, url))
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(404)
+		}
+	}
+}
+
+func getOIDCTestServer(t *testing.T) *httptest.Server {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Start with a placeholder. We need the server URL before setting up the real handler.
+	}))
+	ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		oidcMockHandler(t, ts.URL)(w, r)
+	})
+	return ts
+}
+
+func getKubeClientWithConfig(config map[string]string) *fake.Clientset {
+	return fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-cm",
+			Namespace: "argocd",
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "argocd",
+			},
+		},
+		Data: config,
+	}, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-secret",
+			Namespace: "argocd",
+		},
+		Data: map[string][]byte{
+			"server.secretkey": []byte("Hello, world!"),
+		},
+	})
+}
+
+// privateKey is an RSA key used only for tests.
+var privateKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEA2KHkp2fe0ReHqAt9BimWEec2ryWZIyg9jvB3BdP3mzFf0bOt
+WlHm1FAETFxH4h5jYASUaaWEwRNNyGlT1GhTp+jOMC4xhOSb5/SnI2dt2EITkudQ
+FKsSFUdJAndqOzkjrP2pL4fi4b7JWhuLDO36ufAP4l2m3tnAseGSSTIccWvzLFFU
+s3wsHOHxOcJGCP1Z7rizxl6mTKYL/Z+GHqN17OJslDf901uPXsUeDCYL2iigGPhD
+Ao6k8POsfbpqLG7poCDTK50FLnS5qEocjxt+J4ZjBEWTU/DOFXWYstzfbhm8OZPQ
+pSSEiBCxpg+zjtkQfCyZxXB5RQ84CY78fXOI9QIDAQABAoIBAG8jL0FLIp62qZvm
+uO9ualUo/37/lP7aaCpq50UQJ9lwjS3yNh8+IWQO4QWj2iUBXg4mi1Vf2ymKk78b
+eixgkXp1D0Lcj/8ToYBwnUami04FKDGXhhf0Y8SS27vuM4vKlqjrQd7modkangYi
+V0X82UKHDD8fuLpfkGIxzXDLypfMzjMuVpSntnWaf2YX3VR/0/66yEp9GejftF2k
+wqhGoWM6r68pN5XuCqWd5PRluSoDy/o4BAFMhYCSfp9PjgZE8aoeWHgYzlZ3gUyn
+r+HaDDNWbibhobXk/9h8lwAJ6KCZ5RZ+HFfh0HuwIxmocT9OCFgy/S0g1p+o3m9K
+VNd5AMkCgYEA5fbS5UK7FBzuLoLgr1hktmbLJhpt8y8IPHNABHcUdE+O4/1xTQNf
+pMUwkKjGG1MtrGjLOIoMGURKKn8lR1GMZueOTSKY0+mAWUGvSzl6vwtJwvJruT8M
+otEO03o0tPnRKGxbFjqxkp2b6iqJ8MxCRZ3lSidc4mdi7PHzv9lwgvsCgYEA8Siq
+7weCri9N6y+tIdORAXgRzcW54BmJyqB147c72RvbMacb6rN28KXpM3qnRXyp3Llb
+yh81TW3FH10GqrjATws7BK8lP9kkAw0Z/7kNiS1NgH3pUbO+5H2kAa/6QW35nzRe
+Jw2lyfYGWqYO4hYXH14ML1kjgS1hgd3XHOQ64M8CgYAKcjDYSzS2UC4dnMJaFLjW
+dErsGy09a7iDDnUs/r/GHMsP3jZkWi/hCzgOiiwdl6SufUAl/FdaWnjH/2iRGco3
+7nLPXC/3CFdVNp+g2iaSQRADtAFis9N+HeL/hkCYq/RtUqa8lsP0NgacF3yWnKCy
+Ct8chDc67ZlXzBHXeCgdOwKBgHHGFPbWXUHeUW1+vbiyvrupsQSanznp8oclMtkv
+Dk48hSokw9fzuU6Jh77gw9/Vk7HtxS9Tj+squZA1bDrJFPl1u+9WzkUUJZhG6xgp
+bwhj1iejv5rrKUlVOTYOlwudXeJNa4oTNz9UEeVcaLMjZt9GmIsSC90a0uDZD26z
+AlAjAoGAEoqm2DcNN7SrH6aVFzj1EVOrNsHYiXj/yefspeiEmf27PSAslP+uF820
+SDpz4h+Bov5qTKkzcxuu1QWtA4M0K8Iy6IYLwb83DZEm1OsAf4i0pODz21PY/I+O
+VHzjB10oYgaInHZgMUdyb6F571UdiYSB6a/IlZ3ngj5touy3VIM=
+-----END RSA PRIVATE KEY-----`)
+
+func TestSessionManager_VerifyToken(t *testing.T) {
+	t.Run("oidcConfig.rootCA is respected", func(t *testing.T) {
+		oidcTestServer := getOIDCTestServer(t)
+		defer oidcTestServer.Close()
+
+		cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: oidcTestServer.TLS.Certificates[0].Certificate[0]})
+
+		dexConfig := map[string]string{
+			"url": "",
+			"oidc.config": fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: xxx
+clientSecret: yyy
+requestedScopes: ["oidc"]
+rootCA: |
+  %s
+`, oidcTestServer.URL, strings.Replace(string(cert), "\n", "\n  ", -1)),
+		}
+
+		settingsMgr := settings.NewSettingsManager(context.Background(), getKubeClientWithConfig(dexConfig), "argocd")
+		mgr := NewSessionManager(settingsMgr, getProjLister(), "", NewUserStateStorage(nil))
+		mgr.verificationDelayNoiseEnabled = false
+
+		claims := jwt.RegisteredClaims{Audience: jwt.ClaimStrings{"test-client"}, Subject: "admin", ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 24))}
+		claims.Issuer = oidcTestServer.URL
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
+		require.NoError(t, err)
+		tokenString, err := token.SignedString(key)
+		require.NoError(t, err)
+
+		_, _, err = mgr.VerifyToken(tokenString)
+		// If the root CA is being respected, we won't get this error.
+		assert.NotContains(t, err.Error(), "certificate is not trusted")
+	})
 }


### PR DESCRIPTION
The API server currently uses `settings.TLSConfig()` for _all_ OIDC requests. That only makes sense if you're using Dex.

This change uses `settings.OIDCTLSConfig()` which, if an external OIDC provider is configured, uses `oidcConfig.rootCA`. If an external OIDC provider is _not_ configured, it falls back to previous behavior - i.e. use `settings.TLSConfig()`.

```go
func (a *ArgoCDSettings) OIDCTLSConfig() *tls.Config {
	if oidcConfig := a.OIDCConfig(); oidcConfig != nil {
		if oidcConfig.RootCA != "" {
			certPool := x509.NewCertPool()
			ok := certPool.AppendCertsFromPEM([]byte(oidcConfig.RootCA))
			if !ok {
				log.Warn("invalid oidc root ca cert - returning default tls.Config instead")
				return &tls.Config{}
			}
			return &tls.Config{
				RootCAs: certPool,
			}
		}
	}
	tlsConfig := a.TLSConfig()
	if tlsConfig != nil {
		tlsConfig.InsecureSkipVerify = true
	}
	return tlsConfig
}
```

Fixes #9505