### PR TITLE
chore: [E2E Test]: Allow Insecure connection in TestClusterName and TestClusterURL (#11023)

### DIFF
--- a/test/e2e/fixture/http.go
+++ b/test/e2e/fixture/http.go
@@ -2,6 +2,7 @@ package fixture
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -26,8 +27,17 @@ func DoHttpRequest(method string, path string, data ...byte) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	// Http Client with TLS verification set to false.
+	// Required when dealing with self-signed certificates.
+	hc := &http.Client{Transport: tr}
+
 	req.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: token})
-	return http.DefaultClient.Do(req)
+	return hc.Do(req)
 }
 
 // DoHttpJsonRequest executes a http request against the Argo CD API server and unmarshals the response body as JSON


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

Note on DCO:
If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Closes #11023 