### PR TITLE
fix: only add baseURL in github_app client for GHE client

### DIFF
--- a/applicationset/services/internal/github_app/client.go
+++ b/applicationset/services/internal/github_app/client.go
@@ -19,12 +19,13 @@ func Client(g github_app_auth.Authentication, url string) (*github.Client, error
 	if url == "" {
 		url = g.EnterpriseBaseURL
 	}
-	rt.BaseURL = url
 	var client *github.Client
-	httpClient := http.Client{Transport: rt}
 	if url == "" {
+		httpClient := http.Client{Transport: rt}
 		client = github.NewClient(&httpClient)
 	} else {
+		rt.BaseURL = url
+		httpClient := http.Client{Transport: rt}
 		client, err = github.NewEnterpriseClient(url, url, &httpClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create github enterprise client: %w", err)


### PR DESCRIPTION
fixes #11613

As described in https://github.com/argoproj/argo-cd/pull/11613#issuecomment-1343172852 this will fix the problem with GitHub.com API baseURL.

The `BaseURL` will then only be specified if another URL was provided in the AppSet - if not the default `github.NewClient` will be used.
This will uses the `api.github.com` by [default](https://github.com/google/go-github/blob/v35.3.0/github/github.go#L31).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a **bug fix**, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] ~~I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~~
* [x] ~~Does this PR require documentation updates?~~
* [x] ~~I've updated documentation as required by this PR.~~
* [x] ~~Optional. My organization is added to USERS.md.~~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] ~~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~~
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

@crenshaw-dev

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))