### PR TITLE
chore: ignore CVE-2022-0624 - not exploitable in Argo CD

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -28,5 +28,13 @@ ignore:
     - '*':
         reason: >-
           Code is only run client-side. No risk of arbitrary file upload.
+  SNYK-JS-PARSEPATH-2936439:
+    - '*':
+        reason: >-
+          The issue is that, for specific URLs, parse-path may incorrectly identify the "resource" (domain name)
+          portion. For example, in "http://127.0.0.1#@example.com", it identifies "example.com" as the "resource".
+
+          We use parse-path on the client side, but permissions for git URLs are checked server-side. This is a
+          potential usability issue, but it is not a security issue.
 patch: {}
 


### PR DESCRIPTION
There's a good description of the vulnerability here: https://huntr.dev/bounties/afffb2bd-fb06-4144-829e-ecbbcbc85388/