### PR TITLE
chore: Replace deprecated ioutil in hacks

### DIFF
--- a/hack/dev-mounter/main.go
+++ b/hack/dev-mounter/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -88,7 +87,7 @@ func newCommand() *cobra.Command {
 				// Create or update files that are specified in ConfigMap
 				for name, data := range cm.Data {
 					p := path.Join(destPath, name)
-					err := ioutil.WriteFile(p, []byte(data), 0644)
+					err := os.WriteFile(p, []byte(data), 0644)
 					if err != nil {
 						log.Warnf("Failed to create file %s: %v", p, err)
 					}

--- a/hack/gen-catalog/main.go
+++ b/hack/gen-catalog/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -82,7 +81,7 @@ func newCatalogCommand() *cobra.Command {
 			d, err := yaml.Marshal(cm)
 			dieOnError(err, "Failed to marshal final configmap")
 
-			err = ioutil.WriteFile(target, d, 0644)
+			err = os.WriteFile(target, d, 0644)
 			dieOnError(err, "Failed to write builtin configmap")
 
 		},
@@ -103,14 +102,14 @@ func newDocsCommand() *cobra.Command {
 			notificationTemplates, notificationTriggers, err := buildConfigFromFS(templatesDir, triggersDir)
 			dieOnError(err, "Failed to build builtin config")
 			generateBuiltInTriggersDocs(&builtItDocsData, notificationTriggers, notificationTemplates)
-			if err := ioutil.WriteFile("./docs/operator-manual/notifications/catalog.md", builtItDocsData.Bytes(), 0644); err != nil {
+			if err := os.WriteFile("./docs/operator-manual/notifications/catalog.md", builtItDocsData.Bytes(), 0644); err != nil {
 				log.Fatal(err)
 			}
 			var commandDocs bytes.Buffer
 			if err := generateCommandsDocs(&commandDocs); err != nil {
 				log.Fatal(err)
 			}
-			if err := ioutil.WriteFile("./docs/operator-manual/notifications/troubleshooting-commands.md", commandDocs.Bytes(), 0644); err != nil {
+			if err := os.WriteFile("./docs/operator-manual/notifications/troubleshooting-commands.md", commandDocs.Bytes(), 0644); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -185,7 +184,7 @@ func buildConfigFromFS(templatesDir string, triggersDir string) (map[string]serv
 		if info.IsDir() {
 			return nil
 		}
-		data, err := ioutil.ReadFile(p)
+		data, err := os.ReadFile(p)
 		if err != nil {
 			return err
 		}
@@ -209,7 +208,7 @@ func buildConfigFromFS(templatesDir string, triggersDir string) (map[string]serv
 		if info.IsDir() {
 			return nil
 		}
-		data, err := ioutil.ReadFile(p)
+		data, err := os.ReadFile(p)
 		if err != nil {
 			return err
 		}

--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -132,7 +131,7 @@ func writeCRDintoFile(crd *extensionsobj.CustomResourceDefinition, path string) 
 	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
 	checkErr(err)
 
-	err = ioutil.WriteFile(path, yamlBytes, 0644)
+	err = os.WriteFile(path, yamlBytes, 0644)
 	checkErr(err)
 }
 

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -35,7 +34,7 @@ func generateNotificationsDocs() {
 func updateMkDocsNav(parent string, child string, subchild string, files []string) error {
 	trimPrefixes(files, "docs/")
 	sort.Strings(files)
-	data, err := ioutil.ReadFile("mkdocs.yml")
+	data, err := os.ReadFile("mkdocs.yml")
 	if err != nil {
 		return err
 	}
@@ -62,7 +61,7 @@ func updateMkDocsNav(parent string, child string, subchild string, files []strin
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile("mkdocs.yml", newmkdocs, 0644)
+	return os.WriteFile("mkdocs.yml", newmkdocs, 0644)
 }
 
 func trimPrefixes(files []string, prefix string) {

--- a/hack/gen-resources/generators/repo_generator.go
+++ b/hack/gen-resources/generators/repo_generator.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -39,7 +39,7 @@ func fetchRepos(token string, page int) ([]Repo, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/gen-resources/util/gen_options_parser.go
+++ b/hack/gen-resources/util/gen_options_parser.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -46,7 +46,7 @@ type GenerateOpts struct {
 }
 
 func Parse(opts *GenerateOpts, file string) error {
-	fp, err := ioutil.ReadFile(file)
+	fp, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/hack/known_types/main.go
+++ b/hack/known_types/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/importer"
 	"go/types"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -78,12 +77,12 @@ import corev1 "k8s.io/api/core/v1"
 func init() {%s
 }`, strings.Join(mapItems, ""))
 			if docsOutputPath != "" {
-				if err = ioutil.WriteFile(docsOutputPath, []byte(strings.Join(docs, "\n")), 0644); err != nil {
+				if err = os.WriteFile(docsOutputPath, []byte(strings.Join(docs, "\n")), 0644); err != nil {
 					return err
 				}
 			}
 
-			return ioutil.WriteFile(outputPath, []byte(res), 0644)
+			return os.WriteFile(outputPath, []byte(res), 0644)
 		},
 	}
 	command.Flags().StringVar(&docsOutputPath, "docs", "", "Docs output file path")


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16.

This is part 3/x of getting rid of `io/ioutil` in our codebase, replacing it by appropriate other methods from Go's standard library.

Focus: Code generators in `hacks/`.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

