### PR TITLE
refactor: Make fsnotify event more readable.

### DIFF
--- a/reposerver/gpgwatcher.go
+++ b/reposerver/gpgwatcher.go
@@ -31,10 +31,10 @@ func StartGPGWatcher(sourcePath string) error {
 				if !ok {
 					return
 				}
-				if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Remove == fsnotify.Remove {
+				if event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) {
 					// In case our watched path is re-created (i.e. during e2e tests), we need to watch again
 					// For more robustness, we retry re-creating the watcher up to maxRecreateRetries
-					if event.Name == sourcePath && event.Op&fsnotify.Remove == fsnotify.Remove {
+					if event.Name == sourcePath && event.Has(fsnotify.Remove) {
 						log.Warnf("Re-creating watcher on %s", sourcePath)
 						attempt := 0
 						for {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

As [fsnotify v1.6.0](https://github.com/fsnotify/fsnotify/releases/tag/v1.6.0) mentioned.
We can replace 
```
 if event.Op&Write == Write && !(event.Op&Remove == Remove) {
  }
```

with 
```
 if event.Has(Write) && !event.Has(Remove) {
  }
```
will be more readable and maintenance.