### PR TITLE
chore: add script to generate release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -275,7 +275,7 @@ jobs:
           draft: ${{ env.DRAFT_RELEASE }}
           prerelease: ${{ env.PRE_RELEASE }}
           generate_release_notes: true
-          body: ${{ steps.release-notes.outputs.content }}  # Appended to the generated notes
+          body: ${{ steps.release-notes.outputs.content }}  # Pre-pended to the generated notes
           files: |
             dist/argocd-*
             /tmp/sbom.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -274,7 +274,8 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           draft: ${{ env.DRAFT_RELEASE }}
           prerelease: ${{ env.PRE_RELEASE }}
-          body: ${{ steps.release-notes.outputs.content }}
+          generate_release_notes: true
+          body: ${{ steps.release-notes.outputs.content }}  # Appended to the generated notes
           files: |
             dist/argocd-*
             /tmp/sbom.tar.gz

--- a/hack/generate-release-notes.sh
+++ b/hack/generate-release-notes.sh
@@ -66,18 +66,12 @@ more_log=$(git log --pretty="format:%s %ae" "$new_ref..$old_ref")
 
 new_commits=$(diff --new-line-format="" --unchanged-line-format="" <(echo "$less_log") <(echo "$more_log") | grep -v "Merge pull request from GHSA")
 new_commits_no_email=$(echo "$new_commits" | strip_last_word)
-features=$(echo "$new_commits_no_email" | grep '^feat' | to_list_items)
-fixes=$(echo "$new_commits_no_email" | grep '^fix' | to_list_items)
-docs=$(echo "$new_commits_no_email" | grep '^docs' | to_list_items)
-other=$(echo "$new_commits_no_email" | grep -v -e '^feat' -e '^fix' -e '^docs' | to_list_items)
 
 contributors_num=$(echo "$new_commits" | only_last_word | sort -u | nonempty_line_count)
 
 new_commits_num=$(echo "$new_commits" | nonempty_line_count)
-features_num=$(echo "$features" | nonempty_line_count)
-fixes_num=$(echo "$fixes" | nonempty_line_count)
-docs_num=$(echo "$docs" | nonempty_line_count)
-other_num=$(echo "$other" | nonempty_line_count)
+features_num=$(echo "$new_commits_no_email" | grep '^feat' | nonempty_line_count)
+fixes_num=$(echo "$new_commits_no_email" | grep '^fix' | nonempty_line_count)
 
 previous_contributors=$(git log --pretty="format:%an %ae" "$old_ref" | sort -uf)
 all_contributors=$(git log --pretty="format:%an %ae" "$new_ref" | sort -uf)
@@ -97,29 +91,5 @@ echo
 if [ "$new_contributors_num" -lt 20 ] && [ "$new_contributors_num" -gt 0 ]; then
   echo "A special thanks goes to the $new_contributors_num new contributors:"
   echo "$new_contributors_names"
-  echo
-fi
-if [ "$features_num" -gt 0 ]; then
-  echo "### Features"
-  echo
-  echo "$features"
-  echo
-fi
-if [ "$fixes_num" -gt 0 ]; then
-  echo "### Bug fixes"
-  echo
-  echo "$fixes"
-  echo
-fi
-if [ "$docs_num" -gt 0 ]; then
-  echo "### Documentation"
-  echo
-  echo "$docs"
-  echo
-fi
-if [ "$other_num" -gt 0 ]; then
-  echo "### Other"
-  echo
-  echo "$other"
   echo
 fi

