### PR TITLE
Make the docs on Kustomize environment builld variables consistent (not supported).

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -1,6 +1,6 @@
 # Build Environment
 
-[Custom tools](../operator-manual/config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md), and [Kustomize](kustomize.md) support the following build env vars:
+[Custom tools](../operator-manual/config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md) support the following build env vars:
 
 | Variable                            | Description                                                             |
 | ----------------------------------- | ----------------------------------------------------------------------- |

--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -1,6 +1,6 @@
 # Build Environment
 
-[Custom tools](../operator-manual/config-management-plugins.md), [Helm](helm.md), [Jsonnet](jsonnet.md) support the following build env vars:
+[Custom tools](../operator-manual/config-management-plugins.md), [Helm](helm.md) and [Jsonnet](jsonnet.md) support the following build env vars:
 
 | Variable                            | Description                                                             |
 | ----------------------------------- | ----------------------------------------------------------------------- |


### PR DESCRIPTION
This is only to update the inconsistent state of the documentation. At [build environment page](https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/) it is stated that Kustomize supports this. On the [ArgoCD Kustomize page](https://argo-cd.readthedocs.io/en/stable/user-guide/kustomize/#build-environment) it clearly states that it is not supported.
