### PR TITLE
fix: only port-forward pods that are running and ready (#10610)

### DIFF
--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -361,3 +361,13 @@ func (a *Actions) SetTrackingLabel(trackingLabel string) *Actions {
 	fixture.SetTrackingLabel(trackingLabel)
 	return a
 }
+
+func (a *Actions) StopAPIServer() *Actions {
+	fixture.StopAPIServer()
+	return a
+}
+
+func (a *Actions) RollbackAPIServer() *Actions {
+	fixture.RollbackAPIServer()
+	return a
+}

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -825,6 +825,32 @@ func RestartAPIServer() {
 	}
 }
 
+// RollbackAPIServer performs a rollback of the API server deployemt.
+func RollbackAPIServer() {
+	if IsRemote() {
+		log.Infof("Waiting for API server to restart")
+		prefix := os.Getenv("ARGOCD_E2E_NAME_PREFIX")
+		workload := "argocd-server"
+		if prefix != "" {
+			workload = prefix + "-server"
+		}
+		FailOnErr(Run("", "kubectl", "rollout", "undo", "deployment", workload))
+	}
+}
+
+// StopAPIServer stops the API server deployemt.
+func StopAPIServer() {
+	if IsRemote() {
+		log.Infof("Waiting for API server to restart")
+		prefix := os.Getenv("ARGOCD_E2E_NAME_PREFIX")
+		workload := "argocd-server"
+		if prefix != "" {
+			workload = prefix + "-server"
+		}
+		FailOnErr(Run("", "kubectl", "scale", "deployment", workload, "--replicas=0"))
+	}
+}
+
 // LocalOrRemotePath selects a path for a given application based on whether
 // tests are running local or remote.
 func LocalOrRemotePath(base string) string {


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo-cd/issues/10610

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

