### PR TITLE
fix: Retry IsConflict for account update. Map more kube API errors to HTTP status codes

### DIFF
--- a/util/settings/accounts.go
+++ b/util/settings/accounts.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/argoproj/argo-cd/v2/common"
 )
@@ -127,17 +128,19 @@ func (mgr *SettingsManager) GetAccount(name string) (*Account, error) {
 }
 
 // UpdateAccount runs the callback function against an account that matches to the specified name
-//and persist changes applied by the callback.
+// and persist changes applied by the callback.
 func (mgr *SettingsManager) UpdateAccount(name string, callback func(account *Account) error) error {
-	account, err := mgr.GetAccount(name)
-	if err != nil {
-		return err
-	}
-	err = callback(account)
-	if err != nil {
-		return err
-	}
-	return mgr.saveAccount(name, *account)
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		account, err := mgr.GetAccount(name)
+		if err != nil {
+			return err
+		}
+		err = callback(account)
+		if err != nil {
+			return err
+		}
+		return mgr.saveAccount(name, *account)
+	})
 }
 
 // GetAccounts returns list of configured accounts


### PR DESCRIPTION
1. When making updates to account (e.g. token creation), it is possible to get into a resource Conflict errors because we are updating the same configmap/secret. The following change will retry the UpdateAccount call upon Kubernetes IsConflict errors.

2. Similarly, we now add the following mapping of Kubernetes API errors to gRPC codes to HTTP Status Codes.

| Kubernetes | gRPC |  HTTP Status |
|---|---|---|
| ServerTimeout | Unavailable | StatusServiceUnavailable (503) |
| Conflict | Aborted | StatusConflict (409) |
| TooManyRequests | ResourceExhausted  | StatusTooManyRequests (429) |

This will make it possible for client side to make more intelligent decision on retries such as https://github.com/hashicorp/go-retryablehttp

Signed-off-by: Jesse Suen <jesse@akuity.io>
