### PR TITLE
fix: rollback react to known working version (#11601)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -28,7 +28,7 @@
     "monaco-editor": "^0.33.0",
     "path": "^0.12.7",
     "prop-types": "^15.8.1",
-    "react": "17",
+    "react": "^16.9.3",
     "react-autocomplete": "^1.8.1",
     "react-diff-view": "^2.4.10",
     "react-dom": "^16.9.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7907,13 +7907,14 @@ react-toastify@^9.0.8:
   dependencies:
     clsx "^1.1.1"
 
-react@17:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^16.9.3:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 readable-stream@^2.0.1:
   version "2.3.6"


### PR DESCRIPTION
mitigates #11601 

this version is known to work: https://github.com/argoproj/argo-cd/pull/11467/files#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL31

Signed-off-by: Alex Eftimie <alex.eftimie@getyourguide.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

