### PR TITLE
chore: add security log issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_logs.md
+++ b/.github/ISSUE_TEMPLATE/security_logs.md
@@ -1,0 +1,19 @@
+---
+name: Security log
+about: Propose adding security-related logs or tagging existing logs with security fields
+title: "seclog: [Event Description]"
+labels: security-log
+assignees: notfromstatefarm
+---
+# Event to be logged
+
+Specify the event that needs to be logged or existing logs that need to be tagged.
+
+# Proposed level
+
+What security level should these events be logged under? Refer to https://argo-cd.readthedocs.io/en/latest/operator-manual/security/#security-field for more info.
+
+# Common Weakness Enumeration
+
+Is there an associated [CWE](https://cwe.mitre.org/) that could be tagged as well?
+


### PR DESCRIPTION
Signed-off-by: notfromstatefarm <86763948+notfromstatefarm@users.noreply.github.com>

Now that #10256 has been merged, we've got a lot of work to do. This formalizes a template for opening issues and I've also volunteered for being the default assignee (although I have no objections to removing this!)