### PR TITLE
fix: update deploymentConfig's healthcheck to wait for replicationController to be Available

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -173,6 +173,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Smilee.io](https://smilee.io)
 1. [Snapp](https://snapp.ir/)
 1. [Snyk](https://snyk.io/)
+1. [Softway Medical](https://www.softwaymedical.fr/)
 1. [South China Morning Post (SCMP)](https://www.scmp.com/)
 1. [Speee](https://speee.jp/)
 1. [Spendesk](https://spendesk.com/)

--- a/resource_customizations/apps.openshift.io/DeploymentConfig/health.lua
+++ b/resource_customizations/apps.openshift.io/DeploymentConfig/health.lua
@@ -3,7 +3,7 @@ if obj.status ~= nil then
   if obj.status.conditions ~= nil and obj.status.replicas ~= nil then
     numTrue = 0
     for i, condition in pairs(obj.status.conditions) do
-      if (condition.type == "Available" or condition.type == "Progressing") and condition.status == "True" then
+      if (condition.type == "Available" or (condition.type == "Progressing" and condition.reason == "NewReplicationControllerAvailable")) and condition.status == "True" then
         numTrue = numTrue + 1
       end
     end

--- a/resource_customizations/apps.openshift.io/DeploymentConfig/health_test.yaml
+++ b/resource_customizations/apps.openshift.io/DeploymentConfig/health_test.yaml
@@ -4,6 +4,10 @@ tests:
     message: "replication controller is waiting for pods to run"
   inputPath: testdata/progressing.yaml
 - healthStatus:
+    status: Progressing
+    message: "replication controller is waiting for pods to run"
+  inputPath: testdata/progressing_rc_updated.yaml
+- healthStatus:
     status: Degraded
     message: "Deployment config is degraded"
   inputPath: testdata/degraded.yaml

--- a/resource_customizations/apps.openshift.io/DeploymentConfig/testdata/progressing_rc_updated.yaml
+++ b/resource_customizations/apps.openshift.io/DeploymentConfig/testdata/progressing_rc_updated.yaml
@@ -1,0 +1,66 @@
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example
+  namespace: default
+spec:
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      maxUnavailable: 25%
+      maxSurge: 25%
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ConfigChange
+  replicas: 3
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    app: httpd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: httpd
+    spec:
+      containers:
+        - name: httpd
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+status:
+  observedGeneration: 1
+  details:
+    message: config change
+    causes:
+      - type: ConfigChange
+  availableReplicas: 3
+  conditions:
+    - type: Available
+      status: 'True'
+      lastUpdateTime: '2021-08-25T23:48:29Z'
+      lastTransitionTime: '2021-08-25T23:48:29Z'
+      message: Deployment config has minimum availability.
+    - type: Progressing
+      status: 'True'
+      lastUpdateTime: '2021-08-25T23:48:29Z'
+      lastTransitionTime: '2021-08-25T23:48:15Z'
+      reason: ReplicationControllerUpdated
+      message: replication controller "example-1" is progressing
+  replicas: 3
+  readyReplicas: 3


### PR DESCRIPTION
This PR follows the discussion [10434](https://github.com/argoproj/argo-cd/discussions/10434).

To quote @iam-veeramalla:
```md
DeploymentConfig should be considered healthy either when the `deployer pod is in completed state` or `replicationController is in available state`.
```

This allows, among other things, to leverage the waves and phases mechanisms of ArgoCD to deploy multiple resources sequentially when using the DeploymentConfig ressource.

A test has been added to make explicit that a DC for which the replicationController is updated but not yet available is expected to be in a `Progressing` state and not `Healthy`

Signed-off-by: Roncajolo Gerald <groncajolo@softwaymedical.fr>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the Details link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
~~* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.~~
No related issue as the PR has been made following a discussion. Tell me if one is needed! 
* [x] Does this PR require documentation updates? -> No
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 