### PR TITLE
fix: flags & environmental variables added for the CLI to configure pod selector labels (#10200)

### DIFF
--- a/cmd/argocd/commands/account.go
+++ b/cmd/argocd/commands/account.go
@@ -17,11 +17,13 @@ import (
 	"golang.org/x/term"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	accountpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/account"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/session"
 	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/localconfig"
@@ -133,6 +135,10 @@ has appropriate RBAC permissions to change other accounts.
 	command.Flags().StringVar(&currentPassword, "current-password", "", "password of the currently logged on user")
 	command.Flags().StringVar(&newPassword, "new-password", "", "new password you want to update to")
 	command.Flags().StringVar(&account, "account", "", "an account name that should be updated. Defaults to current user account")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -179,11 +185,15 @@ func NewAccountGetUserInfoCommand(clientOpts *argocdclient.ClientOptions) *cobra
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "", "Output format. One of: yaml, json")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
 func NewAccountCanICommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	return &cobra.Command{
+	var command = &cobra.Command{
 		Use:   "can-i ACTION RESOURCE SUBRESOURCE",
 		Short: "Can I",
 		Example: fmt.Sprintf(`
@@ -219,6 +229,11 @@ Resources: %v
 			fmt.Println(response.Value)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
+	return command
 }
 
 func printAccountNames(accounts []*accountpkg.Account) {
@@ -267,6 +282,10 @@ func NewAccountListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|name")
+	cmd.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	cmd.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	cmd.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	cmd.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return cmd
 }
 
@@ -321,6 +340,10 @@ argocd account get --account <account-name>`,
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|name")
 	cmd.Flags().StringVarP(&account, "account", "a", "", "Account name. Defaults to the current account.")
+	cmd.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	cmd.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	cmd.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	cmd.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return cmd
 }
 
@@ -387,6 +410,10 @@ argocd account generate-token --account <account-name>`,
 	cmd.Flags().StringVarP(&account, "account", "a", "", "Account name. Defaults to the current account.")
 	cmd.Flags().StringVarP(&expiresIn, "expires-in", "e", "0s", "Duration before the token will expire. (Default: No expiration)")
 	cmd.Flags().StringVar(&id, "id", "", "Optional token id. Fall back to uuid if not value specified.")
+	cmd.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	cmd.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	cmd.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	cmd.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return cmd
 }
 
@@ -422,5 +449,9 @@ argocd account delete-token --account <account-name> ID`,
 		},
 	}
 	cmd.Flags().StringVarP(&account, "account", "a", "", "Account name. Defaults to the current account.")
+	cmd.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	cmd.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	cmd.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	cmd.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return cmd
 }

--- a/cmd/argocd/commands/admin/dashboard.go
+++ b/cmd/argocd/commands/admin/dashboard.go
@@ -9,13 +9,18 @@ import (
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/initialize"
 	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 )
 
 func NewDashboardCommand() *cobra.Command {
 	var (
-		port    int
-		address string
+		port               int
+		address            string
+		repoServerName     string
+		redisHaHaProxyName string
+		redisName          string
+		serverName         string
 	)
 	cmd := &cobra.Command{
 		Use:   "dashboard",
@@ -23,7 +28,13 @@ func NewDashboardCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 
-			errors.CheckError(headless.StartLocalServer(ctx, &argocdclient.ClientOptions{Core: true}, initialize.RetrieveContextIfChanged(cmd.Flag("context")), &port, &address))
+			errors.CheckError(headless.StartLocalServer(ctx, &argocdclient.ClientOptions{
+				Core:               true,
+				ServerName:         serverName,
+				RedisHaHaProxyName: redisHaHaProxyName,
+				RedisName:          redisName,
+				RepoServerName:     repoServerName},
+				initialize.RetrieveContextIfChanged(cmd.Flag("context")), &port, &address))
 			println(fmt.Sprintf("Argo CD UI is available at http://%s:%d", address, port))
 			<-ctx.Done()
 		},
@@ -31,5 +42,9 @@ func NewDashboardCommand() *cobra.Command {
 	initialize.InitCommand(cmd)
 	cmd.Flags().IntVar(&port, "port", common.DefaultPortAPIServer, "Listen on given port")
 	cmd.Flags().StringVar(&address, "address", common.DefaultAddressAPIServer, "Listen on given address")
+	cmd.Flags().StringVar(&serverName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	cmd.Flags().StringVar(&redisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	cmd.Flags().StringVar(&redisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	cmd.Flags().StringVar(&repoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return cmd
 }

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -48,6 +48,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/argo"
 	argodiff "github.com/argoproj/argo-cd/v2/util/argo/diff"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/grpc"
@@ -201,6 +202,10 @@ func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 		log.Fatal(err)
 	}
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Namespace where the application will be created in")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	cmdutil.AddAppFlags(command, &appOpts)
 	return command
 }
@@ -343,6 +348,10 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 	command.Flags().BoolVar(&showParams, "show-params", false, "Show application parameters and overrides")
 	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -435,6 +444,10 @@ func NewApplicationLogsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringVar(&filter, "filter", "", "Show logs contain this string")
 	command.Flags().StringVar(&container, "container", "", "Optional container name")
 	command.Flags().BoolVarP(&previous, "previous", "p", false, "Specify if the previously terminated container logs should be returned")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 
 	return command
 }
@@ -647,6 +660,10 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 		},
 	}
 	cmdutil.AddAppFlags(command, &appOpts)
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -727,6 +744,10 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 	command.Flags().StringArrayVar(&opts.kustomizeImages, "kustomize-image", []string{}, "Kustomize images name (e.g. --kustomize-image node --kustomize-image mysql)")
 	command.Flags().StringArrayVar(&opts.pluginEnvs, "plugin-env", []string{}, "Unset plugin env variables (e.g --plugin-env name)")
 	command.Flags().BoolVar(&opts.passCredentials, "pass-credentials", false, "Unset passCredentials")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -991,6 +1012,10 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", "/", "Path to the repository root. Used together with --local allows setting the repository root")
 	command.Flags().BoolVar(&serverSideGenerate, "server-side-generate", false, "Used with --local, this will send your manifests to the server for diffing")
 	command.Flags().StringArrayVar(&localIncludes, "local-include", []string{"*.yaml", "*.yml", "*.json"}, "Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path.")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -1216,6 +1241,10 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 	command.Flags().StringVarP(&propagationPolicy, "propagation-policy", "p", "foreground", "Specify propagation policy for deletion of application's resources. One of: foreground|background")
 	command.Flags().BoolVarP(&noPrompt, "yes", "y", false, "Turn off prompting to confirm cascaded deletion of application resources")
 	command.Flags().StringVarP(&selector, "selector", "l", "", "Delete all apps with matching label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -1332,6 +1361,10 @@ func NewApplicationListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringVarP(&repo, "repo", "r", "", "List apps by source repo URL")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only list applications in namespace")
 	command.Flags().StringVarP(&cluster, "cluster", "c", "", "List apps by cluster name or url")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -1506,6 +1539,10 @@ func NewApplicationWaitCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringArrayVar(&resources, "resource", []string{}, fmt.Sprintf("Sync only specific resources as GROUP%[1]sKIND%[1]sNAME or %[2]sGROUP%[1]sKIND%[1]sNAME. Fields may be blank and '*' can be used. This option may be specified repeatedly", resourceFieldDelimiter, resourceExcludeIndicator))
 	command.Flags().BoolVar(&watch.operation, "operation", false, "Wait for pending operations")
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -1818,6 +1855,10 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&diffChangesConfirm, "assumeYes", false, "Assume yes as answer for all user queries or prompts")
 	command.Flags().BoolVar(&diffChanges, "preview-changes", false, "Preview difference against the target and live state before syncing app and wait for user confirmation")
 	command.Flags().StringArrayVar(&projects, "project", []string{}, "Sync apps that belong to the specified projects. This option may be specified repeatedly.")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -2220,6 +2261,10 @@ func NewApplicationHistoryCommand(clientOpts *argocdclient.ClientOptions) *cobra
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: wide|id")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -2295,6 +2340,10 @@ func NewApplicationRollbackCommand(clientOpts *argocdclient.ClientOptions) *cobr
 	}
 	command.Flags().BoolVar(&prune, "prune", false, "Allow deleting unexpected resources")
 	command.Flags().UintVar(&timeout, "timeout", defaultCheckTimeoutSeconds, "Time out after this many seconds")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -2413,6 +2462,10 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 	command.Flags().StringVar(&revision, "revision", "", "Show manifests at a specific revision")
 	command.Flags().StringVar(&local, "local", "", "If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", ".", "Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'.")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -2439,6 +2492,10 @@ func NewApplicationTerminateOpCommand(clientOpts *argocdclient.ClientOptions) *c
 			fmt.Printf("Application '%s' operation terminating\n", appName)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -2497,6 +2554,10 @@ func NewApplicationEditCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			})
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -2541,5 +2602,9 @@ func NewApplicationPatchCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 
 	command.Flags().StringVar(&patch, "patch", "", "Patch body")
 	command.Flags().StringVar(&patchType, "type", "json", "The type of patch being provided; one of [json merge]")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(argocommon.EnvServerName, argocommon.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(argocommon.EnvRedisHaHaproxyName, argocommon.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(argocommon.EnvRedisName, argocommon.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(argocommon.EnvRepoServerName, argocommon.DefaultRepoServerName), "Repo server name")
 	return &command
 }

--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/argoproj/argo-cd/v2/cmd/util"
+	"github.com/argoproj/argo-cd/v2/common"
 
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
@@ -20,6 +21,7 @@ import (
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	v1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
 )
@@ -121,6 +123,10 @@ func NewApplicationResourceActionsListCommand(clientOpts *argocdclient.ClientOpt
 	command.Flags().StringVar(&group, "group", "", "Group")
 	command.Flags().StringVar(&namespace, "namespace", "", "Namespace")
 	command.Flags().StringVarP(&output, "out", "o", "", "Output format. One of: yaml, json")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 
 	return command
 }
@@ -184,6 +190,10 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 			errors.CheckError(err)
 		}
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 

--- a/cmd/argocd/commands/app_resources.go
+++ b/cmd/argocd/commands/app_resources.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 
 	"github.com/argoproj/argo-cd/v2/cmd/util"
@@ -17,6 +18,7 @@ import (
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/util/argo"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
 
@@ -47,6 +49,10 @@ func NewApplicationPatchResourceCommand(clientOpts *argocdclient.ClientOptions) 
 	command.Flags().StringVar(&group, "group", "", "Group")
 	command.Flags().StringVar(&namespace, "namespace", "", "Namespace")
 	command.Flags().BoolVar(&all, "all", false, "Indicates whether to patch multiple matching of resources")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	command.Run = func(c *cobra.Command, args []string) {
 		ctx := c.Context()
 
@@ -109,6 +115,10 @@ func NewApplicationDeleteResourceCommand(clientOpts *argocdclient.ClientOptions)
 	command.Flags().BoolVar(&force, "force", false, "Indicates whether to orphan the dependents of the deleted resource")
 	command.Flags().BoolVar(&orphan, "orphan", false, "Indicates whether to force delete the resource")
 	command.Flags().BoolVar(&all, "all", false, "Indicates whether to patch multiple matching of resources")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	command.Run = func(c *cobra.Command, args []string) {
 		ctx := c.Context()
 
@@ -194,5 +204,9 @@ func NewApplicationListResourcesCommand(clientOpts *argocdclient.ClientOptions) 
 		},
 	}
 	command.Flags().BoolVar(&orphaned, "orphaned", false, "Lists only orphaned resources")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }

--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -13,10 +13,12 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
 	cmdutil "github.com/argoproj/argo-cd/v2/cmd/util"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/applicationset"
 	arogappsetv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/grpc"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
