### PR TITLE
fix: skip redirect url validation when it's the base href (#10058)

### DIFF
--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -195,7 +195,7 @@ func (a *ClientApp) verifyAppState(r *http.Request, w http.ResponseWriter, state
 	redirectURL := a.baseHRef
 	parts := strings.SplitN(cookieVal, ":", 2)
 	if len(parts) == 2 && parts[1] != "" {
-		if !isValidRedirectURL(parts[1], []string{a.settings.URL}) {
+		if !isValidRedirectURL(parts[1], []string{a.settings.URL, a.baseHRef}) {
 			sanitizedUrl := parts[1]
 			if len(sanitizedUrl) > 100 {
 				sanitizedUrl = sanitizedUrl[:100]

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -191,6 +191,52 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 	})
 }
 
+func Test_Login_Flow(t *testing.T) {
+	// Show that SSO login works when no redirect URL is provided, and we fall back to the configured base href for the
+	// Argo CD instance.
+
+	oidcTestServer := test.GetOIDCTestServer(t)
+	t.Cleanup(oidcTestServer.Close)
+
+	cdSettings := &settings.ArgoCDSettings{
+		URL: "https://argocd.example.com",
+		OIDCConfigRAW: fmt.Sprintf(`
+name: Test
+issuer: %s
+clientID: xxx
+clientSecret: yyy
+requestedScopes: ["oidc"]`, oidcTestServer.URL),
+		OIDCTLSInsecureSkipVerify: true,
+	}
+
+	// The base href (the last argument for NewClientApp) is what HandleLogin will fall back to when no explicit
+	// redirect URL is given.
+	app, err := NewClientApp(cdSettings, "", "/")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+
+	req := httptest.NewRequest("GET", "https://argocd.example.com/auth/login", nil)
+
+	app.HandleLogin(w, req)
+
+	redirectUrl, err := w.Result().Location()
+	require.NoError(t, err)
+
+	state := redirectUrl.Query()["state"]
+
+	req = httptest.NewRequest("GET", fmt.Sprintf("https://argocd.example.com/auth/callback?state=%s&code=abc", state), nil)
+	for _, cookie := range w.Result().Cookies() {
+		req.AddCookie(cookie)
+	}
+
+	w = httptest.NewRecorder()
+
+	app.HandleCallback(w, req)
+
+	assert.NotContains(t, w.Body.String(), InvalidRedirectURLError.Error())
+}
+
 func TestClientApp_HandleCallback(t *testing.T) {
 	oidcTestServer := test.GetOIDCTestServer(t)
 	t.Cleanup(oidcTestServer.Close)

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -211,7 +211,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 	// The base href (the last argument for NewClientApp) is what HandleLogin will fall back to when no explicit
 	// redirect URL is given.
-	app, err := NewClientApp(cdSettings, "", "/")
+	app, err := NewClientApp(cdSettings, "", nil, "/")
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()


### PR DESCRIPTION
If the Oauth provider doesn't set the `return_url` on a request to the login handler, we use the server's configured base href as the redirect URL.

This change causes that base href to pass the validation step in the callback handler.