### PR TITLE
docs: Removed outdated truncation comment from RevisionMetadata.Message

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -7482,8 +7482,8 @@
           "$ref": "#/definitions/v1Time"
         },
         "message": {
-          "type": "string",
-          "title": "Message contains the message associated with the revision, most likely the commit message.\nThe message is truncated to the first newline or 64 characters (which ever comes first)"
+          "description": "Message contains the message associated with the revision, most likely the commit message.",
+          "type": "string"
         },
         "signatureInfo": {
           "description": "SignatureInfo contains a hint on the signer if the revision was signed with GPG, and signature verification is enabled.",

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -1571,7 +1571,6 @@ message RevisionMetadata {
   repeated string tags = 3;
 
   // Message contains the message associated with the revision, most likely the commit message.
-  // The message is truncated to the first newline or 64 characters (which ever comes first)
   optional string message = 4;
 
   // SignatureInfo contains a hint on the signer if the revision was signed with GPG, and signature verification is enabled.

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -5390,7 +5390,7 @@ func schema_pkg_apis_application_v1alpha1_RevisionMetadata(ref common.ReferenceC
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Message contains the message associated with the revision, most likely the commit message. The message is truncated to the first newline or 64 characters (which ever comes first)",
+							Description: "Message contains the message associated with the revision, most likely the commit message.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -835,7 +835,6 @@ type RevisionMetadata struct {
 	// Floating tags can move from one revision to another
 	Tags []string `json:"tags,omitempty" protobuf:"bytes,3,opt,name=tags"`
 	// Message contains the message associated with the revision, most likely the commit message.
-	// The message is truncated to the first newline or 64 characters (which ever comes first)
 	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
 	// SignatureInfo contains a hint on the signer if the revision was signed with GPG, and signature verification is enabled.
 	SignatureInfo string `json:"signatureInfo,omitempty" protobuf:"bytes,5,opt,name=signatureInfo"`


### PR DESCRIPTION
Truncation of [RevisionMetadata.Message](https://github.com/argoproj/argo-cd/blob/bff48605631b66b27deb7e83a8e1d6af812d9738/pkg/apis/application/v1alpha1/types.go#L839) was moved from the API to the UI in #5313. This PR removes API comments/doc mentioning truncation of the Message field. 

Updated [types.go](https://github.com/argoproj/argo-cd/blob/bff48605631b66b27deb7e83a8e1d6af812d9738/pkg/apis/application/v1alpha1/types.go) and ran `make codegen`. 


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

