### PR TITLE
docs: Fix list formatting in "Resource Actions" docs page

### DIFF
--- a/docs/operator-manual/resource_actions.md
+++ b/docs/operator-manual/resource_actions.md
@@ -9,9 +9,8 @@ Operators can add actions to custom resources in form of a Lua script and expand
 
 Argo CD supports custom resource actions written in [Lua](https://www.lua.org/). This is useful if you:
 
-    * Have a custom resource for which Argo CD does not provide any built-in actions.
-    * Have a commonly performed manual task that might be error prone if executed by users via `kubectl`
-
+* Have a custom resource for which Argo CD does not provide any built-in actions.
+* Have a commonly performed manual task that might be error prone if executed by users via `kubectl`
 
 You can define your own custom resource actions in the `argocd-cm` ConfigMap.
 


### PR DESCRIPTION
Signed-off-by: James Brady <goodgravy@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. (N/A: just a docs fix)
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A: just a docs fix)
* [x] Does this PR require documentation updates? Yes – in this PR 😬 
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. (N/A: just a docs fix)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

