### PR TITLE
feat: add prompting to confirm remove of cluster resources

### DIFF
--- a/docs/user-guide/commands/argocd_cluster_rm.md
+++ b/docs/user-guide/commands/argocd_cluster_rm.md
@@ -17,6 +17,7 @@ argocd cluster rm cluster-name
 
 ```
   -h, --help   help for rm
+  -y, --yes    Turn off prompting to confirm remove of cluster resources
 ```
 
 ### Options inherited from parent commands

--- a/test/e2e/fixture/cluster/actions.go
+++ b/test/e2e/fixture/cluster/actions.go
@@ -106,14 +106,14 @@ func (a *Actions) Get() *Actions {
 func (a *Actions) DeleteByName() *Actions {
 	a.context.t.Helper()
 
-	a.runCli("cluster", "rm", a.context.name)
+	a.runCli("cluster", "rm", a.context.name, "--yes")
 	return a
 }
 
 func (a *Actions) DeleteByServer() *Actions {
 	a.context.t.Helper()
 
-	a.runCli("cluster", "rm", a.context.server)
+	a.runCli("cluster", "rm", a.context.server, "--yes")
 	return a
 }
 


### PR DESCRIPTION
Add prompting to confirm remove of cluster resources

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

