### PR TITLE
feat: Support Custom Application Actions in CLI #7577

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1988,7 +1988,7 @@ func (s *Server) logResourceEvent(res *appv1.ResourceNode, ctx context.Context, 
 }
 
 func (s *Server) ListResourceActions(ctx context.Context, q *application.ApplicationResourceRequest) (*application.ResourceActionsListResponse, error) {
-	obj, err := s.getUnstructuredLiveResourceOrApp(ctx, rbacpolicy.ActionGet, q)
+	obj, _, _, _, err := s.getUnstructuredLiveResourceOrApp(ctx, rbacpolicy.ActionGet, q)
 	if err != nil {
 		return nil, err
 	}
@@ -2009,35 +2009,30 @@ func (s *Server) ListResourceActions(ctx context.Context, q *application.Applica
 	return &application.ResourceActionsListResponse{Actions: actionsPtr}, nil
 }
 
-func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacRequest string, q *application.ApplicationResourceRequest) (obj *unstructured.Unstructured, err error) {
-	var (
-		app       *appv1.Application
-		config    *rest.Config
-	)
+func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacRequest string, q *application.ApplicationResourceRequest) (obj *unstructured.Unstructured, res *appv1.ResourceNode, app *appv1.Application, config *rest.Config, err error) {
 	if q.GetKind() == "Application" && q.GetGroup() == "argoproj.io" && q.GetName() == q.GetResourceName() {
 		namespace := s.appNamespaceOrDefault(q.GetAppNamespace())
 		app, err = s.appLister.Applications(namespace).Get(q.GetName())
 		if err != nil {
-			return nil, fmt.Errorf("error getting app by name: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("error getting app by name: %w", err)
 		}
 		if err = s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacRequest, app.RBACName(s.ns)); err != nil {
-			return nil, err
+			return nil, nil, nil, nil, err
 		}
 		config, err = s.getApplicationClusterConfig(ctx, app)
 		if err != nil {
-			return nil, fmt.Errorf("error getting application cluster config: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("error getting application cluster config: %w", err)
 		}
 		obj, err = kube.ToUnstructured(app)
 	} else {
-		var res *appv1.ResourceNode
 		res, config, app, err = s.getAppLiveResource(ctx, rbacRequest, q)
 		if err != nil {
-			return nil, fmt.Errorf("error getting app live resource: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("error getting app live resource: %w", err)
 		}
 		obj, err = s.kubectl.GetResource(ctx, config, res.GroupKindVersion(), res.Name, res.Namespace)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error getting resource: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("error getting resource: %w", err)
 	}
 	return
 }
@@ -2073,13 +2068,9 @@ func (s *Server) RunResourceAction(ctx context.Context, q *application.ResourceA
 		Group:        q.Group,
 	}
 	actionRequest := fmt.Sprintf("%s/%s/%s/%s", rbacpolicy.ActionAction, q.GetGroup(), q.GetKind(), q.GetAction())
-	res, config, a, err := s.getAppLiveResource(ctx, actionRequest, resourceRequest)
+	liveObj, res, a, config, err := s.getUnstructuredLiveResourceOrApp(ctx, actionRequest, resourceRequest)
 	if err != nil {
-		return nil, fmt.Errorf("error getting app live resource: %w", err)
-	}
-	liveObj, err := s.kubectl.GetResource(ctx, config, res.GroupKindVersion(), res.Name, res.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("error getting resource: %w", err)
+		return nil, err
 	}
 
 	resourceOverrides, err := s.settingsMgr.GetResourceOverrides()
@@ -2150,8 +2141,12 @@ func (s *Server) RunResourceAction(ctx context.Context, q *application.ResourceA
 		}
 	}
 
-	s.logAppEvent(a, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s on resource %s/%s/%s", q.GetAction(), res.Group, res.Kind, res.Name))
-	s.logResourceEvent(res, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s", q.GetAction()))
+	if res == nil {
+		s.logAppEvent(a, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s", q.GetAction()))
+	} else {
+		s.logAppEvent(a, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s on resource %s/%s/%s", q.GetAction(), res.Group, res.Kind, res.Name))
+		s.logResourceEvent(res, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s", q.GetAction()))
+	}
 	return &application.ApplicationResponse{}, nil
 }
 


### PR DESCRIPTION
This abstracts the fetching of resources that can provide custom resource actions for a given Application via the CLI to a new private function next to the two Commands that do it.  It then adds the Application itself to this set of resources, to support Application-targeting Custom Resource Actions.

Further, on the Server Side, specification of the parent Application is detected, and used to shortcut the fetching of resource nodes when searching for or running resource actions. Instead, in this case, the live manifest of the parent Application itself is used. Later references to the resource node, such as for audit logging, are made dependent on there being a resource node (previously a given).

Progresses #7577

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/7577) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* _n/a_: I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change.
* [x] I have confirmed that my change doesn't break the e2e tests covering the affected feature.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

