### PR TITLE
fix: error from `argocd app create` when using  `--dest name` instead of  `--dest server`

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2295,6 +2295,17 @@ func (dest ApplicationDestination) Equals(other ApplicationDestination) bool {
 	return reflect.DeepEqual(dest, other)
 }
 
+// Equals compares two instances of ApplicationSpec and returns true if instances are equal.
+func (spec ApplicationSpec) Equals(other ApplicationSpec) bool {
+	return reflect.DeepEqual(spec.Info, other.Info) &&
+		reflect.DeepEqual(spec.IgnoreDifferences, other.IgnoreDifferences) &&
+		reflect.DeepEqual(spec.Project, other.Project) &&
+		reflect.DeepEqual(spec.RevisionHistoryLimit, other.RevisionHistoryLimit) &&
+		reflect.DeepEqual(spec.SyncPolicy, other.SyncPolicy) &&
+		spec.Source.Equals(other.Source) &&
+		spec.Destination.Equals(other.Destination)
+}
+
 // GetProject returns the application's project. This is preferred over spec.Project which may be empty
 func (spec ApplicationSpec) GetProject() string {
 	if spec.Project == "" {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -235,7 +235,8 @@ func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateReq
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to check existing application details (%s): %v", appNs, err)
 	}
-	equalSpecs := reflect.DeepEqual(existing.Spec, a.Spec) &&
+
+	equalSpecs := existing.Spec.Equals(a.Spec) &&
 		reflect.DeepEqual(existing.Labels, a.Labels) &&
 		reflect.DeepEqual(existing.Annotations, a.Annotations) &&
 		reflect.DeepEqual(existing.Finalizers, a.Finalizers)


### PR DESCRIPTION
Fixes #10063

This error was created due to poor compare of apps Spec's. 

In this PR I change the compare from reflect.DeepEqual to compare each property properly.
The `Destination` weren't equal because we didn't use their compare function - https://github.com/argoproj/argo-cd/blob/41d4ce6fa4820f8790396fc2164b7d75e9139a8e/pkg/apis/application/v1alpha1/types.go#L2283