### PR TITLE
chore: no non-container scans in workflow (scan limit hit)

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -49,31 +49,6 @@ jobs:
       # build
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-
-      - name: Run non-container Snyk scans
-        if: github.event_name == 'push'
-        working-directory: ./src/github.com/argoproj/argo-cd
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: |
-          npm install -g snyk
-
-          ./hack/snyk-non-container-tests.sh
-          jq '.runs[].automationDetails.id |= "iac-install"' /tmp/argocd-iac-test-install.sarif > /tmp/argocd-iac-test-install-categorized.sarif
-          jq '.runs[].automationDetails.id |= "iac-namespace-install"' /tmp/argocd-iac-test-namespace-install.sarif > /tmp/argocd-iac-test-namespace-install-categorized.sarif
-      - uses: github/codeql-action/upload-sarif@v2
-        if: github.event_name == 'push'
-        with:
-          category: code
-          sarif_file: /tmp/argocd-test.sarif
-      - uses: github/codeql-action/upload-sarif@v2
-        if: github.event_name == 'push'
-        with:
-          sarif_file: /tmp/argocd-iac-test-install-categorized.sarif
-      - uses: github/codeql-action/upload-sarif@v2
-        if: github.event_name == 'push'
-        with:
-          sarif_file: /tmp/argocd-iac-test-namespace-install-categorized.sarif
       - run: |
           IMAGE_PLATFORMS=linux/amd64
           if [[ "${{ github.event_name }}" == "push" || "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]
@@ -85,14 +60,6 @@ jobs:
             -t ghcr.io/argoproj/argocd:${{ steps.image.outputs.tag }} \
             -t quay.io/argoproj/argocd:latest .
         working-directory: ./src/github.com/argoproj/argo-cd
-
-      - name: Run container Snyk scans
-        if: github.event_name == 'push'
-        working-directory: ./src/github.com/argoproj/argo-cd
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: |
-          make snyk-container-tests
       - uses: github/codeql-action/upload-sarif@v2
         if: github.event_name == 'push'
         with:


### PR DESCRIPTION
Since these scans aren't technically "open source" (they're run directly against source instead of against a public image or similar) they count against the Snyk scan limits.

This info is surfaced in the Snyk Scan docs anyway, so I don't think we need it in the CI checks.