### PR TITLE
 fix: #10536 Allow merging Cluster Decision values key into Template params["values"] and "values.%s"

### DIFF
--- a/applicationset/generators/duck_type.go
+++ b/applicationset/generators/duck_type.go
@@ -210,8 +210,23 @@ func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.A
 				continue
 			}
 
+			if values, ok := cluster.(map[string]interface{})["values"]; ok {
+				for key, value := range values.(map[string]interface{}) {
+					if v, ok := value.(string); ok {
+						appSetGenerator.ClusterDecisionResource.Values[key] = v
+					} else {
+						log.WithField(fmt.Sprintf("decision values %s", key), value).Warning("not a string")
+					}
+				}
+				delete(cluster.(map[string]interface{}), "values")
+			}
+
 			for key, value := range cluster.(map[string]interface{}) {
-				params[key] = value.(string)
+				if v, ok := value.(string); ok {
+					params[key] = v
+				} else {
+					log.WithField(fmt.Sprintf("decision value %s", key), value).Warning("not a string")
+				}
 			}
 
 			for key, value := range appSetGenerator.ClusterDecisionResource.Values {

--- a/applicationset/generators/duck_type_test.go
+++ b/applicationset/generators/duck_type_test.go
@@ -116,6 +116,28 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 		},
 	}
 
+	duckTypeProdOnlyWithValues := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": resourceApiVersion,
+			"kind":       "Duck",
+			"metadata": map[string]interface{}{
+				"name":      resourceName,
+				"namespace": "namespace",
+				"labels":    map[string]interface{}{"duck": "spotted"},
+			},
+			"status": map[string]interface{}{
+				"decisions": []interface{}{
+					map[string]interface{}{
+						"clusterName": "production-01",
+						"values": map[string]interface{}{
+							"targetRef": "branch",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	duckTypeEmpty := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": resourceApiVersion,
@@ -191,6 +213,18 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 			},
 			expected: []map[string]interface{}{
 				{"clusterName": "production-01", "values.foo": "bar", "name": "production-01", "server": "https://production-01.example.com"},
+			},
+			expectedError: nil,
+		},
+		{
+			name:         "production-only-with-values",
+			resourceName: resourceName,
+			resource:     duckTypeProdOnlyWithValues,
+			values: map[string]string{
+				"foo": "bar",
+			},
+			expected: []map[string]interface{}{
+				{"values.targetRef": "branch", "clusterName": "production-01", "values.foo": "bar", "name": "production-01", "server": "https://production-01.example.com"},
 			},
 			expectedError: nil,
 		},
@@ -414,6 +448,28 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 		},
 	}
 
+	duckTypeProdOnlyWithValues := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": resourceApiVersion,
+			"kind":       "Duck",
+			"metadata": map[string]interface{}{
+				"name":      resourceName,
+				"namespace": "namespace",
+				"labels":    map[string]interface{}{"duck": "spotted"},
+			},
+			"status": map[string]interface{}{
+				"decisions": []interface{}{
+					map[string]interface{}{
+						"clusterName": "production-01",
+						"values": map[string]interface{}{
+							"targetRef": "branch",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	duckTypeEmpty := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": resourceApiVersion,
@@ -489,6 +545,18 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 			},
 			expected: []map[string]interface{}{
 				{"clusterName": "production-01", "values": map[string]string{"foo": "bar"}, "name": "production-01", "server": "https://production-01.example.com"},
+			},
+			expectedError: nil,
+		},
+		{
+			name:         "production-only-with-values",
+			resourceName: resourceName,
+			resource:     duckTypeProdOnlyWithValues,
+			values: map[string]string{
+				"foo": "bar",
+			},
+			expected: []map[string]interface{}{
+				{"clusterName": "production-01", "values": map[string]string{"foo": "bar", "targetRef": "branch"}, "name": "production-01", "server": "https://production-01.example.com"},
 			},
 			expectedError: nil,
 		},


### PR DESCRIPTION
Fixes #10536

Fix interface conversion panic with string type check

Adds ability to provide values map[string]string in DuckType CRD which are copied
into the ClusterDecisionResource.Values. This allows for dynamic templating
values that are interoperable with values defined in other generators via the
Merge Generator.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

