### PR TITLE
Migrate deployment extensions/v1beta1 to apps/v1

### DIFF
--- a/test/e2e/testdata/deprecated-extensions/deployment.yaml
+++ b/test/e2e/testdata/deprecated-extensions/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: extensions-deployment

--- a/test/e2e/testdata/multi-namespace/deployment-with-namespace.yaml
+++ b/test/e2e/testdata/multi-namespace/deployment-with-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: helm-guestbook

--- a/test/e2e/testdata/multi-namespace/deployment.yaml
+++ b/test/e2e/testdata/multi-namespace/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: helm-guestbook

--- a/util/helm/testdata/redis/templates/metrics-deployment.yaml
+++ b/util/helm/testdata/redis/templates/metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metrics.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "redis.fullname" . }}-metrics

--- a/util/helm/testdata/redis/templates/redis-slave-deployment.yaml
+++ b/util/helm/testdata/redis/templates/redis-slave-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cluster.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "redis.fullname" . }}-slave

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const depWithoutSelector = `
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
@@ -34,7 +34,7 @@ spec:
 `
 
 const depWithSelector = `
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment


### PR DESCRIPTION
The apiversion for deployment about extensions/v1beta1 has been deprecated

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

