### PR TITLE
chore: support gzip compression for data stored in redis

### DIFF
--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -84,7 +84,7 @@ func loadClusters(ctx context.Context, kubeClient *kubernetes.Clientset, appClie
 			return nil, err
 		}
 		client := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("localhost:%d", port)})
-		cache = appstatecache.NewCache(cacheutil.NewCache(cacheutil.NewRedisCache(client, time.Hour, false)), time.Hour)
+		cache = appstatecache.NewCache(cacheutil.NewCache(cacheutil.NewRedisCache(client, time.Hour, cacheutil.RedisCompressionNone)), time.Hour)
 	} else {
 		cache, err = cacheSrc()
 		if err != nil {

--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -84,7 +84,7 @@ func loadClusters(ctx context.Context, kubeClient *kubernetes.Clientset, appClie
 			return nil, err
 		}
 		client := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("localhost:%d", port)})
-		cache = appstatecache.NewCache(cacheutil.NewCache(cacheutil.NewRedisCache(client, time.Hour)), time.Hour)
+		cache = appstatecache.NewCache(cacheutil.NewCache(cacheutil.NewRedisCache(client, time.Hour, false)), time.Hour)
 	} else {
 		cache, err = cacheSrc()
 		if err != nil {

--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -58,7 +58,7 @@ func (c *forwardCacheClient) doLazy(action func(client cache.CacheClient) error)
 		}
 
 		redisClient := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("localhost:%d", redisPort)})
-		c.client = cache.NewRedisCache(redisClient, time.Hour, false)
+		c.client = cache.NewRedisCache(redisClient, time.Hour, cache.RedisCompressionNone)
 	})
 	if c.err != nil {
 		return c.err

--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -58,7 +58,7 @@ func (c *forwardCacheClient) doLazy(action func(client cache.CacheClient) error)
 		}
 
 		redisClient := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("localhost:%d", redisPort)})
