### PR TITLE
docs: clarify how default RBAC policy works

### DIFF
--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -86,6 +86,10 @@ configures a custom role, named `org-admin`. The role is assigned to any user wh
 `your-github-org:your-team` group. All other users get the default policy of `role:readonly`,
 which cannot modify Argo CD settings.
 
+!!! warning
+    All authenticated users get _at least_ the permissions granted by the default policy. This access cannot be blocked 
+    by a `deny` rule. Instead, restrict the default policy and then grant permissions to individual roles as needed.
+
 *ArgoCD ConfigMap `argocd-rbac-cm` Example:*
 
 ```yaml


### PR DESCRIPTION
I was surprised by this behavior, as was [this user](https://github.com/argoproj/argo-cd/issues/10877). I think other folks would be as well.