### PR TITLE
feat: Support for DeleteNamespace SyncOption(#4435, #7875)

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -155,6 +155,7 @@ spec:
     syncOptions:     # Sync options which modifies sync behavior
     - Validate=false # disables resource validation (equivalent to 'kubectl apply --validate=false') ( true by default ).
     - CreateNamespace=true # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
+    - DeleteNamespace=true # Delete Auto-Created namespace. Ignored when CreateNamespace=true is not set.
     - PrunePropagationPolicy=foreground # Supported policies are background, foreground and orphan.
     - PruneLast=true # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
     managedNamespaceMetadata: # Sets the metadata for the application namespace. Only valid if CreateNamespace=true (see above), otherwise it's a no-op.

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -280,6 +280,13 @@ The example above shows how an Argo CD Application can be configured so it will 
 
 Note that the namespace to be created must be informed in the `spec.destination.namespace` field of the Application resource. The `metadata.namespace` field in the Application's child manifests must match this value, or can be omitted, so resources are created in the proper destination.
 
+### Delete Namespace
+
+If `DeleteNamespace=true` is set, we can delete an auto-created namespace when an application is deleted.
+Note that the namespace is deleted only when both `CreateNamespace=true` and `DeleteNamespace=true` are set.  
+In addition, the namespace must have a label or an annotation to indicate the application tracks the namespace [see [resource tracking](resource_tracking.md)].  
+Otherwise, the application is deleted, but the namespace remains throwing error.
+
 ### Namespace Metadata
 
 We can also add labels and annotations to the namespace through `managedNamespaceMetadata`. If we extend the example above

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -31,7 +31,7 @@ type ResourceTracking interface {
 	Normalize(config, live *unstructured.Unstructured, labelKey, trackingMethod string) error
 }
 
-//AppInstanceValue store information about resource tracking info
+// AppInstanceValue store information about resource tracking info
 type AppInstanceValue struct {
 	ApplicationName string
 	Group           string
@@ -146,12 +146,12 @@ func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, v
 	}
 }
 
-//BuildAppInstanceValue build resource tracking id in format <application-name>;<group>/<kind>/<namespace>/<name>
+// BuildAppInstanceValue build resource tracking id in format <application-name>;<group>/<kind>/<namespace>/<name>
 func (rt *resourceTracking) BuildAppInstanceValue(value AppInstanceValue) string {
 	return fmt.Sprintf("%s:%s/%s:%s/%s", value.ApplicationName, value.Group, value.Kind, value.Namespace, value.Name)
 }
 
-//ParseAppInstanceValue parse resource tracking id from format <application-name>:<group>/<kind>:<namespace>/<name> to struct
+// ParseAppInstanceValue parse resource tracking id from format <application-name>:<group>/<kind>:<namespace>/<name> to struct
 func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceValue, error) {
 	var appInstanceValue AppInstanceValue
 	parts := strings.Split(value, ":")


### PR DESCRIPTION
Closes #4435
Closes #7875

## Description

- After this PR is merged, we can specify `DeleteNamespace` syncOption, which enables a feature to delete an auto-created namespace.
- We can delete a namespace only when:
  - `CreateNamespace=true` and `DeleteNamespace=true`
  - The target namespace is tracked by an application. 
    - e.g.) The namespace must have a label, `app.kubernetes.io/instance=${applicationName}`

## Test

We can test this feature by the following manifest.
After PR #11350 merged, I think `app.kubernetes.io/instance` is automatically labeled.

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: guestbook
  namespace: argocd
spec:
  project: default
  destination:
    server: https://kubernetes.default.svc/
    namespace: test
  source:
    repoURL: https://github.com/argoproj/argocd-example-apps.git
    path: guestbook
    targetRevision: HEAD
  syncPolicy:
    syncOptions:
    - CreateNamespace=true
    - DeleteNamespace=true
    managedNamespaceMetadata:
      labels:
        app.kubernetes.io/instance: guestbook
```

## Notes

Because deleting a namespace destroys all resources in the namespace, I think this feature is not breaking but dangerous.
So any suggestions to increase safety would be greatly appreciated.

## Template

Signed-off-by: toyamagu2021@gmail.com <toyamagu2021@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
