### PR TITLE
fix: set baseURL for ApplicationSet in github_app client

### DIFF
--- a/applicationset/services/internal/github_app/client.go
+++ b/applicationset/services/internal/github_app/client.go
@@ -19,6 +19,7 @@ func Client(g github_app_auth.Authentication, url string) (*github.Client, error
 	if url == "" {
 		url = g.EnterpriseBaseURL
 	}
+	rt.BaseURL = url
 	var client *github.Client
 	httpClient := http.Client{Transport: rt}
 	if url == "" {


### PR DESCRIPTION
# Summary

When using a GitHub Enterprise with an ApplicationSet and authentication it via [GitHub App](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#github-app-repositories) (inside a [SCM provider](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-SCM-Provider/#github)) it does not work.
The `baseURL` has to be set as described in bradeleyfalzon/ghinstallation [README](https://github.com/bradleyfalzon/ghinstallation/blob/06d918f00e53b1e9deeac92578101af21178df82/README.md\?plain\=1\#L60).

Otherwise the organizsation can not be read ([`scm_provider.ListRepos`](https://github.com/argoproj/argo-cd/blob/661afe0ad9653418aa0e3e2cc7939e42e0db40ab/applicationset/generators/scm_provider.go#L138-L142) will fail).
In this step Argo CD tries to fetch the refresh_token from GitHub.com instead of GitHub Enterprise (see log below).

# Problem

When the ApplicationSet tries to access the GitHub organization via `AppSecretName` instead of a token (which works) the task fails.
Because the baseURL for the client used here is configured to use the GitHub.com API URL.

```log
time="2022-12-07T20:32:37Z"
  level=error msg="error generating application from params"
  error="error listing repos: error listing repositories for ghe-orgname: Get \"https://ghe-baseurl/api/v3/orgs/ghe-orgname/repos?per_page=100\": could not refresh installation id ghe-id's token: received non 2xx response status \"401 Unauthorized\" when fetching https://api.github.com/app/installations/ghe-id/access_tokens"
  generator="{nil nil nil &SCMProviderGenerator{Github:&SCMProviderGeneratorGithub{Organization:ghe-orgname,API:https://ghe-baseurl/,TokenRef:nil,AppSecretName:argo-github-app-repo-creds,AllBranches:false,},Gitlab:nil,Bitbucket:nil,BitbucketServer:nil,Gitea:nil,AzureDevOps:nil,Filters:[]SCMProviderGeneratorFilter{SCMProviderGeneratorFilter{RepositoryMatch:nil,PathsExist:[],PathsDoNotExist:[],LabelMatch:*argocd-helm,BranchMatch:nil,},},CloneProtocol:https,RequeueAfterSeconds:nil,Template:ApplicationSetTemplate{ApplicationSetTemplateMeta:ApplicationSetTemplateMeta{Name:,Namespace:,Labels:map[string]string{},Annotations:map[string]string{},Finalizers:[],},Spec:ApplicationSpec{Source:ApplicationSource{RepoURL:,Path:,TargetRevision:,Helm:nil,Kustomize:nil,Directory:nil,Plugin:nil,Chart:,},Destination:ApplicationDestination{Server:,Namespace:,Name:,},Project:,SyncPolicy:nil,IgnoreDifferences:[]ResourceIgnoreDifferences{},Info:[]Info{},RevisionHistoryLimit:nil,},},} nil nil nil nil nil}"
```

Instead of connecting to `https://ghe-baseurl/api/v3/app/installations/ghe-id/access_tokens` Argo CD tries accessing `https://api.github.com/app/installations/ghe-id/access_tokens`.

# Additional informations

- I built a [image](https://hub.docker.com/layers/fty4/argocd/fix-appset-ghe-baseurl/images/sha256-97e025dce386b06c59bcea0ddd0568eeb67efd2322b919a5f587a4d7d653882f?context=repo) from this branch and tested it with our GHE instance which worked as expected.

- The baseURL is already set for the git util:
  https://github.com/argoproj/argo-cd/blob/661afe0ad9653418aa0e3e2cc7939e42e0db40ab/util/git/creds.go#L408 
  For the usage with the ApplicationSet it is missing and will be added with this commit.


# Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a **bug fix**, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] ~~I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.~~
* [x] ~~I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~~
* [x] Does this PR require documentation updates? -> _No - bug fix_
* [x] ~~I've updated documentation as required by this PR.~~
* [x] ~~Optional. My organization is added to USERS.md.~~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] ~~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~~
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))