### PR TITLE
feat: additional RBAC configmaps

### DIFF
--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -315,7 +315,7 @@ func getPolicyConfigMap(ctx context.Context, client kubernetes.Interface, namesp
 // checkPolicy checks whether given subject is allowed to execute specified
 // action against specified resource
 func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole, matchMode string, strict bool) bool {
-	enf := rbac.NewEnforcer(nil, "argocd", "argocd-rbac-cm", nil)
+	enf := rbac.NewEnforcer(nil, "argocd", common.ArgoCDRBACConfigMapName, nil)
 	enf.SetDefaultRole(defaultRole)
 	enf.SetMatchMode(matchMode)
 	if builtinPolicy != "" {
@@ -329,7 +329,7 @@ func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPoli
 			log.Fatalf("invalid user policy: %v", err)
 			return false
 		}
-		if err := enf.SetUserPolicy(userPolicy); err != nil {
+		if err := enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, userPolicy); err != nil {
 			log.Fatalf("could not set user policy: %v", err)
 			return false
 		}

--- a/common/common.go
+++ b/common/common.go
@@ -293,3 +293,12 @@ const (
 	// Keep alive is 2x enforcement minimum to ensure network jitter does not introduce ENHANCE_YOUR_CALM errors
 	GRPCKeepAliveTime = 2 * GRPCKeepAliveEnforcementMinimum
 )
+
+// Security log levels
+const (
+	SecurityField    = "security"
+	SecurityCritical = "4"
+	SecurityHigh     = "3"
+	SecurityMedium   = "2"
+	SecurityLow      = "1"
+)

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -214,9 +214,9 @@ Yes
 ```
 
 ### Adding additional RBAC configmaps
-Since v2.5, you now have the ability to create additional ConfigMaps to append to the policy specified in `argocd-rbac-cm`.
+Since v2.5, you now have the ability to create additional ConfigMaps to augment the policy specified in `argocd-rbac-cm`.
 
-Simply create a ConfigMap with the label `rbac.argoproj.io=additional` and specify the `policy.csv` key.
+Simply create a ConfigMap with the label `argocd.argoproj.io/cm-type=additional-rbac` and specify the `policy.csv` key.
 
 ```yaml
 apiVersion: v1
@@ -225,7 +225,7 @@ metadata:
   name: argocd-rbac-cm-extra
   namespace: argocd
   labels:
-    rbac.argoproj.io: additional
+    argocd.argoproj.io/cm-type: additional-rbac
   policy.csv: |
     p, role:org-admin, applications, *, */*, allow
     p, role:org-admin, clusters, get, *, allow

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -216,7 +216,7 @@ Yes
 ### Adding additional RBAC configmaps
 Since v2.5, you now have the ability to create additional ConfigMaps to augment the policy specified in `argocd-rbac-cm`.
 
-Simply create a ConfigMap with the label `argocd.argoproj.io/cm-type=additional-rbac` and specify the `policy.csv` key.
+Simply create a ConfigMap in the `argocd` namespace with the label `argocd.argoproj.io/cm-type=additional-rbac` and specify the `policy.csv` key.
 
 ```yaml
 apiVersion: v1
@@ -226,6 +226,7 @@ metadata:
   namespace: argocd
   labels:
     argocd.argoproj.io/cm-type: additional-rbac
+data:
   policy.csv: |
     p, role:org-admin, applications, *, */*, allow
     p, role:org-admin, clusters, get, *, allow

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -212,3 +212,29 @@ Or against the group defined:
 $ argocd admin settings rbac can db-admins get applications 'staging-db-admins/*' --policy-file policy.csv
 Yes
 ```
+
+### Adding additional RBAC configmaps
+Since v2.5, you now have the ability to create additional ConfigMaps to append to the policy specified in `argocd-rbac-cm`.
+
+Simply create a ConfigMap with the label `rbac.argoproj.io=additional` and specify the `policy.csv` key.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm-extra
+  namespace: argocd
+  labels:
+    rbac.argoproj.io: additional
+  policy.csv: |
+    p, role:org-admin, applications, *, */*, allow
+    p, role:org-admin, clusters, get, *, allow
+    p, role:org-admin, repositories, get, *, allow
+    p, role:org-admin, repositories, create, *, allow
+    p, role:org-admin, repositories, update, *, allow
+    p, role:org-admin, repositories, delete, *, allow
+    p, role:org-admin, logs, get, *, allow
+    p, role:org-admin, exec, create, */*, allow
+
+    g, your-github-org:your-team, role:org-admin
+```

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -342,7 +342,7 @@ g, group-47, role:test2
 p, role:test3, applications, *, proj-20/*, allow
 g, group-49, role:test3
 `
-		_ = enf.SetUserPolicy(policy)
+		_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 	}
 	appServer := newTestAppServerWithEnforcerConfigure(f, objects...)
 

--- a/server/rbacpolicy/rbacpolicy_test.go
+++ b/server/rbacpolicy/rbacpolicy_test.go
@@ -54,7 +54,7 @@ func TestEnforceAllPolicies(t *testing.T) {
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableLog(true)
 	_ = enf.SetBuiltinPolicy(`p, alice, applications, create, my-proj/*, allow` + "\n" + `p, alice, logs, get, my-proj/*, allow` + "\n" + `p, alice, exec, create, my-proj/*, allow`)
-	_ = enf.SetUserPolicy(`p, bob, applications, create, my-proj/*, allow` + "\n" + `p, bob, logs, get, my-proj/*, allow` + "\n" + `p, bob, exec, create, my-proj/*, allow`)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, `p, bob, applications, create, my-proj/*, allow`+"\n"+`p, bob, logs, get, my-proj/*, allow`+"\n"+`p, bob, exec, create, my-proj/*, allow`)
 	rbacEnf := NewRBACPolicyEnforcer(enf, projLister)
 	enf.SetClaimsEnforcerFunc(rbacEnf.EnforceClaims)
 
@@ -128,7 +128,7 @@ func TestInvalidatedCache(t *testing.T) {
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableLog(true)
 	_ = enf.SetBuiltinPolicy(`p, alice, applications, create, my-proj/*, allow` + "\n" + `p, alice, logs, get, my-proj/*, allow` + "\n" + `p, alice, exec, create, my-proj/*, allow`)
-	_ = enf.SetUserPolicy(`p, bob, applications, create, my-proj/*, allow` + "\n" + `p, bob, logs, get, my-proj/*, allow` + "\n" + `p, bob, exec, create, my-proj/*, allow`)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, `p, bob, applications, create, my-proj/*, allow`+"\n"+`p, bob, logs, get, my-proj/*, allow`+"\n"+`p, bob, exec, create, my-proj/*, allow`)
 	rbacEnf := NewRBACPolicyEnforcer(enf, projLister)
 	enf.SetClaimsEnforcerFunc(rbacEnf.EnforceClaims)
 
@@ -143,7 +143,7 @@ func TestInvalidatedCache(t *testing.T) {
 	assert.True(t, enf.Enforce(claims, "exec", "create", "my-proj/my-app"))
 
 	_ = enf.SetBuiltinPolicy(`p, alice, applications, create, my-proj2/*, allow` + "\n" + `p, alice, logs, get, my-proj2/*, allow` + "\n" + `p, alice, exec, create, my-proj2/*, allow`)
-	_ = enf.SetUserPolicy(`p, bob, applications, create, my-proj2/*, allow` + "\n" + `p, bob, logs, get, my-proj2/*, allow` + "\n" + `p, bob, exec, create, my-proj2/*, allow`)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, `p, bob, applications, create, my-proj2/*, allow`+"\n"+`p, bob, logs, get, my-proj2/*, allow`+"\n"+`p, bob, exec, create, my-proj2/*, allow`)
 	claims = jwt.MapClaims{"sub": "alice"}
 	assert.True(t, enf.Enforce(claims, "applications", "create", "my-proj2/my-app"))
 	assert.True(t, enf.Enforce(claims, "logs", "get", "my-proj2/my-app"))

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -394,7 +394,7 @@ func TestRepositoryServerGetAppDetails(t *testing.T) {
 		repoServerClient := mocks.RepoServerServiceClient{}
 		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
 		enforcer := newEnforcer(kubeclientset)
-		_ = enforcer.SetUserPolicy("p, role:readrepos, repositories, get, *, allow")
+		_ = enforcer.SetUserPolicy(common.ArgoCDRBACConfigMapName, "p, role:readrepos, repositories, get, *, allow")
 		enforcer.SetDefaultRole("role:readrepos")
 
 		url := "https://test"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -185,7 +185,7 @@ func TestEnforceClaims(t *testing.T) {
 g, org2:team2, role:admin
 g, bob, role:admin
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 	allowed := []jwt.Claims{
 		jwt.MapClaims{"groups": []string{"org1:team1", "org2:team2"}},
 		jwt.RegisteredClaims{Subject: "admin"},

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -362,7 +362,7 @@ func (e *Enforcer) DeleteUserPolicy(policyName string) error {
 	return e.LoadPolicy()
 }
 
-// newInformers returns an informer which watches updates on the rbac configmap
+// newInformer returns an informer which watches updates on the rbac configmap
 func (e *Enforcer) newInformer() cache.SharedIndexInformer {
 	tweakConfigMap := func(options *metav1.ListOptions) {
 		cmFieldSelector := fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", e.configmap))
@@ -372,7 +372,7 @@ func (e *Enforcer) newInformer() cache.SharedIndexInformer {
 	return v1.NewFilteredConfigMapInformer(e.clientset, e.namespace, defaultRBACSyncPeriod, indexers, tweakConfigMap)
 }
 
-// newInformers returns an informer which watches updates on the rbac configmap
+// newAdditionalInformer returns an informer which watches updates on the rbac configmap
 func (e *Enforcer) newAdditionalInformer() cache.SharedIndexInformer {
 	tweakConfigMap := func(options *metav1.ListOptions) {
 		options.LabelSelector = "argocd.argoproj.io/cm-type=additional-rbac"

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -375,7 +375,7 @@ func (e *Enforcer) newInformer() cache.SharedIndexInformer {
 // newInformers returns an informer which watches updates on the rbac configmap
 func (e *Enforcer) newAdditionalInformer() cache.SharedIndexInformer {
 	tweakConfigMap := func(options *metav1.ListOptions) {
-		options.LabelSelector = "rbac.argoproj.io=additional"
+		options.LabelSelector = "argocd.argoproj.io/cm-type=additional-rbac"
 	}
 	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
 	return v1.NewFilteredConfigMapInformer(e.clientset, e.namespace, defaultRBACSyncPeriod, indexers, tweakConfigMap)

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/util/assets"
 	"github.com/argoproj/argo-cd/v2/util/glob"
 	jwtutil "github.com/argoproj/argo-cd/v2/util/jwt"
@@ -408,7 +409,7 @@ func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *apiv1.Con
 					if err != nil {
 						log.Error(err)
 					} else {
-						log.Infof("RBAC ConfigMap '%s' added", cm.Name)
+						log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC ConfigMap '%s' added", cm.Name)
 					}
 				}
 			},
@@ -422,7 +423,7 @@ func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *apiv1.Con
 				if err != nil {
 					log.Error(err)
 				} else {
-					log.Infof("RBAC ConfigMap '%s' updated", newCM.Name)
+					log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC ConfigMap '%s' updated", newCM.Name)
 				}
 			},
 		},
@@ -456,7 +457,7 @@ func (e *Enforcer) runAdditionalInformer(ctx context.Context) {
 					if err != nil {
 						log.Error(err)
 					} else {
-						log.Infof("RBAC Additional ConfigMap '%s' added", cm.Name)
+						log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC Additional ConfigMap '%s' added", cm.Name)
 					}
 				}
 			},
@@ -470,7 +471,7 @@ func (e *Enforcer) runAdditionalInformer(ctx context.Context) {
 				if err != nil {
 					log.Error(err)
 				} else {
-					log.Infof("RBAC Additional ConfigMap '%s' updated", newCM.Name)
+					log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC Additional ConfigMap '%s' updated", newCM.Name)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -479,7 +480,7 @@ func (e *Enforcer) runAdditionalInformer(ctx context.Context) {
 				if err != nil {
 					log.Error(err)
 				} else {
-					log.Infof("RBAC Additional ConfigMap '%s' deleted", cm.Name)
+					log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC Additional ConfigMap '%s' deleted", cm.Name)
 				}
 			},
 		},

--- a/util/rbac/rbac_norace_test.go
+++ b/util/rbac/rbac_norace_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -78,7 +79,7 @@ p, trudy, applications/secrets, get, foo/obj, deny
 p, danny, applications, get, */obj, allow
 p, danny, applications, get, proj1/a*p1, allow
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 
 	// Verify the resource wildcard
 	assert.True(t, enf.Enforce("alice", "applications", "get", "foo/obj"))

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/util/assets"
 )
 
