### PR TITLE
docs: Replaced "go get" with "go install"

### DIFF
--- a/docs/developer-guide/dependencies.md
+++ b/docs/developer-guide/dependencies.md
@@ -13,7 +13,7 @@ After your GitOps Engine PR has been merged, ArgoCD needs to be updated to pull 
 * Retrieve the SHA hash for your commit. You will use this in the next step.
 * From the `argo-cd` folder, run the following command
 
-    `go get github.com/argoproj/gitops-engine@<git-commit-sha>`
+    `go install github.com/argoproj/gitops-engine@<git-commit-sha>`
 
     If you get an error message `invalid version: unknown revision` then you got the wrong SHA hash
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
ref: https://go.dev/doc/go-get-install-deprecation
