### PR TITLE
added ./ for broken url link

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -138,16 +138,16 @@ An example repository containing a guestbook application is available at
 
 ### Creating Apps Via CLI
 
+First we need to set the current namespace to argocd running the following command:
+
+```bash
+kubectl config set-context --current --namespace=argocd
+```
+
 Create the example guestbook application with the following command:
 
 ```bash
 argocd app create guestbook --repo https://github.com/argoproj/argocd-example-apps.git --path guestbook --dest-server https://kubernetes.default.svc --dest-namespace default
-```
-
-Command for setting default namespace:
-
-```bash
-kubectl config set-context --current --namespace=argocd
 ```
 
 ### Creating Apps Via UI

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -144,6 +144,12 @@ Create the example guestbook application with the following command:
 argocd app create guestbook --repo https://github.com/argoproj/argocd-example-apps.git --path guestbook --dest-server https://kubernetes.default.svc --dest-namespace default
 ```
 
+Command for setting default namespace:
+
+``'bash
+kubectl config set-context --current --namespace=argocd
+```
+
 ### Creating Apps Via UI
 
 Open a browser to the Argo CD external UI, and login by visiting the IP/hostname in a browser and use the credentials set in step 4.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -146,7 +146,7 @@ argocd app create guestbook --repo https://github.com/argoproj/argocd-example-ap
 
 Command for setting default namespace:
 
-``'bash
+```bash
 kubectl config set-context --current --namespace=argocd
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -32,7 +32,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/st
 This default installation will have a self-signed certificate and cannot be accessed without a bit of extra work.
 Do one of:
 
-* Follow the [instructions to configure a certificate](operator-manual/tls.md) (and ensure that the client OS trusts it).
+* Follow the [instructions to configure a certificate](./operator-manual/tls.md) (and ensure that the client OS trusts it).
 * Configure the client OS to trust the self signed certificate.
 * Use the --insecure flag on all Argo CD CLI operations in this guide.
 


### PR DESCRIPTION
I have modified the broken URL link that was giving the 404 error by adding ./at the beginning of the URL link.

fixes #10376
