### PR TITLE
replace deprecated labels for region

### DIFF
--- a/resource_customizations/cassandra.rook.io/Cluster/testdata/healthy.yaml
+++ b/resource_customizations/cassandra.rook.io/Cluster/testdata/healthy.yaml
@@ -75,11 +75,11 @@ spec:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
                 - matchExpressions:
-                  - key: failure-domain.beta.kubernetes.io/region
+                  - key: topology.kubernetes.io/region
                     operator: In
                     values:
                       - us-east-1
-                  - key: failure-domain.beta.kubernetes.io/zone
+                  - key: topology.kubernetes.io/region
                     operator: In
                     values:
                       - us-east-1a


### PR DESCRIPTION
Starting in v1.17, this label is deprecated in favor of `topology.kubernetes.io/region`.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

