### PR TITLE
feat: display managed namespaces in ui (#11196)

### DIFF
--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -393,7 +393,7 @@ func TestCompareAppStateManagedNamespaceMetadataWithLiveNs(t *testing.T) {
 		},
 	}
 	ctrl := newFakeController(&data)
-	compRes := ctrl.appStateManager.CompareAppState(app, &defaultProj, "", app.Spec.Source, false, false, nil)
+	compRes := ctrl.appStateManager.CompareAppState(app, &defaultProj, []string{}, app.Spec.Sources, false, false, nil, false)
 
 	assert.NotNil(t, compRes)
 	assert.Equal(t, 0, len(app.Status.Conditions))

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -365,7 +365,7 @@ func TestCompareAppStateDuplicatedNamespacedResources(t *testing.T) {
 	assert.Equal(t, 4, len(compRes.resources))
 }
 
-func TestCompareAppStateManagedNamespaceMetadata(t *testing.T) {
+func TestCompareAppStateManagedNamespaceMetadataWithLiveNs(t *testing.T) {
 	app := newFakeApp()
 	app.Spec.SyncPolicy = &argoappv1.SyncPolicy{
 		ManagedNamespaceMetadata: &argoappv1.ManagedNamespaceMetadata{
@@ -377,6 +377,8 @@ func TestCompareAppStateManagedNamespaceMetadata(t *testing.T) {
 	ns := NewNamespace()
 	ns.SetName(test.FakeDestNamespace)
 	ns.SetNamespace(test.FakeDestNamespace)
+	ns.SetAnnotations(map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"})
+
 	_ = argo.NewResourceTracking().SetAppInstance(ns, common.LabelKeyAppInstance, app.Name, "", argo.TrackingMethodLabel)
 
 	data := fakeData{

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -290,7 +290,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 	}
 
 	if syncOp.SyncOptions.HasOption("CreateNamespace=true") {
-		opts = append(opts, sync.WithNamespaceModifier(syncNamespace(m.resourceTracking, appLabelKey, trackingMethod, app)))
+		opts = append(opts, sync.WithNamespaceModifier(syncNamespace(m.resourceTracking, appLabelKey, trackingMethod, app, m.namespace)))
 	}
 
 	syncCtx, cleanup, err := sync.NewSyncContext(

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -290,7 +290,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 	}
 
 	if syncOp.SyncOptions.HasOption("CreateNamespace=true") {
-		opts = append(opts, sync.WithNamespaceModifier(syncNamespace(m.resourceTracking, appLabelKey, trackingMethod, app.Name, app.Spec.SyncPolicy)))
+		opts = append(opts, sync.WithNamespaceModifier(syncNamespace(m.resourceTracking, appLabelKey, trackingMethod, app)))
 	}
 
 	syncCtx, cleanup, err := sync.NewSyncContext(

--- a/controller/sync_namespace_test.go
+++ b/controller/sync_namespace_test.go
@@ -1,19 +1,18 @@
 package controller
 
 import (
+	"errors"
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/argo"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 	"testing"
 )
 
-func createFakeNamespace(uid string, resourceVersion string, labels map[string]string, annotations map[string]string) *unstructured.Unstructured {
+func createFakeNamespace(labels map[string]string, annotations map[string]string) *unstructured.Unstructured {
 	un := unstructured.Unstructured{}
-	un.SetUID(types.UID(uid))
-	un.SetResourceVersion(resourceVersion)
 	un.SetLabels(labels)
 	un.SetAnnotations(annotations)
 	un.SetKind("Namespace")
@@ -28,6 +27,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 		managedNs           *unstructured.Unstructured
 		liveNs              *unstructured.Unstructured
 		expected            bool
+		expectedErr         error
 		expectedLabels      map[string]string
 		expectedAnnotations map[string]string
 	}{
@@ -66,7 +66,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			expected:            true,
 			expectedLabels:      map[string]string{},
 			expectedAnnotations: map[string]string{},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: nil,
@@ -75,8 +75,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 		{
 			name:                "namespace does not yet exist and managedNamespaceMetadata not nil",
 			expected:            true,
-			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{},
@@ -86,8 +86,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace does not yet exist and managedNamespaceMetadata has empty labels map",
 			expected:            true,
 			expectedLabels:      map[string]string{},
-			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -98,8 +98,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 		{
 			name:                "namespace does not yet exist and managedNamespaceMetadata has empty annotations map",
 			expected:            true,
-			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -111,8 +111,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace does not yet exist and managedNamespaceMetadata has empty annotations and labels map",
 			expected:            true,
 			expectedLabels:      map[string]string{},
-			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -125,8 +125,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace does not yet exist and managedNamespaceMetadata has labels",
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
-			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -138,8 +138,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 		{
 			name:                "namespace does not yet exist and managedNamespaceMetadata has annotations",
 			expected:            true,
-			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -152,8 +152,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace does not yet exist and managedNamespaceMetadata has annotations and labels",
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
-			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			liveNs:              nil,
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
@@ -166,9 +166,8 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace exists with no labels or annotations and managedNamespaceMetadata has labels",
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
-			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
-			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 					Labels: map[string]string{"my-cool-label": "some-value"},
@@ -178,9 +177,9 @@ func Test_shouldNamespaceSync(t *testing.T) {
 		{
 			name:                "namespace exists with no labels or annotations and managedNamespaceMetadata has annotations",
 			expected:            true,
-			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
-			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{}, map[string]string{}),
 			syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 					Annotations: map[string]string{"my-cool-annotation": "some-value"},
@@ -191,10 +190,9 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace exists with no labels or annotations and managedNamespaceMetadata has annotations and labels",
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
-			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
-			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{}),
-			syncPolicy: &v1alpha1.SyncPolicy{
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{}, map[string]string{}), syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 					Labels:      map[string]string{"my-cool-label": "some-value"},
 					Annotations: map[string]string{"my-cool-annotation": "some-value"},
@@ -204,11 +202,10 @@ func Test_shouldNamespaceSync(t *testing.T) {
 		{
 			name:                "namespace exists with labels and managedNamespaceMetadata has mismatching labels",
 			expected:            true,
-			expectedAnnotations: map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
 			expectedLabels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
-			liveNs:              createFakeNamespace("something", "1", map[string]string{"my-cool-label": "some-value"}, map[string]string{}),
-			syncPolicy: &v1alpha1.SyncPolicy{
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{"my-cool-label": "some-value"}, map[string]string{}), syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 					Labels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
 					Annotations: map[string]string{},
@@ -219,10 +216,9 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace exists with annotations and managedNamespaceMetadata has mismatching annotations",
 			expected:            true,
 			expectedLabels:      map[string]string{},
-			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
-			liveNs:              createFakeNamespace("something", "1", map[string]string{}, map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"}),
-			syncPolicy: &v1alpha1.SyncPolicy{
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{}, map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"}), syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 					Labels:      map[string]string{},
 					Annotations: map[string]string{"my-cool-annotation": "some-value"},
@@ -233,29 +229,57 @@ func Test_shouldNamespaceSync(t *testing.T) {
 			name:                "namespace exists with annotations and labels managedNamespaceMetadata has mismatching annotations and labels",
 			expected:            true,
 			expectedLabels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
-			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
-			managedNs:           createFakeNamespace("", "", map[string]string{}, map[string]string{}),
-			liveNs:              createFakeNamespace("something", "1", map[string]string{"my-cool-label": "some-value"}, map[string]string{"my-cool-annotation": "some-value"}),
-			syncPolicy: &v1alpha1.SyncPolicy{
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value", "argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{"my-cool-label": "some-value"}, map[string]string{"my-cool-annotation": "some-value"}), syncPolicy: &v1alpha1.SyncPolicy{
 				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 					Labels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
 					Annotations: map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"},
 				},
 			},
 		},
+		{
+			name:        "managed namespace exists with liveNs ownership set to another application",
+			expected:    false,
+			expectedErr: errors.New("namespace some-namespace is managed by another application than some-app"),
+			managedNs:   createFakeNamespace(map[string]string{"my-cool-label": "some-value"}, map[string]string{"argocd.argoproj.io/tracking-id": "some-app:/Namespace:/some-namespace", "my-cool-annotation": "some-value"}),
+			liveNs:      createFakeNamespace(map[string]string{"my-cool-label": "some-value"}, map[string]string{"argocd.argoproj.io/tracking-id": "some-other-app:/Namespace:/some-other-namespace", "my-cool-annotation": "some-value"}), syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
+					Annotations: map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"},
+				},
+			},
+		},
+		{
+			name:                "managed namespace does not exist with liveNs ownership set to another application",
+			expected:            false,
+			expectedErr:         nil,
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{"my-cool-label": "some-value"}, map[string]string{"argocd.argoproj.io/tracking-id": "some-other-app:/Namespace:/some-other-namespace", "my-cool-annotation": "some-value"}), syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := syncNamespace(argo.NewResourceTracking(), common.LabelKeyAppInstance, argo.TrackingMethodAnnotation, "some-app", tt.syncPolicy)(tt.managedNs, tt.liveNs)
-			assert.NoError(t, err)
+			actual, err := syncNamespace(argo.NewResourceTracking(), common.LabelKeyAppInstance, argo.TrackingMethodAnnotation, &v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "some-app",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					SyncPolicy: tt.syncPolicy,
+				},
+			})(tt.managedNs, tt.liveNs)
+			assert.Equalf(t, tt.expected, actual, "syncNamespace(%v)", tt.syncPolicy)
+			assert.Equalf(t, tt.expectedErr, err, "error mismatch: syncNamespace(%v)", tt.syncPolicy)
 
-			if tt.managedNs != nil {
+			if tt.managedNs != nil && tt.expectedErr == nil {
 				assert.Equal(t, tt.expectedLabels, tt.managedNs.GetLabels())
 				assert.Equal(t, tt.expectedAnnotations, tt.managedNs.GetAnnotations())
 			}
-
-			assert.Equalf(t, tt.expected, actual, "syncNamespace(%v)", tt.syncPolicy)
 		})
 	}
 }

--- a/controller/sync_namespace_test.go
+++ b/controller/sync_namespace_test.go
@@ -30,6 +30,7 @@ func Test_shouldNamespaceSync(t *testing.T) {
 		expectedErr         error
 		expectedLabels      map[string]string
 		expectedAnnotations map[string]string
+		appNamespace        string
 	}{
 		{
 			name:       "liveNs is nil and syncPolicy is nil",
@@ -261,18 +262,202 @@ func Test_shouldNamespaceSync(t *testing.T) {
 				ManagedNamespaceMetadata: nil,
 			},
 		},
+		{
+			name:                "namespace does not yet exist and managedNamespaceMetadata not nil (namespaced)",
+			expected:            true,
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              nil,
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{},
+			},
+		},
+		{
+			name:                "namespace does not yet exist and managedNamespaceMetadata has empty labels map (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              nil,
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels: map[string]string{},
+				},
+			},
+		},
+		{
+			name:                "namespace does not yet exist and managedNamespaceMetadata has empty annotations map (namespaced)",
+			expected:            true,
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              nil,
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name:                "namespace does not yet exist and managedNamespaceMetadata has empty annotations and labels map (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              nil,
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name:                "namespace does not yet exist and managedNamespaceMetadata has labels (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              nil,
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{"my-cool-label": "some-value"},
+					Annotations: nil,
+				},
+			},
+		},
+		{
+			name:                "namespace does not yet exist and managedNamespaceMetadata has annotations (namespaced)",
+			expected:            true,
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              nil,
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      nil,
+					Annotations: map[string]string{"my-cool-annotation": "some-value"},
+				},
+			},
+		},
+		{
+			name:                "namespace does not yet exist and managedNamespaceMetadata has annotations and labels (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              nil,
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{"my-cool-label": "some-value"},
+					Annotations: map[string]string{"my-cool-annotation": "some-value"},
+				},
+			},
+		},
+		{
+			name:                "namespace exists with no labels or annotations and managedNamespaceMetadata has labels (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels: map[string]string{"my-cool-label": "some-value"},
+				},
+			},
+		},
+		{
+			name:                "namespace exists with no labels or annotations and managedNamespaceMetadata has annotations (namespaced)",
+			expected:            true,
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{}, map[string]string{}),
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Annotations: map[string]string{"my-cool-annotation": "some-value"},
+				},
+			},
+		},
+		{
+			name:                "namespace exists with no labels or annotations and managedNamespaceMetadata has annotations and labels (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{"my-cool-label": "some-value"},
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{}, map[string]string{}),
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{"my-cool-label": "some-value"},
+					Annotations: map[string]string{"my-cool-annotation": "some-value"},
+				},
+			},
+		},
+		{
+			name:                "namespace exists with labels and managedNamespaceMetadata has mismatching labels (namespaced)",
+			expected:            true,
+			expectedAnnotations: map[string]string{"argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			expectedLabels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{"my-cool-label": "some-value"}, map[string]string{}),
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name:                "namespace exists with annotations and managedNamespaceMetadata has mismatching annotations (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{}, map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"}),
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{"my-cool-annotation": "some-value"},
+				},
+			},
+		},
+		{
+			name:                "namespace exists with annotations and labels managedNamespaceMetadata has mismatching annotations and labels (namespaced)",
+			expected:            true,
+			expectedLabels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
+			expectedAnnotations: map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value", "argocd.argoproj.io/tracking-id": "argocd-namespace_some-app:/Namespace:/some-namespace", "argocd.argoproj.io/sync-options": "ServerSideApply=true"},
+			managedNs:           createFakeNamespace(map[string]string{}, map[string]string{}),
+			liveNs:              createFakeNamespace(map[string]string{"my-cool-label": "some-value"}, map[string]string{"my-cool-annotation": "some-value"}),
+			appNamespace:        "argocd-namespace",
+			syncPolicy: &v1alpha1.SyncPolicy{
+				ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
+					Labels:      map[string]string{"my-cool-label": "some-value", "my-other-label": "some-other-value"},
+					Annotations: map[string]string{"my-cool-annotation": "some-value", "my-other-annotation": "some-other-value"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, err := syncNamespace(argo.NewResourceTracking(), common.LabelKeyAppInstance, argo.TrackingMethodAnnotation, &v1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "some-app",
+					Name:      "some-app",
+					Namespace: tt.appNamespace,
 				},
 				Spec: v1alpha1.ApplicationSpec{
 					SyncPolicy: tt.syncPolicy,
 				},
-			})(tt.managedNs, tt.liveNs)
+			}, "")(tt.managedNs, tt.liveNs)
 			assert.Equalf(t, tt.expected, actual, "syncNamespace(%v)", tt.syncPolicy)
 			assert.Equalf(t, tt.expectedErr, err, "error mismatch: syncNamespace(%v)", tt.syncPolicy)
 

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -339,6 +339,10 @@ spec:
     - CreateNamespace=true
 ```
 
+Keep in mind that having *multiple ArgoCD applications managing namespace metadata will raise an error*. It is fine for 
+other applications to have `CreateNamespace=true` set, as along as `managedNamespaceMetadata` is not present in said 
+namespaces (the metadata will remain untouched in those cases).
+
 In the case where ArgoCD is "adopting" an existing namespace which already has metadata set on it, we rely on using
 Server Side Apply in order not to lose metadata which has already been set. The main implication here is that it takes
 a few extra steps to get rid of an already preexisting field.

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -1916,7 +1916,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
+			assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:/%s", AppNamespace(), app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"bar": "bat", "argocd.argoproj.io/sync-options": "ServerSideApply=true"}, ns.Annotations)
@@ -1942,7 +1942,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
+			assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:/%s", AppNamespace(), app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"new": "label"}, ns.Labels)
 			assert.Equal(t, map[string]string{"bar": "bat", "argocd.argoproj.io/sync-options": "ServerSideApply=true"}, ns.Annotations)
@@ -1965,7 +1965,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
+			assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:/%s", AppNamespace(), app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"new": "label"}, ns.Labels)
 			assert.Equal(t, map[string]string{"new": "custom-annotation", "argocd.argoproj.io/sync-options": "ServerSideApply=true"}, ns.Annotations)
@@ -2012,7 +2012,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadataAndNsManifest(t *testing.T) 
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(namespace, func(app *Application, ns *v1.Namespace) {
-			assert.NotEmpty(t, app.Status.Conditions)
+			assert.Empty(t, app.Status.Conditions)
 
 			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
 
@@ -2024,7 +2024,8 @@ func TestNamespacedNamespaceAutoCreationWithMetadataAndNsManifest(t *testing.T) 
 
 			// TODO: The tracking id is different for namespace manifests vs namespaces generated with CreateNamespace=true
 			// Should that be the case or should we change the format to be the same for both types?
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:%s/%s", app.Name, AppNamespace(), namespace), trackingId)
+			//assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:/%s", AppNamespace(), app.Name, namespace), trackingId)
+			assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:%s/%s", AppNamespace(), app.Name, namespace, namespace), trackingId)
 
 			// The application namespace manifest takes precedence over what is in managedNamespaceMetadata
 			assert.Equal(t, map[string]string{"test": "true"}, ns.Labels)
@@ -2110,7 +2111,7 @@ metadata:
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
+			assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:/%s", AppNamespace(), app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"test": "true", "foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true", "something": "whatevs", "bar": "bat"}, ns.Annotations)
@@ -2133,7 +2134,7 @@ metadata:
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
+			assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:/%s", AppNamespace(), app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"test": "true", "foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true", "something": "hmm", "bar": "bat"}, ns.Annotations)
@@ -2157,7 +2158,7 @@ metadata:
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
 
-			assert.Equal(t, fmt.Sprintf("%s:/Namespace:/%s", app.Name, updatedNamespace), trackingId)
+			assert.Equal(t, fmt.Sprintf("%s_%s:/Namespace:/%s", AppNamespace(), app.Name, updatedNamespace), trackingId)
 
 			assert.Equal(t, map[string]string{"test": "true", "foo": "bar"}, ns.Labels)
 			assert.Equal(t, map[string]string{"argocd.argoproj.io/sync-options": "ServerSideApply=true", "bar": "bat"}, ns.Annotations)

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1968,7 +1968,7 @@ func TestNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Expect(ResourceSyncStatusWithNamespaceIs("Deployment", "guestbook-ui", updatedNamespace, SyncStatusCodeSynced)).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(ArgoCDNamespace).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/spec/syncPolicy/managedNamespaceMetadata/labels", "value": {"new":"label"} }]`), metav1.PatchOptions{}))
 		}).
 		Sync().
