### PR TITLE
feat: Support Custom Application Actions in UI #7577

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -633,9 +633,9 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
                             });
                         }
                     }
-                }));
+                })) as MenuItem[];
             })
-            .catch(() => items);
+            .catch(() => [] as MenuItem[]);
         return [
             {
                 iconClassName: 'fa fa-info-circle',
@@ -650,13 +650,11 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
             },
             {
                 iconClassName: 'fa fa-sync',
-                title: resourceActions.length ? (
+                title: (
                     <React.Fragment>
                         <ActionMenuItem actionLabel='Sync' />
                         <DropDownMenu items={resourceActions} anchor={() => <i className='fa fa-caret-down' />} />
                     </React.Fragment>
-                ) : (
-                    <ActionMenuItem actionLabel='Sync' />
                 ),
                 action: () => AppUtils.showDeploy('all', this.appContext)
             },

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -308,6 +308,33 @@ export class ApplicationsService {
             .then(res => (res.body.actions as models.ResourceAction[]) || []);
     }
 
+    public getApplicationActions(name: string, appNamespace: string): Promise<models.ResourceAction[]> {
+        return requests
+            .get(`/applications/${name}/resource/actions`)
+            .query({
+                namespace: appNamespace,
+                resourceName: name,
+                version: 'v1alpha1',
+                kind: 'Application',
+                group: 'argoproj.io'
+            })
+            .then(res => (res.body.actions as models.ResourceAction[]) || []);
+    }
+
+    public runApplicationAction(name: string, appNamespace: string, action: string): Promise<models.ResourceAction[]> {
+        return requests
+            .post(`/applications/${name}/resource/actions`)
+            .query({
+                namespace: appNamespace,
+                resourceName: name,
+                version: 'v1alpha1',
+                kind: 'Application',
+                group: 'argoproj.io'
+            })
+            .send(JSON.stringify(action))
+            .then(res => (res.body.actions as models.ResourceAction[]) || []);
+    }
+
     public patchResource(name: string, appNamspace: string, resource: models.ResourceNode, patch: string, patchType: string): Promise<models.State> {
         return requests
             .post(`/applications/${name}/resource`)


### PR DESCRIPTION
Prior to this change, custom resource actions targeting an Application
could be viewed and run from the CLI, but were not made available via
the UI.

This change adds any custom Application actions to a drop down menu on
the Sync button in all instances of the Application menu; if no such
actions exist the drop down UI element is omitted from the Sync button,
leaving the UI unchanged.

Follows https://github.com/argoproj/argo-cd/pull/10015

Closes #7577

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/7577) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* _n/a_: I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

