### PR TITLE
chore: install snyk before generating report

### DIFF
--- a/hack/snyk-report.sh
+++ b/hack/snyk-report.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-npm install snyk-to-html -g
+npm install snyk snyk-to-html --location=global
 
 # Choose the branch where docs changes will actually be written.
 target_branch="$1"


### PR DESCRIPTION
First timed run of the snyk report was a [raging success](https://github.com/argoproj/argo-cd/runs/7594989282?check_suite_focus=true). 

```
./hack/snyk-report.sh: line 67: snyk: command not found
```

The flag change is in response to this:

```
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
```