### PR TITLE
fix: handle apiGroup updates in resource-tracking

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -715,9 +715,10 @@ func (m *appStateManager) isSelfReferencedObj(live, config *unstructured.Unstruc
 		return true
 	}
 
-	// Ideally the Tracking Id should be built from the config object.
-	// This is necessary because in case of an ApiGroup upgrade in the desired
-	// state, the comparison must be made with the new tracking id.
+	// config != nil is the best-case scenario for constructing an accurate
+	// Tracking ID. `config` is the "desired state" (from git/helm/etc.).
+	// Using the desired state is important when there is an ApiGroup upgrade.
+	// When upgrading, the comparison must be made with the new tracking ID.
 	// Example:
 	//     live resource annotation will be:
 	//        ingress-app:extensions/Ingress:default/some-ingress
@@ -743,6 +744,10 @@ func (m *appStateManager) isSelfReferencedObj(live, config *unstructured.Unstruc
 	return true
 }
 
+// isSelfReferencedObj returns true if the given Tracking ID (`aiv`) matches
+// the given object. It returns false when the ID doesn't match. This sometimes
+// happens when a tracking label or annotation gets accidentally copied to a
+// different resource.
 func isSelfReferencedObj(obj *unstructured.Unstructured, aiv argo.AppInstanceValue) bool {
 	return (obj.GetNamespace() == aiv.Namespace || obj.GetNamespace() == "") &&
 		obj.GetName() == aiv.Name &&

--- a/controller/state.go
+++ b/controller/state.go
@@ -717,7 +717,7 @@ func (m *appStateManager) isSelfReferencedObj(live, config *unstructured.Unstruc
 
 	// Ideally the Tracking Id should be built from the config object.
 	// This is necessary because in case of an ApiGroup upgrade in the desired
-	// state, the comparison must be maid with the new tracking id.
+	// state, the comparison must be made with the new tracking id.
 	// Example:
 	//     live resource annotation will be:
 	//        ingress-app:extensions/Ingress:default/some-ingress

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -944,7 +944,10 @@ func TestIsLiveResourceManaged(t *testing.T) {
 		// given
 		t.Parallel()
 		config := managedWrongAPIGroup.DeepCopy()
-		argo.NewResourceTracking().SetAppInstance(config, "", appName, "", argo.TrackingMethodAnnotation)
+		err := argo.NewResourceTracking().SetAppInstance(config, "", appName, "", argo.TrackingMethodAnnotation)
+		if err != nil {
+			t.Fatalf("error setting app instance: %s", err)
+		}
 
 		// then
 		assert.True(t, manager.isSelfReferencedObj(managedWrongAPIGroup, config, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -870,30 +870,59 @@ func TestIsLiveResourceManaged(t *testing.T) {
 	})
 
 	manager := ctrl.appStateManager.(*appStateManager)
+	appName := "guestbook"
 
-	// Managed resource w/ annotations
-	assert.True(t, manager.isSelfReferencedObj(managedObj, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
-	assert.True(t, manager.isSelfReferencedObj(managedObj, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+	t.Run("will return true if trackingid matches the resource", func(t *testing.T) {
+		// given
+		t.Parallel()
+		configObj := managedObj.DeepCopy()
 
-	// Managed resource w/ label
-	assert.True(t, manager.isSelfReferencedObj(managedObjWithLabel, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
+		// then
+		assert.True(t, manager.isSelfReferencedObj(managedObj, configObj, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
+		assert.True(t, manager.isSelfReferencedObj(managedObj, configObj, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+	})
+	t.Run("will return true if tracked with label", func(t *testing.T) {
+		// given
+		t.Parallel()
+		configObj := managedObjWithLabel.DeepCopy()
 
-	// Wrong resource name
-	assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongName, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
-	assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+		// then
+		assert.True(t, manager.isSelfReferencedObj(managedObjWithLabel, configObj, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
+	})
+	t.Run("will handle if trackingId has wrong resource name", func(t *testing.T) {
+		// given
+		t.Parallel()
 
-	// Wrong resource group
-	assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongGroup, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
-	assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongGroup, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+		// then
+		assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongName, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
+		assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongName, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+	})
+	t.Run("will handle if trackingId has wrong resource group", func(t *testing.T) {
+		// given
+		t.Parallel()
 
-	// Wrong resource kind
-	assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongKind, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
-	assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongKind, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+		// then
+		assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongGroup, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
+		assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongGroup, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+	})
+	t.Run("will handle if trackingId has wrong kind", func(t *testing.T) {
+		// given
+		t.Parallel()
 
-	// Wrong resource namespace
-	assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongNamespace, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
-	assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongNamespace, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotationAndLabel))
+		// then
+		assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongKind, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
+		assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongKind, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+	})
+	t.Run("will handle if trackingId has wrong namespace", func(t *testing.T) {
+		// given
+		t.Parallel()
 
-	// Nil resource
-	assert.True(t, manager.isSelfReferencedObj(nil, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+		// then
+		assert.True(t, manager.isSelfReferencedObj(unmanagedObjWrongNamespace, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodLabel))
+		assert.False(t, manager.isSelfReferencedObj(unmanagedObjWrongNamespace, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotationAndLabel))
+	})
+	t.Run("will return true if live is nil", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, manager.isSelfReferencedObj(nil, nil, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))
+	})
 }

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -944,10 +944,7 @@ func TestIsLiveResourceManaged(t *testing.T) {
 		// given
 		t.Parallel()
 		config := managedWrongAPIGroup.DeepCopy()
-		err := argo.NewResourceTracking().SetAppInstance(config, "", appName, "", argo.TrackingMethodAnnotation)
-		if err != nil {
-			t.Fatalf("error setting app instance: %s", err)
-		}
+		delete(config.GetAnnotations(), common.AnnotationKeyAppInstance)
 
 		// then
 		assert.True(t, manager.isSelfReferencedObj(managedWrongAPIGroup, config, appName, common.AnnotationKeyAppInstance, argo.TrackingMethodAnnotation))

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -246,7 +246,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		sync.WithResourcesFilter(func(key kube.ResourceKey, target *unstructured.Unstructured, live *unstructured.Unstructured) bool {
 			return (len(syncOp.Resources) == 0 ||
 				argo.ContainsSyncResource(key.Name, key.Namespace, schema.GroupVersionKind{Kind: key.Kind, Group: key.Group}, syncOp.Resources)) &&
-				m.isSelfReferencedObj(live, appLabelKey, trackingMethod)
+				m.isSelfReferencedObj(live, target, app.GetName(), appLabelKey, trackingMethod)
 		}),
 		sync.WithManifestValidation(!syncOp.SyncOptions.HasOption(common.SyncOptionsDisableValidation)),
 		sync.WithNamespaceCreation(syncOp.SyncOptions.HasOption("CreateNamespace=true"), func(un *unstructured.Unstructured) bool {

--- a/util/argo/diff/diff.go
+++ b/util/argo/diff/diff.go
@@ -334,7 +334,7 @@ func (c *diffConfig) DiffFromCache(appName string) (bool, []*appv1.ResourceDiff)
 }
 
 // preDiffNormalize applies the normalization of live and target resources before invoking
-// the diff. None of the attributes in the preDiffNormalizeParams will be modified.
+// the diff. None of the attributes in the lives and targets params will be modified.
 func preDiffNormalize(lives, targets []*unstructured.Unstructured, diffConfig DiffConfig) (*NormalizationResult, error) {
 	if diffConfig == nil {
 		return nil, fmt.Errorf("preDiffNormalize error: diffConfig can not be nil")

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -103,7 +103,9 @@ func (rt *resourceTracking) GetAppInstance(un *unstructured.Unstructured, key st
 }
 
 // UnstructuredToAppInstanceValue will build the AppInstanceValue based
-// on the provided unstructured
+// on the provided unstructured. The given namespace works as a default
+// value if the resource's namespace is not defined. It should be the
+// Application's target destination namespace.
 func UnstructuredToAppInstanceValue(un *unstructured.Unstructured, appName, namespace string) AppInstanceValue {
 	ns := un.GetNamespace()
 	if ns == "" {

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -4,17 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-
 	"github.com/argoproj/argo-cd/v2/common"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/argoproj/argo-cd/v2/util/settings"
-
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-
+	"github.com/argoproj/argo-cd/v2/util/kube"
 	argokube "github.com/argoproj/argo-cd/v2/util/kube"
+	"github.com/argoproj/argo-cd/v2/util/settings"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
@@ -193,7 +188,7 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, l
 		return err
 	}
 
-	if argokube.GetAppInstanceLabel(config, labelKey) == "" {
+	if argokube.GetAppInstanceLabel(config, labelKey) != "" {
 		argokube.RemoveLabel(live, labelKey)
 	}
 

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -102,21 +102,27 @@ func (rt *resourceTracking) GetAppInstance(un *unstructured.Unstructured, key st
 	}
 }
 
+// UnstructuredToAppInstanceValue will build the AppInstanceValue based
+// on the provided unstructured
+func UnstructuredToAppInstanceValue(un *unstructured.Unstructured, appName, namespace string) AppInstanceValue {
+	ns := un.GetNamespace()
+	if ns == "" {
+		ns = namespace
+	}
+	gvk := un.GetObjectKind().GroupVersionKind()
+	return AppInstanceValue{
+		ApplicationName: appName,
+		Group:           gvk.Group,
+		Kind:            gvk.Kind,
+		Namespace:       ns,
+		Name:            un.GetName(),
+	}
+}
+
 // SetAppInstance set label/annotation base on tracking method
 func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, val, namespace string, trackingMethod v1alpha1.TrackingMethod) error {
 	setAppInstanceAnnotation := func() error {
-		ns := un.GetNamespace()
-		if ns == "" {
-			ns = namespace
-		}
-		gvk := un.GetObjectKind().GroupVersionKind()
-		appInstanceValue := AppInstanceValue{
-			ApplicationName: val,
-			Group:           gvk.Group,
-			Kind:            gvk.Kind,
-			Namespace:       ns,
-			Name:            un.GetName(),
-		}
+		appInstanceValue := UnstructuredToAppInstanceValue(un, val, namespace)
 		return argokube.SetAppInstanceAnnotation(un, common.AnnotationKeyAppInstance, rt.BuildAppInstanceValue(appInstanceValue))
 	}
 	switch trackingMethod {

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -188,7 +188,7 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, l
 		return err
 	}
 
-	if argokube.GetAppInstanceLabel(config, labelKey) != "" {
+	if argokube.GetAppInstanceLabel(config, labelKey) == "" {
 		argokube.RemoveLabel(live, labelKey)
 	}
 


### PR DESCRIPTION
We noticed a strange behaviour in Argo CD 2.4.11 when users upgrade to a newer APIGroup (e.g. going from `extensions/Ingress` to `networking.k8s.io/Ingress`). In this case the resource sync status displays as `unknown` and Argo CD is unable to manage the resource anymore even if it is present in the source (git). 

The issue is caused because the trackingId annotation (`argocd.argoproj.io/tracking-id`) changes like in the example below:
`ingress-app:extensions/Ingress:default/some-ingress`
`ingress-app:networking.k8s.io/Ingress:default/some-ingress`

This is related to the code introduced in https://github.com/argoproj/argo-cd/pull/9791 and https://github.com/argoproj/argo-cd/pull/10198 while addressing the issue https://github.com/argoproj/argo-cd/issues/8683. In this case Argo CD displays the Ingress resource but stops managing it, skipping all future change in the desired state (git).

Maybe https://github.com/argoproj/argo-cd/issues/8683 needs to be re-assessed to find a different solution not relying on the APIGroup for comparison. 

Another possible fix is stop verifying the APIGroup in `isSelfReferencedObj` method which would make it simpler and work even when SSA is enabled. However I'd like to get @jannfis or @jessesuen opinion first before going in this direction to make sure https://github.com/argoproj/argo-cd/pull/9791 is still covered in this case.

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

