### PR TITLE
Allow use of values in cluster secret

### DIFF
--- a/applicationset/generators/cluster.go
+++ b/applicationset/generators/cluster.go
@@ -122,9 +122,12 @@ func (g *ClusterGenerator) GenerateParams(
 	for _, cluster := range secretsFound {
 		params := map[string]interface{}{}
 
-		params["name"] = string(cluster.Data["name"])
+		for k, v := range cluster.Data {
+			if k != "config" {
+				params[k] = string(v)
+			}
+		}
 		params["nameNormalized"] = utils.SanitizeName(string(cluster.Data["name"]))
-		params["server"] = string(cluster.Data["server"])
 
 		if appSet.Spec.GoTemplate {
 			meta := map[string]interface{}{}


### PR DESCRIPTION
Allows values from the cluster secret to be used in ApplicationSets when generating applications using the cluster generator

Signed-off-by: Matt Martyn <MMartyn@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

