### PR TITLE
docs: revert appset path.path and path.segments docs

### DIFF
--- a/applicationset/examples/design-doc/git-directory-discovery-fasttemplate.yaml
+++ b/applicationset/examples/design-doc/git-directory-discovery-fasttemplate.yaml
@@ -38,7 +38,7 @@ spec:
       source:
         repoURL: https://github.com/infra-team/cluster-deployments.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: http://kubernetes.default.svc
         namespace: '{{path.basename}}'

--- a/applicationset/examples/matrix/cluster-and-git-fasttemplate.yaml
+++ b/applicationset/examples/matrix/cluster-and-git-fasttemplate.yaml
@@ -27,7 +27,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: '{{server}}'
         namespace: '{{path.basename}}'

--- a/applicationset/examples/matrix/list-and-git-fasttemplate.yaml
+++ b/applicationset/examples/matrix/list-and-git-fasttemplate.yaml
@@ -33,7 +33,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: '{{url}}'
         namespace: '{{path.basename}}'

--- a/applicationset/examples/matrix/list-and-list-fasttemplate.yaml
+++ b/applicationset/examples/matrix/list-and-list-fasttemplate.yaml
@@ -31,7 +31,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: '{{url}}'
         namespace: '{{path.basename}}'

--- a/applicationset/examples/matrix/matrix-and-union-in-matrix-fasttemplate.yaml
+++ b/applicationset/examples/matrix/matrix-and-union-in-matrix-fasttemplate.yaml
@@ -61,7 +61,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: '{{url}}'
         namespace: '{{path.basename}}'

--- a/applicationset/generators/git.go
+++ b/applicationset/generators/git.go
@@ -224,7 +224,7 @@ func (g *GitGenerator) filterApps(Directories []argoprojiov1alpha1.GitDirectoryG
 }
 
 func (g *GitGenerator) generateParamsFromApps(requestedApps []string, _ *argoprojiov1alpha1.ApplicationSetGenerator, useGoTemplate bool) []map[string]interface{} {
-	// TODO: At some point, the appicationSetGenerator param should be used
+	// TODO: At some point, the applicationSetGenerator param should be used
 
 	res := make([]map[string]interface{}, len(requestedApps))
 	for i, a := range requestedApps {

--- a/docs/operator-manual/applicationset/Generators-Git.md
+++ b/docs/operator-manual/applicationset/Generators-Git.md
@@ -45,7 +45,7 @@ spec:
       - path: applicationset/examples/git-generator-directory/cluster-addons/*
   template:
     metadata:
-      name: '{{path.segments[0]}}'
+      name: '{{path[0]}}'
     spec:
       project: "my-project"
       source:

--- a/docs/operator-manual/applicationset/Generators-Git.md
+++ b/docs/operator-manual/applicationset/Generators-Git.md
@@ -51,7 +51,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: https://kubernetes.default.svc
         namespace: '{{path.basename}}'
@@ -60,8 +60,8 @@ spec:
 
 The generator parameters are:
 
-- `{{path.path}}`: The directory paths within the Git repository that match the `path` wildcard.
-- `{{path.segments[n]}}`: The directory paths within the Git repository that match the `path` wildcard, split into array elements (`n` - array index)
+- `{{path}}`: The directory paths within the Git repository that match the `path` wildcard.
+- `{{path[n]}}`: The directory paths within the Git repository that match the `path` wildcard, split into array elements (`n` - array index)
 - `{{path.basename}}`: For any directory path within the Git repository that matches the `path` wildcard, the right-most path name is extracted (e.g. `/directory/directory2` would produce `directory2`).
 - `{{path.basenameNormalized}}`: This field is the same as `path.basename` with unsupported characters replaced with `-` (e.g. a `path` of `/directory/directory_2`, and `path.basename` of `directory_2` would produce `directory-2` here).
 
@@ -100,7 +100,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: https://kubernetes.default.svc
         namespace: '{{path.basename}}'
@@ -181,7 +181,7 @@ spec:
       source:
         repoURL: https://github.com/example/example-repo.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: https://kubernetes.default.svc
         namespace: '{{path.basename}}'

--- a/docs/operator-manual/applicationset/Generators-Matrix.md
+++ b/docs/operator-manual/applicationset/Generators-Matrix.md
@@ -56,7 +56,7 @@ spec:
       source:
         repoURL: https://github.com/argoproj/argo-cd.git
         targetRevision: HEAD
-        path: '{{path.path}}'
+        path: '{{path}}'
       destination:
         server: '{{server}}'
         namespace: '{{path.basename}}'

--- a/docs/operator-manual/applicationset/GoTemplate.md
+++ b/docs/operator-manual/applicationset/GoTemplate.md
@@ -82,7 +82,7 @@ By activating Go Templating, `{{ .path }}` becomes an object. Therefore, some ch
 generators' templating:
 
 - `{{ path }}` becomes `{{ .path.path }}`
-- `{{ path[n] }}` becomes `{{path.segments[n]}}`
+- `{{ path[n] }}` becomes `{{ .path.segments[n] }}`
 
 Here is an example:
 


### PR DESCRIPTION
I think the find/replace when just slightly too far in https://github.com/argoproj/argo-cd/pull/10026.

@speedfl could you take a look and confirm that this reversion is correct?