### PR TITLE
docs: add info about sync interval

### DIFF
--- a/docs/user-guide/auto_sync.md
+++ b/docs/user-guide/auto_sync.md
@@ -88,4 +88,4 @@ which is controlled by `--self-heal-timeout-seconds` flag of `argocd-application
   and parameters had failed.
 
 * Rollback cannot be performed against an application with automated sync enabled.
-* The automatic sync interval is determined by [the `timeout.reconciliation` value in the `argocd-cm` ConfigMap](../faq.md#how-often-does-argo-cd-check-for-changes-to-my-git-or-helm-repository).
+* The automatic sync interval is determined by [the `timeout.reconciliation` value in the `argocd-cm` ConfigMap](../faq.md#how-often-does-argo-cd-check-for-changes-to-my-git-or-helm-repository), which defaults to `180s` (3 minutes).

--- a/docs/user-guide/auto_sync.md
+++ b/docs/user-guide/auto_sync.md
@@ -88,3 +88,4 @@ which is controlled by `--self-heal-timeout-seconds` flag of `argocd-application
   and parameters had failed.
 
 * Rollback cannot be performed against an application with automated sync enabled.
+* The automatic sync interval is determined by [the `timeout.reconciliation` value in the `argocd-cm` ConfigMap](../faq.md#how-often-does-argo-cd-check-for-changes-to-my-git-or-helm-repository).


### PR DESCRIPTION
Add information about the sync interval to the Automated Sync Policy page. Users will likely check this page when looking for how to configure the sync interval.

Signed-off-by: Nicholas Morey <nicholas@morey.tech>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

