### PR TITLE
fix: add check for trailing/leading whitespace in project role group names (#10919)

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1634,10 +1634,10 @@ func validateGroupName(name string) error {
 		return status.Errorf(codes.InvalidArgument, "group '%s' contains invalid characters", name)
 	}
 	if len(n) > 1 && unicode.IsSpace(n[0]) {
-		return status.Errorf(codes.InvalidArgument, "group '%s' contains a leading whtiespace", name)
+		return status.Errorf(codes.InvalidArgument, "group '%s' contains a leading space", name)
 	}
 	if len(n) > 1 && unicode.IsSpace(n[len(n)-1]) {
-		return status.Errorf(codes.InvalidArgument, "group '%s' contains a trailing whtiespace", name)
+		return status.Errorf(codes.InvalidArgument, "group '%s' contains a trailing space", name)
 	}
 	return nil
 }

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/argoproj/gitops-engine/pkg/health"
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
@@ -1618,6 +1619,7 @@ func validateRoleName(name string) error {
 var invalidChars = regexp.MustCompile("[\"\n\r\t]")
 
 func validateGroupName(name string) error {
+	n := []rune(name)
 	name = strings.TrimSpace(name)
 	if len(name) > 1 && strings.HasPrefix(name, "\"") && strings.HasSuffix(name, "\"") {
 		// Remove surrounding quotes for further inspection of the group name
@@ -1625,12 +1627,17 @@ func validateGroupName(name string) error {
 	} else if strings.Contains(name, ",") {
 		return status.Errorf(codes.InvalidArgument, "group '%s' must be quoted", name)
 	}
-
 	if name == "" {
 		return status.Errorf(codes.InvalidArgument, "group '%s' is empty", name)
 	}
 	if invalidChars.MatchString(name) {
 		return status.Errorf(codes.InvalidArgument, "group '%s' contains invalid characters", name)
+	}
+	if len(n) > 1 && unicode.IsSpace(n[0]) {
+		return status.Errorf(codes.InvalidArgument, "group '%s' contains a leading whtiespace", name)
+	}
+	if len(n) > 1 && unicode.IsSpace(n[len(n)-1]) {
+		return status.Errorf(codes.InvalidArgument, "group '%s' contains a trailing whtiespace", name)
 	}
 	return nil
 }

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -651,6 +651,8 @@ func TestAppProject_ValidateGroupName(t *testing.T) {
 		"my,group",
 		"my\ngroup",
 		"my\rgroup",
+		" my:group",
+		"my:group ",
 	}
 	for _, badName := range badGroupNames {
 		p.Spec.Roles[0].Groups = []string{badName}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2937,7 +2937,7 @@ func Test_validateGroupName(t *testing.T) {
 		{"Normal group name", "foo", true},
 		{"Quoted with commas", "\"foo,bar,baz\"", true},
 		{"Quoted without commas", "\"foo\"", true},
-		{"Quoted with leading and trailing whitespace", "  \"foo\" ", true},
+		{"Quoted with leading and trailing whitespace", "  \"foo\" ", false},
 		{"Empty group name", "", false},
 		{"Empty group name with quotes", "\"\"", false},
 		{"Unquoted with comma", "foo,bar,baz", false},


### PR DESCRIPTION
Fixes #10919
instead of changing the user's config without their knowledge and potentially causing cascading errors, i think it would be nicer to alert the user with an error that their group name contains trailing/leading whitespaces. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

