### PR TITLE
feat: support multiple extensions per resource group/kind

### DIFF
--- a/docs/developer-guide/ui-extensions.md
+++ b/docs/developer-guide/ui-extensions.md
@@ -1,0 +1,61 @@
+# UI Extensions
+
+Argo CD web user interface can be extended with additional UI elements. Extensions should be delivered as a javascript file
+in the `argocd-server` Pods that are placed in the `/tmp/extensions` directory and starts with `extension` prefix ( matches to `^extension(.*).js$` regex ).
+
+```
+/tmp/extensions
+├── example1
+│   └── extension-1.js
+└── example2
+    └── extension-2.js
+```
+
+Extensions are loaded during initial page rendering and should register themselves using API exposed in the `extensionsAPI` global variable. (See
+corresponding extention type details for additional information).
+
+The extension should provide a React component that is responsible for rendering the UI element. Extension should not bundle the React library.
+Instead extension should use the `react` global variable. You can leverage `externals` setting if you are using webpack:
+
+```js
+  externals: {
+    react: 'React'
+  }
+```
+
+## Resource Tab Extensions
+
+Resource Tab extensions is an extension that provides an additional tab for the resource sliding panel at the Argo CD Application details page.
+
+<img width="568" alt="image" src="https://user-images.githubusercontent.com/426437/176794114-cb3707a4-1d65-4468-91d7-4fd54e9e9d42.png">
+
+The resource tab extension should be registered using the `extensionsAPI.registerResourceExtension` method:
+
+```typescript
+registerResourceExtension(component: ExtensionComponent, group: string, kind: string, tabTitle: string)
+```
+
+
+
+* `component: ExtensionComponent` is a React component that receives the following properties:
+
+    * resource: State - the kubernetes resource object;
+    * tree: ApplicationTree - includes list of all resources that comprise the application;
+
+    See properties interfaces in [models.ts](https://github.com/argoproj/argo-cd/blob/master/ui/src/app/shared/models.ts)
+
+* `group: string` - the glob expression that matches the group of the resource;
+* `kind: string` - the glob expression that matches the kind of the resource;
+* `tabTitle: string` - the extension tab title.
+
+Below is an example of a resource tab extension:
+
+```javascript
+((window) => {
+    const component = () => {
+        return React.createElement( 'div', {}, 'Hello World' );
+    };
+    window.extensionsAPI.registerResourceExtension(component, '*', '*', 'Nice extension');
+})(window)
+```
+

--- a/docs/developer-guide/ui-extensions.md
+++ b/docs/developer-guide/ui-extensions.md
@@ -1,7 +1,7 @@
 # UI Extensions
 
 Argo CD web user interface can be extended with additional UI elements. Extensions should be delivered as a javascript file
-in the `argocd-server` Pods that are placed in the `/tmp/extensions` directory and starts with `extension` prefix ( matches to `^extension(.*).js$` regex ).
+in the `argocd-server` Pods that are placed in the `/tmp/extensions` directory and starts with `extension` prefix ( matches to `^extension(.*)\.js$` regex ).
 
 ```
 /tmp/extensions
@@ -12,7 +12,7 @@ in the `argocd-server` Pods that are placed in the `/tmp/extensions` directory a
 ```
 
 Extensions are loaded during initial page rendering and should register themselves using API exposed in the `extensionsAPI` global variable. (See
-corresponding extention type details for additional information).
+corresponding extension type details for additional information).
 
 The extension should provide a React component that is responsible for rendering the UI element. Extension should not bundle the React library.
 Instead extension should use the `react` global variable. You can leverage `externals` setting if you are using webpack:
