### PR TITLE
chore: upgrade golangci-lint to 1.50.1

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
         with:
-          version: v1.46.2
+          version: v1.50.1
           args: --timeout 10m --exclude SA5011 --verbose
 
   test-go:

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1

--- a/util/tls/tls_test.go
+++ b/util/tls/tls_test.go
@@ -4,7 +4,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -390,24 +392,66 @@ func TestCreateServerTLSConfig(t *testing.T) {
 	})
 }
 
+// getCert does the same thing as tls.AppendCertsFromPEM, but throws an error if something goes wrong.
+func getCert(pemCerts []byte) (*x509.Certificate, error) {
+	var block *pem.Block
+	block, pemCerts = pem.Decode(pemCerts)
+	if block == nil {
+		return nil, errors.New("failed to decode pem block")
+	}
+	if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+		return nil, errors.New("encountered something other than a certificate")
+	}
+
+	certBytes := block.Bytes
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+func getCertFromFile(path string) (*x509.Certificate, error) {
+	certBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return getCert(certBytes)
+}
+
 func TestLoadX509CertPool(t *testing.T) {
 	t.Run("Successfully load single cert", func(t *testing.T) {
 		p, err := LoadX509CertPool("testdata/valid_tls.crt")
 		require.NoError(t, err)
 		require.NotNil(t, p)
-		assert.Len(t, p.Subjects(), 1)
+
+		cert, err := getCertFromFile("testdata/valid_tls.crt")
+		require.NoError(t, err)
+		groundTruthPool := x509.NewCertPool()
+		groundTruthPool.AddCert(cert)
+
+		assert.True(t, groundTruthPool.Equal(p))
 	})
 	t.Run("Successfully load single existing cert from multiple list", func(t *testing.T) {
 		p, err := LoadX509CertPool("testdata/invalid_tls.crt", "testdata/valid_tls.crt")
 		require.NoError(t, err)
 		require.NotNil(t, p)
-		assert.Len(t, p.Subjects(), 1)
+
+		cert, err := getCertFromFile("testdata/valid_tls.crt")
+		require.NoError(t, err)
+		groundTruthPool := x509.NewCertPool()
+		groundTruthPool.AddCert(cert)
+
+		assert.True(t, groundTruthPool.Equal(p))
 	})
 	t.Run("Only non-existing certs in list", func(t *testing.T) {
 		p, err := LoadX509CertPool("testdata/invalid_tls.crt", "testdata/valid_tls2.crt")
 		require.NoError(t, err)
 		require.NotNil(t, p)
-		assert.Len(t, p.Subjects(), 0)
+
+		groundTruthPool := x509.NewCertPool()
+
+		assert.True(t, groundTruthPool.Equal(p))
 	})
 	t.Run("Invalid cert in requested cert list", func(t *testing.T) {
 		p, err := LoadX509CertPool("testdata/empty_tls.crt", "testdata/valid_tls2.crt")


### PR DESCRIPTION
CertPool.Subjects was deprecated, so I had to rework a test.