### PR TITLE
feat: set cluster command (#9996)

### DIFF
--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -27,6 +27,17 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/text/label"
 )
 
+const (
+	// type of the cluster ID is 'name'
+	clusterIdTypeName = "name"
+	// cluster field is 'name'
+	clusterFieldName = "name"
+	// cluster field is 'namespaces'
+	clusterFieldNamespaces = "namespaces"
+	// indicates managing all namespaces
+	allNamespaces = "*"
+)
+
 // NewClusterCommand returns a new instance of an `argocd cluster` command
 func NewClusterCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clientcmd.PathOptions) *cobra.Command {
 	var command = &cobra.Command{
@@ -47,7 +58,10 @@ func NewClusterCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clientc
 
   # Remove a target cluster context from ArgoCD
   argocd cluster rm example-cluster
-`,
+
+  # Set a target cluster context from ArgoCD
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace '*'
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace namespace-one --namespace namespace-two`,
 	}
 
 	command.AddCommand(NewClusterAddCommand(clientOpts, pathOpts))
@@ -55,6 +69,7 @@ func NewClusterCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clientc
 	command.AddCommand(NewClusterListCommand(clientOpts))
 	command.AddCommand(NewClusterRemoveCommand(clientOpts, pathOpts))
 	command.AddCommand(NewClusterRotateAuthCommand(clientOpts))
+	command.AddCommand(NewClusterSetCommand(clientOpts))
 	return command
 }
 
@@ -183,6 +198,72 @@ func getRestConfig(pathOpts *clientcmd.PathOptions, ctxName string) (*rest.Confi
 	}
 
 	return conf, nil
+}
+
+// NewClusterSetCommand returns a new instance of an `argocd cluster set` command
+func NewClusterSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
+	var (
+		clusterOptions cmdutil.ClusterOptions
+		clusterName    string
+	)
+	var command = &cobra.Command{
+		Use:   "set NAME",
+		Short: "Set cluster information",
+		Example: `  # Set cluster information
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace '*'
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace namespace-one --namespace namespace-two`,
+		Run: func(c *cobra.Command, args []string) {
+			ctx := c.Context()
+			if len(args) != 1 {
+				c.HelpFunc()(c, args)
+				os.Exit(1)
+			}
+			// name of the cluster whose fields have to be updated.
+			clusterName = args[0]
+			conn, clusterIf := headless.NewClientOrDie(clientOpts, c).NewClusterClientOrDie()
+			defer io.Close(conn)
+			// checks the fields that needs to be updated
+			updatedFields := checkFieldsToUpdate(clusterOptions)
+			namespaces := clusterOptions.Namespaces
+			// check if all namespaces have to be considered
+			if len(namespaces) == 1 && strings.EqualFold(namespaces[0], allNamespaces) {
+				namespaces[0] = ""
+			}
+			if updatedFields != nil {
+				clusterUpdateRequest := clusterpkg.ClusterUpdateRequest{
+					Cluster: &argoappv1.Cluster{
+						Name:       clusterOptions.Name,
+						Namespaces: namespaces,
+					},
+					UpdatedFields: updatedFields,
+					Id: &clusterpkg.ClusterID{
+						Type:  clusterIdTypeName,
+						Value: clusterName,
+					},
+				}
+				_, err := clusterIf.Update(ctx, &clusterUpdateRequest)
+				errors.CheckError(err)
+				fmt.Printf("Cluster '%s' updated.\n", clusterName)
+			} else {
+				fmt.Print("Specify the cluster field to be updated.\n")
+			}
+		},
+	}
+	command.Flags().StringVar(&clusterOptions.Name, "name", "", "Overwrite the cluster name")
+	command.Flags().StringArrayVar(&clusterOptions.Namespaces, "namespace", nil, "List of namespaces which are allowed to manage. Specify '*' to manage all namespaces")
+	return command
+}
+
+// checkFieldsToUpdate returns the fields that needs to be updated
+func checkFieldsToUpdate(clusterOptions cmdutil.ClusterOptions) []string {
+	var updatedFields []string
+	if clusterOptions.Name != "" {
+		updatedFields = append(updatedFields, clusterFieldName)
+	}
+	if clusterOptions.Namespaces != nil {
+		updatedFields = append(updatedFields, clusterFieldNamespaces)
+	}
+	return updatedFields
 }
 
 // NewClusterGetCommand returns a new instance of an `argocd cluster get` command

--- a/cmd/argocd/commands/completion.go
+++ b/cmd/argocd/commands/completion.go
@@ -146,6 +146,7 @@ __argocd_custom_func() {
 			;;
 		argocd_cluster_get | \
 		argocd_cluster_rm | \
+		argocd_cluster_set | \
 		argocd_login | \
 		argocd_cluster_add)
 			__argocd_list_servers

--- a/docs/user-guide/commands/argocd_cluster.md
+++ b/docs/user-guide/commands/argocd_cluster.md
@@ -21,6 +21,9 @@ argocd cluster [flags]
   # Remove a target cluster context from ArgoCD
   argocd cluster rm example-cluster
 
