### PR TITLE
feat: equality-based and set-based filtering by label keys and values for list, sync, delete and wait App commands (#10548)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1132,13 +1132,18 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 	var command = &cobra.Command{
 		Use:   "delete APPNAME",
 		Short: "Delete an application",
-		Example: `argocd app delete app1
+		Example: `  # Delete an app
+  argocd app delete my-app
 
-# Delete multiple apps
-argocd app delete app1 app2
+  # Delete multiple apps
+  argocd app delete my-app other-app
 
-# Delete apps by label
-argocd app delete -l foo=bar`,
+  # Delete apps by label
+  argocd app delete -l app.kubernetes.io/instance=my-app
+  argocd app delete -l app.kubernetes.io/instance!=my-app
+  argocd app delete -l app.kubernetes.io/instance
+  argocd app delete -l '!app.kubernetes.io/instance'
+  argocd app delete -l 'app.kubernetes.io/instance notin (my-app,other-app)'`,
 		Run: func(c *cobra.Command, args []string) {
 			ctx := c.Context()
 
@@ -1207,7 +1212,7 @@ argocd app delete -l foo=bar`,
 	command.Flags().BoolVar(&cascade, "cascade", true, "Perform a cascaded deletion of all application resources")
 	command.Flags().StringVarP(&propagationPolicy, "propagation-policy", "p", "foreground", "Specify propagation policy for deletion of application's resources. One of: foreground|background")
 	command.Flags().BoolVarP(&noPrompt, "yes", "y", false, "Turn off prompting to confirm cascaded deletion of application resources")
-	command.Flags().StringVarP(&selector, "selector", "l", "", "Delete all apps with matching label")
+	command.Flags().StringVarP(&selector, "selector", "l", "", "Delete all apps with matching label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.")
 	return command
 }
 
@@ -1266,7 +1271,11 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
   argocd app list
 
   # List apps by label, in this example we listing apps that are children of another app (aka app-of-apps)
-  argocd app list -l app.kubernetes.io/instance=my-app`,
+  argocd app list -l app.kubernetes.io/instance=my-app
+  argocd app list -l app.kubernetes.io/instance!=my-app
+  argocd app list -l app.kubernetes.io/instance
+  argocd app list -l '!app.kubernetes.io/instance'
+  argocd app list -l 'app.kubernetes.io/instance notin (my-app,other-app)'`,
 		Run: func(c *cobra.Command, args []string) {
 			ctx := c.Context()
 
@@ -1315,7 +1324,7 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: wide|name|json|yaml")
-	command.Flags().StringVarP(&selector, "selector", "l", "", "List apps by label")
+	command.Flags().StringVarP(&selector, "selector", "l", "", "List apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.")
 	command.Flags().StringArrayVarP(&projects, "project", "p", []string{}, "Filter by project name")
 	command.Flags().StringVarP(&repo, "repo", "r", "", "List apps by source repo URL")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only list applications in namespace")
@@ -1436,7 +1445,11 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
   argocd app wait my-app other-app
 
   # Wait for apps by label, in this example we waiting for apps that are children of another app (aka app-of-apps)
-  argocd app wait -l app.kubernetes.io/instance=apps`,
+  argocd app wait -l app.kubernetes.io/instance=my-app
+  argocd app wait -l app.kubernetes.io/instance!=my-app
+  argocd app wait -l app.kubernetes.io/instance
+  argocd app wait -l '!app.kubernetes.io/instance'
+  argocd app wait -l 'app.kubernetes.io/instance notin (my-app,other-app)'`,
 		Run: func(c *cobra.Command, args []string) {
 			ctx := c.Context()
 
@@ -1468,7 +1481,7 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&watch.health, "health", false, "Wait for health")
 	command.Flags().BoolVar(&watch.suspended, "suspended", false, "Wait for suspended")
 	command.Flags().BoolVar(&watch.degraded, "degraded", false, "Wait for degraded")
-	command.Flags().StringVarP(&selector, "selector", "l", "", "Wait for apps by label")
+	command.Flags().StringVarP(&selector, "selector", "l", "", "Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.")
 	command.Flags().StringArrayVar(&resources, "resource", []string{}, fmt.Sprintf("Sync only specific resources as GROUP%sKIND%sNAME. Fields may be blank. This option may be specified repeatedly", resourceFieldDelimiter, resourceFieldDelimiter))
 	command.Flags().BoolVar(&watch.operation, "operation", false, "Wait for pending operations")
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
@@ -1520,6 +1533,10 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 
   # Sync apps by label, in this example we sync apps that are children of another app (aka app-of-apps)
   argocd app sync -l app.kubernetes.io/instance=my-app
+  argocd app sync -l app.kubernetes.io/instance!=my-app
+  argocd app sync -l app.kubernetes.io/instance
+  argocd app sync -l '!app.kubernetes.io/instance'
+  argocd app sync -l 'app.kubernetes.io/instance notin (my-app,other-app)'
 
   # Sync a specific resource
   # Resource should be formatted as GROUP:KIND:NAME. If no GROUP is specified then :KIND:NAME
@@ -1751,7 +1768,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&prune, "prune", false, "Allow deleting unexpected resources")
 	command.Flags().StringVar(&revision, "revision", "", "Sync to a specific revision. Preserves parameter overrides")
 	command.Flags().StringArrayVar(&resources, "resource", []string{}, fmt.Sprintf("Sync only specific resources as GROUP%sKIND%sNAME. Fields may be blank. This option may be specified repeatedly", resourceFieldDelimiter, resourceFieldDelimiter))
-	command.Flags().StringVarP(&selector, "selector", "l", "", "Sync apps that match this label")
+	command.Flags().StringVarP(&selector, "selector", "l", "", "Sync apps that match this label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.")
 	command.Flags().StringArrayVar(&labels, "label", []string{}, "Sync only specific resources with a label. This option may be specified repeatedly.")
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
 	command.Flags().Int64Var(&retryLimit, "retry-limit", 0, "Max number of allowed sync retries")

--- a/docs/user-guide/commands/argocd_app_delete.md
+++ b/docs/user-guide/commands/argocd_app_delete.md
@@ -9,13 +9,18 @@ argocd app delete APPNAME [flags]
 ### Examples
 
 ```
-argocd app delete app1
+  # Delete an app
+  argocd app delete my-app
 
-# Delete multiple apps
-argocd app delete app1 app2
+  # Delete multiple apps
+  argocd app delete my-app other-app
 
-# Delete apps by label
-argocd app delete -l foo=bar
+  # Delete apps by label
+  argocd app delete -l app.kubernetes.io/instance=my-app
+  argocd app delete -l app.kubernetes.io/instance!=my-app
+  argocd app delete -l app.kubernetes.io/instance
+  argocd app delete -l '!app.kubernetes.io/instance'
+  argocd app delete -l 'app.kubernetes.io/instance notin (my-app,other-app)'
 ```
 
 ### Options
@@ -24,7 +29,7 @@ argocd app delete -l foo=bar
       --cascade                     Perform a cascaded deletion of all application resources (default true)
   -h, --help                        help for delete
   -p, --propagation-policy string   Specify propagation policy for deletion of application's resources. One of: foreground|background (default "foreground")
-  -l, --selector string             Delete all apps with matching label
+  -l, --selector string             Delete all apps with matching label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
   -y, --yes                         Turn off prompting to confirm cascaded deletion of application resources
 ```
 

--- a/docs/user-guide/commands/argocd_app_list.md
+++ b/docs/user-guide/commands/argocd_app_list.md
@@ -14,6 +14,10 @@ argocd app list [flags]
 
   # List apps by label, in this example we listing apps that are children of another app (aka app-of-apps)
   argocd app list -l app.kubernetes.io/instance=my-app
+  argocd app list -l app.kubernetes.io/instance!=my-app
+  argocd app list -l app.kubernetes.io/instance
+  argocd app list -l '!app.kubernetes.io/instance'
+  argocd app list -l 'app.kubernetes.io/instance notin (my-app,other-app)'
 ```
 
 ### Options
@@ -25,7 +29,7 @@ argocd app list [flags]
   -o, --output string          Output format. One of: wide|name|json|yaml (default "wide")
   -p, --project stringArray    Filter by project name
   -r, --repo string            List apps by source repo URL
-  -l, --selector string        List apps by label
+  -l, --selector string        List apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -17,6 +17,10 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
 
   # Sync apps by label, in this example we sync apps that are children of another app (aka app-of-apps)
   argocd app sync -l app.kubernetes.io/instance=my-app
+  argocd app sync -l app.kubernetes.io/instance!=my-app
+  argocd app sync -l app.kubernetes.io/instance
+  argocd app sync -l '!app.kubernetes.io/instance'
+  argocd app sync -l 'app.kubernetes.io/instance notin (my-app,other-app)'
 
   # Sync a specific resource
   # Resource should be formatted as GROUP:KIND:NAME. If no GROUP is specified then :KIND:NAME
@@ -48,7 +52,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --retry-backoff-max-duration duration   Max retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
       --retry-limit int                       Max number of allowed sync retries
       --revision string                       Sync to a specific revision. Preserves parameter overrides
-  -l, --selector string                       Sync apps that match this label
+  -l, --selector string                       Sync apps that match this label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
       --server-side                           Use server-side apply while syncing the application
       --strategy string                       Sync strategy (one of: apply|hook)
       --timeout uint                          Time out after this many seconds

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -16,7 +16,11 @@ argocd app wait [APPNAME.. | -l selector] [flags]
   argocd app wait my-app other-app
 
   # Wait for apps by label, in this example we waiting for apps that are children of another app (aka app-of-apps)
-  argocd app wait -l app.kubernetes.io/instance=apps
+  argocd app wait -l app.kubernetes.io/instance=my-app
+  argocd app wait -l app.kubernetes.io/instance!=my-app
+  argocd app wait -l app.kubernetes.io/instance
+  argocd app wait -l '!app.kubernetes.io/instance'
+  argocd app wait -l 'app.kubernetes.io/instance notin (my-app,other-app)'
 ```
 
 ### Options
@@ -27,7 +31,7 @@ argocd app wait [APPNAME.. | -l selector] [flags]
   -h, --help                   help for wait
       --operation              Wait for pending operations
       --resource stringArray   Sync only specific resources as GROUP:KIND:NAME. Fields may be blank. This option may be specified repeatedly
-  -l, --selector string        Wait for apps by label
+  -l, --selector string        Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
       --suspended              Wait for suspended
       --sync                   Wait for sync
       --timeout uint           Time out after this many seconds

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -132,15 +132,15 @@ func NewServer(
 
 // List returns list of applications
 func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*appv1.ApplicationList, error) {
-	labelsMap, err := labels.ConvertSelectorToLabelsMap(q.GetSelector())
+	selector, err := labels.Parse(q.GetSelector())
 	if err != nil {
-		return nil, fmt.Errorf("error converting selector to labels map: %w", err)
+		return nil, fmt.Errorf("error parsing the selector: %w", err)
 	}
 	var apps []*appv1.Application
 	if q.GetAppNamespace() == "" {
-		apps, err = s.appLister.List(labelsMap.AsSelector())
+		apps, err = s.appLister.List(selector)
 	} else {
-		apps, err = s.appLister.Applications(q.GetAppNamespace()).List(labelsMap.AsSelector())
+		apps, err = s.appLister.Applications(q.GetAppNamespace()).List(selector)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error listing apps with selectors: %w", err)


### PR DESCRIPTION
This PR resolves the `-l / --selector flag` part of the issue #10548 , where apps can be filtered with theirs labels and values. It achieves feature-parity with [kubectl](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).

List, Sync, Delete and Wait commands to manage applications can now be filtered by label keys and values. Matching apps must satisfy all of the specified label constraints, though they may have additional labels as well. Equality-based operators allowed are =, == and !=. Set-based operators allowed are exists, not exists, in & notin.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 