### PR TITLE
feat: add prompting to confirm deletion of gpg public key

### DIFF
--- a/docs/user-guide/commands/argocd_gpg_rm.md
+++ b/docs/user-guide/commands/argocd_gpg_rm.md
@@ -10,6 +10,7 @@ argocd gpg rm KEYID [flags]
 
 ```
   -h, --help   help for rm
+  -y, --yes    Turn off prompting to confirm deletion of GPG public key
 ```
 
 ### Options inherited from parent commands

--- a/test/e2e/fixture/gpgkeys/gpgkeys.go
+++ b/test/e2e/fixture/gpgkeys/gpgkeys.go
@@ -27,7 +27,7 @@ func AddGPGPublicKey() {
 }
 
 func DeleteGPGPublicKey() {
-	args := []string{"gpg", "rm", fixture.GpgGoodKeyID}
+	args := []string{"gpg", "rm", fixture.GpgGoodKeyID, "--yes"}
 	errors.FailOnErr(fixture.RunCli(args...))
 	if fixture.IsLocal() {
 		errors.CheckError(os.Remove(fmt.Sprintf("%s/app/config/gpg/source/%s", fixture.TmpDir, fixture.GpgGoodKeyID)))


### PR DESCRIPTION
Add prompting to confirm deletion of gpg public key.
The test result:
```shell
$ ./dist/argocd gpg rm FBE8575B2C49B77A
Are you sure you want to remove 'FBE8575B2C49B77A'? [y/n] n
The command to delete key with key ID 'FBE8575B2C49B77A' was cancelled.
$ ./dist/argocd gpg rm FBE8575B2C49B77A
Are you sure you want to remove 'FBE8575B2C49B77A'? [y/n] y
Deleted key with key ID FBE8575B2C49B77A
$ ./dist/argocd gpg rm FBE8575B2C49B77A -y
Deleted key with key ID FBE8575B2C49B77A
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

