### PR TITLE
fix: add missing download CLI tool URL response for ppc64le, s390x

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -1239,7 +1239,7 @@ func (mgr *SettingsManager) ensureSynced(forceResync bool) error {
 
 func getDownloadBinaryUrlsFromConfigMap(argoCDCM *apiv1.ConfigMap) map[string]string {
 	binaryUrls := map[string]string{}
-	for _, archType := range []string{"darwin-amd64", "darwin-arm64", "windows-amd64", "linux-arm64", "linux-amd64"} {
+	for _, archType := range []string{"darwin-amd64", "darwin-arm64", "windows-amd64", "linux-amd64", "linux-arm64", "linux-ppc64le", "linux-s390x"} {
 		if val, ok := argoCDCM.Data[settingsBinaryUrlsKey+"."+archType]; ok {
 			binaryUrls[archType] = val
 		}

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -668,11 +668,12 @@ func TestSettingsManager_GetHelp(t *testing.T) {
 	t.Run("GetBinaryUrls", func(t *testing.T) {
 		_, settingsManager := fixtures(map[string]string{
 			"help.download.darwin-amd64": "amd64-path",
+			"help.download.linux-s390x": "s390x-path",
 			"help.download.unsupported":  "nowhere",
 		})
 		h, err := settingsManager.GetHelp()
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]string{"darwin-amd64": "amd64-path"}, h.BinaryURLs)
+		assert.Equal(t, map[string]string{"darwin-amd64": "amd64-path", "linux-s390x": "s390x-path"}, h.BinaryURLs)
 	})
 }
 
@@ -985,6 +986,13 @@ func TestDownloadArgoCDBinaryUrls(t *testing.T) {
 	argoCDCM, err := settingsManager.getConfigMap()
 	assert.NoError(t, err)
 	assert.Equal(t, "some-url", argoCDCM.Data["help.download.darwin-amd64"])
+
+	_, settingsManager = fixtures(map[string]string{
+		"help.download.linux-s390x": "some-url",
+	})
+	argoCDCM, err = settingsManager.getConfigMap()
+	assert.NoError(t, err)
+	assert.Equal(t, "some-url", argoCDCM.Data["help.download.linux-s390x"])
 
 	_, settingsManager = fixtures(map[string]string{
 		"help.download.unsupported": "some-url",


### PR DESCRIPTION
Follow up of #9649, which is lack of backend allowlist addition.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

