### PR TITLE
feat(UI): allow applications to declare default view preferences (#12019)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -16,7 +16,7 @@ import {AppDetailsPreferences, AppsDetailsViewKey, AppsDetailsViewType, services
 import {ApplicationConditions} from '../application-conditions/application-conditions';
 import {ApplicationDeploymentHistory} from '../application-deployment-history/application-deployment-history';
 import {ApplicationOperationState} from '../application-operation-state/application-operation-state';
-import {PodView} from '../application-pod-view/pod-view';
+import {PodGroupType, PodView} from '../application-pod-view/pod-view';
 import {ApplicationResourceTree, ResourceTreeNode} from '../application-resource-tree/application-resource-tree';
 import {ApplicationStatusPanel} from '../application-status-panel/application-status-panel';
 import {ApplicationSyncPanel} from '../application-sync-panel/application-sync-panel';
@@ -169,6 +169,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
                         load={name =>
                             combineLatest([this.loadAppInfo(name, this.appNamespace), services.viewPreferences.getPreferences(), q]).pipe(
                                 map(items => {
+                                    const application = items[0].application;
                                     const pref = items[1].appDetails;
                                     const params = items[2];
                                     if (params.get('resource') != null) {
@@ -179,9 +180,26 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
                                     }
                                     if (params.get('view') != null) {
                                         pref.view = params.get('view') as AppsDetailsViewType;
+                                    } else {
+                                        const appDefaultView = (application.metadata &&
+                                            application.metadata.annotations &&
+                                            application.metadata.annotations[appModels.AnnotationDefaultView]) as AppsDetailsViewType;
+                                        if (appDefaultView != null) {
+                                            pref.view = appDefaultView;
+                                        }
                                     }
                                     if (params.get('orphaned') != null) {
                                         pref.orphanedResources = params.get('orphaned') === 'true';
+                                    }
+                                    if (params.get('podSortMode') != null) {
+                                        pref.podView.sortMode = params.get('podSortMode') as PodGroupType;
+                                    } else {
+                                        const appDefaultPodSort = (application.metadata &&
+                                            application.metadata.annotations &&
+                                            application.metadata.annotations[appModels.AnnotationDefaultPodSort]) as PodGroupType;
+                                        if (appDefaultPodSort != null) {
+                                            pref.podView.sortMode = appDefaultPodSort;
+                                        }
                                     }
                                     return {...items[0], pref};
                                 })

--- a/ui/src/app/applications/components/application-pod-view/pod-view.tsx
+++ b/ui/src/app/applications/components/application-pod-view/pod-view.tsx
@@ -285,6 +285,7 @@ export class PodView extends React.Component<PodViewProps> {
                 </React.Fragment>
             ),
             action: () => {
+                this.appContext.apis.navigation.goto('.', {podSortMode: mode});
                 services.viewPreferences.updatePreferences({appDetails: {...prefs.appDetails, podView: {...podPrefs, sortMode: mode}}});
             }
         }));

--- a/ui/src/app/shared/models.ts
+++ b/ui/src/app/shared/models.ts
@@ -123,6 +123,8 @@ export interface ResourceResult {
 export const AnnotationRefreshKey = 'argocd.argoproj.io/refresh';
 export const AnnotationHookKey = 'argocd.argoproj.io/hook';
 export const AnnotationSyncWaveKey = 'argocd.argoproj.io/sync-wave';
+export const AnnotationDefaultView = 'pref.argocd.argoproj.io/default-view';
+export const AnnotationDefaultPodSort = 'pref.argocd.argoproj.io/default-pod-sort';
 
 export interface Application {
     apiVersion?: string;


### PR DESCRIPTION
setting these annotations on the Application:

```
'pref.argocd.argoproj.io/default-view': 'pods'
'pref.argocd.argoproj.io/default-pod-sort': 'parentResource'
```
would land the user on the parentResource view (which is way less expensive to render than the treeView, for applications that have more than 200 resources.

<img width="1203" alt="Screenshot 2023-01-23 at 13 46 29" src="https://user-images.githubusercontent.com/346576/214043249-d39c6d13-1570-402c-a339-b44b5f760b18.png">


partial fix of #12019 

Signed-off-by: Alex Eftimie <alex.eftimie@getyourguide.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

