### PR TITLE
fix: Set HOST_ARCH for yarn build from platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,12 +92,13 @@ COPY ["ui/", "."]
 
 ARG ARGO_VERSION=latest
 ENV ARGO_VERSION=$ARGO_VERSION
-RUN HOST_ARCH='amd64' NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
+ARG TARGETARCH
+RUN HOST_ARCH=$TARGETARCH NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
 
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM  docker.io/library/golang:1.18 AS argocd-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.18 AS argocd-build
 
 WORKDIR /go/src/github.com/argoproj/argo-cd
 

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -36,8 +36,9 @@ data:
   help.chatUrl: "https://mycorp.slack.com/argo-cd"
   # the text for getting chat help, defaults to "Chat now!"
   help.chatText: "Chat now!"
-  # The URLs to download additional ArgoCD binaries (besides the Linux amd64 binary included by default)
+  # The URLs to download additional ArgoCD binaries (besides the Linux with current platform binary included by default)
   # for different OS architectures. If provided, additional download buttons will be displayed on the help page.
+  help.download.linux-amd64: "path-or-url-to-download"
   help.download.linux-arm64: "path-or-url-to-download"
   help.download.linux-ppc64le: "path-or-url-to-download"
   help.download.linux-s390x: "path-or-url-to-download"

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -38,7 +38,7 @@ export const Help = () => {
                                         <div className='help-box'>
                                             <p>Want to download the CLI tool?</p>
                                             <a href={`download/argocd-linux-${process.env.HOST_ARCH}`} className='user-info-panel-buttons argo-button argo-button--base'>
-                                                <i className='fab fa-linux' /> Linux (amd64)
+                                                <i className='fab fa-linux' /> Linux ({process.env.HOST_ARCH})
                                             </a>
                                             &nbsp;
                                             {Object.keys(binaryUrls || {}).map(binaryName => {


### PR DESCRIPTION
Follow up of #9649, regarding my question:

> QUESTION: the above part has not matched href(`download/argocd-linux-${process.env.HOST_ARCH}`) and button name("Linux (amd64)"). Could I unify this to `${process.env.HOST_ARCH}`?

I've found that `docker buildx` only performs the `argocd-ui` stage for amd64, so I updated Dockerfile also.

![image](https://user-images.githubusercontent.com/6624567/179405391-2a141337-6fb5-4c13-a4b7-20b7be0b22e0.png)

Left: as-is (amd64 link in arm64 instance), Right: to-be (arm64 link in arm64 instance)

Can be cherry-picked to 2.4, but should be with #9564 since the `argocd-ui` stage needs multi-platform as I stated.

From [build log](https://github.com/KENNYSOFT/argo-cd/runs/7378322579?check_suite_focus=true#step:9:2447):

> ```
> #47 [linux/amd64->arm64 argocd-ui 6/6] RUN HOST_ARCH=arm64 NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
> ```

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