--- a/hack/generate-release-notes.sh
+++ b/hack/generate-release-notes.sh
@@ -61,10 +61,10 @@ If upgrading from a different minor version, be sure to read the [upgrading](htt
 EOM
 
 # Adapted from https://stackoverflow.com/a/67029088/684776
-right_log=$(git log --pretty="format:%s %ae" --cherry-pick --left-only --no-merges "$new_ref...$old_ref")
-left_log=$(git log --pretty="format:%s %ae" "$new_ref..$old_ref")
+less_log=$(git log --pretty="format:%s %ae" --cherry-pick --left-only --no-merges "$new_ref...$old_ref")
+more_log=$(git log --pretty="format:%s %ae" "$new_ref..$old_ref")
 
-new_commits=$(comm -13 <(echo "$left_log") <(echo "$right_log") | grep -v "Merge pull request from GHSA")
+new_commits=$(diff --new-line-format="" --unchanged-line-format="" <(echo "$less_log") <(echo "$more_log") | grep -v "Merge pull request from GHSA")
 new_commits_no_email=$(echo "$new_commits" | strip_last_word)
 features=$(echo "$new_commits_no_email" | grep '^feat' | to_list_items)
 fixes=$(echo "$new_commits_no_email" | grep '^fix' | to_list_items)

--- a/hack/generate-release-notes.sh
+++ b/hack/generate-release-notes.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+if [ "$1" == "" ] || [ "$2" == "" ] || [ "$3" == "" ]; then
+cat <<-EOM
+USAGE:
+
+  generate-release-notes.sh NEW_REF OLD_REF NEW_VERSION
+
+EXAMPLES:
+
+  # For releasing a new minor version:
+  generate-release-notes.sh release-2.5 release-2.4 v2.5.0-rc1 > /tmp/release.md
+
+  # For a patch release:
+  generate-release-notes.sh release-2.4 v2.4.13 v2.4.14 > /tmp/release.md
+EOM
+exit 1
+fi
+
+function to_list_items() {
+  sed 's/^/- /'
+}
+
+function strip_last_word() {
+  sed 's/ [^ ]*$//'
+}
+
+function nonempty_line_count() {
+  sed '/^\s*$/d' | wc -l | tr -d ' \n'
+}
+
+function only_last_word() {
+  awk 'NF>1{print $NF}'
+}
+
+new_ref=$1
+old_ref=$2
+version=$3
+
+cat <<-EOM
+## Quick Start
+
+### Non-HA:
+
+\`\`\`shell
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/$version/manifests/install.yaml
+\`\`\`
+
+### HA:
+
+\`\`\`shell
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/$version/manifests/ha/install.yaml
+\`\`\`
+
+## Upgrading
+
+If upgrading from a different minor version, be sure to read the [upgrading](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/overview/)
+documentation.
+
+EOM
+
+# Adapted from https://stackoverflow.com/a/67029088/684776
+right_log=$(git log --pretty="format:%s %ae" --cherry-pick --left-only --no-merges "$new_ref...$old_ref")
+left_log=$(git log --pretty="format:%s %ae" "$new_ref..$old_ref")
+
+new_commits=$(comm -13 <(echo "$left_log") <(echo "$right_log") | grep -v "Merge pull request from GHSA")
+new_commits_no_email=$(echo "$new_commits" | strip_last_word)
+features=$(echo "$new_commits_no_email" | grep '^feat' | to_list_items)
+fixes=$(echo "$new_commits_no_email" | grep '^fix' | to_list_items)
+docs=$(echo "$new_commits_no_email" | grep '^docs' | to_list_items)
+other=$(echo "$new_commits_no_email" | grep -v -e '^feat' -e '^fix' -e '^docs' | to_list_items)
+
+contributors_num=$(echo "$new_commits" | only_last_word | sort -u | nonempty_line_count)
+
+new_commits_num=$(echo "$new_commits" | nonempty_line_count)
+features_num=$(echo "$features" | nonempty_line_count)
+fixes_num=$(echo "$fixes" | nonempty_line_count)
+docs_num=$(echo "$docs" | nonempty_line_count)
+other_num=$(echo "$other" | nonempty_line_count)
+
+previous_contributors=$(git log --pretty="format:%an %ae" "$old_ref" | sort -uf)
+all_contributors=$(git log --pretty="format:%an %ae" "$new_ref" | sort -uf)
+new_contributors=$(diff --new-line-format="" --unchanged-line-format="" <(echo "$all_contributors") <(echo "$previous_contributors"))
+new_contributors_num=$(echo "$new_contributors" | only_last_word | nonempty_line_count)  # Count contributors by email
+new_contributors_names=$(echo "$new_contributors" | strip_last_word | to_list_items)
+
+new_contributors_message=""
+if [ "$new_contributors_num" -gt 0 ]; then
+  new_contributors_message=" ($new_contributors_num of them new)"
+fi
+
+echo "## Changes"
+echo
+echo "This release includes $new_commits_num contributions from $contributors_num contributors$new_contributors_message with $features_num features and $fixes_num bug fixes."
+echo
+if [ "$new_contributors_num" -lt 20 ] && [ "$new_contributors_num" -gt 0 ]; then
+  echo "A special thanks goes to the $new_contributors_num new contributors:"
+  echo "$new_contributors_names"
+  echo
+fi
+if [ "$features_num" -gt 0 ]; then
+  echo "### Features"
+  echo
+  echo "$features"
+  echo
+fi
+if [ "$fixes_num" -gt 0 ]; then
+  echo "### Bug fixes"
+  echo
+  echo "$fixes"
+  echo
+fi
+if [ "$docs_num" -gt 0 ]; then
+  echo "### Documentation"
+  echo
+  echo "$docs"
+  echo
+fi
+if [ "$other_num" -gt 0 ]; then
+  echo "### Other"
+  echo
+  echo "$other"
+  echo
+fi

--- a/hack/generate-release-notes.sh
+++ b/hack/generate-release-notes.sh
@@ -56,8 +56,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/$v
 
 ## Upgrading
 
-If upgrading from a different minor version, be sure to read the [upgrading](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/overview/)
-documentation.
+If upgrading from a different minor version, be sure to read the [upgrading](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/overview/) documentation.
 
 EOM
 

--- a/hack/trigger-release.sh
+++ b/hack/trigger-release.sh
@@ -30,6 +30,7 @@ cleanup() {
 
 if test "${NEW_TAG}" = "" -o "${GIT_REMOTE}" = ""; then
 	echo "!! Usage: $0 <release tag> <remote> [path to release notes file]" >&2
+	echo "You can use generate-release-notes.sh to generate the release notes file." >&2
 	exit 1
 fi
 


### PR DESCRIPTION
This script generates some stats to add to the release notes. 

It also uses GitHub's auto-generated release notes for the details. Rollouts uses it: https://github.com/argoproj/argo-rollouts/releases/tag/v1.3.1