### PR TITLE
fix: support relative links in OCI tags query response

### DIFF
--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -440,9 +440,7 @@ func getNextUrl(resp *http.Response) (string, error) {
 	} else {
 		link = link[1:i]
 	}
-	fmt.Println(link)
 	linkURL, err := resp.Request.URL.Parse(link)
-	fmt.Println(linkURL)
 	if err != nil {
 		return "", err
 	}

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -407,7 +407,7 @@ func (c *nativeHelmChart) getTags(chart string) ([]byte, error) {
 	allTags := &TagsList{}
 	var data []byte
 	for nextURL != "" {
-		log.Debugf("fetching %s tags from %s", chart, text.Trunc(nextURL, 100))
+		log.Debugf("fetching %s tags from %s", chart, sanitizeLog(text.Trunc(nextURL, 100)))
 		data, nextURL, err = c.getTagsFromUrl(nextURL)
 		if err != nil && err != errNoLink {
 			return nil, fmt.Errorf("failed tags part: %v", err)
@@ -445,6 +445,12 @@ func getNextUrl(resp *http.Response) (string, error) {
 		return "", err
 	}
 	return linkURL.String(), nil
+}
+
+func sanitizeLog(input string) string {
+	sanitized := strings.ReplaceAll(input, "\r", "")
+	sanitized = strings.ReplaceAll(sanitized, "\n", "")
+	return sanitized
 }
 
 func (c *nativeHelmChart) getTagsFromUrl(tagsURL string) ([]byte, string, error) {

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -391,10 +391,10 @@ func getTagsListURL(rawURL string, chart string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to parse repo url: %v", err)
 	}
+	tagsPathFormat := "%s/v2/%s/tags/list"
 	repoURL.Scheme = "https"
-	tagsList := strings.Join([]string{"v2", url.PathEscape(chart), "tags/list"}, "/")
-	repoURL.Path = strings.Join([]string{repoURL.Path, tagsList}, "/")
-	repoURL.RawPath = strings.Join([]string{repoURL.RawPath, tagsList}, "/")
+	repoURL.Path = fmt.Sprintf(tagsPathFormat, repoURL.Path, chart)
+	repoURL.RawPath = fmt.Sprintf(tagsPathFormat, repoURL.RawPath, url.PathEscape(chart))
 	return repoURL.String(), nil
 }
 

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -33,7 +33,6 @@ import (
 var (
 	globalLock = sync.NewKeyLock()
 	indexLock  = sync.NewKeyLock()
-	errNoLink  = errors.New("no Link header in response")
 )
 
 type Creds struct {
@@ -409,7 +408,7 @@ func (c *nativeHelmChart) getTags(chart string) ([]byte, error) {
 	for nextURL != "" {
 		log.Debugf("fetching %s tags from %s", chart, sanitizeLog(text.Trunc(nextURL, 100)))
 		data, nextURL, err = c.getTagsFromUrl(nextURL)
-		if err != nil && err != errNoLink {
+		if err != nil {
 			return nil, fmt.Errorf("failed tags part: %v", err)
 		}
 
@@ -430,7 +429,7 @@ func (c *nativeHelmChart) getTags(chart string) ([]byte, error) {
 func getNextUrl(resp *http.Response) (string, error) {
 	link := resp.Header.Get("Link")
 	if link == "" {
-		return "", errNoLink
+		return "", nil
 	}
 	if link[0] != '<' {
 		return "", fmt.Errorf("invalid next link %q: missing '<'", link)

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -189,7 +189,7 @@ func Test_getNextUrl(t *testing.T) {
 	}
 	nextUrl, err := getNextUrl(resp)
 	assert.Equal(t, nextUrl, "")
-	assert.Equal(t, err, errNoLink)
+	assert.NoError(t, err)
 
 	var nextUrlAbsolute = "https://my.repo.com/v2/chart/tags/list?n=123&orderby="
 	resp.Header = http.Header{

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -221,4 +221,14 @@ func Test_getTagsListURL(t *testing.T) {
 	tagsListURL, err = getTagsListURL("https://account.dkr.ecr.eu-central-1.amazonaws.com/", "dss")
 	assert.Nil(t, err)
 	assert.Equal(t, tagsListURL, "https://account.dkr.ecr.eu-central-1.amazonaws.com/v2/dss/tags/list")
+
+	// with unescaped characters allowed by https://www.rfc-editor.org/rfc/rfc3986#page-50
+	tagsListURL, err = getTagsListURL("https://account.dkr.ecr.eu-central-1.amazonaws.com/", "charts.-_~$&+=:@dss")
+	assert.Nil(t, err)
+	assert.Equal(t, tagsListURL, "https://account.dkr.ecr.eu-central-1.amazonaws.com/v2/charts.-_~$&+=:@dss/tags/list")
+
+	// with escaped characters not allowed in path by https://www.rfc-editor.org/rfc/rfc3986#page-50
+	tagsListURL, err = getTagsListURL("https://account.dkr.ecr.eu-central-1.amazonaws.com/", "charts%/dss")
+	assert.Nil(t, err)
+	assert.Equal(t, tagsListURL, "https://account.dkr.ecr.eu-central-1.amazonaws.com/v2/charts%25%2Fdss/tags/list")
 }

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -196,6 +196,7 @@ func Test_getNextUrl(t *testing.T) {
 		"Link": []string{fmt.Sprintf(`<%s>; rel="next"`, nextUrlAbsolute)},
 	}
 	nextUrl, err = getNextUrl(resp)
+	assert.NoError(t, err)
 	assert.Equal(t, nextUrl, nextUrlAbsolute)
 
 	var nextUrlRelative = "/v2/chart/tags/list?n=123&orderby="
@@ -203,6 +204,7 @@ func Test_getNextUrl(t *testing.T) {
 		"Link": []string{fmt.Sprintf(`<%s>; rel="next"`, nextUrlRelative)},
 	}
 	nextUrl, err = getNextUrl(resp)
+	assert.NoError(t, err)
 	assert.Equal(t, nextUrl, "https://my.repo.com/v2/chart/tags/list?n=123&orderby=")
 }
 


### PR DESCRIPTION
Pagination for OCI tags retrieval is not supported when the Link header URI is relative.
According to https://docs.docker.com/registry/spec/api/#pagination and the therein referenced RFC
https://www.rfc-editor.org/rfc/rfc5988#section-5
relative links should be resolved to the initial request URL

Inspiration for the fixed url resolving taken from the oras-go project: https://github.com/oras-project/oras-go/blob/main/registry/remote/utils.go#L40 and https://github.com/oras-project/oras-go/blob/main/registry/remote/repository.go#L308

Example:

Azure Container Registries, when querying the following OCI repository for its tags

```shell
curl --location --request GET 'https://registry.azurecr.io/v2/helm/chart/tags/list' --header 'Authorization: xxx'
```

Responds with the following headers:

```shell
< HTTP/1.1 200 OK
< Server: openresty
< Date: Wed, 14 Dec 2022 15:53:28 GMT
< Content-Type: application/json; charset=utf-8
...
< Link: </v2/helm/chart/tags/list?last=0.0.xxx&n=100&orderby=>; rel="next"
...
```

**Expected behaviour:**

The Argo Helm client queries `https://registry.azurecr.io/v2/helm/chart/tags/list?last=0.0.xxx&n=100&orderby=`

**Actual behaviour:**

The Argo Helm client queries `/v2/helm/chart/tags/list?last=0.0.xxx&n=100&orderby=` and errors with 
```
rpc error: code = Unknown desc = unable to tags: failed to get tags: failed tags part: request failed: Get "/v2/helm/chart/tags/list?last=0.0.xxx&n=100&orderby=": unsupported protocol scheme "" 
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

