### PR TITLE
chore: update redis to avoid CVE-2022-2097

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -878,7 +878,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
       - name: config-init
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -906,7 +906,7 @@ spec:
 
       containers:
       - name: redis
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         command:
         - redis-server
@@ -947,7 +947,7 @@ spec:
         lifecycle:
           {}
       - name: sentinel
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         command:
           - redis-sentinel

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -15,6 +15,6 @@ redis-ha:
       client: 6m
     checkInterval: 3s
   image:
-    tag: 7.0.0-alpine
+    tag: 7.0.3-alpine
   sentinel:
     bind: "0.0.0.0"

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -11512,7 +11512,7 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -11550,7 +11550,7 @@ spec:
         - /data/conf/sentinel.conf
         command:
         - redis-sentinel
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -11596,7 +11596,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2286,7 +2286,7 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -2324,7 +2324,7 @@ spec:
         - /data/conf/sentinel.conf
         command:
         - redis-sentinel
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -2370,7 +2370,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.0-alpine
+        image: redis:7.0.3-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:


### PR DESCRIPTION
The vulnerability showed up in a Snyk scan. https://argo-cd--9856.org.readthedocs.build/en/9856/snyk/master/redis%3A7.0.0-alpine.html

`snyk container test redis:7.0.3-alpine` shows the vulnerability as absent.