### PR TITLE
fix: populate parentRefs correctly with multiple owners

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -220,10 +220,10 @@ func asResourceNode(r *clustercache.Resource) appv1.ResourceNode {
 		gv = schema.GroupVersion{}
 	}
 	parentRefs := make([]appv1.ResourceRef, len(r.OwnerRefs))
-	for _, ownerRef := range r.OwnerRefs {
+	for i, ownerRef := range r.OwnerRefs {
 		ownerGvk := schema.FromAPIVersionAndKind(ownerRef.APIVersion, ownerRef.Kind)
 		ownerKey := kube.NewResourceKey(ownerGvk.Group, ownerRef.Kind, r.Ref.Namespace, ownerRef.Name)
-		parentRefs[0] = appv1.ResourceRef{Name: ownerRef.Name, Kind: ownerKey.Kind, Namespace: r.Ref.Namespace, Group: ownerKey.Group, UID: string(ownerRef.UID)}
+		parentRefs[i] = appv1.ResourceRef{Name: ownerRef.Name, Kind: ownerKey.Kind, Namespace: r.Ref.Namespace, Group: ownerKey.Group, UID: string(ownerRef.UID)}
 	}
 	var resHealth *appv1.HealthStatus
 	resourceInfo := resInfo(r)

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -6,10 +6,11 @@ import (
 	"net/url"
 	"testing"
 
-	apierr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/argoproj/gitops-engine/pkg/cache"
 	"github.com/argoproj/gitops-engine/pkg/cache/mocks"
@@ -152,4 +153,52 @@ func TestIsRetryableError(t *testing.T) {
 	t.Run("ConnectionReset", func(t *testing.T) {
 		assert.True(t, isRetryableError(connectionReset))
 	})
+}
+
+func Test_asResourceNode_owner_refs(t *testing.T) {
+	resNode := asResourceNode(&cache.Resource{
+		ResourceVersion: "",
+		Ref: v1.ObjectReference{
+			APIVersion: "v1",
+		},
+		OwnerRefs: []metav1.OwnerReference{
+			{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "cm-1",
+			},
+			{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "cm-2",
+			},
+		},
+		CreationTimestamp: nil,
+		Info:              nil,
+		Resource:          nil,
+	})
+	expected := appv1.ResourceNode{
+		ResourceRef: appv1.ResourceRef{
+			Version: "v1",
+		},
+		ParentRefs: []appv1.ResourceRef{
+			{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  "cm-1",
+			},
+			{
+				Group: "",
+				Kind:  "ConfigMap",
+				Name:  "cm-2",
+			},
+		},
+		Info:            nil,
+		NetworkingInfo:  nil,
+		ResourceVersion: "",
+		Images:          nil,
+		Health:          nil,
+		CreatedAt:       nil,
+	}
+	assert.Equal(t, expected, resNode)
 }


### PR DESCRIPTION
If you have a resource with multiple ownerReferences, argocd currently only shows one "parent" due to a bug in the code.

Fixes #3910

For example;
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: child
  namespace: argocd
  ownerReferences:
  - apiVersion: v1
    kind: ConfigMap
    name: parent-a
    uid: 8d01d369-5e4d-41d9-9fa7-087aca58dce0
  - apiVersion: v1
    kind: ConfigMap
    name: parent-b
    uid: 4e9c8e32-aa48-4a54-9a12-0823879c4131
  resourceVersion: "5273"
  uid: 6f53e375-c493-4f56-94e2-b91d2db6ba8b
```

Before:
![image](https://user-images.githubusercontent.com/759887/207840230-8dc1b689-807d-4035-95d5-b511b7244a27.png)
After:
![image](https://user-images.githubusercontent.com/759887/207840270-9461111e-60f5-4f08-a398-cc01fb67d1ad.png)


The api endpoint (http://localhost:4000/api/v1/applications/a/resource-tree?appNamespace=argocd) looks like this;

Before:
```json
    {
      "version": "v1",
      "kind": "ConfigMap",
      "namespace": "argocd",
      "name": "child",
      "uid": "6f53e375-c493-4f56-94e2-b91d2db6ba8b",
      "parentRefs": [
        {
          "kind": "ConfigMap",
          "namespace": "argocd",
          "name": "parent-b",
          "uid": "4e9c8e32-aa48-4a54-9a12-0823879c4131"
        },
        {}
      ],
      "resourceVersion": "5273",
      "createdAt": "2022-12-15T09:48:06Z"
    },
```

After:
```json
    {
      "version": "v1",
      "kind": "ConfigMap",
      "namespace": "argocd",
      "name": "child",
      "uid": "6f53e375-c493-4f56-94e2-b91d2db6ba8b",
      "parentRefs": [
        {
          "kind": "ConfigMap",
          "namespace": "argocd",
          "name": "parent-a",
          "uid": "8d01d369-5e4d-41d9-9fa7-087aca58dce0"
        },
        {
          "kind": "ConfigMap",
          "namespace": "argocd",
          "name": "parent-b",
          "uid": "4e9c8e32-aa48-4a54-9a12-0823879c4131"
        }
      ],
      "resourceVersion": "5273",
      "createdAt": "2022-12-15T09:48:06Z"
    },
```


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

