### PR TITLE
chore: upgrade redis-ha chart to 4.17.8, HAProxy v2.6.2

### DIFF
--- a/docs/operator-manual/upgrading/2.4-2.5.md
+++ b/docs/operator-manual/upgrading/2.4-2.5.md
@@ -48,9 +48,10 @@ The bundled Kustomize version has been upgraded from 4.4.1 to 4.5.5.
 
 ## Upgraded HAProxy version
 
-The HAProxy version in the HA manifests has been upgraded from 2.0.25 to 2.5.7. To read about the changes/improvements,
+The HAProxy version in the HA manifests has been upgraded from 2.0.25 to 2.6.2. To read about the changes/improvements,
 see the HAProxy major release announcements ([2.1.0](https://www.mail-archive.com/haproxy@formilux.org/msg35491.html),
 [2.2.0](https://www.mail-archive.com/haproxy@formilux.org/msg37852.html),
 [2.3.0](https://www.mail-archive.com/haproxy@formilux.org/msg38812.html),
-[2.4.0](https://www.mail-archive.com/haproxy@formilux.org/msg40499.html), and
-[2.5.0](https://www.mail-archive.com/haproxy@formilux.org/msg41508.html).
+[2.4.0](https://www.mail-archive.com/haproxy@formilux.org/msg40499.html),
+[2.5.0](https://www.mail-archive.com/haproxy@formilux.org/msg41508.html), and
+[2.6.0](https://www.mail-archive.com/haproxy@formilux.org/msg42371.html).

--- a/manifests/ha/base/redis-ha/chart/requirements.lock
+++ b/manifests/ha/base/redis-ha/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts
-  version: 4.17.2
-digest: sha256:2e3eed4046cbb7084d461dba66b99088abaf91d843e707decfba3b7723260f2c
-generated: "2022-07-18T14:06:59.32663-04:00"
+  version: 4.17.8
+digest: sha256:24b66a7cd8e6ec23502173bd643bfaa66cf0d062df0361370226754e0cedda12
+generated: "2022-08-12T00:12:34.042365707-07:00"

--- a/manifests/ha/base/redis-ha/chart/requirements.yaml
+++ b/manifests/ha/base/redis-ha/chart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-ha
-  version: 4.17.2
+  version: 4.17.8
   repository: https://dandydeveloper.github.io/charts

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
     app: argocd-redis-ha
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
     app: argocd-redis-ha
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -33,12 +33,14 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
     app: argocd-redis-ha
 data:
   redis.conf: |
     dir "/data"
     port 6379
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
     bind 0.0.0.0
     maxmemory 0
     maxmemory-policy volatile-lru
@@ -106,7 +108,6 @@ data:
     identify_master() {
         echo "Identifying redis master (get-master-addr-by-name).."
         echo "  using sentinel (argocd-redis-ha), sentinel group name (argocd)"
-        echo "  $(date).."
         MASTER="$(sentinel_get_master_retry 3)"
         if [ -n "${MASTER}" ]; then
             echo "  $(date) Found redis master (${MASTER})"
@@ -219,14 +220,12 @@ data:
         else
             echo "  ping (${MASTER}:${REDIS_PORT})"
         fi
-        echo "  $(date).."
         if [ "$(redis_ping_retry 3)" != "PONG" ]; then
             echo "  $(date) Can't ping redis master (${MASTER})"
             echo "Attempting to force failover (sentinel failover).."
 
             if [ "$SENTINEL_PORT" -eq 0 ]; then
                 echo "  on sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}"   --tls --cacert /tls-certs/ca.crt --cert /tls-certs/redis.crt --key /tls-certs/redis.key sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -235,7 +234,6 @@ data:
                 fi
             else
                 echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -252,7 +250,6 @@ data:
             else
                 echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
             fi
-            echo "  $(date).."
             MASTER="$(sentinel_get_master)"
             if [ "${MASTER}" ]; then
                 echo "  $(date) Found redis master (${MASTER})"
@@ -378,7 +375,6 @@ data:
     identify_master() {
         echo "Identifying redis master (get-master-addr-by-name).."
         echo "  using sentinel (argocd-redis-ha), sentinel group name (argocd)"
-        echo "  $(date).."
         MASTER="$(sentinel_get_master_retry 3)"
         if [ -n "${MASTER}" ]; then
             echo "  $(date) Found redis master (${MASTER})"
@@ -491,14 +487,12 @@ data:
         else
             echo "  ping (${MASTER}:${REDIS_PORT})"
         fi
-        echo "  $(date).."
         if [ "$(redis_ping_retry 3)" != "PONG" ]; then
             echo "  $(date) Can't ping redis master (${MASTER})"
             echo "Attempting to force failover (sentinel failover).."
 
             if [ "$SENTINEL_PORT" -eq 0 ]; then
                 echo "  on sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}"   --tls --cacert /tls-certs/ca.crt --cert /tls-certs/redis.crt --key /tls-certs/redis.key sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -507,7 +501,6 @@ data:
                 fi
             else
                 echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -524,7 +517,6 @@ data:
             else
                 echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
             fi
-            echo "  $(date).."
             MASTER="$(sentinel_get_master)"
             if [ "${MASTER}" ]; then
                 echo "  $(date) Found redis master (${MASTER})"
@@ -772,7 +764,7 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
     app: argocd-redis-ha
 data:
   redis_liveness.sh: |
@@ -822,7 +814,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
 rules:
 - apiGroups:
     - ""
@@ -841,7 +833,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
     component: argocd-redis-ha-haproxy
 rules:
 - apiGroups:
@@ -861,7 +853,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha
@@ -880,7 +872,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
     component: argocd-redis-ha-haproxy
 subjects:
 - kind: ServiceAccount
@@ -900,7 +892,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -930,7 +922,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -960,7 +952,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -990,7 +982,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
   annotations:
 spec:
   type: ClusterIP
@@ -1018,7 +1010,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
     component: argocd-redis-ha-haproxy
   annotations:
 spec:
@@ -1042,7 +1034,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
 spec:
   strategy:
     type: RollingUpdate
@@ -1080,7 +1072,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: haproxy:2.5.7-alpine
+        image: haproxy:2.6.2-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -1100,7 +1092,7 @@ spec:
         runAsUser: 1000
       containers:
       - name: haproxy
-        image: haproxy:2.5.7-alpine
+        image: haproxy:2.6.2-alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1148,7 +1140,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.2
+    chart: redis-ha-4.17.8
   annotations:
     {}
 spec:
@@ -1164,7 +1156,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/init-config: 1a8461b83fdc5614ce24a7d4d15976f9ef3b5c68a35475b5a3f57299c6f48ae8
+        checksum/init-config: 226aec192d2f29b5355769c9f1fbf093bf36c3a1e15b574b71fb8fe73fd37c05
       labels:
         release: argocd
         app: redis-ha

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -9,7 +9,7 @@ redis-ha:
   haproxy:
     enabled: true
     image:
-      tag: 2.5.7-alpine
+      tag: 2.6.2-alpine
     timeout:
       server: 6m
       client: 6m

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9819,7 +9819,6 @@ data:
     identify_master() {
         echo "Identifying redis master (get-master-addr-by-name).."
         echo "  using sentinel (argocd-redis-ha), sentinel group name (argocd)"
-        echo "  $(date).."
         MASTER="$(sentinel_get_master_retry 3)"
         if [ -n "${MASTER}" ]; then
             echo "  $(date) Found redis master (${MASTER})"
@@ -9932,14 +9931,12 @@ data:
         else
             echo "  ping (${MASTER}:${REDIS_PORT})"
         fi
-        echo "  $(date).."
         if [ "$(redis_ping_retry 3)" != "PONG" ]; then
             echo "  $(date) Can't ping redis master (${MASTER})"
             echo "Attempting to force failover (sentinel failover).."
 
             if [ "$SENTINEL_PORT" -eq 0 ]; then
                 echo "  on sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}"   --tls --cacert /tls-certs/ca.crt --cert /tls-certs/redis.crt --key /tls-certs/redis.key sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -9948,7 +9945,6 @@ data:
                 fi
             else
                 echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -9965,7 +9961,6 @@ data:
             else
                 echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
             fi
-            echo "  $(date).."
             MASTER="$(sentinel_get_master)"
             if [ "${MASTER}" ]; then
                 echo "  $(date) Found redis master (${MASTER})"
@@ -10219,7 +10214,6 @@ data:
     identify_master() {
         echo "Identifying redis master (get-master-addr-by-name).."
         echo "  using sentinel (argocd-redis-ha), sentinel group name (argocd)"
-        echo "  $(date).."
         MASTER="$(sentinel_get_master_retry 3)"
         if [ -n "${MASTER}" ]; then
             echo "  $(date) Found redis master (${MASTER})"
@@ -10332,14 +10326,12 @@ data:
         else
             echo "  ping (${MASTER}:${REDIS_PORT})"
         fi
-        echo "  $(date).."
         if [ "$(redis_ping_retry 3)" != "PONG" ]; then
             echo "  $(date) Can't ping redis master (${MASTER})"
             echo "Attempting to force failover (sentinel failover).."
 
             if [ "$SENTINEL_PORT" -eq 0 ]; then
                 echo "  on sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}"   --tls --cacert /tls-certs/ca.crt --cert /tls-certs/redis.crt --key /tls-certs/redis.key sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -10348,7 +10340,6 @@ data:
                 fi
             else
                 echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -10365,7 +10356,6 @@ data:
             else
                 echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
             fi
-            echo "  $(date).."
             MASTER="$(sentinel_get_master)"
             if [ "${MASTER}" ]; then
                 echo "  $(date) Found redis master (${MASTER})"
@@ -10443,6 +10433,8 @@ data:
   redis.conf: |
     dir "/data"
     port 6379
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
     bind 0.0.0.0
     maxmemory 0
     maxmemory-policy volatile-lru
@@ -11102,7 +11094,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.5.7-alpine
+      - image: haproxy:2.6.2-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -11138,7 +11130,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.5.7-alpine
+        image: haproxy:2.6.2-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:
@@ -11915,7 +11907,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/init-config: 1a8461b83fdc5614ce24a7d4d15976f9ef3b5c68a35475b5a3f57299c6f48ae8
+        checksum/init-config: 226aec192d2f29b5355769c9f1fbf093bf36c3a1e15b574b71fb8fe73fd37c05
       labels:
         app.kubernetes.io/name: argocd-redis-ha
     spec:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -508,7 +508,6 @@ data:
     identify_master() {
         echo "Identifying redis master (get-master-addr-by-name).."
         echo "  using sentinel (argocd-redis-ha), sentinel group name (argocd)"
-        echo "  $(date).."
         MASTER="$(sentinel_get_master_retry 3)"
         if [ -n "${MASTER}" ]; then
             echo "  $(date) Found redis master (${MASTER})"
@@ -621,14 +620,12 @@ data:
         else
             echo "  ping (${MASTER}:${REDIS_PORT})"
         fi
-        echo "  $(date).."
         if [ "$(redis_ping_retry 3)" != "PONG" ]; then
             echo "  $(date) Can't ping redis master (${MASTER})"
             echo "Attempting to force failover (sentinel failover).."
 
             if [ "$SENTINEL_PORT" -eq 0 ]; then
                 echo "  on sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}"   --tls --cacert /tls-certs/ca.crt --cert /tls-certs/redis.crt --key /tls-certs/redis.key sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -637,7 +634,6 @@ data:
                 fi
             else
                 echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -654,7 +650,6 @@ data:
             else
                 echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
             fi
-            echo "  $(date).."
             MASTER="$(sentinel_get_master)"
             if [ "${MASTER}" ]; then
                 echo "  $(date) Found redis master (${MASTER})"
@@ -908,7 +903,6 @@ data:
     identify_master() {
         echo "Identifying redis master (get-master-addr-by-name).."
         echo "  using sentinel (argocd-redis-ha), sentinel group name (argocd)"
-        echo "  $(date).."
         MASTER="$(sentinel_get_master_retry 3)"
         if [ -n "${MASTER}" ]; then
             echo "  $(date) Found redis master (${MASTER})"
@@ -1021,14 +1015,12 @@ data:
         else
             echo "  ping (${MASTER}:${REDIS_PORT})"
         fi
-        echo "  $(date).."
         if [ "$(redis_ping_retry 3)" != "PONG" ]; then
             echo "  $(date) Can't ping redis master (${MASTER})"
             echo "Attempting to force failover (sentinel failover).."
 
             if [ "$SENTINEL_PORT" -eq 0 ]; then
                 echo "  on sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}"   --tls --cacert /tls-certs/ca.crt --cert /tls-certs/redis.crt --key /tls-certs/redis.key sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -1037,7 +1029,6 @@ data:
                 fi
             else
                 echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
-                echo "  $(date).."
                 if redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
                     echo "  $(date) Failover returned with 'NOGOODSLAVE'"
                     echo "Setting defaults for this pod.."
@@ -1054,7 +1045,6 @@ data:
             else
                 echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
             fi
-            echo "  $(date).."
             MASTER="$(sentinel_get_master)"
             if [ "${MASTER}" ]; then
                 echo "  $(date) Found redis master (${MASTER})"
@@ -1132,6 +1122,8 @@ data:
   redis.conf: |
     dir "/data"
     port 6379
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
     bind 0.0.0.0
     maxmemory 0
     maxmemory-policy volatile-lru
@@ -1791,7 +1783,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.5.7-alpine
+      - image: haproxy:2.6.2-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -1827,7 +1819,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.5.7-alpine
+        image: haproxy:2.6.2-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:
@@ -2604,7 +2596,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/init-config: 1a8461b83fdc5614ce24a7d4d15976f9ef3b5c68a35475b5a3f57299c6f48ae8
+        checksum/init-config: 226aec192d2f29b5355769c9f1fbf093bf36c3a1e15b574b71fb8fe73fd37c05
       labels:
         app.kubernetes.io/name: argocd-redis-ha
     spec:


### PR DESCRIPTION
Follow up of #10032 

Upstream chart 4.17.8 now includes HAProxy v2.6.2 by default.  Previous version of [HAProxy](https://www.haproxy.org/) is EOL 2023-Q1.

Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

