### PR TITLE
typo: user->use

### DIFF
--- a/docs/operator-manual/user-management/google.md
+++ b/docs/operator-manual/user-management/google.md
@@ -7,7 +7,7 @@ There are three different ways to integrate Argo CD login with your Google Works
 * [SAML App Auth using Dex](#saml-app-auth-using-dex)  
   Dex [recommends avoiding this method](https://dexidp.io/docs/connectors/saml/#warning). Also, you won't get Google Groups membership information through this method.
 * [OpenID Connect plus Google Groups using Dex](#openid-connect-plus-google-groups-using-dex)  
-  This is the recommended method if you need to user Google Groups membership in your RBAC configuration.
+  This is the recommended method if you need to use Google Groups membership in your RBAC configuration.
 
 Once you've set up one of the above integrations, be sure to edit `argo-rbac-cm` to configure permissions (as in the example below). See [RBAC Configurations](../rbac.md) for more detailed scenarios.
 


### PR DESCRIPTION
Small typo in the documentation - should say use not user

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

