### PR TITLE
feat: allow persistence of custom K8s client configuration in core mode (#7992)

### DIFF
--- a/cmd/argocd/commands/context_test.go
+++ b/cmd/argocd/commands/context_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testConfig = `contexts:
+const configPlaceholder = `contexts:
 - name: argocd1.example.com:443
   server: argocd1.example.com:443
   user: argocd1.example.com:443
@@ -19,12 +20,16 @@ const testConfig = `contexts:
 - name: localhost:8080
   server: localhost:8080
   user: localhost:8080
-current-context: localhost:8080
+- name: kubernetes
+  server: kubernetes
+  user: kubernetes
+current-context: %s
 servers:
 - server: argocd1.example.com:443
 - server: argocd2.example.com:443
 - plain-text: true
   server: localhost:8080
+- server: kubernetes
 users:
 - auth-token: vErrYS3c3tReFRe$hToken
   name: argocd1.example.com:443
@@ -33,7 +38,12 @@ users:
   name: argocd2.example.com:443
   refresh-token: vErrYS3c3tReFRe$hToken
 - auth-token: vErrYS3c3tReFRe$hToken
-  name: localhost:8080`
+  name: localhost:8080
+- auth-token: vErrYS3c3tReFRe$hToken
+  name: kubernetes`
+
+var testConfig = fmt.Sprintf(configPlaceholder, "localhost:8080")
+var testCoreConfig = fmt.Sprintf(configPlaceholder, "kubernetes")
 
 const testConfigFilePath = "./testdata/local.config"
 

--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -42,6 +42,7 @@ func NewLoginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comman
 		sso         bool
 		ssoPort     int
 		skipTestTLS bool
+		kubeConfig  string
 	)
 	var command = &cobra.Command{
 		Use:   "login SERVER",
@@ -170,6 +171,9 @@ argocd login cd.argoproj.io --core`,
 				User:   ctxName,
 				Server: server,
 			})
+			if kubeConfig != "" && globalClientOpts.Core {
+				localCfg.DefaultKubeconfig = kubeConfig
+			}
 			err = localconfig.WriteLocalConfig(*localCfg, globalClientOpts.ConfigPath)
 			errors.CheckError(err)
 			fmt.Printf("Context '%s' updated\n", ctxName)
@@ -182,6 +186,8 @@ argocd login cd.argoproj.io --core`,
 	command.Flags().IntVar(&ssoPort, "sso-port", DefaultSSOLocalPort, "port to run local OAuth2 login application")
 	command.Flags().
 		BoolVar(&skipTestTLS, "skip-test-tls", false, "Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)")
+	command.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path of a Kubernetes client configuration file")
+
 	return command
 }
 

--- a/cmd/argocd/commands/login_test.go
+++ b/cmd/argocd/commands/login_test.go
@@ -1,10 +1,14 @@
 package commands
 
 import (
+	"os"
 	"testing"
 
+	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
+	"github.com/argoproj/argo-cd/v2/util/localconfig"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //
@@ -28,4 +32,25 @@ func Test_userDisplayName_sub(t *testing.T) {
 	actualName := userDisplayName(claims)
 	expectedName := "foo"
 	assert.Equal(t, expectedName, actualName)
+}
+
+func Test_CoreLogin(t *testing.T) {
+	var customKubeConfig = "/etc/rancher/k3s/k3s.yaml"
+	// Write the test config file
+	err := os.WriteFile(testConfigFilePath, []byte(testCoreConfig), os.ModePerm)
+	assert.NoError(t, err)
+	defer os.Remove(testConfigFilePath)
+
+	err = os.Chmod(testConfigFilePath, 0600)
+	require.NoError(t, err)
+
+	command := NewLoginCommand(&argocdclient.ClientOptions{ConfigPath: testConfigFilePath, Core: true})
+	_ = command.Flags().Set("kubeconfig", customKubeConfig)
+	command.Run(command, []string{"kubernetes"})
+
+	localConfig, err := localconfig.ReadLocalConfig(testConfigFilePath)
+	assert.NoError(t, err)
+	assert.Equal(t, localConfig.DefaultKubeconfig, customKubeConfig)
+	assert.Equal(t, localConfig.CurrentContext, "kubernetes")
+
 }

--- a/cmd/argocd/commands/logout.go
+++ b/cmd/argocd/commands/logout.go
@@ -40,6 +40,10 @@ func NewLogoutCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comma
 			if err != nil {
 				log.Fatalf("Error in logging out: %s", err)
 			}
+			if globalClientOpts.Core {
+				// during logout in core mode, clearing the default config location
+				localCfg.DefaultKubeconfig = ""
+			}
 			err = localconfig.WriteLocalConfig(*localCfg, globalClientOpts.ConfigPath)
 			errors.CheckError(err)
 

--- a/docs/user-guide/commands/argocd_login.md
+++ b/docs/user-guide/commands/argocd_login.md
@@ -26,13 +26,14 @@ argocd login cd.argoproj.io --core
 ### Options
 
 ```
