### PR TITLE
chore: add kustomize project for testing param CMP locally

### DIFF
--- a/test/manifests/cmp/README.md
+++ b/test/manifests/cmp/README.md
@@ -1,0 +1,15 @@
+This folder contains an Argo CD configuration file to allow
+testing CMP plugins locally. The Kustomize project will:
+
+- Install Argo CD in the current k8s context
+- Patch repo server configuring a test CMP plugin
+- Install an application that can be used to interact with the CMP plugin
+
+To install Argo CD with this Kustomize project run the following
+command:
+
+`kustomize build ./test/manifests/cmp | sed 's/imagePullPolicy: Always/imagePullPolicy: Never/g' | kubectl apply -f -`
+
+In Argo CD UI login with user/pass: admin/password
+
+An application with name `cmp-sidecar` should be available for testing.

--- a/test/manifests/cmp/app.yaml
+++ b/test/manifests/cmp/app.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plugin-test-app
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argo-cd.git
+    path: test/manifests/cmp/app
+    plugin:
+      env:
+        - name: FOO
+          value: bar
+        - name: REV
+          value: test-$ARGOCD_APP_REVISION
+      parameters:
+        - name: array-param
+          array:
+            - override
+            - values
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc

--- a/test/manifests/cmp/app/subdir/sidecar.yaml
+++ b/test/manifests/cmp/app/subdir/sidecar.yaml
@@ -1,0 +1,4 @@
+# This yaml is used mainly to trigger the CMP plugin
+# for testing purposes. In real world, it should contain
+# proper kubernetes manifest files.
+name: sidecar-plugin

--- a/test/manifests/cmp/kustomization.yaml
+++ b/test/manifests/cmp/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - ../../../manifests/namespace-install
+  - ../../../manifests/crds
+  - ../../../manifests/cluster-rbac
+  - plugin.yaml
+  - app.yaml
+
+patchesStrategicMerge:
+  - repo-patch.yaml
+  - secret-patch.yaml
+
+images:
+  - name: quay.io/argoproj/argocd
+    newName: argocd
+    newTag: param

--- a/test/manifests/cmp/plugin.yaml
+++ b/test/manifests/cmp/plugin.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-plugin-config
+data:
+  plugin.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: my-plugin
+    spec:
+      version: v1.0
+      init:
+        command: [sh , -c, 'echo "params: $ARGOCD_APP_PARAMETERS"']
+      generate:
+        command: [jq, -n, '{"kind": "ConfigMap", "apiVersion": "v1", "metadata": { "name": env.ARGOCD_APP_NAME, "namespace": env.ARGOCD_APP_NAMESPACE, "annotations": {"test": "annotation test", "KubeVersion": env.KUBE_VERSION }}, "data": { "params": env.ARGOCD_APP_PARAMETERS } }']
+      discover:
+        fileName: "./subdir/s*.yaml"
+      parameters:
+        static:
+          - name: string-param
+            string: default-string-value
+          - name: array-param
+            array: [default, items]
+            collectionType: array
+          - name: map-param
+            map:
+              some: value
+            collectionType: map

--- a/test/manifests/cmp/repo-patch.yaml
+++ b/test/manifests/cmp/repo-patch.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-repo-server
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: repo-server
+  name: argocd-repo-server
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-repo-server
+    spec:
+      serviceAccountName: argocd-repo-server
+      automountServiceAccountToken: false
+      containers:
+        - name: my-plugin
+          command: [/var/run/argocd/argocd-cmp-server]
+          image: stedolan/jq
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+          volumeMounts:
+            - mountPath: /var/run/argocd
+              name: var-files
+            - mountPath: /home/argocd/cmp-server/plugins
+              name: plugins
+            - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+              subPath: plugin.yaml
+              name: my-plugin-config
+      volumes:
+        - configMap:
+            name: my-plugin-config
+          name: my-plugin-config
+        - emptyDir: {}
+          name: cmp-tmp

--- a/test/manifests/cmp/secret-patch.yaml
+++ b/test/manifests/cmp/secret-patch.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
+  labels:
+    app.kubernetes.io/name: argocd-secret
+    app.kubernetes.io/part-of: argocd
+stringData:
+  # admin.password is "password"
+  admin.password: $2a$10$RncPyHW/B5ll2Z3J8s.IBOnbZ9uoJ4JhHLKzj5lzG/kU1KN1Oj3/K
+  admin.passwordMtime: 2019-03-20T17:54:53Z
+type: Opaque


### PR DESCRIPTION
Pushing the kustomize project I used while validating the parametrized CMP PR: https://github.com/argoproj/argo-cd/pull/9216

It can be useful for anyone willing to quickly bootstrap Argo CD locally and interact with an application configured with parameterized  CMP.

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

