### PR TITLE
ci: Update K3s version matrix in e2e tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        k3s-version: [v1.24.1, v1.23.3, v1.22.6, v1.21.2]
+        k3s-version: [v1.24.3, v1.23.3, v1.22.6]
     needs: 
       - build-go
     env:


### PR DESCRIPTION
* Removed v1.21 since it's reached end-of-life. https://endoflife.date/kubernetes
* Bumped v1.24 patch version.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
