### PR TITLE
chore: Fix import of context package across codebase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/xanzy/go-gitlab v0.60.0
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
-	golang.org/x/net v0.0.0-20220621193019-9d032be2e588
+	golang.org/x/net v0.0.0-20220621193019-9d032be2e588 // indirect
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"time"
 
+	"context"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/kubectl/pkg/util/slice"

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	kubecache "github.com/argoproj/gitops-engine/pkg/cache"
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
@@ -19,7 +20,6 @@ import (
 	"github.com/argoproj/pkg/sync"
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"

--- a/server/certificate/certificate.go
+++ b/server/certificate/certificate.go
@@ -1,7 +1,7 @@
 package certificate
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	certificatepkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/certificate"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -3,9 +3,9 @@ package cluster
 import (
 	"time"
 
+	"context"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/server/gpgkey/gpgkey.go
+++ b/server/gpgkey/gpgkey.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	gpgkeypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/gpgkey"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/server/repocreds/repocreds.go
+++ b/server/repocreds/repocreds.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/util/argo"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
+	"context"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/gitops-engine/pkg/utils/text"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apierr "k8s.io/apimachinery/pkg/api/errors"

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,7 @@ import (
 	// nolint:staticcheck
 	golang_proto "github.com/golang/protobuf/proto"
 
+	netCtx "context"
 	"github.com/argoproj/pkg/sync"
 	"github.com/go-redis/redis/v8"
 	"github.com/golang-jwt/jwt/v4"
@@ -35,7 +36,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	netCtx "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"

--- a/server/settings/settings.go
+++ b/server/settings/settings.go
@@ -1,8 +1,8 @@
 package settings
 
 import (
+	"context"
 	"github.com/ghodss/yaml"
-	"golang.org/x/net/context"
 
 	sessionmgr "github.com/argoproj/argo-cd/v2/util/session"
 

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -1,9 +1,9 @@
 package version
 
 import (
+	"context"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/go-jsonnet"
-	"golang.org/x/net/context"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/version"

--- a/util/db/certificate.go
+++ b/util/db/certificate.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
+	"context"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/context"
 
 	log "github.com/sirupsen/logrus"
 

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"hash/fnv"
 
+	"context"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"

--- a/util/db/repository_legacy.go
+++ b/util/db/repository_legacy.go
@@ -3,8 +3,8 @@ package db
 import (
 	"strings"
 
+	"context"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"

--- a/util/db/repository_secrets.go
+++ b/util/db/repository_secrets.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"

--- a/util/db/repository_secrets_test.go
+++ b/util/db/repository_secrets_test.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"testing"
 
+	"context"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -3,8 +3,8 @@ package db
 import (
 	"testing"
 
+	"context"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/util/db/secrets.go
+++ b/util/db/secrets.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/util/grpc/errors.go
+++ b/util/grpc/errors.go
@@ -3,8 +3,8 @@ package grpc
 import (
 	"errors"
 
+	"context"
 	giterr "github.com/go-git/go-git/v5/plumbing/transport"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/util/grpc/grpc.go
+++ b/util/grpc/grpc.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"

--- a/util/grpc/logging.go
+++ b/util/grpc/logging.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"context"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	ctx_logrus "github.com/grpc-ecosystem/go-grpc-middleware/tags/logrus"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/util/grpc/sanitizer.go
+++ b/util/grpc/sanitizer.go
@@ -6,12 +6,15 @@ import (
 	"strings"
 
 	"context"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 )
 
+type sanitizerKey string
+
 const (
-	contextKey = "sanitizer"
+	contextKey sanitizerKey = "sanitizer"
 )
 
 // ErrorSanitizerUnaryServerInterceptor returns a new unary server interceptor that sanitizes error messages

--- a/util/grpc/sanitizer.go
+++ b/util/grpc/sanitizer.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 )

--- a/util/grpc/useragent.go
+++ b/util/grpc/useragent.go
@@ -3,8 +3,8 @@ package grpc
 import (
 	"strings"
 
+	"context"
 	"github.com/Masterminds/semver/v3"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"


### PR DESCRIPTION
Several packages were importing `context` from `golang.org/x/net/context`, while it's been integrated into the standard library for some serious while now.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

