### PR TITLE
fix: configurable CMP tar exclusions (#9675)

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -37,6 +37,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Chargetrip](https://chargetrip.com)
 1. [Chime](https://www.chime.com)
 1. [Cisco ET&I](https://eti.cisco.com/)
+1. [Cobalt](https://www.cobalt.io/)
 1. [Codefresh](https://www.codefresh.io/)
 1. [Codility](https://www.codility.com/)
 1. [Commonbond](https://commonbond.co/)

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -191,7 +191,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&otlpAddress, "otlp-address", env.StringFromEnv("ARGOCD_REPO_SERVER_OTLP_ADDRESS", ""), "OpenTelemetry collector address to send traces to")
 	command.Flags().BoolVar(&disableTLS, "disable-tls", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_DISABLE_TLS", false), "Disable TLS on the gRPC endpoint")
 	command.Flags().StringVar(&maxCombinedDirectoryManifestsSize, "max-combined-directory-manifests-size", env.StringFromEnv("ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE", "10M"), "Max combined size of manifest files in a directory-type Application")
-	command.Flags().StringArrayVar(&cmpTarExcludedGlobs, "cmp-tar-exclude", env.StringsFromEnv("ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS", []string{".git"}, ";"), "Globs to filter when sending tarballs to sidecar CMPs.")
+	command.Flags().StringArrayVar(&cmpTarExcludedGlobs, "plugin-tar-exclude", env.StringsFromEnv("ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS", []string{}, ";"), "Globs to filter when sending tarballs to plugins.")
 
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
 	cacheSrc = reposervercache.AddCacheFlagsToCmd(&command, func(client *redis.Client) {

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -81,6 +81,7 @@ func NewCommand() *cobra.Command {
 		redisClient                       *redis.Client
 		disableTLS                        bool
 		maxCombinedDirectoryManifestsSize string
+		cmpTarExcludedGlobs               []string
 	)
 	var command = cobra.Command{
 		Use:               cliName,
@@ -113,6 +114,7 @@ func NewCommand() *cobra.Command {
 				PauseGenerationOnFailureForRequests:          getPauseGenerationOnFailureForRequests(),
 				SubmoduleEnabled:                             getSubmoduleEnabled(),
 				MaxCombinedDirectoryManifestsSize:            maxCombinedDirectoryManifestsQuantity,
+				CMPTarExcludedGlobs:                          cmpTarExcludedGlobs,
 			}, askPassServer)
 			errors.CheckError(err)
 
@@ -189,6 +191,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&otlpAddress, "otlp-address", env.StringFromEnv("ARGOCD_REPO_SERVER_OTLP_ADDRESS", ""), "OpenTelemetry collector address to send traces to")
 	command.Flags().BoolVar(&disableTLS, "disable-tls", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_DISABLE_TLS", false), "Disable TLS on the gRPC endpoint")
 	command.Flags().StringVar(&maxCombinedDirectoryManifestsSize, "max-combined-directory-manifests-size", env.StringFromEnv("ARGOCD_REPO_SERVER_MAX_COMBINED_DIRECTORY_MANIFESTS_SIZE", "10M"), "Max combined size of manifest files in a directory-type Application")
+	command.Flags().StringArrayVar(&cmpTarExcludedGlobs, "cmp-tar-exclude", env.StringsFromEnv("ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS", []string{".git"}, ";"), "Globs to filter when sending tarballs to sidecar CMPs.")
 
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
 	cacheSrc = reposervercache.AddCacheFlagsToCmd(&command, func(client *redis.Client) {

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -111,3 +111,5 @@ data:
   # for 300x memory expansion and N Applications running at the same time.
   # (example 10M max * 300 expansion * 10 Apps = 30G max theoretical memory usage).
   reposerver.max.combined.directory.manifests.size: '10M'
+  # Paths to be excluded from the tarball streamed to the CMP server. Separate with ;
+  reposerver.cmp.tar.exclusions: ".git"

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -111,5 +111,5 @@ data:
   # for 300x memory expansion and N Applications running at the same time.
   # (example 10M max * 300 expansion * 10 Apps = 30G max theoretical memory usage).
   reposerver.max.combined.directory.manifests.size: '10M'
-  # Paths to be excluded from the tarball streamed to the CMP server. Separate with ;
-  reposerver.cmp.tar.exclusions: ".git"
+  # Paths to be excluded from the tarball streamed to plugins. Separate with ;
+  reposerver.plugin.tar.exclusions: ""

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -13,7 +13,7 @@ argocd-repo-server [flags]
 ### Options
 
 ```
-      --cmp-tar-exclude stringArray                    Globs to filter when sending tarballs to sidecar CMPs. (default [.git])
+      --plugin-tar-exclude stringArray                 Globs to filter when sending tarballs to sidecar plugins. (default [.git])
       --default-cache-expiration duration              Cache expiration default (default 24h0m0s)
       --disable-tls                                    Disable TLS on the gRPC endpoint
   -h, --help                                           help for argocd-repo-server

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -13,6 +13,7 @@ argocd-repo-server [flags]
 ### Options
 
 ```
+      --cmp-tar-exclude stringArray                    Globs to filter when sending tarballs to sidecar CMPs. (default [.git])
       --default-cache-expiration duration              Cache expiration default (default 24h0m0s)
       --disable-tls                                    Disable TLS on the gRPC endpoint
   -h, --help                                           help for argocd-repo-server

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -13,7 +13,6 @@ argocd-repo-server [flags]
 ### Options
 
 ```
-      --plugin-tar-exclude stringArray                 Globs to filter when sending tarballs to sidecar plugins. (default [.git])
       --default-cache-expiration duration              Cache expiration default (default 24h0m0s)
       --disable-tls                                    Disable TLS on the gRPC endpoint
   -h, --help                                           help for argocd-repo-server
@@ -23,6 +22,7 @@ argocd-repo-server [flags]
       --metrics-port int                               Start metrics server on given port (default 8084)
       --otlp-address string                            OpenTelemetry collector address to send traces to
       --parallelismlimit int                           Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit.
+      --plugin-tar-exclude stringArray                 Globs to filter when sending tarballs to plugins.
       --port int                                       Listen on given port for incoming connections (default 8081)
       --redis string                                   Redis server hostname and port (e.g. argocd-redis:6379). 
       --redis-ca-certificate string                    Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.

--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -238,8 +238,5 @@ If you don't need to set any environment variables, you can set an empty plugin 
 ## Tarball stream filtering
 
 In order to increase the speed of manifest generation, certain files and folders can be excluded from being sent to your
-CMP sidecar by using the `--cmp-tar-exclude` argument on the repo server.
-
-!!! important
-    By default, the `.git` folder is not transmitted. This is usually where the bulk of unnecessary data lies. If you for
-    some reason require the `.git` folder, simply override the default `--cmp-tar-exclude` with a dummy filter.
+plugin by using the `--plugin-tar-exclude` argument on the repo server or the `reposerver.plugin.tar.exclusions` key
+in `argocd-cmd-params-cm`.

--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -234,3 +234,12 @@ If you don't need to set any environment variables, you can set an empty plugin 
     Each CMP command will also independently timeout on the `ARGOCD_EXEC_TIMEOUT` set for the CMP sidecar. The default
     is 90s. So if you increase the repo server timeout greater than 90s, be sure to set `ARGOCD_EXEC_TIMEOUT` on the
     sidecar.
+
+## Tarball stream filtering
+
+In order to increase the speed of manifest generation, certain files and folders can be excluded from being sent to your
+CMP sidecar by using the `--cmp-tar-exclude` argument on the repo server.
+
+!!! important
+    By default, the `.git` folder is not transmitted. This is usually where the bulk of unnecessary data lies. If you for
+    some reason require the `.git` folder, simply override the default `--cmp-tar-exclude` with a dummy filter.

--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -238,5 +238,13 @@ If you don't need to set any environment variables, you can set an empty plugin 
 ## Tarball stream filtering
 
 In order to increase the speed of manifest generation, certain files and folders can be excluded from being sent to your
-plugin by using the `--plugin-tar-exclude` argument on the repo server or the `reposerver.plugin.tar.exclusions` key
-in `argocd-cmd-params-cm`.
+plugin. We recommend excluding your `.git` folder if it isn't necessary. Use Go's 
+[filepatch.Match](https://pkg.go.dev/path/filepath#Match) syntax.
+
+You can set it one of three ways:
+1. The `--plugin-tar-exclude` argument on the repo server.
+2. The `reposerver.plugin.tar.exclusions` key if you are using `argocd-cmd-params-cm`
+3. Directly setting 'ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS' environment variable on the repo server.
+
+For option 1, the flag can be repeated multiple times. For option 2 and 3, you can specify multiple globs by separating
+them with semicolons.

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -107,11 +107,11 @@ spec:
                 name: argocd-cmd-params-cm
                 key: reposerver.max.combined.directory.manifests.size
                 optional: true
-          - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+          - name: ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS
             valueFrom:
               configMapKeyRef:
                 name: argocd-cmd-params-cm
-                key: reposerver.cmp.tar.exclusions
+                key: reposerver.plugin.tar.exclusions
                 optional: true
           - name: HELM_CACHE_HOME
             value: /helm-working-dir

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -107,6 +107,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: reposerver.max.combined.directory.manifests.size
                 optional: true
+          - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: reposerver.cmp.tar.exclusions
+                optional: true
           - name: HELM_CACHE_HOME
             value: /helm-working-dir
           - name: HELM_CONFIG_HOME

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9753,10 +9753,10 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+        - name: ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS
           valueFrom:
             configMapKeyRef:
-              key: reposerver.cmp.tar.exclusions
+              key: reposerver.plugin.tar.exclusions
               name: argocd-cmd-params-cm
               optional: true
         - name: HELM_CACHE_HOME

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9753,6 +9753,12 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.cmp.tar.exclusions
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10856,10 +10856,10 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+        - name: ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS
           valueFrom:
             configMapKeyRef:
-              key: reposerver.cmp.tar.exclusions
+              key: reposerver.plugin.tar.exclusions
               name: argocd-cmd-params-cm
               optional: true
         - name: HELM_CACHE_HOME

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10856,6 +10856,12 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.cmp.tar.exclusions
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1630,6 +1630,12 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.cmp.tar.exclusions
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1630,10 +1630,10 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+        - name: ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS
           valueFrom:
             configMapKeyRef:
-              key: reposerver.cmp.tar.exclusions
+              key: reposerver.plugin.tar.exclusions
               name: argocd-cmd-params-cm
               optional: true
         - name: HELM_CACHE_HOME

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10196,10 +10196,10 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+        - name: ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS
           valueFrom:
             configMapKeyRef:
-              key: reposerver.cmp.tar.exclusions
+              key: reposerver.plugin.tar.exclusions
               name: argocd-cmd-params-cm
               optional: true
         - name: HELM_CACHE_HOME

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10196,6 +10196,12 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.cmp.tar.exclusions
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -970,10 +970,10 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
-        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+        - name: ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS
           valueFrom:
             configMapKeyRef:
-              key: reposerver.cmp.tar.exclusions
+              key: reposerver.plugin.tar.exclusions
               name: argocd-cmd-params-cm
               optional: true
         - name: HELM_CACHE_HOME

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -970,6 +970,12 @@ spec:
               key: reposerver.max.combined.directory.manifests.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REPO_SERVER_CMP_TAR_EXCLUSIONS
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.cmp.tar.exclusions
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1049,15 +1049,15 @@ func TestGenerateNullList(t *testing.T) {
 }
 
 func TestIdentifyAppSourceTypeByAppDirWithKustomizations(t *testing.T) {
-	sourceType, err := GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yaml", "testapp", map[string]bool{})
+	sourceType, err := GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yaml", "testapp", map[string]bool{}, []string{})
 	assert.Nil(t, err)
 	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
 
-	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yml", "testapp", map[string]bool{})
+	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yml", "testapp", map[string]bool{}, []string{})
 	assert.Nil(t, err)
 	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
 
-	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/Kustomization", "testapp", map[string]bool{})
+	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/Kustomization", "testapp", map[string]bool{}, []string{})
 	assert.Nil(t, err)
 	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
 }
@@ -1582,7 +1582,7 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 			source := &argoappv1.ApplicationSource{
 				Path: path,
 			}
-			sourceCopy := source.DeepCopy()  // make a copy in case GenerateManifest mutates it.
+			sourceCopy := source.DeepCopy() // make a copy in case GenerateManifest mutates it.
 			_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
 				Repo:              &argoappv1.Repository{},
 				ApplicationSource: sourceCopy,

--- a/util/app/discovery/discovery.go
+++ b/util/app/discovery/discovery.go
@@ -33,7 +33,7 @@ func Discover(ctx context.Context, repoPath string, enableGenerateManifests map[
 	apps := make(map[string]string)
 
 	// Check if it is CMP
-	conn, _, err := DetectConfigManagementPlugin(ctx, repoPath, []string{})
+	conn, _, err := DetectConfigManagementPlugin(ctx, repoPath, []string{}, []string{})
 	if err == nil {
 		// Found CMP
 		io.Close(conn)
@@ -82,7 +82,7 @@ func AppType(ctx context.Context, path string, enableGenerateManifests map[strin
 // 3. check isSupported(path)?
 // 4.a if no then close connection
 // 4.b if yes then return conn for detected plugin
-func DetectConfigManagementPlugin(ctx context.Context, repoPath string, env []string) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, error) {
+func DetectConfigManagementPlugin(ctx context.Context, repoPath string, env []string, tarExcludedGlobs []string) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, error) {
 	var conn io.Closer
 	var cmpClient pluginclient.ConfigManagementPluginServiceClient
 
@@ -106,7 +106,7 @@ func DetectConfigManagementPlugin(ctx context.Context, repoPath string, env []st
 				continue
 			}
 
-			isSupported, err := matchRepositoryCMP(ctx, repoPath, cmpClient, env)
+			isSupported, err := matchRepositoryCMP(ctx, repoPath, cmpClient, env, tarExcludedGlobs)
 			if err != nil {
 				log.Errorf("repository %s is not the match because %v", repoPath, err)
 				continue
@@ -131,13 +131,13 @@ func DetectConfigManagementPlugin(ctx context.Context, repoPath string, env []st
 // matchRepositoryCMP will send the repoPath to the cmp-server. The cmp-server will
 // inspect the files and return true if the repo is supported for manifest generation.
 // Will return false otherwise.
-func matchRepositoryCMP(ctx context.Context, repoPath string, client pluginclient.ConfigManagementPluginServiceClient, env []string) (bool, error) {
+func matchRepositoryCMP(ctx context.Context, repoPath string, client pluginclient.ConfigManagementPluginServiceClient, env []string, tarExcludedGlobs []string) (bool, error) {
 	matchRepoStream, err := client.MatchRepository(ctx, grpc_retry.Disable())
 	if err != nil {
 		return false, fmt.Errorf("error getting stream client: %s", err)
 	}
 
-	err = cmp.SendRepoStream(ctx, repoPath, repoPath, matchRepoStream, env)
+	err = cmp.SendRepoStream(ctx, repoPath, repoPath, matchRepoStream, env, tarExcludedGlobs)
 	if err != nil {
 		return false, fmt.Errorf("error sending stream: %s", err)
 	}

--- a/util/app/discovery/discovery.go
+++ b/util/app/discovery/discovery.go
@@ -29,11 +29,11 @@ func IsManifestGenerationEnabled(sourceType v1alpha1.ApplicationSourceType, enab
 	return enabled
 }
 
-func Discover(ctx context.Context, repoPath string, enableGenerateManifests map[string]bool) (map[string]string, error) {
+func Discover(ctx context.Context, repoPath string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (map[string]string, error) {
 	apps := make(map[string]string)
 
 	// Check if it is CMP
-	conn, _, err := DetectConfigManagementPlugin(ctx, repoPath, []string{}, []string{})
+	conn, _, err := DetectConfigManagementPlugin(ctx, repoPath, []string{}, tarExcludedGlobs)
 	if err == nil {
 		// Found CMP
 		io.Close(conn)
@@ -65,8 +65,8 @@ func Discover(ctx context.Context, repoPath string, enableGenerateManifests map[
 	return apps, err
 }
 
-func AppType(ctx context.Context, path string, enableGenerateManifests map[string]bool) (string, error) {
-	apps, err := Discover(ctx, path, enableGenerateManifests)
+func AppType(ctx context.Context, path string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (string, error) {
+	apps, err := Discover(ctx, path, enableGenerateManifests, tarExcludedGlobs)
 	if err != nil {
 		return "", err
 	}

--- a/util/app/discovery/discovery_test.go
+++ b/util/app/discovery/discovery_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDiscover(t *testing.T) {
-	apps, err := Discover(context.Background(), "./testdata", map[string]bool{})
+	apps, err := Discover(context.Background(), "./testdata", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"foo": "Kustomize",
@@ -19,15 +19,15 @@ func TestDiscover(t *testing.T) {
 }
 
 func TestAppType(t *testing.T) {
-	appType, err := AppType(context.Background(), "./testdata/foo", map[string]bool{})
+	appType, err := AppType(context.Background(), "./testdata/foo", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Kustomize", appType)
 
-	appType, err = AppType(context.Background(), "./testdata/baz", map[string]bool{})
+	appType, err = AppType(context.Background(), "./testdata/baz", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Helm", appType)
 
-	appType, err = AppType(context.Background(), "./testdata", map[string]bool{})
+	appType, err = AppType(context.Background(), "./testdata", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 }
@@ -37,15 +37,15 @@ func TestAppType_Disabled(t *testing.T) {
 		string(v1alpha1.ApplicationSourceTypeKustomize): false,
 		string(v1alpha1.ApplicationSourceTypeHelm):      false,
 	}
-	appType, err := AppType(context.Background(), "./testdata/foo", enableManifestGeneration)
+	appType, err := AppType(context.Background(), "./testdata/foo", enableManifestGeneration, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 
-	appType, err = AppType(context.Background(), "./testdata/baz", enableManifestGeneration)
+	appType, err = AppType(context.Background(), "./testdata/baz", enableManifestGeneration, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 
-	appType, err = AppType(context.Background(), "./testdata", enableManifestGeneration)
+	appType, err = AppType(context.Background(), "./testdata", enableManifestGeneration, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 }

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -84,11 +84,11 @@ func WithTarDoneChan(ch chan<- bool) SenderOption {
 
 // SendRepoStream will compress the files under the given repoPath and send
 // them using the plugin stream sender.
-func SendRepoStream(ctx context.Context, appPath, repoPath string, sender StreamSender, env []string, opts ...SenderOption) error {
+func SendRepoStream(ctx context.Context, appPath, repoPath string, sender StreamSender, env []string, excludedGlobs []string, opts ...SenderOption) error {
 	opt := newSenderOption(opts...)
 
 	// compress all files in appPath in tgz
-	tgz, checksum, err := compressFiles(repoPath)
+	tgz, checksum, err := compressFiles(repoPath, excludedGlobs)
 	if err != nil {
 		return fmt.Errorf("error compressing repo files: %w", err)
 	}
@@ -165,8 +165,7 @@ func closeAndDelete(f *os.File) {
 // directory excluding the .git folder. Returns the file alongside
 // its sha256 hash to be used as checksum. It is the responsibility
 // of the caller to close the file.
-func compressFiles(appPath string) (*os.File, string, error) {
-	excluded := []string{".git"}
+func compressFiles(appPath string, excluded []string) (*os.File, string, error) {
 	appName := filepath.Base(appPath)
 	tempDir, err := files.CreateTempDir(os.TempDir())
 	if err != nil {

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -162,9 +162,9 @@ func closeAndDelete(f *os.File) {
 }
 
 // compressFiles will create a tgz file with all contents of appPath
-// directory excluding the .git folder. Returns the file alongside
-// its sha256 hash to be used as checksum. It is the responsibility
-// of the caller to close the file.
+// directory excluding globs in the excluded array. Returns the file
+// alongside its sha256 hash to be used as checksum. It is the
+// responsibility of the caller to close the file.
 func compressFiles(appPath string, excluded []string) (*os.File, string, error) {
 	appName := filepath.Base(appPath)
 	tempDir, err := files.CreateTempDir(os.TempDir())

--- a/util/cmp/stream_test.go
+++ b/util/cmp/stream_test.go
@@ -86,7 +86,7 @@ func (m *streamMock) sendFile(ctx context.Context, t *testing.T, basedir string,
 	defer func() {
 		m.done <- true
 	}()
-	err := cmp.SendRepoStream(ctx, basedir, basedir, sender, env)
+	err := cmp.SendRepoStream(ctx, basedir, basedir, sender, env, []string{})
 	require.NoError(t, err)
 }
 

--- a/util/cmp/stream_test.go
+++ b/util/cmp/stream_test.go
@@ -60,7 +60,7 @@ func TestReceiveApplicationStream(t *testing.T) {
 			close(streamMock.messages)
 			os.RemoveAll(workdir)
 		}()
-		go streamMock.sendFile(context.Background(), t, appDir, streamMock, []string{"env1", "env2"})
+		go streamMock.sendFile(context.Background(), t, appDir, streamMock, []string{"env1", "env2"}, []string{"DUMMY.md", "dummy/*"})
 
 		// when
 		env, err := cmp.ReceiveRepoStream(context.Background(), streamMock, workdir)
@@ -77,16 +77,18 @@ func TestReceiveApplicationStream(t *testing.T) {
 		}
 		assert.Contains(t, names, "README.md")
 		assert.Contains(t, names, "applicationset")
+		assert.NotContains(t, names, "DUMMY.md")
+		assert.NotContains(t, names, "dummy")
 		assert.NotNil(t, env)
 	})
 }
 
-func (m *streamMock) sendFile(ctx context.Context, t *testing.T, basedir string, sender cmp.StreamSender, env []string) {
+func (m *streamMock) sendFile(ctx context.Context, t *testing.T, basedir string, sender cmp.StreamSender, env []string, excludedGlobs []string) {
 	t.Helper()
 	defer func() {
 		m.done <- true
 	}()
-	err := cmp.SendRepoStream(ctx, basedir, basedir, sender, env, []string{})
+	err := cmp.SendRepoStream(ctx, basedir, basedir, sender, env, excludedGlobs)
 	require.NoError(t, err)
 }
 

--- a/util/cmp/stream_test.go
+++ b/util/cmp/stream_test.go
@@ -60,7 +60,7 @@ func TestReceiveApplicationStream(t *testing.T) {
 			close(streamMock.messages)
 			os.RemoveAll(workdir)
 		}()
-		go streamMock.sendFile(context.Background(), t, appDir, streamMock, []string{"env1", "env2"}, []string{"DUMMY.md", "dummy/*"})
+		go streamMock.sendFile(context.Background(), t, appDir, streamMock, []string{"env1", "env2"}, []string{"DUMMY.md", "dum*"})
 
 		// when
 		env, err := cmp.ReceiveRepoStream(context.Background(), streamMock, workdir)

--- a/util/cmp/testdata/app/DUMMY.md
+++ b/util/cmp/testdata/app/DUMMY.md
@@ -1,0 +1,1 @@
+This file is used to test the tar stream exclusions.

--- a/util/cmp/testdata/app/dummy/DUMMY2.md
+++ b/util/cmp/testdata/app/dummy/DUMMY2.md
@@ -1,0 +1,1 @@
+This is another file that should get excluded because the entire directory is excluded.

--- a/util/env/env.go
+++ b/util/env/env.go
@@ -126,6 +126,13 @@ func StringFromEnv(env string, defaultValue string) string {
 	return defaultValue
 }
 
+func StringsFromEnv(env string, defaultValue []string, separator string) []string {
+	if str := os.Getenv(env); str != "" {
+		return strings.Split(str, separator)
+	}
+	return defaultValue
+}
+
 // ParseBoolFromEnv retrieves a boolean value from given environment envVar.
 // Returns default value if envVar is not set.
 //


### PR DESCRIPTION
Signed-off-by: notfromstatefarm <86763948+notfromstatefarm@users.noreply.github.com>

Fixes #9675

Recently, a breaking change was implemented where the `.git` folder will not be transmitted to CMP sidecars. @crenshaw-dev suggested making this configurable. This PR sets out to do that via the repo server arguments.

This is my first PR, so apologies if I missed anything!

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

