### PR TITLE
fix: upgrade redis-ha chart to 4.22.3, redis regression

### DIFF
--- a/manifests/base/redis/argocd-redis-network-policy.yaml
+++ b/manifests/base/redis/argocd-redis-network-policy.yaml
@@ -25,7 +25,8 @@ spec:
           port: 6379
   egress:
     - to:
-      - namespaceSelector: {}
+      - ipBlock:
+          cidr: 0.0.0.0/24
       ports:
         - port: 53
           protocol: UDP

--- a/manifests/base/redis/argocd-redis-network-policy.yaml
+++ b/manifests/base/redis/argocd-redis-network-policy.yaml
@@ -26,7 +26,7 @@ spec:
   egress:
     - to:
       - ipBlock:
-          cidr: 0.0.0.0/24
+          cidr: 0.0.0.0/0
       ports:
         - port: 53
           protocol: UDP

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -10301,7 +10301,8 @@ spec:
     - port: 53
       protocol: TCP
     to:
-    - namespaceSelector: {}
+    - ipBlock:
+        cidr: 0.0.0.0/24
   ingress:
   - from:
     - podSelector:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -10302,7 +10302,7 @@ spec:
       protocol: TCP
     to:
     - ipBlock:
-        cidr: 0.0.0.0/24
+        cidr: 0.0.0.0/0
   ingress:
   - from:
     - podSelector:

--- a/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
+++ b/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
@@ -36,7 +36,6 @@ spec:
         - port: 26379
           protocol: TCP
     - to:
-      - namespaceSelector: {}
       ports:
         - port: 53
           protocol: UDP

--- a/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
+++ b/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
@@ -36,6 +36,8 @@ spec:
         - port: 26379
           protocol: TCP
     - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
       ports:
         - port: 53
           protocol: UDP

--- a/manifests/ha/base/redis-ha/argocd-redis-ha-server-network-policy.yaml
+++ b/manifests/ha/base/redis-ha/argocd-redis-ha-server-network-policy.yaml
@@ -33,6 +33,8 @@ spec:
         - port: 26379
           protocol: TCP
     - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
       ports:
         - port: 53
           protocol: UDP

--- a/manifests/ha/base/redis-ha/argocd-redis-ha-server-network-policy.yaml
+++ b/manifests/ha/base/redis-ha/argocd-redis-ha-server-network-policy.yaml
@@ -33,7 +33,6 @@ spec:
         - port: 26379
           protocol: TCP
     - to:
-      - namespaceSelector: {}
       ports:
         - port: 53
           protocol: UDP

--- a/manifests/ha/base/redis-ha/chart/requirements.lock
+++ b/manifests/ha/base/redis-ha/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts
-  version: 4.17.8
-digest: sha256:24b66a7cd8e6ec23502173bd643bfaa66cf0d062df0361370226754e0cedda12
-generated: "2022-08-12T00:12:34.042365707-07:00"
+  version: 4.22.3
+digest: sha256:ae773caf65b172bdd2216072c03ba76ef3c0383dbd1e2478934a67b9455f6a2e
+generated: "2022-11-02T16:57:25.047025473-07:00"

--- a/manifests/ha/base/redis-ha/chart/requirements.yaml
+++ b/manifests/ha/base/redis-ha/chart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: redis-ha
-  version: 4.17.8
+  version: 4.22.3
   repository: https://dandydeveloper.github.io/charts

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -1051,7 +1051,9 @@ spec:
       
       serviceAccountName: argocd-redis-ha-haproxy
       securityContext: 
-        null
+        fsGroup: 99
+        runAsNonRoot: true
+        runAsUser: 99
       nodeSelector:
         {}
       tolerations:
@@ -1168,7 +1170,9 @@ spec:
                   argocd-redis-ha: replica
               topologyKey: kubernetes.io/hostname
       securityContext: 
-        null
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       serviceAccountName: argocd-redis-ha
       automountServiceAccountToken: false
       initContainers:

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
     app: argocd-redis-ha
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
     app: argocd-redis-ha
 ---
 # Source: redis-ha/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -33,7 +33,7 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
     app: argocd-redis-ha
 data:
   redis.conf: |
@@ -41,7 +41,6 @@ data:
     port 6379
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
-    bind 0.0.0.0
     maxmemory 0
     maxmemory-policy volatile-lru
     min-replicas-max-lag 5
