### PR TITLE
feat: argocd app delete apps by label

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1773,7 +1773,7 @@ func getAppNamesBySelector(ctx context.Context, appIf applicationpkg.Application
 	if selector != "" {
 		list, err := appIf.List(ctx, &applicationpkg.ApplicationQuery{Selector: pointer.String(selector)})
 		if err != nil {
-			return []string{}, nil
+			return []string{}, err
 		}
 		// unlike list, we'd want to fail if nothing was found
 		if len(list.Items) == 0 {

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1531,6 +1531,11 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
+
+			if len(args) > 1 && selector != "" {
+				log.Fatal("Cannot use selector option when application name(s) passed as argument(s)")
+			}
+
 			acdClient := headless.NewClientOrDie(clientOpts, c)
 			conn, appIf := acdClient.NewApplicationClientOrDie()
 			defer argoio.Close(conn)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1127,14 +1127,22 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 		cascade           bool
 		noPrompt          bool
 		propagationPolicy string
+		selector          string
 	)
 	var command = &cobra.Command{
 		Use:   "delete APPNAME",
 		Short: "Delete an application",
+		Example: `argocd app delete app1
+
+# Delete multiple apps
+argocd delete app1 app2
+
+# Delete apps by label
+argocd app delete -l foo=bar`,
 		Run: func(c *cobra.Command, args []string) {
 			ctx := c.Context()
 
-			if len(args) == 0 {
+			if len(args) == 0 && selector == "" {
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
@@ -1147,7 +1155,15 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 			if promptFlag.Changed && promptFlag.Value.String() == "true" {
 				noPrompt = true
 			}
-			for _, appFullName := range args {
+
+			appNames, err := getAppNamesBySelector(ctx, appIf, selector)
+			errors.CheckError(err)
+
+			if len(appNames) == 0 {
+				appNames = args
+			}
+
+			for _, appFullName := range appNames {
 				appName, appNs := argo.ParseAppQualifiedName(appFullName, "")
 				appDeleteReq := applicationpkg.ApplicationDeleteRequest{
 					Name:         &appName,
@@ -1191,6 +1207,7 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 	command.Flags().BoolVar(&cascade, "cascade", true, "Perform a cascaded deletion of all application resources")
 	command.Flags().StringVarP(&propagationPolicy, "propagation-policy", "p", "foreground", "Specify propagation policy for deletion of application's resources. One of: foreground|background")
 	command.Flags().BoolVarP(&noPrompt, "yes", "y", false, "Turn off prompting to confirm cascaded deletion of application resources")
+	command.Flags().StringVarP(&selector, "selector", "l", "", "Delete all apps with matching label")
 	return command
 }
 
@@ -1744,6 +1761,24 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&diffChanges, "preview-changes", false, "Preview difference against the target and live state before syncing app and wait for user confirmation")
 	command.Flags().StringArrayVar(&projects, "project", []string{}, "Sync apps that belong to the specified projects. This option may be specified repeatedly.")
 	return command
+}
+
+func getAppNamesBySelector(ctx context.Context, appIf applicationpkg.ApplicationServiceClient, selector string) ([]string, error) {
+	appNames := []string{}
+	if selector != "" {
+		list, err := appIf.List(ctx, &applicationpkg.ApplicationQuery{Selector: pointer.String(selector)})
+		if err != nil {
+			return []string{}, nil
+		}
+		// unlike list, we'd want to fail if nothing was found
+		if len(list.Items) == 0 {
+			return []string{}, fmt.Errorf("no apps match selector %v", selector)
+		}
+		for _, i := range list.Items {
+			appNames = append(appNames, i.Name)
+		}
+	}
+	return appNames, nil
 }
 
 // ResourceDiff tracks the state of a resource when waiting on an application status.

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1135,7 +1135,7 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 		Example: `argocd app delete app1
 
 # Delete multiple apps
-argocd delete app1 app2
+argocd app delete app1 app2
 
 # Delete apps by label
 argocd app delete -l foo=bar`,

--- a/docs/user-guide/commands/argocd_app_delete.md
+++ b/docs/user-guide/commands/argocd_app_delete.md
@@ -6,12 +6,25 @@ Delete an application
 argocd app delete APPNAME [flags]
 ```
 
+### Examples
+
+```
+argocd app delete app1
+
+# Delete multiple apps
+argocd delete app1 app2
+
+# Delete apps by label
+argocd app delete -l foo=bar
+```
+
 ### Options
 
 ```
       --cascade                     Perform a cascaded deletion of all application resources (default true)
   -h, --help                        help for delete
   -p, --propagation-policy string   Specify propagation policy for deletion of application's resources. One of: foreground|background (default "foreground")
+  -l, --selector string             Delete all apps with matching label
   -y, --yes                         Turn off prompting to confirm cascaded deletion of application resources
 ```
 

--- a/docs/user-guide/commands/argocd_app_delete.md
+++ b/docs/user-guide/commands/argocd_app_delete.md
@@ -12,7 +12,7 @@ argocd app delete APPNAME [flags]
 argocd app delete app1
 
 # Delete multiple apps
-argocd delete app1 app2
+argocd app delete app1 app2
 
 # Delete apps by label
 argocd app delete -l foo=bar

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -44,6 +44,7 @@ func TestDeletingAppStuckInSync(t *testing.T) {
 
 func TestDeletingAppByLabel(t *testing.T) {
 	Given(t).
+		Path("arbitrary-path").
 		When().
 		CreateApp("--label=foo=bar").
 		Sync().

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -41,3 +41,23 @@ func TestDeletingAppStuckInSync(t *testing.T) {
 		// delete is successful
 		Expect(DoesNotExist())
 }
+
+func TestDeletingAppByLabel(t *testing.T) {
+	Given(t).
+		When().
+		CreateApp("--label=foo=bar").
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationRunning)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		When().
+		DeleteBySelector("foo=baz").
+		Then().
+		// delete is unsuccessful since no selector match
+		Expect(Error("no apps match selector: foo=baz", "")).
+		When().
+		DeleteBySelector("foo=bar").
+		Then().
+		// delete is successful
+		Expect(DoesNotExist())
+}

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -58,7 +58,7 @@ func TestDeletingAppByLabel(t *testing.T) {
 		// delete is unsuccessful since no selector match
 		AndCLIOutput(
 			func(output string, err error) {
-				assert.Equal(t, "no apps match selector foo=baz", err.Error())
+				assert.Contains(t, "no apps match selector foo=baz", err.Error())
 			},
 		).
 		When().

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -49,7 +49,7 @@ func TestDeletingAppByLabel(t *testing.T) {
 		CreateApp("--label=foo=bar").
 		Sync().
 		Then().
-		Expect(SyncStatusIs(SyncStatusCode(OperationSucceeded))).
+		Expect(SyncStatusIs(SyncStatusCode(SyncStatusCodeSynced))).
 		When().
 		DeleteBySelector("foo=baz").
 		Then().

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -57,7 +57,7 @@ func TestDeletingAppByLabel(t *testing.T) {
 		// delete is unsuccessful since no selector match
 		AndCLIOutput(
 			func(output string, err error) {
-				assert.Equal(t, "no apps match selector foo=baz", output)
+				assert.Equal(t, "no apps match selector foo=baz", err.Error())
 			},
 		).
 		// delete is unsuccessful since no selector match

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -49,8 +49,7 @@ func TestDeletingAppByLabel(t *testing.T) {
 		CreateApp("--label=foo=bar").
 		Sync().
 		Then().
-		Expect(OperationPhaseIs(OperationRunning)).
-		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(SyncStatusIs(SyncStatusCode(OperationSucceeded))).
 		When().
 		DeleteBySelector("foo=baz").
 		Then().

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -58,7 +58,7 @@ func TestDeletingAppByLabel(t *testing.T) {
 		// delete is unsuccessful since no selector match
 		AndCLIOutput(
 			func(output string, err error) {
-				assert.Contains(t, "no apps match selector foo=baz", err.Error())
+				assert.Contains(t, err.Error(), "no apps match selector foo=baz")
 			},
 		).
 		When().

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -44,7 +44,7 @@ func TestDeletingAppStuckInSync(t *testing.T) {
 
 func TestDeletingAppByLabel(t *testing.T) {
 	Given(t).
-		Path("arbitrary-path").
+		Path(guestbookPath).
 		When().
 		CreateApp("--label=foo=bar").
 		Sync().

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -52,6 +52,7 @@ func TestDeletingAppByLabel(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCode(SyncStatusCodeSynced))).
 		When().
+		IgnoreErrors().
 		DeleteBySelector("foo=baz").
 		Then().
 		// delete is unsuccessful since no selector match
@@ -60,7 +61,6 @@ func TestDeletingAppByLabel(t *testing.T) {
 				assert.Equal(t, "no apps match selector foo=baz", err.Error())
 			},
 		).
-		// delete is unsuccessful since no selector match
 		When().
 		DeleteBySelector("foo=bar").
 		Then().

--- a/test/e2e/app_deletion_test.go
+++ b/test/e2e/app_deletion_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/stretchr/testify/assert"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
@@ -54,7 +55,12 @@ func TestDeletingAppByLabel(t *testing.T) {
 		DeleteBySelector("foo=baz").
 		Then().
 		// delete is unsuccessful since no selector match
-		Expect(Error("no apps match selector: foo=baz", "")).
+		AndCLIOutput(
+			func(output string, err error) {
+				assert.Equal(t, "no apps match selector foo=baz", output)
+			},
+		).
+		// delete is unsuccessful since no selector match
 		When().
 		DeleteBySelector("foo=bar").
 		Then().

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -317,6 +317,12 @@ func (a *Actions) Delete(cascade bool) *Actions {
 	return a
 }
 
+func (a *Actions) DeleteBySelector(selector string) *Actions {
+	a.context.t.Helper()
+	a.runCli("app", "delete", a.context.name, fmt.Sprintf("--selector=%s", selector), "--yes")
+	return a
+}
+
 func (a *Actions) SetParamInSettingConfigMap(key, value string) *Actions {
 	fixture.SetParamInSettingConfigMap(key, value)
 	return a

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -319,7 +319,7 @@ func (a *Actions) Delete(cascade bool) *Actions {
 
 func (a *Actions) DeleteBySelector(selector string) *Actions {
 	a.context.t.Helper()
-	a.runCli("app", "delete", a.context.name, fmt.Sprintf("--selector=%s", selector), "--yes")
+	a.runCli("app", "delete", fmt.Sprintf("--selector=%s", selector), "--yes")
 	return a
 }
 

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -90,3 +90,9 @@ func (c *Consequences) Timeout(timeout int) *Consequences {
 	c.timeout = timeout
 	return c
 }
+
+func (c *Consequences) AndCLIOutput(block func(output string, err error)) *Consequences {
+	c.context.t.Helper()
+	block(c.actions.lastOutput, c.actions.lastError)
+	return c
+}


### PR DESCRIPTION
Closes #10091 

Allow `argocd app delete` command to delete apps having a common label. UX is `argocd app delete -l foo=bar`. Similar to `argocd app sync -l` experience. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

