### PR TITLE
docs: add api field example in the appset security doc

### DIFF
--- a/docs/operator-manual/applicationset/Security.md
+++ b/docs/operator-manual/applicationset/Security.md
@@ -11,8 +11,8 @@ resources of Argo CD itself (like the RBAC ConfigMap).
 ApplicationSets can also quickly create an arbitrary number of Applications and just as quickly delete them.
 
 Finally, ApplicationSets can reveal privileged information. For example, the [git generator](./Generators-Git.md) can
-read Secrets in the Argo CD namespace and send them to arbitrary URLs as auth headers. (This functionality is intended
-for authorizing requests to SCM providers like GitHub, but it could be abused by a malicious user.)
+read Secrets in the Argo CD namespace and send them to arbitrary URLs (e.g. URL provided for the `api` field) as auth headers.
+(This functionality is intended for authorizing requests to SCM providers like GitHub, but it could be abused by a malicious user.)
 
 For these reasons, **only admins** may be given permission (via Kubernetes RBAC or any other mechanism) to create, 
 update, or delete ApplicationSets.


### PR DESCRIPTION
It seems like most of the work for the mentioned issue below is done
under the PR #9466 but from the issue description, it's probably
worth to mention the example as added here.

Closes #9352

Signed-off-by: Sahdev Zala <spzala@us.ibm.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