+  # Set a target cluster context from ArgoCD
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace '*'
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace namespace-one --namespace namespace-two
 ```
 
 ### Options
@@ -78,4 +81,5 @@ argocd cluster [flags]
 * [argocd cluster list](argocd_cluster_list.md)	 - List configured clusters
 * [argocd cluster rm](argocd_cluster_rm.md)	 - Remove cluster credentials
 * [argocd cluster rotate-auth](argocd_cluster_rotate-auth.md)	 - argocd cluster rotate-auth SERVER/NAME
+* [argocd cluster set](argocd_cluster_set.md)	 - Set cluster information
 

--- a/docs/user-guide/commands/argocd_cluster_set.md
+++ b/docs/user-guide/commands/argocd_cluster_set.md
@@ -1,0 +1,51 @@
+## argocd cluster set
+
+Set cluster information
+
+```
+argocd cluster set NAME [flags]
+```
+
+### Examples
+
+```
+  # Set cluster information
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace '*'
+  argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace namespace-one --namespace namespace-two
+```
+
+### Options
+
+```
+  -h, --help                    help for set
+      --name string             Overwrite the cluster name
+      --namespace stringArray   List of namespaces which are allowed to manage. Specify '*' to manage all namespaces
+```
+
+### Options inherited from parent commands
+
+```
+      --auth-token string               Authentication token
+      --client-crt string               Client certificate file
+      --client-crt-key string           Client certificate key file
+      --config string                   Path to Argo CD config (default "/home/user/.config/argocd/config")
+      --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
+      --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
+      --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
+  -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)
+      --http-retry-max int              Maximum number of retries to establish http connection to Argo CD server
+      --insecure                        Skip server certificate and domain verification
+      --kube-context string             Directs the command to the given kube-context
+      --logformat string                Set the logging format. One of: text|json (default "text")
+      --loglevel string                 Set the logging level. One of: debug|info|warn|error (default "info")
+      --plaintext                       Disable TLS
+      --port-forward                    Connect to a random argocd-server port using port forwarding
+      --port-forward-namespace string   Namespace name which should be used for port forwarding
+      --server string                   Argo CD server address
+      --server-crt string               Server certificate file
+```
+
+### SEE ALSO
+
+* [argocd cluster](argocd_cluster.md)	 - Manage cluster credentials
+

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -133,6 +133,25 @@ func TestClusterListDenied(t *testing.T) {
 		})
 }
 
+func TestClusterSet(t *testing.T) {
+	EnsureCleanState(t)
+	defer RecordTestRun(t)
+	clusterFixture.
+		GivenWithSameState(t).
+		Project(ProjectName).
+		Name("in-cluster").
+		Namespaces([]string{"namespace-edit-1", "namespace-edit-2"}).
+		Server(KubernetesInternalAPIServerAddr).
+		When().
+		SetNamespaces().
+		GetByName("in-cluster").
+		Then().
+		AndCLIOutput(func(output string, err error) {
+			assert.True(t, strings.Contains(output, "namespace-edit-1"))
+			assert.True(t, strings.Contains(output, "namespace-edit-2"))
+		})
+}
+
 func TestClusterGet(t *testing.T) {
 	SkipIfAlreadyRun(t)
 	EnsureCleanState(t)

--- a/test/e2e/fixture/cluster/actions.go
+++ b/test/e2e/fixture/cluster/actions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -100,6 +101,18 @@ func (a *Actions) List() *Actions {
 func (a *Actions) Get() *Actions {
 	a.context.t.Helper()
 	a.runCli("cluster", "get", a.context.server)
+	return a
+}
+
+func (a *Actions) GetByName(name string) *Actions {
+	a.context.t.Helper()
+	a.runCli("cluster", "get", name)
+	return a
+}
+
+func (a *Actions) SetNamespaces() *Actions {
+	a.context.t.Helper()
+	a.runCli("cluster", "set", a.context.name, "--namespace", strings.Join(a.context.namespaces, ","))
 	return a
 }
 

--- a/test/e2e/fixture/cluster/context.go
+++ b/test/e2e/fixture/cluster/context.go
@@ -12,11 +12,12 @@ import (
 type Context struct {
 	t *testing.T
 	// seconds
-	timeout int
-	name    string
-	project string
-	server  string
-	upsert  bool
+	timeout    int
+	name       string
+	project    string
+	server     string
+	upsert     bool
+	namespaces []string
 }
 
 func Given(t *testing.T) *Context {
@@ -42,6 +43,11 @@ func (c *Context) Name(name string) *Context {
 
 func (c *Context) Server(server string) *Context {
 	c.server = server
+	return c
+}
+
+func (c *Context) Namespaces(namespaces []string) *Context {
+	c.namespaces = namespaces
 	return c
 }
 


### PR DESCRIPTION
New set cluster command has been implemented, using which the name and the namespaces can be updated. 

Closes #9996

Example:
```
argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace '*'
argocd cluster set CLUSTER_NAME --name new-cluster-name --namespace namespace-one --namespace namespace-two
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

