### PR TITLE
chore: add debug logs around CMP manifest generation

### DIFF
--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -203,6 +203,11 @@ func (s *Service) generateManifest(ctx context.Context, appDir string, envEntrie
 
 	manifests, err := kube.SplitYAMLToString([]byte(out))
 	if err != nil {
+		sanitizedManifests := manifests
+		if len(sanitizedManifests) > 1000 {
+			sanitizedManifests = manifests[:1000]
+		}
+		log.Debugf("Failed to split generated manifests. Beginning of generated manifests: %q", sanitizedManifests)
 		return &apiclient.ManifestResponse{}, err
 	}
 

--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -63,6 +63,10 @@ metadata:
   name: cmp-plugin
 spec:
   version: v1.0
+  init:
+    # Init always happens immediately before generate, but its output is not treated as manifests.
+    # This is a good place to, for example, download chart dependencies.
+    command: [sh, -c, 'echo "Initializing..."']
   generate:
     command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"']
   discover:
@@ -110,6 +114,8 @@ data:
       name: cmp-plugin
     spec:
       version: v1.0
+      init:
+        command: [sh, -c, 'echo "Initializing..."']
       generate:
         command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"']
       discover:
@@ -230,6 +236,11 @@ If you don't need to set any environment variables, you can set an empty plugin 
     Each CMP command will also independently timeout on the `ARGOCD_EXEC_TIMEOUT` set for the CMP sidecar. The default
     is 90s. So if you increase the repo server timeout greater than 90s, be sure to set `ARGOCD_EXEC_TIMEOUT` on the
     sidecar.
+
+!!! note
+    Each Application can only have one config management plugin configured at a time. If you're converting an existing
+    plugin configured through the `argocd-cm` ConfigMap to a sidecar, make sure the discovery mechanism only returns
+    true for Applications that have had their `name` field in the `plugin` section of their spec removed.
 
 ## Plugin tar stream exclusions
 

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1635,6 +1635,11 @@ func runConfigManagementPluginSidecars(ctx context.Context, appPath, repoPath st
 	for _, manifestString := range cmpManifests.Manifests {
 		manifestObjs, err := kube.SplitYAML([]byte(manifestString))
 		if err != nil {
+			sanitizedManifestString := manifestString
+			if len(manifestString) > 1000 {
+				sanitizedManifestString = sanitizedManifestString[:1000]
+			}
+			log.Debugf("Failed to convert generated manifests. Beginning of generated manifests: %q", sanitizedManifestString)
 			return nil, fmt.Errorf("failed to convert CMP manifests to unstructured objects: %s", err.Error())
 		}
 		manifests = append(manifests, manifestObjs...)


### PR DESCRIPTION
Per [my conversation](https://cloud-native.slack.com/archives/C01TSERG0KZ/p1667320882828149) with @crenshaw-dev, adding:

1. Debug logs around manifest generation/manipulation both on the sidecar container and on the main repo-server container
2. Clarifying in docs that only one cmp can be configured at a time for a given Application

I haven't found test cases for log statements, but I'd be happy to submit some manually produced evidence.