-		c.client = cache.NewRedisCache(redisClient, time.Hour)
+		c.client = cache.NewRedisCache(redisClient, time.Hour, false)
 	})
 	if c.err != nil {
 		return c.err

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -14,6 +14,8 @@ data:
 
   # Redis server hostname and port (e.g. argocd-redis:6379)
   redis.server: "argocd-redis:6379"
+  # Enable compression for data sent to Redis. (default false)
+  redis.compress: false
   # Redis database
   redis.db:
 

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -14,8 +14,8 @@ data:
 
   # Redis server hostname and port (e.g. argocd-redis:6379)
   redis.server: "argocd-redis:6379"
-  # Enable compression for data sent to Redis. (default false)
-  redis.compress: false
+  # Enable compression for data sent to Redis with the required compression algorithm. (default 'none')
+  redis.compression: none
   # Redis database
   redis.db:
 

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -44,6 +44,7 @@ argocd-application-controller [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress                        Enable compression for data stored in Redis.
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -44,7 +44,7 @@ argocd-application-controller [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress                        Enable compression for data stored in Redis.
+      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -29,6 +29,7 @@ argocd-repo-server [flags]
       --redis-ca-certificate string                    Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                        Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress                                 Enable compression for data stored in Redis.
       --redis-insecure-skip-tls-verify                 Skip Redis server certificate validation.
       --redis-use-tls                                  Use TLS when connecting to Redis. 
       --redisdb int                                    Redis database.

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -29,7 +29,7 @@ argocd-repo-server [flags]
       --redis-ca-certificate string                    Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                        Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress                                 Enable compression for data stored in Redis.
+      --redis-compress string                          Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
       --redis-insecure-skip-tls-verify                 Skip Redis server certificate validation.
       --redis-use-tls                                  Use TLS when connecting to Redis. 
       --redisdb int                                    Redis database.

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -50,7 +50,7 @@ argocd-server [flags]
       --redis-ca-certificate string                   Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string               Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                       Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress                                Enable compression for data stored in Redis.
+      --redis-compress string                         Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
       --redis-insecure-skip-tls-verify                Skip Redis server certificate validation.
       --redis-use-tls                                 Use TLS when connecting to Redis. 
       --redisdb int                                   Redis database.

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -50,6 +50,7 @@ argocd-server [flags]
       --redis-ca-certificate string                   Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string               Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                       Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress                                Enable compression for data stored in Redis.
       --redis-insecure-skip-tls-verify                Skip Redis server certificate validation.
       --redis-use-tls                                 Use TLS when connecting to Redis. 
       --redisdb int                                   Redis database.

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -30,7 +30,7 @@ argocd admin cluster shards [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress                        Enable compression for data stored in Redis.
+      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -30,6 +30,7 @@ argocd admin cluster shards [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress                        Enable compression for data stored in Redis.
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -30,6 +30,7 @@ argocd admin cluster stats [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress                        Enable compression for data stored in Redis.
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -30,7 +30,7 @@ argocd admin cluster stats [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress                        Enable compression for data stored in Redis.
+      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -107,11 +107,11 @@ spec:
                 name: argocd-cmd-params-cm
                 key: redis.server
                 optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
               name: argocd-cmd-params-cm
-              key: redis.compress
+              key: redis.compression
               optional: true
         - name: REDISDB
           valueFrom:

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -107,6 +107,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: redis.server
                 optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: redis.compress
+              optional: true
         - name: REDISDB
           valueFrom:
               configMapKeyRef:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -83,11 +83,11 @@ spec:
                   name: argocd-cmd-params-cm
                   key: redis.server
                   optional: true
-          - name: REDIS_COMPRESS
+          - name: REDIS_COMPRESSION
             valueFrom:
               configMapKeyRef:
                 name: argocd-cmd-params-cm
-                key: redis.compress
+                key: redis.compression
                 optional: true
           - name: REDISDB
             valueFrom:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -83,6 +83,12 @@ spec:
                   name: argocd-cmd-params-cm
                   key: redis.server
                   optional: true
+          - name: REDIS_COMPRESS
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: redis.compress
+                optional: true
           - name: REDISDB
             valueFrom:
                 configMapKeyRef:

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -172,6 +172,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: redis.server
                 optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: redis.compress
+              optional: true
         - name: REDISDB
           valueFrom:
               configMapKeyRef:

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -172,11 +172,11 @@ spec:
                 name: argocd-cmd-params-cm
                 key: redis.server
                 optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
               name: argocd-cmd-params-cm
-              key: redis.compress
+              key: redis.compression
               optional: true
         - name: REDISDB
           valueFrom:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9733,6 +9733,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -9995,6 +10001,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.server
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9733,10 +9733,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -10003,10 +10003,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10874,10 +10874,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -11210,10 +11210,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -11443,10 +11443,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10874,6 +10874,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -11204,6 +11210,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -11429,6 +11441,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.server
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1648,10 +1648,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -1984,10 +1984,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -2217,10 +2217,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1648,6 +1648,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -1978,6 +1984,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -2203,6 +2215,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.server
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10202,6 +10202,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -10528,6 +10534,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -10747,6 +10759,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.server
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10202,10 +10202,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -10534,10 +10534,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -10761,10 +10761,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -976,10 +976,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -1308,10 +1308,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB
@@ -1535,10 +1535,10 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
-        - name: REDIS_COMPRESS
+        - name: REDIS_COMPRESSION
           valueFrom:
             configMapKeyRef:
-              key: redis.compress
+              key: redis.compression
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -976,6 +976,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -1302,6 +1308,12 @@ spec:
               key: redis.server
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
+              name: argocd-cmd-params-cm
+              optional: true
         - name: REDISDB
           valueFrom:
             configMapKeyRef:
@@ -1521,6 +1533,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.server
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_COMPRESS
+          valueFrom:
+            configMapKeyRef:
+              key: redis.compress
               name: argocd-cmd-params-cm
               optional: true
         - name: REDISDB

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -83,6 +83,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	redisClientKey := ""
 	redisUseTLS := false
 	insecureRedis := false
+	compressionEnabled := false
 	var defaultCacheExpiration time.Duration
 
 	cmd.Flags().StringVar(&redisAddress, "redis", env.StringFromEnv("REDIS_SERVER", ""), "Redis server hostname and port (e.g. argocd-redis:6379). ")
@@ -95,6 +96,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	cmd.Flags().StringVar(&redisClientKey, "redis-client-key", "", "Path to Redis client key (e.g. /etc/certs/redis/client.crt).")
 	cmd.Flags().BoolVar(&insecureRedis, "redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
 	cmd.Flags().StringVar(&redisCACerticate, "redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
+	cmd.Flags().BoolVar(&compressionEnabled, "redis-compress", env.ParseBoolFromEnv("REDIS_COMPRESS", false), "Enable compression for data stored in Redis.")
 	return func() (*Cache, error) {
 		var tlsConfig *tls.Config = nil
 		if redisUseTLS {
@@ -130,7 +132,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 			for i := range opts {
 				opts[i](client)
 			}
-			return NewCache(NewRedisCache(client, defaultCacheExpiration)), nil
+			return NewCache(NewRedisCache(client, defaultCacheExpiration, compressionEnabled)), nil
 		}
 		if redisAddress == "" {
 			redisAddress = common.DefaultRedisAddr
@@ -140,7 +142,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 		for i := range opts {
 			opts[i](client)
 		}
-		return NewCache(NewRedisCache(client, defaultCacheExpiration)), nil
+		return NewCache(NewRedisCache(client, defaultCacheExpiration, compressionEnabled)), nil
 	}
 }
 

--- a/util/cache/redis_test.go
+++ b/util/cache/redis_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -18,30 +19,54 @@ func TestRedisSetCache(t *testing.T) {
 	assert.NotNil(t, mr)
 
 	t.Run("Successful set", func(t *testing.T) {
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 60*time.Second)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 60*time.Second, false)
 		err = client.Set(&Item{Key: "foo", Object: "bar"})
 		assert.NoError(t, err)
 	})
 
 	t.Run("Successful get", func(t *testing.T) {
 		var res string
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, false)
 		err = client.Get("foo", &res)
 		assert.NoError(t, err)
 		assert.Equal(t, res, "bar")
 	})
 
 	t.Run("Successful delete", func(t *testing.T) {
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, false)
 		err = client.Delete("foo")
 		assert.NoError(t, err)
 	})
 
 	t.Run("Cache miss", func(t *testing.T) {
 		var res string
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, false)
 		err = client.Get("foo", &res)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cache: key is missing")
 	})
+}
+
+func TestRedisSetCacheCompressed(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer mr.Close()
+	assert.NotNil(t, mr)
+
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	client := NewRedisCache(redisClient, 10*time.Second, true)
+	testValue := "my-value"
+	assert.NoError(t, client.Set(&Item{Key: "my-key", Object: testValue}))
+
+	compressedData, err := redisClient.Get(context.Background(), "my-key.gz").Bytes()
+	assert.NoError(t, err)
+	assert.True(t, len(compressedData) > len([]byte(testValue)), "compressed data is bigger than uncompressed")
+
+	var result string
+	assert.NoError(t, client.Get("my-key", &result))
+
+	assert.Equal(t, testValue, result)
 }

--- a/util/cache/redis_test.go
+++ b/util/cache/redis_test.go
@@ -19,28 +19,28 @@ func TestRedisSetCache(t *testing.T) {
 	assert.NotNil(t, mr)
 
 	t.Run("Successful set", func(t *testing.T) {
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 60*time.Second, false)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 60*time.Second, RedisCompressionNone)
 		err = client.Set(&Item{Key: "foo", Object: "bar"})
 		assert.NoError(t, err)
 	})
 
 	t.Run("Successful get", func(t *testing.T) {
 		var res string
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, false)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, RedisCompressionNone)
 		err = client.Get("foo", &res)
 		assert.NoError(t, err)
 		assert.Equal(t, res, "bar")
 	})
 
 	t.Run("Successful delete", func(t *testing.T) {
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, false)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, RedisCompressionNone)
 		err = client.Delete("foo")
 		assert.NoError(t, err)
 	})
 
 	t.Run("Cache miss", func(t *testing.T) {
 		var res string
-		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, false)
+		client := NewRedisCache(redis.NewClient(&redis.Options{Addr: mr.Addr()}), 10*time.Second, RedisCompressionNone)
 		err = client.Get("foo", &res)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cache: key is missing")
@@ -57,7 +57,7 @@ func TestRedisSetCacheCompressed(t *testing.T) {
 
 	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
-	client := NewRedisCache(redisClient, 10*time.Second, true)
+	client := NewRedisCache(redisClient, 10*time.Second, RedisCompressionGZip)
 	testValue := "my-value"
 	assert.NoError(t, client.Set(&Item{Key: "my-key", Object: testValue}))
 


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The application controller & repo server sends a lot of data to/from Redis. Since Redis replicas are typically running in different availability zones ( for high availability ) the traffic might be quite expensive.

PR adds the ability to compress data stored in Redis that significantly reduce the amount of data transferred to Redis and make it cheaper to run Argo CD.