### PR TITLE
docs: remove unused plugin config fields

### DIFF
--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -25,8 +25,6 @@ type PluginConfigSpec struct {
 	Init             Command  `json:"init,omitempty"`
 	Generate         Command  `json:"generate"`
 	Discover         Discover `json:"discover"`
-	AllowConcurrency bool     `json:"allowConcurrency"`
-	LockRepo         bool     `json:"lockRepo"`
 }
 
 //Discover holds find and fileName

--- a/cmpserver/plugin/testdata/ksonnet/config/plugin.yaml
+++ b/cmpserver/plugin/testdata/ksonnet/config/plugin.yaml
@@ -11,5 +11,3 @@ spec:
   discover:
     find:
       glob: "**/*/main.jsonnet"
-  allowConcurrency: false
-  lockRepo: false

--- a/cmpserver/plugin/testdata/kustomize-neg/config/plugin-bad.yaml
+++ b/cmpserver/plugin/testdata/kustomize-neg/config/plugin-bad.yaml
@@ -12,5 +12,3 @@ spec:
     find:
       command: [sh, -c, find . -name kustomization.yaml]
       glob: "**/*/kustomization.yaml"
-  allowConcurrency: true
-  lockRepo: false

--- a/cmpserver/plugin/testdata/kustomize/config/plugin.yaml
+++ b/cmpserver/plugin/testdata/kustomize/config/plugin.yaml
@@ -12,5 +12,3 @@ spec:
     find:
       command: [sh, -c, find . -name kustomization.yaml]
       glob: "**/*/kustomization.yaml"
-  allowConcurrency: true
-  lockRepo: false

--- a/docs/proposals/config-management-plugin-v2.md
+++ b/docs/proposals/config-management-plugin-v2.md
@@ -168,7 +168,6 @@ spec:
     check:
     - command: [-f ./main.ts]
       glob: "main.ts"
-  allowConcurrency: true # enables generating multiple manifests in parallel. 
 ```
 
 #### Config Management Plugin API Server (cmp-server)
@@ -320,6 +319,5 @@ spec:
     check:
     - command: [-f ./main.ts]
       glob: "main.ts"
-  allowConcurrency: true # enables generating multiple manifests in parallel. 
 ```
 2. Something magically patches the relevant manifest to add the sidecar.

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -336,8 +336,8 @@ spec:
                           and is only valid for applications sourced from Git.
                         type: string
                       plugin:
-                        description: ConfigManagementPlugin holds config management
-                          plugin specific options
+                        description: Plugin holds config management plugin specific
+                          options
                         properties:
                           env:
                             description: Env is a list of environment variable entries
@@ -682,8 +682,7 @@ spec:
                       and is only valid for applications sourced from Git.
                     type: string
                   plugin:
-                    description: ConfigManagementPlugin holds config management plugin
-                      specific options
+                    description: Plugin holds config management plugin specific options
                     properties:
                       env:
                         description: Env is a list of environment variable entries
@@ -1038,8 +1037,8 @@ spec:
                             and is only valid for applications sourced from Git.
                           type: string
                         plugin:
-                          description: ConfigManagementPlugin holds config management
-                            plugin specific options
+                          description: Plugin holds config management plugin specific
+                            options
                           properties:
                             env:
                               description: Env is a list of environment variable entries
@@ -1410,8 +1409,8 @@ spec:
                                   from Git.
                                 type: string
                               plugin:
-                                description: ConfigManagementPlugin holds config management
-                                  plugin specific options
+                                description: Plugin holds config management plugin
+                                  specific options
                                 properties:
                                   env:
                                     description: Env is a list of environment variable
@@ -1754,8 +1753,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable
@@ -2088,8 +2087,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -335,8 +335,8 @@ spec:
                           and is only valid for applications sourced from Git.
                         type: string
                       plugin:
-                        description: ConfigManagementPlugin holds config management
-                          plugin specific options
+                        description: Plugin holds config management plugin specific
+                          options
                         properties:
                           env:
                             description: Env is a list of environment variable entries
@@ -681,8 +681,7 @@ spec:
                       and is only valid for applications sourced from Git.
                     type: string
                   plugin:
-                    description: ConfigManagementPlugin holds config management plugin
-                      specific options
+                    description: Plugin holds config management plugin specific options
                     properties:
                       env:
                         description: Env is a list of environment variable entries
@@ -1037,8 +1036,8 @@ spec:
                             and is only valid for applications sourced from Git.
                           type: string
                         plugin:
-                          description: ConfigManagementPlugin holds config management
-                            plugin specific options
+                          description: Plugin holds config management plugin specific
+                            options
                           properties:
                             env:
                               description: Env is a list of environment variable entries
@@ -1409,8 +1408,8 @@ spec:
                                   from Git.
                                 type: string
                               plugin:
-                                description: ConfigManagementPlugin holds config management
-                                  plugin specific options
+                                description: Plugin holds config management plugin
+                                  specific options
                                 properties:
                                   env:
                                     description: Env is a list of environment variable
@@ -1753,8 +1752,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable
@@ -2087,8 +2086,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -336,8 +336,8 @@ spec:
                           and is only valid for applications sourced from Git.
                         type: string
                       plugin:
