### PR TITLE
chore: disable docker sbom and attestations

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -62,7 +62,7 @@ jobs:
             IMAGE_PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           fi
           echo "Building image for platforms: $IMAGE_PLATFORMS"
-          docker buildx build --platform $IMAGE_PLATFORMS --push="${{ github.event_name == 'push' }}" \
+          docker buildx build --platform $IMAGE_PLATFORMS --sbom=false --provenance=false --push="${{ github.event_name == 'push' }}" \
             -t ghcr.io/argoproj/argo-cd/argocd:${{ steps.image.outputs.tag }} \
             -t quay.io/argoproj/argocd:latest .
         working-directory: ./src/github.com/argoproj/argo-cd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -207,7 +207,7 @@ jobs:
           set -ue
           git clean -fd
           mkdir -p dist/
-          docker buildx build --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le --push -t ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION} -t argoproj/argocd:v${TARGET_VERSION} .
+          docker buildx build --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le --sbom=false --provenance=false --push -t ${IMAGE_NAMESPACE}/argocd:v${TARGET_VERSION} -t argoproj/argocd:v${TARGET_VERSION} .
           make release-cli
           make checksums
           chmod +x ./dist/argocd-linux-amd64


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>


The newer [BuildKit v0.11](https://www.docker.com/blog/highlights-buildkit-v0-11-release/) now enables a provenance attestation by default. These attestations are stored as a manifest object of `unknown on unknown` attached to the root image index object.  `"To prevent container runtimes from accidentally pulling or running the image described in the manifest, the platform property of the attestation manifest will be set to unknown/unknown"`  This prevents our current Sbom generation from working properly.  

This PR is a workaround by disabling attestations and sboms by default.

Note:  I have tested this workaround locally.

![image](https://user-images.githubusercontent.com/76892343/213659204-a298b001-e93c-473d-9d21-c89edccf3ed8.png)
