### PR TITLE
fix Insufficient permissions for appset list

### DIFF
--- a/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
@@ -32,6 +32,7 @@ rules:
   - "argoproj.io"
   resources:
   - "applications"
+  - "applicationsets"
   verbs:
   - get
   - list

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9604,6 +9604,7 @@ rules:
   - argoproj.io
   resources:
   - applications
+  - applicationsets
   verbs:
   - get
   - list

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9563,6 +9563,7 @@ rules:
   - argoproj.io
   resources:
   - applications
+  - applicationsets
   verbs:
   - get
   - list


### PR DESCRIPTION
The `argocd appset list` result:
```
$ argocd appset list
FATA[0000] rpc error: code = PermissionDenied desc = error listing ApplicationSets with selectors: applicationsets.argoproj.io is forbidden: User "system:serviceaccount:argocd:argocd-server" cannot list resource "applicationsets" in API group "argoproj.io" in the namespace "argocd"
```

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

