### PR TITLE
chore: fix codeql category error

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -62,16 +62,16 @@ jobs:
       - uses: github/codeql-action/upload-sarif@v1
         if: github.event_name == 'push'
         with:
-          category: Snyk code scan
+          category: code
           sarif_file: /tmp/argocd-test.sarif
       - uses: github/codeql-action/upload-sarif@v1
         if: github.event_name == 'push'
         with:
-          category: Snyk IaC scan for cluster install manifests
+          category: iac-install
           sarif_file: /tmp/argocd-iac-test-install.sarif
       - uses: github/codeql-action/upload-sarif@v1
         if: github.event_name == 'push'
-        with:
+        with: iac-namespace-install
           category: Snyk IaC scan for namespace install manifests
           sarif_file: /tmp/argocd-iac-test-namespace-install.sarif
       - run: |
@@ -96,7 +96,7 @@ jobs:
       - uses: github/codeql-action/upload-sarif@v1
         if: github.event_name == 'push'
         with:
-          category: Snyk scan for Argo CD image
+          category: image
           sarif_file: /tmp/argocd-image.sarif
 
       # deploy


### PR DESCRIPTION
Error from a previous run:

```
  Error: Aborting upload: only one run of the codeql/analyze or codeql/upload-sarif actions is allowed per job per tool/category. The easiest fix is to specify a unique value for the `category` input. Category: (snyk-iac) Tool: (Snyk IaC)
```

Looks like the Action was only taking the first two works of the category name?