### PR TITLE
fix(#9963): Add logic to handle for f.Close() in util/localconfig/

### DIFF
--- a/util/localconfig/localconfig_test.go
+++ b/util/localconfig/localconfig_test.go
@@ -74,7 +74,9 @@ func TestFilePermission(t *testing.T) {
 
 			f, err := os.Create(filePath)
 			require.NoError(t, err, "Could not write  create config file: %v", err)
-			defer f.Close()
+			defer func() {
+				assert.NoError(t, f.Close())
+			}()
 
 			err = f.Chmod(c.perm)
 			require.NoError(t, err, "Could not change the file permission to %s: %v", c.perm, err)


### PR DESCRIPTION
Add logic to handle for f.Close() for util/localconfig/

part of issue: https://github.com/argoproj/argo-cd/issues/9963

Checklist:
* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
