### PR TITLE
docs: update troubleshooting to reflect merge in argo-cd and add map examples in services 

### DIFF
--- a/docs/operator-manual/notifications/troubleshooting.md
+++ b/docs/operator-manual/notifications/troubleshooting.md
@@ -61,14 +61,17 @@ docker run --rm -it -w /src -v $(pwd):/src \
 
 ### In your cluster
 
-SSH into the running `argocd-notifications-controller` pod and use `kubectl exec` command to validate in-cluster
-configuration.
+If you are running the **old** `argoprojlabs/argocd-notifications`, exec into the running `argo-cd-notifications-controller`
+using `kubectl exec`. The binary is located in `/app/argocd-notifications`:
 
 **Example**
 ```bash
 kubectl exec -it argocd-notifications-controller-<pod-hash> \
   /app/argocd-notifications trigger get
 ```
+
+If you are running `quay.io/argoproj/argocd`, the client binary is not available in the image and you should
+look into running `argocd-notifications` CLI from your laptop.
 
 ## Commands
 


### PR DESCRIPTION
This follows questions asked on #argo-cd-notifications:
- It is not always clear whether the map keys are defined by ArgoCD or defined by the user. This small update aims to add example to ensure the information is clearer to the user. (If merged, generated docs will need an update: https://github.com/argoproj/notifications-engine/pull/104)
- The troubleshooting page has a procedure for when argocd-notifications was not merged into argo-cd. The binary location is wrong and the ability to execute the client from the new image is not available. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

