### PR TITLE
fix: set security headers on oidc handler responses

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/kube"
+	"github.com/argoproj/argo-cd/v2/util/security"
 	"github.com/argoproj/argo-cd/v2/util/tls"
 	traceutil "github.com/argoproj/argo-cd/v2/util/trace"
 )
@@ -150,8 +151,10 @@ func NewCommand() *cobra.Command {
 				EnableGZip:            enableGZip,
 				TLSConfigCustomizer:   tlsConfigCustomizer,
 				Cache:                 cache,
-				XFrameOptions:         frameOptions,
-				ContentSecurityPolicy: contentSecurityPolicy,
+				SecurityHeaders: security.Headers{
+					XFrameOptions:         frameOptions,
+					ContentSecurityPolicy: contentSecurityPolicy,
+				},
 				RedisClient:           redisClient,
 				StaticAssetsDir:       staticAssetsDir,
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -32,6 +32,7 @@ import (
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v2/util/rbac"
+	"github.com/argoproj/argo-cd/v2/util/security"
 	settings_util "github.com/argoproj/argo-cd/v2/util/settings"
 )
 
@@ -53,8 +54,10 @@ func fakeServer() (*ArgoCDServer, func()) {
 		AppClientset:          appClientSet,
 		Insecure:              true,
 		DisableAuth:           true,
-		XFrameOptions:         "sameorigin",
-		ContentSecurityPolicy: "frame-ancestors 'self';",
+		SecurityHeaders: security.Headers{
+			XFrameOptions:         "sameorigin",
+			ContentSecurityPolicy: "frame-ancestors 'self';",
+		},
 		Cache: servercache.NewCache(
 			appstatecache.NewCache(
 				cacheutil.NewCache(cacheutil.NewInMemoryCache(1*time.Hour)),

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/server/settings/oidc"
 	"github.com/argoproj/argo-cd/v2/util"
 	"github.com/argoproj/argo-cd/v2/util/crypto"
+	"github.com/argoproj/argo-cd/v2/util/security"
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
@@ -191,7 +192,7 @@ func TestGenerateAppState(t *testing.T) {
 	signature, err := util.MakeSignature(32)
 	require.NoError(t, err)
 	expectedReturnURL := "http://argocd.example.com/"
-	app, err := NewClientApp(&settings.ArgoCDSettings{ServerSignature: signature}, "", "")
+	app, err := NewClientApp(&settings.ArgoCDSettings{ServerSignature: signature}, "", "", security.Headers{})
 	require.NoError(t, err)
 	generateResponse := httptest.NewRecorder()
 	state, err := app.generateAppState(expectedReturnURL, generateResponse)
@@ -230,7 +231,7 @@ func TestGenerateAppState_NoReturnURL(t *testing.T) {
 	encrypted, err := crypto.Encrypt([]byte("123"), key)
 	require.NoError(t, err)
 
-	app, err := NewClientApp(cdSettings, "", "/argo-cd")
+	app, err := NewClientApp(cdSettings, "", "/argo-cd", security.Headers{})
 	require.NoError(t, err)
 
 	req.AddCookie(&http.Cookie{Name: common.StateCookieName, Value: hex.EncodeToString(encrypted)})

--- a/util/security/headers.go
+++ b/util/security/headers.go
@@ -1,0 +1,18 @@
+package security
+
+import "net/http"
+
+type Headers struct {
+	XFrameOptions string
+	ContentSecurityPolicy string
+}
+
+func SetSecurityHeaders(w http.ResponseWriter, headers Headers) {
+	if headers.XFrameOptions != "" {
+		w.Header().Set("X-Frame-Options", headers.XFrameOptions)
+	}
+	if headers.ContentSecurityPolicy != "" {
+		w.Header().Set("Content-Security-Policy", headers.ContentSecurityPolicy)
+	}
+	w.Header().Set("X-XSS-Protection", "1")
+}


### PR DESCRIPTION
I need to think about this some more. I'm not convinced it's Obvious that all these responses should have those headers (for example, what about redirects?).