### PR TITLE
fix: spec.executor.instances is Optional, Support a flexible number of executors

### DIFF
--- a/resource_customizations/sparkoperator.k8s.io/SparkApplication/health.lua
+++ b/resource_customizations/sparkoperator.k8s.io/SparkApplication/health.lua
@@ -5,10 +5,10 @@ infinity = 2^1024-1
 local function executor_range_api()
   min_executor_instances = 0
   max_executor_instances = infinity
-  if obj.spec.dynamicAllocation.maxExecutors then 
+  if obj.spec.dynamicAllocation.maxExecutors then
     max_executor_instances = obj.spec.dynamicAllocation.maxExecutors
   end
-  if obj.spec.dynamicAllocation.minExecutors then 
+  if obj.spec.dynamicAllocation.minExecutors then
     min_executor_instances = obj.spec.dynamicAllocation.minExecutors
   end
   return min_executor_instances, max_executor_instances
@@ -17,7 +17,7 @@ end
 local function maybe_executor_range_spark_conf()
   min_executor_instances = 0
   max_executor_instances = infinity
-  if obj.spec.sparkConf["spark.streaming.dynamicAllocation.enabled"] ~= nil and 
+  if obj.spec.sparkConf["spark.streaming.dynamicAllocation.enabled"] ~= nil and
      obj.spec.sparkConf["spark.streaming.dynamicAllocation.enabled"] == "true" then
     if(obj.spec.sparkConf["spark.streaming.dynamicAllocation.maxExecutors"] ~= nil) then
       max_executor_instances = tonumber(obj.spec.sparkConf["spark.streaming.dynamicAllocation.maxExecutors"])
@@ -26,7 +26,7 @@ local function maybe_executor_range_spark_conf()
       min_executor_instances = tonumber(obj.spec.sparkConf["spark.streaming.dynamicAllocation.minExecutors"])
     end
     return min_executor_instances, max_executor_instances
-  elseif obj.spec.sparkConf["spark.dynamicAllocation.enabled"] ~= nil and 
+  elseif obj.spec.sparkConf["spark.dynamicAllocation.enabled"] ~= nil and
      obj.spec.sparkConf["spark.dynamicAllocation.enabled"] == "true" then
     if(obj.spec.sparkConf["spark.dynamicAllocation.maxExecutors"] ~= nil) then
       max_executor_instances = tonumber(obj.spec.sparkConf["spark.dynamicAllocation.maxExecutors"])
@@ -45,8 +45,16 @@ local function maybe_executor_range()
     return executor_range_api()
   elseif obj.spec["sparkConf"] ~= nil then
     return maybe_executor_range_spark_conf()
-  else 
+  else
     return nil
+  end
+end
+
+local function dynamic_executors_without_spec_config()
+  if obj.spec.dynamicAllocation == nil and obj.spec.executor.instances == nil then
+    return true
+  else
+    return false
   end
 end
 
@@ -60,23 +68,26 @@ if obj.status ~= nil then
     if obj.status.applicationState.state == "RUNNING" then
       if obj.status.executorState ~= nil then
         count=0
-        executor_instances = obj.spec.executor.instances
         for i, executorState in pairs(obj.status.executorState) do
           if executorState == "RUNNING" then
             count=count+1
           end
         end
-        if executor_instances == count then
+        if obj.spec.executor.instances ~= nil and obj.spec.executor.instances == count then
           health_status.status = "Healthy"
           health_status.message = "SparkApplication is Running"
           return health_status
         elseif maybe_executor_range() then
           min_executor_instances, max_executor_instances = maybe_executor_range()
-          if count >= min_executor_instances and count <= max_executor_instances then 
+          if count >= min_executor_instances and count <= max_executor_instances then
             health_status.status = "Healthy"
             health_status.message = "SparkApplication is Running"
             return health_status
           end
+        elseif dynamic_executors_without_spec_config() and count >= 1 then
+          health_status.status = "Healthy"
+          health_status.message = "SparkApplication is Running"
+          return health_status
         end
       end
     end

--- a/resource_customizations/sparkoperator.k8s.io/SparkApplication/health_test.yaml
+++ b/resource_customizations/sparkoperator.k8s.io/SparkApplication/health_test.yaml
@@ -23,3 +23,7 @@ tests:
     status: Healthy
     message: "SparkApplication is Running"
   inputPath: testdata/healthy_dynamic_alloc_operator_api.yaml
+- healthStatus:
+    status: Healthy
+    message: "SparkApplication is Running"
+  inputPath: testdata/healthy_dynamic_alloc_without_spec_config.yaml

--- a/resource_customizations/sparkoperator.k8s.io/SparkApplication/testdata/healthy_dynamic_alloc_without_spec_config.yaml
+++ b/resource_customizations/sparkoperator.k8s.io/SparkApplication/testdata/healthy_dynamic_alloc_without_spec_config.yaml
@@ -1,0 +1,31 @@
+apiVersion: sparkoperator.k8s.io/v1beta2
+kind: SparkApplication
+metadata:
+  generation: 4
+  labels:
+    argocd.argoproj.io/instance: spark-job
+  name: spark-job-app
+  namespace: spark-cluster
+  resourceVersion: "31812990"
+  uid: bfee52b0-74ca-4465-8005-f6643097ed64
+spec:
+  executor: {}
+status:
+  applicationState:
+    state: RUNNING
+  driverInfo:
+    podName: ingestion-datalake-news-app-driver
+    webUIAddress: 172.20.207.161:4040
+    webUIPort: 4040
+    webUIServiceName: ingestion-datalake-news-app-ui-svc
+  executionAttempts: 13
+  executorState:
+    ingestion-datalake-news-app-1591613851251-exec-1: RUNNING
+    ingestion-datalake-news-app-1591613851251-exec-2: RUNNING
+    ingestion-datalake-news-app-1591613851251-exec-4: RUNNING
+    ingestion-datalake-news-app-1591613851251-exec-5: RUNNING
+  lastSubmissionAttemptTime: "2020-06-08T10:57:32Z"
+  sparkApplicationId: spark-a5920b2a5aa04d22a737c60759b5bf82
+  submissionAttempts: 1
+  submissionID: 3e713ec8-9f6c-4e78-ac28-749797c846f0
+  terminationTime: null


### PR DESCRIPTION
This PR changes the health script for Spark applications a bit after #11522
Spark enables the execution of a flexible number of executors via the `spark.dynamicAllocation.enabled` configuration.
Therefore, it is not necessary to specify a number of executors in the Spark operator ([ExecutorSpec](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/docs/api-docs.md#sparkoperator.k8s.io/v1beta2.ExecutorSpec)). [spec.dynamicAllocation](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blo]b/master/docs/api-docs.md#sparkoperator.k8s.io/v1beta2.SparkApplicationSpec) is also optional. For example, you can place a ConfigMap in the Spark operator. This can save a lot of duplicate configuration on various SparkApplications.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