@@ -54,7 +53,6 @@ data:
   sentinel.conf: |
     dir "/data"
     port 26379
-    bind 0.0.0.0
         sentinel down-after-milliseconds argocd 10000
         sentinel failover-timeout argocd 180000
         maxclients 10000
@@ -176,11 +174,11 @@ data:
             echo "Getting redis master ip.."
             echo "  blindly assuming (${SERVICE}-announce-0) or (${SERVICE}-server-0) are master"
             DEFAULT_MASTER="$(getent_hosts 0 | awk '{ print $1 }')"
-            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             if [ -z "${DEFAULT_MASTER}" ]; then
                 echo "Error: Unable to resolve redis master (getent hosts)."
                 exit 1
             fi
+            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             echo "Setting default slave config for redis and sentinel.."
             echo "  using master ip (${DEFAULT_MASTER})"
             redis_update "${DEFAULT_MASTER}"
@@ -277,11 +275,7 @@ data:
     getent_hosts() {
         index=${1:-${INDEX}}
         service="${SERVICE}-announce-${index}"
-        pod="${SERVICE}-server-${index}"
         host=$(getent hosts "${service}")
-        if [ -z "${host}" ]; then
-            host=$(getent hosts "${pod}")
-        fi
         echo "${host}"
     }
 
@@ -443,11 +437,11 @@ data:
             echo "Getting redis master ip.."
             echo "  blindly assuming (${SERVICE}-announce-0) or (${SERVICE}-server-0) are master"
             DEFAULT_MASTER="$(getent_hosts 0 | awk '{ print $1 }')"
-            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             if [ -z "${DEFAULT_MASTER}" ]; then
                 echo "Error: Unable to resolve redis master (getent hosts)."
                 exit 1
             fi
+            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             echo "Setting default slave config for redis and sentinel.."
             echo "  using master ip (${DEFAULT_MASTER})"
             redis_update "${DEFAULT_MASTER}"
@@ -544,11 +538,7 @@ data:
     getent_hosts() {
         index=${1:-${INDEX}}
         service="${SERVICE}-announce-${index}"
-        pod="${SERVICE}-server-${index}"
         host=$(getent hosts "${service}")
-        if [ -z "${host}" ]; then
-            host=$(getent hosts "${pod}")
-        fi
         echo "${host}"
     }
 
@@ -593,18 +583,24 @@ data:
 
     identify_announce_ip
 
+    while [ -z "${ANNOUNCE_IP}" ]; do
+        echo "Error: Could not resolve the announce ip for this pod."
+        sleep 30
+        identify_announce_ip
+    done
+
     while true; do
         sleep 60
 
         # where is redis master
         identify_master
 
-        if [ "$MASTER" == "$ANNOUNCE_IP" ]; then
+        if [ "$MASTER" = "$ANNOUNCE_IP" ]; then
             redis_role
             if [ "$ROLE" != "master" ]; then
                 reinit
             fi
-        else
+        elif [ "${MASTER}" ]; then
             identify_redis_master
             if [ "$REDIS_MASTER" != "$MASTER" ]; then
                 reinit
@@ -622,7 +618,7 @@ data:
       timeout check 2s
 
     listen health_check_http_url
-      bind [::]:8888 v4v6
+      bind [::]:8888  v4v6
       mode http
       monitor-uri /healthz
       option      dontlognull
@@ -636,7 +632,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE0
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -650,7 +645,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE1
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -664,7 +658,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE2
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -764,7 +757,7 @@ metadata:
   labels:
     heritage: Helm
     release: argocd
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
     app: argocd-redis-ha
 data:
   redis_liveness.sh: |
@@ -814,7 +807,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
 rules:
 - apiGroups:
     - ""
@@ -833,7 +826,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
     component: argocd-redis-ha-haproxy
 rules:
 - apiGroups:
@@ -853,7 +846,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha
@@ -872,7 +865,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
     component: argocd-redis-ha-haproxy
 subjects:
 - kind: ServiceAccount
@@ -892,7 +885,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -922,7 +915,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -952,7 +945,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -982,7 +975,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
   annotations:
 spec:
   type: ClusterIP
@@ -1010,7 +1003,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
     component: argocd-redis-ha-haproxy
   annotations:
 spec:
@@ -1034,7 +1027,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
 spec:
   strategy:
     type: RollingUpdate
@@ -1052,11 +1045,13 @@ spec:
         release: argocd
         revision: "1"
       annotations:
-        checksum/config: 33967cee643b636d6e9a66e82b7f85814ceb8c55fba7a1d8af439ef056934e5c
+        checksum/config: 1f7a9ffcacb3871ceb9b0741c0714e3f7fa656d426a398c1f727fffb01073f35
     spec:
       # Needed when using unmodified rbac-setup.yml
       
       serviceAccountName: argocd-redis-ha-haproxy
+      securityContext: 
+        null
       nodeSelector:
         {}
       tolerations:
@@ -1080,20 +1075,20 @@ spec:
         - sh
         args:
         - /readonly/haproxy_init.sh
+        securityContext: 
+          null
         volumeMounts:
         - name: config-volume
           mountPath: /readonly
           readOnly: true
         - name: data
           mountPath: /data
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
       containers:
       - name: haproxy
         image: haproxy:2.6.2-alpine
         imagePullPolicy: IfNotPresent
+        securityContext: 
+          null
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1140,7 +1135,7 @@ metadata:
     app: redis-ha
     heritage: "Helm"
     release: "argocd"
-    chart: redis-ha-4.17.8
+    chart: redis-ha-4.22.3
   annotations:
     {}
 spec:
@@ -1156,7 +1151,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/init-config: 226aec192d2f29b5355769c9f1fbf093bf36c3a1e15b574b71fb8fe73fd37c05
+        checksum/init-config: 84ccf6a9b8a7fa3ae5b62a8f17d6c65a5197e9605da9b2761179bf942828eefe
       labels:
         release: argocd
         app: redis-ha
@@ -1172,10 +1167,8 @@ spec:
                   release: argocd
                   argocd-redis-ha: replica
               topologyKey: kubernetes.io/hostname
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
+      securityContext: 
+        null
       serviceAccountName: argocd-redis-ha
       automountServiceAccountToken: false
       initContainers:
@@ -1188,6 +1181,8 @@ spec:
         - sh
         args:
         - /readonly-config/init.sh
+        securityContext: 
+          null        
         env:
         - name: SENTINEL_ID_0
           value: 3c0d9c0320bb34888c2df5757c718ce6ca992ce6
@@ -1211,6 +1206,8 @@ spec:
         - redis-server
         args:
         - /data/conf/redis.conf
+        securityContext: 
+          null
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 15
@@ -1259,6 +1256,8 @@ spec:
           - redis-sentinel
         args:
           - /data/conf/sentinel.conf
+        securityContext: 
+          null
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 15
@@ -1301,6 +1300,8 @@ spec:
           - sh
         args:
           - /readonly-config/fix-split-brain.sh
+        securityContext: 
+          null        
         env:
         - name: SENTINEL_ID_0
           value: 3c0d9c0320bb34888c2df5757c718ce6ca992ce6

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -10,7 +10,6 @@ redis-ha:
     image:
       tag: 2.6.2-alpine
     containerSecurityContext: null
-    securityContext: null
     timeout:
       server: 6m
       client: 6m
@@ -18,4 +17,3 @@ redis-ha:
   image:
     tag: 7.0.5-alpine
   containerSecurityContext: null
-  securityContext: null

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -5,16 +5,17 @@ redis-ha:
     masterGroupName: argocd
     config:
       save: "\"\""
-      bind: "0.0.0.0"
   haproxy:
     enabled: true
     image:
       tag: 2.6.2-alpine
+    containerSecurityContext: null
+    securityContext: null
     timeout:
       server: 6m
       client: 6m
     checkInterval: 3s
   image:
     tag: 7.0.5-alpine
-  sentinel:
-    bind: "0.0.0.0"
+  containerSecurityContext: null
+  securityContext: null

--- a/manifests/ha/base/redis-ha/overlays/statefulset-containers-securityContext.yaml
+++ b/manifests/ha/base/redis-ha/overlays/statefulset-containers-securityContext.yaml
@@ -25,3 +25,12 @@
       - ALL
     seccompProfile:
       type: RuntimeDefault
+- op: add
+  path: /spec/template/spec/containers/2/securityContext
+  value:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9911,11 +9911,11 @@ data:
             echo "Getting redis master ip.."
             echo "  blindly assuming (${SERVICE}-announce-0) or (${SERVICE}-server-0) are master"
             DEFAULT_MASTER="$(getent_hosts 0 | awk '{ print $1 }')"
