### PR TITLE
feat: add skip-test-tls flag to optionally skip testing for tls (#9679)

### DIFF
--- a/docs/user-guide/commands/argocd_login.md
+++ b/docs/user-guide/commands/argocd_login.md
@@ -29,6 +29,7 @@ argocd login cd.argoproj.io --core
   -h, --help              help for login
       --name string       name to use for the context
       --password string   the password of an account to authenticate
+      --skip-test-tls     Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)
       --sso               perform SSO login
       --sso-port int      port to run local OAuth2 login application (default 8085)
       --username string   the username of an account to authenticate


### PR DESCRIPTION
This issue fixes #9679 by implementing a new CLI flag `--skip-test-tls`, which optionally skips checking whether the server is configured with tls.

As mentioned in the related issue, adding this flag is probably the best solution here: https://github.com/argoproj/argo-cd/issues/9679#issuecomment-1185752420

My company is blocked from updating the argocd-cli at the moment, same as many others using AWS ELB in the setup. This MR at least gives us a way forward by using the new flag.

Let me know if I need to make any further adjustments.

Thanks and best regards!

Signed-off-by: msvechla <m.svechla@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

