### PR TITLE
feat: support https for dex server (#9424)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -14,7 +14,7 @@ const (
 	// DefaultRepoServerAddr is the gRPC address of the Argo CD repo server
 	DefaultRepoServerAddr = "argocd-repo-server:8081"
 	// DefaultDexServerAddr is the HTTP address of the Dex OIDC server, which we run a reverse proxy against
-	DefaultDexServerAddr = "http://argocd-dex-server:5556"
+	DefaultDexServerAddr = "argocd-dex-server:5556"
 	// DefaultRedisAddr is the default redis address
 	DefaultRedisAddr = "argocd-redis:6379"
 )

--- a/docs/operator-manual/upgrading/2.3-2.4.md
+++ b/docs/operator-manual/upgrading/2.3-2.4.md
@@ -225,3 +225,7 @@ Starting in 2.4, sidecar plugins will not receive environment variables from the
 that any environment variables necessary for the sidecar plugin to function are set on the sidecar plugin.
 
 argocd-cm plugins will continue to receive environment variables from the main repo-server container.
+
+## dex server HTTPS support
+To support HTTPS on the Dex server, we had to change the semantics of the `dex-server` argument on argo-server. Previously,
+it would accept the protocol i.e. `http://`. Starting in 2.4, the protocol should _not_ be specified.

--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -26,9 +26,18 @@ func GenerateDexConfigYAML(settings *settings.ArgoCDSettings) ([]byte, error) {
 	dexCfg["storage"] = map[string]interface{}{
 		"type": "memory",
 	}
-	dexCfg["web"] = map[string]interface{}{
-		"http": "0.0.0.0:5556",
+	if settings.Certificate == nil {
+		dexCfg["web"] = map[string]interface{}{
+			"http": "0.0.0.0:5556",
+		}
+	} else {
+		dexCfg["web"] = map[string]interface{}{
+			"https":   "0.0.0.0:5556",
+			"tlsCert": "/tmp/tls.crt",
+			"tlsKey":  "/tmp/tls.key",
+		}
 	}
+
 	dexCfg["grpc"] = map[string]interface{}{
 		"addr": "0.0.0.0:5557",
 	}

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -377,7 +377,7 @@ func Test_DexReverseProxy(t *testing.T) {
 		}))
 		defer fakeDex.Close()
 		fmt.Printf("Fake Dex listening on %s\n", fakeDex.URL)
-		server := httptest.NewServer(http.HandlerFunc(NewDexHTTPReverseProxy(fakeDex.URL, "/")))
+		server := httptest.NewServer(http.HandlerFunc(NewDexHTTPReverseProxy(fakeDex.URL, "/", true)))
 		fmt.Printf("Fake API Server listening on %s\n", server.URL)
 		defer server.Close()
 		target, _ := url.Parse(fakeDex.URL)
@@ -395,7 +395,7 @@ func Test_DexReverseProxy(t *testing.T) {
 		}))
 		defer fakeDex.Close()
 		fmt.Printf("Fake Dex listening on %s\n", fakeDex.URL)
-		server := httptest.NewServer(http.HandlerFunc(NewDexHTTPReverseProxy(fakeDex.URL, "/")))
+		server := httptest.NewServer(http.HandlerFunc(NewDexHTTPReverseProxy(fakeDex.URL, "/", true)))
 		fmt.Printf("Fake API Server listening on %s\n", server.URL)
 		defer server.Close()
 		client := &http.Client{
@@ -414,7 +414,7 @@ func Test_DexReverseProxy(t *testing.T) {
 	t.Run("Invalid URL for Dex reverse proxy", func(t *testing.T) {
 		// Can't test for now, since it would call exit
 		t.Skip()
-		f := NewDexHTTPReverseProxy(invalidURL, "/")
+		f := NewDexHTTPReverseProxy(invalidURL, "/", true)
 		assert.Nil(t, f)
 	})
 


### PR DESCRIPTION
Signed-off-by: notfromstatefarm <86763948+notfromstatefarm@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Closes #9424

This PR enables HTTPS on the Dex server by sharing the certificate used by argo-server.