-            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             if [ -z "${DEFAULT_MASTER}" ]; then
                 echo "Error: Unable to resolve redis master (getent hosts)."
                 exit 1
             fi
+            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             echo "Setting default slave config for redis and sentinel.."
             echo "  using master ip (${DEFAULT_MASTER})"
             redis_update "${DEFAULT_MASTER}"
@@ -10012,11 +10012,7 @@ data:
     getent_hosts() {
         index=${1:-${INDEX}}
         service="${SERVICE}-announce-${index}"
-        pod="${SERVICE}-server-${index}"
         host=$(getent hosts "${service}")
-        if [ -z "${host}" ]; then
-            host=$(getent hosts "${pod}")
-        fi
         echo "${host}"
     }
 
@@ -10061,18 +10057,24 @@ data:
 
     identify_announce_ip
 
+    while [ -z "${ANNOUNCE_IP}" ]; do
+        echo "Error: Could not resolve the announce ip for this pod."
+        sleep 30
+        identify_announce_ip
+    done
+
     while true; do
         sleep 60
 
         # where is redis master
         identify_master
 
-        if [ "$MASTER" == "$ANNOUNCE_IP" ]; then
+        if [ "$MASTER" = "$ANNOUNCE_IP" ]; then
             redis_role
             if [ "$ROLE" != "master" ]; then
                 reinit
             fi
-        else
+        elif [ "${MASTER}" ]; then
             identify_redis_master
             if [ "$REDIS_MASTER" != "$MASTER" ]; then
                 reinit
@@ -10088,7 +10090,7 @@ data:
       timeout check 2s
 
     listen health_check_http_url
-      bind [::]:8888 v4v6
+      bind [::]:8888  v4v6
       mode http
       monitor-uri /healthz
       option      dontlognull
@@ -10102,7 +10104,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE0
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -10116,7 +10117,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE1
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -10130,7 +10130,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE2
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -10306,11 +10305,11 @@ data:
             echo "Getting redis master ip.."
             echo "  blindly assuming (${SERVICE}-announce-0) or (${SERVICE}-server-0) are master"
             DEFAULT_MASTER="$(getent_hosts 0 | awk '{ print $1 }')"
-            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             if [ -z "${DEFAULT_MASTER}" ]; then
                 echo "Error: Unable to resolve redis master (getent hosts)."
                 exit 1
             fi
+            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             echo "Setting default slave config for redis and sentinel.."
             echo "  using master ip (${DEFAULT_MASTER})"
             redis_update "${DEFAULT_MASTER}"
@@ -10407,11 +10406,7 @@ data:
     getent_hosts() {
         index=${1:-${INDEX}}
         service="${SERVICE}-announce-${index}"
-        pod="${SERVICE}-server-${index}"
         host=$(getent hosts "${service}")
-        if [ -z "${host}" ]; then
-            host=$(getent hosts "${pod}")
-        fi
         echo "${host}"
     }
 
@@ -10459,7 +10454,6 @@ data:
     port 6379
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
-    bind 0.0.0.0
     maxmemory 0
     maxmemory-policy volatile-lru
     min-replicas-max-lag 5
@@ -10471,7 +10465,6 @@ data:
   sentinel.conf: |
     dir "/data"
     port 26379
-    bind 0.0.0.0
         sentinel down-after-milliseconds argocd 10000
         sentinel failover-timeout argocd 180000
         maxclients 10000
@@ -11159,7 +11152,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 33967cee643b636d6e9a66e82b7f85814ceb8c55fba7a1d8af439ef056934e5c
+        checksum/config: 1f7a9ffcacb3871ceb9b0741c0714e3f7fa656d426a398c1f727fffb01073f35
       labels:
         app.kubernetes.io/name: argocd-redis-ha-haproxy
       name: argocd-redis-ha-haproxy
@@ -11224,10 +11217,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
+      securityContext: null
       serviceAccountName: argocd-redis-ha-haproxy
       volumes:
       - configMap:
@@ -12025,7 +12015,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/init-config: 226aec192d2f29b5355769c9f1fbf093bf36c3a1e15b574b71fb8fe73fd37c05
+        checksum/init-config: 84ccf6a9b8a7fa3ae5b62a8f17d6c65a5197e9605da9b2761179bf942828eefe
       labels:
         app.kubernetes.io/name: argocd-redis-ha
     spec:
@@ -12151,6 +12141,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
+        securityContext: null
         volumeMounts:
         - mountPath: /readonly-config
           name: config
