### PR TITLE
#10290 - Added pod age icon details in the grid view and used trash can for showing that resource that is out of sync and will be pruned on sync. 

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.scss
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.scss
@@ -6,6 +6,12 @@ $pods-per-row: 8;
 $pods-per-column: 4;
 $max-rows: 5;
 $num-stats: 2;
+$pod-age-icon-clr: #ffce25;
+
+.circle-icon {
+    color: $pod-age-icon-clr;
+    font-size: 10px;
+}
 
 .pod-view {
     &__settings {
@@ -67,7 +73,7 @@ $num-stats: 2;
             margin: 1em 0;
             padding: 10px;
             border-radius: 3px;
-            background-color: $argo-color-gray-3;                            
+            background-color: $argo-color-gray-3;
             color: $argo-color-gray-6;
             div {
                 display: flex;
@@ -149,7 +155,7 @@ $num-stats: 2;
             }
             &__new-pod-icon {
                 background: none;
-                color: #FFCE25;
+                color: $pod-age-icon-clr;
                 display: block;
                 left: 20px;
                 margin: 0px;

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -173,6 +173,14 @@ export class PodView extends React.Component<PodViewProps> {
                                                                                             <span> ago ({<Moment local={true}>{pod.createdAt}</Moment>})</span>
                                                                                         </span>
                                                                                     )}
+                                                                                    <div>
+                                                                                        {isYoungerThanXMinutes(pod, 30) && (
+                                                                                            <span>
+                                                                                                <i className='fas fa-circle circle-icon' /> &nbsp;
+                                                                                                <span>pod age less than 30min</span>
+                                                                                            </span>
+                                                                                        )}
+                                                                                    </div>
                                                                                 </div>
                                                                             }
                                                                             popperOptions={{

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -245,10 +245,10 @@ export const ComparisonStatusIcon = ({
             break;
         case appModels.SyncStatuses.OutOfSync:
             const requiresPruning = resource && resource.requiresPruning;
-            className = requiresPruning ? 'fa fa-times-circle' : 'fa fa-arrow-alt-circle-up';
+            className = requiresPruning ? 'fa fa-trash' : 'fa fa-arrow-alt-circle-up';
             title = 'OutOfSync';
             if (requiresPruning) {
-                title = `${title} (requires pruning)`;
+                title = `${title} (This resource is not present in the application’s source. It will be deleted from Kubernetes if the prune option is enabled during sync)`;
             }
             color = COLORS.sync.out_of_sync;
             break;


### PR DESCRIPTION
Signed-off-by: “schakradari” <“saisindhu_chakradari@intuit.com”>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ x] The title of the PR states what changed and the related issues number (used for the release note).
* [x ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

