### PR TITLE
fix: make sure api server informer does not stop after setting change

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -160,6 +160,7 @@ func NewCommand() *cobra.Command {
 			stats.StartStatsTicker(10 * time.Minute)
 			stats.RegisterHeapDumper("memprofile")
 			argocd := server.NewServer(context.Background(), argoCDOpts)
+			argocd.Init(context.Background())
 			lns, err := argocd.Listen()
 			errors.CheckError(err)
 			for {

--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -215,6 +215,7 @@ func StartLocalServer(clientOpts *apiclient.ClientOptions, ctxStr string, port *
 		ListenHost:    *address,
 		RepoClientset: &forwardRepoClientset{namespace: namespace, context: ctxStr},
 	})
+	srv.Init(ctx)
 
 	lns, err := srv.Listen()
 	if err != nil {

--- a/server/server_norace_test.go
+++ b/server/server_norace_test.go
@@ -36,6 +36,7 @@ func TestUserAgent(t *testing.T) {
 	defer cancelInformer()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	s.Init(ctx)
 	go s.Run(ctx, lns)
 	defer func() { time.Sleep(3 * time.Second) }()
 
@@ -101,6 +102,7 @@ func Test_StaticHeaders(t *testing.T) {
 		defer cancelInformer()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		s.Init(ctx)
 		go s.Run(ctx, lns)
 		defer func() { time.Sleep(3 * time.Second) }()
 
@@ -129,6 +131,7 @@ func Test_StaticHeaders(t *testing.T) {
 		assert.NoError(t, err)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		s.Init(ctx)
 		go s.Run(ctx, lns)
 		defer func() { time.Sleep(3 * time.Second) }()
 
@@ -157,6 +160,7 @@ func Test_StaticHeaders(t *testing.T) {
 		assert.NoError(t, err)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		s.Init(ctx)
 		go s.Run(ctx, lns)
 		defer func() { time.Sleep(3 * time.Second) }()
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -66,7 +66,8 @@ func fakeServer() (*ArgoCDServer, func()) {
 		),
 		RedisClient: redis,
 	}
-	return NewServer(context.Background(), argoCDOpts), closer
+	srv := NewServer(context.Background(), argoCDOpts)
+	return srv, closer
 }
 
 func TestEnforceProjectToken(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR fixes the bug introduced by https://github.com/argoproj/argo-cd/pull/9778. After changing any SSO-related setting the API server returns a stale list of applications/projects. The issue is happening because API server attempts to restart application/app project informers which is not supported. Informer just stops and quietly refuses to start.