### PR TITLE
chore: exclude docs from Sonar check

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,10 +14,10 @@ sonar.sourceEncoding=UTF-8
 sonar.host.url=https://sonarcloud.io
 
 # Exclude following set of patterns from coverage analysis
-sonar.coverage.exclusions=**/*.pb.go,**/*.pb.gw.go,**/mocks/**,**/*.ts*,**/vendor/**,**/openapi_generated.go,**/*_test.go,**/*_generated*,test/**,pkg/client/**,pkg/apiclient/**
+sonar.coverage.exclusions=**/*.pb.go,**/*.pb.gw.go,**/mocks/**,**/*.ts*,**/vendor/**,**/openapi_generated.go,**/*_test.go,**/*_generated*,test/**,pkg/client/**,pkg/apiclient/**,docs/**
 
 # Exclude following set of patterns from code analysis
-sonar.go.exclusions=**/vendor/**,*/*.pb.go,**/*_test.go,**/*.pb.gw.go,**/mocks/**,**/openapi_generated.go,**/*_generated*.go
+sonar.go.exclusions=**/vendor/**,*/*.pb.go,**/*_test.go,**/*.pb.gw.go,**/mocks/**,**/openapi_generated.go,**/*_generated*.go,docs/**
 
 # Exclude following set of patterns from duplication detection
-sonar.cpd.exclusions=**/*.pb.go,**/*.g.cs,**/*.gw.go,**/mocks/*
+sonar.cpd.exclusions=**/*.pb.go,**/*.g.cs,**/*.gw.go,**/mocks/*,docs/**


### PR DESCRIPTION
This should fix the broken CI check.