### PR TITLE
chore: Replace deprecated ioutil in util packages

### DIFF
--- a/util/argo/normalizers/knowntypes_normalizer_test.go
+++ b/util/argo/normalizers/knowntypes_normalizer_test.go
@@ -2,7 +2,7 @@ package normalizers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -286,7 +286,7 @@ func TestOverrideKeyWithoutGroup(t *testing.T) {
 }
 
 func TestKnownTypes(t *testing.T) {
-	typesData, err := ioutil.ReadFile("./diffing_known_types.txt")
+	typesData, err := os.ReadFile("./diffing_known_types.txt")
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -1,7 +1,7 @@
 package argo
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-cd/v2/util/kube"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestSetAppInstanceLabel(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 
 	var obj unstructured.Unstructured
@@ -30,7 +30,7 @@ func TestSetAppInstanceLabel(t *testing.T) {
 }
 
 func TestSetAppInstanceAnnotation(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 
 	var obj unstructured.Unstructured
@@ -47,7 +47,7 @@ func TestSetAppInstanceAnnotation(t *testing.T) {
 }
 
 func TestSetAppInstanceAnnotationAndLabel(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
@@ -63,7 +63,7 @@ func TestSetAppInstanceAnnotationAndLabel(t *testing.T) {
 }
 
 func TestSetAppInstanceAnnotationNotFound(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 
 	var obj unstructured.Unstructured
@@ -108,7 +108,7 @@ func TestParseAppInstanceValueCorrectFormat(t *testing.T) {
 }
 
 func sampleResource() *unstructured.Unstructured {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/util/cert/cert_test.go
+++ b/util/cert/cert_test.go
@@ -2,7 +2,6 @@ package cert
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -473,11 +472,11 @@ func TestGetSSHKnownHostsDataPath(t *testing.T) {
 func TestGetCertificateForConnect(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		temppath := t.TempDir()
-		cert, err := ioutil.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
+		cert, err := os.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
 		if err != nil {
 			panic(err)
 		}
-		err = ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), cert, 0666)
+		err = os.WriteFile(path.Join(temppath, "127.0.0.1"), cert, 0666)
 		if err != nil {
 			panic(err)
 		}
@@ -497,7 +496,7 @@ func TestGetCertificateForConnect(t *testing.T) {
 
 	t.Run("No valid cert in file", func(t *testing.T) {
 		temppath := t.TempDir()
-		err := ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
+		err := os.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
 		if err != nil {
 			panic(err)
 		}
@@ -513,11 +512,11 @@ func TestGetCertificateForConnect(t *testing.T) {
 func TestGetCertBundlePathForRepository(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		temppath := t.TempDir()
-		cert, err := ioutil.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
+		cert, err := os.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
 		if err != nil {
 			panic(err)
 		}
-		err = ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), cert, 0666)
+		err = os.WriteFile(path.Join(temppath, "127.0.0.1"), cert, 0666)
 		if err != nil {
 			panic(err)
 		}
@@ -537,7 +536,7 @@ func TestGetCertBundlePathForRepository(t *testing.T) {
 
 	t.Run("No valid cert in file", func(t *testing.T) {
 		temppath := t.TempDir()
-		err := ioutil.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
+		err := os.WriteFile(path.Join(temppath, "127.0.0.1"), []byte("foobar"), 0666)
 		if err != nil {
 			panic(err)
 		}

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -180,7 +179,7 @@ func SetGLogLevel(glogLevel int) {
 }
 
 func writeToTempFile(pattern string, data []byte) string {
-	f, err := ioutil.TempFile("", pattern)
+	f, err := os.CreateTemp("", pattern)
 	errors.CheckError(err)
 	defer io.Close(f)
 	_, err = f.Write(data)
@@ -252,10 +251,10 @@ func InteractiveEdit(filePattern string, data []byte, save func(input []byte) er
 		err := (term.TTY{In: os.Stdin, TryDev: true}).Safe(cmd.Run)
 		errors.CheckError(err)
 
-		updated, err := ioutil.ReadFile(tempFile)
+		updated, err := os.ReadFile(tempFile)
 		errors.CheckError(err)
 		if string(updated) == "" || string(updated) == string(data) {
-			errors.CheckError(fmt.Errorf("Edit cancelled, no valid changes were saved."))
+			errors.CheckError(fmt.Errorf("edit cancelled, no valid changes were saved"))
 			break
 		} else {
 			data = stripComments(updated)
@@ -272,7 +271,7 @@ func InteractiveEdit(filePattern string, data []byte, save func(input []byte) er
 // PrintDiff prints a diff between two unstructured objects to stdout using an external diff utility
 // Honors the diff utility set in the KUBECTL_EXTERNAL_DIFF environment variable
 func PrintDiff(name string, live *unstructured.Unstructured, target *unstructured.Unstructured) error {
-	tempDir, err := ioutil.TempDir("", "argocd-diff")
+	tempDir, err := os.MkdirTemp("", "argocd-diff")
 	if err != nil {
 		return err
 	}
@@ -284,7 +283,7 @@ func PrintDiff(name string, live *unstructured.Unstructured, target *unstructure
 			return err
 		}
 	}
-	err = ioutil.WriteFile(targetFile, targetData, 0644)
+	err = os.WriteFile(targetFile, targetData, 0644)
 	if err != nil {
 		return err
 	}
@@ -296,7 +295,7 @@ func PrintDiff(name string, live *unstructured.Unstructured, target *unstructure
 			return err
 		}
 	}
-	err = ioutil.WriteFile(liveFile, liveData, 0644)
+	err = os.WriteFile(liveFile, liveData, 0644)
 	if err != nil {
 		return err
 	}

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -2,7 +2,7 @@ package clusterauth
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -36,7 +36,7 @@ var (
 )
 
 func newServiceAccount() *corev1.ServiceAccount {
-	saBytes, err := ioutil.ReadFile("./testdata/argocd-manager-sa.yaml")
+	saBytes, err := os.ReadFile("./testdata/argocd-manager-sa.yaml")
 	errors.CheckError(err)
 	var sa corev1.ServiceAccount
 	err = yaml.Unmarshal(saBytes, &sa)
@@ -45,7 +45,7 @@ func newServiceAccount() *corev1.ServiceAccount {
 }
 
 func newServiceAccountSecret() *corev1.Secret {
-	secretBytes, err := ioutil.ReadFile("./testdata/argocd-manager-sa-token.yaml")
+	secretBytes, err := os.ReadFile("./testdata/argocd-manager-sa-token.yaml")
 	errors.CheckError(err)
 	var secret corev1.Secret
 	err = yaml.Unmarshal(secretBytes, &secret)

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,7 +170,7 @@ func compressFiles(appPath string, excluded []string) (*os.File, string, error) 
 	if err != nil {
 		return nil, "", fmt.Errorf("error creating tempDir for compressing files: %s", err)
 	}
-	tgzFile, err := ioutil.TempFile(tempDir, appName)
+	tgzFile, err := os.CreateTemp(tempDir, appName)
 	if err != nil {
 		return nil, "", fmt.Errorf("error creating app temp tgz file: %w", err)
 	}
@@ -198,7 +197,7 @@ func compressFiles(appPath string, excluded []string) (*os.File, string, error) 
 // It is responsibility of the caller to close the returned file.
 func receiveFile(ctx context.Context, receiver StreamReceiver, checksum, dst string) (*os.File, error) {
 	hasher := sha256.New()
-	file, err := ioutil.TempFile(dst, "")
+	file, err := os.CreateTemp(dst, "")
 	if err != nil {
 		return nil, fmt.Errorf("error creating file: %w", err)
 	}

--- a/util/cmp/stream_test.go
+++ b/util/cmp/stream_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,7 +67,7 @@ func TestReceiveApplicationStream(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.NotEmpty(t, workdir)
-		files, err := ioutil.ReadDir(workdir)
+		files, err := os.ReadDir(workdir)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(files))
 		names := []string{}

--- a/util/config/reader.go
+++ b/util/config/reader.go
@@ -3,15 +3,15 @@ package config
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/ghodss/yaml"
 )
 
 // UnmarshalReader is used to read manifests from stdin
 func UnmarshalReader(reader io.Reader, obj interface{}) error {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func unmarshalObject(data []byte, obj interface{}) error {
 func MarshalLocalYAMLFile(path string, obj interface{}) error {
 	yamlData, err := yaml.Marshal(obj)
 	if err == nil {
-		err = ioutil.WriteFile(path, yamlData, 0600)
+		err = os.WriteFile(path, yamlData, 0600)
 	}
 	return err
 }
@@ -52,7 +52,7 @@ func MarshalLocalYAMLFile(path string, obj interface{}) error {
 // UnmarshalLocalFile retrieves JSON or YAML from a file on disk.
 // The caller is responsible for checking error return values.
 func UnmarshalLocalFile(path string, obj interface{}) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err == nil {
 		err = unmarshalObject(data, obj)
 	}
@@ -82,7 +82,7 @@ func ReadRemoteFile(url string) ([]byte, error) {
 		defer func() {
 			_ = resp.Body.Close()
 		}()
-		data, err = ioutil.ReadAll(resp.Body)
+		data, err = io.ReadAll(resp.Body)
 	}
 	return data, err
 }

--- a/util/config/reader_test.go
+++ b/util/config/reader_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -21,7 +20,7 @@ func TestUnmarshalLocalFile(t *testing.T) {
 	)
 	sentinel := fmt.Sprintf("---\nfield1: %q\nfield2: %d", field1, field2)
 
-	file, err := ioutil.TempFile(os.TempDir(), "")
+	file, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		panic(err)
 	}

--- a/util/db/gpgkeys.go
+++ b/util/db/gpgkeys.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -15,13 +14,13 @@ import (
 
 // Validates a single GnuPG key and returns the key's ID
 func validatePGPKey(keyData string) (*appsv1.GnuPGPublicKey, error) {
-	f, err := ioutil.TempFile("", "gpg-public-key")
+	f, err := os.CreateTemp("", "gpg-public-key")
 	if err != nil {
 		return nil, err
 	}
 	defer os.Remove(f.Name())
 
-	err = ioutil.WriteFile(f.Name(), []byte(keyData), 0600)
+	err = os.WriteFile(f.Name(), []byte(keyData), 0600)
 	if err != nil {
 		return nil, err
 	}

--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -3,7 +3,7 @@ package dex
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -34,7 +34,7 @@ func NewDexHTTPReverseProxy(serverAddr string, baseHRef string) func(writer http
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if resp.StatusCode == 500 {
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return err
 			}
@@ -47,7 +47,7 @@ func NewDexHTTPReverseProxy(serverAddr string, baseHRef string) func(writer http
 			resp.Header.Set("Content-Length", strconv.Itoa(0))
 			resp.Header.Set("Location", fmt.Sprintf("%s?has_sso_error=true", path.Join(baseHRef, "login")))
 			resp.StatusCode = http.StatusSeeOther
-			resp.Body = ioutil.NopCloser(bytes.NewReader(make([]byte, 0)))
+			resp.Body = io.NopCloser(bytes.NewReader(make([]byte, 0)))
 			return nil
 		}
 		return nil

--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -153,10 +152,10 @@ func (c HTTPSCreds) Environ() (io.Closer, []string, error) {
 		// We need to actually create two temp files, one for storing cert data and
 		// another for storing the key. If we fail to create second fail, the first
 		// must be removed.
-		certFile, err := ioutil.TempFile(argoio.TempDir, "")
+		certFile, err := os.CreateTemp(argoio.TempDir, "")
 		if err == nil {
 			defer certFile.Close()
-			keyFile, err = ioutil.TempFile(argoio.TempDir, "")
+			keyFile, err = os.CreateTemp(argoio.TempDir, "")
 			if err != nil {
 				removeErr := os.Remove(certFile.Name())
 				if removeErr != nil {
@@ -244,7 +243,7 @@ func (f authFilePaths) Close() error {
 
 func (c SSHCreds) Environ() (io.Closer, []string, error) {
 	// use the SHM temp dir from util, more secure
-	file, err := ioutil.TempFile(argoio.TempDir, "")
+	file, err := os.CreateTemp(argoio.TempDir, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -315,10 +314,10 @@ func (g GitHubAppCreds) Environ() (io.Closer, []string, error) {
 		// We need to actually create two temp files, one for storing cert data and
 		// another for storing the key. If we fail to create second fail, the first
 		// must be removed.
-		certFile, err := ioutil.TempFile(argoio.TempDir, "")
+		certFile, err := os.CreateTemp(argoio.TempDir, "")
 		if err == nil {
 			defer certFile.Close()
-			keyFile, err = ioutil.TempFile(argoio.TempDir, "")
+			keyFile, err = os.CreateTemp(argoio.TempDir, "")
 			if err != nil {
 				removeErr := os.Remove(certFile.Name())
 				if removeErr != nil {

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -47,7 +46,7 @@ func TestHTTPSCreds_Environ_no_cert_cleanup(t *testing.T) {
 	var nonce string
 	for _, envVar := range env {
 		if strings.HasPrefix(envVar, ASKPASS_NONCE_ENV) {
-			nonce = envVar[len(ASKPASS_NONCE_ENV) + 1:]
+			nonce = envVar[len(ASKPASS_NONCE_ENV)+1:]
 			break
 		}
 	}
@@ -109,10 +108,10 @@ func TestHTTPSCreds_Environ_clientCert(t *testing.T) {
 	assert.NotEmpty(t, cert)
 	assert.NotEmpty(t, key)
 
-	certBytes, err := ioutil.ReadFile(cert)
+	certBytes, err := os.ReadFile(cert)
 	assert.NoError(t, err)
 	assert.Equal(t, "clientCertData", string(certBytes))
-	keyBytes, err := ioutil.ReadFile(key)
+	keyBytes, err := os.ReadFile(key)
 	assert.Equal(t, "clientCertKey", string(keyBytes))
 	assert.NoError(t, err)
 

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -138,11 +138,11 @@ func TestCustomHTTPClient(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", keyFile)
 
-	certData, err := ioutil.ReadFile(certFile)
+	certData, err := os.ReadFile(certFile)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", string(certData))
 
-	keyData, err := ioutil.ReadFile(keyFile)
+	keyData, err := os.ReadFile(keyFile)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", string(keyData))
 
@@ -205,11 +205,11 @@ func TestCustomHTTPClient(t *testing.T) {
 		assert.Equal(t, "http://proxy-from-env:7878", proxy.String())
 	}
 	// GetRepoHTTPClient with root ca
-	cert, err := ioutil.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
+	cert, err := os.ReadFile("../../test/fixture/certs/argocd-test-server.crt")
 	assert.NoError(t, err)
 	temppath := t.TempDir()
 	defer os.RemoveAll(temppath)
-	err = ioutil.WriteFile(filepath.Join(temppath, "127.0.0.1"), cert, 0666)
+	err = os.WriteFile(filepath.Join(temppath, "127.0.0.1"), cert, 0666)
 	assert.NoError(t, err)
 	os.Setenv(common.EnvVarTLSDataPath, temppath)
 	client = GetRepoHTTPClient("https://127.0.0.1", false, creds, "")
@@ -290,7 +290,7 @@ func TestLFSClient(t *testing.T) {
 	assert.NoError(t, err)
 	if err == nil {
 		defer fileHandle.Close()
-		text, err := ioutil.ReadAll(fileHandle)
+		text, err := io.ReadAll(fileHandle)
 		assert.NoError(t, err)
 		if err == nil {
 			assert.Equal(t, "This is not a YAML, sorry.\n", string(text))

--- a/util/gpg/gpg.go
+++ b/util/gpg/gpg.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -154,12 +153,12 @@ func getGPGEnviron() []string {
 
 // Helper function to write some data to a temp file and return its path
 func writeKeyToFile(keyData string) (string, error) {
-	f, err := ioutil.TempFile("", "gpg-public-key")
+	f, err := os.CreateTemp("", "gpg-public-key")
 	if err != nil {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(f.Name(), []byte(keyData), 0600)
+	err = os.WriteFile(f.Name(), []byte(keyData), 0600)
 	if err != nil {
 		os.Remove(f.Name())
 		return "", err
@@ -244,12 +243,12 @@ func InitializeGnuPG() error {
 		}
 	}
 
-	err = ioutil.WriteFile(filepath.Join(gnuPgHome, canaryMarkerFilename), []byte("canary"), 0644)
+	err = os.WriteFile(filepath.Join(gnuPgHome, canaryMarkerFilename), []byte("canary"), 0644)
 	if err != nil {
 		return fmt.Errorf("could not create canary: %v", err)
 	}
 
-	f, err := ioutil.TempFile("", "gpg-key-recipe")
+	f, err := os.CreateTemp("", "gpg-key-recipe")
 	if err != nil {
 		return err
 	}
@@ -271,7 +270,7 @@ func InitializeGnuPG() error {
 }
 
 func ImportPGPKeysFromString(keyData string) ([]*appsv1.GnuPGPublicKey, error) {
-	f, err := ioutil.TempFile("", "gpg-key-import")
+	f, err := os.CreateTemp("", "gpg-key-import")
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +338,7 @@ func ValidatePGPKeysFromString(keyData string) (map[string]*appsv1.GnuPGPublicKe
 // is, they contain all relevant information
 func ValidatePGPKeys(keyFile string) (map[string]*appsv1.GnuPGPublicKey, error) {
 	keys := make(map[string]*appsv1.GnuPGPublicKey)
-	tempHome, err := ioutil.TempDir("", "gpg-verify-key")
+	tempHome, err := os.MkdirTemp("", "gpg-verify-key")
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +385,7 @@ func SetPGPTrustLevel(pgpKeys []*appsv1.GnuPGPublicKey, trustLevel string) error
 	}
 
 	// We need to store ownertrust specification in a temp file. Format is <fingerprint>:<level>
-	f, err := ioutil.TempFile("", "gpg-key-fps")
+	f, err := os.CreateTemp("", "gpg-key-fps")
 	if err != nil {
 		return err
 	}

--- a/util/gpg/gpg_test.go
+++ b/util/gpg/gpg_test.go
@@ -3,7 +3,6 @@ package gpg
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -31,7 +30,7 @@ var syncTestSources = map[string]string{
 func initTempDir(t *testing.T) string {
 	// Intentionally avoid using t.TempDir. That function creates really long paths, which can exceed the socket file
 	// path length on some OSes. The GPG tests rely on sockets.
-	p, err := ioutil.TempDir(os.TempDir(), "")
+	p, err := os.MkdirTemp(os.TempDir(), "")
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +86,7 @@ func Test_GPG_InitializeGnuPG(t *testing.T) {
 	assert.Equal(t, keys[0].Trust, "ultimate")
 
 	// GNUPGHOME is a file - we need to error out
-	f, err := ioutil.TempFile("", "gpg-test")
+	f, err := os.CreateTemp("", "gpg-test")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -303,7 +302,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Good case
 	{
-		c, err := ioutil.ReadFile("testdata/good_signature.txt")
+		c, err := os.ReadFile("testdata/good_signature.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -317,7 +316,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Signature with unknown key - considered invalid
 	{
-		c, err := ioutil.ReadFile("testdata/unknown_signature1.txt")
+		c, err := os.ReadFile("testdata/unknown_signature1.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -331,7 +330,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Signature with unknown key and additional fields - considered invalid
 	{
-		c, err := ioutil.ReadFile("testdata/unknown_signature2.txt")
+		c, err := os.ReadFile("testdata/unknown_signature2.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -345,7 +344,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad signature with known key
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_bad.txt")
+		c, err := os.ReadFile("testdata/bad_signature_bad.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -359,7 +358,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: Manipulated/invalid clear text signature
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_manipulated.txt")
+		c, err := os.ReadFile("testdata/bad_signature_manipulated.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -370,7 +369,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: Incomplete signature data #1
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_preeof1.txt")
+		c, err := os.ReadFile("testdata/bad_signature_preeof1.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -381,7 +380,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: Incomplete signature data #2
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_preeof2.txt")
+		c, err := os.ReadFile("testdata/bad_signature_preeof2.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -392,7 +391,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: No signature data #1
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_nodata.txt")
+		c, err := os.ReadFile("testdata/bad_signature_nodata.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -403,7 +402,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: Malformed signature data #1
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_malformed1.txt")
+		c, err := os.ReadFile("testdata/bad_signature_malformed1.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -414,7 +413,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: Malformed signature data #2
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_malformed2.txt")
+		c, err := os.ReadFile("testdata/bad_signature_malformed2.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -425,7 +424,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: Malformed signature data #3
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_malformed3.txt")
+		c, err := os.ReadFile("testdata/bad_signature_malformed3.txt")
 		if err != nil {
 			panic(err.Error())
 		}
@@ -436,7 +435,7 @@ func Test_GPG_ParseGitCommitVerification(t *testing.T) {
 
 	// Bad case: Invalid key ID in signature
 	{
-		c, err := ioutil.ReadFile("testdata/bad_signature_badkeyid.txt")
+		c, err := os.ReadFile("testdata/bad_signature_badkeyid.txt")
 		if err != nil {
 			panic(err.Error())
 		}

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -10,7 +9,7 @@ import (
 	"regexp"
 
 	executil "github.com/argoproj/argo-cd/v2/util/exec"
-	"github.com/argoproj/argo-cd/v2/util/io"
+	argoio "github.com/argoproj/argo-cd/v2/util/io"
 	pathutil "github.com/argoproj/argo-cd/v2/util/io/path"
 	"github.com/argoproj/argo-cd/v2/util/proxy"
 )
@@ -36,7 +35,7 @@ func NewCmd(workDir string, version string, proxy string) (*Cmd, error) {
 }
 
 func NewCmdWithVersion(workDir string, version HelmVer, isHelmOci bool, proxy string) (*Cmd, error) {
-	tmpDir, err := ioutil.TempDir("", "helm")
+	tmpDir, err := os.MkdirTemp("", "helm")
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +94,7 @@ func (c *Cmd) RegistryLogin(repo string, creds Creds) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer io.Close(closer)
+		defer argoio.Close(closer)
 		args = append(args, "--cert-file", filePath)
 	}
 	if len(creds.KeyData) > 0 {
@@ -103,7 +102,7 @@ func (c *Cmd) RegistryLogin(repo string, creds Creds) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer io.Close(closer)
+		defer argoio.Close(closer)
 		args = append(args, "--key-file", filePath)
 	}
 
@@ -125,7 +124,7 @@ func (c *Cmd) RegistryLogout(repo string, creds Creds) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer io.Close(closer)
+		defer argoio.Close(closer)
 		args = append(args, "--cert-file", filePath)
 	}
 	if len(creds.KeyData) > 0 {
@@ -133,7 +132,7 @@ func (c *Cmd) RegistryLogout(repo string, creds Creds) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer io.Close(closer)
+		defer argoio.Close(closer)
 		args = append(args, "--key-file", filePath)
 	}
 
@@ -141,7 +140,7 @@ func (c *Cmd) RegistryLogout(repo string, creds Creds) (string, error) {
 }
 
 func (c *Cmd) RepoAdd(name string, url string, opts Creds, passCredentials bool) (string, error) {
-	tmp, err := ioutil.TempDir("", "helm")
+	tmp, err := os.MkdirTemp("", "helm")
 	if err != nil {
 		return "", err
 	}
@@ -166,7 +165,7 @@ func (c *Cmd) RepoAdd(name string, url string, opts Creds, passCredentials bool)
 	}
 
 	if len(opts.CertData) > 0 {
-		certFile, err := ioutil.TempFile("", "helm")
+		certFile, err := os.CreateTemp("", "helm")
 		if err != nil {
 			return "", err
 		}
@@ -179,7 +178,7 @@ func (c *Cmd) RepoAdd(name string, url string, opts Creds, passCredentials bool)
 	}
 
 	if len(opts.KeyData) > 0 {
-		keyFile, err := ioutil.TempFile("", "helm")
+		keyFile, err := os.CreateTemp("", "helm")
 		if err != nil {
 			return "", err
 		}
@@ -200,18 +199,18 @@ func (c *Cmd) RepoAdd(name string, url string, opts Creds, passCredentials bool)
 	return c.run(args...)
 }
 
-func writeToTmp(data []byte) (string, io.Closer, error) {
-	file, err := ioutil.TempFile("", "")
+func writeToTmp(data []byte) (string, argoio.Closer, error) {
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", nil, err
 	}
-	err = ioutil.WriteFile(file.Name(), data, 0644)
+	err = os.WriteFile(file.Name(), data, 0644)
 	if err != nil {
 		_ = os.RemoveAll(file.Name())
 		return "", nil, err
 	}
 	defer file.Close()
-	return file.Name(), io.NewCloser(func() error {
+	return file.Name(), argoio.NewCloser(func() error {
 		return os.RemoveAll(file.Name())
 	}), nil
 }
@@ -241,7 +240,7 @@ func (c *Cmd) Fetch(repo, chartName, version, destination string, creds Creds, p
 		if err != nil {
 			return "", err
 		}
-		defer io.Close(closer)
+		defer argoio.Close(closer)
 		args = append(args, "--cert-file", filePath)
 	}
 	if len(creds.KeyData) > 0 {
@@ -249,7 +248,7 @@ func (c *Cmd) Fetch(repo, chartName, version, destination string, creds Creds, p
 		if err != nil {
 			return "", err
 		}
-		defer io.Close(closer)
+		defer argoio.Close(closer)
 		args = append(args, "--key-file", filePath)
 	}
 	if passCredentials && c.helmPassCredentialsSupported {

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -153,7 +152,7 @@ func (h *helm) GetParameters(valuesFiles []pathutil.ResolvedFilePath, appPath, r
 			if _, err := os.Stat(file); os.IsNotExist(err) {
 				continue
 			}
-			fileValues, err = ioutil.ReadFile(file)
+			fileValues, err = os.ReadFile(file)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read value file %s: %s", file, err)

--- a/util/io/files/tar_test.go
+++ b/util/io/files/tar_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ func TestTgz(t *testing.T) {
 	setup := func(t *testing.T) *fixture {
 		t.Helper()
 		testDir := getTestDataDir(t)
-		f, err := ioutil.TempFile(testDir, "")
+		f, err := os.CreateTemp(testDir, "")
 		require.NoError(t, err)
 		return &fixture{
 			file: f,
@@ -103,7 +102,7 @@ func TestTgz(t *testing.T) {
 func TestUntgz(t *testing.T) {
 	createTmpDir := func(t *testing.T) string {
 		t.Helper()
-		tmpDir, err := ioutil.TempDir(getTestDataDir(t), "")
+		tmpDir, err := os.MkdirTemp(getTestDataDir(t), "")
 		if err != nil {
 			t.Fatalf("error creating tmpDir: %s", err)
 		}
@@ -118,7 +117,7 @@ func TestUntgz(t *testing.T) {
 	}
 	createTgz := func(t *testing.T, fromDir, destDir string) *os.File {
 		t.Helper()
-		f, err := ioutil.TempFile(destDir, "")
+		f, err := os.CreateTemp(destDir, "")
 		if err != nil {
 			t.Fatalf("error creating tmpFile in %q: %s", destDir, err)
 		}

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -2,8 +2,8 @@ package kube
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -108,7 +108,7 @@ func TestSetLegacyLabels(t *testing.T) {
 }
 
 func TestSetLegacyJobLabel(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/job.yaml")
+	yamlBytes, err := os.ReadFile("testdata/job.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
@@ -134,7 +134,7 @@ func TestSetLegacyJobLabel(t *testing.T) {
 }
 
 func TestSetSvcLabel(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
@@ -163,7 +163,7 @@ func TestIsValidResourceName(t *testing.T) {
 }
 
 func TestSetAppInstanceAnnotation(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
@@ -185,7 +185,7 @@ func TestSetAppInstanceAnnotation(t *testing.T) {
 }
 
 func TestGetAppInstanceAnnotation(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
@@ -197,7 +197,7 @@ func TestGetAppInstanceAnnotation(t *testing.T) {
 }
 
 func TestGetAppInstanceLabel(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
@@ -208,7 +208,7 @@ func TestGetAppInstanceLabel(t *testing.T) {
 }
 
 func TestRemoveLabel(t *testing.T) {
-	yamlBytes, err := ioutil.ReadFile("testdata/svc.yaml")
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)

--- a/util/lua/custom_actions_test.go
+++ b/util/lua/custom_actions_test.go
@@ -2,7 +2,6 @@ package lua
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +47,7 @@ func TestLuaResourceActionsScript(t *testing.T) {
 		assert.NoError(t, err)
 		dir := filepath.Dir(path)
 		//TODO: Change to path
-		yamlBytes, err := ioutil.ReadFile(dir + "/action_test.yaml")
+		yamlBytes, err := os.ReadFile(dir + "/action_test.yaml")
 		assert.NoError(t, err)
 		var resourceTest ActionTestStructure
 		err = yaml.Unmarshal(yamlBytes, &resourceTest)

--- a/util/lua/health_test.go
+++ b/util/lua/health_test.go
@@ -1,7 +1,6 @@
 package lua
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,7 +24,7 @@ type IndividualTest struct {
 }
 
 func getObj(path string) *unstructured.Unstructured {
-	yamlBytes, err := ioutil.ReadFile(path)
+	yamlBytes, err := os.ReadFile(path)
 	errors.CheckError(err)
 	obj := make(map[string]interface{})
 	err = yaml.Unmarshal(yamlBytes, &obj)
@@ -40,7 +39,7 @@ func TestLuaHealthScript(t *testing.T) {
 		}
 		errors.CheckError(err)
 		dir := filepath.Dir(path)
-		yamlBytes, err := ioutil.ReadFile(dir + "/health_test.yaml")
+		yamlBytes, err := os.ReadFile(dir + "/health_test.yaml")
 		errors.CheckError(err)
 		var resourceTest TestStructure
 		err = yaml.Unmarshal(yamlBytes, &resourceTest)

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -3,10 +3,10 @@ package oidc
 import (
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	gooidc "github.com/coreos/go-oidc"
@@ -24,7 +24,7 @@ import (
 func TestInferGrantType(t *testing.T) {
 	for _, path := range []string{"dex", "okta", "auth0", "onelogin"} {
 		t.Run(path, func(t *testing.T) {
-			rawConfig, err := ioutil.ReadFile("testdata/" + path + ".json")
+			rawConfig, err := os.ReadFile("testdata/" + path + ".json")
 			assert.NoError(t, err)
 			var config OIDCConfiguration
 			err = json.Unmarshal(rawConfig, &config)

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -349,7 +348,7 @@ func LoadX509CertPool(paths ...string) (*x509.CertPool, error) {
 			// ...but everything else is considered an error
 			return nil, fmt.Errorf("could not load TLS certificate: %v", err)
 		} else {
-			f, err := ioutil.ReadFile(path)
+			f, err := os.ReadFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("failure to load TLS certificates from %s: %v", path, err)
 			}

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -59,9 +60,9 @@ func TestGitHubCommitEvent(t *testing.T) {
 	h := NewMockHandler()
 	req := httptest.NewRequest("POST", "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
-	eventJSON, err := ioutil.ReadFile("github-commit-event.json")
+	eventJSON, err := os.ReadFile("github-commit-event.json")
 	assert.NoError(t, err)
-	req.Body = ioutil.NopCloser(bytes.NewReader(eventJSON))
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
 	assert.Equal(t, w.Code, http.StatusOK)
@@ -75,9 +76,9 @@ func TestGitHubTagEvent(t *testing.T) {
 	h := NewMockHandler()
 	req := httptest.NewRequest("POST", "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
-	eventJSON, err := ioutil.ReadFile("github-tag-event.json")
+	eventJSON, err := os.ReadFile("github-tag-event.json")
 	assert.NoError(t, err)
-	req.Body = ioutil.NopCloser(bytes.NewReader(eventJSON))
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
 	assert.Equal(t, w.Code, http.StatusOK)
@@ -91,9 +92,9 @@ func TestBitbucketServerRepositoryReferenceChangedEvent(t *testing.T) {
 	h := NewMockHandler()
 	req := httptest.NewRequest("POST", "/api/webhook", nil)
 	req.Header.Set("X-Event-Key", "repo:refs_changed")
-	eventJSON, err := ioutil.ReadFile("bitbucket-server-event.json")
+	eventJSON, err := os.ReadFile("bitbucket-server-event.json")
 	assert.NoError(t, err)
-	req.Body = ioutil.NopCloser(bytes.NewReader(eventJSON))
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
 	assert.Equal(t, w.Code, http.StatusOK)
@@ -123,9 +124,9 @@ func TestGogsPushEvent(t *testing.T) {
 	h := NewMockHandler()
 	req := httptest.NewRequest("POST", "/api/webhook", nil)
 	req.Header.Set("X-Gogs-Event", "push")
-	eventJSON, err := ioutil.ReadFile("gogs-event.json")
+	eventJSON, err := os.ReadFile("gogs-event.json")
 	assert.NoError(t, err)
-	req.Body = ioutil.NopCloser(bytes.NewReader(eventJSON))
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
 	assert.Equal(t, w.Code, http.StatusOK)
@@ -139,9 +140,9 @@ func TestGitLabPushEvent(t *testing.T) {
 	h := NewMockHandler()
 	req := httptest.NewRequest("POST", "/api/webhook", nil)
 	req.Header.Set("X-Gitlab-Event", "Push Hook")
-	eventJSON, err := ioutil.ReadFile("gitlab-event.json")
+	eventJSON, err := os.ReadFile("gitlab-event.json")
 	assert.NoError(t, err)
-	req.Body = ioutil.NopCloser(bytes.NewReader(eventJSON))
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
 	assert.Equal(t, w.Code, http.StatusOK)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16.

This is part 2/x of getting rid of `io/ioutil` in our codebase, replacing it by appropriate other methods from Go's standard library.

Focus: util packages code.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