@@ -1991,7 +1991,7 @@ func TestNamespaceAutoCreationWithMetadata(t *testing.T) {
 		})).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(ArgoCDNamespace).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/spec/syncPolicy/managedNamespaceMetadata/annotations", "value": {"new":"custom-annotation"} }]`), metav1.PatchOptions{}))
 		}).
 		Sync().
@@ -2051,7 +2051,7 @@ func TestNamespaceAutoCreationWithMetadataAndNsManifest(t *testing.T) {
 		Then().
 		Expect(Success("")).
 		Expect(Namespace(namespace, func(app *Application, ns *v1.Namespace) {
-			assert.NotEmpty(t, app.Status.Conditions)
+			assert.Empty(t, app.Status.Conditions)
 
 			trackingId := ns.Annotations["argocd.argoproj.io/tracking-id"]
 
@@ -2097,7 +2097,7 @@ metadata:
   labels:
     test: "true"
   annotations:
-    something: "whatevs"		
+    something: "whatevs"
 `
 	s := fmt.Sprintf(existingNs, updatedNamespace)
 
@@ -2155,7 +2155,7 @@ metadata:
 		})).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(ArgoCDNamespace).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "add", "path": "/spec/syncPolicy/managedNamespaceMetadata/annotations/something", "value": "hmm" }]`), metav1.PatchOptions{}))
 		}).
 		Sync().
