### PR TITLE
chore: fix git push command in Snyk update workflow

### DIFF
--- a/.github/workflows/update-snyk.yaml
+++ b/.github/workflows/update-snyk.yaml
@@ -33,5 +33,5 @@ jobs:
           git add docs/snyk/index.md
           git add docs/snyk/*/*.html
           git commit -m "[Bot] Update Snyk reports" --signoff
-          git push --set-upstream origin
+          git push --set-upstream origin "$pr_branch"
           gh pr create -B master -H "$pr_branch" --title '[Bot] docs: Update Snyk report' --body ''


### PR DESCRIPTION
Based on this output of the last run, I think this change will work.

```
fatal: The current branch snyk-update-c70d68101d7580ca57a3 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin snyk-update-c70d68101d7580ca57a3
```