### PR TITLE
fix: Support source references in remote values

### DIFF
--- a/docs/user-guide/multiple_sources.md
+++ b/docs/user-guide/multiple_sources.md
@@ -55,17 +55,18 @@ spec:
     targetRevision: 15.7.1
     helm:
       valueFiles:
-      - $values/charts/prometheus/values.yaml
+      - '$(values)/charts/prometheus/values.yaml'
+      - 'secrets://$(values)/charts/prometheus/values.yaml'
   - repoURL: 'https://git.example.gom/org/value-files.git'
     targetRevision: dev
     ref: values
 ```
 
 In the above example, the `prometheus` chart will use the value file from `git.example.gom/org/value-files.git`. 
-`$values` resolves to the root of the `value-files` repository. The `$values` variable may only be specified at the 
-beginning of the value file path.
+`$(values)` resolves to the root of the `value-files` repository. The `$(values)` reference can be specified anywhere at the value file path.
+To prevent the evaluation inside of `$(values)` inside URL, you have to url-encode the string, e.g. `%24%28values%29`
 
-If the `path` field is set in the `$values` source, Argo CD will attempt to generate resources from the git repository
+If the `path` field is set in the `$(values)` source, Argo CD will attempt to generate resources from the git repository
 at that URL. If the `path` field is not set, Argo CD will use the repository solely as a source of value files.
 
 !!! note

--- a/util/io/path/resolved.go
+++ b/util/io/path/resolved.go
@@ -148,7 +148,7 @@ func resolveFileOrDirectory(appPath string, repoRoot string, fileOrDirectory str
 			return "", resolveFailure(repoRoot, err)
 		}
 		path = filepath.Join(absWorkDir, path)
-	} else {
+	} else if !strings.HasPrefix(path, absRepoPath) {
 		path = filepath.Join(absRepoPath, path)
 	}
 


### PR DESCRIPTION
fixes #11866 

This PR includes support for multi-source applications in combination with helm-secrets. Before reviewing the code, I would like to discuss the concept and idea first.

instead use `$ref` for source references, use `$(ref)` which is district from env substitution. Kubernetes follows the same pattern. https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/#define-an-environment-dependent-variable-for-a-container

To prevent unexpected evaluation from URL parameters, URLs parameter should be URL encoded, e.g. %24%28values%29
to prevent replacing from ArgoCD itself.

This PR is a result from a discussion in CNCF slack (https://cloud-native.slack.com/archives/C01TSERG0KZ/p1673265568561419)

---

Note sure, if this is way to late for 2.6.0. But if 2.6.0 GA is released with the current implementation, we have think about breaking changes.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

