### PR TITLE
docs: add an example ApplicationSet to document all fields

### DIFF
--- a/docs/operator-manual/applicationset.yaml
+++ b/docs/operator-manual/applicationset.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: test-hello-world-appset
+  namespace: argocd
+spec:
+  # See docs for available generators and their specs.
+  generators:
+  - list:
+      elements:
+      - cluster: https://kubernetes.default.svc
+  # Determines whether go templating will be used in the `template` field below.
+  goTemplate: false
+  # These fields are identical to the Application spec.
+  template:
+    metadata:
+      name: test-hello-world-app
+    spec:
+      project: my-project
+  # This sync policy pertains to the ApplicationSet, not to the Applications it creates.
+  syncPolicy:
+    # Determines whether the controller will delete Applications when an ApplicationSet is deleted.
+    preserveResourcesOnDeletion: false
+  # Alpha feature to determine the order in which ApplicationSet applies changes.
+  strategy:


### PR DESCRIPTION
We have one of these for applications and projects, so I think it makes sense to have one for applicationsets as well.