### PR TITLE
docs: clusterResources in declarative cluster config

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -489,6 +489,7 @@ The secret data must include following fields:
 * `name` - cluster name
 * `server` - cluster api server url
 * `namespaces` - optional comma-separated list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
+* `clusterResources` - optional boolean string (`"true"` or `"false"`) determining whether Argo CD can manage cluster-level resources on this cluster. This setting is used only if list of managed namespaces is not empty.
 * `config` - JSON representation of following data structure:
 
 ```yaml

--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -489,7 +489,7 @@ The secret data must include following fields:
 * `name` - cluster name
 * `server` - cluster api server url
 * `namespaces` - optional comma-separated list of namespaces which are accessible in that cluster. Cluster level resources would be ignored if namespace list is not empty.
-* `clusterResources` - optional boolean string (`"true"` or `"false"`) determining whether Argo CD can manage cluster-level resources on this cluster. This setting is used only if list of managed namespaces is not empty.
+* `clusterResources` - optional boolean string (`"true"` or `"false"`) determining whether Argo CD can manage cluster-level resources on this cluster. This setting is used only if the list of managed namespaces is not empty.
 * `config` - JSON representation of following data structure:
 
 ```yaml


### PR DESCRIPTION
The feature was added [here](https://github.com/argoproj/argo-cd/commit/58ac345f2bd4054a12b4991a8909c56a035867d9) but was not documented in the declarative config docs.

[2.1](https://github.com/argoproj/argo-cd/releases/tag/v2.1.0) was the first release with this feature, so we should cherry-pick docs back to currently-supported versions.