### PR TITLE
feat: add app skip reconcile annotation to optionally bypass application controller processing (Alpha) (#11728)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -157,6 +157,10 @@ const (
 	// Ex: "http://grafana.example.com/d/yu5UH4MMz/deployments"
 	// Ex: "Go to Dashboard|http://grafana.example.com/d/yu5UH4MMz/deployments"
 	AnnotationKeyLinkPrefix = "link.argocd.argoproj.io/"
+
+	// AnnotationKeyAppSkipReconcile tells the Application to skip the Application controller reconcile.
+	// Skip reconcile when the value is "true" or any other string values that can be strconv.ParseBool() to be true.
+	AnnotationKeyAppSkipReconcile = "argocd.argoproj.io/skip-reconcile"
 )
 
 // Environment variables for tuning and debugging Argo CD

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1402,6 +1402,32 @@ func Test_canProcessApp(t *testing.T) {
 	})
 }
 
+func Test_canProcessAppSkipReconcileAnnotation(t *testing.T) {
+	appSkipReconcileInvalid := newFakeApp()
+	appSkipReconcileInvalid.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "invalid-value"}
+	appSkipReconcileFalse := newFakeApp()
+	appSkipReconcileFalse.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "false"}
+	appSkipReconcileTrue := newFakeApp()
+	appSkipReconcileTrue.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "true"}
+	ctrl := newFakeController(&fakeData{})
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected bool
+	}{
+		{"No skip reconcile annotation", newFakeApp(), true},
+		{"Contains skip reconcile annotation ", appSkipReconcileInvalid, true},
+		{"Contains skip reconcile annotation value false", appSkipReconcileFalse, true},
+		{"Contains skip reconcile annotation value true", appSkipReconcileTrue, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ctrl.canProcessApp(tt.input))
+		})
+	}
+}
+
 func Test_syncDeleteOption(t *testing.T) {
 	app := newFakeApp()
 	ctrl := newFakeController(&fakeData{apps: []runtime.Object{app}})

--- a/docs/user-guide/skip_reconcile.md
+++ b/docs/user-guide/skip_reconcile.md
@@ -1,0 +1,70 @@
+# Skip Application Reconcile
+
+!!! warning "Alpha Feature"
+    This is an experimental, alpha-quality feature.
+    The primary use case is to provide integration with third party projects.
+    This feature may be removed in future releases or modified in backwards-incompatible ways.
+
+Argo CD allows users to stop an Application from reconciling.
+The skip reconcile option is configured with the `argocd.argoproj.io/skip-reconcile: "true"` annotation.
+When the Application is configured to skip reconcile,
+all processing is stopped for the Application.
+During the period of time when the Application is not processing,
+the Application `status` field will not be updated.
+If an Application is newly created with the skip reconcile annotation,
+then the Application `status` field will not be present.
+To resume the reconciliation or processing of the Application,
+remove the annotation or set the value to `"false"`.
+
+See the below example for enabling an Application to skip reconcile:
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/skip-reconcile: "true"
+```
+
+See the below example for an Application that is newly created with the skip reconcile enabled:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/skip-reconcile: "true"
+  name: guestbook
+  namespace: argocd
+spec:
+  destination:
+    namespace: guestbook
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: guestbook
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+```
+
+The `status` field is not present.
+
+## Primary Use Case
+
+The skip reconcile option is intended to be used with third party projects that wishes 
+to make updates to the Application status without having the changes being overwritten by the Application controller.
+An example of this usage is the [Open Cluster Management (OCM)](https://github.com/open-cluster-management-io/) project using 
+[pull-integration](https://github.com/open-cluster-management-io/argocd-pull-integration) controller.
+In the example, the hub cluster Application is not meant to be reconciled by the Argo CD Application controller.
+Instead, the OCM pull-integration controller will populate the primary/hub cluster Application status 
+using the collected Application status from the remote/spoke/managed cluster.
+
+## Alternative Use Cases
+
+There are other alternative use cases for this skip reconcile option. 
+It's important to note that this is an experimental, alpha-quality feature 
+and the following use cases are generally not recommended.
+
+* Ease of debugging when the Application reconcile is skipped.
+* Orphan resources without deleting the Application might provide a safer way to migrate applications.
+* ApplicationSet can generate dry-run like Applications that don't reconcile automatically. 
+* Pause and resume Applications reconcile during a disaster recovery process.
+* Provide another alternative approval flow by not allowing an Application to start reconciling right away.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
   - user-guide/selective_sync.md
   - user-guide/sync-waves.md
   - user-guide/sync_windows.md
+  - user-guide/skip_reconcile.md
   - Generating Applications with ApplicationSet: user-guide/application-set.md
   - user-guide/ci_automation.md
   - user-guide/app_deletion.md

--- a/test/e2e/app_skipreconcile_test.go
+++ b/test/e2e/app_skipreconcile_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
+)
+
+func TestAppSkipReconcileTrue(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		// app should have no status
+		CreateFromFile(func(app *Application) {
+			app.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "true"}
+		}).
+		Then().
+		Expect(NoStatus())
+}
+
+func TestAppSkipReconcileFalse(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		// app should have status
+		CreateFromFile(func(app *Application) {
+			app.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "false"}
+		}).
+		Then().
+		Expect(StatusExists())
+}
+
+func TestAppSkipReconcileNonBooleanValue(t *testing.T) {
+	Given(t).
+		Path(guestbookPath).
+		When().
+		// app should have status
+		CreateFromFile(func(app *Application) {
+			app.Annotations = map[string]string{common.AnnotationKeyAppSkipReconcile: "not a boolean value"}
+		}).
+		Then().
+		Expect(StatusExists())
+}

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -81,6 +82,26 @@ func NoConditions() Expectation {
 	return func(c *Consequences) (state, string) {
 		message := "no conditions"
 		if len(c.app().Status.Conditions) == 0 {
+			return succeeded, message
+		}
+		return pending, message
+	}
+}
+
+func NoStatus() Expectation {
+	return func(c *Consequences) (state, string) {
+		message := "no status"
+		if reflect.ValueOf(c.app().Status).IsZero() {
+			return succeeded, message
+		}
+		return pending, message
+	}
+}
+
+func StatusExists() Expectation {
+	return func(c *Consequences) (state, string) {
+		message := "status exists"
+		if !reflect.ValueOf(c.app().Status).IsZero() {
 			return succeeded, message
 		}
 		return pending, message


### PR DESCRIPTION
Closes #11728

Introduce a new annotation for Application CR that will allow it to skip the Application controller's reconcile/processing. 
```
metadata:
  annotations:
    argocd.argoproj.io/skip-reconcile: "true"
```
Mainly used for third party integration projects to write status to the Application CR without the status being overwritten by the ArgoCD application controller. See #11728 for more details.

Signed-off-by: Mike Ng <ming@redhat.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
Discussed and recommended by the community in the Contributors Office Hours on 2022 Dec. 15th.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ]  I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
Not applicable, internal usage for third party projects integration.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

**For future reference and prosperity:** 

As requested by the community, documenting the community driven discussions that lead to the decision on why this skip reconcile annotation is required:

The initial presentation and suggestion from the [Open Cluster Management (OCM)](https://open-cluster-management.io/) maintainers is to introduce an optional way for ArgoCD app delivery that uses the hub-spoke pattern or pull model. The ApplicationSet controller will need to be updated to generate OCM [ManifestWork CRs](https://open-cluster-management.io/concepts/manifestwork/) which wraps the Application CRs as payload instead of generating the usual Application CRs. Once the ManifestWorks are created on the hub/primary/multicluster-controlplane cluster, the spoke/managed cluster will pull the payload (Application) down to the managed cluster and the Application will reconcile on the spoke/managed cluster accordingly. This requires the ArgoCD project importing the OCM API and making significant changes to the ApplicationSet API and controller.

The ArgoCD community welcomes the idea of having an optional pull model like behavior but did not like the fact that it requires importing a new API and making significant changes to ApplicationSet. The ArgoCD maintainers suggested to instead create a side project that watches for the ArgoCD Applications and then wrap them in OCM ManifestWorks as payload. This is a great idea that has minimal impact to the ArgoCD code base and the OCM maintainers have created a new [OCM argocd-pull-integration](https://github.com/open-cluster-management-io/argocd-pull-integration) project to do exactly that.

In this model, the Application CRs act as templates and should not be reconciled on the primary/hub/multicluster-controlplane cluster. The OCM maintainers would also like the pulled Application status in the remote/spoke clusters sync back to the original primary/hub cluster Application status. If the Application continues to reconcile, then the status will be overwritten by the Application controller. Therefore, the ArgoCD community suggested adding an annotation to skip the reconcile.

The primary concern is the niche aspect of this annotation. It seems to be mainly focus on this particular third party integration. However, it's discussed that maybe this feature might be useful in the case of debugging, migration, disaster recovery, approval, etc. But those use cases need to be further analyze and should not be recommended yet. Therefore, the community decision is to mark this feature as alpha and clearly state the primary usage (and briefly mention the potential future usage) in the documentation. Another community concern is the visibility of an Application that skipped reconcile in the UI. This is a tricky problem because from the OCM integration perspective, it will be nice if the UI experience is consistent with the existing push like model. The community decided that it's better to make UI changes in the future if this annotation picks up more significant usage out side of the primary intended purpose.