### PR TITLE
docs: Linux & Mac CLI - address de-duplication and errors in procedure

### DIFF
--- a/docs/cli_installation.md
+++ b/docs/cli_installation.md
@@ -22,6 +22,7 @@ brew install argocd
 
 ```bash
 curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+mkdir -p /usr/local/bin/
 sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
 rm argocd-linux-amd64
 ```

--- a/docs/cli_installation.md
+++ b/docs/cli_installation.md
@@ -22,9 +22,6 @@ brew install argocd
 
 ```bash
 curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-mkdir -p /usr/local/bin/
-sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
-rm argocd-linux-amd64
 ```
 
 #### Download concrete version
@@ -33,10 +30,18 @@ Set `VERSION` replacing `<TAG>` in the command below with the version of Argo CD
 
 ```bash
 VERSION=<TAG> # Select desired TAG from https://github.com/argoproj/argo-cd/releases
-curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-linux-amd64
+curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/${VERSION}/download/argocd-linux-amd64
+```
+
+#### Installation steps
+
+```bash
+mkdir -p /usr/local/bin/
 sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
 rm argocd-linux-amd64
 ```
+
+Update `$PATH` environment variable if necessary (https://linuxconfig.org/linux-path-environment-variable).
 
 You should now be able to run `argocd` commands.
 
@@ -50,24 +55,7 @@ brew install argocd
 
 ### Download With Curl
 
-You can view the latest version of Argo CD at the link above or run the following command to grab the version:
-
-```bash
-VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-```
-
-Replace `VERSION` in the command below with the version of Argo CD you would like to download:
-
-```bash
-curl -sSL -o argocd-darwin-amd64 https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-darwin-amd64
-```
-
-Install the Argo CD CLI binary:
-
-```bash
-sudo install -m 555 argocd-darwin-amd64 /usr/local/bin/argocd
-rm argocd-darwin-amd64
-```
+See [Linux curl instructions](#download-with-curl).
 
 After finishing either of the instructions above, you should now be able to run `argocd` commands.
 


### PR DESCRIPTION
Fixes addressed:
* Not all Linux systems will by default have `/usr/local/bin` directory.
* Collapse duplication in Linux section (manual steps)
* Collapse duplication in Mac section (manual steps are same as Linux)
* Fix a few other minor errors

Signed-off-by: mcallaghan-geotab <78922178+mcallaghan-geotab@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

