### PR TITLE
fix: ssa e2e tests failing after updating to kubectl 1.26

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -374,14 +374,6 @@ jobs:
       - name: GH actions workaround - Kill XSP4 process
         run: |
           sudo pkill mono || true
-      # ubuntu-22.04 comes with kubectl, but the version is not pinned. The version as of 2022-12-05 is 1.26.0 which
-      # breaks the `TestNamespacedResourceDiffing` e2e test. So we'll pin to 1.25 and then fix the underlying issue.
-      - name: Install kubectl
-        run: |
-          rm /usr/local/bin/kubectl
-          curl -LO https://dl.k8s.io/release/v1.25.4/bin/linux/amd64/kubectl
-          mv kubectl /usr/local/bin/kubectl
-          chmod +x /usr/local/bin/kubectl
       - name: Install K3S
         env:
           INSTALL_K3S_VERSION: ${{ matrix.k3s-version }}+k3s1

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -765,6 +765,16 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 		Given().
 		When().
 		And(func() {
+			// Now we migrate from client-side apply to server-side apply
+			// This is necessary, as starting with kubectl 1.26, all previously
+			// client-side owned fields have ownership migrated to the manager from
+			// the first ssa.
+			// More details: https://github.com/kubernetes/kubectl/issues/1337
+			output, err := RunWithStdin(testdata.GuestbookDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=previous-manager", "--validate=false", "--force-conflicts", "-f", "-")
+			assert.NoError(t, err)
+			assert.Contains(t, output, "serverside-applied")
+		}).
+		And(func() {
 			output, err := RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
 			assert.NoError(t, err)
 			assert.Contains(t, output, "serverside-applied")
@@ -776,7 +786,9 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 		ResourceOverrides(map[string]ResourceOverride{"apps/Deployment": {
 			IgnoreDifferences: OverrideIgnoreDiff{
 				ManagedFieldsManagers: []string{"revision-history-manager"},
-				JSONPointers:          []string{"/spec/template/spec/containers/0/image"},
+				JSONPointers: []string{"/spec/template/spec/containers/0/image",
+					"/metadata/annotations/argocd.argoproj.io~1tracking-id",
+					"/metadata/labels/app.kubernetes.io~1instance"},
 			},
 		}}).
 		When().

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -743,16 +743,17 @@ func TestResourceDiffing(t *testing.T) {
 		}).
 		Given().
 		When().
-		And(func() {
-			// Now we migrate from client-side apply to server-side apply
-			// This is necessary, as starting with kubectl 1.26, all previously
-			// client-side owned fields have ownership migrated to the manager from
-			// the first ssa.
-			// More details: https://github.com/kubernetes/kubectl/issues/1337
-			output, err := RunWithStdin(testdata.GuestbookDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=previous-manager", "--validate=false", "--force-conflicts", "-f", "-")
-			assert.NoError(t, err)
-			assert.Contains(t, output, "serverside-applied")
-		}).
+		// Now we migrate from client-side apply to server-side apply
+		// This is necessary, as starting with kubectl 1.26, all previously
+		// client-side owned fields have ownership migrated to the manager from
+		// the first ssa.
+		// More details: https://github.com/kubernetes/kubectl/issues/1337
+		PatchApp(`[{
+			"op": "add",
+			"path": "/spec/syncPolicy",
+			"value": { "syncOptions": ["ServerSideApply=true"] }
+			}]`).
+		Sync().
 		And(func() {
 			output, err := RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
 			assert.NoError(t, err)
@@ -765,9 +766,7 @@ func TestResourceDiffing(t *testing.T) {
 		ResourceOverrides(map[string]ResourceOverride{"apps/Deployment": {
 			IgnoreDifferences: OverrideIgnoreDiff{
 				ManagedFieldsManagers: []string{"revision-history-manager"},
-				JSONPointers: []string{"/spec/template/spec/containers/0/image",
-					"/metadata/annotations/argocd.argoproj.io~1tracking-id",
-					"/metadata/labels/app.kubernetes.io~1instance"},
+				JSONPointers:          []string{"/spec/template/spec/containers/0/image"},
 			},
 		}}).
 		When().

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -707,7 +707,6 @@ stringData:
 func TestResourceDiffing(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
-		SetTrackingMethod("annotation").
 		When().
 		CreateApp().
 		Sync().

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -707,6 +707,7 @@ stringData:
 func TestResourceDiffing(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
+		SetTrackingMethod("annotation").
 		When().
 		CreateApp().
 		Sync().
@@ -743,6 +744,16 @@ func TestResourceDiffing(t *testing.T) {
 		Given().
 		When().
 		And(func() {
+			// Now we migrate from client-side apply to server-side apply
+			// This is necessary, as starting with kubectl 1.26, all previously
+			// client-side owned fields have ownership migrated to the manager from
+			// the first ssa.
+			// More details: https://github.com/kubernetes/kubectl/issues/1337
+			output, err := RunWithStdin(testdata.GuestbookDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=previous-manager", "--validate=false", "--force-conflicts", "-f", "-")
+			assert.NoError(t, err)
+			assert.Contains(t, output, "serverside-applied")
+		}).
+		And(func() {
 			output, err := RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
 			assert.NoError(t, err)
 			assert.Contains(t, output, "serverside-applied")
@@ -754,7 +765,9 @@ func TestResourceDiffing(t *testing.T) {
 		ResourceOverrides(map[string]ResourceOverride{"apps/Deployment": {
 			IgnoreDifferences: OverrideIgnoreDiff{
 				ManagedFieldsManagers: []string{"revision-history-manager"},
-				JSONPointers:          []string{"/spec/template/spec/containers/0/image"},
+				JSONPointers: []string{"/spec/template/spec/containers/0/image",
+					"/metadata/annotations/argocd.argoproj.io~1tracking-id",
+					"/metadata/labels/app.kubernetes.io~1instance"},
 			},
 		}}).
 		When().

--- a/test/e2e/testdata/data.go
+++ b/test/e2e/testdata/data.go
@@ -5,4 +5,7 @@ import _ "embed"
 var (
 	//go:embed ssa-revision-history/deployment.yaml
 	SSARevisionHistoryDeployment string
+
+	//go:embed guestbook/guestbook-ui-deployment.yaml
+	GuestbookDeployment string
 )


### PR DESCRIPTION
Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

