### PR TITLE
chore: use set-output environment file

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -36,7 +36,7 @@ jobs:
           path: src/github.com/argoproj/argo-cd
 
       # get image tag
-      - run: echo ::set-output name=tag::$(cat ./VERSION)-${GITHUB_SHA::8}
+      - run: echo "tag=$(cat ./VERSION)-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
         working-directory: ./src/github.com/argoproj/argo-cd
         id: image
 


### PR DESCRIPTION
This appears to be the new, more secure way to do things: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/