### PR TITLE
fix: 'unexpected reserved bits' breaking web terminal (#9605)

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -290,4 +290,4 @@ data:
   exec.enabled: "false"
 
   # exec.shells determines which shells are allowed for `exec`, and in which order they are attempted
-  exec.shells: "sh,bash,powershell,cmd"
+  exec.shells: "bash,sh,powershell,cmd"

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -288,3 +288,6 @@ data:
 
   # exec.enabled indicates whether the UI exec feature is enabled. It is disabled by default.
   exec.enabled: "false"
+
+  # exec.shells determines which shells are allowed for `exec`, and in which order they are attempted
+  exec.shells: "sh,bash,powershell,cmd"

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -289,5 +289,5 @@ data:
   # exec.enabled indicates whether the UI exec feature is enabled. It is disabled by default.
   exec.enabled: "false"
 
-  # exec.shells determines which shells are allowed for `exec`, and in which order they are attempted
+  # exec.shells restricts which shells are allowed for `exec`, and in which order they are attempted
   exec.shells: "bash,sh,powershell,cmd"

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -218,15 +218,11 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer session.Done()
 
-	validShell := isValidShell(*s.allowedShells, shell)
-	if validShell {
+	if isValidShell(*s.allowedShells, shell) {
 		cmd := []string{shell}
 		err = startProcess(kubeClientset, config, namespace, podName, container, cmd, session)
-	}
-
-	if !validShell || err != nil {
-		// No shell given, the given shell was invalid, or the given shell failed: try some shells until one succeeds or
-		// all fail
+	} else {
+		// No shell given or the given shell was not allowed: try the configured shells until one succeeds or all fail.
 		for _, testShell := range *s.allowedShells {
 			cmd := []string{testShell}
 			if err = startProcess(kubeClientset, config, namespace, podName, container, cmd, session); err == nil {

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -33,17 +33,19 @@ type terminalHandler struct {
 	enf               *rbac.Enforcer
 	cache             *servercache.Cache
 	appResourceTreeFn func(ctx context.Context, app *appv1.Application) (*appv1.ApplicationTree, error)
+	allowedShells     *[]string
 }
 
 // NewHandler returns a new terminal handler.
 func NewHandler(appLister applisters.ApplicationNamespaceLister, db db.ArgoDB, enf *rbac.Enforcer, cache *servercache.Cache,
-	appResourceTree AppResourceTreeFn) *terminalHandler {
+	appResourceTree AppResourceTreeFn, allowedShells *[]string) *terminalHandler {
 	return &terminalHandler{
 		appLister:         appLister,
 		db:                db,
 		enf:               enf,
 		cache:             cache,
 		appResourceTreeFn: appResourceTree,
+		allowedShells:     allowedShells,
 	}
 }
 
@@ -123,7 +125,7 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Namespace name is not valid", http.StatusBadRequest)
 		return
 	}
-	shell := q.Get("shell") // No need to validate. Will only buse used if it's in the allow-list.
+	shell := q.Get("shell") // No need to validate. Will only use used if it's in the allow-list.
 
 	ctx := r.Context()
 
@@ -216,14 +218,16 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer session.Done()
 
-	validShells := []string{"bash", "sh", "powershell", "cmd"}
-	if isValidShell(validShells, shell) {
+	validShell := isValidShell(*s.allowedShells, shell)
+	if validShell {
 		cmd := []string{shell}
 		err = startProcess(kubeClientset, config, namespace, podName, container, cmd, session)
-	} else {
-		// No shell given or it was not valid: try some shells until one succeeds or all fail
-		// FIXME: if the first shell fails then the first keyboard event is lost
-		for _, testShell := range validShells {
+	}
+
+	if !validShell || err != nil {
+		// No shell given, the given shell was invalid, or the given shell failed: try some shells until one succeeds or
+		// all fail
+		for _, testShell := range *s.allowedShells {
 			cmd := []string{testShell}
 			if err = startProcess(kubeClientset, config, namespace, podName, container, cmd, session); err == nil {
 				break

--- a/server/application/websocket.go
+++ b/server/application/websocket.go
@@ -27,7 +27,7 @@ type terminalSession struct {
 	sizeChan chan remotecommand.TerminalSize
 	doneChan chan struct{}
 	tty      bool
-	readMu   sync.Mutex
+	readLock sync.Mutex
 }
 
 // newTerminalSession create terminalSession
@@ -62,9 +62,9 @@ func (t *terminalSession) Next() *remotecommand.TerminalSize {
 
 // Read called in a loop from remotecommand as long as the process is running
 func (t *terminalSession) Read(p []byte) (int, error) {
-	t.readMu.Lock()
+	t.readLock.Lock()
 	_, message, err := t.wsConn.ReadMessage()
-	t.readMu.Unlock()
+	t.readLock.Unlock()
 	if err != nil {
 		log.Errorf("read message err: %v", err)
 		return copy(p, EndOfTransmission), err

--- a/server/server.go
+++ b/server/server.go
@@ -801,7 +801,7 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 	}
 	mux.Handle("/api/", handler)
 
-	terminalHandler := application.NewHandler(a.appLister, a.db, a.enf, a.Cache, appResourceTreeFn)
+	terminalHandler := application.NewHandler(a.appLister, a.db, a.enf, a.Cache, appResourceTreeFn, &a.settings.ExecShells)
 	mux.HandleFunc("/terminal", func(writer http.ResponseWriter, request *http.Request) {
 		argocdSettings, err := a.settingsMgr.GetSettings()
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -801,7 +801,7 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 	}
 	mux.Handle("/api/", handler)
 
-	terminalHandler := application.NewHandler(a.appLister, a.db, a.enf, a.Cache, appResourceTreeFn, &a.settings.ExecShells)
+	terminalHandler := application.NewHandler(a.appLister, a.db, a.enf, a.Cache, appResourceTreeFn, a.settings.ExecShells)
 	mux.HandleFunc("/terminal", func(writer http.ResponseWriter, request *http.Request) {
 		argocdSettings, err := a.settingsMgr.GetSettings()
 		if err != nil {

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -1282,7 +1282,7 @@ func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *apiv1.Confi
 		settings.ExecShells = strings.Split(execShells, ",")
 	} else {
 		// Fall back to default. If you change this list, also change docs/operator-manual/argocd-cm.yaml.
-		settings.ExecShells = []string{"sh", "bash", "powershell", "cmd"}
+		settings.ExecShells = []string{"bash", "sh", "powershell", "cmd"}
 	}
 	settings.TrackingMethod = argoCDCM.Data[settingsResourceTrackingMethodKey]
 }

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -99,7 +99,7 @@ type ArgoCDSettings struct {
 	ServerRBACLogEnforceEnable bool `json:"serverRBACLogEnforceEnable"`
 	// ExecEnabled indicates whether the UI exec feature is enabled
 	ExecEnabled bool `json:"execEnabled"`
-	// ExecShells determines which shells are allowed for `exec` and in which order they are tried
+	// ExecShells restricts which shells are allowed for `exec` and in which order they are tried
 	ExecShells []string `json:"execShells"`
 	// TrackingMethod defines the resource tracking method to be used
 	TrackingMethod string `json:"application.resourceTrackingMethod,omitempty"`

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -99,6 +99,8 @@ type ArgoCDSettings struct {
 	ServerRBACLogEnforceEnable bool `json:"serverRBACLogEnforceEnable"`
 	// ExecEnabled indicates whether the UI exec feature is enabled
 	ExecEnabled bool `json:"execEnabled"`
+	// ExecShells determines which shells are allowed for `exec` and in which order they are tried
+	ExecShells []string `json:"execShells"`
 	// TrackingMethod defines the resource tracking method to be used
 	TrackingMethod string `json:"application.resourceTrackingMethod,omitempty"`
 }
@@ -408,6 +410,8 @@ const (
 	helmValuesFileSchemesKey = "helm.valuesFileSchemes"
 	// execEnabledKey is the key to configure whether the UI exec feature is enabled
 	execEnabledKey = "exec.enabled"
+	// execShellsKey is the key to configure which shells are allowed for `exec` and in what order they are tried
+	execShellsKey = "exec.shells"
 )
 
 var (
@@ -1273,6 +1277,13 @@ func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *apiv1.Confi
 	}
 	settings.InClusterEnabled = argoCDCM.Data[inClusterEnabledKey] != "false"
 	settings.ExecEnabled = argoCDCM.Data[execEnabledKey] == "true"
+	execShells := argoCDCM.Data[execShellsKey]
+	if execShells != "" {
+		settings.ExecShells = strings.Split(execShells, ",")
+	} else {
+		// Fall back to default. If you change this list, also change docs/operator-manual/argocd-cm.yaml.
+		settings.ExecShells = []string{"sh", "bash", "powershell", "cmd"}
+	}
 	settings.TrackingMethod = argoCDCM.Data[settingsResourceTrackingMethodKey]
 }
 


### PR DESCRIPTION
Fixes #9605 
Fixes #9641
Fixes #9643

Hi I'm Michael, and I suck at concurrent programming.

**But** [another issue](https://github.com/gorilla/websocket/issues/373) directed me to run web terminal with the race detector enabled.

And I got a bunch of text that I didn't understand.

<details>
<summary>Very boring race detector output</summary>

```
==================
WARNING: DATA RACE
Write at 0x00c0016f0008 by goroutine 44:
  runtime.racewriterange()
      <autogenerated>:1 +0x29
  internal/poll.ignoringEINTRIO()
      /usr/local/go/src/internal/poll/fd_unix.go:794 +0x44b
  internal/poll.(*FD).Read()
      /usr/local/go/src/internal/poll/fd_unix.go:163 +0x26
  net.(*netFD).Read()
      /usr/local/go/src/net/fd_posix.go:55 +0x50
  net.(*conn).Read()
      /usr/local/go/src/net/net.go:183 +0xb0
  net.(*TCPConn).Read()
      <autogenerated>:1 +0x64
  github.com/soheilhy/cmux.(*bufferedReader).Read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/soheilhy/cmux/buffer.go:53 +0x2f7
  github.com/soheilhy/cmux.(*MuxConn).Read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/soheilhy/cmux/cmux.go:297 +0x50
  bufio.(*Reader).fill()
      /usr/local/go/src/bufio/bufio.go:106 +0x293
  bufio.(*Reader).Peek()
      /usr/local/go/src/bufio/bufio.go:144 +0xcb
  github.com/gorilla/websocket.(*Conn).read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/gorilla/websocket/conn.go:370 +0x5a
  github.com/gorilla/websocket.(*Conn).advanceFrame()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/gorilla/websocket/conn.go:798 +0x124
  github.com/gorilla/websocket.(*Conn).NextReader()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/gorilla/websocket/conn.go:980 +0x164
  github.com/gorilla/websocket.(*Conn).ReadMessage()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/gorilla/websocket/conn.go:1064 +0x30
  github.com/argoproj/argo-cd/v2/server/application.(*terminalSession).Read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/application/websocket.go:63 +0x69
  k8s.io/client-go/tools/remotecommand.readerWrapper.Read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/reader.go:40 +0x79
  k8s.io/client-go/tools/remotecommand.(*readerWrapper).Read()
      <autogenerated>:1 +0x29
  io.copyBuffer()
      /usr/local/go/src/io/io.go:426 +0x28a
  io.Copy()
      /usr/local/go/src/io/io.go:385 +0x1ab
  k8s.io/client-go/tools/remotecommand.(*streamProtocolV2).copyStdin.func1()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/v2.go:104 +0xfd

Previous read at 0x00c0016f0008 by goroutine 125:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:295 +0x0
  bufio.(*Reader).Read()
      /usr/local/go/src/bufio/bufio.go:249 +0x6c4
  github.com/gorilla/websocket.(*messageReader).Read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/gorilla/websocket/conn.go:1021 +0x3cc
  io.ReadAll()
      /usr/local/go/src/io/io.go:645 +0x102
  io/ioutil.ReadAll()
      /usr/local/go/src/io/ioutil/ioutil.go:27 +0x75
  github.com/gorilla/websocket.(*Conn).ReadMessage()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/github.com/gorilla/websocket/conn.go:1068 +0x6a
  github.com/argoproj/argo-cd/v2/server/application.(*terminalSession).Read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/application/websocket.go:63 +0x69
  k8s.io/client-go/tools/remotecommand.readerWrapper.Read()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/reader.go:40 +0x79
  k8s.io/client-go/tools/remotecommand.(*readerWrapper).Read()
      <autogenerated>:1 +0x29
  io.copyBuffer()
      /usr/local/go/src/io/io.go:426 +0x28a
  io.Copy()
      /usr/local/go/src/io/io.go:385 +0x1ab
  k8s.io/client-go/tools/remotecommand.(*streamProtocolV2).copyStdin.func1()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/v2.go:104 +0xfd

Goroutine 44 (running) created at:
  k8s.io/client-go/tools/remotecommand.(*streamProtocolV2).copyStdin()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/v2.go:96 +0x11a
  k8s.io/client-go/tools/remotecommand.(*streamProtocolV4).stream()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/v4.go:65 +0x131
  k8s.io/client-go/tools/remotecommand.(*streamExecutor).Stream()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/remotecommand.go:141 +0xbd5
  github.com/argoproj/argo-cd/v2/server/application.startProcess()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/application/terminal.go:296 +0x4cc
  github.com/argoproj/argo-cd/v2/server/application.(*terminalHandler).ServeHTTP()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/application/terminal.go:232 +0x1fee
  github.com/argoproj/argo-cd/v2/server.(*ArgoCDServer).newHTTPServer.func1()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/server.go:836 +0x6fb
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2084 +0x4d
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2462 +0xc5
  github.com/argoproj/argo-cd/v2/server.(*handlerSwitcher).ServeHTTP()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/server.go:1132 +0x1bc
  github.com/argoproj/argo-cd/v2/server.(*bug21955Workaround).ServeHTTP()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/server.go:1157 +0x235
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2916 +0x896
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1966 +0xbaa
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3071 +0x58

Goroutine 125 (finished) created at:
  k8s.io/client-go/tools/remotecommand.(*streamProtocolV2).copyStdin()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/v2.go:96 +0x11a
  k8s.io/client-go/tools/remotecommand.(*streamProtocolV4).stream()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/v4.go:65 +0x131
  k8s.io/client-go/tools/remotecommand.(*streamExecutor).Stream()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/vendor/k8s.io/client-go/tools/remotecommand/remotecommand.go:141 +0xbd5
  github.com/argoproj/argo-cd/v2/server/application.startProcess()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/application/terminal.go:296 +0x4cc
  github.com/argoproj/argo-cd/v2/server/application.(*terminalHandler).ServeHTTP()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/application/terminal.go:232 +0x1fee
  github.com/argoproj/argo-cd/v2/server.(*ArgoCDServer).newHTTPServer.func1()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/server.go:836 +0x6fb
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2084 +0x4d
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2462 +0xc5
  github.com/argoproj/argo-cd/v2/server.(*handlerSwitcher).ServeHTTP()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/server.go:1132 +0x1bc
  github.com/argoproj/argo-cd/v2/server.(*bug21955Workaround).ServeHTTP()
      /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/server/server.go:1157 +0x235
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2916 +0x896
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1966 +0xbaa
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3071 +0x58
==================
```
</details>

Aimlessly clicking around led me to [this issue](https://github.com/gorilla/websocket/issues/400#issuecomment-408699663) linking to [some websocket documentation](https://pkg.go.dev/github.com/gorilla/websocket?utm_source=godoc#hdr-Concurrency) which seems to say that when we use `ReadMessage`, we gotta protect it with a mutex.

So I added a mutex around `ReadMessage` - and everything works! Conclusion: I am a genius who is excellent at concurrent programming.

This PR also makes the shell list/order configurable, because we need that anyway. I didn't change the order.

I've tested `debian:latest` and `alpine:latest`. Both work with the default shell order.

Should we also protect the `WriteMessage` call with a mutex? I'm not sure. I guess maybe wait until there's a bug to fix?