### PR TITLE
fix: do not mutate live when managed namespace enabled

### DIFF
--- a/controller/sync_namespace.go
+++ b/controller/sync_namespace.go
@@ -1,46 +1,50 @@
 package controller
 
 import (
-	"fmt"
-	cdcommon "github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/argo"
 	gitopscommon "github.com/argoproj/gitops-engine/pkg/sync/common"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func syncNamespace(resourceTracking argo.ResourceTracking, appLabelKey string, trackingMethod v1alpha1.TrackingMethod, appName string, syncPolicy *v1alpha1.SyncPolicy) func(un *unstructured.Unstructured) (bool, error) {
-	return func(liveNs *unstructured.Unstructured) (bool, error) {
-		if liveNs != nil && kube.GetAppInstanceLabel(liveNs, cdcommon.LabelKeyAppInstance) != "" {
-			kube.UnsetLabel(liveNs, cdcommon.LabelKeyAppInstance)
-			return true, nil
+// syncNamespace determine if Argo CD should create and/or manage the namespace
+// where the application will be deployed.
+func syncNamespace(resourceTracking argo.ResourceTracking, appLabelKey string, trackingMethod v1alpha1.TrackingMethod, appName string, syncPolicy *v1alpha1.SyncPolicy) func(m, l *unstructured.Unstructured) (bool, error) {
+	// This function must return true for the managed namespace to be synced.
+	return func(managedNs, liveNs *unstructured.Unstructured) (bool, error) {
+		if managedNs == nil {
+			return false, nil
 		}
 
-		isNewNamespace := liveNs != nil && liveNs.GetUID() == "" && liveNs.GetResourceVersion() == ""
+		isNewNamespace := liveNs == nil
+		isManagedNamespace := syncPolicy != nil && syncPolicy.ManagedNamespaceMetadata != nil
 
-		if liveNs != nil && syncPolicy != nil {
-			// managedNamespaceMetadata relies on SSA, and since the diffs are computed by the k8s control plane we
-			// always need to call the k8s api server, so we'll always need to return true if managedNamespaceMetadata is set.
-			hasManagedMetadata := syncPolicy.ManagedNamespaceMetadata != nil
-			if hasManagedMetadata {
-				managedNamespaceMetadata := syncPolicy.ManagedNamespaceMetadata
-				liveNs.SetLabels(managedNamespaceMetadata.Labels)
-				liveNs.SetAnnotations(appendSSAAnnotation(managedNamespaceMetadata.Annotations))
-
-				err := resourceTracking.SetAppInstance(liveNs, appLabelKey, appName, "", trackingMethod)
-				if err != nil {
-					return false, fmt.Errorf("failed to set app instance tracking on the namespace %s: %s", liveNs.GetName(), err)
-				}
-
-				return true, nil
-			}
+		// should only sync the namespace if it doesn't exist in k8s or if
+		// syncPolicy is defined to manage the metadata
+		if !isManagedNamespace && !isNewNamespace {
+			return false, nil
 		}
 
-		return isNewNamespace, nil
+		if isManagedNamespace {
+			managedNamespaceMetadata := syncPolicy.ManagedNamespaceMetadata
+			managedNs.SetLabels(managedNamespaceMetadata.Labels)
+			// managedNamespaceMetadata relies on SSA in order to avoid overriding
+			// existing labels and annotations in namespaces
+			managedNs.SetAnnotations(appendSSAAnnotation(managedNamespaceMetadata.Annotations))
+		}
+
+		// TODO: https://github.com/argoproj/argo-cd/issues/11196
+		// err := resourceTracking.SetAppInstance(managedNs, appLabelKey, appName, "", trackingMethod)
+		// if err != nil {
+		// 	return false, fmt.Errorf("failed to set app instance tracking on the namespace %s: %s", managedNs.GetName(), err)
+		// }
+
+		return true, nil
 	}
 }
 
+// appendSSAAnnotation will set the managed namespace to be synced
+// with server-side apply
 func appendSSAAnnotation(in map[string]string) map[string]string {
 	r := map[string]string{}
 	for k, v := range in {

--- a/controller/sync_namespace_test.go
+++ b/controller/sync_namespace_test.go
@@ -86,11 +86,10 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			},
 		},
 		{
-			name:           "namespace does not yet exist and managedNamespaceMetadata nil",
-			expected:       true,
-			expectedLabels: map[string]string{},
-			//expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace"},
-			expectedAnnotations: map[string]string{},
+			name:                "namespace does not yet exist and managedNamespaceMetadata nil",
+			expected:            true,
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace"},
 			un:                  createFakeNamespace("", "", map[string]string{}, map[string]string{}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: nil,

--- a/controller/sync_namespace_test.go
+++ b/controller/sync_namespace_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"errors"
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/argo"
@@ -10,33 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"testing"
 )
-
-type fakeResourceTracking struct {
-}
-
-func (f fakeResourceTracking) GetAppName(un *unstructured.Unstructured, key string, trackingMethod v1alpha1.TrackingMethod) string {
-	panic("implement me")
-}
-
-func (f fakeResourceTracking) GetAppInstance(un *unstructured.Unstructured, key string, trackingMethod v1alpha1.TrackingMethod) *argo.AppInstanceValue {
-	return nil
-}
-
-func (f fakeResourceTracking) SetAppInstance(un *unstructured.Unstructured, key, val, namespace string, trackingMethod v1alpha1.TrackingMethod) error {
-	return errors.New("some error")
-}
-
-func (f fakeResourceTracking) BuildAppInstanceValue(value argo.AppInstanceValue) string {
-	panic("implement me")
-}
-
-func (f fakeResourceTracking) ParseAppInstanceValue(value string) (*argo.AppInstanceValue, error) {
-	panic("implement me")
-}
-
-func (f fakeResourceTracking) Normalize(config, live *unstructured.Unstructured, labelKey, trackingMethod string) error {
-	panic("implement me")
-}
 
 func createFakeNamespace(uid string, resourceVersion string, labels map[string]string, annotations map[string]string) *unstructured.Unstructured {
 	un := unstructured.Unstructured{}

--- a/controller/sync_namespace_test.go
+++ b/controller/sync_namespace_test.go
@@ -195,7 +195,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
 			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
+			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
 			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -207,7 +207,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace exists with no labels or annotations and managedNamespaceMetadata has annotations",
 			expected:            true,
 			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
+			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
 			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -220,7 +220,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
 			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
+			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
 			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -234,7 +234,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			expected:            true,
 			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
 			expectedLabels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
-			managedNs:           createFakeNamespace("something", "1", map[string]string{"my-cool-label": "some-value"}, map[string]string{}),
+			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
 			liveNs:              createFakeNamespace("something", "1", map[string]string{"my-cool-label": "some-value"}, map[string]string{}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -248,7 +248,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			expected:            true,
 			expectedLabels:      map[string]string{},
 			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("something", "1", map[string]string{}, map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"}),
+			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
 			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -262,7 +262,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
 			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("something", "1", map[string]string{"my-cool-label": "some-value"}, map[string]string{"my-cool-annotation": "some-value"}),
+			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
 			liveNs:              createFakeNamespace("something", "1", map[string]string{"my-cool-label": "some-value"}, map[string]string{"my-cool-annotation": "some-value"}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{

--- a/go.mod
+++ b/go.mod
@@ -252,6 +252,7 @@ require (
 )
 
 replace (
+	github.com/argoproj/gitops-engine => github.com/leoluz/gitops-engine v0.4.1-0.20221104145611-3e05051d9be3
 	// https://github.com/golang/go/issues/33546#issuecomment-519656923
 	github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
 

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,6 @@ github.com/antonmedv/expr v1.8.9/go.mod h1:5qsM3oLGDND7sDmQGDXHkYfkjYMUX14qsgqmH
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/appscode/go v0.0.0-20190808133642-1d4ef1f1c1e0/go.mod h1:iy07dV61Z7QQdCKJCIvUoDL21u6AIceRhZzyleh2ymc=
-github.com/argoproj/gitops-engine v0.7.1-0.20221103192913-b371e3bfc5e9 h1:qk4O1fw6ZtWwm0vNM1HFACSAJYnhuKweLNP6XzDJchE=
-github.com/argoproj/gitops-engine v0.7.1-0.20221103192913-b371e3bfc5e9/go.mod h1:WpA/B7tgwfz+sdNE3LqrTrb7ArEY1FOPI2pAGI0hfPc=
 github.com/argoproj/notifications-engine v0.3.1-0.20220812180936-4d8552b0775f h1:xTts6TJ/SBbY9zV8qpueokUd3+SlJN6Abt4W6lAjOKM=
 github.com/argoproj/notifications-engine v0.3.1-0.20220812180936-4d8552b0775f/go.mod h1:R3zlopt+/juYlebQc9Jarn9vBQ2xZruWOWjUNkfGY9M=
 github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0 h1:Cfp7rO/HpVxnwlRqJe0jHiBbZ77ZgXhB6HWlYD02Xdc=
@@ -751,6 +749,8 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/ktrysmt/go-bitbucket v0.9.40 h1:LcvdyW7u58vfbUi9bCQB+ihyqDzoy+9WBq/odmBsXrg=
 github.com/ktrysmt/go-bitbucket v0.9.40/go.mod h1:FWxy2UK7GlK5b0NSJGc5hPqnssVlkNnsChvyuOf/Xno=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
+github.com/leoluz/gitops-engine v0.4.1-0.20221104145611-3e05051d9be3 h1:QueLyPTVnAeZuZQa4NV+2HnZvoltq5oQZG0+cHkhIVY=
+github.com/leoluz/gitops-engine v0.4.1-0.20221104145611-3e05051d9be3/go.mod h1:WpA/B7tgwfz+sdNE3LqrTrb7ArEY1FOPI2pAGI0hfPc=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -1868,6 +1868,10 @@ func TestNamespacedNamespaceAutoCreation(t *testing.T) {
 //
 //	    Verify application --dest-namespace is created with managedNamespaceMetadata
 func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
+	oldval := os.Getenv("ARGOCD_GPG_ENABLED")
+	os.Setenv("ARGOCD_GPG_ENABLED", "false")
+	defer os.Setenv("ARGOCD_GPG_ENABLED", oldval)
+
 	SkipOnEnv(t, "OPENSHIFT")
 	updatedNamespace := getNewNamespace(t)
 	defer func() {
@@ -1927,14 +1931,11 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
-			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
 
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
-
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"new": "label"}, ns.Labels)
 			assert.Equal(t, map[string]string{"bar": "bat", "argocd.argoproj.io/sync-options": "ServerSideApply=true"}, ns.Annotations)
@@ -1950,14 +1951,10 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
-			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
-
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
-
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"new": "label"}, ns.Labels)
 			assert.Equal(t, map[string]string{"new": "custom-annotation", "argocd.argoproj.io/sync-options": "ServerSideApply=true"}, ns.Annotations)
@@ -2004,17 +2001,11 @@ func TestNamespacedNamespaceAutoCreationWithMetadataAndNsManifest(t *testing.T) 
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(namespace, func(app *Application, ns *v1.Namespace) {
-			//assert.NotEmpty(t, app.Status.Conditions)
-
-			//trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
-
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Labels, "kubectl.kubernetes.io/last-applied-configuration")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
-
-			//assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s/%s", AppNamespace(), namespace, namespace), trackingId)
 
 			// The application namespace manifest takes precedence over what is in managedNamespaceMetadata
 			assert.Equal(t, map[string]string{"test": "true"}, ns.Labels)
@@ -2091,16 +2082,12 @@ metadata:
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
-			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
-
 			assert.Empty(t, app.Status.Conditions)
 
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
-
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"test": "true", "foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true", "something": "whatevs", "bar": "bat"}, ns.Annotations)
@@ -2114,7 +2101,6 @@ metadata:
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
-			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
 
 			assert.Empty(t, app.Status.Conditions)
 
@@ -2122,8 +2108,6 @@ metadata:
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
-
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"test": "true", "foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true", "something": "hmm", "bar": "bat"}, ns.Annotations)
@@ -2138,7 +2122,6 @@ metadata:
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
-			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
 
 			assert.Empty(t, app.Status.Conditions)
 
@@ -2146,8 +2129,6 @@ metadata:
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
-
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"test": "true", "foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true", "bar": "bat"}, ns.Annotations)

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -1868,10 +1868,6 @@ func TestNamespacedNamespaceAutoCreation(t *testing.T) {
 //
 //	    Verify application --dest-namespace is created with managedNamespaceMetadata
 func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
-	oldval := os.Getenv("ARGOCD_GPG_ENABLED")
-	os.Setenv("ARGOCD_GPG_ENABLED", "false")
-	defer os.Setenv("ARGOCD_GPG_ENABLED", oldval)
-
 	SkipOnEnv(t, "OPENSHIFT")
 	updatedNamespace := getNewNamespace(t)
 	defer func() {

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -1905,14 +1905,10 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
 			assert.Empty(t, app.Status.Conditions)
 
-			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
-
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
-
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"bar": "bat", "argocd.argoproj.io/sync-options": "ServerSideApply=true"}, ns.Annotations)


### PR DESCRIPTION
While testing managed namespaces locally I noticed 2 issues:
- When enabled, managed namespace shouldn't mutate the live state directly.
- We can't set resource tracking without changing the diff logic to handle it correctly. More details in #11196

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

