### PR TITLE
feat: refactor redis-ha NetworkPolicy to include egress rules (#9968)

### DIFF
--- a/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
+++ b/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
@@ -8,6 +8,7 @@ spec:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
   policyTypes:
   - Ingress
+  - Egress
   ingress:
     - from:
       - podSelector:
@@ -19,7 +20,25 @@ spec:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-application-controller
-      # Redis HA server need to talk to proxy as well
+      ports:
+        - port: 6379
+          protocol: TCP
+        - port: 26379
+          protocol: TCP
+  egress:
+    - to:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-redis-ha
+      ports:
+        - port: 6379
+          protocol: TCP
+        - port: 26379
+          protocol: TCP
+    - to:
+      - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP

--- a/manifests/ha/base/redis-ha/argocd-redis-ha-server-network-policy.yaml
+++ b/manifests/ha/base/redis-ha/argocd-redis-ha-server-network-policy.yaml
@@ -8,13 +8,34 @@ spec:
       app.kubernetes.io/name: argocd-redis-ha
   policyTypes:
   - Ingress
+  - Egress
   ingress:
     - from:
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-redis-ha-haproxy
-      # Redis HA server pods need to talk to each other
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-redis-ha
-
+      ports:
+        - port: 6379
+          protocol: TCP
+        - port: 26379
+          protocol: TCP
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: argocd-redis-ha
+      ports:
+        - port: 6379
+          protocol: TCP
+        - port: 26379
+          protocol: TCP
+    - to:
+      - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -12149,6 +12149,23 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-ha-proxy-network-policy
 spec:
+  egress:
+  - ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-redis-ha
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - podSelector:
@@ -12160,20 +12177,40 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-application-controller
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: argocd-redis-ha
+    ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
   policyTypes:
   - Ingress
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: argocd-redis-ha-server-network-policy
 spec:
+  egress:
+  - ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-redis-ha
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - podSelector:
@@ -12182,11 +12219,17 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-redis-ha
+    ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-redis-ha
   policyTypes:
   - Ingress
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2854,6 +2854,23 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-ha-proxy-network-policy
 spec:
+  egress:
+  - ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-redis-ha
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - podSelector:
@@ -2865,20 +2882,40 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-application-controller
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: argocd-redis-ha
+    ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
   policyTypes:
   - Ingress
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: argocd-redis-ha-server-network-policy
 spec:
+  egress:
+  - ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-redis-ha
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - podSelector:
@@ -2887,11 +2924,17 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: argocd-redis-ha
+    ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: argocd-redis-ha
   policyTypes:
   - Ingress
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
Fixes #9968

This policy change includes egress rules to only allow DNS traffic outbound and maintain inter-Redis and Sentinel connectivity. ```argocd-redis-ha-server & argocd-redis-ha-proxy``` should not be allowed to communicate with other pods in the cluster to prevent lateral movement in the event a redis pod is breached.


```bash 
kubectl describe networkpolicies.networking.k8s.io argocd-redis-ha-server-network-policy 

Name:         argocd-redis-ha-server-network-policy
Namespace:    argocd
Created on:   2022-08-05 17:36:44 -0700 PDT
Labels:       <none>
Annotations:  <none>
Spec:
  PodSelector:     app.kubernetes.io/name=argocd-redis-ha
  Allowing ingress traffic:
    To Port: 6379/TCP
    To Port: 26379/TCP
    From:
      PodSelector: app.kubernetes.io/name=argocd-redis-ha-haproxy
    From:
      PodSelector: app.kubernetes.io/name=argocd-redis-ha
  Allowing egress traffic:
    To Port: 6379/TCP
    To Port: 26379/TCP
    To:
      PodSelector: app.kubernetes.io/name=argocd-redis-ha
    ----------
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: <none>
  Policy Types: Ingress, Egress
```
```bash
kubectl describe networkpolicies.networking.k8s.io argocd-redis-ha-proxy-network-policy

Name:         argocd-redis-ha-proxy-network-policy
Namespace:    argocd
Created on:   2022-08-05 17:36:44 -0700 PDT
Labels:       <none>
Annotations:  <none>
Spec:
  PodSelector:     app.kubernetes.io/name=argocd-redis-ha-haproxy
  Allowing ingress traffic:
    To Port: 6379/TCP
    To Port: 26379/TCP
    From:
      PodSelector: app.kubernetes.io/name=argocd-server
    From:
      PodSelector: app.kubernetes.io/name=argocd-repo-server
    From:
      PodSelector: app.kubernetes.io/name=argocd-application-controller
  Allowing egress traffic:
    To Port: 6379/TCP
    To Port: 26379/TCP
    To:
      PodSelector: app.kubernetes.io/name=argocd-redis-ha
    ----------
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: <none>
  Policy Types: Ingress, Egress
```
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

