### PR TITLE
docs: added scopes field to RBAC example for google SSO

### DIFF
--- a/docs/operator-manual/user-management/google.md
+++ b/docs/operator-manual/user-management/google.md
@@ -19,6 +19,10 @@ metadata:
   namespace: argocd
 data:
   policy.default: role:readonly
+  
+  # scopes controls which OIDC scopes to examine during rbac enforcement (in addition to `sub` scope).
+  # If omitted, defaults to: '[groups]'. The scope value can be a string, or a list of strings.
+  scopes: '[cognito:groups, email]'
 ```
 
 ## OpenID Connect using Dex


### PR DESCRIPTION
added `scopes:` field to the docs example rbac for google. Since google doesn't use groups for RBAC the example will not work. 

I couldn't figure out why rbac wasn't working, until I saw you need to use the email scopes for Google SSO. 

Signed-off-by: Smig <89040888+smiggiddy@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

