### PR TITLE
docs: Bump elasticsearch version to 8.5.1 in multi-sources example

### DIFF
--- a/docs/user-guide/multiple_sources.md
+++ b/docs/user-guide/multiple_sources.md
@@ -27,7 +27,7 @@ spec:
   sources:
     - chart: elasticsearch
       repoURL: https://helm.elastic.co
-      targetRevision: 7.6.0
+      targetRevision: 8.5.1
     - repoURL: https://github.com/argoproj/argocd-example-apps.git
       path: guestbook
       targetRevision: HEAD


### PR DESCRIPTION
Elasticsearch v7.6.0 uses `policy/v1beta1` API version of PodDisruptionBudget is no longer served as of v1.25.
We can use the policy/v1 API version, available since v1.21.

Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

Signed-off-by: toyamagu2021@gmail.com <toyamagu2021@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
