### PR TITLE
fix: Add missing statuses to MinIO Tenant health check

### DIFF
--- a/resource_customizations/minio.min.io/Tenant/health.lua
+++ b/resource_customizations/minio.min.io/Tenant/health.lua
@@ -36,7 +36,17 @@ if obj.status ~= nil then
             health_status.message = obj.status.currentState
             return health_status
         end
+        if obj.status.currentState == "Tenant credentials are not set properly" then
+            health_status.status = "Degraded"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
         if obj.status.currentState == "Different versions across MinIO Pools" then
+            health_status.status = "Degraded"
+            health_status.message = obj.status.currentState
+            return health_status
+        end
+        if obj.status.currentState == "Pool Decommissioning Not Allowed" then
             health_status.status = "Degraded"
             health_status.message = obj.status.currentState
             return health_status

--- a/resource_customizations/minio.min.io/Tenant/health_test.yaml
+++ b/resource_customizations/minio.min.io/Tenant/health_test.yaml
@@ -25,8 +25,16 @@ tests:
   inputPath: testdata/another_tenant_exists.yaml
 - healthStatus:
     status: Degraded
+    message: "Tenant credentials are not set properly"
+  inputPath: testdata/incorrect_tenant_credentials.yaml
+- healthStatus:
+    status: Degraded
     message: "Different versions across MinIO Pools"
   inputPath: testdata/versions_mismatch.yaml
+- healthStatus:
+    status: Degraded
+    message: "Pool Decommissioning Not Allowed"
+  inputPath: testdata/pool_decommissioning_not_allowed.yaml
 - healthStatus:
     status: Progressing
     message: "<unknown status message>"

--- a/resource_customizations/minio.min.io/Tenant/testdata/incorrect_tenant_credentials.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/incorrect_tenant_credentials.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Tenant credentials are not set properly

--- a/resource_customizations/minio.min.io/Tenant/testdata/pool_decommissioning_not_allowed.yaml
+++ b/resource_customizations/minio.min.io/Tenant/testdata/pool_decommissioning_not_allowed.yaml
@@ -1,0 +1,13 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio-tenant
+spec:
+  image: minio/minio:latest
+  pools:
+    - name: pool-0
+      servers: 1
+      volumesPerServer: 4
+status:
+  revision: 0
+  currentState: Pool Decommissioning Not Allowed


### PR DESCRIPTION
The PR adds support for ["Tenant credentials are not set properly"](https://github.com/minio/operator/blob/master/pkg/controller/cluster/main-controller.go#L117) and ["Pool Decommissioning Not Allowed"](https://github.com/minio/operator/blob/master/pkg/controller/cluster/main-controller.go#L120) statuses to MinIO Tenant health check.

Signed-off-by: dnskr <dnskrv88@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

