### PR TITLE
chore: upgrade dex to v2.32.1-distroless

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -406,7 +406,7 @@ jobs:
           git config --global user.email "john.doe@example.com"
       - name: Pull Docker image required for tests
         run: |
-          docker pull quay.io/dexidp/dex:v2.25.0
+          docker pull ghcr.io/dexidp/dex:v2.32.1-distroless
           docker pull argoproj/argo-cd-ci-builder:v1.0.0
           docker pull redis:7.0.4-alpine
       - name: Create target directory for binaries in the build-process

--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: dex
-        image: ghcr.io/dexidp/dex:v2.32.0-distroless
+        image: ghcr.io/dexidp/dex:v2.32.1-distroless
         imagePullPolicy: Always
         command: [/shared/argocd-dex, rundex]
         env:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10962,7 +10962,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.0-distroless
+        image: ghcr.io/dexidp/dex:v2.32.1-distroless
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1631,7 +1631,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.0-distroless
+        image: ghcr.io/dexidp/dex:v2.32.1-distroless
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10033,7 +10033,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.0-distroless
+        image: ghcr.io/dexidp/dex:v2.32.1-distroless
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -702,7 +702,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.0-distroless
+        image: ghcr.io/dexidp/dex:v2.32.1-distroless
         imagePullPolicy: Always
         name: dex
         ports:


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Argo CD version 2.5/master uses `ghcr.io/dexidp/dex:v2.32.0-distroless` while 2.2-4.x use `ghcr.io/dexidp/dex:v2.32.0`. The non distroless containers contain a few vulnerabilities at the container level. 

| CVE | Library | Score|
| -- | -- | -- |
|CVE-2022-30065 | busybox |7.8
|CVE-2022-37434 | zlib | 9.8


I created an issue upstream and they agreed to release dex:v2.32.1 which is now available and fixes these vulnerabilities.  However they normally only patch the latest 2 versions.  I would recommend that we switch to the distroless images.

Unfortunately at this time we cannot upgrade to dex:v2.33.x or dex:v2.34.x, please see #10617

Please consider cherry picking into 2.4, 2.3, and 2.2. 



Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

