### PR TITLE
feat: enable applicationset leader election by default

### DIFF
--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -102,7 +102,7 @@ func NewCommand() *cobra.Command {
 				NewCache:               cache.MultiNamespacedCacheBuilder([]string{namespace}),
 				HealthProbeBindAddress: probeBindAddr,
 				Port:                   9443,
-				LeaderElection:         enableLeaderElection,
+				LeaderElection:         true,
 				LeaderElectionID:       "58ac56fa.applicationsets.argoproj.io",
 				DryRunClient:           dryRun,
 			})

--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
@@ -28,10 +28,6 @@ spec:
           - containerPort: 8080
             name: metrics
           env:
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_LEADER_ELECTION
             valueFrom:
               configMapKeyRef:
@@ -102,11 +98,26 @@ spec:
               drop:
               - ALL
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true 
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
       serviceAccountName: argocd-applicationset-controller
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-applicationset-controller
+              topologyKey: kubernetes.io/hostname
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm

--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
@@ -24,17 +24,17 @@ rules:
   - apiGroups:
       - argoproj.io
     resources:
-      - appprojects
-    verbs:
-      - get
-  - apiGroups:
-      - argoproj.io
-    resources:
       - applicationsets/status
     verbs:
       - get
       - patch
       - update
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - appprojects
+    verbs:
+      - get
   - apiGroups:
       - ''
     resources:
@@ -46,10 +46,21 @@ rules:
       - patch
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - ''
     resources:
       - secrets
-      - configmaps
     verbs:
       - get
       - list
@@ -63,3 +74,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -9585,17 +9585,17 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
-  - appprojects
-  verbs:
-  - get
-- apiGroups:
-  - argoproj.io
-  resources:
   - applicationsets/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -9609,8 +9609,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
   verbs:
   - get
   - list
@@ -9623,6 +9634,18 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -9870,15 +9893,26 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-applicationset-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
+            weight: 5
       containers:
       - command:
         - entrypoint.sh
         - argocd-applicationset-controller
         env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_LEADER_ELECTION
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/base/kustomization.yaml
+++ b/manifests/ha/base/kustomization.yaml
@@ -3,9 +3,10 @@ kind: Kustomization
 
 
 patchesStrategicMerge:
+- overlays/argocd-application-controller-statefulset.yaml
+- overlays/argocd-applicationset-controller-deployment.yaml
 - overlays/argocd-repo-server-deployment.yaml
 - overlays/argocd-server-deployment.yaml
-- overlays/argocd-application-controller-statefulset.yaml
 
 
 images:

--- a/manifests/ha/base/overlays/argocd-applicationset-controller-deployment.yaml
+++ b/manifests/ha/base/overlays/argocd-applicationset-controller-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-applicationset-controller
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - name: argocd-application-controller
+        command:
+        - entrypoint.sh
+        - argocd-applicationset-controller
+        - --enable-leader-election=true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-applicationset-controller
+            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-applicationset-controller
+              topologyKey: failure-domain.beta.kubernetes.io/zone

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9621,17 +9621,17 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
-  - appprojects
-  verbs:
-  - get
-- apiGroups:
-  - argoproj.io
-  resources:
   - applicationsets/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -9645,8 +9645,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
   verbs:
   - get
   - list
@@ -9659,6 +9670,18 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11104,6 +11127,7 @@ metadata:
     app.kubernetes.io/part-of: argocd-applicationset
   name: argocd-applicationset-controller
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-applicationset-controller
@@ -11112,15 +11136,30 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-applicationset-controller
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-applicationset-controller
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - entrypoint.sh
         - argocd-applicationset-controller
+        - --enable-leader-election=true
+        name: argocd-application-controller
+      - command:
+        - entrypoint.sh
+        - argocd-applicationset-controller
         env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_LEADER_ELECTION
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -136,17 +136,17 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
-  - appprojects
-  verbs:
-  - get
-- apiGroups:
-  - argoproj.io
-  resources:
   - applicationsets/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -160,8 +160,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
   verbs:
   - get
   - list
@@ -174,6 +185,18 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1526,6 +1549,7 @@ metadata:
     app.kubernetes.io/part-of: argocd-applicationset
   name: argocd-applicationset-controller
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-applicationset-controller
@@ -1534,15 +1558,30 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-applicationset-controller
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: argocd-applicationset-controller
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - entrypoint.sh
         - argocd-applicationset-controller
+        - --enable-leader-election=true
+        name: argocd-application-controller
+      - command:
+        - entrypoint.sh
+        - argocd-applicationset-controller
         env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_LEADER_ELECTION
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9612,17 +9612,17 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
-  - appprojects
-  verbs:
-  - get
-- apiGroups:
-  - argoproj.io
-  resources:
   - applicationsets/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -9636,8 +9636,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
   verbs:
   - get
   - list
@@ -9650,6 +9661,18 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10190,15 +10213,26 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-applicationset-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
+            weight: 5
       containers:
       - command:
         - entrypoint.sh
         - argocd-applicationset-controller
         env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_LEADER_ELECTION
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -127,17 +127,17 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
-  - appprojects
-  verbs:
-  - get
-- apiGroups:
-  - argoproj.io
-  resources:
   - applicationsets/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -151,8 +151,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
   verbs:
   - get
   - list
@@ -165,6 +176,18 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -612,15 +635,26 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-applicationset-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
+            weight: 5
       containers:
       - command:
         - entrypoint.sh
         - argocd-applicationset-controller
         env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_LEADER_ELECTION
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Closes: https://github.com/argoproj/argo-cd/issues/11148

RBAC rules for coordination are ported from argocd-helm repository

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
