### PR TITLE
fix: use non distroless image for dex

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -412,7 +412,7 @@ jobs:
           git config --global user.email "john.doe@example.com"
       - name: Pull Docker image required for tests
         run: |
-          docker pull ghcr.io/dexidp/dex:v2.35.3-distroless
+          docker pull ghcr.io/dexidp/dex:v2.35.3
           docker pull argoproj/argo-cd-ci-builder:v1.0.0
           docker pull redis:7.0.5-alpine
       - name: Create target directory for binaries in the build-process

--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: dex
-        image: ghcr.io/dexidp/dex:v2.35.3-distroless
+        image: ghcr.io/dexidp/dex:v2.35.3
         imagePullPolicy: Always
         command: [/shared/argocd-dex, rundex]
         env:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -11256,7 +11256,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.35.3-distroless
+        image: ghcr.io/dexidp/dex:v2.35.3
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1678,7 +1678,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.35.3-distroless
+        image: ghcr.io/dexidp/dex:v2.35.3
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10334,7 +10334,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.35.3-distroless
+        image: ghcr.io/dexidp/dex:v2.35.3
         imagePullPolicy: Always
         name: dex
         ports:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -756,7 +756,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.35.3-distroless
+        image: ghcr.io/dexidp/dex:v2.35.3
         imagePullPolicy: Always
         name: dex
         ports:


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>
Closes #11182
Closes #11105
Closes #11071

This PR reverts using a distroless image for Dex.   There are permission errors between ArgoCD-dex & Dex binaries.   

Two workarounds were tested successfully 
  1. Set securityContext.fsGroup=999 at the pod level 
 or
 2. Set securityContext.runAsUser=999 at the container level. 
  
First class stability and compatability should be provided. Rather than using a workaround that may be incompatible with certain cluster types. 

Big thanks to @pdrastil for testing and verifying the workarounds and fix. 


