### PR TITLE
chore: exclude docs from Sonar check completely

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,8 @@ sonar.projectVersion=1.0
  
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
+
+sonar.exclusions=docs/**
  
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Looks like the current exclusions don't apply to the "bugs" check.