### PR TITLE
fix: add missing ClusterRole permissions to argo-cd-server

### DIFF
--- a/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
@@ -35,4 +35,5 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -9854,6 +9854,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -9813,6 +9813,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Add missing ClusterRole permissions to argo-cd-server to manage Application in all namespaces

Signed-off-by: Elad Dolev <dolevelad@gmail.com>

Following [#9755](https://github.com/argoproj/argo-cd/pull/9755), argo-cd server needs permissions to update Applications in every namespace

Steps to reproduce:
- Create an application in a namespace outside of the controller's namespace
- Press "Update" from the UI
- Getting the following error:

```shell
Unable to deploy revision: error setting app operation: error updating application "<my_app>": applications.argoproj.io "<my_app>" is forbidden: User "system:serviceaccount:<controller_namespace>:argocd-server" cannot update resource "applications" in API group "argoproj.io" in the namespace "<app_namespace>"
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

