### PR TITLE
docs: add vendor resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ The following links are to resources hosted by Argo CD vendors (companies which 
 These resources are vendor-neutral (overwhelmingly _about_ Argo CD, but may briefly mention the vendor) and do not require providing information for marketing purposes.
 
 1. [Unveil the Secret Ingredients of Continuous Delivery at Enterprise Scale with Argo CD](https://blog.akuity.io/unveil-the-secret-ingredients-of-continuous-delivery-at-enterprise-scale-with-argo-cd-7c5b4057ee49)
-1. [Argo Sandbox (demo instance)](https://argocd.argo.opsmx.net/) (requires logging into the demo instance with a Google account)
+1. [Argo CD Sandbox (demo instance)](https://argocd.argo.opsmx.net/) (requires logging into the demo instance with a Google account)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Participation in the Argo CD project is governed by the [CNCF Code of Conduct](h
 ### Vendor-sponsored community resources
 
 The following links are to resources hosted by Argo CD vendors (companies which use Argo CD as part of their software offerings). 
-These resources are vendor-neutral and do not require providing information for marketing purposes.
+These resources are vendor-neutral (overwhelmingly _about_ Argo CD, but may briefly mention the vendor) and do not require providing information for marketing purposes.
 
 1. [Unveil the Secret Ingredients of Continuous Delivery at Enterprise Scale with Argo CD](https://blog.akuity.io/unveil-the-secret-ingredients-of-continuous-delivery-at-enterprise-scale-with-argo-cd-7c5b4057ee49)
 1. [Argo Sandbox (demo instance)](https://argocd.argo.opsmx.net/) (requires logging into the demo instance with a Google account)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Participation in the Argo CD project is governed by the [CNCF Code of Conduct](h
 1. [Argo CD: Applying GitOps Principles To Manage Production Environment In Kubernetes](https://youtu.be/vpWQeoaiRM4)
 1. [Tutorial: Everything You Need To Become A GitOps Ninja](https://www.youtube.com/watch?v=r50tRQjisxw) 90m tutorial on GitOps and Argo CD.
 1. [Comparison of Argo CD, Spinnaker, Jenkins X, and Tekton](https://www.inovex.de/blog/spinnaker-vs-argo-cd-vs-tekton-vs-jenkins-x/)
-1. [Simplify and Automate Deployments Using GitOps with IBM Multicloud Manager 3.1.2](https://www.ibm.com/cloud/blog/simplify-and-automate-deployments-using-gitops-with-ibm-multicloud-manager-3-1-2)
 1. [GitOps for Kubeflow using Argo CD](https://v0-6.kubeflow.org/docs/use-cases/gitops-for-kubeflow/)
 1. [GitOps Toolsets on Kubernetes with CircleCI and Argo CD](https://www.digitalocean.com/community/tutorials/webinar-series-gitops-tool-sets-on-kubernetes-with-circleci-and-argo-cd)
 1. [CI/CD in Light Speed with K8s and Argo CD](https://www.youtube.com/watch?v=OdzH82VpMwI&feature=youtu.be)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Participation in the Argo CD project is governed by the [CNCF Code of Conduct](h
 ### Blogs and Presentations
 
 1. [Awesome-Argo: A Curated List of Awesome Projects and Resources Related to Argo](https://github.com/terrytangyuan/awesome-argo)
-1. [Unveil the Secret Ingredients of Continuous Delivery at Enterprise Scale with Argo CD](https://blog.akuity.io/unveil-the-secret-ingredients-of-continuous-delivery-at-enterprise-scale-with-argo-cd-7c5b4057ee49)
 1. [GitOps Without Pipelines With ArgoCD Image Updater](https://youtu.be/avPUQin9kzU)
 1. [Combining Argo CD (GitOps), Crossplane (Control Plane), And KubeVela (OAM)](https://youtu.be/eEcgn_gU3SM)
 1. [How to Apply GitOps to Everything - Combining Argo CD and Crossplane](https://youtu.be/yrj4lmScKHQ)
@@ -51,7 +50,6 @@ Participation in the Argo CD project is governed by the [CNCF Code of Conduct](h
 1. [Automation of Everything - How To Combine Argo Events, Workflows & Pipelines, CD, and Rollouts](https://youtu.be/XNXJtxkUKeY)
 1. [Environments Based On Pull Requests (PRs): Using Argo CD To Apply GitOps Principles On Previews](https://youtu.be/cpAaI8p4R60)
 1. [Argo CD: Applying GitOps Principles To Manage Production Environment In Kubernetes](https://youtu.be/vpWQeoaiRM4)
-1. [Creating Temporary Preview Environments Based On Pull Requests With Argo CD And Codefresh](https://codefresh.io/continuous-deployment/creating-temporary-preview-environments-based-pull-requests-argo-cd-codefresh/)
 1. [Tutorial: Everything You Need To Become A GitOps Ninja](https://www.youtube.com/watch?v=r50tRQjisxw) 90m tutorial on GitOps and Argo CD.
 1. [Comparison of Argo CD, Spinnaker, Jenkins X, and Tekton](https://www.inovex.de/blog/spinnaker-vs-argo-cd-vs-tekton-vs-jenkins-x/)
 1. [Simplify and Automate Deployments Using GitOps with IBM Multicloud Manager 3.1.2](https://www.ibm.com/cloud/blog/simplify-and-automate-deployments-using-gitops-with-ibm-multicloud-manager-3-1-2)
@@ -63,7 +61,6 @@ Participation in the Argo CD project is governed by the [CNCF Code of Conduct](h
 1. [Introduction to Argo CD : Kubernetes DevOps CI/CD](https://www.youtube.com/watch?v=2WSJF7d8dUg&feature=youtu.be)
 1. [GitOps Deployment and Kubernetes - using Argo CD](https://medium.com/riskified-technology/gitops-deployment-and-kubernetes-f1ab289efa4b)
 1. [Deploy Argo CD with Ingress and TLS in Three Steps: No YAML Yak Shaving Required](https://itnext.io/deploy-argo-cd-with-ingress-and-tls-in-three-steps-no-yaml-yak-shaving-required-bc536d401491)
-1. [GitOps Continuous Delivery with Argo and Codefresh](https://codefresh.io/events/cncf-member-webinar-gitops-continuous-delivery-argo-codefresh/)
 1. [Stay up to date with Argo CD and Renovate](https://mjpitz.com/blog/2020/12/03/renovate-your-gitops/)
 1. [Setting up Argo CD with Helm](https://www.arthurkoziel.com/setting-up-argocd-with-helm/)
 1. [Applied GitOps with Argo CD](https://thenewstack.io/applied-gitops-with-argocd/)
@@ -73,3 +70,10 @@ Participation in the Argo CD project is governed by the [CNCF Code of Conduct](h
 1. [Getting Started with ArgoCD for GitOps Deployments](https://youtu.be/AvLuplh1skA)
 1. [Using Argo CD & Datree for Stable Kubernetes CI/CD Deployments](https://youtu.be/17894DTru2Y)
 
+### Vendor-sponsored community resources
+
+The following links are to resources hosted by Argo CD vendors (companies which use Argo CD as part of their software offerings). 
+These resources are vendor-neutral and do not require providing information for marketing purposes.
+
+1. [Unveil the Secret Ingredients of Continuous Delivery at Enterprise Scale with Argo CD](https://blog.akuity.io/unveil-the-secret-ingredients-of-continuous-delivery-at-enterprise-scale-with-argo-cd-7c5b4057ee49)
+1. [Argo Sandbox (demo instance)](https://argocd.argo.opsmx.net/) (requires logging into the demo instance with a Google account)


### PR DESCRIPTION
Attempting to implement the proposal here: https://github.com/argoproj/argo-cd/pull/11355#issuecomment-1327850583

I have removed two links from the README as non-vendor neutral. Justifications:

1. The first link includes this text in the "Requirements" section:

    > Finally, I will assume that you installed [Codefresh CLI](https://codefresh-io.github.io/cli/getting-started/) and authenticated it against your Codefresh account.

2. Much of the video seems to assume "GitOps as done by Codefresh". For example, the diagrams explaining gitops have a large node titles "CI/CD Platform / codefresh". The 14-minute "Demo in Argo" chapter spends about ~50% of its time in the Codefresh UI (as measured by scrubbing and watching the thumbnail).

In contrast, the Akuity blog post mentions the company briefly at the top and the bottom. The post contents are exclusively about Argo CD. The OpsMx demo instance mentions the company only in the URL.

**Edit:** I also removed an IBM link that I think is clearly not vendor neutral.