### PR TITLE
docs: Adjust definition of Argo CD

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 ## What Is Argo CD?
 <!-- markdownlint-enable MD026 -->
 
-Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
+Argo CD is a declarative, GitOps continuous deployment tool for Kubernetes.
 
 ![Argo CD UI](assets/argocd-ui.gif)
 


### PR DESCRIPTION
I've noticed that in the docs, Argo CD is defined as continuous delivery. I think, "continuous deployment" fits Argo CD better, because (if auto sync is enabled) it automatically deploys application(s). "Continuous delivery" is primarily used to describe a setup where deployment is still manual. While Argo CD can be configured in this way, my suggestion is to update the definition to focus on the deployment. 

Signed-off-by: Kirill Shirinkin <kirill@hey.com>
