### PR TITLE
fix(#9963):Add logic to handle for fileHandle.Close()

### DIFF
--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -289,7 +289,11 @@ func TestLFSClient(t *testing.T) {
 	fileHandle, err := os.Open(fmt.Sprintf("%s/test3.yaml", tempDir))
 	assert.NoError(t, err)
 	if err == nil {
-		defer fileHandle.Close()
+		defer func() {
+			if err = fileHandle.Close(); err != nil {
+				assert.NoError(t, err)
+			}
+		}()
 		text, err := io.ReadAll(fileHandle)
 		assert.NoError(t, err)
 		if err == nil {


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Fix(#9963):Add logic to handle for fileHandle.Close()
Close: https://github.com/argoproj/argo-cd/issues/9963

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

