### PR TITLE
fix: Update custom health check for kiali.io/Kiali

### DIFF
--- a/resource_customizations/kiali.io/Kiali/health.lua
+++ b/resource_customizations/kiali.io/Kiali/health.lua
@@ -3,14 +3,18 @@ if obj.status ~= nil then
   if obj.status.conditions ~= nil then
     for i, condition in ipairs(obj.status.conditions) do
       health_status.message = condition.message
-      if condition.reason == "Successful" then
+      if condition.type == "Successful" and condition.status == "True" then
         health_status.status = "Healthy"
-      elseif condition.reason == "Running" then
-        health_status.status = "Progressing"
-      else
-        health_status.status = "Degraded"
+        return health_status
       end
-      return health_status
+      if condition.type == "Failure" and condition.status == "True" then
+        health_status.status = "Degraded"
+        return health_status
+      end
+      if condition.type == "Running" and condition.reason == "Running" then
+        health_status.status = "Progressing"
+        return health_status
+      end
     end
   end
 end

--- a/resource_customizations/kiali.io/Kiali/health_test.yaml
+++ b/resource_customizations/kiali.io/Kiali/health_test.yaml
@@ -9,5 +9,5 @@ tests:
   inputPath: testdata/degraded.yaml
 - healthStatus:
     status: Healthy
-    message: "Awaiting next reconciliation"
+    message: "Last reconciliation succeeded"
   inputPath: testdata/healthy.yaml

--- a/resource_customizations/kiali.io/Kiali/testdata/degraded.yaml
+++ b/resource_customizations/kiali.io/Kiali/testdata/degraded.yaml
@@ -14,14 +14,24 @@ metadata:
 spec: {}
 status:
   conditions:
-  - ansibleResult:
-      changed: 1
-      completion: 2020-06-08T13:41:20.133525
-      failures: 0
-      ok: 56
-      skipped: 82
-    lastTransitionTime: "2020-06-04T17:47:31Z"
-    message: Error Reconciling
-    reason: null 
-    status: "True"
-    type: Running
+    - lastTransitionTime: '2022-10-19T09:44:32Z'
+      message: ''
+      reason: ''
+      status: 'False'
+      type: Failure
+    - ansibleResult:
+        changed: 18
+        completion: '2022-10-19T09:44:32.289505'
+        failures: 0
+        ok: 101
+        skipped: 101
+      lastTransitionTime: '2022-10-19T09:43:39Z'
+      message: Awaiting next reconciliation
+      reason: Successful
+      status: 'True'
+      type: Running
+    - lastTransitionTime: '2022-10-19T09:44:32Z'
+      message: Error Reconciling
+      reason: Failure
+      status: 'True'
+      type: Failure

--- a/resource_customizations/kiali.io/Kiali/testdata/healthy.yaml
+++ b/resource_customizations/kiali.io/Kiali/testdata/healthy.yaml
@@ -14,14 +14,24 @@ metadata:
 spec: {}
 status:
   conditions:
-  - ansibleResult:
-      changed: 1
-      completion: 2020-06-08T13:41:20.133525
-      failures: 0
-      ok: 56
-      skipped: 82
-    lastTransitionTime: "2020-06-04T17:47:31Z"
-    message: Awaiting next reconciliation
-    reason: Successful
-    status: "True"
-    type: Running
+    - lastTransitionTime: '2022-10-19T09:44:32Z'
+      message: ''
+      reason: ''
+      status: 'False'
+      type: Failure
+    - ansibleResult:
+        changed: 18
+        completion: '2022-10-19T09:44:32.289505'
+        failures: 0
+        ok: 101
+        skipped: 101
+      lastTransitionTime: '2022-10-19T09:43:39Z'
+      message: Awaiting next reconciliation
+      reason: Successful
+      status: 'True'
+      type: Running
+    - lastTransitionTime: '2022-10-19T09:44:32Z'
+      message: Last reconciliation succeeded
+      reason: Successful
+      status: 'True'
+      type: Successful


### PR DESCRIPTION
With Kiali v1.57.1 an additional status condition was added:
```
    - lastTransitionTime: '2022-10-14T11:56:24Z'
      message: ''
      reason: ''
      status: 'False'
      type: Failure
```

Based on the discussion in https://github.com/kiali/kiali/issues/5560 this should not lead to a degraded health state.

This will no longer return Degraded as a catch-all and use the `type` and `status` fields of the condition to determine the CR health.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

