### PR TITLE
fix: only template owner into repoUrl if available

### DIFF
--- a/ui/src/app/shared/components/urls.ts
+++ b/ui/src/app/shared/components/urls.ts
@@ -19,7 +19,13 @@ export function repoUrl(url: string): string {
             return null;
         }
 
-        return `${protocol(parsed.protocol)}://${parsed.resource}/${parsed.owner}/${parsed.name}`;
+        let url_parsed = `${protocol(parsed.protocol)}://${parsed.resource}`
+        if (parsed.owner) {
+            url_parsed += `/${parsed.owner}`
+        }
+        url_parsed += `/${parsed.name}`
+
+        return url_parsed
     } catch {
         return null;
     }


### PR DESCRIPTION
## Summary

When the owner is not available in the parsed GitUrl it should not be parsed. Otherwise an additional slash will be added.

## Problem

When I specify a credential template in Argo CD a hyperlink will be created to link with the repository.
When using a credential template I might not want to specify the complete URL to the repository, but only to the organization.

In this case the link will be broken as follows:

When configuring e.g. `https://github.com/my-org/`

`https://github.com//my-org` instead of `https://github.com/my-org` will be linked.

## Description

The string generated from function `repoUrl` should check if a owner is available.
This PR will add this check.

## Reference

see https://github.com/argoproj/argo-cd/pull/2344#issuecomment-1343976240

## Checklist

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a **bug fix**, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] ~~I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.~~
* [x] ~~I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~~
* [x] ~~Does this PR require documentation updates?~~
* [x] ~~I've updated documentation as required by this PR.~~
* [x] ~~Optional. My organization is added to USERS.md.~~
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] ~~I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.~~
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

