### PR TITLE
feat: Support environment variables in Helm value file paths

### DIFF
--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -164,6 +164,17 @@ Or via declarative syntax:
           value: $ARGOCD_APP_NAME
 ```
 
+It's also possible to use build environment variables for the Helm values file path:
+
+```yaml
+  spec:
+    source:
+      helm:
+        valueFiles:
+              - values.yaml
+              - myprotocol://somepath/$ARGOCD_APP_NAME/$ARGOCD_APP_REVISION
+```
+
 ## Helm plugins
 
 > v1.5

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -171,8 +171,8 @@ It's also possible to use build environment variables for the Helm values file p
     source:
       helm:
         valueFiles:
-              - values.yaml
-              - myprotocol://somepath/$ARGOCD_APP_NAME/$ARGOCD_APP_REVISION
+        - values.yaml
+        - myprotocol://somepath/$ARGOCD_APP_NAME/$ARGOCD_APP_REVISION
 ```
 
 ## Helm plugins

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -777,7 +777,7 @@ func helmTemplate(appPath string, repoRoot string, env *v1alpha1.Env, q *apiclie
 		for _, val := range appHelm.ValueFiles {
 
 			// This will resolve val to an absolute path (or an URL)
-			path, isRemote, err := pathutil.ResolveFilePath(appPath, repoRoot, val, q.GetValuesFileSchemes())
+			path, isRemote, err := pathutil.ResolveFilePath(appPath, repoRoot, env.Envsubst(val), q.GetValuesFileSchemes())
 			if err != nil {
 				return nil, err
 			}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -771,6 +771,39 @@ func TestHelmWithMissingValueFiles(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGenerateHelmWithEnvVars(t *testing.T) {
+	service := newService("../../util/helm/testdata/redis")
+
+	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
+		Repo:    &argoappv1.Repository{},
+		AppName: "production",
+		ApplicationSource: &argoappv1.ApplicationSource{
+			Path: ".",
+			Helm: &argoappv1.ApplicationSourceHelm{
+				ValueFiles: []string{"values-$ARGOCD_APP_NAME.yaml"},
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+
+	replicasVerified := false
+	for _, src := range res.Manifests {
+		obj := unstructured.Unstructured{}
+		err = json.Unmarshal([]byte(src), &obj)
+		assert.NoError(t, err)
+
+		if obj.GetKind() == "Deployment" && obj.GetName() == "production-redis-slave" {
+			var dep v1.Deployment
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &dep)
+			assert.NoError(t, err)
+			assert.Equal(t, int32(3), *dep.Spec.Replicas)
+			replicasVerified = true
+		}
+	}
+	assert.True(t, replicasVerified)
+}
+
 // The requested value file (`../minio/values.yaml`) is outside the app path (`./util/helm/testdata/redis`), however
 // since the requested value is sill under the repo directory (`~/go/src/github.com/argoproj/argo-cd`), it is allowed
 func TestGenerateHelmWithValuesDirectoryTraversal(t *testing.T) {


### PR DESCRIPTION
Hey Team!
Just a tiny PR that adds support for env vars in the Helm value file paths.

I have a use case where I need access to ARGOCD_APP_NAME and ARGOCD_APP_REVISION in combination with a custom protocol. The Helm configuration would look like this:

```
helm:
    valueFiles:
      - values.yaml
      - myprotocol://somepath/$ARGOCD_APP_NAME/$ARGOCD_APP_REVISION
```

Env vars are already supported for Helm `parameters` but not for `valueFiles`, this PR adds this functionality.
 
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

