### PR TITLE
fix: expose missing ReactDOM to enable extensions implementation

### DIFF
--- a/ui/src/app/index.tsx
+++ b/ui/src/app/index.tsx
@@ -13,3 +13,4 @@ if (mdl.hot) {
 }
 
 (window as any).React = React;
+(window as any).ReactDOM = ReactDOM;


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

React based extensions need access to both React and ReactDOM. PR exposes missing ReactDOM via global variable 