### PR TITLE
docs: use quotes to emphasize that ConfigMap value is a string

### DIFF
--- a/docs/operator-manual/web_based_terminal.md
+++ b/docs/operator-manual/web_based_terminal.md
@@ -12,7 +12,7 @@ Kubernetes), then the user effectively has the same privileges as that ServiceAc
 
 ## Enabling the terminal
 
-1. Set the `exec.enabled` key to `true` on the `argocd-cm` ConfigMap.
+1. Set the `exec.enabled` key to `"true"` on the `argocd-cm` ConfigMap.
 
 2. Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
 to exec into pods


### PR DESCRIPTION
This bites me sometimes. The ConfigMap values have to be strings. Hopefully adding the quote marks will help folks avoid getting an error.  :-) 