### PR TITLE
chore: use --password-stdin for docker login

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -42,8 +42,8 @@ jobs:
 
       # login
       - run: |
-          docker login ghcr.io --username $USERNAME --password $PASSWORD
-          docker login quay.io --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
+          docker login ghcr.io --username $USERNAME --password-stdin <<< "$PASSWORD"
+          docker login quay.io --username "$DOCKER_USERNAME" --password-stdin <<< "$DOCKER_TOKEN"
         if: github.event_name == 'push'
         env:
           USERNAME: ${{ secrets.USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,9 +195,9 @@ jobs:
           QUAY_TOKEN: ${{ secrets.RELEASE_QUAY_TOKEN }}
         run: |
           set -ue
-          docker login quay.io --username "${QUAY_USERNAME}" --password "${QUAY_TOKEN}"
+          docker login quay.io --username "${QUAY_USERNAME}" --password-stdin <<< "${QUAY_TOKEN}"
           # Remove the following when Docker Hub is gone
-          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}"
+          docker login --username "${DOCKER_USERNAME}" --password-stdin <<< "${DOCKER_TOKEN}"
         if: ${{ env.DRY_RUN != 'true' }}
 
       - uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
In response to this warning [from GitHub Actions](https://github.com/argoproj/argo-cd/actions/runs/3481756384/jobs/5823249085):

```
Run docker login ghcr.io --username $USERNAME -***
WARNING! Using -*** the CLI is insecure. Use --password-stdin.
```