-  -h, --help              help for login
-      --name string       name to use for the context
-      --password string   the password of an account to authenticate
-      --skip-test-tls     Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)
-      --sso               perform SSO login
-      --sso-port int      port to run local OAuth2 login application (default 8085)
-      --username string   the username of an account to authenticate
+  -h, --help                help for login
+      --kubeconfig string   Path of a Kubernetes client configuration file
+      --name string         name to use for the context
+      --password string     the password of an account to authenticate
+      --skip-test-tls       Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)
+      --sso                 perform SSO login
+      --sso-port int        port to run local OAuth2 login application (default 8085)
+      --username string     the username of an account to authenticate
 ```
 
 ### Options inherited from parent commands

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -67,12 +67,21 @@ func AddKubectlFlagsToCmd(cmd *cobra.Command) clientcmd.ClientConfig {
 // AddKubectlFlagsToSet adds kubectl like flags to a provided flag set and returns the ClientConfig interface
 // for retrieving the values.
 func AddKubectlFlagsToSet(flags *pflag.FlagSet) clientcmd.ClientConfig {
+	return AddKubectlFlagsToSetInCore(flags, false, "")
+}
+
+// AddKubectlFlagsToSetInCore adds kubectl like flags to a provided flag set and returns the ClientConfig interface for retrieving the values and support Core mode to set custom kubeconfig file location.
+func AddKubectlFlagsToSetInCore(flags *pflag.FlagSet, coreMode bool, kubeConfigLocation string) clientcmd.ClientConfig {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	overrides := clientcmd.ConfigOverrides{}
 	kflags := clientcmd.RecommendedConfigOverrideFlags("")
-	flags.StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
-	clientcmd.BindOverrideFlags(&overrides, flags, kflags)
+	if coreMode && kubeConfigLocation != "" {
+		loadingRules.ExplicitPath = kubeConfigLocation
+	} else {
+		flags.StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to a kube config. Only required if out-of-cluster")
+		clientcmd.BindOverrideFlags(&overrides, flags, kflags)
+	}
 	return clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
 }
 

--- a/util/cli/cli_test.go
+++ b/util/cli/cli_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	k3sLocation string = "/etc/rancher/k3s/k3s.yaml"
+	k8sLocation string = "/home/.kube/config"
+)
+
+func TestCustomKubeConfigLocation(t *testing.T) {
+	testCases := []struct {
+		name             string
+		coreMode         bool
+		newLocation      string
+		expectedLocation string
+	}{
+		{
+			name:             "kubeconfig is specified in non core mode",
+			coreMode:         false,
+			newLocation:      k8sLocation,
+			expectedLocation: "",
+		},
+		{
+			name:             "kubeconfig is not specified in non core mode",
+			coreMode:         false,
+			newLocation:      "",
+			expectedLocation: "",
+		},
+		{
+			name:             "kubeconfig is not specified in core mode",
+			coreMode:         true,
+			newLocation:      "",
+			expectedLocation: "",
+		},
+		{
+			name:             "kubeconfig is specified in core mode",
+			coreMode:         true,
+			newLocation:      k3sLocation,
+			expectedLocation: k3sLocation,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var fakeFlags *pflag.FlagSet = pflag.NewFlagSet("tmp", pflag.ContinueOnError)
+
+			clientConfig := AddKubectlFlagsToSetInCore(fakeFlags, testCase.coreMode, testCase.newLocation)
+			assert.Equal(t, testCase.expectedLocation, clientConfig.ConfigAccess().GetExplicitFile())
+
+		})
+	}
+}

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -2,13 +2,13 @@ package localconfig
 
 import (
 	"fmt"
-	"github.com/golang-jwt/jwt/v4"
 	"os"
 	"os/user"
 	"path"
 	"strings"
 
 	configUtil "github.com/argoproj/argo-cd/v2/util/config"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // LocalConfig is a local Argo CD config file
@@ -17,6 +17,8 @@ type LocalConfig struct {
 	Contexts       []ContextRef `json:"contexts"`
 	Servers        []Server     `json:"servers"`
 	Users          []User       `json:"users"`
+	//Default kubeconfig location only used in core mode
+	DefaultKubeconfig string `json:"default-kubeconfig" default:""`
 }
 
 // ContextRef is a reference to a Server and User for an API client


### PR DESCRIPTION
This PR Closes [#7992], the enhancement related to allowing persistence of custom kubeconfig location in core mode.

Login command now includes a new flag --kubeconfig, when added in presence of --core enables querying against a kubernetes cluster whose kube-config file location is other than default location. While logging in with kubeconfig flag set to the custom kubeconfig file, any subsequent command e,g, argocd app list --core, argocd app sync <app_name> --core, etc. will all query and fetch results from the custom kubernetes cluster.

Steps:

1. While logging in the core mode set custom kubeconfig file
argocd login --core --kubeconfig /etc/rancher/k3s/k3s.yaml

2. Execute the commands in core mode without specifying the custom kubeconfig location
argocd app list --core
argocd app sync <app_name> --core
....

3. Finally logging out of the core mode, default kubeconfig location will be restored. 
argocd logout --core

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

