### PR TITLE
feat: allow argocd cluster rotate-auth to accept cluster name

### DIFF
--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -385,17 +385,13 @@ argocd cluster rotate-auth cluster-name`,
 			}
 			conn, clusterIf := headless.NewClientOrDie(clientOpts, c).NewClusterClientOrDie()
 			defer io.Close(conn)
-			clusterQuery := getQueryBySelector(args[0])
+
+			cluster := args[0]
+			clusterQuery := getQueryBySelector(cluster)
 			_, err := clusterIf.RotateAuth(ctx, clusterQuery)
 			errors.CheckError(err)
 
-			var clstNameOrServer string
-			if clusterQuery.Name != "" {
-				clstNameOrServer = clusterQuery.Name
-			} else {
-				clstNameOrServer = clusterQuery.Server
-			}
-			fmt.Printf("Cluster '%s' rotated auth\n", clstNameOrServer)
+			fmt.Printf("Cluster '%s' rotated auth\n", cluster)
 		},
 	}
 	return command

--- a/docs/user-guide/commands/argocd_cluster.md
+++ b/docs/user-guide/commands/argocd_cluster.md
@@ -76,5 +76,5 @@ argocd cluster [flags]
 * [argocd cluster get](argocd_cluster_get.md)	 - Get cluster information
 * [argocd cluster list](argocd_cluster_list.md)	 - List configured clusters
 * [argocd cluster rm](argocd_cluster_rm.md)	 - Remove cluster credentials
-* [argocd cluster rotate-auth](argocd_cluster_rotate-auth.md)	 - argocd cluster rotate-auth SERVER
+* [argocd cluster rotate-auth](argocd_cluster_rotate-auth.md)	 - argocd cluster rotate-auth SERVER/NAME
 

--- a/docs/user-guide/commands/argocd_cluster_rotate-auth.md
+++ b/docs/user-guide/commands/argocd_cluster_rotate-auth.md
@@ -1,15 +1,16 @@
 ## argocd cluster rotate-auth
 
-argocd cluster rotate-auth SERVER
+argocd cluster rotate-auth SERVER/NAME
 
 ```
-argocd cluster rotate-auth SERVER [flags]
+argocd cluster rotate-auth SERVER/NAME [flags]
 ```
 
 ### Examples
 
 ```
 argocd cluster rotate-auth https://12.34.567.89
