### PR TITLE
chore: fix sarif upload categories

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -59,6 +59,9 @@ jobs:
           npm install -g snyk
 
           ./hack/snyk-non-container-tests.sh
+
+          jq '.runs[].automationDetails.id |= "iac-install"' /tmp/argocd-iac-test-install.sarif > /tmp/argocd-iac-test-install-categorized.sarif
+          jq '.runs[].automationDetails.id |= "iac-namespace-install"' /tmp/argocd-iac-test-namespace-install.sarif > /tmp/argocd-iac-test-namespace-install-categorized.sarif
       - uses: github/codeql-action/upload-sarif@v1
         if: github.event_name == 'push'
         with:
@@ -67,13 +70,11 @@ jobs:
       - uses: github/codeql-action/upload-sarif@v1
         if: github.event_name == 'push'
         with:
-          category: iac-install
-          sarif_file: /tmp/argocd-iac-test-install.sarif
+          sarif_file: /tmp/argocd-iac-test-install-categorized.sarif
       - uses: github/codeql-action/upload-sarif@v1
         if: github.event_name == 'push'
         with:
-          category: iac-namespace-install
-          sarif_file: /tmp/argocd-iac-test-namespace-install.sarif
+          sarif_file: /tmp/argocd-iac-test-namespace-install-categorized.sarif
       - run: |
           IMAGE_PLATFORMS=linux/amd64
           if [[ "${{ github.event_name }}" == "push" || "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]


### PR DESCRIPTION
I validated that the category is being pulled from the sarif file instead of the GitHub workflow option.  https://github.com/argoproj/argo-cd/pull/10170

As far as I can tell, there's no way to ask the Snyk CLI to use a different automation ID. So I had to manually override the ID.

If this works, I'll put up a PR against the GitHub action to improve the error message.