### PR TITLE
docs: getting started notes on self-signed cert (#9429)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -174,7 +174,9 @@ argocd ... --grpc-web
 
 ## Why Am I Getting `x509: certificate signed by unknown authority` When Using The CLI?
 
-Your not running your server with correct certs.
+The certificate created by default by Argo CD is not automatically recognised by the Argo CD CLI, in order
+to create a secure system you must follow the instructions to [install a certificate](/operator-manual/tls/)
+and configure your client OS to trust that certificate.
 
 If you're not running in a production system (e.g. you're testing Argo CD out), try the `--insecure` flag:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,9 +29,11 @@ kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml
 ```
 
-This default installation will have a self-signed certificate and cannot be accessed securely.
-Either follow the [instructions to configure a certificate](./operator-manual/tls) (and ensure that the client OS trusts it) or
-use the --insecure flag on all Argo CD CLI operations in this guide.
+This default installation will have a self-signed certificate and cannot be accessed without a bit of extra work.
+Do one of:
+* Follow the [instructions to configure a certificate](./operator-manual/tls) (and ensure that the client OS trusts it).
+* Configure the client OS to trust the self signed certificate.
+* Use the --insecure flag on all Argo CD CLI operations in this guide.
 
 Use `argocd login --core` to [configure](./user-guide/commands/argocd_login.md) CLI access and skip steps 3-5.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,6 +29,10 @@ kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml
 ```
 
+This default installation will have a self-signed certificate and cannot be accessed securely.
+Either follow the [instructions to configure a certificate](./operator-manual/tls) (and ensure that the client OS trusts it) or
+use the --insecure flag on all Argo CD CLI operations in this guide.
+
 Use `argocd login --core` to [configure](./user-guide/commands/argocd_login.md) CLI access and skip steps 3-5.
 
 ## 2. Download Argo CD CLI


### PR DESCRIPTION
The default certificate created by Argo CD is a standard self-signed certificate.
There is nothing wrong with this, but it means that the instructions in the Getting Started guide cannot be followed.
This PR adds a note to point users in the correct direction to set up a secure cert (or to use --insecure on all the examples in Getting Started).

Signed-off-by: Jim Talbut <jim.talbut@groupgti.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

