### PR TITLE
chore: update redis to 7.0.4 to avoid CVE-2022-30065

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -407,7 +407,7 @@ jobs:
         run: |
           docker pull quay.io/dexidp/dex:v2.25.0
           docker pull argoproj/argo-cd-ci-builder:v1.0.0
-          docker pull redis:7.0.0-alpine
+          docker pull redis:7.0.4-alpine
       - name: Create target directory for binaries in the build-process
         run: |
           mkdir -p dist

--- a/manifests/base/redis/argocd-redis-deployment.yaml
+++ b/manifests/base/redis/argocd-redis-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: argocd-redis        
       containers:
       - name: redis
-        image: redis:7.0.0-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: Always
         args:
         - "--save"

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9617,7 +9617,7 @@ spec:
         - ""
         - --appendonly
         - "no"
-        image: redis:7.0.0-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -878,7 +878,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
       - name: config-init
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -906,7 +906,7 @@ spec:
 
       containers:
       - name: redis
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         command:
         - redis-server
@@ -947,7 +947,7 @@ spec:
         lifecycle:
           {}
       - name: sentinel
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         command:
           - redis-sentinel

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -15,6 +15,6 @@ redis-ha:
       client: 6m
     checkInterval: 3s
   image:
-    tag: 7.0.3-alpine
+    tag: 7.0.4-alpine
   sentinel:
     bind: "0.0.0.0"

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -11512,7 +11512,7 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -11550,7 +11550,7 @@ spec:
         - /data/conf/sentinel.conf
         command:
         - redis-sentinel
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -11596,7 +11596,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2286,7 +2286,7 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -2324,7 +2324,7 @@ spec:
         - /data/conf/sentinel.conf
         command:
         - redis-sentinel
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -2370,7 +2370,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.3-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10086,7 +10086,7 @@ spec:
         - ""
         - --appendonly
         - "no"
-        image: redis:7.0.0-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -860,7 +860,7 @@ spec:
         - ""
         - --appendonly
         - "no"
-        image: redis:7.0.0-alpine
+        image: redis:7.0.4-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/redis:7.0.0 as redis
+FROM docker.io/library/redis:7.0.4 as redis
 
 # There are libraries we will want to copy from here in the final stage of the
 # build, but the COPY directive does not have a way to determine system


### PR DESCRIPTION
Avoids [CVE-2022-30065](https://security.snyk.io/vuln/SNYK-ALPINE316-BUSYBOX-2953070)
Also a follow up of #10031 

Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

