### PR TITLE
docs: add OpsVerse as an official user (USERS.md)

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -138,6 +138,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [openLooKeng](https://openlookeng.io)
 1. [OpenSaaS Studio](https://opensaas.studio)
 1. [Opensurvey](https://www.opensurvey.co.kr/)
+1. [OpsVerse](https://opsverse.io)
 1. [Optoro](https://www.optoro.com/)
 1. [Orbital Insight](https://orbitalinsight.com/)
 1. [p3r](https://www.p3r.one/)


### PR DESCRIPTION
OpsVerse uses ArgoCD (et al) across its cloud native infrastructure and is an advocate for it within its community.

Signed-off-by: sat-devopsnow <sat@opsverse.io>


Checklist:

* [x] (c) this does not need to be in the release notes.
* [x] This PR does not require and documentation / issue closing
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)