@@ -12185,10 +12176,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
+      securityContext: null
       serviceAccountName: argocd-redis-ha
       terminationGracePeriodSeconds: 60
       volumes:
@@ -12302,8 +12290,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to:
-    - namespaceSelector: {}
+    to: null
   ingress:
   - from:
     - podSelector:
@@ -12347,8 +12334,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to:
-    - namespaceSelector: {}
+    to: null
   ingress:
   - from:
     - podSelector:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -12144,7 +12144,13 @@ spec:
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
-        securityContext: null
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /readonly-config
           name: config
@@ -12296,7 +12302,9 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to: null
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
   ingress:
   - from:
     - podSelector:
@@ -12340,7 +12348,9 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to: null
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
   ingress:
   - from:
     - podSelector:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -11217,7 +11217,10 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext: null
+      securityContext:
+        fsGroup: 99
+        runAsNonRoot: true
+        runAsUser: 99
       serviceAccountName: argocd-redis-ha-haproxy
       volumes:
       - configMap:
@@ -12176,7 +12179,10 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext: null
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       serviceAccountName: argocd-redis-ha
       terminationGracePeriodSeconds: 60
       volumes:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1883,7 +1883,10 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext: null
+      securityContext:
+        fsGroup: 99
+        runAsNonRoot: true
+        runAsUser: 99
       serviceAccountName: argocd-redis-ha-haproxy
       volumes:
       - configMap:
@@ -2842,7 +2845,10 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext: null
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       serviceAccountName: argocd-redis-ha
       terminationGracePeriodSeconds: 60
       volumes:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2810,7 +2810,13 @@ spec:
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
-        securityContext: null
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /readonly-config
           name: config
@@ -2962,7 +2968,9 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to: null
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
   ingress:
   - from:
     - podSelector:
@@ -3006,7 +3014,9 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to: null
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
   ingress:
   - from:
     - podSelector:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -577,11 +577,11 @@ data:
             echo "Getting redis master ip.."
             echo "  blindly assuming (${SERVICE}-announce-0) or (${SERVICE}-server-0) are master"
             DEFAULT_MASTER="$(getent_hosts 0 | awk '{ print $1 }')"
-            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             if [ -z "${DEFAULT_MASTER}" ]; then
                 echo "Error: Unable to resolve redis master (getent hosts)."
                 exit 1
             fi
+            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             echo "Setting default slave config for redis and sentinel.."
             echo "  using master ip (${DEFAULT_MASTER})"
             redis_update "${DEFAULT_MASTER}"
@@ -678,11 +678,7 @@ data:
     getent_hosts() {
         index=${1:-${INDEX}}
         service="${SERVICE}-announce-${index}"
-        pod="${SERVICE}-server-${index}"
         host=$(getent hosts "${service}")
-        if [ -z "${host}" ]; then
-            host=$(getent hosts "${pod}")
-        fi
         echo "${host}"
     }
 
@@ -727,18 +723,24 @@ data:
 
     identify_announce_ip
 
+    while [ -z "${ANNOUNCE_IP}" ]; do
+        echo "Error: Could not resolve the announce ip for this pod."
+        sleep 30
+        identify_announce_ip
+    done
+
     while true; do
         sleep 60
 
         # where is redis master
         identify_master
 
-        if [ "$MASTER" == "$ANNOUNCE_IP" ]; then
+        if [ "$MASTER" = "$ANNOUNCE_IP" ]; then
             redis_role
             if [ "$ROLE" != "master" ]; then
                 reinit
             fi
-        else
+        elif [ "${MASTER}" ]; then
             identify_redis_master
             if [ "$REDIS_MASTER" != "$MASTER" ]; then
                 reinit
@@ -754,7 +756,7 @@ data:
       timeout check 2s
 
     listen health_check_http_url
-      bind [::]:8888 v4v6
+      bind [::]:8888  v4v6
       mode http
       monitor-uri /healthz
       option      dontlognull
@@ -768,7 +770,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE0
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -782,7 +783,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE1
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -796,7 +796,6 @@ data:
       tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
       tcp-check expect string REPLACE_ANNOUNCE2
       tcp-check send QUIT\r\n
-      tcp-check expect string +OK
       server R0 argocd-redis-ha-announce-0:26379 check inter 3s
       server R1 argocd-redis-ha-announce-1:26379 check inter 3s
       server R2 argocd-redis-ha-announce-2:26379 check inter 3s
