### PR TITLE
chore: downgrade React to v17 (#11601)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -28,7 +28,7 @@
     "monaco-editor": "^0.33.0",
     "path": "^0.12.7",
     "prop-types": "^15.8.1",
-    "react": "18",
+    "react": "17",
     "react-autocomplete": "^1.8.1",
     "react-diff-view": "^2.4.10",
     "react-dom": "^16.9.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7907,12 +7907,13 @@ react-toastify@^9.0.8:
   dependencies:
     clsx "^1.1.1"
 
-react@18:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react@17:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 readable-stream@^2.0.1:
   version "2.3.6"


### PR DESCRIPTION
Fixes #11601

I looked into just Actually Fixing the problem, but it was well beyond my skill level.

Downgrading for now unblocks us for 2.6.0-rc1, scheduled for Dec. 19.