### PR TITLE
Add a newline character to fix the render

### DIFF
--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -71,6 +71,7 @@ Scraped at the `argocd-server-metrics:8083/metrics` endpoint.
 reconciliation. |
 | `grpc_server_handled_total` | counter | Total number of RPCs completed on the server, regardless of success or failure. |
 | `grpc_server_msg_sent_total` | counter | Total number of gRPC stream messages sent by the server. |
+
 ## Repo Server Metrics
 Metrics about the Repo Server.
 Scraped at the `argocd-repo-server:8084/metrics` endpoint.


### PR DESCRIPTION
Fix this documentation rendering issue:

<img width="788" alt="image" src="https://user-images.githubusercontent.com/736329/186148434-00652d91-2307-4dbb-890e-9d9cd8543b30.png">

On https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/#api-server-metrics

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

