### PR TITLE
docs: update how to access arrays in Go templates

### DIFF
--- a/docs/operator-manual/applicationset/GoTemplate.md
+++ b/docs/operator-manual/applicationset/GoTemplate.md
@@ -87,7 +87,7 @@ By activating Go Templating, `{{ .path }}` becomes an object. Therefore, some ch
 generators' templating:
 
 - `{{ path }}` becomes `{{ .path.path }}`
-- `{{ path[n] }}` becomes `{{ .path.segments[n] }}`
+- `{{ path[n] }}` becomes `{{ index .path.segments n }}`
 
 Here is an example:
 
@@ -155,7 +155,7 @@ It is also possible to use Sprig functions to construct the path variables manua
 | `{{path.filename}}` | `{{.path.filename}}` | `{{.path.filename}}` |
 | `{{path.basenameNormalized}}` | `{{.path.basenameNormalized}}` | `{{normalize .path.path}}` |
 | `{{path.filenameNormalized}}` | `{{.path.filenameNormalized}}` | `{{normalize .path.filename}}` |
-| `{{path[N]}}` | `{{.path.segments[N]}}` | `{{index (splitList "/" .path.path) N}}` |
+| `{{path[N]}}` | `-` | `{{index .path.segments N}}` |
 
 ## Examples
 


### PR DESCRIPTION
First of, huge thanks for incorporating Go template support in Applicationsets and Argo-CD in general!

I did notice though while going through the docs the use of square brackets to access array items, which doesn't work in Go templates (requiring the `index` function instead). This small PR updates the docs to reflect that.

Signed-off-by: Dieter Bocklandt <dieterbocklandt@gmail.com>

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