@@ -972,11 +971,11 @@ data:
             echo "Getting redis master ip.."
             echo "  blindly assuming (${SERVICE}-announce-0) or (${SERVICE}-server-0) are master"
             DEFAULT_MASTER="$(getent_hosts 0 | awk '{ print $1 }')"
-            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             if [ -z "${DEFAULT_MASTER}" ]; then
                 echo "Error: Unable to resolve redis master (getent hosts)."
                 exit 1
             fi
+            echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
             echo "Setting default slave config for redis and sentinel.."
             echo "  using master ip (${DEFAULT_MASTER})"
             redis_update "${DEFAULT_MASTER}"
@@ -1073,11 +1072,7 @@ data:
     getent_hosts() {
         index=${1:-${INDEX}}
         service="${SERVICE}-announce-${index}"
-        pod="${SERVICE}-server-${index}"
         host=$(getent hosts "${service}")
-        if [ -z "${host}" ]; then
-            host=$(getent hosts "${pod}")
-        fi
         echo "${host}"
     }
 
@@ -1125,7 +1120,6 @@ data:
     port 6379
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
-    bind 0.0.0.0
     maxmemory 0
     maxmemory-policy volatile-lru
     min-replicas-max-lag 5
@@ -1137,7 +1131,6 @@ data:
   sentinel.conf: |
     dir "/data"
     port 26379
-    bind 0.0.0.0
         sentinel down-after-milliseconds argocd 10000
         sentinel failover-timeout argocd 180000
         maxclients 10000
@@ -1825,7 +1818,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 33967cee643b636d6e9a66e82b7f85814ceb8c55fba7a1d8af439ef056934e5c
+        checksum/config: 1f7a9ffcacb3871ceb9b0741c0714e3f7fa656d426a398c1f727fffb01073f35
       labels:
         app.kubernetes.io/name: argocd-redis-ha-haproxy
       name: argocd-redis-ha-haproxy
@@ -1890,10 +1883,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
+      securityContext: null
       serviceAccountName: argocd-redis-ha-haproxy
       volumes:
       - configMap:
@@ -2691,7 +2681,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/init-config: 226aec192d2f29b5355769c9f1fbf093bf36c3a1e15b574b71fb8fe73fd37c05
+        checksum/init-config: 84ccf6a9b8a7fa3ae5b62a8f17d6c65a5197e9605da9b2761179bf942828eefe
       labels:
         app.kubernetes.io/name: argocd-redis-ha
     spec:
@@ -2817,6 +2807,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
+        securityContext: null
         volumeMounts:
         - mountPath: /readonly-config
           name: config
@@ -2851,10 +2842,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data
-      securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
+      securityContext: null
       serviceAccountName: argocd-redis-ha
       terminationGracePeriodSeconds: 60
       volumes:
@@ -2968,8 +2956,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to:
-    - namespaceSelector: {}
+    to: null
   ingress:
   - from:
     - podSelector:
@@ -3013,8 +3000,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to:
-    - namespaceSelector: {}
+    to: null
   ingress:
   - from:
     - podSelector:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11118,7 +11118,8 @@ spec:
     - port: 53
       protocol: TCP
     to:
-    - namespaceSelector: {}
+    - ipBlock:
+        cidr: 0.0.0.0/24
   ingress:
   - from:
     - podSelector:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -11119,7 +11119,7 @@ spec:
       protocol: TCP
     to:
     - ipBlock:
-        cidr: 0.0.0.0/24
+        cidr: 0.0.0.0/0
   ingress:
   - from:
     - podSelector:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1784,7 +1784,8 @@ spec:
     - port: 53
       protocol: TCP
     to:
-    - namespaceSelector: {}
+    - ipBlock:
+        cidr: 0.0.0.0/24
   ingress:
   - from:
     - podSelector:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1785,7 +1785,7 @@ spec:
       protocol: TCP
     to:
     - ipBlock:
-        cidr: 0.0.0.0/24
+        cidr: 0.0.0.0/0
   ingress:
   - from:
     - podSelector:


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Supersedes #11127
Fixes #11126  

Fixes split-brain-fix problem associated with pods going into a crashing loop.  Also allows redis pods to make DNS queries outside the cluster. 

Special thanks for the awesome people that provided reporting, logs,  analysis, and testing. 
