### PR TITLE
fix: support health assessment for prometheus operator < v0.56 (#5620)

### DIFF
--- a/resource_customizations/monitoring.coreos.com/Prometheus/health.lua
+++ b/resource_customizations/monitoring.coreos.com/Prometheus/health.lua
@@ -1,23 +1,30 @@
-local hs={ status = "Progressing", message = "Waiting for initialization" }
+local hs = { status = "Progressing", message = "Waiting for initialization" }
+found_status = false 
 
 if obj.status ~= nil then
   if obj.status.conditions ~= nil then
     for i, condition in ipairs(obj.status.conditions) do
 
-      if condition.type == "Available" and condition.status ~= "True" then
-        if condition.reason == "SomePodsNotReady" then
-          hs.status = "Progressing"
+      if condition.type == "Available" then
+        found_status = true
+        if condition.status ~= "True" then
+            if condition.reason == "SomePodsNotReady" then
+              hs.status = "Progressing"
+            else
+              hs.status = "Degraded"
+            end
+            hs.message = condition.message or condition.reason
         else
-          hs.status = "Degraded"
+            hs.status = "Healthy"
+            hs.message = "All instances are available"
         end
-        hs.message = condition.message or condition.reason
-      end
-      if condition.type == "Available" and condition.status == "True" then
-        hs.status = "Healthy"
-        hs.message = "All instances are available"
       end
     end
   end
+end
+
+if not found_status then
+    hs = { status = "Unknown", message = "Status is not provided" }
 end
 
 return hs

--- a/resource_customizations/monitoring.coreos.com/Prometheus/health_test.yaml
+++ b/resource_customizations/monitoring.coreos.com/Prometheus/health_test.yaml
@@ -11,3 +11,7 @@ tests:
       status: Degraded
       message: "shard 0: pod prometheus-prometheus-stack-kube-prom-prometheus-0: 0/5 nodes are available: 2 node(s) didn't match Pod's node affinity/selector, 3 node(s) were unschedulable.\nshard 0: pod prometheus-prometheus-stack-kube-prom-prometheus-1: 0/5 nodes are available: 2 node(s) didn't match Pod's node affinity/selector, 3 node(s) were unschedulable."
     inputPath: testdata/degraded.yaml
+  - healthStatus:
+      status: Unknown
+      message: "Status is not provided"
+    inputPath: testdata/unknown.yaml

--- a/resource_customizations/monitoring.coreos.com/Prometheus/testdata/unknown.yaml
+++ b/resource_customizations/monitoring.coreos.com/Prometheus/testdata/unknown.yaml
@@ -1,0 +1,112 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: >-
+      prometheus-stack:monitoring.coreos.com/Prometheus:prometheus/prometheus-stack-kube-prom-prometheus
+  creationTimestamp: '2021-12-09T15:51:10Z'
+  generation: 46
+  labels:
+    app: kube-prometheus-stack-prometheus
+    app.kubernetes.io/instance: prometheus-stack
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: kube-prometheus-stack
+    app.kubernetes.io/version: 34.10.0
+    chart: kube-prometheus-stack-34.10.0
+    heritage: Helm
+    release: prometheus-stack
+  name: prometheus-stack-kube-prom-prometheus
+  namespace: prometheus
+  resourceVersion: '200307978'
+  uid: 6f2e1016-926d-44e7-945b-dec4c975595b
+spec:
+  additionalScrapeConfigs:
+    key: prometheus-additional.yaml
+    name: additional-scrape-configs
+  alerting:
+    alertmanagers:
+      - apiVersion: v2
+        name: prometheus-stack-kube-prom-alertmanager
+        namespace: prometheus
+        pathPrefix: /
+        port: http-web
+  containers:
+    - name: prometheus
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+    - name: config-reloader
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+  enableAdminAPI: false
+  evaluationInterval: 30s
+  externalUrl: 'http://prometheus-stack-kube-prom-prometheus.prometheus:9090'
+  image: 'quay.io/prometheus/prometheus:v2.37.0'
+  initContainers:
+    - name: init-config-reloader
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+  listenLocal: false
+  logFormat: logfmt
+  logLevel: info
+  paused: false
+  podMonitorNamespaceSelector: {}
+  podMonitorSelector: {}
+  portName: http-web
+  probeNamespaceSelector: {}
+  probeSelector: {}
+  replicas: 2
+  resources:
+    requests:
+      memory: 700Mi
+  retention: 6h
+  routePrefix: /
+  ruleNamespaceSelector: {}
+  ruleSelector: {}
+  scrapeInterval: 10s
+  securityContext:
+    fsGroup: 2000
+    runAsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccountName: prometheus-stack-kube-prom-prometheus
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector: {}
+  shards: 1
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+        storageClassName: default
+  topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+  version: v2.37.0


### PR DESCRIPTION
Support health for prometheus operator < v0.56. 
Before v0.56, prometheus operator was not updating the status subresource which made the custom health check remain in `Progressing` state forever. See https://github.com/prometheus-operator/prometheus-operator/blob/main/CHANGELOG.md#0560--2022-04-20

All thanks goes to @pstatham-tx

Fixes #5620 
Fixes #11261
Relates to #11782

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

