### PR TITLE
docs: Fix TLS configure link on getting started

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -32,7 +32,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/st
 This default installation will have a self-signed certificate and cannot be accessed without a bit of extra work.
 Do one of:
 
-* Follow the [instructions to configure a certificate](./operator-manual/tls.md) (and ensure that the client OS trusts it).
+* Follow the [instructions to configure a certificate](operator-manual/tls.md) (and ensure that the client OS trusts it).
 * Configure the client OS to trust the self signed certificate.
 * Use the --insecure flag on all Argo CD CLI operations in this guide.
 
@@ -123,12 +123,12 @@ for docker-desktop context, run:
 argocd cluster add docker-desktop
 ```
 
-The above command installs a ServiceAccount (`argocd-manager`), into the kube-system namespace of 
+The above command installs a ServiceAccount (`argocd-manager`), into the kube-system namespace of
 that kubectl context, and binds the service account to an admin-level ClusterRole. Argo CD uses this
 service account token to perform its management tasks (i.e. deploy/monitoring).
 
 !!! note
-    The rules of the `argocd-manager-role` role can be modified such that it only has `create`, `update`, `patch`, `delete` privileges to a limited set of namespaces, groups, kinds. 
+    The rules of the `argocd-manager-role` role can be modified such that it only has `create`, `update`, `patch`, `delete` privileges to a limited set of namespaces, groups, kinds.
     However `get`, `list`, `watch` privileges are required at the cluster-scope for Argo CD to function.
 
 ## 6. Create An Application From A Git Repository


### PR DESCRIPTION
Needs operator-manual root instead of nested under getting started

Co-authored-by: jmeridth <jmeridth@gmail.com>
Co-authored-by: rogerogers <rogerogers@outlook.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

