### PR TITLE
test: Use dedicated multi-arch workloads in e2e tests

### DIFF
--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -948,7 +948,7 @@ func TestLocalManifestSync(t *testing.T) {
 		And(func(app *Application) {
 			res, _ := RunCli("app", "manifests", app.Name)
 			assert.Contains(t, res, "containerPort: 80")
-			assert.Contains(t, res, "image: gcr.io/heptio-images/ks-guestbook-demo:0.2")
+			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.2")
 		}).
 		Given().
 		LocalPath(guestbookPathLocal).
@@ -959,7 +959,7 @@ func TestLocalManifestSync(t *testing.T) {
 		And(func(app *Application) {
 			res, _ := RunCli("app", "manifests", app.Name)
 			assert.Contains(t, res, "containerPort: 81")
-			assert.Contains(t, res, "image: gcr.io/heptio-images/ks-guestbook-demo:0.3")
+			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.3")
 		}).
 		Given().
 		LocalPath("").
@@ -970,7 +970,7 @@ func TestLocalManifestSync(t *testing.T) {
 		And(func(app *Application) {
 			res, _ := RunCli("app", "manifests", app.Name)
 			assert.Contains(t, res, "containerPort: 80")
-			assert.Contains(t, res, "image: gcr.io/heptio-images/ks-guestbook-demo:0.2")
+			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.2")
 		})
 }
 
@@ -1191,7 +1191,8 @@ func TestPermissionWithScopedRepo(t *testing.T) {
 		Name(projName).
 		Destination("*,*").
 		When().
-		Create()
+		Create().
+		AddSource("*")
 
 	repoFixture.Given(t, true).
 		When().

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -22,7 +22,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:3.10.2
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"
@@ -43,7 +43,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:3.10.2
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"

--- a/test/e2e/fixture/project/context.go
+++ b/test/e2e/fixture/project/context.go
@@ -15,6 +15,7 @@ type Context struct {
 	timeout     int
 	name        string
 	destination string
+	repos       []string
 }
 
 func Given(t *testing.T) *Context {
@@ -40,6 +41,11 @@ func (c *Context) Name(name string) *Context {
 
 func (c *Context) Destination(destination string) *Context {
 	c.destination = destination
+	return c
+}
+
+func (c *Context) SourceRepositories(repos []string) *Context {
+	c.repos = repos
 	return c
 }
 

--- a/test/e2e/hook_test.go
+++ b/test/e2e/hook_test.go
@@ -171,7 +171,7 @@ spec:
   containers:
     - command:
         - "true"
-      image: "alpine:latest"
+      image: "quay.io/argoprojlabs/argocd-e2e-container:0.1"
       imagePullPolicy: IfNotPresent
       name: main
   restartPolicy: Never
@@ -202,7 +202,7 @@ spec:
   containers:
     - command:
         - "true"
-      image: "alpine:latest"
+      image: "quay.io/argoprojlabs/argocd-e2e-container:0.1"
       imagePullPolicy: IfNotPresent
       name: main
   restartPolicy: Never
@@ -218,7 +218,7 @@ spec:
   containers:
     - command:
         - "false"
-      image: "alpine:latest"
+      image: "quay.io/argoprojlabs/argocd-e2e-container:0.1"
       imagePullPolicy: IfNotPresent
       name: main
   restartPolicy: Never

--- a/test/e2e/multiarch-container/Dockerfile
+++ b/test/e2e/multiarch-container/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.io/library/busybox
+CMD exec sh -c "trap : TERM INT; echo 'Hi' && tail -f /dev/null"

--- a/test/e2e/multiarch-container/build.sh
+++ b/test/e2e/multiarch-container/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -x
+VERSIONS="0.1 0.2 0.3"
+PLATFORMS="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le"
+for version in $VERSIONS; do
+	docker buildx build \
+		-t "quay.io/argoprojlabs/argocd-e2e-container:${version}" \
+		--platform "${PLATFORMS}" \
+		--push \
+		.
+done

--- a/test/e2e/testdata/cluster-role/pod.yaml
+++ b/test/e2e/testdata/cluster-role/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:3.10.2
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"

--- a/test/e2e/testdata/crd-validation/deployment.yaml
+++ b/test/e2e/testdata/crd-validation/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.17.4-alpine
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
           ports:
             - containerPort: "80"
           imagePullPolicy: IfNotPresent

--- a/test/e2e/testdata/deployment/deployment.yaml
+++ b/test/e2e/testdata/deployment/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.17.4-alpine
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
           ports:
             - containerPort: 80

--- a/test/e2e/testdata/deprecated-extensions/deployment.yaml
+++ b/test/e2e/testdata/deprecated-extensions/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: extensions-deployment
-          image: "gcr.io/heptio-images/ks-guestbook-demo:0.2"
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/e2e/testdata/git-submodule/submodule-pod.yaml
+++ b/test/e2e/testdata/git-submodule/submodule-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:3.10.2
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"

--- a/test/e2e/testdata/guestbook-logs/guestbook-ui-deployment.yaml
+++ b/test/e2e/testdata/guestbook-logs/guestbook-ui-deployment.yaml
@@ -14,13 +14,8 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: busybox
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.1
         imagePullPolicy: IfNotPresent
         name: guestbook-ui
-        command:
-          - sh
-        args:
-           - -c
-           - "echo \"Hi\" && tail -f /dev/null"
         ports:
         - containerPort: 80

--- a/test/e2e/testdata/guestbook-with-namespace/guestbook-ui-deployment-ns.yaml
+++ b/test/e2e/testdata/guestbook-with-namespace/guestbook-ui-deployment-ns.yaml
@@ -15,7 +15,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.1
         imagePullPolicy: IfNotPresent
         name: guestbook-ui
         ports:

--- a/test/e2e/testdata/guestbook-with-namespace/guestbook-ui-deployment.yaml
+++ b/test/e2e/testdata/guestbook-with-namespace/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: quay.io/argoprojlabs/argocd-e2e-container:0.1
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.2
         imagePullPolicy: IfNotPresent
         name: guestbook-ui
         ports:

--- a/test/e2e/testdata/guestbook-with-namespace/guestbook-ui-deployment.yaml
+++ b/test/e2e/testdata/guestbook-with-namespace/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.1
         imagePullPolicy: IfNotPresent
         name: guestbook-ui
         ports:

--- a/test/e2e/testdata/guestbook/guestbook-ui-deployment.yaml
+++ b/test/e2e/testdata/guestbook/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.2
         imagePullPolicy: IfNotPresent
         name: guestbook-ui
         ports:

--- a/test/e2e/testdata/guestbook_local/guestbook-ui-deployment.yaml
+++ b/test/e2e/testdata/guestbook_local/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.3
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.3
         name: guestbook-ui
         ports:
         - containerPort: 81

--- a/test/e2e/testdata/hook-and-deployment/deployment.yaml
+++ b/test/e2e/testdata/hook-and-deployment/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: nginx:1.17.4-alpine
+        image: quay.io/argoprojlabs/argocd-e2e-container:0.1
         imagePullPolicy: IfNotPresent
         readinessProbe:
           failureThreshold: 3

--- a/test/e2e/testdata/hook-and-deployment/hook.yaml
+++ b/test/e2e/testdata/hook-and-deployment/hook.yaml
@@ -10,7 +10,7 @@ spec:
       containers:
         - command:
             - "true"
-          image: "alpine:3.10.2"
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
           imagePullPolicy: IfNotPresent
           name: main
       restartPolicy: Never

--- a/test/e2e/testdata/hook/hook.yaml
+++ b/test/e2e/testdata/hook/hook.yaml
@@ -8,7 +8,7 @@ spec:
   containers:
     - command:
         - "true"
-      image: "alpine:latest"
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       name: main
   restartPolicy: Never

--- a/test/e2e/testdata/hook/pod.yaml
+++ b/test/e2e/testdata/hook/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:latest
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"

--- a/test/e2e/testdata/kustomize/pod.yaml
+++ b/test/e2e/testdata/kustomize/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:3.10.2
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"

--- a/test/e2e/testdata/multi-namespace-hook/multi-namespace-hook.yaml
+++ b/test/e2e/testdata/multi-namespace-hook/multi-namespace-hook.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.17.4-alpine
+        image: quay.io/argoprojlabs/argocd-e2e-container:0.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -39,7 +39,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: main
-    image: alpine:3.10.2
+    image: quay.io/argoprojlabs/argocd-e2e-container:0.1
     imagePullPolicy: IfNotPresent
     command: [sh, -c, "sleep 10"]
 
@@ -56,6 +56,6 @@ spec:
   restartPolicy: Never
   containers:
   - name: main
-    image: alpine:3.10.2
+    image: quay.io/argoprojlabs/argocd-e2e-container:0.1
     imagePullPolicy: IfNotPresent
     command: [sh, -c, "sleep 10"]

--- a/test/e2e/testdata/multi-namespace/deployment-with-namespace.yaml
+++ b/test/e2e/testdata/multi-namespace/deployment-with-namespace.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: helm-guestbook
-          image: "gcr.io/heptio-images/ks-guestbook-demo:0.2"
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/e2e/testdata/multi-namespace/deployment-with-namespace.yaml
+++ b/test/e2e/testdata/multi-namespace/deployment-with-namespace.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: helm-guestbook
-          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/e2e/testdata/multi-namespace/deployment.yaml
+++ b/test/e2e/testdata/multi-namespace/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: helm-guestbook
-          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/e2e/testdata/multi-namespace/deployment.yaml
+++ b/test/e2e/testdata/multi-namespace/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: helm-guestbook
-          image: "gcr.io/heptio-images/ks-guestbook-demo:0.2"
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/e2e/testdata/networking/guestbook-ui-deployment.yaml
+++ b/test/e2e/testdata/networking/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: quay.io/argoprojlabs/argocd-e2e-container:0.1
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.2
         name: guestbook-ui
         ports:
         - containerPort: 80

--- a/test/e2e/testdata/networking/guestbook-ui-deployment.yaml
+++ b/test/e2e/testdata/networking/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+      - image: quay.io/argoprojlabs/argocd-e2e-container:0.1
         name: guestbook-ui
         ports:
         - containerPort: 80

--- a/test/e2e/testdata/one-deployment/deployment.yaml
+++ b/test/e2e/testdata/one-deployment/deployment.yaml
@@ -16,6 +16,6 @@ spec:
       containers:
         - name: main
           command: ["sleep", "999"]
-          image: alpine:3.10.2
+          image: quay.io/argoprojlabs/argocd-e2e-container:0.1
           imagePullPolicy: IfNotPresent
 

--- a/test/e2e/testdata/two-nice-pods/pod-1.yaml
+++ b/test/e2e/testdata/two-nice-pods/pod-1.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:3.10.2
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"

--- a/test/e2e/testdata/two-nice-pods/pod-2.yaml
+++ b/test/e2e/testdata/two-nice-pods/pod-2.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine:3.10.2
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
       imagePullPolicy: IfNotPresent
       command:
         - "true"


### PR DESCRIPTION
The end-to-end tests use a variety of different container images in their workloads.

This has several problems:

- Some of them are not available for the arches that Argo CD support, making it impractical to run end-to-end tests on a target platform
- Most are hosted on DockerHub, which rate limits pulls. This may impose problems for larger, highly concurrent testing environments

This PR introduces a new, small container image, hosted at `quay.io/argoprojlabs` which is built for all the architectures that Argo CD currently supports.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

