### PR TITLE
feat: Expose OPA warnings to ArgoCD UI

### DIFF
--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -122,6 +122,14 @@ test('OperationState.Sync OK', () => {
     expect(tree).toMatchSnapshot();
 });
 
+test('OperationState.Sync warning', () => {
+    const tree = renderer
+        .create(<OperationState app={{metadata: {}, status: {operationState: {operation: {sync: {}}, phase: OperationPhases.Warning}}} as Application} />)
+        .toJSON();
+
+    expect(tree).toMatchSnapshot();
+});
+
 test('OperationState.Sync error', () => {
     const tree = renderer.create(<OperationState app={{metadata: {}, status: {operationState: {operation: {sync: {}}, phase: OperationPhases.Error}}} as Application} />).toJSON();
 
@@ -212,6 +220,12 @@ test('ResourceResultIcon.SyncFailed', () => {
     expect(tree).toMatchSnapshot();
 });
 
+test('ResourceResultIcon.SyncedWithWarning', () => {
+    const tree = renderer.create(<ResourceResultIcon resource={{status: ResultCodes.SyncedWithWarning} as ResourceResult} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+});
+
 test('ResourceResultIcon.Hook.Running', () => {
     const tree = renderer
         .create(
@@ -250,6 +264,12 @@ test('ResourceResultIcon.Hook.Succeeded', () => {
 
 test('ResourceResultIcon.Hook.Terminating', () => {
     const tree = renderer.create(<ResourceResultIcon resource={{hookType: 'Sync', hookPhase: OperationPhases.Terminating} as ResourceResult} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+});
+
+test('ResourceResultIcon.Hook.Warning', () => {
+    const tree = renderer.create(<ResourceResultIcon resource={{hookType: 'Sync', hookPhase: OperationPhases.Warning} as ResourceResult} />).toJSON();
 
     expect(tree).toMatchSnapshot();
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -206,6 +206,10 @@ export const OperationPhaseIcon = ({app}: {app: appModels.Application}) => {
             className = 'fa fa-check-circle';
             color = COLORS.operation.success;
             break;
+        case appModels.OperationPhases.Warning:
+            className = 'fa fa-check-circle';
+            color = COLORS.operation.warning;
+            break;
         case appModels.OperationPhases.Error:
             className = 'fa fa-times-circle';
             color = COLORS.operation.error;
@@ -764,6 +768,10 @@ export const ResourceResultIcon = ({resource}: {resource: appModels.ResourceResu
             case appModels.ResultCodes.PruneSkipped:
                 icon = 'fa-heart';
                 break;
+            case appModels.ResultCodes.SyncedWithWarning:
+                color = COLORS.sync_result.SyncedWithWarning;
+                icon = 'fa-heart-broken';
+                break;
         }
         let title: string = resource.message;
         if (resource.message) {
@@ -793,6 +801,10 @@ export const ResourceResultIcon = ({resource}: {resource: appModels.ResourceResu
             case appModels.OperationPhases.Terminating:
                 color = COLORS.operation.terminating;
                 className = 'fa fa-circle-notch fa-spin';
+                break;
+            case appModels.OperationPhases.Warning:
+                color = COLORS.operation.warning;
+                className = 'fa fa-heart-broken';
                 break;
         }
         let title: string = resource.message;
@@ -867,6 +879,8 @@ const getOperationStateTitle = (app: appModels.Application) => {
                     return 'Sync OK';
                 case 'Terminating':
                     return 'Terminated';
+                case 'Warning':
+                    return 'Sync warning';
             }
     }
     return 'Unknown';
@@ -877,7 +891,7 @@ export const OperationState = ({app, quiet}: {app: appModels.Application; quiet?
     if (appOperationState === undefined) {
         return <React.Fragment />;
     }
-    if (quiet && [appModels.OperationPhases.Running, appModels.OperationPhases.Failed, appModels.OperationPhases.Error].indexOf(appOperationState.phase) === -1) {
+    if (quiet && [appModels.OperationPhases.Running, appModels.OperationPhases.Failed, appModels.OperationPhases.Error, appModels.OperationPhases.Warning].indexOf(appOperationState.phase) === -1) {
         return <React.Fragment />;
     }
 

--- a/ui/src/app/shared/components/colors.ts
+++ b/ui/src/app/shared/components/colors.ts
@@ -25,18 +25,21 @@ export const COLORS = {
         failed: ARGO_FAILED_COLOR,
         running: ARGO_RUNNING_COLOR,
         success: ARGO_SUCCESS_COLOR,
-        terminating: ARGO_TERMINATING_COLOR
+        terminating: ARGO_TERMINATING_COLOR,
+        warning: ARGO_WARNING_COLOR
     },
     sync: {
         synced: ARGO_SUCCESS_COLOR,
         out_of_sync: ARGO_WARNING_COLOR,
-        unknown: ARGO_GRAY4_COLOR
+        unknown: ARGO_GRAY4_COLOR,
+        SyncedWithWarning: ARGO_WARNING_COLOR
     },
     sync_result: {
         failed: ARGO_FAILED_COLOR,
         synced: ARGO_SUCCESS_COLOR,
         pruned: ARGO_GRAY4_COLOR,
-        unknown: ARGO_GRAY4_COLOR
+        unknown: ARGO_GRAY4_COLOR,
+        SyncedWithWarning: ARGO_WARNING_COLOR
     },
     sync_window: {
         deny: ARGO_FAILED_COLOR,

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -62,14 +62,15 @@ export interface Operation {
     initiatedBy: OperationInitiator;
 }
 
-export type OperationPhase = 'Running' | 'Error' | 'Failed' | 'Succeeded' | 'Terminating';
+export type OperationPhase = 'Running' | 'Error' | 'Failed' | 'Succeeded' | 'Terminating' | 'Warning';
 
 export const OperationPhases = {
     Running: 'Running' as OperationPhase,
     Failed: 'Failed' as OperationPhase,
     Error: 'Error' as OperationPhase,
     Succeeded: 'Succeeded' as OperationPhase,
-    Terminating: 'Terminating' as OperationPhase
+    Terminating: 'Terminating' as OperationPhase,
+    Warning: 'Warning' as OperationPhase
 };
 
 /**
@@ -99,13 +100,14 @@ export interface SyncOperationResult {
     revision: string;
 }
 
-export type ResultCode = 'Synced' | 'SyncFailed' | 'Pruned' | 'PruneSkipped';
+export type ResultCode = 'Synced' | 'SyncFailed' | 'Pruned' | 'PruneSkipped' | 'SyncedWithWarning';
 
 export const ResultCodes = {
     Synced: 'Synced',
     SyncFailed: 'SyncFailed',
     Pruned: 'Pruned',
-    PruneSkipped: 'PruneSkipped'
+    PruneSkipped: 'PruneSkipped',
+    SyncedWithWarning: 'SyncedWithWarning'
 };
 
 export interface ResourceResult {


### PR DESCRIPTION
Closes [#9256](https://github.com/argoproj/argo-cd/issues/9256)
## Description
The PR implement exposing OPA warning to Argo CD UI
The changes depend on gitops-engine [PR](https://github.com/argoproj/gitops-engine/pull/493)
Warnings in the ArgoCD UI will look like this:

<img width="1672" alt="Screen Shot 2022-12-28 at 2 43 40 PM" src="https://user-images.githubusercontent.com/96204102/209997821-703a329f-c110-490e-a1d4-eb954375c822.png">

<img width="1507" alt="Screen Shot 2022-12-28 at 2 44 01 PM" src="https://user-images.githubusercontent.com/96204102/209997015-907c915f-6863-43b5-8656-52595d2ee7ac.png">

Probably makes sense to add a warning icon to affected resources, but I need some assistance with this.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:


* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

