### PR TITLE
docs: correct the api field description for the GitLab example

### DIFF
--- a/docs/operator-manual/applicationset/Generators-SCM-Provider.md
+++ b/docs/operator-manual/applicationset/Generators-SCM-Provider.md
@@ -76,7 +76,7 @@ spec:
       gitlab:
         # The base GitLab group to scan.  You can either use the group id or the full namespaced path.
         group: "8675309"
-        # For GitLab Enterprise:
+        # For self-hosted GitLab:
         api: https://gitlab.example.com/
         # If true, scan every branch of every repository. If false, scan only the default branch. Defaults to false.
         allBranches: true
@@ -91,7 +91,7 @@ spec:
 ```
 
 * `group`: Required name of the base GitLab group to scan. If you have multiple base groups, use multiple generators.
-* `api`: If using GitHub Enterprise, the URL to access it.
+* `api`: If using self-hosted GitLab, the URL to access it.
 * `allBranches`: By default (false) the template will only be evaluated for the default branch of each repo. If this is true, every branch of every repository will be passed to the filters. If using this flag, you likely want to use a `branchMatch` filter.
 * `includeSubgroups`: By default (false) the controller will only search for repos directly in the base group. If this is true, it will recurse through all the subgroups searching for repos to scan.
 * `tokenRef`: A `Secret` name and key containing the GitLab access token to use for requests. If not specified, will make anonymous requests which have a lower rate limit and can only see public repositories.


### PR DESCRIPTION
The api field description for the GitLab example seems mistakenly
copied from the GitHub example.

Signed-off-by: Sahdev Zala <spzala@us.ibm.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

