### PR TITLE
docs: remove kustomize from build env page

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -1,6 +1,6 @@
 # Build Environment
 
-[Custom tools](config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md), and [Kustomize](kustomize.md) support the following build env vars:
+[Helm](helm.md), [Jsonnet](jsonnet.md), and [Custom tools](config-management-plugins.md) support the following build env vars:
 
 * `ARGOCD_APP_NAME` - name of application
 * `ARGOCD_APP_NAMESPACE` - destination application namespace.


### PR DESCRIPTION
Based on [the kustomize section of the user guide](https://argo-cd.readthedocs.io/en/stable/user-guide/kustomize/#build-environment), it doesn't support the build env vars since it doesn't support parameters. This removes the reference to kustomize.

Signed-off-by: Nicholas Morey <nicholas@morey.tech>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

