### PR TITLE
fix: disable edit button on App Details Summary and Parameters tabs multi-source apps

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -376,6 +376,7 @@ export const ApplicationParameters = (props: {
             title={props.details.type.toLocaleUpperCase()}
             items={attributes}
             noReadonlyMode={props.noReadonlyMode}
+            hasMultipleSources={app.spec.sources && app.spec.sources.length > 0}
         />
     );
 };

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -473,6 +473,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                 title={app.metadata.name.toLocaleUpperCase()}
                 items={attributes}
                 onModeSwitch={() => notificationSubscriptions.onResetNotificationSubscriptions()}
+                hasMultipleSources={app.spec.sources && app.spec.sources.length > 0}
             />
             <Consumer>
                 {ctx => (

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -21,7 +21,7 @@ import {services} from '../../../shared/services';
 
 import {ApplicationSyncOptionsField} from '../application-sync-options/application-sync-options';
 import {RevisionFormField} from '../revision-form-field/revision-form-field';
-import {ComparisonStatusIcon, HealthStatusIcon, syncStatusMessage, urlPattern, formatCreationTimestamp, getAppDefaultSource, getAppSpecDefaultSource} from '../utils';
+import {ComparisonStatusIcon, HealthStatusIcon, syncStatusMessage, urlPattern, formatCreationTimestamp, getAppDefaultSource, getAppSpecDefaultSource, helpTip} from '../utils';
 import {ApplicationRetryOptions} from '../application-retry-options/application-retry-options';
 import {ApplicationRetryView} from '../application-retry-view/application-retry-view';
 import {Link} from 'react-router-dom';
@@ -52,6 +52,8 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
 
     const notificationSubscriptions = useEditNotificationSubscriptions(app.metadata.annotations || {});
     const updateApp = notificationSubscriptions.withNotificationSubscriptions(props.updateApp);
+
+    const hasMultipleSources = app.spec.sources && app.spec.sources.length > 0;
 
     const attributes = [
         {
@@ -159,7 +161,12 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
         {
             title: 'REPO URL',
             view: <Repo url={source.repoURL} />,
-            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.repoURL' component={Text} />
+            edit: (formApi: FormApi) =>
+                hasMultipleSources ? (
+                    helpTip('REPO URL is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
+                ) : (
+                    <FormField formApi={formApi} field='spec.source.repoURL' component={Text} />
+                )
         },
         ...(isHelm
             ? [
@@ -170,54 +177,62 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                               {source.chart}:{source.targetRevision}
                           </span>
                       ),
-                      edit: (formApi: FormApi) => (
-                          <DataLoader
-                              input={{repoURL: getAppSpecDefaultSource(formApi.getFormState().values.spec).repoURL}}
-                              load={src => services.repos.charts(src.repoURL).catch(() => new Array<models.HelmChart>())}>
-                              {(charts: models.HelmChart[]) => (
-                                  <div className='row'>
-                                      <div className='columns small-8'>
-                                          <FormField
-                                              formApi={formApi}
-                                              field='spec.source.chart'
-                                              component={AutocompleteField}
-                                              componentProps={{
-                                                  items: charts.map(chart => chart.name),
-                                                  filterSuggestions: true
-                                              }}
-                                          />
+                      edit: (formApi: FormApi) =>
+                          hasMultipleSources ? (
+                              helpTip('CHART is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
+                          ) : (
+                              <DataLoader
+                                  input={{repoURL: getAppSpecDefaultSource(formApi.getFormState().values.spec).repoURL}}
+                                  load={src => services.repos.charts(src.repoURL).catch(() => new Array<models.HelmChart>())}>
+                                  {(charts: models.HelmChart[]) => (
+                                      <div className='row'>
+                                          <div className='columns small-8'>
+                                              <FormField
+                                                  formApi={formApi}
+                                                  field='spec.source.chart'
+                                                  component={AutocompleteField}
+                                                  componentProps={{
+                                                      items: charts.map(chart => chart.name),
+                                                      filterSuggestions: true
+                                                  }}
+                                              />
+                                          </div>
+                                          <DataLoader
+                                              input={{charts, chart: getAppSpecDefaultSource(formApi.getFormState().values.spec).chart}}
+                                              load={async data => {
+                                                  const chartInfo = data.charts.find(chart => chart.name === data.chart);
+                                                  return (chartInfo && chartInfo.versions) || new Array<string>();
+                                              }}>
+                                              {(versions: string[]) => (
+                                                  <div className='columns small-4'>
+                                                      <FormField
+                                                          formApi={formApi}
+                                                          field='spec.source.targetRevision'
+                                                          component={AutocompleteField}
+                                                          componentProps={{
+                                                              items: versions
+                                                          }}
+                                                      />
+                                                      <RevisionHelpIcon type='helm' top='0' />
+                                                  </div>
+                                              )}
+                                          </DataLoader>
                                       </div>
-                                      <DataLoader
-                                          input={{charts, chart: getAppSpecDefaultSource(formApi.getFormState().values.spec).chart}}
-                                          load={async data => {
-                                              const chartInfo = data.charts.find(chart => chart.name === data.chart);
-                                              return (chartInfo && chartInfo.versions) || new Array<string>();
-                                          }}>
-                                          {(versions: string[]) => (
-                                              <div className='columns small-4'>
-                                                  <FormField
-                                                      formApi={formApi}
-                                                      field='spec.source.targetRevision'
-                                                      component={AutocompleteField}
-                                                      componentProps={{
-                                                          items: versions
-                                                      }}
-                                                  />
-                                                  <RevisionHelpIcon type='helm' top='0' />
-                                              </div>
-                                          )}
-                                      </DataLoader>
-                                  </div>
-                              )}
-                          </DataLoader>
-                      )
+                                  )}
+                              </DataLoader>
+                          )
                   }
               ]
             : [
                   {
                       title: 'TARGET REVISION',
                       view: <Revision repoUrl={source.repoURL} revision={source.targetRevision || 'HEAD'} />,
-                      edit: (formApi: FormApi) => <RevisionFormField helpIconTop={'0'} hideLabel={true} formApi={formApi} repoURL={source.repoURL} />
+                      edit: (formApi: FormApi) =>
+                          hasMultipleSources ? (
+                              helpTip('TARGET REVISION is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
+                          ) : (
+                              <RevisionFormField helpIconTop={'0'} hideLabel={true} formApi={formApi} repoURL={source.repoURL} />
+                          )
                   },
                   {
                       title: 'PATH',
@@ -226,7 +241,12 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                               {source.path ?? ''}
                           </Revision>
                       ),
-                      edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.path' component={Text} />
+                      edit: (formApi: FormApi) =>
+                          hasMultipleSources ? (
+                              helpTip('PATH is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
+                          ) : (
+                              <FormField formApi={formApi} field='spec.source.path' component={Text} />
+                          )
                   }
               ]),
 
@@ -473,7 +493,6 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                 title={app.metadata.name.toLocaleUpperCase()}
                 items={attributes}
                 onModeSwitch={() => notificationSubscriptions.onResetNotificationSubscriptions()}
-                hasMultipleSources={app.spec.sources && app.spec.sources.length > 0}
             />
             <Consumer>
                 {ctx => (

--- a/ui/src/app/shared/components/editable-panel/editable-panel.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.tsx
@@ -2,6 +2,7 @@ import {ErrorNotification, NotificationType} from 'argo-ui';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import {Form, FormApi} from 'react-form';
+import {helpTip} from '../../../applications/components/utils';
 
 import {Consumer} from '../../context';
 import {Spinner} from '../spinner';
@@ -25,6 +26,7 @@ export interface EditablePanelProps<T> {
     noReadonlyMode?: boolean;
     view?: string | React.ReactNode;
     edit?: (formApi: FormApi) => React.ReactNode;
+    hasMultipleSources?: boolean;
 }
 
 interface EditablePanelState {
@@ -64,7 +66,10 @@ export class EditablePanel<T = {}> extends React.Component<EditablePanelProps<T>
                                                 this.setState({edit: true});
                                                 this.onModeSwitch();
                                             }}
+                                            disabled={this.props.hasMultipleSources}
                                             className='argo-button argo-button--base'>
+                                            {this.props.hasMultipleSources &&
+                                                helpTip('Parameters are not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')}{' '}
                                             Edit
                                         </button>
                                     )}


### PR DESCRIPTION
fix: disable edit button on App Details Summary and Parameters tabs multi-source apps

fixes #11757 & #11758

* Summary Tab
![image](https://user-images.githubusercontent.com/46771830/216404263-febe5165-493b-4ca5-ab71-cb63a0e12e65.png)


* Parameters Tab
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/46771830/213520974-c74351d1-8d1c-4a19-9582-9b9018349895.png">


Signed-off-by: ishitasequeira <ishiseq29@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

