### PR TITLE
docs: Add Gepardec to users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -74,6 +74,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [G DATA CyberDefense AG](https://www.gdata-software.com/)
 1. [Garner](https://www.garnercorp.com)
 1. [Generali Deutschland AG](https://www.generali.de/)
+2. [Gepardec](https://gepardec.com/)
 1. [Gitpod](https://www.gitpod.io)
 1. [Gllue](https://gllue.com)
 1. [gloat](https://gloat.com/)


### PR DESCRIPTION
As we are heavily using the argo ecosystem for the management of our OpenShift Clusters and applications as well as implementing our CICD solutions we would like to reflect that on the users list :) 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

