### PR TITLE
chore: Ignore VERSION file for Snyk scan

### DIFF
--- a/hack/snyk-report.sh
+++ b/hack/snyk-report.sh
@@ -37,9 +37,8 @@ git clone https://github.com/argoproj/argo-cd.git
 cd argo-cd
 git checkout master
 
-minor_version=$(sed -E 's/\.[0-9]+$//g' VERSION)
-patch_num=$(git tag -l | grep "v$minor_version." | grep -o "[[:digit:]]*$" | sort -g | tail -n 1)
-version="v$minor_version.$patch_num"
+version=$(git tag -l | sort -g | tail -n 1 )
+minor_version=$(echo $version | grep -Eo '[0-9]\.[0-9]+')
 versions="master "
 for i in 1 2 3; do
   if [ "$version" == "" ]; then break; fi


### PR DESCRIPTION
Signed-off-by: Omer Kahani <8766193+OmerKahani@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 


--
part of #8657

The VERSION file might include a version that is pre-release and doesn't have any tag. The suggested change takes the latest tag and ignores the version in the VERSION file.

Currently, the VERSION file has the value of: `v2.5.0`, which case an error in the original script. The suggested change will perform scan on version: `master v2.4.9 v2.3.7 v2.2.12`