### PR TITLE
docs: clarify finalizer effect and link to app-of-apps 

### DIFF
--- a/docs/user-guide/app_deletion.md
+++ b/docs/user-guide/app_deletion.md
@@ -47,6 +47,6 @@ metadata:
 
 When deleting an Application with this finalizer, the Argo CD application controller will perform a cascading delete of the Application's resources.
 
-Adding the finalizer enables casading deletes when implementing [the App of Apps pattern](../operator-manual/cluster-bootstrapping.md#cascading-deletion).
+Adding the finalizer enables cascading deletes when implementing [the App of Apps pattern](../operator-manual/cluster-bootstrapping.md#cascading-deletion).
 
 When you invoke `argocd app delete` with `--cascade`, the finalizer is added automatically.

--- a/docs/user-guide/app_deletion.md
+++ b/docs/user-guide/app_deletion.md
@@ -45,8 +45,8 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 ```
 
-When an Application with this finializer is deleted, the Argo CD application controller will perform a cascading delete.
+When deleting an Application with this finalizer, the Argo CD application controller will perform a cascading delete of the Application's resources.
 
-This is useful for performing [casading deletes when implementing the App of Apps pattern](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#cascading-deletion).
+Adding the finalizer enables casading deletes when implementing [the App of Apps pattern](../operator-manual/cluster-bootstrapping.md#cascading-deletion).
 
 When you invoke `argocd app delete` with `--cascade`, the finalizer is added automatically.

--- a/docs/user-guide/app_deletion.md
+++ b/docs/user-guide/app_deletion.md
@@ -39,14 +39,14 @@ kubectl delete app APPNAME
 
 # About The Deletion Finalizer
 
-For the technical amongst you, the Argo CD application controller watches for this finalizer:
-
 ```yaml
 metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 ```
 
-Argo CD's app controller watches for this and will then delete both the app and its resources.
+When an Application with this finializer is deleted, the Argo CD application controller will perform a cascading delete.
+
+This is useful for performing [casading deletes when implementing the App of Apps pattern](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#cascading-deletion).
 
 When you invoke `argocd app delete` with `--cascade`, the finalizer is added automatically.


### PR DESCRIPTION
> app controller watches for this and will then delete both the app and its resources

I was confused after first reading this. It seems to imply that when the application controller sees the finalizer, it will then delete it and the resources. That omits the important distinction that it will only delete the Application when it has been requested.

This is probably a minor point since it's geared toward technical users. Despite this, I think these changes will provide clarity.

I've also added a mention of how the finalizer is used in the App of Apps pattern.

--

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

