### PR TITLE
feature: pkce for UI #9890

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"html"
 	"net/http"
@@ -30,6 +28,7 @@ import (
 	jwtutil "github.com/argoproj/argo-cd/v2/util/jwt"
 	"github.com/argoproj/argo-cd/v2/util/localconfig"
 	oidcutil "github.com/argoproj/argo-cd/v2/util/oidc"
+	"github.com/argoproj/argo-cd/v2/util/oidc/pkce"
 	"github.com/argoproj/argo-cd/v2/util/rand"
 )
 
@@ -228,14 +227,7 @@ func oauth2Login(
 		completionChan <- errMsg
 	}
 
-	// PKCE implementation of https://tools.ietf.org/html/rfc7636
-	codeVerifier, err := rand.StringFromCharset(
-		43,
-		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
-	)
-	errors.CheckError(err)
-	codeChallengeHash := sha256.Sum256([]byte(codeVerifier))
-	codeChallenge := base64.RawURLEncoding.EncodeToString(codeChallengeHash[:])
+	pkceCodes := pkce.GeneratePKCECodes()
 
 	// Authorization redirect callback from OAuth2 auth flow.
 	// Handles both implicit and authorization code flow
@@ -276,7 +268,7 @@ func oauth2Login(
 				handleErr(w, fmt.Sprintf("no code in request: %q", r.Form))
 				return
 			}
