### PR TITLE
chore: don't generate release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -303,7 +303,6 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           draft: ${{ env.DRAFT_RELEASE }}
           prerelease: ${{ env.PRE_RELEASE }}
-          generate_release_notes: true
           body: ${{ steps.release-notes.outputs.content }}  # Pre-pended to the generated notes
           files: |
             dist/argocd-*


### PR DESCRIPTION
This causes issues for the 2.5.0 release. I'll revisit later.