### PR TITLE
feat: add deny sources (#11639)

### DIFF
--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -47,6 +47,33 @@ argocd proj add-source <PROJECT> <REPO>
 argocd proj remove-source <PROJECT> <REPO>
 ```
 
+We can also do negations of sources (i.e. do _not_ use this repo).
+
+```bash
+argocd proj add-source <PROJECT> !<REPO>
+argocd proj remove-source <PROJECT> !<REPO>
+```
+
+Declaratively we can do something like this:
+
+```yaml
+spec:
+  sourceRepos:
+    # Do not use the test repo in argoproj
+    - '!ssh://git@GITHUB.com:argoproj/test'
+    # Nor any Gitlab repo under group/ 
+    - '!https://gitlab.com/group/**'
+    # Any other repo is fine though
+    - '*'
+```
+
+A source repository is considered valid if the following conditions hold:
+
+1) _Any_ allow source rule (i.e. a rule which isn't prefixed with `!`) permits the source
+2) AND *no* deny source (i.e. a rule which is prefixed with `!`) rejects the source
+
+Keep in mind that `!*` is an invalid rule, since it doesn't make any sense to disallow everything.
+
 Permitted destination clusters and namespaces are managed with the commands (for clusters always provide server, the name is not used for matching):
 
 ```bash
@@ -54,7 +81,7 @@ argocd proj add-destination <PROJECT> <CLUSTER>,<NAMESPACE>
 argocd proj remove-destination <PROJECT> <CLUSTER>,<NAMESPACE>
 ```
 
-We can also do negations of destinations (i.e. install anywhere _apart from_).
+As with sources, we can also do negations of destinations (i.e. install anywhere _apart from_).
 
 ```bash
 argocd proj add-destination <PROJECT> !<CLUSTER>,!<NAMESPACE>
@@ -77,7 +104,7 @@ spec:
     server: '*'
 ```
 
-A destination is considered valid if the following conditions hold:
+As with sources, a destination is considered valid if the following conditions hold:
 
 1) _Any_ allow destination rule (i.e. a rule which isn't prefixed with `!`) permits the destination
 2) AND *no* deny destination (i.e. a rule which is prefixed with `!`) rejects the destination

--- a/pkg/apis/application/v1alpha1/app_project_types.go
+++ b/pkg/apis/application/v1alpha1/app_project_types.go
@@ -187,6 +187,10 @@ func (p *AppProject) ValidateProject() error {
 
 	srcRepos := make(map[string]bool)
 	for _, src := range p.Spec.SourceRepos {
+		if src == "!*" {
+			return status.Errorf(codes.InvalidArgument, "source repository has an invalid format, '!*'")
+		}
+
 		if _, ok := srcRepos[src]; ok {
 			return status.Errorf(codes.InvalidArgument, "source repository '%s' already added", src)
 		}
@@ -365,7 +369,7 @@ func (proj *AppProject) RemoveFinalizer() {
 }
 
 func globMatch(pattern string, val string, allowNegation bool, separators ...rune) bool {
-	if allowNegation && isDenyDestination(pattern) {
+	if allowNegation && isDenyPattern(pattern) {
 		return !glob.Match(pattern[1:], val, separators...)
 	}
 
@@ -378,13 +382,26 @@ func globMatch(pattern string, val string, allowNegation bool, separators ...run
 // IsSourcePermitted validates if the provided application's source is a one of the allowed sources for the project.
 func (proj AppProject) IsSourcePermitted(src ApplicationSource) bool {
 	srcNormalized := git.NormalizeGitURL(src.RepoURL)
+
+	var normalized string
+	anySourceMatched := false
+
 	for _, repoURL := range proj.Spec.SourceRepos {
-		normalized := git.NormalizeGitURL(repoURL)
-		if globMatch(normalized, srcNormalized, false, '/') {
-			return true
+		if isDenyPattern(repoURL) {
+			normalized = "!" + git.NormalizeGitURL(strings.TrimPrefix(repoURL, "!"))
+		} else {
+			normalized = git.NormalizeGitURL(repoURL)
+		}
+
+		matched := globMatch(normalized, srcNormalized, true, '/')
+		if matched {
+			anySourceMatched = true
+		} else if !matched && isDenyPattern(normalized) {
+			return false
 		}
 	}
-	return false
+
+	return anySourceMatched
 }
 
 // IsDestinationPermitted validates if the provided application's destination is one of the allowed destinations for the project
@@ -420,7 +437,7 @@ func (proj AppProject) isDestinationMatched(dst ApplicationDestination) bool {
 		matched := (dstServerMatched || dstNameMatched) && dstNamespaceMatched
 		if matched {
 			anyDestinationMatched = true
-		} else if ((!dstNameMatched && isDenyDestination(item.Name)) || (!dstServerMatched && isDenyDestination(item.Server))) || (!dstNamespaceMatched && isDenyDestination(item.Namespace)) {
+		} else if ((!dstNameMatched && isDenyPattern(item.Name)) || (!dstServerMatched && isDenyPattern(item.Server))) || (!dstNamespaceMatched && isDenyPattern(item.Namespace)) {
 			noDenyDestinationsMatched = false
 		}
 	}
@@ -428,7 +445,7 @@ func (proj AppProject) isDestinationMatched(dst ApplicationDestination) bool {
 	return anyDestinationMatched && noDenyDestinationsMatched
 }
 
-func isDenyDestination(pattern string) bool {
+func isDenyPattern(pattern string) bool {
 	return strings.HasPrefix(pattern, "!")
 }
 


### PR DESCRIPTION
This commit adds the ability to deny a source when it is prefixed with `!`, in the same manner as with the "deny destinations" feature. Fixes #11639.

Signed-off-by: Blake Pettersson <blake.pettersson@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* ~[ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.~
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

