### PR TITLE
Expose the Argo CD ID through an ENV in the Dockerfile #10113

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,11 @@ FROM $BASE_IMAGE AS argocd-base
 
 USER root
 
+ENV ARGOCD_USER_ID=999
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN groupadd -g 999 argocd && \
-    useradd -r -u 999 -g argocd argocd && \
+RUN groupadd -g $ARGOCD_USER_ID argocd && \
+    useradd -r -u $ARGOCD_USER_ID -g argocd argocd && \
     mkdir -p /home/argocd && \
     chown argocd:0 /home/argocd && \
     chmod g=u /home/argocd && \
@@ -74,7 +75,7 @@ RUN mkdir -p tls && \
 
 ENV USER=argocd
 
-USER 999
+USER $ARGOCD_USER_ID
 WORKDIR /home/argocd
 
 ####################################################################################################
@@ -128,4 +129,4 @@ RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server && \
     ln -s /usr/local/bin/argocd /usr/local/bin/argocd-applicationset-controller && \
     ln -s /usr/local/bin/argocd /usr/local/bin/argocd-k8s-auth
 
-USER 999
+USER $ARGOCD_USER_ID


### PR DESCRIPTION
Signed-off-by: rumstead <rjumstead@gmail.com>

closes #10113

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