@@ -141,7 +142,7 @@ p, alice, repositories, *, foo/*, allow
 p, bob, repositories, *, foo/https://github.com/argoproj/argo-cd.git, allow
 p, cathy, repositories, *, foo/*, allow
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 
 	assert.True(t, enf.Enforce("alice", "repositories", "delete", "foo/https://github.com/argoproj/argo-cd.git"))
 	assert.True(t, enf.Enforce("alice", "repositories", "delete", "foo/https://github.com/golang/go.git"))
@@ -158,7 +159,7 @@ func TestEnableDisableEnforce(t *testing.T) {
 p, alice, *, get, foo/obj, allow
 p, mike, *, get, foo/obj, deny
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 	enf.SetClaimsEnforcerFunc(func(claims jwt.Claims, rvals ...interface{}) bool {
 		return false
 	})
@@ -183,15 +184,15 @@ func TestUpdatePolicy(t *testing.T) {
 	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 
-	_ = enf.SetUserPolicy("p, alice, *, get, foo/obj, allow")
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, "p, alice, *, get, foo/obj, allow")
 	assert.True(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.False(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 
-	_ = enf.SetUserPolicy("p, bob, *, get, foo/obj, allow")
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, "p, bob, *, get, foo/obj, allow")
 	assert.False(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.True(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 
-	_ = enf.SetUserPolicy("")
+	_ = enf.DeleteUserPolicy(common.ArgoCDRBACConfigMapName)
 	assert.False(t, enf.Enforce("alice", "applications", "get", "foo/obj"))
 	assert.False(t, enf.Enforce("bob", "applications", "get", "foo/obj"))
 
@@ -346,7 +347,7 @@ func TestDefaultGlobMatchMode(t *testing.T) {
 	policy := `
 p, alice, clusters, get, "https://github.com/*/*.git", allow
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 
 	assert.True(t, enf.Enforce("alice", "clusters", "get", "https://github.com/argoproj/argo-cd.git"))
 	assert.False(t, enf.Enforce("alice", "repositories", "get", "https://github.com/argoproj/argo-cd.git"))
