### PR TITLE
fix(ui): Remove application namespace field in app creation

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -202,16 +202,7 @@ export const ApplicationCreatePanel = (props: {
                                                         component={Text}
                                                     />
                                                 </div>
-                                                <div className='argo-form-row'>
-                                                    <FormField
-                                                        formApi={api}
-                                                        label='Application Namespace'
-                                                        qeId='application-create-field-app-namespace'
-                                                        field='metadata.namespace'
-                                                        component={Text}
-                                                    />
-                                                </div>
-                                                <div className='argo-form-row'>
+                                               <div className='argo-form-row'>
                                                     <FormField
                                                         formApi={api}
                                                         label='Project Name'

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -202,7 +202,7 @@ export const ApplicationCreatePanel = (props: {
                                                         component={Text}
                                                     />
                                                 </div>
-                                               <div className='argo-form-row'>
+                                                <div className='argo-form-row'>
                                                     <FormField
                                                         formApi={api}
                                                         label='Project Name'

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -582,6 +582,13 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                 createApp={async app => {
                                                                     setAppCreatePending(true);
                                                                     try {
+                                                                        // Namespace may be specified in the app name. We need to
+                                                                        // parse and handle it accordingly.
+                                                                        if (app.metadata.name.includes('/')) {
+                                                                            var nns = app.metadata.name.split('/', 2)
+                                                                            app.metadata.name = nns[1]
+                                                                            app.metadata.namespace = nns[0]
+                                                                        }
                                                                         await services.applications.create(app);
                                                                         ctx.navigation.goto('.', {new: null}, {replace: true});
                                                                     } catch (e) {

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -582,13 +582,6 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                 createApp={async app => {
                                                                     setAppCreatePending(true);
                                                                     try {
-                                                                        // Namespace may be specified in the app name. We need to
-                                                                        // parse and handle it accordingly.
-                                                                        if (app.metadata.name.includes('/')) {
-                                                                            const nns = app.metadata.name.split('/', 2);
-                                                                            app.metadata.name = nns[1];
-                                                                            app.metadata.namespace = nns[0];
-                                                                        }
                                                                         await services.applications.create(app);
                                                                         ctx.navigation.goto('.', {new: null}, {replace: true});
                                                                     } catch (e) {

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -585,9 +585,9 @@ export const ApplicationsList = (props: RouteComponentProps<{}>) => {
                                                                         // Namespace may be specified in the app name. We need to
                                                                         // parse and handle it accordingly.
                                                                         if (app.metadata.name.includes('/')) {
-                                                                            var nns = app.metadata.name.split('/', 2)
-                                                                            app.metadata.name = nns[1]
-                                                                            app.metadata.namespace = nns[0]
+                                                                            const nns = app.metadata.name.split('/', 2);
+                                                                            app.metadata.name = nns[1];
+                                                                            app.metadata.namespace = nns[0];
                                                                         }
                                                                         await services.applications.create(app);
                                                                         ctx.navigation.goto('.', {new: null}, {replace: true});

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -120,6 +120,13 @@ export class ApplicationsService {
     }
 
     public create(app: models.Application): Promise<models.Application> {
+        // Namespace may be specified in the app name. We need to parse and
+        // handle it accordingly.
+        if (app.metadata.name.includes('/')) {
+            const nns = app.metadata.name.split('/', 2);
+            app.metadata.name = nns[1];
+            app.metadata.namespace = nns[0];
+        }
         return requests
             .post(`/applications`)
             .send(app)


### PR DESCRIPTION
This removes the newly introduced "Application namespace" field in the app creation dialog.

Namespace is now inferred from the application name, similar to how the CLI does it. E.g. the application name `somens/someapp` would create the app `someapp` in the namespace `somens`.

If namespace is omitted, the app will be created in the control plane's namespace.

Fixes #10392

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

