### PR TITLE
docs: fix web terminal step list numbering

### DIFF
--- a/docs/operator-manual/web_based_terminal.md
+++ b/docs/operator-manual/web_based_terminal.md
@@ -16,7 +16,7 @@ Kubernetes), then the user effectively has the same privileges as that ServiceAc
 
 2. Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
 to exec into pods
-
+    
     ```yaml
     - apiGroups:
       - ""
@@ -27,7 +27,7 @@ to exec into pods
     ```
 
 3. Add RBAC rules to allow your users to `create` the `exec` resource, i.e. 
-
+    
     ```
     p, role:myrole, exec, create, */*, allow
     ```

--- a/docs/operator-manual/web_based_terminal.md
+++ b/docs/operator-manual/web_based_terminal.md
@@ -11,25 +11,25 @@ they have the `exec/create` privilege. If the Pod mounts a ServiceAccount token 
 Kubernetes), then the user effectively has the same privileges as that ServiceAccount.
 
 ## Enabling the terminal
-<!-- Use - instead of . for the numbered list to support fenced code blocks without breaking the numbering. See #11590 -->
+<!-- Use indented code blocks for the numbered list to prevent breaking the numbering. See #11590 -->
 
-1 - Set the `exec.enabled` key to `"true"` on the `argocd-cm` ConfigMap.
+1. Set the `exec.enabled` key to `"true"` on the `argocd-cm` ConfigMap.
 
-2 - Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
+2. Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
 to exec into pods
-```yaml
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
-```
 
-3 - Add RBAC rules to allow your users to `create` the `exec` resource, i.e. 
-```
-p, role:myrole, exec, create, */*, allow
-```
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+
+
+3. Add RBAC rules to allow your users to `create` the `exec` resource, i.e. 
+
+        p, role:myrole, exec, create, */*, allow
+
 
 See [RBAC Configuration](rbac.md#exec-resource) for more info.
 

--- a/docs/operator-manual/web_based_terminal.md
+++ b/docs/operator-manual/web_based_terminal.md
@@ -16,6 +16,7 @@ Kubernetes), then the user effectively has the same privileges as that ServiceAc
 
 2. Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
 to exec into pods
+
     ```yaml
     - apiGroups:
       - ""
@@ -25,7 +26,8 @@ to exec into pods
       - create
     ```
 
-3. Add RBAC rules to allow your users to `create` the `exec` resource, i.e.
+3. Add RBAC rules to allow your users to `create` the `exec` resource, i.e. 
+
     ```
     p, role:myrole, exec, create, */*, allow
     ```

--- a/docs/operator-manual/web_based_terminal.md
+++ b/docs/operator-manual/web_based_terminal.md
@@ -11,26 +11,25 @@ they have the `exec/create` privilege. If the Pod mounts a ServiceAccount token 
 Kubernetes), then the user effectively has the same privileges as that ServiceAccount.
 
 ## Enabling the terminal
+<!-- Use - instead of . for the numbered list to support fenced code blocks without breaking the numbering. See #11590 -->
 
-1. Set the `exec.enabled` key to `"true"` on the `argocd-cm` ConfigMap.
+1 - Set the `exec.enabled` key to `"true"` on the `argocd-cm` ConfigMap.
 
-2. Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
+2 - Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
 to exec into pods
-    
-    ```yaml
-    - apiGroups:
-      - ""
-      resources:
-      - pods/exec
-      verbs:
-      - create
-    ```
+```yaml
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+```
 
-3. Add RBAC rules to allow your users to `create` the `exec` resource, i.e. 
-    
-    ```
-    p, role:myrole, exec, create, */*, allow
-    ```
+3 - Add RBAC rules to allow your users to `create` the `exec` resource, i.e. 
+```
+p, role:myrole, exec, create, */*, allow
+```
 
 See [RBAC Configuration](rbac.md#exec-resource) for more info.
 

--- a/docs/operator-manual/web_based_terminal.md
+++ b/docs/operator-manual/web_based_terminal.md
@@ -16,19 +16,19 @@ Kubernetes), then the user effectively has the same privileges as that ServiceAc
 
 2. Patch the `argocd-server` Role (if using namespaced Argo) or ClusterRole (if using clustered Argo) to allow `argocd-server`
 to exec into pods
-```yaml
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
-```
+    ```yaml
+    - apiGroups:
+      - ""
+      resources:
+      - pods/exec
+      verbs:
+      - create
+    ```
 
 3. Add RBAC rules to allow your users to `create` the `exec` resource, i.e.
-```
-p, role:myrole, exec, create, */*, allow
-```
+    ```
+    p, role:myrole, exec, create, */*, allow
+    ```
 
 See [RBAC Configuration](rbac.md#exec-resource) for more info.
 


### PR DESCRIPTION
The fenced code blocks at the document root break the numbered list, causing the third item to show as `1` (despite being a `3`). Replace the `.` with a `-` in the number list to prevent Readthedocs from rendering it as a `1`.

![Xnapper-2022-12-07-10 57 03](https://user-images.githubusercontent.com/4213435/206227724-0358a1f5-3b7e-45b4-a091-f3a7d6027c0b.png)

Signed-off-by: Nicholas Morey <nicholas@morey.tech>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