+argocd cluster rotate-auth cluster-name
 ```
 
 ### Options

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -202,6 +203,94 @@ func TestDeleteClusterByName(t *testing.T) {
 
 		_, err = db.GetCluster(context.Background(), "https://my-cluster-server")
 		assert.EqualError(t, err, `rpc error: code = NotFound desc = cluster "https://my-cluster-server" not found`)
+	})
+}
+
+func TestRotateAuth(t *testing.T) {
+	testNamespace := "kube-system"
+	token := "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJhcmdvY2QtbWFuYWdlci10b2tlbi10ajc5ciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJhcmdvY2QtbWFuYWdlciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjkxZGQzN2NmLThkOTItMTFlOS1hMDkxLWQ2NWYyYWU3ZmE4ZCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDprdWJlLXN5c3RlbTphcmdvY2QtbWFuYWdlciJ9.ytZjt2pDV8-A7DBMR06zQ3wt9cuVEfq262TQw7sdra-KRpDpMPnziMhc8bkwvgW-LGhTWUh5iu1y-1QhEx6mtbCt7vQArlBRxfvM5ys6ClFkplzq5c2TtZ7EzGSD0Up7tdxuG9dvR6TGXYdfFcG779yCdZo2H48sz5OSJfdEriduMEY1iL5suZd3ebOoVi1fGflmqFEkZX6SvxkoArl5mtNP6TvZ1eTcn64xh4ws152hxio42E-eSnl_CET4tpB5vgP5BVlSKW2xB7w2GJxqdETA5LJRI_OilY77dTOp8cMr_Ck3EOeda3zHfh4Okflg8rZFEeAuJYahQNeAILLkcA"
+	config := v1alpha1.ClusterConfig{
+		BearerToken: token,
+	}
+
+	configMarshal, err := json.Marshal(config)
+	if err != nil {
+		t.Errorf("failed to marshal config for test: %v", err)
+	}
+
+	clientset := getClientset(nil, testNamespace,
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster-secret",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					common.LabelKeySecretType: common.LabelValueSecretTypeCluster,
+				},
+				Annotations: map[string]string{
+					common.AnnotationKeyManagedBy: common.AnnotationValueManagedByArgoCD,
+				},
+			},
+			Data: map[string][]byte{
+				"name":   []byte("my-cluster-name"),
+				"server": []byte("https://my-cluster-name"),
+				"config": configMarshal,
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-system",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-manager-token-tj79r",
+				Namespace: "kube-system",
+			},
+			Data: map[string][]byte{
+				"token": []byte(token),
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-manager",
+				Namespace: "kube-system",
+			},
+			Secrets: []corev1.ObjectReference{
+				{
+					Kind: "Secret",
+					Name: "argocd-manager-token-tj79r",
+				},
+			},
+		})
+
+	db := db.NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
+	server := NewServer(db, newNoopEnforcer(), newServerInMemoryCache(), &kubetest.MockKubectlCmd{})
+
+	t.Run("RotateAuth by Unknown Name", func(t *testing.T) {
+		_, err := server.RotateAuth(context.Background(), &clusterapi.ClusterQuery{
+			Name: "foo",
+		})
+
+		assert.EqualError(t, err, `rpc error: code = PermissionDenied desc = permission denied`)
+	})
+
+	// While this tests results for the next two tests result in an error, they do
+	// demonstrate the proper mapping of cluster names/server to server info (i.e. my-cluster-name
+	// results in https://my-cluster-name info being used and https://my-cluster-name results in https://my-cluster-name).
+	t.Run("RotateAuth by Name - Error from no such host", func(t *testing.T) {
+		_, err := server.RotateAuth(context.Background(), &clusterapi.ClusterQuery{
+			Name: "my-cluster-name",
+		})
+
+		assert.EqualError(t, err, "Get \"https://my-cluster-name/api/v1/namespaces/kube-system/secrets/argocd-manager-token-tj79r\": dial tcp: lookup my-cluster-name: no such host")
+	})
+
+	t.Run("RotateAuth by Server - Error from no such host", func(t *testing.T) {
+		_, err := server.RotateAuth(context.Background(), &clusterapi.ClusterQuery{
+			Server: "https://my-cluster-name",
+		})
+
+		assert.EqualError(t, err, "Get \"https://my-cluster-name/api/v1/namespaces/kube-system/secrets/argocd-manager-token-tj79r\": dial tcp: lookup my-cluster-name: no such host")
 	})
 }
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -274,7 +274,7 @@ func TestRotateAuth(t *testing.T) {
 		assert.EqualError(t, err, `rpc error: code = PermissionDenied desc = permission denied`)
 	})
 
-	// While this tests results for the next two tests result in an error, they do
+	// While the tests results for the next two tests result in an error, they do
 	// demonstrate the proper mapping of cluster names/server to server info (i.e. my-cluster-name
 	// results in https://my-cluster-name info being used and https://my-cluster-name results in https://my-cluster-name).
 	t.Run("RotateAuth by Name - Error from no such host", func(t *testing.T) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -282,7 +282,8 @@ func TestRotateAuth(t *testing.T) {
 			Name: "my-cluster-name",
 		})
 
-		assert.EqualError(t, err, "Get \"https://my-cluster-name/api/v1/namespaces/kube-system/secrets/argocd-manager-token-tj79r\": dial tcp: lookup my-cluster-name: no such host")
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "Get \"https://my-cluster-name/")
 	})
 
 	t.Run("RotateAuth by Server - Error from no such host", func(t *testing.T) {
@@ -290,7 +291,8 @@ func TestRotateAuth(t *testing.T) {
 			Server: "https://my-cluster-name",
 		})
 
-		assert.EqualError(t, err, "Get \"https://my-cluster-name/api/v1/namespaces/kube-system/secrets/argocd-manager-token-tj79r\": dial tcp: lookup my-cluster-name: no such host")
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "Get \"https://my-cluster-name/")
 	})
 }
 


### PR DESCRIPTION
Closes #9554 

Allows the argocd cluster rotate-auth command to accept the cluster name as argument in addition to server.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

