### PR TITLE
docs: explain rightmost git generator path parameter behavior

### DIFF
--- a/docs/operator-manual/applicationset/Generators-Git.md
+++ b/docs/operator-manual/applicationset/Generators-Git.md
@@ -65,6 +65,8 @@ The generator parameters are:
 - `{{path.basename}}`: For any directory path within the Git repository that matches the `path` wildcard, the right-most path name is extracted (e.g. `/directory/directory2` would produce `directory2`).
 - `{{path.basenameNormalized}}`: This field is the same as `path.basename` with unsupported characters replaced with `-` (e.g. a `path` of `/directory/directory_2`, and `path.basename` of `directory_2` would produce `directory-2` here).
 
+**Note**: The right-most path name always becomes `{{path.basename}}`. For example, to use `four` as a parameter from `- path: /one/two/three/four`, use `{{path.basename}}` not `{{path[3]}}`.
+
 Whenever a new Helm chart/Kustomize YAML/Application/plain subfolder is added to the Git repository, the ApplicationSet controller will detect this change and automatically deploy the resulting manifests within new `Application` resources.
 
 As with other generators, clusters *must* already be defined within Argo CD, in order to generate Applications for them.
@@ -273,6 +275,9 @@ In addition to the flattened key/value pairs from the configuration file, the fo
 - `{{path[n]}}`: The path to the matching configuration file within the Git repository, split into array elements (`n` - array index). Example: `path[0]: clusters`, `path[1]: clusterA`
 - `{{path.basename}}`: Basename of the path to the folder containing the configuration file (e.g. `clusterA`, with the above example.)
 - `{{path.basenameNormalized}}`: This field is the same as `path.basename` with unsupported characters replaced with `-` (e.g. a `path` of `/directory/directory_2`, and `path.basename` of `directory_2` would produce `directory-2` here).
+
+**Note**: The right-most path name always becomes `{{path.basename}}`. For example, to use `four` as a parameter from `- path: /one/two/three/four/config.json`, use `{{path.basename}}` not `{{path[3]}}`.
+
 
 ## Webhook Configuration
 


### PR DESCRIPTION
There was some confusion regarding how the AppSet Git Generator provides path parameters. This clarifies docs to explain that the final directory in a path is not accessible via {{path[n]}} but is always {{path.basename}}.