-			opts := []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("code_verifier", codeVerifier)}
+			opts := []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("code_verifier", pkceCodes.CodeVerifier)}
 			tok, err := oauth2conf.Exchange(ctx, code, opts...)
 			if err != nil {
 				handleErr(w, err.Error())
@@ -313,8 +305,8 @@ func oauth2Login(
 
 	switch grantType {
 	case oidcutil.GrantTypeAuthorizationCode:
-		opts = append(opts, oauth2.SetAuthURLParam("code_challenge", codeChallenge))
-		opts = append(opts, oauth2.SetAuthURLParam("code_challenge_method", "S256"))
+		opts = append(opts, oauth2.SetAuthURLParam("code_challenge", pkceCodes.CodeChallenge))
+		opts = append(opts, oauth2.SetAuthURLParam("code_challenge_method", pkceCodes.CodeChallengeHash))
 		url = oauth2conf.AuthCodeURL(stateNonce, opts...)
 	case oidcutil.GrantTypeImplicit:
 		url, err = oidcutil.ImplicitFlowURL(oauth2conf, stateNonce, opts...)

--- a/util/oidc/pkce/pkcemanager.go
+++ b/util/oidc/pkce/pkcemanager.go
@@ -1,0 +1,56 @@
+package pkce
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"time"
+
+	"github.com/argoproj/argo-cd/v2/util/errors"
+	"github.com/argoproj/argo-cd/v2/util/rand"
+)
+
+// PKCEManager handles code verifications and their associated auth tokens
+type PKCEManager struct {
+	storage PKCEStateStorage
+}
+
+type PKCECodes struct {
+	CodeVerifier      string
+	CodeChallenge     string
+	AuthCode          string
+	Nonce             string
+	CodeChallengeHash string
+}
+
+func GeneratePKCECodes() *PKCECodes {
+	// PKCE implementation of https://tools.ietf.org/html/rfc7636
+	codeVerifier, err := rand.StringFromCharset(
+		43,
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
+	)
+	errors.CheckError(err)
+	codeChallengeHash := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(codeChallengeHash[:])
+	return &PKCECodes{
+		CodeVerifier:      codeVerifier,
+		CodeChallenge:     codeChallenge,
+		CodeChallengeHash: "S256",
+	}
+}
+
+// PKCEManager creates a new pkce manager
+func NewPKCEManager(storage PKCEStateStorage) *PKCEManager {
+	s := PKCEManager{
+		storage: storage,
+	}
+	return &s
+}
+
+func (mgr *PKCEManager) StorePKCEEntry(ctx context.Context, pkceCodes *PKCECodes, expiringAt time.Duration) error {
+	return mgr.storage.StorePKCEEntry(ctx, pkceCodes, expiringAt)
+}
+
+func (mgr *PKCEManager) RetrieveVerifierCode(nonce string) string {
+	return mgr.storage.RetrieveCodeVerifier(nonce)
+}

--- a/util/oidc/pkce/state.go
+++ b/util/oidc/pkce/state.go
@@ -1,0 +1,156 @@
+package pkce
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	log "github.com/sirupsen/logrus"
+
+	util "github.com/argoproj/argo-cd/v2/util/io"
+)
+
+const (
+	pkceEntryPrefix         = "pkce-auth|"
+	newVerifierCodeWithAuth = "new-verifier-code-with-auth"
+)
+
+type pkceStateStorage struct {
+	redis          *redis.Client
+	pkceAuthCodes  map[string]string
+	lock           sync.RWMutex
+	resyncDuration time.Duration
+}
+
+var _ PKCEStateStorage = &pkceStateStorage{}
+
+func NewPKCEStateStorage(redis *redis.Client) *pkceStateStorage {
+	return &pkceStateStorage{
+		pkceAuthCodes:  map[string]string{},
+		resyncDuration: time.Hour,
+		redis:          redis,
+	}
+}
+
+func buildRedisEntry(pkceCodes *PKCECodes) string {
+	return pkceEntryPrefix + buildRedisValue(pkceCodes)
+}
+
+func buildRedisValue(pkceCodes *PKCECodes) string {
+	return pkceCodes.Nonce + "~" + pkceCodes.CodeVerifier
+}
+
+func (storage *pkceStateStorage) Init(ctx context.Context) {
+	go storage.watchPKCEEntries(ctx)
+	ticker := time.NewTicker(storage.resyncDuration)
+	go func() {
+		storage.loadPKCEEntriesSafe()
+		for range ticker.C {
+			storage.loadPKCEEntriesSafe()
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		ticker.Stop()
+	}()
+}
+
+func (storage *pkceStateStorage) watchPKCEEntries(ctx context.Context) {
+	pubsub := storage.redis.Subscribe(ctx, newVerifierCodeWithAuth)
+	defer util.Close(pubsub)
+
+	ch := pubsub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case val := <-ch:
+			storage.lock.Lock()
+			pkceParts := strings.Split(val.Payload, "~")
+			storage.pkceAuthCodes[pkceParts[0]] = strings.Join(pkceParts[1:], "")
+			storage.lock.Unlock()
+		}
+	}
+}
+
+func (storage *pkceStateStorage) loadPKCEEntriesSafe() {
+	err := storage.loadPKCEEntries()
+	for err != nil {
+		log.Warnf("Failed to resync pkce entries. retrying again in 1 minute: %v", err)
+		time.Sleep(time.Minute)
+		err = storage.loadPKCEEntries()
+	}
+}
+
+func (storage *pkceStateStorage) loadPKCEEntries() error {
+	storage.lock.Lock()
+	defer storage.lock.Unlock()
+	storage.pkceAuthCodes = map[string]string{}
+	iterator := storage.redis.Scan(context.Background(), 0, pkceEntryPrefix+"*", -1).Iterator()
+	for iterator.Next(context.Background()) {
+		parts := strings.Split(iterator.Val(), "|")
+		if len(parts) < 2 {
+			log.Warnf("Unexpected redis key prefixed with '%s'. Must have nonce and code verifier, tilde separated, after the prefix but got: '%s'.",
+				pkceEntryPrefix,
+				iterator.Val())
+			continue
+		}
+		pkceParts := strings.Split(parts[1], "~")
+		storage.pkceAuthCodes[pkceParts[0]] = strings.Join(pkceParts[1:], "")
+	}
+	if iterator.Err() != nil {
+		return iterator.Err()
+	}
+
+	return nil
+}
+
+func (storage *pkceStateStorage) StorePKCEEntry(ctx context.Context, pkceCodes *PKCECodes, expiringAt time.Duration) error {
+	storage.lock.Lock()
+	storage.pkceAuthCodes[pkceCodes.Nonce] = pkceCodes.CodeVerifier
+	storage.lock.Unlock()
+	if err := storage.redis.Set(ctx, buildRedisEntry(pkceCodes), "", expiringAt).Err(); err != nil {
+		return err
+	}
+	return storage.redis.Publish(ctx, newVerifierCodeWithAuth, buildRedisValue(pkceCodes)).Err()
+}
+
+func (storage *pkceStateStorage) RetrieveCodeVerifier(nonce string) string {
+	storage.lock.Lock()
+	defer storage.lock.Unlock()
+	if codeVerifier, ok := storage.pkceAuthCodes[nonce]; ok {
+		return codeVerifier
+	} else {
+		//go to redis
+		iterator := storage.redis.Scan(context.Background(), 0, pkceEntryPrefix+nonce+"*", 1).Iterator()
+		if iterator.Next(context.Background()) {
+			parts := strings.Split(iterator.Val(), "|")
+			if len(parts) < 2 {
+				log.Warnf("Unexpected redis key prefixed with '%s'. Must have nonce and code verifier, tilde separated, after the prefix but got: '%s'.",
+					pkceEntryPrefix+nonce,
+					iterator.Val())
+				return ""
+			}
+			pkceParts := strings.Split(parts[1], "~")
+			codeVerifier := strings.Join(pkceParts[1:], "")
+			storage.pkceAuthCodes[nonce] = codeVerifier
+			return codeVerifier
+		}
+
+		if iterator.Err() != nil {
+			log.Warnf("Unexpected redis error when optimistically looking in redis for nonce '%s' : %v", nonce, iterator.Err())
+		}
+	}
+	log.Warnf("Did not find code verifier for nonce '%s'", nonce)
+	return ""
+}
+
+type PKCEStateStorage interface {
+	Init(ctx context.Context)
+	// StorePKCEEntry stores the verifier code and authorization code combination
+	StorePKCEEntry(ctx context.Context, pkceEntry *PKCECodes, expiringAt time.Duration) error
+	// RetrieveCodeVerifier gets the verifier code in memory
+	RetrieveCodeVerifier(nonce string) string
+}


### PR DESCRIPTION
Fixes [ISSUE #9890] .  Implementation for PXCE using redis storage for the UI.  Use the "state" nonce as the key for looking up the code verifier.

Signed-off-by: mmerrill3 <jjpaacks@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