@@ -26,8 +26,6 @@ Instead extension should use the `react` global variable. You can leverage `exte
 ## Resource Tab Extensions
 
 Resource Tab extensions is an extension that provides an additional tab for the resource sliding panel at the Argo CD Application details page.
-
-<img width="568" alt="image" src="https://user-images.githubusercontent.com/426437/176794114-cb3707a4-1d65-4468-91d7-4fd54e9e9d42.png">
 
 The resource tab extension should be registered using the `extensionsAPI.registerResourceExtension` method:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ nav:
   - developer-guide/releasing.md
   - developer-guide/site.md
   - developer-guide/static-code-analysis.md
+  - developer-guide/ui-extensions.md
   - developer-guide/faq.md
 - faq.md
 - security_considerations.md

--- a/server/server.go
+++ b/server/server.go
@@ -895,12 +895,12 @@ func (a *ArgoCDServer) serveExtensions(extensionsSharedPath string, w http.Respo
 
 				f, err := os.Open(filePath)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to open file '%s': %w", filePath, err)
 				}
 				defer io.Close(f)
 
 				if _, err := goio.Copy(w, f); err != nil {
-					return err
+					return fmt.Errorf("failed to copy file '%s': %w", filePath, err)
 				}
 
 				return nil

--- a/server/server.go
+++ b/server/server.go
@@ -100,6 +100,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/healthz"
 	httputil "github.com/argoproj/argo-cd/v2/util/http"
 	"github.com/argoproj/argo-cd/v2/util/io"
+	"github.com/argoproj/argo-cd/v2/util/io/files"
 	jwtutil "github.com/argoproj/argo-cd/v2/util/jwt"
 	kubeutil "github.com/argoproj/argo-cd/v2/util/kube"
 	"github.com/argoproj/argo-cd/v2/util/oidc"
@@ -887,7 +888,7 @@ func (a *ArgoCDServer) serveExtensions(extensionsSharedPath string, w http.Respo
 		if err != nil {
 			return fmt.Errorf("failed to iterate files in '%s': %w", extensionsSharedPath, err)
 		}
-		if !info.IsDir() && extensionsPattern.MatchString(info.Name()) {
+		if !files.IsSymlink(info) && !info.IsDir() && extensionsPattern.MatchString(info.Name()) {
 			processFile := func() error {
 				if _, err = w.Write([]byte(fmt.Sprintf("// source: %s/%s \n", filePath, info.Name()))); err != nil {
 					return fmt.Errorf("failed to write to response: %w", err)

--- a/ui/src/app/index.html
+++ b/ui/src/app/index.html
@@ -9,6 +9,7 @@
     <link rel='icon' type='image/png' href='assets/favicon/favicon-32x32.png' sizes='32x32'/>
     <link rel='icon' type='image/png' href='assets/favicon/favicon-16x16.png' sizes='16x16'/>
     <link href="assets/fonts.css" rel="stylesheet">
+
 </head>
 
 <body>
@@ -20,5 +21,5 @@
     </noscript>
     <div id="app"></div>
 </body>
-
+<script defer src="extensions.js"></script>
 </html>

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,11 +1,41 @@
 import * as React from 'react';
+import * as minimatch from 'minimatch';
+
 import {ApplicationTree, State} from '../models';
 
-const extensions: {resources: {[key: string]: Extension}} = {resources: {}};
-const cache = new Map<string, Promise<Extension>>();
+const extensions = {
+    resourceExtentions: new Array<ResourceTabExtension>()
+};
+
+function registerResourceExtension(component: ExtensionComponent, group: string, kind: string, tabTitle: string) {
+    extensions.resourceExtentions.push({component, group, kind, title: tabTitle});
+}
+
+let legacyInitialized = false;
+
+function initLegacyExtensions() {
+    if (legacyInitialized) {
+        return;
+    }
+    legacyInitialized = true;
+    const resources = (window as any).extensions.resources;
+    Object.keys(resources).forEach(key => {
+        const [group, kind] = key.split('/');
+        registerResourceExtension(resources[key].component, group, kind, 'More');
+    });
+}
+
+export interface ResourceTabExtension {
+    title: string;
+    group: string;
+    kind: string;
+    component: ExtensionComponent;
+}
+
+export type ExtensionComponent = React.ComponentType<ExtensionComponentProps>;
 
 export interface Extension {
-    component: React.ComponentType<ExtensionComponentProps>;
+    component: ExtensionComponent;
 }
 
 export interface ExtensionComponentProps {
@@ -14,27 +44,17 @@ export interface ExtensionComponentProps {
 }
 
 export class ExtensionsService {
-    public async loadResourceExtension(group: string, kind: string): Promise<Extension> {
-        const key = `${group}/${kind}`;
-        const res =
-            cache.get(key) ||
-            new Promise<Extension>((resolve, reject) => {
-                const script = document.createElement('script');
-                script.src = `extensions/resources/${group}/${kind}/ui/extensions.js`;
-                script.onload = () => {
-                    const ext = extensions.resources[key];
-                    if (!ext) {
-                        reject(`Failed to load extension for ${group}/${kind}`);
-                    } else {
-                        resolve(ext);
-                    }
-                };
-                script.onerror = reject;
-                document.body.appendChild(script);
-            });
-        cache.set(key, res);
-        return res;
+    public getResourceTabs(group: string, kind: string): ResourceTabExtension[] {
+        initLegacyExtensions();
+        const items = extensions.resourceExtentions.filter(extension => minimatch(group, extension.group) && minimatch(kind, extension.kind)).slice();
+        return items.sort((a, b) => a.title.localeCompare(b.title));
     }
 }
 
-(window as any).extensions = extensions;
+((window: any) => {
+    // deprecated: kept for backwards compatibility
+    window.extensions = {resources: {}};
+    window.extensionsAPI = {
+        registerResourceExtension
+    };
+})(window);


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR improves the UI extensions functionality and allows having multiple extensions for the same resource group/kind.  The changes are documented in `docs/developer-guide/ui-extensions.md`. Duplicating it here for convenience: 
# UI Extensions

Argo CD web user interface can be extended with additional UI elements. Extensions should be delivered as a javascript file
in the `argocd-server` Pods that are placed in the `/tmp/extensions` directory and starts with `extension` prefix ( matches to `^extension(.*).js$` regex ).

```
/tmp/extensions
├── example1
│   └── extension-1.js
└── example2
    └── extension-2.js
