### PR TITLE
docs: improve build env variable list formatting

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -2,14 +2,16 @@
 
 [Custom tools](config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md), and [Kustomize](kustomize.md) support the following build env vars:
 
-* `ARGOCD_APP_NAME` - The name of the application.
-* `ARGOCD_APP_NAMESPACE` - The destination namespace of the application.
-* `ARGOCD_APP_REVISION` - The resolved revision, e.g. `f913b6cbf58aa5ae5ca1f8a2b149477aebcbd9d8`.
-* `ARGOCD_APP_SOURCE_PATH` - The path of the app within the source repo.
-* `ARGOCD_APP_SOURCE_REPO_URL` - The source repo URL.
-* `ARGOCD_APP_SOURCE_TARGET_REVISION` - The target revision from the spec, e.g. `master`.
-* `KUBE_VERSION` - The version of Kubernetes.
-* `KUBE_API_VERSIONS` - The version of the Kubernetes API.
+| Variable                            | Description                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------- |
+| `ARGOCD_APP_NAME`                   | - The name of the application.                                            |
+| `ARGOCD_APP_NAMESPACE`              | - The destination namespace of the application.                           |
+| `ARGOCD_APP_REVISION`               | - The resolved revision, e.g. `f913b6cbf58aa5ae5ca1f8a2b149477aebcbd9d8`. |
+| `ARGOCD_APP_SOURCE_PATH`            | - The path of the app within the source repo.                             |
+| `ARGOCD_APP_SOURCE_REPO_URL`        | - The source repo URL.                                                    |
+| `ARGOCD_APP_SOURCE_TARGET_REVISION` | - The target revision from the spec, e.g. `master`.                       |
+| `KUBE_VERSION`                      | - The version of Kubernetes.                                              |
+| `KUBE_API_VERSIONS`                 | - The version of the Kubernetes API.                                      |
 
 In case you don't want a variable to be interpolated, `$` can be escaped via `$$`.
 

--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -2,14 +2,14 @@
 
 [Custom tools](config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md), and [Kustomize](kustomize.md) support the following build env vars:
 
-* `ARGOCD_APP_NAME` - name of application
-* `ARGOCD_APP_NAMESPACE` - destination application namespace.
-* `ARGOCD_APP_REVISION` - the resolved revision, e.g. `f913b6cbf58aa5ae5ca1f8a2b149477aebcbd9d8`
-* `ARGOCD_APP_SOURCE_PATH` - the path of the app within the repo
-* `ARGOCD_APP_SOURCE_REPO_URL` the repo's URL
-* `ARGOCD_APP_SOURCE_TARGET_REVISION` - the target revision from the spec, e.g. `master`.
-* `KUBE_VERSION` - the version of kubernetes
-* `KUBE_API_VERSIONS` = the version of kubernetes API
+* `ARGOCD_APP_NAME` - The name of the application.
+* `ARGOCD_APP_NAMESPACE` - The destination namespace of the application.
+* `ARGOCD_APP_REVISION` - The resolved revision, e.g. `f913b6cbf58aa5ae5ca1f8a2b149477aebcbd9d8`.
+* `ARGOCD_APP_SOURCE_PATH` - The path of the app within the source repo.
+* `ARGOCD_APP_SOURCE_REPO_URL` - The source repo URL.
+* `ARGOCD_APP_SOURCE_TARGET_REVISION` - The target revision from the spec, e.g. `master`.
+* `KUBE_VERSION` - The version of Kubernetes.
+* `KUBE_API_VERSIONS` - The version of the Kubernetes API.
 
 In case you don't want a variable to be interpolated, `$` can be escaped via `$$`.
 

--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -2,16 +2,16 @@
 
 [Custom tools](config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md), and [Kustomize](kustomize.md) support the following build env vars:
 
-| Variable                            | Description                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------- |
-| `ARGOCD_APP_NAME`                   | - The name of the application.                                            |
-| `ARGOCD_APP_NAMESPACE`              | - The destination namespace of the application.                           |
-| `ARGOCD_APP_REVISION`               | - The resolved revision, e.g. `f913b6cbf58aa5ae5ca1f8a2b149477aebcbd9d8`. |
-| `ARGOCD_APP_SOURCE_PATH`            | - The path of the app within the source repo.                             |
-| `ARGOCD_APP_SOURCE_REPO_URL`        | - The source repo URL.                                                    |
-| `ARGOCD_APP_SOURCE_TARGET_REVISION` | - The target revision from the spec, e.g. `master`.                       |
-| `KUBE_VERSION`                      | - The version of Kubernetes.                                              |
-| `KUBE_API_VERSIONS`                 | - The version of the Kubernetes API.                                      |
+| Variable                            | Description                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| `ARGOCD_APP_NAME`                   | The name of the application.                                            |
+| `ARGOCD_APP_NAMESPACE`              | The destination namespace of the application.                           |
+| `ARGOCD_APP_REVISION`               | The resolved revision, e.g. `f913b6cbf58aa5ae5ca1f8a2b149477aebcbd9d8`. |
+| `ARGOCD_APP_SOURCE_PATH`            | The path of the app within the source repo.                             |
+| `ARGOCD_APP_SOURCE_REPO_URL`        | The source repo URL.                                                    |
+| `ARGOCD_APP_SOURCE_TARGET_REVISION` | The target revision from the spec, e.g. `master`.                       |
+| `KUBE_VERSION`                      | The version of Kubernetes.                                              |
+| `KUBE_API_VERSIONS`                 | The version of the Kubernetes API.                                      |
 
 In case you don't want a variable to be interpolated, `$` can be escaped via `$$`.
 


### PR DESCRIPTION
Normalize the build env list with complete sentences and use a table for better formatting, separating the variable and description.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

