### PR TITLE
fix: Use passed namespace argument on argocd cli commands (#11348)

### DIFF
--- a/cmd/argocd/commands/admin/dashboard.go
+++ b/cmd/argocd/commands/admin/dashboard.go
@@ -23,7 +23,7 @@ func NewDashboardCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 
-			errors.CheckError(headless.StartLocalServer(ctx, &argocdclient.ClientOptions{Core: true}, initialize.RetrieveContextIfChanged(cmd.Flag("context")), &port, &address))
+			errors.CheckError(headless.StartLocalServer(ctx, &argocdclient.ClientOptions{Core: true}, initialize.RetrieveContextIfChanged(cmd.Flag("context")), initialize.RetrieveNamespaceIfChanged(cmd.Flag("namespace")), &port, &address))
 			println(fmt.Sprintf("Argo CD UI is available at http://%s:%d", address, port))
 			<-ctx.Done()
 		},

--- a/cmd/argocd/commands/initialize/cmd.go
+++ b/cmd/argocd/commands/initialize/cmd.go
@@ -14,6 +14,12 @@ func RetrieveContextIfChanged(contextFlag *flag.Flag) string {
 	}
 	return ""
 }
+func RetrieveNamespaceIfChanged(namespaceFlag *flag.Flag) string {
+	if namespaceFlag != nil && namespaceFlag.Changed {
+		return namespaceFlag.Value.String()
+	}
+	return ""
+}
 
 // InitCommand allows executing command in a headless mode: on the fly starts Argo CD API server and
 // changes provided client options to use started API server port


### PR DESCRIPTION
Signed-off-by: Liam Jarvis <jarviliam@gmail.com>

Fixes [ISSUE #11348]
Users using the core installation are unable to run argocd cli commands in other namespaces despite supplying a `--namespace argocd` argument. Looking into `headless.go` , it appears that the namespace in kubecontext is used by default and the user supplied namespace argument isn't being used. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

