### PR TITLE
chore: upgrade Dex to 2.35.0

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -406,7 +406,7 @@ jobs:
           git config --global user.email "john.doe@example.com"
       - name: Pull Docker image required for tests
         run: |
-          docker pull ghcr.io/dexidp/dex:v2.32.1-distroless
+          docker pull ghcr.io/dexidp/dex:v2.35.0-distroless
           docker pull argoproj/argo-cd-ci-builder:v1.0.0
           docker pull redis:7.0.5-alpine
       - name: Create target directory for binaries in the build-process

--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: dex
-        image: ghcr.io/dexidp/dex:v2.32.1-distroless
+        image: ghcr.io/dexidp/dex:v2.35.0-distroless
         imagePullPolicy: Always
         command: [/shared/argocd-dex, rundex]
         env:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10962,7 +10962,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.1-distroless
+        image: ghcr.io/dexidp/dex:v2.35.0-distroless
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1631,7 +1631,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.1-distroless
+        image: ghcr.io/dexidp/dex:v2.35.0-distroless
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10033,7 +10033,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.1-distroless
+        image: ghcr.io/dexidp/dex:v2.35.0-distroless
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -702,7 +702,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.32.1-distroless
+        image: ghcr.io/dexidp/dex:v2.35.0-distroless
         imagePullPolicy: Always
         name: dex
         ports:


### PR DESCRIPTION
Supersedes https://github.com/argoproj/argo-cd/pull/10617

Closes https://github.com/argoproj/argo-cd/pull/10615