### PR TITLE
chore: fix username for ghcr.io

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -47,7 +47,7 @@ jobs:
           docker login quay.io --username "$DOCKER_USERNAME" --password-stdin <<< "$DOCKER_TOKEN"
         if: github.event_name == 'push'
         env:
-          USERNAME: ${{ secrets.USERNAME }}
+          USERNAME: ${{ github.actor }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.RELEASE_QUAY_USERNAME }}
           DOCKER_TOKEN: ${{ secrets.RELEASE_QUAY_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Fixes USERNAME env to be compatible with ```GITHUB_TOKEN```. 

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