```

Extensions are loaded during initial page rendering and should register themselves using API exposed in the `extensionsAPI` global variable. (See
corresponding extention type details for additional information).

The extension should provide a React component that is responsible for rendering the UI element. Extension should not bundle the React library.
Instead extension should use the `react` global variable. You can leverage `externals` setting if you are using webpack:

```js
  externals: {
    react: 'React'
  }
```

## Resource Tab Extensions

Resource Tab extensions is an extension that provides an additional tab for the resource sliding panel at the Argo CD Application details page.

<img width="568" alt="image" src="https://user-images.githubusercontent.com/426437/176794114-cb3707a4-1d65-4468-91d7-4fd54e9e9d42.png">

The resource tab extension should be registered using the `extensionsAPI.registerResourceExtension` method:

```typescript
registerResourceExtension(component: ExtensionComponent, group: string, kind: string, tabTitle: string)
```



* `component: ExtensionComponent` is a React component that receives the following properties:

    * resource: State - the kubernetes resource object;
    * tree: ApplicationTree - includes list of all resources that comprise the application;

    See properties interfaces in [models.ts](https://github.com/argoproj/argo-cd/blob/master/ui/src/app/shared/models.ts)

* `group: string` - the glob expression that matches the group of the resource;
* `kind: string` - the glob expression that matches the kind of the resource;
* `tabTitle: string` - the extension tab title.

Below is an example of a resource tab extension:

```javascript
((window) => {
    const component = () => {
        return React.createElement( 'div', {}, 'Hello World' );
    };
    window.extensionsAPI.registerResourceExtension(component, '*', '*', 'Nice extension');
})(window)
```

