### PR TITLE
docs: Add CSI secret driver to the secret management options

### DIFF
--- a/docs/operator-manual/secret-management.md
+++ b/docs/operator-manual/secret-management.md
@@ -12,5 +12,6 @@ Argo CD is un-opinionated about how secrets are managed. There's many ways to do
 * [KSOPS](https://github.com/viaduct-ai/kustomize-sops#argo-cd-integration)
 * [argocd-vault-plugin](https://github.com/argoproj-labs/argocd-vault-plugin)
 * [argocd-vault-replacer](https://github.com/crumbhole/argocd-vault-replacer)
+* [Kubernetes Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver)
 
 For discussion, see [#1364](https://github.com/argoproj/argo-cd/issues/1364)


### PR DESCRIPTION
When investigating secret management options I found that CSI secret store is not in this list. It's something I've been using for a while and it definately has its use cases. 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

