### PR TITLE
Fix Broken Link in Getting Started Docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -32,7 +32,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/st
 This default installation will have a self-signed certificate and cannot be accessed without a bit of extra work.
 Do one of:
 
-* Follow the [instructions to configure a certificate](operator-manual/tls) (and ensure that the client OS trusts it).
+* Follow the [instructions to configure a certificate](operator-manual/tls.md) (and ensure that the client OS trusts it).
 * Configure the client OS to trust the self signed certificate.
 * Use the --insecure flag on all Argo CD CLI operations in this guide.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -32,7 +32,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/st
 This default installation will have a self-signed certificate and cannot be accessed without a bit of extra work.
 Do one of:
 
-* Follow the [instructions to configure a certificate](./operator-manual/tls) (and ensure that the client OS trusts it).
+* Follow the [instructions to configure a certificate](operator-manual/tls) (and ensure that the client OS trusts it).
 * Configure the client OS to trust the self signed certificate.
 * Use the --insecure flag on all Argo CD CLI operations in this guide.
 


### PR DESCRIPTION
Signed-off-by: Greg Knoblauch <knoblauch.greg@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