@@ -363,7 +364,7 @@ func TestGlobMatchMode(t *testing.T) {
 	policy := `
 p, alice, clusters, get, "https://github.com/*/*.git", allow
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 
 	assert.True(t, enf.Enforce("alice", "clusters", "get", "https://github.com/argoproj/argo-cd.git"))
 	assert.False(t, enf.Enforce("alice", "clusters", "get", "https://github.com/argo-cd.git"))
@@ -380,7 +381,7 @@ func TestRegexMatchMode(t *testing.T) {
 	policy := `
 p, alice, clusters, get, "https://github.com/argo[a-z]{4}/argo-[a-z]+.git", allow
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 
 	assert.True(t, enf.Enforce("alice", "clusters", "get", "https://github.com/argoproj/argo-cd.git"))
 	assert.False(t, enf.Enforce("alice", "clusters", "get", "https://github.com/argoproj/1argo-cd.git"))


### PR DESCRIPTION
Signed-off-by: notfromstatefarm <86763948+notfromstatefarm@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Closes https://github.com/argoproj/argo-cd/issues/8324

This PR implements 'additional configmaps' for RBAC. Any configmaps with the label `argocd.argoproj.io/cm-type=additional-rbac` will be used and watched for changes. The `policy.csv` key is merged from all of them. This allows users to easily deploy new RBAC rules by simply deploying additional ConfigMaps.

This PR also introduces a new concept suggested by @crenshaw-dev: a standardized `security` field on logs where the value indicates severity/level of paranoia.

I've tested this locally and it works like a charm!