### PR TITLE
docs: Use new Google Analytics 4 ID (latest)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 extra:
   analytics:
-    property: UA-105170809-2
+    property: G-5Z1VTPDL73
     provider: google
 extra_css:
 - assets/versions.css


### PR DESCRIPTION
- Contributes to https://github.com/argoproj/argo-site/issues/102
- As mentioned in that umbrella issue, the UA site tag is [connected] from the new GA4 site tag and so will continue receiving events.

/cc @alexmt @alexef @crenshaw-dev 

[connected]: https://support.google.com/analytics/answer/9973999