### PR TITLE
chore: sign checksum file for release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -219,10 +219,10 @@ jobs:
         with:
           cosign-release: 'v1.13.0'
 
-      - name: Sign Argo CD container images
+      - name: Sign Argo CD container images and assets
         run: |
           cosign sign --key env://COSIGN_PRIVATE_KEY ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION}
-          cosign sign --key env://COSIGN_PRIVATE_KEY docker.io/argoproj/argocd:v${TARGET_VERSION}
+          cosign sign-blob --key env://COSIGN_PRIVATE_KEY ./dist/argocd-${TARGET_VERSION}-checksums.txt > ./dist/argocd-${TARGET_VERSION}-checksums.sig
           # Retrieves the public key to release as an asset
           cosign public-key --key env://COSIGN_PRIVATE_KEY > ./dist/argocd-cosign.pub
         env:


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

This PR signs the checksum file for release binaries.  Also removes adding a signature to the Dockerhub image since we know Quay is working well.  We can add this back at a later time.  Once we know if the images should still be pushed Dockerhub.

Follow up PR coming soon.  It will contain user documentation on how to verify the signatures for containers and release notes containing our public key.

