### PR TITLE
fix: Explicitly set private key type for GPG key generation

### DIFF
--- a/util/gpg/gpg.go
+++ b/util/gpg/gpg.go
@@ -48,7 +48,7 @@ var verificationStatusMatch = regexp.MustCompile(`^gpg: ([a-zA-Z]+) signature fr
 // creating the trustdb in a specific argocd-repo-server pod.
 var batchKeyCreateRecipe = `%no-protection
 %transient-key
-Key-Type: default
+Key-Type: RSA
 Key-Length: 2048
 Key-Usage: sign
 Name-Real: Anon Ymous


### PR DESCRIPTION
While running `make test-local` on a Fedora 37 box, the GnuPG key creation failed in the unit tests. After doing some research, it seems that recent versions of GnuPG have a bug [1] when specifying the key type to be generated as `Default`, so this PR explicitly sets it to RSA. We really don't care about the long term security of the private key, as it's only used to initialize the trust db and is transient by nature.

Submitting this fix before it hits us :)

Current version of GnuPG in our most recent release (v2.5.4):
```
$ docker run --rm -it quay.io/argoproj/argocd:v2.5.4 gpg --version | head -1
gpg (GnuPG) 2.2.27
```

Version from Fedora 37:
```
$ gpg --version | head -1
gpg (GnuPG) 2.3.8
```

[1] https://dev.gnupg.org/T5444

Signed-off-by: jannfis <jann@mistrust.net>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

