### PR TITLE
Propagate Application labels to application manifest as way to define…

### DIFF
--- a/docs/user-guide/resource_tracking.md
+++ b/docs/user-guide/resource_tracking.md
@@ -20,13 +20,15 @@ This approach works ok in most cases, as the name of the label is standardized a
 
 There are however several limitations:
 
-* Labels are truncated to 63 characters. Depending on the size of the label you might want to store a longer name for your application
-* Other external tools might write/append to this label and create conflicts with Argo CD. For example several Helm charts and operators also use this label for generated manifests confusing Argo CD about the owner of the application
-* You might want to deploy more than one Argo CD instance on the same cluster (with cluster wide privileges) and have an easy way to identify which resource is managed by which instance of Argo CD
+- Labels are truncated to 63 characters. Depending on the size of the label you might want to store a longer name for your application
+- Other external tools might write/append to this label and create conflicts with Argo CD. For example several Helm charts and operators also use this label for generated manifests confusing Argo CD about the owner of the application
+- You might want to deploy more than one Argo CD instance on the same cluster (with cluster wide privileges) and have an easy way to identify which resource is managed by which instance of Argo CD
+
+ArgoCD propagates manually set Application labels to every object of manifest it propagates `app.kubernetes.io/instance` label. The feature allows building logging/monitoring ecosystem based on environment-specific labels.
 
 ## Additional tracking methods via an annotation
 
->v2.2
+> v2.2
 
 To offer more flexible options for tracking resources and solve some of the issues outlined in the previous section Argo CD can be instructed to use the following methods for tracking:
 
