### PR TITLE
docs: use environment variable for argo cd user

### DIFF
--- a/docs/operator-manual/custom_tools.md
+++ b/docs/operator-manual/custom_tools.md
@@ -69,5 +69,5 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/sops
 
 # Switch back to non-root user
-USER 999
+USER $ARGOCD_USER_ID
 ```


### PR DESCRIPTION
#10113 the Argo CD user ID is exposed as an environment variable. It is better to rely on that than hardcoding `999`.

Signed-off-by: rumstead <37445536+rumstead@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