-                        description: ConfigManagementPlugin holds config management
-                          plugin specific options
+                        description: Plugin holds config management plugin specific
+                          options
                         properties:
                           env:
                             description: Env is a list of environment variable entries
@@ -682,8 +682,7 @@ spec:
                       and is only valid for applications sourced from Git.
                     type: string
                   plugin:
-                    description: ConfigManagementPlugin holds config management plugin
-                      specific options
+                    description: Plugin holds config management plugin specific options
                     properties:
                       env:
                         description: Env is a list of environment variable entries
@@ -1038,8 +1037,8 @@ spec:
                             and is only valid for applications sourced from Git.
                           type: string
                         plugin:
-                          description: ConfigManagementPlugin holds config management
-                            plugin specific options
+                          description: Plugin holds config management plugin specific
+                            options
                           properties:
                             env:
                               description: Env is a list of environment variable entries
@@ -1410,8 +1409,8 @@ spec:
                                   from Git.
                                 type: string
                               plugin:
-                                description: ConfigManagementPlugin holds config management
-                                  plugin specific options
+                                description: Plugin holds config management plugin
+                                  specific options
                                 properties:
                                   env:
                                     description: Env is a list of environment variable
@@ -1754,8 +1753,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable
@@ -2088,8 +2087,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -336,8 +336,8 @@ spec:
                           and is only valid for applications sourced from Git.
                         type: string
                       plugin:
-                        description: ConfigManagementPlugin holds config management
-                          plugin specific options
+                        description: Plugin holds config management plugin specific
+                          options
                         properties:
                           env:
                             description: Env is a list of environment variable entries
@@ -682,8 +682,7 @@ spec:
                       and is only valid for applications sourced from Git.
                     type: string
                   plugin:
-                    description: ConfigManagementPlugin holds config management plugin
-                      specific options
+                    description: Plugin holds config management plugin specific options
                     properties:
                       env:
                         description: Env is a list of environment variable entries
@@ -1038,8 +1037,8 @@ spec:
                             and is only valid for applications sourced from Git.
                           type: string
                         plugin:
-                          description: ConfigManagementPlugin holds config management
-                            plugin specific options
+                          description: Plugin holds config management plugin specific
+                            options
                           properties:
                             env:
                               description: Env is a list of environment variable entries
@@ -1410,8 +1409,8 @@ spec:
                                   from Git.
                                 type: string
                               plugin:
-                                description: ConfigManagementPlugin holds config management
-                                  plugin specific options
+                                description: Plugin holds config management plugin
+                                  specific options
                                 properties:
                                   env:
                                     description: Env is a list of environment variable
@@ -1754,8 +1753,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable
@@ -2088,8 +2087,8 @@ spec:
                               and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
+                            description: Plugin holds config management plugin specific
+                              options
                             properties:
                               env:
                                 description: Env is a list of environment variable

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -166,7 +166,7 @@ message ApplicationSource {
   // Directory holds path/directory specific options
   optional ApplicationSourceDirectory directory = 10;
 
-  // ConfigManagementPlugin holds config management plugin specific options
+  // Plugin holds config management plugin specific options
   optional ApplicationSourcePlugin plugin = 11;
 
   // Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -653,7 +653,7 @@ func schema_pkg_apis_application_v1alpha1_ApplicationSource(ref common.Reference
 					},
 					"plugin": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ConfigManagementPlugin holds config management plugin specific options",
+							Description: "Plugin holds config management plugin specific options",
 							Ref:         ref("github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1.ApplicationSourcePlugin"),
 						},
 					},

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -166,7 +166,7 @@ type ApplicationSource struct {
 	Kustomize *ApplicationSourceKustomize `json:"kustomize,omitempty" protobuf:"bytes,8,opt,name=kustomize"`
 	// Directory holds path/directory specific options
 	Directory *ApplicationSourceDirectory `json:"directory,omitempty" protobuf:"bytes,10,opt,name=directory"`
-	// ConfigManagementPlugin holds config management plugin specific options
+	// Plugin holds config management plugin specific options
 	Plugin *ApplicationSourcePlugin `json:"plugin,omitempty" protobuf:"bytes,11,opt,name=plugin"`
 	// Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
 	Chart string `json:"chart,omitempty" protobuf:"bytes,12,opt,name=chart"`

--- a/test/cmp/plugin.yaml
+++ b/test/cmp/plugin.yaml
@@ -9,5 +9,3 @@ spec:
   discover:
     find:
       glob: "**/kustomization.yaml"
-  allowConcurrency: true
-  lockRepo: false

--- a/test/e2e/testdata/cmp-find-command/plugin.yaml
+++ b/test/e2e/testdata/cmp-find-command/plugin.yaml
@@ -9,5 +9,3 @@ spec:
   discover:
     find:
       command: [sh, -c, find . -name env.yaml]
-  allowConcurrency: true
-  lockRepo: false

--- a/test/e2e/testdata/cmp-find-glob/plugin.yaml
+++ b/test/e2e/testdata/cmp-find-glob/plugin.yaml
@@ -12,5 +12,3 @@ spec:
     find:
       command: [sh, -c, find . -name kustomization.yaml]
       glob: "**/kustomization.yaml"
-  allowConcurrency: true
-  lockRepo: false


### PR DESCRIPTION
These fields aren't used in code, so they shouldn't be in documentation.