### PR TITLE
feat: restrict egress on redis (#9968)

### DIFF
--- a/manifests/base/redis/argocd-redis-network-policy.yaml
+++ b/manifests/base/redis/argocd-redis-network-policy.yaml
@@ -8,6 +8,7 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
+  - Egress
   ingress:
     - from:
       - podSelector:
@@ -22,3 +23,13 @@ spec:
       ports:
         - protocol: TCP
           port: 6379
+  egress:
+    - to:
+      - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP 
+    
+      

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -10166,6 +10166,14 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-network-policy
 spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - podSelector:
@@ -10185,6 +10193,7 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10961,6 +10961,14 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-network-policy
 spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - podSelector:
@@ -10980,6 +10988,7 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1666,6 +1666,14 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-network-policy
 spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
   ingress:
   - from:
     - podSelector:
@@ -1685,6 +1693,7 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
+  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/9968

This policy change includes egress rules to only allow outbound DNS traffic.  ```argocd-redis``` should not be allowed to communicate with other pods in the cluster to prevent lateral movement in the event a redis pod is breached.
```bash
kubectl describe networkpolicies.networking.k8s.io argocd-redis-network-policy

Name:         argocd-redis-network-policy
Namespace:    argocd
Created on:   2022-08-05 23:21:51 -0700 PDT
Labels:       <none>
Annotations:  <none>
Spec:
  PodSelector:     app.kubernetes.io/name=argocd-redis
  Allowing ingress traffic:
    To Port: 6379/TCP
    From:
      PodSelector: app.kubernetes.io/name=argocd-server
    From:
      PodSelector: app.kubernetes.io/name=argocd-repo-server
    From:
      PodSelector: app.kubernetes.io/name=argocd-application-controller
  Allowing egress traffic:
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: <none>
  Policy Types: Ingress, Egress
```

Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

