### PR TITLE
docs(applicationset): fix layout matrix/merge generator restrictions

### DIFF
--- a/docs/operator-manual/applicationset/Generators-Matrix.md
+++ b/docs/operator-manual/applicationset/Generators-Matrix.md
@@ -169,68 +169,68 @@ with the label `kubernetes.io/environment: dev` will have only dev-specific conf
 ## Restrictions
 
 1. The Matrix generator currently only supports combining the outputs of only two child generators (eg does not support generating combinations for 3 or more).
+
 1. You should specify only a single generator per array entry, eg this is not valid:
-```yaml
-- matrix:
-    generators:
-     - list: # (...)
-       git: # (...)
-```
+
+        - matrix:
+            generators:
+            - list: # (...)
+              git: # (...)
+
     - While this *will* be accepted by Kubernetes API validation, the controller will report an error on generation. Each generator should be specified in a separate array element, as in the examples above.
+
 1. The Matrix generator does not currently support [`template` overrides](Template.md#generator-templates) specified on child generators, eg this `template` will not be processed:
-```yaml
-- matrix:
-    generators:
-      - list:
-          elements:
-            - # (...)
-          template: { } # Not processed
-```
+
+        - matrix:
+            generators:
+              - list:
+                  elements:
+                    - # (...)
+                  template: { } # Not processed
+
 1. Combination-type generators (matrix or merge) can only be nested once. For example, this will not work:
-```yaml
-- matrix:
-    generators:
-      - matrix:
-          generators:
-            - matrix:  # This third level is invalid.
-                generators:
-                  - list:
-                      elements:
-                        - # (...)
-```
+
+        - matrix:
+            generators:
+              - matrix:
+                  generators:
+                    - matrix:  # This third level is invalid.
+                        generators:
+                          - list:
+                              elements:
+                                - # (...)
+
 1. When using parameters from one child generator inside another child generator, the child generator that *consumes* the parameters **must come after** the child generator that *produces* the parameters.
 For example, the below example would be invalid (cluster-generator must come after the git-files generator):
-```yaml
-- matrix:
-    generators:
-      # cluster generator, 'child' #1
-      - clusters:
-          selector:
-            matchLabels:
-              argocd.argoproj.io/secret-type: cluster
-              kubernetes.io/environment: '{{path.basename}}' # {{path.basename}} is produced by git-files generator
-      # git generator, 'child' #2
-      - git:
-          repoURL: https://github.com/argoproj/applicationset.git
-          revision: HEAD
-          files:
-            - path: "examples/git-generator-files-discovery/cluster-config/**/config.json"
-```
-1. You cannot have both child generators consuming parameters from each another. In the example below, the cluster generator is consuming the `{{path.basename}}` parameter produced by the git-files generator, whereas the git-files generator is consuming the `{{name}}` parameter produced by the cluster generator. This will result in a circular dependency, which is invalid.
-```yaml
-- matrix:
-    generators:
-      # cluster generator, 'child' #1
-      - clusters:
-          selector:
-            matchLabels:
-              argocd.argoproj.io/secret-type: cluster
-              kubernetes.io/environment: '{{path.basename}}' # {{path.basename}} is produced by git-files generator
-      # git generator, 'child' #2
-      - git:
-          repoURL: https://github.com/argoproj/applicationset.git
-          revision: HEAD
-          files:
-            - path: "examples/git-generator-files-discovery/cluster-config/engineering/{{name}}**/config.json" # {{name}} is produced by cluster generator
-```
 
+        - matrix:
+            generators:
+              # cluster generator, 'child' #1
+              - clusters:
+                  selector:
+                    matchLabels:
+                      argocd.argoproj.io/secret-type: cluster
+                      kubernetes.io/environment: '{{path.basename}}' # {{path.basename}} is produced by git-files generator
+              # git generator, 'child' #2
+              - git:
+                  repoURL: https://github.com/argoproj/applicationset.git
+                  revision: HEAD
+                  files:
+                    - path: "examples/git-generator-files-discovery/cluster-config/**/config.json"
+
+1. You cannot have both child generators consuming parameters from each another. In the example below, the cluster generator is consuming the `{{path.basename}}` parameter produced by the git-files generator, whereas the git-files generator is consuming the `{{name}}` parameter produced by the cluster generator. This will result in a circular dependency, which is invalid.
+
+        - matrix:
+            generators:
+              # cluster generator, 'child' #1
+              - clusters:
+                  selector:
+                    matchLabels:
+                      argocd.argoproj.io/secret-type: cluster
+                      kubernetes.io/environment: '{{path.basename}}' # {{path.basename}} is produced by git-files generator
+              # git generator, 'child' #2
+              - git:
+                  repoURL: https://github.com/argoproj/applicationset.git
+                  revision: HEAD
+                  files:
+                    - path: "examples/git-generator-files-discovery/cluster-config/engineering/{{name}}**/config.json" # {{name}} is produced by cluster generator

--- a/docs/operator-manual/applicationset/Generators-Merge.md
+++ b/docs/operator-manual/applicationset/Generators-Merge.md
@@ -114,31 +114,31 @@ When merged with the updated base parameters, the `values.redis` value for the p
 ## Restrictions
 
 1. You should specify only a single generator per array entry. This is not valid:
-```yaml
-- merge:
-    generators:
-     - list: # (...)
-       git: # (...)
-```
+
+        - merge:
+            generators:
+            - list: # (...)
+              git: # (...)
+
     - While this *will* be accepted by Kubernetes API validation, the controller will report an error on generation. Each generator should be specified in a separate array element, as in the examples above.
+
 1. The Merge generator does not support [`template` overrides](Template.md#generator-templates) specified on child generators. This `template` will not be processed:
-```yaml
-- merge:
-    generators:
-      - list:
-          elements:
-            - # (...)
-          template: { } # Not processed
-```
+
+        - merge:
+            generators:
+              - list:
+                  elements:
+                    - # (...)
+                  template: { } # Not processed
+
 1. Combination-type generators (Matrix or Merge) can only be nested once. For example, this will not work:
-```yaml
-- merge:
-    generators:
-      - merge:
-          generators:
-            - merge:  # This third level is invalid.
-                generators:
-                  - list:
-                      elements:
-                        - # (...)
-```
+
+        - merge:
+            generators:
+              - merge:
+                  generators:
+                    - merge:  # This third level is invalid.
+                        generators:
+                          - list:
+                              elements:
+                                - # (...)

--- a/docs/operator-manual/applicationset/Generators.md
+++ b/docs/operator-manual/applicationset/Generators.md
@@ -4,7 +4,7 @@ Generators are responsible for generating *parameters*, which are then rendered 
 
 Generators are primarily based on the data source that they use to generate the template parameters. For example: the List generator provides a set of parameters from a *literal list*, the Cluster generator uses the *Argo CD cluster list* as a source, the Git generator uses files/directories from a *Git repository*, and so.
 
-As of this writing there are seven generators:
+As of this writing there are eight generators:
 
 - [List generator](Generators-List.md): The List generator allows you to target Argo CD Applications to clusters based on a fixed list of cluster name/URL values.
 - [Cluster generator](Generators-Cluster.md): The Cluster generator allows you to target Argo CD Applications to clusters, based on the list of clusters defined within (and managed by) Argo CD (which includes automatically responding to cluster addition/removal events from Argo CD).


### PR DESCRIPTION
The applicationset docs for matrix/merge generators contain a numbered list of restrictions. All items are numbered '1', as the yaml examples reset the markdown numbering.

mkdocs does not support fenced code blocks inside lists, like github markdown does:
> Note that fenced code blocks can not be indented. Therefore, they cannot be nested inside list items, blockquotes, etc.

Using indented code blocks inside the list now, `make serve-docs-local` shows correctly numbered items and formatted code blocks. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