@@ -2179,7 +2179,7 @@ metadata:
 		})).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(ArgoCDNamespace).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "remove", "path": "/spec/syncPolicy/managedNamespaceMetadata/annotations/something" }]`), metav1.PatchOptions{}))
 		}).
 		Sync().

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1878,6 +1878,7 @@ func TestNamespaceAutoCreation(t *testing.T) {
 		}
 	}()
 	Given(t).
+		SetTrackingMethod("annotation").
 		Timeout(30).
 		Path("guestbook").
 		When().
@@ -1926,7 +1927,7 @@ func TestNamespaceAutoCreationWithMetadata(t *testing.T) {
 	}()
 	ctx := Given(t)
 	ctx.
-		//SetTrackingMethod("annotation").
+		SetTrackingMethod("annotation").
 		Timeout(30).
 		Path("guestbook").
 		When().

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1878,7 +1878,6 @@ func TestNamespaceAutoCreation(t *testing.T) {
 		}
 	}()
 	Given(t).
-		SetTrackingMethod("annotation").
 		Timeout(30).
 		Path("guestbook").
 		When().

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"reflect"
 	"regexp"


### PR DESCRIPTION
This commit re-enables the resource tracking for managed namespaces, which is required in order to ensure that multiple applications do not attempt to manage the same (managed) namespace. If multiple applications set `managedNamespaceMetadata` for the same namespace, `syncNamespace` will return an error.

This leads to the fact that we also need to modify `state.go`, since otherwise managed namespaces will always be `OutOfSync`, due to the fact that the managed namespace is not present in the owning Application's git repository.

Signed-off-by: Blake Pettersson <blake.pettersson@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