@@ -59,6 +61,7 @@ data:
   application.resourceTrackingMethod: annotation
 kind: ConfigMap
 ```
+
 Possible values are `label`, `annotation+label` and `annotation` as described in the previous section.
 
 Note that once you change the value you need to sync your applications again (or wait for the sync mechanism to kick-in) in order to apply your changes.

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -31,7 +31,7 @@ type ResourceTracking interface {
 	Normalize(config, live *unstructured.Unstructured, labelKey, trackingMethod string) error
 }
 
-//AppInstanceValue store information about resource tracking info
+// AppInstanceValue store information about resource tracking info
 type AppInstanceValue struct {
 	ApplicationName string
 	Group           string
@@ -129,7 +129,7 @@ func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, v
 	}
 	switch trackingMethod {
 	case TrackingMethodLabel:
-		return argokube.SetAppInstanceLabel(un, key, val)
+		return argokube.SetAppLabel(un, key, val)
 	case TrackingMethodAnnotation:
 		return setAppInstanceAnnotation()
 	case TrackingMethodAnnotationAndLabel:
@@ -140,18 +140,18 @@ func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, v
 		if len(val) > LabelMaxLength {
 			val = val[:LabelMaxLength]
 		}
-		return argokube.SetAppInstanceLabel(un, key, val)
+		return argokube.SetAppLabel(un, key, val)
 	default:
-		return argokube.SetAppInstanceLabel(un, key, val)
+		return argokube.SetAppLabel(un, key, val)
 	}
 }
 
-//BuildAppInstanceValue build resource tracking id in format <application-name>;<group>/<kind>/<namespace>/<name>
+// BuildAppInstanceValue build resource tracking id in format <application-name>;<group>/<kind>/<namespace>/<name>
 func (rt *resourceTracking) BuildAppInstanceValue(value AppInstanceValue) string {
 	return fmt.Sprintf("%s:%s/%s:%s/%s", value.ApplicationName, value.Group, value.Kind, value.Namespace, value.Name)
 }
 
-//ParseAppInstanceValue parse resource tracking id from format <application-name>:<group>/<kind>:<namespace>/<name> to struct
+// ParseAppInstanceValue parse resource tracking id from format <application-name>:<group>/<kind>:<namespace>/<name> to struct
 func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceValue, error) {
 	var appInstanceValue AppInstanceValue
 	parts := strings.Split(value, ":")

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/common"
 )
 
-func TestSetAppInstanceLabel(t *testing.T) {
+func TestSetAppLabel(t *testing.T) {
 	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -6,8 +6,6 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/argoproj/argo-cd/v2/common"
 )
 
 var resourceNamePattern = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
@@ -26,10 +24,6 @@ func SetAppLabel(target *unstructured.Unstructured, key, val string) error {
 	}
 	labels[key] = val
 	target.SetLabels(labels)
-	if key != common.LabelKeyLegacyApplicationName {
-		// we no longer label the pod template sub resources in v0.11
-		return nil
-	}
 
 	gvk := schema.FromAPIVersionAndKind(target.GetAPIVersion(), target.GetKind())
 	// special case for deployment and job types: make sure that derived replicaset, and pod has

--- a/util/kube/kube.go
+++ b/util/kube/kube.go
@@ -17,9 +17,9 @@ func IsValidResourceName(name string) bool {
 	return len(name) < 64 && resourceNamePattern.MatchString(name)
 }
 
-// SetAppInstanceLabel the recommended app.kubernetes.io/instance label against an unstructured object
+// SetAppLabel the recommended app.kubernetes.io/instance label against an unstructured object
 // Uses the legacy labeling if environment variable is set
-func SetAppInstanceLabel(target *unstructured.Unstructured, key, val string) error {
+func SetAppLabel(target *unstructured.Unstructured, key, val string) error {
 	labels := target.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -60,7 +60,7 @@ func TestSetLabels(t *testing.T) {
 		err := yaml.Unmarshal([]byte(yamlStr), &obj)
 		assert.Nil(t, err)
 
-		err = SetAppInstanceLabel(&obj, common.LabelKeyAppInstance, "my-app")
+		err = SetAppLabel(&obj, common.LabelKeyAppInstance, "my-app")
 		assert.Nil(t, err)
 
 		manifestBytes, err := json.MarshalIndent(obj.Object, "", "  ")
@@ -89,7 +89,7 @@ func TestSetLegacyLabels(t *testing.T) {
 		err := yaml.Unmarshal([]byte(yamlStr), &obj)
 		assert.Nil(t, err)
 
-		err = SetAppInstanceLabel(&obj, common.LabelKeyLegacyApplicationName, "my-app")
+		err = SetAppLabel(&obj, common.LabelKeyLegacyApplicationName, "my-app")
 		assert.Nil(t, err)
 
 		manifestBytes, err := json.MarshalIndent(obj.Object, "", "  ")
@@ -113,7 +113,7 @@ func TestSetLegacyJobLabel(t *testing.T) {
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
-	err = SetAppInstanceLabel(&obj, common.LabelKeyLegacyApplicationName, "my-app")
+	err = SetAppLabel(&obj, common.LabelKeyLegacyApplicationName, "my-app")
 	assert.Nil(t, err)
 
 	manifestBytes, err := json.MarshalIndent(obj.Object, "", "  ")
@@ -139,7 +139,7 @@ func TestSetSvcLabel(t *testing.T) {
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
-	err = SetAppInstanceLabel(&obj, common.LabelKeyAppInstance, "my-app")
+	err = SetAppLabel(&obj, common.LabelKeyAppInstance, "my-app")
 	assert.Nil(t, err)
 
 	manifestBytes, err := json.MarshalIndent(obj.Object, "", "  ")
@@ -202,7 +202,7 @@ func TestGetAppInstanceLabel(t *testing.T) {
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
-	err = SetAppInstanceLabel(&obj, common.LabelKeyAppInstance, "my-app")
+	err = SetAppLabel(&obj, common.LabelKeyAppInstance, "my-app")
 	assert.Nil(t, err)
 	assert.Equal(t, "my-app", GetAppInstanceLabel(&obj, common.LabelKeyAppInstance))
 }


### PR DESCRIPTION
 Propagate Application labels to application manifest as way to define environment-specific values for monitoring, logging, incident-management

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

