### PR TITLE
chore: delete old snyk reports

### DIFF
--- a/.github/workflows/update-snyk.yaml
+++ b/.github/workflows/update-snyk.yaml
@@ -30,8 +30,7 @@ jobs:
           git checkout -b "$pr_branch"
           git config --global user.email 'ci@argoproj.com'
           git config --global user.name 'CI'
-          git add docs/snyk/index.md
-          git add docs/snyk/*/*.html
+          git add docs/snyk/*
           git commit -m "[Bot] Update Snyk reports" --signoff
           git push --set-upstream origin "$pr_branch"
           gh pr create -B master -H "$pr_branch" --title '[Bot] docs: Update Snyk report' --body ''


### PR DESCRIPTION
The old `git add` wasn't catching the deletes of old report directories.