### PR TITLE
fix: always prune on git fetch (#10664)

### DIFF
--- a/applicationset/services/repo_service_test.go
+++ b/applicationset/services/repo_service_test.go
@@ -163,7 +163,7 @@ func TestGetFiles(t *testing.T) {
 			revision:            "this-tag-does-not-exist",
 			pattern:             "*",
 			expectSubsetOfPaths: []string{},
-			expectedError:       fmt.Errorf("Error during fetching repo: `git fetch origin this-tag-does-not-exist --tags --force` failed exit status 128: fatal: couldn't find remote ref this-tag-does-not-exist"),
+			expectedError:       fmt.Errorf("Error during fetching repo: `git fetch origin this-tag-does-not-exist --tags --force --prune` failed exit status 128: fatal: couldn't find remote ref this-tag-does-not-exist"),
 		},
 		{
 			name: "pull a specific revision of example apps, and use a ** pattern",

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -320,9 +320,9 @@ func (m *nativeGitClient) IsLFSEnabled() bool {
 func (m *nativeGitClient) fetch(revision string) error {
 	var err error
 	if revision != "" {
-		err = m.runCredentialedCmd("git", "fetch", "origin", revision, "--tags", "--force")
+		err = m.runCredentialedCmd("git", "fetch", "origin", revision, "--tags", "--force", "--prune")
 	} else {
-		err = m.runCredentialedCmd("git", "fetch", "origin", "--tags", "--force")
+		err = m.runCredentialedCmd("git", "fetch", "origin", "--tags", "--force", "--prune")
 	}
 	return err
 }
@@ -334,19 +334,7 @@ func (m *nativeGitClient) Fetch(revision string) error {
 		defer done()
 	}
 
-	var err error
-
-	err = m.fetch(revision)
-	if err != nil {
-		errMsg := strings.ReplaceAll(err.Error(), "\n", "")
-		if strings.Contains(errMsg, "try running 'git remote prune origin'") {
-			// Prune any deleted refs, then try fetching again
-			if err := m.runCredentialedCmd("git", "remote", "prune", "origin"); err != nil {
-				return err
-			}
-			err = m.fetch(revision)
-		}
-	}
+	err := m.fetch(revision)
 
 	// When we have LFS support enabled, check for large files and fetch them too.
 	if err == nil && m.IsLFSEnabled() {


### PR DESCRIPTION
This should clean up any old branches and save on disk space, and fix any errors around bad branch names.

fixes #10664 

Most initial tests of timing the git fetch command with and without prune found that differences in amount of time on large repositories with many changes were within 10-50ms of each other, and with smaller repositories with low amounts of changes the difference was closer to un-measurable if not the same. 

I think this combined with possibly saving space and removing old refs adds up that it makes sense to auto prune on fetch so we can avoid random issues with git branches.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
    - (b) bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
    - Nothing to change
* [x] Does this PR require documentation updates?
    - I don't think so.
* [x] I've updated documentation as required by this PR.
    - N/A
* [x] Optional. My organization is added to USERS.md.
    - Not at this time
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
    - Tests for this case are already written, but git error message was different. Existing test should still work/pass for this.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

