### PR TITLE
fix: Set argocd-dex-server replicas to 1 to avoid split-brain issue

### DIFF
--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/component: dex-server
   name: argocd-dex-server
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -22339,6 +22339,7 @@ metadata:
     app.kubernetes.io/part-of: argocd
   name: argocd-dex-server
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1726,6 +1726,7 @@ metadata:
     app.kubernetes.io/part-of: argocd
   name: argocd-dex-server
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -21434,6 +21434,7 @@ metadata:
     app.kubernetes.io/part-of: argocd
   name: argocd-dex-server
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -821,6 +821,7 @@ metadata:
     app.kubernetes.io/part-of: argocd
   name: argocd-dex-server
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server


### PR DESCRIPTION
Until https://github.com/argoproj/argo-cd/issues/7089 is implemented, the dex-server should be limited to running as a single replica per [the docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#argocd-dex-server-argocd-redis):

> The argocd-dex-server uses an in-memory database, and two or more instances would have inconsistent data.

To ensure the dex server is not misconfigured, this forces the dex server deployment to 1 replica, thus ensuring only one instance is running and no inconsistent data will be returned.

Prior to this change, the deployment did not enforce 1 replica, which led to a situation I encountered where the dex-server was accidentally misconfigured with 2 replicas, leading to various random auth issues. That misconfiguration was allowed by subsequent manifest updates as they did not set `spec.replicas` so the existing value of 2 was used. This should help prevent any future misconfigurations.

Signed-off-by: Eric Tendian <erictendian@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

