### PR TITLE
docs: helm only used for rendering

### DIFF
--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -2,7 +2,9 @@
 
 ## Declarative
 
-You can install Helm charts through the UI, or in the declarative GitOps way. Here is an example:
+You can install Helm charts through the UI, or in the declarative GitOps way.  
+Helm is only used to inflate charts, the lifecycle of the application is handle by  ArgoCD.  
+Here is an example:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -3,7 +3,7 @@
 ## Declarative
 
 You can install Helm charts through the UI, or in the declarative GitOps way.  
-Helm is only used to inflate charts, the lifecycle of the application is handle by  ArgoCD.  
+Helm is only used to inflate charts, the lifecycle of the application is handle by ArgoCD.  
 Here is an example:
 
 ```yaml


### PR DESCRIPTION
Signed-off-by: emirot <nolan.emirot@workday.com>


# What 
Adding specification in the doc regarding how helm is used.

# Why

Helm is just just for inflating the chart nothing else, had this question and found the answer in discussion. 