### PR TITLE
docs: document revision history limit field

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -153,3 +153,9 @@ spec:
     kind: "*"
     managedFieldsManagers:
     - kube-controller-manager
+
+  # RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for
+  # informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional
+  # circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the
+  # space used to store the history, so we do not recommend increasing it.
+  revisionHistoryLimit: 10


### PR DESCRIPTION
Just to help folks who might not immediately recognize what the field does (e.g. https://github.com/argoproj/argo-cd/issues/10300).