### PR TITLE
test: check for error messages from CI env

### DIFF
--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	gooidc "github.com/coreos/go-oidc"
@@ -133,7 +134,9 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleLogin(w, req)
 
-		assert.Contains(t, w.Body.String(), "certificate is not trusted")
+		if !strings.Contains(err.Error(), "certificate signed by unknown authority") && !strings.Contains(err.Error(), "certificate is not trusted") {
+			t.Fatal("did not receive expected certificate verification failure error")
+		}
 
 		cdSettings.OIDCTLSInsecureSkipVerify = true
 
@@ -145,6 +148,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		app.HandleLogin(w, req)
 
 		assert.NotContains(t, w.Body.String(), "certificate is not trusted")
+		assert.NotContains(t, w.Body.String(), "certificate signed by unknown authority")
 	})
 
 	t.Run("dex certificate checking during login should toggle on config", func(t *testing.T) {
@@ -170,7 +174,9 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleLogin(w, req)
 
-		assert.Contains(t, w.Body.String(), "certificate signed by unknown authority")
+		if !strings.Contains(err.Error(), "certificate signed by unknown authority") && !strings.Contains(err.Error(), "certificate is not trusted") {
+			t.Fatal("did not receive expected certificate verification failure error")
+		}
 
 		cdSettings.OIDCTLSInsecureSkipVerify = true
 
@@ -181,6 +187,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleLogin(w, req)
 
+		assert.NotContains(t, w.Body.String(), "certificate is not trusted")
 		assert.NotContains(t, w.Body.String(), "certificate signed by unknown authority")
 	})
 }

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -134,7 +134,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleLogin(w, req)
 
-		if !strings.Contains(err.Error(), "certificate signed by unknown authority") && !strings.Contains(err.Error(), "certificate is not trusted") {
+		if !strings.Contains(w.Body.String(), "certificate signed by unknown authority") && !strings.Contains(w.Body.String(), "certificate is not trusted") {
 			t.Fatal("did not receive expected certificate verification failure error")
 		}
 
@@ -174,7 +174,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleLogin(w, req)
 
-		if !strings.Contains(err.Error(), "certificate signed by unknown authority") && !strings.Contains(err.Error(), "certificate is not trusted") {
+		if !strings.Contains(w.Body.String(), "certificate signed by unknown authority") && !strings.Contains(w.Body.String(), "certificate is not trusted") {
 			t.Fatal("did not receive expected certificate verification failure error")
 		}
 

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -218,7 +218,9 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleCallback(w, req)
 
-		assert.Contains(t, w.Body.String(), "certificate is not trusted")
+		if !strings.Contains(w.Body.String(), "certificate signed by unknown authority") && !strings.Contains(w.Body.String(), "certificate is not trusted") {
+			t.Fatal("did not receive expected certificate verification failure error")
+		}
 
 		cdSettings.OIDCTLSInsecureSkipVerify = true
 
@@ -230,6 +232,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		app.HandleCallback(w, req)
 
 		assert.NotContains(t, w.Body.String(), "certificate is not trusted")
+		assert.NotContains(t, w.Body.String(), "certificate signed by unknown authority")
 	})
 
 	t.Run("dex certificate checking during oidc callback should toggle on config", func(t *testing.T) {
@@ -255,7 +258,9 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleCallback(w, req)
 
-		assert.Contains(t, w.Body.String(), "certificate signed by unknown authority")
+		if !strings.Contains(w.Body.String(), "certificate signed by unknown authority") && !strings.Contains(w.Body.String(), "certificate is not trusted") {
+			t.Fatal("did not receive expected certificate verification failure error")
+		}
 
 		cdSettings.OIDCTLSInsecureSkipVerify = true
 
@@ -266,6 +271,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 		app.HandleCallback(w, req)
 
+		assert.NotContains(t, w.Body.String(), "certificate is not trusted")
 		assert.NotContains(t, w.Body.String(), "certificate signed by unknown authority")
 	})
 }


### PR DESCRIPTION
I don't love having environment-dependent error messages in tests, but I think these tests are fairly important.