### PR TITLE
fix: Application details page crashes with JS error

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -432,7 +432,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
                                                     />
                                                 )) || (
                                                     <DataLoader
-                                                        input={{filteredRes}}
+                                                        input={{filteredRes: filteredRes.map(res => AppUtils.nodeKey(res))}}
                                                         load={async () => {
                                                             const liveStatePromises = filteredRes.map(async resource => {
                                                                 const resourceRow: any = {...resource, group: resource.group || ''};


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/argo-cd/issues/10633

DataLoader component serializes `input` property value to JSON to check if it changed. https://github.com/argoproj/argo-ui/blob/7849bcd279fb0cafeb86481d9cfd6c5a0bbb443b/src/components/data-loader.tsx#L41

Looks like `filteredRes` contains a self-referenced object and only used to force data load reload when list of selected objects changes. The PR ensure that `input` get only list of selected object keys, so DataLoader still re-loads when selection changes but no longer crashes due to self referenced objects.