@@ -104,6 +106,10 @@ func NewApplicationSetGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
 	command.Flags().BoolVar(&showParams, "show-params", false, "Show ApplicationSet parameters and overrides")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -170,6 +176,10 @@ func NewApplicationSetCreateCommand(clientOpts *argocdclient.ClientOptions) *cob
 		},
 	}
 	command.Flags().BoolVar(&upsert, "upsert", false, "Allows to override ApplicationSet with the same name even if supplied ApplicationSet spec is different from existing spec")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -213,7 +223,10 @@ func NewApplicationSetListCommand(clientOpts *argocdclient.ClientOptions) *cobra
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: wide|name|json|yaml")
 	command.Flags().StringVarP(&selector, "selector", "l", "", "List applicationsets by label")
 	command.Flags().StringArrayVarP(&projects, "project", "p", []string{}, "Filter by project name")
-
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -280,6 +293,10 @@ func NewApplicationSetDeleteCommand(clientOpts *argocdclient.ClientOptions) *cob
 		},
 	}
 	command.Flags().BoolVarP(&noPrompt, "yes", "y", false, "Turn off prompting to confirm cascaded deletion of Application resources")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 

--- a/cmd/argocd/commands/cert.go
+++ b/cmd/argocd/commands/cert.go
@@ -11,10 +11,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	certificatepkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/certificate"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	certutil "github.com/argoproj/argo-cd/v2/util/cert"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
 )
@@ -132,6 +134,10 @@ func NewCertAddTLSCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 	}
 	command.Flags().StringVar(&fromFile, "from", "", "read TLS certificate data from file (default is to read from stdin)")
 	command.Flags().BoolVar(&upsert, "upsert", false, "Replace existing TLS certificate if certificate is different in input")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -204,6 +210,10 @@ func NewCertAddSSHCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 	command.Flags().StringVar(&fromFile, "from", "", "Read SSH known hosts data from file (default is to read from stdin)")
 	command.Flags().BoolVar(&batchProcess, "batch", false, "Perform batch processing by reading in SSH known hosts data (mandatory flag)")
 	command.Flags().BoolVar(&upsert, "upsert", false, "Replace existing SSH server public host keys if key is different in input")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -254,6 +264,10 @@ func NewCertRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 	}
 	command.Flags().StringVar(&certType, "cert-type", "", "Only remove certs of given type (ssh, https)")
 	command.Flags().StringVar(&certSubType, "cert-sub-type", "", "Only remove certs of given sub-type (only for ssh)")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -303,6 +317,10 @@ func NewCertListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	command.Flags().StringVar(&sortOrder, "sort", "", "set display sort order for output format wide. One of: hostname|type")
 	command.Flags().StringVar(&certType, "cert-type", "", "only list certificates of given type, valid: 'ssh','https'")
 	command.Flags().StringVar(&hostNamePattern, "hostname-pattern", "", "only list certificates for hosts matching given glob-pattern")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -22,6 +22,7 @@ import (
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
 	"github.com/argoproj/argo-cd/v2/util/clusterauth"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/text/label"
@@ -172,6 +173,10 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 	command.Flags().BoolVarP(&skipConfirmation, "yes", "y", false, "Skip explicit confirmation")
 	command.Flags().StringArrayVar(&labels, "label", nil, "Set metadata labels (e.g. --label key=value)")
 	command.Flags().StringArrayVar(&annotations, "annotation", nil, "Set metadata annotations (e.g. --annotation key=value)")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	cmdutil.AddClusterFlags(command, &clusterOpts)
 	return command
 }
@@ -306,6 +311,10 @@ argocd cluster get in-cluster`,
 	}
 	// we have yaml as default to not break backwards-compatibility
 	command.Flags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml|wide|server")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -408,6 +417,10 @@ argocd cluster rm cluster-name`,
 		},
 	}
 	command.Flags().BoolVarP(&noPrompt, "yes", "y", false, "Turn off prompting to confirm remove of cluster resources")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -473,6 +486,10 @@ func NewClusterListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|server")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -501,5 +518,9 @@ argocd cluster rotate-auth cluster-name`,
 			fmt.Printf("Cluster '%s' rotated auth\n", cluster)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }

--- a/cmd/argocd/commands/gpg.go
+++ b/cmd/argocd/commands/gpg.go
@@ -9,9 +9,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	gpgkeypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/gpgkey"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
 )
@@ -61,6 +63,10 @@ func NewGPGListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -98,6 +104,10 @@ func NewGPGGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -131,6 +141,10 @@ func NewGPGAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 		},
 	}
 	command.Flags().StringVarP(&fromFile, "from", "f", "", "Path to the file that contains the GPG public key to import")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 
 }
@@ -153,6 +167,10 @@ func NewGPGDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command 
 			fmt.Printf("Deleted key with key ID %s\n", args[0])
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 
 }

--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -20,10 +20,12 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	sessionpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/session"
 	settingspkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/settings"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	grpc_util "github.com/argoproj/argo-cd/v2/util/grpc"
 	"github.com/argoproj/argo-cd/v2/util/io"
@@ -106,6 +108,10 @@ argocd login cd.argoproj.io --core`,
 				PortForwardNamespace: globalClientOpts.PortForwardNamespace,
 				Headers:              globalClientOpts.Headers,
 				KubeOverrides:        globalClientOpts.KubeOverrides,
+				ServerName:           globalClientOpts.ServerName,
+				RedisHaHaProxyName:   globalClientOpts.RedisHaHaProxyName,
+				RedisName:            globalClientOpts.RedisName,
+				RepoServerName:       globalClientOpts.RepoServerName,
 			}
 
 			if ctxName == "" {
@@ -182,6 +188,10 @@ argocd login cd.argoproj.io --core`,
 	command.Flags().IntVar(&ssoPort, "sso-port", DefaultSSOLocalPort, "port to run local OAuth2 login application")
 	command.Flags().
 		BoolVar(&skipTestTLS, "skip-test-tls", false, "Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)")
+	command.Flags().StringVar(&globalClientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&globalClientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&globalClientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&globalClientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -18,10 +18,12 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
 	cmdutil "github.com/argoproj/argo-cd/v2/cmd/util"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	projectpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/project"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/gpg"
@@ -102,6 +104,10 @@ func NewProjectCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 	}
 	command.Flags().BoolVar(&upsert, "upsert", false, "Allows to override a project with the same name even if supplied project spec is different from existing spec")
 	command.Flags().StringVarP(&fileURL, "file", "f", "", "Filename or URL to Kubernetes manifests for the project")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	err := command.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
 	if err != nil {
 		log.Fatal(err)
@@ -142,6 +148,10 @@ func NewProjectSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	cmdutil.AddProjFlags(command, &opts)
 	return command
 }
@@ -181,6 +191,10 @@ func NewProjectAddSignatureKeyCommand(clientOpts *argocdclient.ClientOptions) *c
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -221,7 +235,10 @@ func NewProjectRemoveSignatureKeyCommand(clientOpts *argocdclient.ClientOptions)
 			}
 		},
 	}
-
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -268,6 +285,10 @@ func NewProjectAddDestinationCommand(clientOpts *argocdclient.ClientOptions) *co
 		},
 	}
 	command.Flags().BoolVar(&nameInsteadServer, "name", false, "Use name as destination instead server")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -308,7 +329,10 @@ func NewProjectRemoveDestinationCommand(clientOpts *argocdclient.ClientOptions) 
 			}
 		},
 	}
-
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -354,6 +378,10 @@ func NewProjectAddOrphanedIgnoreCommand(clientOpts *argocdclient.ClientOptions) 
 		},
 	}
 	command.Flags().StringVar(&name, "name", "", "Resource name pattern")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -403,6 +431,10 @@ func NewProjectRemoveOrphanedIgnoreCommand(clientOpts *argocdclient.ClientOption
 		},
 	}
 	command.Flags().StringVar(&name, "name", "", "Resource name pattern")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -441,6 +473,10 @@ func NewProjectAddSourceCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -527,6 +563,10 @@ func modifyResourceListCmd(cmdUse, cmdDesc string, clientOpts *argocdclient.Clie
 		},
 	}
 	command.Flags().StringVarP(&listType, "list", "l", defaultList, "Use deny list or allow list. This can only be 'allow' or 'deny'")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -594,7 +634,10 @@ func NewProjectRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *cobr
 			}
 		},
 	}
-
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -618,6 +661,10 @@ func NewProjectDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 			}
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -667,6 +714,10 @@ func NewProjectListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|name")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -836,6 +887,10 @@ func NewProjectGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -883,5 +938,9 @@ func NewProjectEditCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 			})
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }

--- a/cmd/argocd/commands/project_role.go
+++ b/cmd/argocd/commands/project_role.go
@@ -12,9 +12,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	projectpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/project"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/jwt"
@@ -81,6 +83,10 @@ func NewProjectRoleAddPolicyCommand(clientOpts *argocdclient.ClientOptions) *cob
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	addPolicyFlags(command, &opts)
 	return command
 }
@@ -129,6 +135,10 @@ func NewProjectRoleRemovePolicyCommand(clientOpts *argocdclient.ClientOptions) *
 		},
 	}
 	addPolicyFlags(command, &opts)
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -168,6 +178,10 @@ func NewProjectRoleCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 		},
 	}
 	command.Flags().StringVarP(&description, "description", "", "", "Project description")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -204,6 +218,10 @@ func NewProjectRoleDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 			fmt.Printf("Role '%s' deleted\n", roleName)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -279,7 +297,10 @@ func NewProjectRoleCreateTokenCommand(clientOpts *argocdclient.ClientOptions) *c
 	)
 	command.Flags().StringVarP(&tokenID, "id", "i", "", "Token unique identifier. (Default: Random UUID)")
 	command.Flags().BoolVarP(&outputTokenOnly, "token-only", "t", false, "Output token only - for use in scripts.")
-
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -333,6 +354,10 @@ func NewProjectRoleListTokensCommand(clientOpts *argocdclient.ClientOptions) *co
 	command.Flags().BoolVarP(&useUnixTime, "unixtime", "u", false,
 		"Print timestamps as Unix time instead of converting. Useful for piping into delete-token.",
 	)
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -361,6 +386,10 @@ func NewProjectRoleDeleteTokenCommand(clientOpts *argocdclient.ClientOptions) *c
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -416,6 +445,10 @@ func NewProjectRoleListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|name")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -461,6 +494,10 @@ func NewProjectRoleGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			_ = w.Flush()
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -492,6 +529,10 @@ func NewProjectRoleAddGroupCommand(clientOpts *argocdclient.ClientOptions) *cobr
 			fmt.Printf("Group '%s' added to role '%s'\n", groupName, roleName)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -523,5 +564,9 @@ func NewProjectRoleRemoveGroupCommand(clientOpts *argocdclient.ClientOptions) *c
 			fmt.Printf("Group '%s' removed from role '%s'\n", groupName, roleName)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }

--- a/cmd/argocd/commands/projectwindows.go
+++ b/cmd/argocd/commands/projectwindows.go
@@ -10,9 +10,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	projectpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/project"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
 )
