### PR TITLE
fix: websockets for terminal not working on subPath

### DIFF
--- a/ui/src/app/applications/components/pod-terminal-viewer/pod-terminal-viewer.tsx
+++ b/ui/src/app/applications/components/pod-terminal-viewer/pod-terminal-viewer.tsx
@@ -141,8 +141,9 @@ export const PodTerminalViewer: React.FC<PodTerminalViewerProps> = ({selectedNod
 
     function setupConnection() {
         const {name = '', namespace = ''} = selectedNode || {};
+        const url = `${location.host}${appContext.baseHref}`.replace(/\/$/, '');
         webSocket = new WebSocket(
-            `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/terminal?pod=${name}&container=${AppUtils.getContainerName(
+            `${location.protocol === 'https:' ? 'wss' : 'ws'}://${url}/terminal?pod=${name}&container=${AppUtils.getContainerName(
                 podState,
                 activeContainer
             )}&appName=${applicationName}&projectName=${projectName}&namespace=${namespace}`


### PR DESCRIPTION
Fixes #9780

The new Terminal feature on argocd doesn't support running on a subpath. I run argocd across many clusters on an `/argocd/` subpath. 

This PR adds the ability for the typescript to render the websocket url correctly, whether the subpath is `/argocd` or `/argocd/`,  as websockets are not very forgiving with multiple `/`s in a url.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

