### PR TITLE
fix:  Drop all references to exec unless the feature is enabled

### DIFF
--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -50,6 +50,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
         extensionTabs: ResourceTabExtension[],
         tabs: Tab[],
         execEnabled: boolean,
+        execAllowed: boolean,
         logsAllowed: boolean
     ) => {
         if (!node || node === undefined) {
@@ -113,7 +114,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                     }
                 ]);
             }
-            if (execEnabled) {
+            if (execEnabled && execAllowed) {
                 tabs = tabs.concat([
                     {
                         key: 'exec',
@@ -270,7 +271,8 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                         const settings = await services.authService.settings();
                         const execEnabled = settings.execEnabled;
                         const logsAllowed = await services.accounts.canI('logs', 'get', application.spec.project + '/' + application.metadata.name);
-                        return {controlledState, liveState, events, podState, execEnabled, logsAllowed};
+                        const execAllowed = await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
+                        return {controlledState, liveState, events, podState, execEnabled, execAllowed, logsAllowed};
                     }}>
                     {data => (
                         <React.Fragment>
@@ -315,6 +317,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                                         }
                                     ],
                                     data.execEnabled,
+                                    data.execAllowed,
                                     data.logsAllowed
                                 )}
                                 selectedTabKey={props.tab}

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -440,13 +440,15 @@ function getActionItems(
         .then(async settings => {
             const execAllowed = await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
             if (resource.kind === 'Pod' && settings.execEnabled && execAllowed) {
-                return items.concat([{
-                    title: 'Exec',
-                    iconClassName: 'fa fa-terminal',
-                    action: async () => appContext.apis.navigation.goto('.', {node: nodeKey(resource), tab: 'exec'}, {replace: true})
-                }]);
+                return items.concat([
+                    {
+                        title: 'Exec',
+                        iconClassName: 'fa fa-terminal',
+                        action: async () => appContext.apis.navigation.goto('.', {node: nodeKey(resource), tab: 'exec'}, {replace: true})
+                    }
+                ]);
             }
-            return items
+            return items;
         })
         .catch(() => items);
 

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -430,16 +430,26 @@ function getActionItems(
             action: () => appContext.apis.navigation.goto('.', {node: nodeKey(resource), tab: 'logs'}, {replace: true})
         });
     }
-    if (resource.kind === 'Pod') {
-        items.push({
-            title: 'Exec',
-            iconClassName: 'fa fa-terminal',
-            action: () => appContext.apis.navigation.goto('.', {node: nodeKey(resource), tab: 'exec'}, {replace: true})
-        });
-    }
+
     if (isQuickStart) {
         return from([items]);
     }
+
+    const execAction = services.authService
+        .settings()
+        .then(async settings => {
+            const execAllowed = await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
+            if (resource.kind === 'Pod' && settings.execEnabled && execAllowed) {
+                return items.concat([{
+                    title: 'Exec',
+                    iconClassName: 'fa fa-terminal',
+                    action: async () => appContext.apis.navigation.goto('.', {node: nodeKey(resource), tab: 'exec'}, {replace: true})
+                }]);
+            }
+            return items
+        })
+        .catch(() => items);
+
     const resourceActions = services.applications
         .getResourceActions(application.metadata.name, resource)
         .then(actions => {
@@ -464,7 +474,7 @@ function getActionItems(
             );
         })
         .catch(() => items);
-    menuItems = merge(from([items]), from(resourceActions));
+    menuItems = merge(from([items]), from(resourceActions), from(execAction));
     return menuItems;
 }
 


### PR DESCRIPTION
Signed-off-by: Patrick Kerwood <patrick@kerwood.dk>

Fixes #9920

 The "Terminal" tab on a Pod resources details page and the "Exec" option on the Pod action menu, will only show if the exec feature is enabled and the user has the proper exec permissions.
