### PR TITLE
fix: NotAfter is not set when ValidFor is set

### DIFF
--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -247,6 +247,8 @@ func generate(opts CertOptions) ([]byte, crypto.PrivateKey, error) {
 	var validFor time.Duration
 	if opts.ValidFor == 0 {
 		validFor = 365 * 24 * time.Hour
+	} else {
+		validFor = opts.ValidFor
 	}
 	notAfter := notBefore.Add(validFor)
 

--- a/util/tls/tls_test.go
+++ b/util/tls/tls_test.go
@@ -252,6 +252,21 @@ func TestGenerate(t *testing.T) {
 		assert.NotNil(t, cert)
 		assert.GreaterOrEqual(t, (time.Now().Unix())+int64(1*time.Hour), cert.NotBefore.Unix())
 	})
+
+	for _, year := range []int{1, 2, 3, 10} {
+		t.Run(fmt.Sprintf("Create certificate with specified ValidFor %d year", year), func(t *testing.T) {
+			validFrom, validFor := time.Now(), 365*24*time.Hour*time.Duration(year)
+			opts := CertOptions{Hosts: []string{"localhost"}, Organization: "Acme", ValidFrom: validFrom, ValidFor: validFor}
+			certBytes, privKey, err := generate(opts)
+			assert.NoError(t, err)
+			assert.NotNil(t, privKey)
+			cert, err := x509.ParseCertificate(certBytes)
+			assert.NoError(t, err)
+			assert.NotNil(t, cert)
+			t.Logf("certificate expiration time %s", cert.NotAfter)
+			assert.Equal(t, validFrom.Unix()+int64(validFor.Seconds()), cert.NotAfter.Unix())
+		})
+	}
 }
 
 func TestGeneratePEM(t *testing.T) {


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

