### PR TITLE
docs: Updated the helm documentation to how to use show values

### DIFF
--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -46,6 +46,43 @@ source:
     - values-production.yaml
 ```
 
+## Values
+
+The helm values can be provided in the application definition. 
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sealed-secrets
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: sealed-secrets
+    repoURL: https://bitnami-labs.github.io/sealed-secrets
+    targetRevision: 1.16.1
+    helm:
+      releaseName: sealed-secrets
+      values: |
+        kubeVersion: ""
+        nameOverride: ""
+        fullnameOverride: ""
+        namespace: ""
+        extraDeploy: []
+        commonAnnotations: {}
+        image:
+          registry: docker.io
+          repository: bitnami/sealed-secrets-controller
+          tag: v0.19.4
+          pullPolicy: IfNotPresent
+          pullSecrets: []
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: kubeseal
+
+```
+!!! note
+  The values must be provided as a string. In yaml the | operator can be used to provide a multi-line string as shown in the example above.
 ## Helm Parameters
 
 Helm has the ability to set parameter values, which override any values in

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -82,7 +82,7 @@ spec:
 
 ```
 !!! note
-  The values must be provided as a string. In yaml the | operator can be used to provide a multi-line string as shown in the example above.
+    The values must be provided as a string. In yaml the | operator can be used to provide a multi-line string as shown in the example above.
 ## Helm Parameters
 
 Helm has the ability to set parameter values, which override any values in


### PR DESCRIPTION
Updated the helm documentation to show how to embed the values, for a helm chart in an application definition instead of just a file.

Signed-off-by: RampedIndent <rampedindent@gmail.com>



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

