### PR TITLE
fix: UI can now get clusters with slashes in name (#9812)

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"net/url"
 	"time"
 
 	"context"
@@ -145,6 +146,12 @@ func (s *Server) getCluster(ctx context.Context, q *cluster.ClusterQuery) (*appv
 		q.Name = ""
 		if q.Id.Type == "name" {
 			q.Name = q.Id.Value
+		} else if q.Id.Type == "name_escaped" {
+			nameUnescaped, err := url.QueryUnescape(q.Id.Value)
+			if err != nil {
+				return nil, err
+			}
+			q.Name = nameUnescaped
 		} else {
 			q.Server = q.Id.Value
 		}

--- a/ui/src/app/shared/services/clusters-service.ts
+++ b/ui/src/app/shared/services/clusters-service.ts
@@ -10,7 +10,7 @@ export class ClustersService {
     }
 
     public get(url: string, name: string): Promise<models.Cluster> {
-        const requestUrl = `/clusters/${url ? encodeURIComponent(url) : name}?id.type=${url ? 'url' : 'name'}`;
+        const requestUrl = `/clusters/${url ? encodeURIComponent(url) : encodeURIComponent(name)}?id.type=${url ? 'url' : 'name_escaped'}`;
         return requests.get(requestUrl).then(res => res.body as models.Cluster);
     }
 


### PR DESCRIPTION
Fixes #9812

If a cluster name has a slash in it, the API would not be able
to fetch that cluster and would display "in-cluster (undefined)"
for that application. This fixes that issue by URI-encoding
the cluster name on the UI side and URI-decoding the cluster name
on the API side.

Signed-off-by: Edmund Rhudy <erhudy@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

