### PR TITLE
fix: set Path as empty if path is not specified for a source in multiple sources (#11756)

### DIFF
--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -222,8 +222,8 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                   {
                       title: 'PATH',
                       view: (
-                          <Revision repoUrl={source.repoURL} revision={source.targetRevision || 'HEAD'} path={source.path}>
-                              {source.path}
+                          <Revision repoUrl={source.repoURL} revision={source.targetRevision || 'HEAD'} path={source.path} title='PATH'>
+                              {source.path ?? ''}
                           </Revision>
                       ),
                       edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.path' component={Text} />

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -222,7 +222,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                   {
                       title: 'PATH',
                       view: (
-                          <Revision repoUrl={source.repoURL} revision={source.targetRevision || 'HEAD'} path={source.path} title='PATH'>
+                          <Revision repoUrl={source.repoURL} revision={source.targetRevision || 'HEAD'} path={source.path} isForPath={true}>
                               {source.path ?? ''}
                           </Revision>
                       ),

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import {revisionUrl} from './urls';
 
 export const Revision = ({repoUrl, revision, path, title, children}: {repoUrl: string; revision: string; path?: string; title?: string; children?: React.ReactNode}) => {
-    const hasPath = path && path !== '.';
     if (title == 'PATH' && path) {
+        // This source literally has no path, so we won't show one.
         return <span></span>
     }
     revision = revision || '';
+    const hasPath = path && path !== '.';
     let url = revisionUrl(repoUrl, revision, hasPath);
     if (hasPath) {
         url += '/' + path;

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -3,7 +3,7 @@ import {revisionUrl} from './urls';
 
 export const Revision = ({repoUrl, revision, path, title, children}: {repoUrl: string; revision: string; path?: string; title?: string; children?: React.ReactNode}) => {
     const hasPath = path && path !== '.';
-    if (title == 'PATH' && !hasPath) {
+    if (title == 'PATH' && path) {
         return <span></span>
     }
     revision = revision || '';

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import {revisionUrl} from './urls';
 
-export const Revision = ({repoUrl, revision, path, children}: {repoUrl: string; revision: string; path?: string; children?: React.ReactNode}) => {
-    revision = revision || '';
+export const Revision = ({repoUrl, revision, path, title, children}: {repoUrl: string; revision: string; path?: string; title?: string; children?: React.ReactNode}) => {
     const hasPath = path && path !== '.';
+    if (title == 'PATH' && !hasPath) {
+        return <span></span>
+    }
+    revision = revision || '';
     let url = revisionUrl(repoUrl, revision, hasPath);
     if (hasPath) {
         url += '/' + path;

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {revisionUrl} from './urls';
 
-export const Revision = ({repoUrl, revision, path, title, children}: {repoUrl: string; revision: string; path?: string; title?: string; children?: React.ReactNode}) => {
-    if (title == 'PATH' && path) {
+export const Revision = ({repoUrl, revision, path, isForPath, children}: {repoUrl: string; revision: string; path?: string; isForPath?: boolean; children?: React.ReactNode}) => {
+    if (isForPath && path) {
         // This source literally has no path, so we won't show one.
-        return <span></span>
+        return <span></span>;
     }
     revision = revision || '';
     const hasPath = path && path !== '.';

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -4,7 +4,7 @@ import {revisionUrl} from './urls';
 export const Revision = ({repoUrl, revision, path, isForPath, children}: {repoUrl: string; revision: string; path?: string; isForPath?: boolean; children?: React.ReactNode}) => {
     if (isForPath && path) {
         // This source literally has no path, so we won't show one.
-        return <span/>;
+        return <span />;
     }
     revision = revision || '';
     const hasPath = path && path !== '.';

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {revisionUrl} from './urls';
 
 export const Revision = ({repoUrl, revision, path, isForPath, children}: {repoUrl: string; revision: string; path?: string; isForPath?: boolean; children?: React.ReactNode}) => {
-    if (isForPath && path) {
+    if (isForPath && !path) {
         // This source literally has no path, so we won't show one.
         return <span />;
     }

--- a/ui/src/app/shared/components/revision.tsx
+++ b/ui/src/app/shared/components/revision.tsx
@@ -4,7 +4,7 @@ import {revisionUrl} from './urls';
 export const Revision = ({repoUrl, revision, path, isForPath, children}: {repoUrl: string; revision: string; path?: string; isForPath?: boolean; children?: React.ReactNode}) => {
     if (isForPath && path) {
         // This source literally has no path, so we won't show one.
-        return <span></span>;
+        return <span/>;
     }
     revision = revision || '';
     const hasPath = path && path !== '.';


### PR DESCRIPTION
Fixes: #11756 

After changes:
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/46771830/208686477-8f2c244d-eb37-4417-b8ff-054034a996f4.png">


Signed-off-by: ishitasequeira <ishiseq29@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

