### PR TITLE
fix: add pod age icon details in tooltip (#10290)

### DIFF
--- a/ui/src/app/applications/components/application-pod-view/pod-view.scss
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.scss
@@ -7,6 +7,13 @@ $pods-per-column: 4;
 $max-rows: 5;
 $num-stats: 2;
 
+$pod-age-icon-clr: #ffce25;
+
+.circle-icon {
+    color: $pod-age-icon-clr;
+    font-size: 10px;
+}
+
 .pod-view {
     &__settings {
         align-items: center;
@@ -67,7 +74,7 @@ $num-stats: 2;
             margin: 1em 0;
             padding: 10px;
             border-radius: 3px;
-            background-color: $argo-color-gray-3;                            
+            background-color: $argo-color-gray-3;
             color: $argo-color-gray-6;
             div {
                 display: flex;
@@ -149,7 +156,7 @@ $num-stats: 2;
             }
             &__new-pod-icon {
                 background: none;
-                color: #FFCE25;
+                color: $pod-age-icon-clr;
                 display: block;
                 left: 20px;
                 margin: 0px;

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -171,6 +171,14 @@ export class PodView extends React.Component<PodViewProps> {
                                                                                                 {pod.createdAt}
                                                                                             </Moment>
                                                                                             <span> ago ({<Moment local={true}>{pod.createdAt}</Moment>})</span>
+                                                                                            <div>
+                                                                                                {isYoungerThanXMinutes(pod, 30) && (
+                                                                                                    <span>
+                                                                                                        <i className='fas fa-circle circle-icon' /> &nbsp;
+                                                                                                        <span>pod age less than 30min</span>
+                                                                                                    </span>
+                                                                                                )}
+                                                                                            </div>
                                                                                         </span>
                                                                                     )}
                                                                                 </div>
@@ -195,14 +203,6 @@ export class PodView extends React.Component<PodViewProps> {
                                                                                 )}
                                                                                 <div className={`pod-view__node__pod pod-view__node__pod--${pod.health.toLowerCase()}`}>
                                                                                     <PodHealthIcon state={{status: pod.health, message: ''}} />
-                                                                                </div>
-                                                                                <div>
-                                                                                    {isYoungerThanXMinutes(pod, 30) && (
-                                                                                        <span>
-                                                                                            <i className='fas fa-circle circle-icon' /> &nbsp;
-                                                                                            <span>pod age less than 30min</span>
-                                                                                        </span>
-                                                                                    )}
                                                                                 </div>
                                                                             </div>
                                                                         </Tooltip>

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -196,6 +196,14 @@ export class PodView extends React.Component<PodViewProps> {
                                                                                 <div className={`pod-view__node__pod pod-view__node__pod--${pod.health.toLowerCase()}`}>
                                                                                     <PodHealthIcon state={{status: pod.health, message: ''}} />
                                                                                 </div>
+                                                                                <div>
+                                                                                    {isYoungerThanXMinutes(pod, 30) && (
+                                                                                        <span>
+                                                                                            <i className='fas fa-circle circle-icon' /> &nbsp;
+                                                                                            <span>pod age less than 30min</span>
+                                                                                        </span>
+                                                                                    )}
+                                                                                </div>
                                                                             </div>
                                                                         </Tooltip>
                                                                     )}


### PR DESCRIPTION
Relates to #10290

Signed-off-by: schakradari <58915923+schakrad@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

<img width="447" alt="Screen Shot 2022-11-02 at 4 57 22 PM" src="https://user-images.githubusercontent.com/58915923/199601143-64e0e62b-9b33-4b66-9023-446c7f0587b2.png">

The yellow icon is added in the tooltip with the description what it signifies(pod whose age is less than 30min) and this icon only appears in the tooltip when the pod age is less than 30min.
