### PR TITLE
chore: Remove bad symlink used for tests

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -137,31 +137,6 @@ func newServiceWithCommitSHA(root, revision string) *Service {
 	return service
 }
 
-// createSymlink creates a symlink with name linkName to file destName in
-// workingDir
-func createSymlink(t *testing.T, workingDir, destName, linkName string) error {
-	oldWorkingDir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	if workingDir != "" {
-		err = os.Chdir(workingDir)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if err := os.Chdir(oldWorkingDir); err != nil {
-				t.Fatal(err.Error())
-			}
-		}()
-	}
-	err = os.Symlink(destName, linkName)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func TestGenerateYamlManifestInDir(t *testing.T) {
 	service := newService("../../manifests/base")
 
@@ -2080,9 +2055,9 @@ func Test_getPotentiallyValidManifests(t *testing.T) {
 	t.Run("circular link should throw an error", func(t *testing.T) {
 		const testDir = "./testdata/circular-link"
 		require.DirExists(t, testDir)
-		require.NoError(t, createSymlink(t, testDir, "a.json", "b.json"))
+		require.NoError(t, fileutil.CreateSymlink(t, testDir, "a.json", "b.json"))
 		defer os.Remove(path.Join(testDir, "a.json"))
-		require.NoError(t, createSymlink(t, testDir, "b.json", "a.json"))
+		require.NoError(t, fileutil.CreateSymlink(t, testDir, "b.json", "a.json"))
 		defer os.Remove(path.Join(testDir, "b.json"))
 		manifests, err := getPotentiallyValidManifests(logCtx, "./testdata/circular-link", "./testdata/circular-link", false, "", "", resource.MustParse("0"))
 		assert.Empty(t, manifests)
@@ -2180,9 +2155,9 @@ func Test_findManifests(t *testing.T) {
 	t.Run("circular link should throw an error", func(t *testing.T) {
 		const testDir = "./testdata/circular-link"
 		require.DirExists(t, testDir)
-		require.NoError(t, createSymlink(t, testDir, "a.json", "b.json"))
+		require.NoError(t, fileutil.CreateSymlink(t, testDir, "a.json", "b.json"))
 		defer os.Remove(path.Join(testDir, "a.json"))
-		require.NoError(t, createSymlink(t, testDir, "b.json", "a.json"))
+		require.NoError(t, fileutil.CreateSymlink(t, testDir, "b.json", "a.json"))
 		defer os.Remove(path.Join(testDir, "b.json"))
 		manifests, err := findManifests(logCtx, "./testdata/circular-link", "./testdata/circular-link", nil, noRecurse, nil, resource.MustParse("0"))
 		assert.Empty(t, manifests)

--- a/test/fixture/path/files.go
+++ b/test/fixture/path/files.go
@@ -81,6 +81,7 @@ func copySingleFile(src string, dest string, mode os.FileInfo) error {
 // CreateSymlink creates a symlink with name linkName to file destName in
 // workingDir
 func CreateSymlink(t *testing.T, workingDir, destName, linkName string) error {
+	t.Helper()
 	oldWorkingDir, err := os.Getwd()
 	if err != nil {
 		return err

--- a/test/fixture/path/files.go
+++ b/test/fixture/path/files.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"testing"
 )
 
 // CopyDir copies the contents of a directory from 'src' to 'dest'
@@ -74,5 +75,30 @@ func copySingleFile(src string, dest string, mode os.FileInfo) error {
 		return err
 	}
 
+	return nil
+}
+
+// CreateSymlink creates a symlink with name linkName to file destName in
+// workingDir
+func CreateSymlink(t *testing.T, workingDir, destName, linkName string) error {
+	oldWorkingDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if workingDir != "" {
+		err = os.Chdir(workingDir)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := os.Chdir(oldWorkingDir); err != nil {
+				t.Fatal(err.Error())
+			}
+		}()
+	}
+	err = os.Symlink(destName, linkName)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/util/app/path/path_test.go
+++ b/util/app/path/path_test.go
@@ -1,9 +1,14 @@
 package path
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fileutil "github.com/argoproj/argo-cd/v2/test/fixture/path"
 )
 
 func TestPathRoot(t *testing.T) {
@@ -77,7 +82,10 @@ func TestBadSymlinks3(t *testing.T) {
 
 // No absolute symlinks allowed
 func TestAbsSymlink(t *testing.T) {
-	err := CheckOutOfBoundsSymlinks("./testdata/abslink")
+	const testDir = "./testdata/abslink"
+	require.NoError(t, fileutil.CreateSymlink(t, testDir, "/somethingbad", "abslink"))
+	defer os.Remove(path.Join(testDir, "abslink"))
+	err := CheckOutOfBoundsSymlinks(testDir)
 	oobError := &OutOfBoundsSymlinkError{}
 	assert.ErrorAs(t, err, &oobError)
 	assert.Equal(t, oobError.File, "abslink")

--- a/util/app/path/testdata/abslink/abslink
+++ b/util/app/path/testdata/abslink/abslink
@@ -1,1 +1,0 @@
-/somethingbad


### PR DESCRIPTION
Removes a symlink which points outside the repositry and breaks some build systems.

Instead, create the symlink on the fly.

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

