### PR TITLE
feat: add prompting to confirm remove of repository

### DIFF
--- a/docs/operator-manual/upgrading/2.5-2.6.md
+++ b/docs/operator-manual/upgrading/2.5-2.6.md
@@ -1,0 +1,6 @@
+# v2.4 to 2.5
+
+## argocd repo remove will prompt
+
+A prompt is added when using the command `argocd repo rm` to remove a repo. You can add the parameter `--yes` or `-y` to skip the prompt.
+

--- a/docs/user-guide/commands/argocd_repo_rm.md
+++ b/docs/user-guide/commands/argocd_repo_rm.md
@@ -10,6 +10,7 @@ argocd repo rm REPO [flags]
 
 ```
   -h, --help   help for rm
+  -y, --yes    Turn off prompting to confirm removal of repositories
 ```
 
 ### Options inherited from parent commands

--- a/test/e2e/fixture/repos/actions.go
+++ b/test/e2e/fixture/repos/actions.go
@@ -49,7 +49,7 @@ func (a *Actions) prepareCreateArgs(args []string) []string {
 
 func (a *Actions) Delete() *Actions {
 	a.context.t.Helper()
-	a.runCli("repo", "rm", a.context.path)
+	a.runCli("repo", "rm", a.context.path, "--yes")
 	return a
 }
 

--- a/test/e2e/repo_management_test.go
+++ b/test/e2e/repo_management_test.go
@@ -36,7 +36,7 @@ func TestAddRemovePublicRepo(t *testing.T) {
 		}
 		assert.True(t, exists)
 
-		_, err = fixture.RunCli("repo", "rm", repoUrl)
+		_, err = fixture.RunCli("repo", "rm", repoUrl, "--yes")
 		assert.NoError(t, err)
 
 		repo, err = repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
@@ -94,7 +94,7 @@ func TestAddRemoveHelmRepo(t *testing.T) {
 		}
 		assert.True(t, exists)
 
-		_, err = fixture.RunCli("repo", "rm", fixture.RepoURL(fixture.RepoURLTypeHelm))
+		_, err = fixture.RunCli("repo", "rm", fixture.RepoURL(fixture.RepoURLTypeHelm), "--yes")
 		assert.NoError(t, err)
 
 		repo, err = repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})


### PR DESCRIPTION
Add prompting to confirm remove of repository

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

