### PR TITLE
docs: modify the invalid link

### DIFF
--- a/docs/operator-manual/installation.md
+++ b/docs/operator-manual/installation.md
@@ -33,7 +33,7 @@ Not recommended for production use. This type of installation is typically used 
   > and have to be installed separately. The CRD manifests are located in the [manifests/crds](https://github.com/argoproj/argo-cd/blob/master/manifests/crds) directory.
   > Use the following command to install them:
   > ```bash
-  > kubectl apply -k https://github.com/argoproj/argo-cd/manifests/crds\?ref\=stable
+  > kubectl apply -k https://github.com/argoproj/argo-cd/tree/stable/manifests/crds
   > ```
 
 ### High Availability:


### PR DESCRIPTION
Note on DCO:
The url is invalid:
```
$ curl https://github.com/argoproj/argo-cd/manifests/crds/?ref\=stable
Not Found
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