@@ -70,6 +72,10 @@ func NewProjectWindowsDisableManualSyncCommand(clientOpts *argocdclient.ClientOp
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -107,6 +113,10 @@ func NewProjectWindowsEnableManualSyncCommand(clientOpts *argocdclient.ClientOpt
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -154,7 +164,10 @@ func NewProjectWindowsAddWindowCommand(clientOpts *argocdclient.ClientOptions) *
 	command.Flags().StringSliceVar(&clusters, "clusters", []string{}, "Clusters that the schedule will be applied to. Comma separated, wildcards supported (e.g. --clusters prod,staging)")
 	command.Flags().BoolVar(&manualSync, "manual-sync", false, "Allow manual syncs for both deny and allow windows")
 	command.Flags().StringVar(&timeZone, "time-zone", "UTC", "Time zone of the sync window")
-
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -188,6 +201,10 @@ func NewProjectWindowsDeleteCommand(clientOpts *argocdclient.ClientOptions) *cob
 			errors.CheckError(err)
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -242,6 +259,10 @@ func NewProjectWindowsUpdateCommand(clientOpts *argocdclient.ClientOptions) *cob
 	command.Flags().StringSliceVar(&namespaces, "namespaces", []string{}, "Namespaces that the schedule will be applied to. Comma separated, wildcards supported (e.g. --namespaces default,\\*-prod)")
 	command.Flags().StringSliceVar(&clusters, "clusters", []string{}, "Clusters that the schedule will be applied to. Comma separated, wildcards supported (e.g. --clusters prod,staging)")
 	command.Flags().StringVar(&timeZone, "time-zone", "UTC", "Time zone of the sync window. (e.g. --time-zone \"America/New_York\")")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -278,6 +299,10 @@ func NewProjectWindowsListCommand(clientOpts *argocdclient.ClientOptions) *cobra
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 

--- a/cmd/argocd/commands/relogin.go
+++ b/cmd/argocd/commands/relogin.go
@@ -9,8 +9,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	settingspkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/settings"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/localconfig"
@@ -45,15 +47,19 @@ func NewReloginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comm
 			var tokenString string
 			var refreshToken string
 			clientOpts := argocdclient.ClientOptions{
-				ConfigPath:        "",
-				ServerAddr:        configCtx.Server.Server,
-				Insecure:          configCtx.Server.Insecure,
-				ClientCertFile:    globalClientOpts.ClientCertFile,
-				ClientCertKeyFile: globalClientOpts.ClientCertKeyFile,
-				GRPCWeb:           globalClientOpts.GRPCWeb,
-				GRPCWebRootPath:   globalClientOpts.GRPCWebRootPath,
-				PlainText:         configCtx.Server.PlainText,
-				Headers:           globalClientOpts.Headers,
+				ConfigPath:         "",
+				ServerAddr:         configCtx.Server.Server,
+				Insecure:           configCtx.Server.Insecure,
+				ClientCertFile:     globalClientOpts.ClientCertFile,
+				ClientCertKeyFile:  globalClientOpts.ClientCertKeyFile,
+				GRPCWeb:            globalClientOpts.GRPCWeb,
+				GRPCWebRootPath:    globalClientOpts.GRPCWebRootPath,
+				PlainText:          configCtx.Server.PlainText,
+				Headers:            globalClientOpts.Headers,
+				ServerName:         globalClientOpts.ServerName,
+				RedisHaHaProxyName: globalClientOpts.RedisHaHaProxyName,
+				RedisName:          globalClientOpts.RedisName,
+				RepoServerName:     globalClientOpts.RepoServerName,
 			}
 			acdClient := headless.NewClientOrDie(&clientOpts, c)
 			claims, err := configCtx.User.Claims()
@@ -87,5 +93,9 @@ func NewReloginCommand(globalClientOpts *argocdclient.ClientOptions) *cobra.Comm
 	}
 	command.Flags().StringVar(&password, "password", "", "the password of an account to authenticate")
 	command.Flags().IntVar(&ssoPort, "sso-port", DefaultSSOLocalPort, "port to run local OAuth2 login application")
+	command.Flags().StringVar(&globalClientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&globalClientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&globalClientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&globalClientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }

--- a/cmd/argocd/commands/repo.go
+++ b/cmd/argocd/commands/repo.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
 	cmdutil "github.com/argoproj/argo-cd/v2/cmd/util"
+	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	repositorypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/repository"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/io"
@@ -215,6 +217,10 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	}
 	command.Flags().BoolVar(&repoOpts.Upsert, "upsert", false, "Override an existing repository with the same name even if the spec differs")
 	cmdutil.AddRepoFlags(command, &repoOpts)
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -239,6 +245,10 @@ func NewRepoRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 			}
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -310,6 +320,10 @@ func NewRepoListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|url")
 	command.Flags().StringVar(&refresh, "refresh", "", "Force a cache refresh on connection status , must be one of: 'hard'")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -361,5 +375,9 @@ func NewRepoGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|url")
 	command.Flags().StringVar(&refresh, "refresh", "", "Force a cache refresh on connection status , must be one of: 'hard'")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }

--- a/cmd/argocd/commands/repocreds.go
+++ b/cmd/argocd/commands/repocreds.go
@@ -14,6 +14,7 @@ import (
 	repocredspkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/repocreds"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/io"
@@ -175,6 +176,10 @@ func NewRepoCredsAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 	command.Flags().BoolVar(&repo.EnableOCI, "enable-oci", false, "Specifies whether helm-oci support should be enabled for this repo")
 	command.Flags().StringVar(&repo.Type, "type", common.DefaultRepoType, "type of the repository, \"git\" or \"helm\"")
 	command.Flags().StringVar(&gcpServiceAccountKeyPath, "gcp-service-account-key-path", "", "service account key for the Google Cloud Platform")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -199,6 +204,10 @@ func NewRepoCredsRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			}
 		},
 	}
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }
 
@@ -251,5 +260,9 @@ func NewRepoCredsListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|url")
+	command.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	command.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	command.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	command.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return command
 }

--- a/cmd/argocd/commands/version.go
+++ b/cmd/argocd/commands/version.go
@@ -12,6 +12,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/common"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
 )
@@ -89,6 +90,10 @@ func NewVersionCmd(clientOpts *argocdclient.ClientOptions, serverVersion *versio
 	versionCmd.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|short")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the version number")
 	versionCmd.Flags().BoolVar(&client, "client", false, "client version only (no server required)")
+	versionCmd.Flags().StringVar(&clientOpts.ServerName, "server-name", env.StringFromEnv(common.EnvServerName, common.DefaultServerName), "Server name")
+	versionCmd.Flags().StringVar(&clientOpts.RedisHaHaProxyName, "redis-ha-haproxy-name", env.StringFromEnv(common.EnvRedisHaHaproxyName, common.DefaultRedisHaHaproxyName), "Redis HA HAProxy name")
+	versionCmd.Flags().StringVar(&clientOpts.RedisName, "redis-name", env.StringFromEnv(common.EnvRedisName, common.DefaultRedisName), "Redis name")
+	versionCmd.Flags().StringVar(&clientOpts.RepoServerName, "repo-server-name", env.StringFromEnv(common.EnvRepoServerName, common.DefaultRepoServerName), "Repo server name")
 	return &versionCmd
 }
 

