### PR TITLE
docs: use `install` instead of curling directly to /usr/local/bin

### DIFF
--- a/docs/cli_installation.md
+++ b/docs/cli_installation.md
@@ -21,8 +21,9 @@ brew install argocd
 #### Download latest version
 
 ```bash
-curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-chmod +x /usr/local/bin/argocd
+curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
+rm argocd-linux-amd64
 ```
 
 #### Download concrete version
@@ -31,8 +32,9 @@ Set `VERSION` replacing `<TAG>` in the command below with the version of Argo CD
 
 ```bash
 VERSION=<TAG> # Select desired TAG from https://github.com/argoproj/argo-cd/releases
-curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-linux-amd64
-chmod +x /usr/local/bin/argocd
+curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-linux-amd64
+sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
+rm argocd-linux-amd64
 ```
 
 You should now be able to run `argocd` commands.
@@ -56,13 +58,14 @@ VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/
 Replace `VERSION` in the command below with the version of Argo CD you would like to download:
 
 ```bash
-curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-darwin-amd64
+curl -sSL -o argocd-darwin-amd64 https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-darwin-amd64
 ```
 
-Make the `argocd` CLI executable:
+Install the Argo CD CLI binary:
 
 ```bash
-chmod +x /usr/local/bin/argocd
+sudo install -m 555 argocd-darwin-amd64 /usr/local/bin/argocd
+rm argocd-darwin-amd64
 ```
 
 After finishing either of the instructions above, you should now be able to run `argocd` commands.


### PR DESCRIPTION
Supersedes https://github.com/argoproj/argo-cd/pull/3463