--- a/common/common.go
+++ b/common/common.go
@@ -126,6 +126,8 @@ const (
 	// LabelKeyAppInstance is the label key to use to uniquely identify the instance of an application
 	// The Argo CD application name is used as the instance name
 	LabelKeyAppInstance = "app.kubernetes.io/instance"
+	// The name of the kubernetes application
+	LabelKeyAppName = "app.kubernetes.io/name"
 	// LabelKeyLegacyApplicationName is the legacy label (v0.10 and below) and is superseded by 'app.kubernetes.io/instance'
 	LabelKeyLegacyApplicationName = "applications.argoproj.io/app-name"
 	// LabelKeySecretType contains the type of argocd secret (currently: 'cluster', 'repository', 'repo-config' or 'repo-creds')
@@ -213,6 +215,16 @@ const (
 	EnvCMPChunkSize = "ARGOCD_CMP_CHUNK_SIZE"
 	// EnvCMPWorkDir defines the full path of the work directory used by the CMP server
 	EnvCMPWorkDir = "ARGOCD_CMP_WORKDIR"
+	// EnvServerName is the pod selector labels of the ArgoCD server component.
+	EnvServerName = "ARGOCD_SERVER_NAME"
+	// EnvRepoServerName is the pod selector labels of the ArgoCD repo server component.
+	EnvRepoServerName = "ARGOCD_REPO_SERVER_NAME"
+	// EnvAppControllerName is the pod selector labels of the ArgoCD application controller component.
+	EnvAppControllerName = "ARGOCD_APPLICATION_CONTROLLER_NAME"
+	// EnvRedisName is the pod selector labels of the ArgoCD redis component.
+	EnvRedisName = "ARGOCD_REDIS_NAME"
+	// EnvRedisHaHaproxyName is the pod selector labels of the ArgoCD redis HA HA proxy component.
+	EnvRedisHaHaproxyName = "ARGOCD_REDIS_HA_HAPROXY_NAME"
 )
 
 // Config Management Plugin related constants
@@ -252,6 +264,15 @@ const (
 	DefaultGitRetryMaxDuration time.Duration = time.Second * 5        // 5s
 	DefaultGitRetryDuration    time.Duration = time.Millisecond * 250 // 0.25s
 	DefaultGitRetryFactor                    = int64(2)
+)
+
+// Constants represent the pod selector labels of the ArgoCD component names
+const (
+	DefaultServerName                = "argocd-server"
+	DefaultRepoServerName            = "argocd-repo-server"
+	DefaultApplicationControllerName = "argocd-application-controller"
+	DefaultRedisName                 = "argocd-redis"
+	DefaultRedisHaHaproxyName        = "argocd-redis-ha-haproxy"
 )
 
 // GetGnuPGHomePath retrieves the path to use for GnuPG home directory, which is either taken from GNUPGHOME environment or a default value

--- a/docs/user-guide/commands/argocd_account_can-i.md
+++ b/docs/user-guide/commands/argocd_account_can-i.md
@@ -27,7 +27,11 @@ Resources: [clusters projects applications applicationsets repositories certific
 ### Options
 
 ```
-  -h, --help   help for can-i
+  -h, --help                           help for can-i
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_account_delete-token.md
+++ b/docs/user-guide/commands/argocd_account_delete-token.md
@@ -19,8 +19,12 @@ argocd account delete-token --account <account-name> ID
 ### Options
 
 ```
-  -a, --account string   Account name. Defaults to the current account.
-  -h, --help             help for delete-token
+  -a, --account string                 Account name. Defaults to the current account.
+  -h, --help                           help for delete-token
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_account_generate-token.md
+++ b/docs/user-guide/commands/argocd_account_generate-token.md
@@ -19,10 +19,14 @@ argocd account generate-token --account <account-name>
 ### Options
 
 ```
-  -a, --account string      Account name. Defaults to the current account.
-  -e, --expires-in string   Duration before the token will expire. (Default: No expiration) (default "0s")
-  -h, --help                help for generate-token
-      --id string           Optional token id. Fall back to uuid if not value specified.
+  -a, --account string                 Account name. Defaults to the current account.
+  -e, --expires-in string              Duration before the token will expire. (Default: No expiration) (default "0s")
+  -h, --help                           help for generate-token
+      --id string                      Optional token id. Fall back to uuid if not value specified.
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_account_get-user-info.md
+++ b/docs/user-guide/commands/argocd_account_get-user-info.md
@@ -9,8 +9,12 @@ argocd account get-user-info [flags]
 ### Options
 
 ```
-  -h, --help            help for get-user-info
-  -o, --output string   Output format. One of: yaml, json
+  -h, --help                           help for get-user-info
+  -o, --output string                  Output format. One of: yaml, json
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_account_get.md
+++ b/docs/user-guide/commands/argocd_account_get.md
@@ -19,9 +19,13 @@ argocd account get --account <account-name>
 ### Options
 
 ```
-  -a, --account string   Account name. Defaults to the current account.
-  -h, --help             help for get
-  -o, --output string    Output format. One of: json|yaml|wide|name (default "wide")
+  -a, --account string                 Account name. Defaults to the current account.
+  -h, --help                           help for get
+  -o, --output string                  Output format. One of: json|yaml|wide|name (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_account_list.md
+++ b/docs/user-guide/commands/argocd_account_list.md
@@ -15,8 +15,12 @@ argocd account list
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   Output format. One of: json|yaml|wide|name (default "wide")
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide|name (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_account_update-password.md
+++ b/docs/user-guide/commands/argocd_account_update-password.md
@@ -29,10 +29,14 @@ argocd account update-password [flags]
 ### Options
 
 ```
-      --account string            an account name that should be updated. Defaults to current user account
-      --current-password string   password of the currently logged on user
-  -h, --help                      help for update-password
-      --new-password string       new password you want to update to
+      --account string                 an account name that should be updated. Defaults to current user account
+      --current-password string        password of the currently logged on user
+  -h, --help                           help for update-password
+      --new-password string            new password you want to update to
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_admin_app_get-reconcile-results.md
+++ b/docs/user-guide/commands/argocd_admin_app_get-reconcile-results.md
@@ -27,6 +27,7 @@ argocd admin app get-reconcile-results PATH [flags]
       --proxy-url string               If provided, this URL will be used to connect via proxy
       --refresh                        If set to true then recalculates apps reconciliation
       --repo-server string             Repo server address.
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -10,6 +10,7 @@ argocd admin cluster shards [flags]
 
 ```
       --app-state-cache-expiration duration   Cache expiration for app state (default 1h0m0s)
+      --application-controller-name string    Application controller name (default "argocd-application-controller")
       --as string                             Username to impersonate for the operation
       --as-group stringArray                  Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                         UID to impersonate for the operation
@@ -31,7 +32,9 @@ argocd admin cluster shards [flags]
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
+      --redis-ha-haproxy-name string          Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
+      --redis-name string                     Redis name (default "argocd-redis")
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.
       --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -10,6 +10,7 @@ argocd admin cluster stats [flags]
 
 ```
       --app-state-cache-expiration duration   Cache expiration for app state (default 1h0m0s)
+      --application-controller-name string    Application controller name (default "argocd-application-controller")
       --as string                             Username to impersonate for the operation
       --as-group stringArray                  Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --as-uid string                         UID to impersonate for the operation
@@ -31,7 +32,9 @@ argocd admin cluster stats [flags]
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
+      --redis-ha-haproxy-name string          Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
+      --redis-name string                     Redis name (default "argocd-redis")
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.
       --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified

--- a/docs/user-guide/commands/argocd_admin_dashboard.md
+++ b/docs/user-guide/commands/argocd_admin_dashboard.md
@@ -25,7 +25,11 @@ argocd admin dashboard [flags]
       --password string                Password for basic authentication to the API server
       --port int                       Listen on given port (default 8080)
       --proxy-url string               If provided, this URL will be used to connect via proxy
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --server-name string             Server name (default "argocd-server")
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/docs/user-guide/commands/argocd_app_actions_list.md
+++ b/docs/user-guide/commands/argocd_app_actions_list.md
@@ -9,12 +9,16 @@ argocd app actions list APPNAME [flags]
 ### Options
 
 ```
-      --group string           Group
-  -h, --help                   help for list
-      --kind string            Kind
-      --namespace string       Namespace
-  -o, --out string             Output format. One of: yaml, json
-      --resource-name string   Name of resource
+      --group string                   Group
+  -h, --help                           help for list
+      --kind string                    Kind
+      --namespace string               Namespace
+  -o, --out string                     Output format. One of: yaml, json
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --resource-name string           Name of resource
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_actions_run.md
+++ b/docs/user-guide/commands/argocd_app_actions_run.md
@@ -9,12 +9,16 @@ argocd app actions run APPNAME ACTION [flags]
 ### Options
 
 ```
-      --all                    Indicates whether to run the action on multiple matching resources
-      --group string           Group
-  -h, --help                   help for run
-      --kind string            Kind
-      --namespace string       Namespace
-      --resource-name string   Name of resource
+      --all                            Indicates whether to run the action on multiple matching resources
+      --group string                   Group
+  -h, --help                           help for run
+      --kind string                    Kind
+      --namespace string               Namespace
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --resource-name string           Name of resource
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_create.md
+++ b/docs/user-guide/commands/argocd_app_create.md
@@ -72,11 +72,15 @@ argocd app create APPNAME [flags]
       --path string                                Path in repository to the app directory, ignored if a file is set
       --plugin-env stringArray                     Additional plugin envs
       --project string                             Application project name
+      --redis-ha-haproxy-name string               Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                          Redis name (default "argocd-redis")
       --release-name string                        Helm release-name
       --repo string                                Repository URL, ignored if a file is set
+      --repo-server-name string                    Repo server name (default "argocd-repo-server")
       --revision string                            The tracking source branch, tag, commit or Helm chart version the application will sync to
       --revision-history-limit int                 How many items to keep in revision history (default 10)
       --self-heal                                  Set self healing when sync is automated
+      --server-name string                         Server name (default "argocd-server")
       --set-finalizer                              Sets deletion finalizer on the application, application resources will be cascaded on deletion
       --sync-option Prune=false                    Add or remove a sync option, e.g add Prune=false. Remove using `!` prefix, e.g. `!Prune=false`
       --sync-policy string                         Set the sync policy (one of: none, automated (aliases of automated: auto, automatic))

--- a/docs/user-guide/commands/argocd_app_delete-resource.md
+++ b/docs/user-guide/commands/argocd_app_delete-resource.md
@@ -9,14 +9,18 @@ argocd app delete-resource APPNAME [flags]
 ### Options
 
 ```
-      --all                    Indicates whether to patch multiple matching of resources
-      --force                  Indicates whether to orphan the dependents of the deleted resource
-      --group string           Group
-  -h, --help                   help for delete-resource
-      --kind string            Kind
-      --namespace string       Namespace
-      --orphan                 Indicates whether to force delete the resource
-      --resource-name string   Name of resource
+      --all                            Indicates whether to patch multiple matching of resources
+      --force                          Indicates whether to orphan the dependents of the deleted resource
+      --group string                   Group
+  -h, --help                           help for delete-resource
+      --kind string                    Kind
+      --namespace string               Namespace
+      --orphan                         Indicates whether to force delete the resource
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --resource-name string           Name of resource
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_delete.md
+++ b/docs/user-guide/commands/argocd_app_delete.md
@@ -26,11 +26,15 @@ argocd app delete APPNAME [flags]
 ### Options
 
 ```
-      --cascade                     Perform a cascaded deletion of all application resources (default true)
-  -h, --help                        help for delete
-  -p, --propagation-policy string   Specify propagation policy for deletion of application's resources. One of: foreground|background (default "foreground")
-  -l, --selector string             Delete all apps with matching label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
-  -y, --yes                         Turn off prompting to confirm cascaded deletion of application resources
+      --cascade                        Perform a cascaded deletion of all application resources (default true)
+  -h, --help                           help for delete
+  -p, --propagation-policy string      Specify propagation policy for deletion of application's resources. One of: foreground|background (default "foreground")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+  -l, --selector string                Delete all apps with matching label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
+      --server-name string             Server name (default "argocd-server")
+  -y, --yes                            Turn off prompting to confirm cascaded deletion of application resources
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -15,15 +15,19 @@ argocd app diff APPNAME [flags]
 ### Options
 
 ```
-      --exit-code                   Return non-zero exit code when there is a diff (default true)
-      --hard-refresh                Refresh application data as well as target manifests cache
-  -h, --help                        help for diff
-      --local string                Compare live app to a local manifests
-      --local-include stringArray   Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path. (default [*.yaml,*.yml,*.json])
-      --local-repo-root string      Path to the repository root. Used together with --local allows setting the repository root (default "/")
-      --refresh                     Refresh application data when retrieving
-      --revision string             Compare live app to a particular revision
-      --server-side-generate        Used with --local, this will send your manifests to the server for diffing
+      --exit-code                      Return non-zero exit code when there is a diff (default true)
+      --hard-refresh                   Refresh application data as well as target manifests cache
+  -h, --help                           help for diff
+      --local string                   Compare live app to a local manifests
+      --local-include stringArray      Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path. (default [*.yaml,*.yml,*.json])
+      --local-repo-root string         Path to the repository root. Used together with --local allows setting the repository root (default "/")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --refresh                        Refresh application data when retrieving
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --revision string                Compare live app to a particular revision
+      --server-name string             Server name (default "argocd-server")
+      --server-side-generate           Used with --local, this will send your manifests to the server for diffing
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_edit.md
+++ b/docs/user-guide/commands/argocd_app_edit.md
@@ -9,7 +9,11 @@ argocd app edit APPNAME [flags]
 ### Options
 
 ```
-  -h, --help   help for edit
+  -h, --help                           help for edit
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_get.md
+++ b/docs/user-guide/commands/argocd_app_get.md
@@ -9,12 +9,16 @@ argocd app get APPNAME [flags]
 ### Options
 
 ```
-      --hard-refresh     Refresh application data as well as target manifests cache
-  -h, --help             help for get
-  -o, --output string    Output format. One of: json|yaml|wide (default "wide")
-      --refresh          Refresh application data when retrieving
-      --show-operation   Show application operation
-      --show-params      Show application parameters and overrides
+      --hard-refresh                   Refresh application data as well as target manifests cache
+  -h, --help                           help for get
+  -o, --output string                  Output format. One of: json|yaml|wide (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --refresh                        Refresh application data when retrieving
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --show-operation                 Show application operation
+      --show-params                    Show application parameters and overrides
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_history.md
+++ b/docs/user-guide/commands/argocd_app_history.md
@@ -9,8 +9,12 @@ argocd app history APPNAME [flags]
 ### Options
 
 ```
-  -h, --help            help for history
-  -o, --output string   Output format. One of: wide|id (default "wide")
+  -h, --help                           help for history
+  -o, --output string                  Output format. One of: wide|id (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_list.md
+++ b/docs/user-guide/commands/argocd_app_list.md
@@ -23,13 +23,17 @@ argocd app list [flags]
 ### Options
 
 ```
-  -N, --app-namespace string   Only list applications in namespace
-  -c, --cluster string         List apps by cluster name or url
-  -h, --help                   help for list
-  -o, --output string          Output format. One of: wide|name|json|yaml (default "wide")
-  -p, --project stringArray    Filter by project name
-  -r, --repo string            List apps by source repo URL
-  -l, --selector string        List apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
+  -N, --app-namespace string           Only list applications in namespace
+  -c, --cluster string                 List apps by cluster name or url
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: wide|name|json|yaml (default "wide")
+  -p, --project stringArray            Filter by project name
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+  -r, --repo string                    List apps by source repo URL
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+  -l, --selector string                List apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_logs.md
+++ b/docs/user-guide/commands/argocd_app_logs.md
@@ -9,18 +9,22 @@ argocd app logs APPNAME [flags]
 ### Options
 
 ```
-      --container string    Optional container name
-      --filter string       Show logs contain this string
-      --follow              Specify if the logs should be streamed
-      --group string        Resource group
-  -h, --help                help for logs
-      --kind string         Resource kind
-      --name string         Resource name
-      --namespace string    Resource namespace
-  -p, --previous            Specify if the previously terminated container logs should be returned
-      --since-seconds int   A relative time in seconds before the current time from which to show logs
-      --tail int            The number of lines from the end of the logs to show
-      --until-time string   Show logs until this time
+      --container string               Optional container name
+      --filter string                  Show logs contain this string
+      --follow                         Specify if the logs should be streamed
+      --group string                   Resource group
+  -h, --help                           help for logs
+      --kind string                    Resource kind
+      --name string                    Resource name
+      --namespace string               Resource namespace
+  -p, --previous                       Specify if the previously terminated container logs should be returned
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --since-seconds int              A relative time in seconds before the current time from which to show logs
+      --tail int                       The number of lines from the end of the logs to show
+      --until-time string              Show logs until this time
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_manifests.md
+++ b/docs/user-guide/commands/argocd_app_manifests.md
@@ -9,11 +9,15 @@ argocd app manifests APPNAME [flags]
 ### Options
 
 ```
-  -h, --help                     help for manifests
-      --local string             If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.
-      --local-repo-root string   Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'. (default ".")
-      --revision string          Show manifests at a specific revision
-      --source string            Source of manifests. One of: live|git (default "git")
+  -h, --help                           help for manifests
+      --local string                   If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.
+      --local-repo-root string         Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'. (default ".")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --revision string                Show manifests at a specific revision
+      --server-name string             Server name (default "argocd-server")
+      --source string                  Source of manifests. One of: live|git (default "git")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_patch-resource.md
+++ b/docs/user-guide/commands/argocd_app_patch-resource.md
@@ -9,14 +9,18 @@ argocd app patch-resource APPNAME [flags]
 ### Options
 
 ```
-      --all                    Indicates whether to patch multiple matching of resources
-      --group string           Group
-  -h, --help                   help for patch-resource
-      --kind string            Kind
-      --namespace string       Namespace
-      --patch string           Patch
-      --patch-type string      Which Patching strategy to use: 'application/json-patch+json', 'application/merge-patch+json', or 'application/strategic-merge-patch+json'. Defaults to 'application/merge-patch+json' (default "application/merge-patch+json")
-      --resource-name string   Name of resource
+      --all                            Indicates whether to patch multiple matching of resources
+      --group string                   Group
+  -h, --help                           help for patch-resource
+      --kind string                    Kind
+      --namespace string               Namespace
+      --patch string                   Patch
+      --patch-type string              Which Patching strategy to use: 'application/json-patch+json', 'application/merge-patch+json', or 'application/strategic-merge-patch+json'. Defaults to 'application/merge-patch+json' (default "application/merge-patch+json")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --resource-name string           Name of resource
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_patch.md
+++ b/docs/user-guide/commands/argocd_app_patch.md
@@ -18,9 +18,13 @@ argocd app patch APPNAME [flags]
 ### Options
 
 ```
-  -h, --help           help for patch
-      --patch string   Patch body
-      --type string    The type of patch being provided; one of [json merge] (default "json")
+  -h, --help                           help for patch
+      --patch string                   Patch body
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --type string                    The type of patch being provided; one of [json merge] (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_resources.md
+++ b/docs/user-guide/commands/argocd_app_resources.md
@@ -9,8 +9,12 @@ argocd app resources APPNAME [flags]
 ### Options
 
 ```
-  -h, --help       help for resources
-      --orphaned   Lists only orphaned resources
+  -h, --help                           help for resources
+      --orphaned                       Lists only orphaned resources
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_rollback.md
+++ b/docs/user-guide/commands/argocd_app_rollback.md
@@ -9,9 +9,13 @@ argocd app rollback APPNAME [ID] [flags]
 ### Options
 
 ```
-  -h, --help           help for rollback
-      --prune          Allow deleting unexpected resources
-      --timeout uint   Time out after this many seconds
+  -h, --help                           help for rollback
+      --prune                          Allow deleting unexpected resources
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --timeout uint                   Time out after this many seconds
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -45,11 +45,15 @@ argocd app set APPNAME [flags]
       --path string                                Path in repository to the app directory, ignored if a file is set
       --plugin-env stringArray                     Additional plugin envs
       --project string                             Application project name
+      --redis-ha-haproxy-name string               Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                          Redis name (default "argocd-redis")
       --release-name string                        Helm release-name
       --repo string                                Repository URL, ignored if a file is set
+      --repo-server-name string                    Repo server name (default "argocd-repo-server")
       --revision string                            The tracking source branch, tag, commit or Helm chart version the application will sync to
       --revision-history-limit int                 How many items to keep in revision history (default 10)
       --self-heal                                  Set self healing when sync is automated
+      --server-name string                         Server name (default "argocd-server")
       --sync-option Prune=false                    Add or remove a sync option, e.g add Prune=false. Remove using `!` prefix, e.g. `!Prune=false`
       --sync-policy string                         Set the sync policy (one of: none, automated (aliases of automated: auto, automatic))
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)

--- a/docs/user-guide/commands/argocd_app_sync.md
+++ b/docs/user-guide/commands/argocd_app_sync.md
@@ -48,7 +48,10 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --preview-changes                       Preview difference against the target and live state before syncing app and wait for user confirmation
       --project stringArray                   Sync apps that belong to the specified projects. This option may be specified repeatedly.
       --prune                                 Allow deleting unexpected resources
+      --redis-ha-haproxy-name string          Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                     Redis name (default "argocd-redis")
       --replace                               Use a kubectl create/replace instead apply
+      --repo-server-name string               Repo server name (default "argocd-repo-server")
       --resource stringArray                  Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
       --retry-backoff-duration duration       Retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --retry-backoff-factor int              Factor multiplies the base duration after each failed retry (default 2)
@@ -56,6 +59,7 @@ argocd app sync [APPNAME... | -l selector | --project project-name] [flags]
       --retry-limit int                       Max number of allowed sync retries
       --revision string                       Sync to a specific revision. Preserves parameter overrides
   -l, --selector string                       Sync apps that match this label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
+      --server-name string                    Server name (default "argocd-server")
       --server-side                           Use server-side apply while syncing the application
       --strategy string                       Sync strategy (one of: apply|hook)
       --timeout uint                          Time out after this many seconds

--- a/docs/user-guide/commands/argocd_app_terminate-op.md
+++ b/docs/user-guide/commands/argocd_app_terminate-op.md
@@ -9,7 +9,11 @@ argocd app terminate-op APPNAME [flags]
 ### Options
 
 ```
-  -h, --help   help for terminate-op
+  -h, --help                           help for terminate-op
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_unset.md
+++ b/docs/user-guide/commands/argocd_app_unset.md
@@ -22,17 +22,21 @@ argocd app unset APPNAME parameters [flags]
 ### Options
 
 ```
-  -h, --help                          help for unset
-      --ignore-missing-value-files    Unset the helm ignore-missing-value-files option (revert to false)
-      --kustomize-image stringArray   Kustomize images name (e.g. --kustomize-image node --kustomize-image mysql)
-      --kustomize-version             Kustomize version
-      --nameprefix                    Kustomize nameprefix
-      --namesuffix                    Kustomize namesuffix
-  -p, --parameter stringArray         Unset a parameter override (e.g. -p guestbook=image)
-      --pass-credentials              Unset passCredentials
-      --plugin-env stringArray        Unset plugin env variables (e.g --plugin-env name)
-      --values stringArray            Unset one or more Helm values files
-      --values-literal                Unset literal Helm values block
+  -h, --help                           help for unset
+      --ignore-missing-value-files     Unset the helm ignore-missing-value-files option (revert to false)
+      --kustomize-image stringArray    Kustomize images name (e.g. --kustomize-image node --kustomize-image mysql)
+      --kustomize-version              Kustomize version
+      --nameprefix                     Kustomize nameprefix
+      --namesuffix                     Kustomize namesuffix
+  -p, --parameter stringArray          Unset a parameter override (e.g. -p guestbook=image)
+      --pass-credentials               Unset passCredentials
+      --plugin-env stringArray         Unset plugin env variables (e.g --plugin-env name)
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --values stringArray             Unset one or more Helm values files
+      --values-literal                 Unset literal Helm values block
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_wait.md
+++ b/docs/user-guide/commands/argocd_app_wait.md
@@ -36,15 +36,19 @@ argocd app wait [APPNAME.. | -l selector] [flags]
 ### Options
 
 ```
-      --degraded               Wait for degraded
-      --health                 Wait for health
-  -h, --help                   help for wait
-      --operation              Wait for pending operations
-      --resource stringArray   Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
-  -l, --selector string        Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
-      --suspended              Wait for suspended
-      --sync                   Wait for sync
-      --timeout uint           Time out after this many seconds
+      --degraded                       Wait for degraded
+      --health                         Wait for health
+  -h, --help                           help for wait
+      --operation                      Wait for pending operations
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --resource stringArray           Sync only specific resources as GROUP:KIND:NAME or !GROUP:KIND:NAME. Fields may be blank and '*' can be used. This option may be specified repeatedly
+  -l, --selector string                Wait for apps by label. Supports '=', '==', '!=', in, notin, exists & not exists. Matching apps must satisfy all of the specified label constraints.
+      --server-name string             Server name (default "argocd-server")
+      --suspended                      Wait for suspended
+      --sync                           Wait for sync
+      --timeout uint                   Time out after this many seconds
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_appset_create.md
+++ b/docs/user-guide/commands/argocd_appset_create.md
@@ -16,8 +16,12 @@ argocd appset create [flags]
 ### Options
 
 ```
-  -h, --help     help for create
-      --upsert   Allows to override ApplicationSet with the same name even if supplied ApplicationSet spec is different from existing spec
+  -h, --help                           help for create
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --upsert                         Allows to override ApplicationSet with the same name even if supplied ApplicationSet spec is different from existing spec
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_appset_delete.md
+++ b/docs/user-guide/commands/argocd_appset_delete.md
@@ -16,8 +16,12 @@ argocd appset delete [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
-  -y, --yes    Turn off prompting to confirm cascaded deletion of Application resources
+  -h, --help                           help for delete
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+  -y, --yes                            Turn off prompting to confirm cascaded deletion of Application resources
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_appset_get.md
+++ b/docs/user-guide/commands/argocd_appset_get.md
@@ -9,9 +9,13 @@ argocd appset get APPSETNAME [flags]
 ### Options
 
 ```
-  -h, --help            help for get
-  -o, --output string   Output format. One of: json|yaml|wide (default "wide")
-      --show-params     Show ApplicationSet parameters and overrides
+  -h, --help                           help for get
+  -o, --output string                  Output format. One of: json|yaml|wide (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --show-params                    Show ApplicationSet parameters and overrides
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_appset_list.md
+++ b/docs/user-guide/commands/argocd_appset_list.md
@@ -16,10 +16,14 @@ argocd appset list [flags]
 ### Options
 
 ```
-  -h, --help                  help for list
-  -o, --output string         Output format. One of: wide|name|json|yaml (default "wide")
-  -p, --project stringArray   Filter by project name
-  -l, --selector string       List applicationsets by label
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: wide|name|json|yaml (default "wide")
+  -p, --project stringArray            Filter by project name
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+  -l, --selector string                List applicationsets by label
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cert_add-ssh.md
+++ b/docs/user-guide/commands/argocd_cert_add-ssh.md
@@ -9,10 +9,14 @@ argocd cert add-ssh --batch [flags]
 ### Options
 
 ```
-      --batch         Perform batch processing by reading in SSH known hosts data (mandatory flag)
-      --from string   Read SSH known hosts data from file (default is to read from stdin)
-  -h, --help          help for add-ssh
-      --upsert        Replace existing SSH server public host keys if key is different in input
+      --batch                          Perform batch processing by reading in SSH known hosts data (mandatory flag)
+      --from string                    Read SSH known hosts data from file (default is to read from stdin)
+  -h, --help                           help for add-ssh
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --upsert                         Replace existing SSH server public host keys if key is different in input
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cert_add-tls.md
+++ b/docs/user-guide/commands/argocd_cert_add-tls.md
@@ -9,9 +9,13 @@ argocd cert add-tls SERVERNAME [flags]
 ### Options
 
 ```
-      --from string   read TLS certificate data from file (default is to read from stdin)
-  -h, --help          help for add-tls
-      --upsert        Replace existing TLS certificate if certificate is different in input
+      --from string                    read TLS certificate data from file (default is to read from stdin)
+  -h, --help                           help for add-tls
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --upsert                         Replace existing TLS certificate if certificate is different in input
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cert_list.md
+++ b/docs/user-guide/commands/argocd_cert_list.md
@@ -9,11 +9,15 @@ argocd cert list [flags]
 ### Options
 
 ```
-      --cert-type string          only list certificates of given type, valid: 'ssh','https'
-  -h, --help                      help for list
-      --hostname-pattern string   only list certificates for hosts matching given glob-pattern
-  -o, --output string             Output format. One of: json|yaml|wide (default "wide")
-      --sort string               set display sort order for output format wide. One of: hostname|type
+      --cert-type string               only list certificates of given type, valid: 'ssh','https'
+  -h, --help                           help for list
+      --hostname-pattern string        only list certificates for hosts matching given glob-pattern
+  -o, --output string                  Output format. One of: json|yaml|wide (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --sort string                    set display sort order for output format wide. One of: hostname|type
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cert_rm.md
+++ b/docs/user-guide/commands/argocd_cert_rm.md
@@ -9,9 +9,13 @@ argocd cert rm REPOSERVER [flags]
 ### Options
 
 ```
-      --cert-sub-type string   Only remove certs of given sub-type (only for ssh)
-      --cert-type string       Only remove certs of given type (ssh, https)
-  -h, --help                   help for rm
+      --cert-sub-type string           Only remove certs of given sub-type (only for ssh)
+      --cert-type string               Only remove certs of given type (ssh, https)
+  -h, --help                           help for rm
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cluster_add.md
+++ b/docs/user-guide/commands/argocd_cluster_add.md
@@ -25,6 +25,10 @@ argocd cluster add CONTEXT [flags]
       --name string                        Overwrite the cluster name
       --namespace stringArray              List of namespaces which are allowed to manage
       --project string                     project of the cluster
+      --redis-ha-haproxy-name string       Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                  Redis name (default "argocd-redis")
+      --repo-server-name string            Repo server name (default "argocd-repo-server")
+      --server-name string                 Server name (default "argocd-server")
       --service-account string             System namespace service account to use for kubernetes resource management. If not set then default "argocd-manager" SA will be created
       --shard int                          Cluster shard number; inferred from hostname if not set (default -1)
       --system-namespace string            Use different system namespace (default "kube-system")

--- a/docs/user-guide/commands/argocd_cluster_get.md
+++ b/docs/user-guide/commands/argocd_cluster_get.md
@@ -16,8 +16,12 @@ argocd cluster get in-cluster
 ### Options
 
 ```
-  -h, --help            help for get
-  -o, --output string   Output format. One of: json|yaml|wide|server (default "yaml")
+  -h, --help                           help for get
+  -o, --output string                  Output format. One of: json|yaml|wide|server (default "yaml")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cluster_list.md
+++ b/docs/user-guide/commands/argocd_cluster_list.md
@@ -9,8 +9,12 @@ argocd cluster list [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   Output format. One of: json|yaml|wide|server (default "wide")
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide|server (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cluster_rm.md
+++ b/docs/user-guide/commands/argocd_cluster_rm.md
@@ -16,8 +16,12 @@ argocd cluster rm cluster-name
 ### Options
 
 ```
-  -h, --help   help for rm
-  -y, --yes    Turn off prompting to confirm remove of cluster resources
+  -h, --help                           help for rm
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+  -y, --yes                            Turn off prompting to confirm remove of cluster resources
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_cluster_rotate-auth.md
+++ b/docs/user-guide/commands/argocd_cluster_rotate-auth.md
@@ -16,7 +16,11 @@ argocd cluster rotate-auth cluster-name
 ### Options
 
 ```
-  -h, --help   help for rotate-auth
+  -h, --help                           help for rotate-auth
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_gpg_add.md
+++ b/docs/user-guide/commands/argocd_gpg_add.md
@@ -9,8 +9,12 @@ argocd gpg add [flags]
 ### Options
 
 ```
-  -f, --from string   Path to the file that contains the GPG public key to import
-  -h, --help          help for add
+  -f, --from string                    Path to the file that contains the GPG public key to import
+  -h, --help                           help for add
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_gpg_get.md
+++ b/docs/user-guide/commands/argocd_gpg_get.md
@@ -9,8 +9,12 @@ argocd gpg get KEYID [flags]
 ### Options
 
 ```
-  -h, --help            help for get
-  -o, --output string   Output format. One of: json|yaml|wide (default "wide")
+  -h, --help                           help for get
+  -o, --output string                  Output format. One of: json|yaml|wide (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_gpg_list.md
+++ b/docs/user-guide/commands/argocd_gpg_list.md
@@ -9,8 +9,12 @@ argocd gpg list [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   Output format. One of: json|yaml|wide (default "wide")
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_gpg_rm.md
+++ b/docs/user-guide/commands/argocd_gpg_rm.md
@@ -9,7 +9,11 @@ argocd gpg rm KEYID [flags]
 ### Options
 
 ```
-  -h, --help   help for rm
+  -h, --help                           help for rm
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_login.md
+++ b/docs/user-guide/commands/argocd_login.md
@@ -26,13 +26,17 @@ argocd login cd.argoproj.io --core
 ### Options
 
 ```
-  -h, --help              help for login
-      --name string       name to use for the context
-      --password string   the password of an account to authenticate
-      --skip-test-tls     Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)
-      --sso               perform SSO login
-      --sso-port int      port to run local OAuth2 login application (default 8085)
-      --username string   the username of an account to authenticate
+  -h, --help                           help for login
+      --name string                    name to use for the context
+      --password string                the password of an account to authenticate
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --skip-test-tls                  Skip testing whether the server is configured with TLS (this can help when the command hangs for no apparent reason)
+      --sso                            perform SSO login
+      --sso-port int                   port to run local OAuth2 login application (default 8085)
+      --username string                the username of an account to authenticate
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_add-destination.md
+++ b/docs/user-guide/commands/argocd_proj_add-destination.md
@@ -9,8 +9,12 @@ argocd proj add-destination PROJECT SERVER/NAME NAMESPACE [flags]
 ### Options
 
 ```
-  -h, --help   help for add-destination
-      --name   Use name as destination instead server
+  -h, --help                           help for add-destination
+      --name                           Use name as destination instead server
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_add-orphaned-ignore.md
+++ b/docs/user-guide/commands/argocd_proj_add-orphaned-ignore.md
@@ -9,8 +9,12 @@ argocd proj add-orphaned-ignore PROJECT GROUP KIND [flags]
 ### Options
 
 ```
-  -h, --help          help for add-orphaned-ignore
-      --name string   Resource name pattern
+  -h, --help                           help for add-orphaned-ignore
+      --name string                    Resource name pattern
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_add-signature-key.md
+++ b/docs/user-guide/commands/argocd_proj_add-signature-key.md
@@ -9,7 +9,11 @@ argocd proj add-signature-key PROJECT KEY-ID [flags]
 ### Options
 
 ```
-  -h, --help   help for add-signature-key
+  -h, --help                           help for add-signature-key
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_add-source.md
+++ b/docs/user-guide/commands/argocd_proj_add-source.md
@@ -9,7 +9,11 @@ argocd proj add-source PROJECT URL [flags]
 ### Options
 
 ```
-  -h, --help   help for add-source
+  -h, --help                           help for add-source
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_allow-cluster-resource.md
+++ b/docs/user-guide/commands/argocd_proj_allow-cluster-resource.md
@@ -9,8 +9,12 @@ argocd proj allow-cluster-resource PROJECT GROUP KIND [flags]
 ### Options
 
 ```
-  -h, --help          help for allow-cluster-resource
-  -l, --list string   Use deny list or allow list. This can only be 'allow' or 'deny' (default "allow")
+  -h, --help                           help for allow-cluster-resource
+  -l, --list string                    Use deny list or allow list. This can only be 'allow' or 'deny' (default "allow")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_allow-namespace-resource.md
+++ b/docs/user-guide/commands/argocd_proj_allow-namespace-resource.md
@@ -9,8 +9,12 @@ argocd proj allow-namespace-resource PROJECT GROUP KIND [flags]
 ### Options
 
 ```
-  -h, --help          help for allow-namespace-resource
-  -l, --list string   Use deny list or allow list. This can only be 'allow' or 'deny' (default "deny")
+  -h, --help                           help for allow-namespace-resource
+  -l, --list string                    Use deny list or allow list. This can only be 'allow' or 'deny' (default "deny")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_create.md
+++ b/docs/user-guide/commands/argocd_proj_create.md
@@ -19,6 +19,10 @@ argocd proj create PROJECT [flags]
   -h, --help                                    help for create
       --orphaned-resources                      Enables orphaned resources monitoring
       --orphaned-resources-warn                 Specifies if applications should have a warning condition when orphaned resources detected
+      --redis-ha-haproxy-name string            Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                       Redis name (default "argocd-redis")
+      --repo-server-name string                 Repo server name (default "argocd-repo-server")
+      --server-name string                      Server name (default "argocd-server")
       --signature-keys strings                  GnuPG public key IDs for commit signature verification
       --source-namespaces strings               List of source namespaces for applications
   -s, --src stringArray                         Permitted source repository URL

--- a/docs/user-guide/commands/argocd_proj_delete.md
+++ b/docs/user-guide/commands/argocd_proj_delete.md
@@ -9,7 +9,11 @@ argocd proj delete PROJECT [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
+  -h, --help                           help for delete
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_deny-cluster-resource.md
+++ b/docs/user-guide/commands/argocd_proj_deny-cluster-resource.md
@@ -9,8 +9,12 @@ argocd proj deny-cluster-resource PROJECT GROUP KIND [flags]
 ### Options
 
 ```
-  -h, --help          help for deny-cluster-resource
-  -l, --list string   Use deny list or allow list. This can only be 'allow' or 'deny' (default "allow")
+  -h, --help                           help for deny-cluster-resource
+  -l, --list string                    Use deny list or allow list. This can only be 'allow' or 'deny' (default "allow")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_deny-namespace-resource.md
+++ b/docs/user-guide/commands/argocd_proj_deny-namespace-resource.md
@@ -9,8 +9,12 @@ argocd proj deny-namespace-resource PROJECT GROUP KIND [flags]
 ### Options
 
 ```
-  -h, --help          help for deny-namespace-resource
-  -l, --list string   Use deny list or allow list. This can only be 'allow' or 'deny' (default "deny")
+  -h, --help                           help for deny-namespace-resource
+  -l, --list string                    Use deny list or allow list. This can only be 'allow' or 'deny' (default "deny")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_edit.md
+++ b/docs/user-guide/commands/argocd_proj_edit.md
@@ -9,7 +9,11 @@ argocd proj edit PROJECT [flags]
 ### Options
 
 ```
-  -h, --help   help for edit
+  -h, --help                           help for edit
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_get.md
+++ b/docs/user-guide/commands/argocd_proj_get.md
@@ -9,8 +9,12 @@ argocd proj get PROJECT [flags]
 ### Options
 
 ```
-  -h, --help            help for get
-  -o, --output string   Output format. One of: json|yaml|wide (default "wide")
+  -h, --help                           help for get
+  -o, --output string                  Output format. One of: json|yaml|wide (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_list.md
+++ b/docs/user-guide/commands/argocd_proj_list.md
@@ -9,8 +9,12 @@ argocd proj list [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   Output format. One of: json|yaml|wide|name (default "wide")
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide|name (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_remove-destination.md
+++ b/docs/user-guide/commands/argocd_proj_remove-destination.md
@@ -9,7 +9,11 @@ argocd proj remove-destination PROJECT SERVER NAMESPACE [flags]
 ### Options
 
 ```
-  -h, --help   help for remove-destination
+  -h, --help                           help for remove-destination
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_remove-orphaned-ignore.md
+++ b/docs/user-guide/commands/argocd_proj_remove-orphaned-ignore.md
@@ -9,8 +9,12 @@ argocd proj remove-orphaned-ignore PROJECT GROUP KIND NAME [flags]
 ### Options
 
 ```
-  -h, --help          help for remove-orphaned-ignore
-      --name string   Resource name pattern
+  -h, --help                           help for remove-orphaned-ignore
+      --name string                    Resource name pattern
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_remove-signature-key.md
+++ b/docs/user-guide/commands/argocd_proj_remove-signature-key.md
@@ -9,7 +9,11 @@ argocd proj remove-signature-key PROJECT KEY-ID [flags]
 ### Options
 
 ```
-  -h, --help   help for remove-signature-key
+  -h, --help                           help for remove-signature-key
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_remove-source.md
+++ b/docs/user-guide/commands/argocd_proj_remove-source.md
@@ -9,7 +9,11 @@ argocd proj remove-source PROJECT URL [flags]
 ### Options
 
 ```
-  -h, --help   help for remove-source
+  -h, --help                           help for remove-source
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_add-group.md
+++ b/docs/user-guide/commands/argocd_proj_role_add-group.md
@@ -9,7 +9,11 @@ argocd proj role add-group PROJECT ROLE-NAME GROUP-CLAIM [flags]
 ### Options
 
 ```
-  -h, --help   help for add-group
+  -h, --help                           help for add-group
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_add-policy.md
+++ b/docs/user-guide/commands/argocd_proj_role_add-policy.md
@@ -9,10 +9,14 @@ argocd proj role add-policy PROJECT ROLE-NAME [flags]
 ### Options
 
 ```
-  -a, --action string       Action to grant/deny permission on (e.g. get, create, list, update, delete)
-  -h, --help                help for add-policy
-  -o, --object string       Object within the project to grant/deny access.  Use '*' for a wildcard. Will want access to '<project>/<object>'
-  -p, --permission string   Whether to allow or deny access to object with the action.  This can only be 'allow' or 'deny' (default "allow")
+  -a, --action string                  Action to grant/deny permission on (e.g. get, create, list, update, delete)
+  -h, --help                           help for add-policy
+  -o, --object string                  Object within the project to grant/deny access.  Use '*' for a wildcard. Will want access to '<project>/<object>'
+  -p, --permission string              Whether to allow or deny access to object with the action.  This can only be 'allow' or 'deny' (default "allow")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_create-token.md
+++ b/docs/user-guide/commands/argocd_proj_role_create-token.md
@@ -9,10 +9,14 @@ argocd proj role create-token PROJECT ROLE-NAME [flags]
 ### Options
 
 ```
-  -e, --expires-in string   Duration before the token will expire, e.g. "12h", "7d". (Default: No expiration)
-  -h, --help                help for create-token
-  -i, --id string           Token unique identifier. (Default: Random UUID)
-  -t, --token-only          Output token only - for use in scripts.
+  -e, --expires-in string              Duration before the token will expire, e.g. "12h", "7d". (Default: No expiration)
+  -h, --help                           help for create-token
+  -i, --id string                      Token unique identifier. (Default: Random UUID)
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+  -t, --token-only                     Output token only - for use in scripts.
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_create.md
+++ b/docs/user-guide/commands/argocd_proj_role_create.md
@@ -9,8 +9,12 @@ argocd proj role create PROJECT ROLE-NAME [flags]
 ### Options
 
 ```
-      --description string   Project description
-  -h, --help                 help for create
+      --description string             Project description
+  -h, --help                           help for create
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_delete-token.md
+++ b/docs/user-guide/commands/argocd_proj_role_delete-token.md
@@ -9,7 +9,11 @@ argocd proj role delete-token PROJECT ROLE-NAME ISSUED-AT [flags]
 ### Options
 
 ```
-  -h, --help   help for delete-token
+  -h, --help                           help for delete-token
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_delete.md
+++ b/docs/user-guide/commands/argocd_proj_role_delete.md
@@ -9,7 +9,11 @@ argocd proj role delete PROJECT ROLE-NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
+  -h, --help                           help for delete
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_get.md
+++ b/docs/user-guide/commands/argocd_proj_role_get.md
@@ -9,7 +9,11 @@ argocd proj role get PROJECT ROLE-NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for get
+  -h, --help                           help for get
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_list-tokens.md
+++ b/docs/user-guide/commands/argocd_proj_role_list-tokens.md
@@ -9,8 +9,12 @@ argocd proj role list-tokens PROJECT ROLE-NAME [flags]
 ### Options
 
 ```
-  -h, --help       help for list-tokens
-  -u, --unixtime   Print timestamps as Unix time instead of converting. Useful for piping into delete-token.
+  -h, --help                           help for list-tokens
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+  -u, --unixtime                       Print timestamps as Unix time instead of converting. Useful for piping into delete-token.
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_list.md
+++ b/docs/user-guide/commands/argocd_proj_role_list.md
@@ -9,8 +9,12 @@ argocd proj role list PROJECT [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   Output format. One of: json|yaml|wide|name (default "wide")
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide|name (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_remove-group.md
+++ b/docs/user-guide/commands/argocd_proj_role_remove-group.md
@@ -9,7 +9,11 @@ argocd proj role remove-group PROJECT ROLE-NAME GROUP-CLAIM [flags]
 ### Options
 
 ```
-  -h, --help   help for remove-group
+  -h, --help                           help for remove-group
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_remove-policy.md
+++ b/docs/user-guide/commands/argocd_proj_role_remove-policy.md
@@ -9,10 +9,14 @@ argocd proj role remove-policy PROJECT ROLE-NAME [flags]
 ### Options
 
 ```
-  -a, --action string       Action to grant/deny permission on (e.g. get, create, list, update, delete)
-  -h, --help                help for remove-policy
-  -o, --object string       Object within the project to grant/deny access.  Use '*' for a wildcard. Will want access to '<project>/<object>'
-  -p, --permission string   Whether to allow or deny access to object with the action.  This can only be 'allow' or 'deny' (default "allow")
+  -a, --action string                  Action to grant/deny permission on (e.g. get, create, list, update, delete)
+  -h, --help                           help for remove-policy
+  -o, --object string                  Object within the project to grant/deny access.  Use '*' for a wildcard. Will want access to '<project>/<object>'
+  -p, --permission string              Whether to allow or deny access to object with the action.  This can only be 'allow' or 'deny' (default "allow")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_set.md
+++ b/docs/user-guide/commands/argocd_proj_set.md
@@ -18,6 +18,10 @@ argocd proj set PROJECT [flags]
   -h, --help                                    help for set
       --orphaned-resources                      Enables orphaned resources monitoring
       --orphaned-resources-warn                 Specifies if applications should have a warning condition when orphaned resources detected
+      --redis-ha-haproxy-name string            Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                       Redis name (default "argocd-redis")
+      --repo-server-name string                 Repo server name (default "argocd-repo-server")
+      --server-name string                      Server name (default "argocd-server")
       --signature-keys strings                  GnuPG public key IDs for commit signature verification
       --source-namespaces strings               List of source namespaces for applications
   -s, --src stringArray                         Permitted source repository URL

--- a/docs/user-guide/commands/argocd_proj_windows_add.md
+++ b/docs/user-guide/commands/argocd_proj_windows_add.md
@@ -9,15 +9,19 @@ argocd proj windows add PROJECT [flags]
 ### Options
 
 ```
-      --applications strings   Applications that the schedule will be applied to. Comma separated, wildcards supported (e.g. --applications prod-\*,website)
-      --clusters strings       Clusters that the schedule will be applied to. Comma separated, wildcards supported (e.g. --clusters prod,staging)
-      --duration string        Sync window duration. (e.g. --duration 1h)
-  -h, --help                   help for add
-  -k, --kind string            Sync window kind, either allow or deny
-      --manual-sync            Allow manual syncs for both deny and allow windows
-      --namespaces strings     Namespaces that the schedule will be applied to. Comma separated, wildcards supported (e.g. --namespaces default,\*-prod)
-      --schedule string        Sync window schedule in cron format. (e.g. --schedule "0 22 * * *")
-      --time-zone string       Time zone of the sync window (default "UTC")
+      --applications strings           Applications that the schedule will be applied to. Comma separated, wildcards supported (e.g. --applications prod-\*,website)
+      --clusters strings               Clusters that the schedule will be applied to. Comma separated, wildcards supported (e.g. --clusters prod,staging)
+      --duration string                Sync window duration. (e.g. --duration 1h)
+  -h, --help                           help for add
+  -k, --kind string                    Sync window kind, either allow or deny
+      --manual-sync                    Allow manual syncs for both deny and allow windows
+      --namespaces strings             Namespaces that the schedule will be applied to. Comma separated, wildcards supported (e.g. --namespaces default,\*-prod)
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --schedule string                Sync window schedule in cron format. (e.g. --schedule "0 22 * * *")
+      --server-name string             Server name (default "argocd-server")
+      --time-zone string               Time zone of the sync window (default "UTC")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_windows_delete.md
+++ b/docs/user-guide/commands/argocd_proj_windows_delete.md
@@ -9,7 +9,11 @@ argocd proj windows delete PROJECT ID [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
+  -h, --help                           help for delete
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_windows_disable-manual-sync.md
+++ b/docs/user-guide/commands/argocd_proj_windows_disable-manual-sync.md
@@ -13,7 +13,11 @@ argocd proj windows disable-manual-sync PROJECT ID [flags]
 ### Options
 
 ```
-  -h, --help   help for disable-manual-sync
+  -h, --help                           help for disable-manual-sync
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_windows_enable-manual-sync.md
+++ b/docs/user-guide/commands/argocd_proj_windows_enable-manual-sync.md
@@ -13,7 +13,11 @@ argocd proj windows enable-manual-sync PROJECT ID [flags]
 ### Options
 
 ```
-  -h, --help   help for enable-manual-sync
+  -h, --help                           help for enable-manual-sync
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_windows_list.md
+++ b/docs/user-guide/commands/argocd_proj_windows_list.md
@@ -9,8 +9,12 @@ argocd proj windows list PROJECT [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   Output format. One of: json|yaml|wide (default "wide")
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_windows_update.md
+++ b/docs/user-guide/commands/argocd_proj_windows_update.md
@@ -13,13 +13,17 @@ argocd proj windows update PROJECT ID [flags]
 ### Options
 
 ```
-      --applications strings   Applications that the schedule will be applied to. Comma separated, wildcards supported (e.g. --applications prod-\*,website)
-      --clusters strings       Clusters that the schedule will be applied to. Comma separated, wildcards supported (e.g. --clusters prod,staging)
-      --duration string        Sync window duration. (e.g. --duration 1h)
-  -h, --help                   help for update
-      --namespaces strings     Namespaces that the schedule will be applied to. Comma separated, wildcards supported (e.g. --namespaces default,\*-prod)
-      --schedule string        Sync window schedule in cron format. (e.g. --schedule "0 22 * * *")
-      --time-zone string       Time zone of the sync window. (e.g. --time-zone "America/New_York") (default "UTC")
+      --applications strings           Applications that the schedule will be applied to. Comma separated, wildcards supported (e.g. --applications prod-\*,website)
+      --clusters strings               Clusters that the schedule will be applied to. Comma separated, wildcards supported (e.g. --clusters prod,staging)
+      --duration string                Sync window duration. (e.g. --duration 1h)
+  -h, --help                           help for update
+      --namespaces strings             Namespaces that the schedule will be applied to. Comma separated, wildcards supported (e.g. --namespaces default,\*-prod)
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --schedule string                Sync window schedule in cron format. (e.g. --schedule "0 22 * * *")
+      --server-name string             Server name (default "argocd-server")
+      --time-zone string               Time zone of the sync window. (e.g. --time-zone "America/New_York") (default "UTC")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_relogin.md
+++ b/docs/user-guide/commands/argocd_relogin.md
@@ -13,9 +13,13 @@ argocd relogin [flags]
 ### Options
 
 ```
-  -h, --help              help for relogin
-      --password string   the password of an account to authenticate
-      --sso-port int      port to run local OAuth2 login application (default 8085)
+  -h, --help                           help for relogin
+      --password string                the password of an account to authenticate
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
+      --sso-port int                   port to run local OAuth2 login application (default 8085)
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_repo_add.md
+++ b/docs/user-guide/commands/argocd_repo_add.md
@@ -58,6 +58,10 @@ argocd repo add REPOURL [flags]
       --password string                         password to the repository
       --project string                          project of the repository
       --proxy string                            use proxy to access repository
+      --redis-ha-haproxy-name string            Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                       Redis name (default "argocd-redis")
+      --repo-server-name string                 Repo server name (default "argocd-repo-server")
+      --server-name string                      Server name (default "argocd-server")
       --ssh-private-key-path string             path to the private ssh key (e.g. ~/.ssh/id_rsa)
       --tls-client-cert-key-path string         path to the TLS client cert's key path (must be PEM format)
       --tls-client-cert-path string             path to the TLS client cert (must be PEM format)

--- a/docs/user-guide/commands/argocd_repo_get.md
+++ b/docs/user-guide/commands/argocd_repo_get.md
@@ -9,9 +9,13 @@ argocd repo get [flags]
 ### Options
 
 ```
-  -h, --help             help for get
-  -o, --output string    Output format. One of: json|yaml|wide|url (default "wide")
-      --refresh string   Force a cache refresh on connection status , must be one of: 'hard'
+  -h, --help                           help for get
+  -o, --output string                  Output format. One of: json|yaml|wide|url (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --refresh string                 Force a cache refresh on connection status , must be one of: 'hard'
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_repo_list.md
+++ b/docs/user-guide/commands/argocd_repo_list.md
@@ -9,9 +9,13 @@ argocd repo list [flags]
 ### Options
 
 ```
-  -h, --help             help for list
-  -o, --output string    Output format. One of: json|yaml|wide|url (default "wide")
-      --refresh string   Force a cache refresh on connection status , must be one of: 'hard'
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide|url (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --refresh string                 Force a cache refresh on connection status , must be one of: 'hard'
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_repo_rm.md
+++ b/docs/user-guide/commands/argocd_repo_rm.md
@@ -9,7 +9,11 @@ argocd repo rm REPO [flags]
 ### Options
 
 ```
-  -h, --help   help for rm
+  -h, --help                           help for rm
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_repocreds_add.md
+++ b/docs/user-guide/commands/argocd_repocreds_add.md
@@ -40,6 +40,10 @@ argocd repocreds add REPOURL [flags]
       --github-app-private-key-path string      private key of the GitHub Application
   -h, --help                                    help for add
       --password string                         password to the repository
+      --redis-ha-haproxy-name string            Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string                       Redis name (default "argocd-redis")
+      --repo-server-name string                 Repo server name (default "argocd-repo-server")
+      --server-name string                      Server name (default "argocd-server")
       --ssh-private-key-path string             path to the private ssh key (e.g. ~/.ssh/id_rsa)
       --tls-client-cert-key-path string         path to the TLS client cert's key path (must be PEM format)
       --tls-client-cert-path string             path to the TLS client cert (must be PEM format)

--- a/docs/user-guide/commands/argocd_repocreds_list.md
+++ b/docs/user-guide/commands/argocd_repocreds_list.md
@@ -9,8 +9,12 @@ argocd repocreds list [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   Output format. One of: json|yaml|wide|url (default "wide")
+  -h, --help                           help for list
+  -o, --output string                  Output format. One of: json|yaml|wide|url (default "wide")
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_repocreds_rm.md
+++ b/docs/user-guide/commands/argocd_repocreds_rm.md
@@ -9,7 +9,11 @@ argocd repocreds rm CREDSURL [flags]
 ### Options
 
 ```
-  -h, --help   help for rm
+  -h, --help                           help for rm
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
+      --server-name string             Server name (default "argocd-server")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_version.md
+++ b/docs/user-guide/commands/argocd_version.md
@@ -42,7 +42,11 @@ argocd version [flags]
   -o, --output string                  Output format. One of: json|yaml|wide|short (default "wide")
       --password string                Password for basic authentication to the API server
       --proxy-url string               If provided, this URL will be used to connect via proxy
+      --redis-ha-haproxy-name string   Redis HA HAProxy name (default "argocd-redis-ha-haproxy")
+      --redis-name string              Redis name (default "argocd-redis")
+      --repo-server-name string        Repo server name (default "argocd-repo-server")
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --server-name string             Server name (default "argocd-server")
       --short                          print just the version number
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -7,3 +7,8 @@ The following environment variables can be used with `argocd` CLI:
 | `ARGOCD_SERVER` | the address of the ArgoCD server without `https://` prefix <br> (instead of specifying `--server` for every command) <br> eg. `ARGOCD_SERVER=argocd.mycompany.com` if served through an ingress with DNS |
 | `ARGOCD_AUTH_TOKEN` | the ArgoCD `apiKey` for your ArgoCD user to be able to authenticate |
 | `ARGOCD_OPTS` | command-line options to pass to `argocd` CLI <br> eg. `ARGOCD_OPTS="--grpc-web"` |
+| `ARGOCD_SERVER_NAME` | the ArgoCD API Server name (default "argocd-server") |
+| `ARGOCD_REPO_SERVER_NAME` | the ArgoCD Repository Server name (default "argocd-repo-server") |
+| `ARGOCD_APPLICATION_CONTROLLER_NAME` | the ArgoCD Application Controller name (default "argocd-application-controller") |
+| `ARGOCD_REDIS_NAME` | the ArgoCD Redis name (default "argocd-redis") |
+| `ARGOCD_REDIS_HA_HAPROXY_NAME` | the ArgoCD Redis HA Proxy name (default "argocd-redis-ha-haproxy") |

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -109,24 +109,29 @@ type Client interface {
 
 // ClientOptions hold address, security, and other settings for the API client.
 type ClientOptions struct {
-	ServerAddr           string
-	PlainText            bool
-	Insecure             bool
-	CertFile             string
-	ClientCertFile       string
-	ClientCertKeyFile    string
-	AuthToken            string
-	ConfigPath           string
-	Context              string
-	UserAgent            string
-	GRPCWeb              bool
-	GRPCWebRootPath      string
-	Core                 bool
-	PortForward          bool
-	PortForwardNamespace string
-	Headers              []string
-	HttpRetryMax         int
-	KubeOverrides        *clientcmd.ConfigOverrides
+	ServerAddr                string
+	PlainText                 bool
+	Insecure                  bool
+	CertFile                  string
+	ClientCertFile            string
+	ClientCertKeyFile         string
+	AuthToken                 string
+	ConfigPath                string
+	Context                   string
+	UserAgent                 string
+	GRPCWeb                   bool
+	GRPCWebRootPath           string
+	Core                      bool
+	PortForward               bool
+	PortForwardNamespace      string
+	Headers                   []string
+	HttpRetryMax              int
+	KubeOverrides             *clientcmd.ConfigOverrides
+	ServerName                string
+	RedisHaHaProxyName        string
+	RedisName                 string
+	RepoServerName            string
+	ApplicationControllerName string
 }
 
 type client struct {
@@ -210,7 +215,8 @@ func NewClient(opts *ClientOptions) (Client, error) {
 		if opts.KubeOverrides == nil {
 			opts.KubeOverrides = &clientcmd.ConfigOverrides{}
 		}
-		port, err := kube.PortForward(8080, opts.PortForwardNamespace, opts.KubeOverrides, "app.kubernetes.io/name=argocd-server")
+		serverPodLabelSelector := common.LabelKeyAppName + "=" + opts.ServerName
+		port, err := kube.PortForward(8080, opts.PortForwardNamespace, opts.KubeOverrides, serverPodLabelSelector)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -60,25 +60,35 @@ const (
 )
 
 const (
-	EnvAdminUsername = "ARGOCD_E2E_ADMIN_USERNAME"
-	EnvAdminPassword = "ARGOCD_E2E_ADMIN_PASSWORD"
+	EnvAdminUsername            = "ARGOCD_E2E_ADMIN_USERNAME"
+	EnvAdminPassword            = "ARGOCD_E2E_ADMIN_PASSWORD"
+	EnvArgoCDServerName         = "ARGOCD_E2E_SERVER_NAME"
+	EnvArgoCDRedisHAHAProxyName = "ARGOCD_E2E_REDIS_HA_HAPROXY_NAME"
+	EnvArgoCDRedisName          = "ARGOCD_E2E_REDIS_NAME"
+	EnvArgoCDRepoServerName     = "ARGOCD_E2E_REPO_SERVER_NAME"
+	EnvArgoCDAppControllerName  = "ARGOCD_E2E_APPLICATION_CONTROLLER_NAME"
 )
 
 var (
-	id                  string
-	deploymentNamespace string
-	name                string
-	KubeClientset       kubernetes.Interface
-	KubeConfig          *rest.Config
-	DynamicClientset    dynamic.Interface
-	AppClientset        appclientset.Interface
-	ArgoCDClientset     apiclient.Client
-	adminUsername       string
-	AdminPassword       string
-	apiServerAddress    string
-	token               string
-	plainText           bool
-	testsRun            map[string]bool
+	id                       string
+	deploymentNamespace      string
+	name                     string
+	KubeClientset            kubernetes.Interface
+	KubeConfig               *rest.Config
+	DynamicClientset         dynamic.Interface
+	AppClientset             appclientset.Interface
+	ArgoCDClientset          apiclient.Client
+	adminUsername            string
+	AdminPassword            string
+	apiServerAddress         string
+	token                    string
+	plainText                bool
+	testsRun                 map[string]bool
+	argoCDServerName         string
+	argoCDRedisHAHAProxyName string
+	argoCDRedisName          string
+	argoCDRepoServerName     string
+	argoCDAppControllerName  string
 )
 
 type RepoURLType string
@@ -164,11 +174,26 @@ func init() {
 	adminUsername = GetEnvWithDefault(EnvAdminUsername, defaultAdminUsername)
 	AdminPassword = GetEnvWithDefault(EnvAdminPassword, defaultAdminPassword)
 
+	argoCDServerName = GetEnvWithDefault(EnvArgoCDServerName, common.DefaultServerName)
+	argoCDRedisHAHAProxyName = GetEnvWithDefault(EnvArgoCDRedisHAHAProxyName, common.DefaultRedisHaHaproxyName)
+	argoCDRedisName = GetEnvWithDefault(EnvArgoCDRedisName, common.DefaultRedisName)
+	argoCDRepoServerName = GetEnvWithDefault(EnvArgoCDRepoServerName, common.DefaultRepoServerName)
+	argoCDAppControllerName = GetEnvWithDefault(EnvArgoCDAppControllerName, common.DefaultApplicationControllerName)
+
 	dialTime := 30 * time.Second
 	tlsTestResult, err := grpcutil.TestTLS(apiServerAddress, dialTime)
 	CheckError(err)
 
-	ArgoCDClientset, err = apiclient.NewClient(&apiclient.ClientOptions{Insecure: true, ServerAddr: apiServerAddress, PlainText: !tlsTestResult.TLS})
+	ArgoCDClientset, err = apiclient.NewClient(&apiclient.ClientOptions{
+		Insecure:                  true,
+		ServerAddr:                apiServerAddress,
+		PlainText:                 !tlsTestResult.TLS,
+		ServerName:                argoCDServerName,
+		RedisHaHaProxyName:        argoCDRedisHAHAProxyName,
+		RedisName:                 argoCDRedisName,
+		RepoServerName:            argoCDRepoServerName,
+		ApplicationControllerName: argoCDAppControllerName,
+	})
 	CheckError(err)
 
 	plainText = !tlsTestResult.TLS
@@ -214,10 +239,15 @@ func loginAs(username, password string) {
 	token = sessionResponse.Token
 
 	ArgoCDClientset, err = apiclient.NewClient(&apiclient.ClientOptions{
-		Insecure:   true,
-		ServerAddr: apiServerAddress,
-		AuthToken:  token,
-		PlainText:  plainText,
+		Insecure:                  true,
+		ServerAddr:                apiServerAddress,
+		AuthToken:                 token,
+		PlainText:                 plainText,
+		ServerName:                argoCDServerName,
+		RedisHaHaProxyName:        argoCDRedisHAHAProxyName,
+		RedisName:                 argoCDRedisName,
+		RepoServerName:            argoCDRepoServerName,
+		ApplicationControllerName: argoCDAppControllerName,
 	})
 	CheckError(err)
 }

--- a/util/kube/portforwarder.go
+++ b/util/kube/portforwarder.go
@@ -56,7 +56,7 @@ func PortForward(targetPort int, namespace string, overrides *clientcmd.ConfigOv
 	}
 
 	if pod == nil {
-		return -1, fmt.Errorf("cannot find pod with selector: %v", podSelectors)
+		return -1, fmt.Errorf("cannot find pod with selector: %v. Use the flag in this command or set the environmental variable (Refer to https://argo-cd.readthedocs.io/en/stable/user-guide/environment-variables), to change the ArgoCD component name in the CLI.", podSelectors)
 	}
 
 	url := clientSet.CoreV1().RESTClient().Post().


### PR DESCRIPTION
Fixes #10200 
ArgoCD component names were hard coded as part of the pod selector labels. These values have been made configurable in the CLI by adding new flags and environmental variables.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

