### PR TITLE
docs: how to change default application details view

### DIFF
--- a/docs/operator-manual/ui-customization.md
+++ b/docs/operator-manual/ui-customization.md
@@ -1,0 +1,9 @@
+# UI Customization
+
+## Default Application Details View
+
+By default, the Application Details will show the `Tree` view.
+
+This can be configured on an Application basis, by setting the `pref.argocd.argoproj.io/default-view` annotation, accepting one of: `tree`, `pods`, `network`, `list` as values.
+
+For the Pods view, the default grouping mechanism can be configured using the `pref.argocd.argoproj.io/default-pod-sort` annotation, accepting one of: `node`, `parentResource`, `topLevelResource` as values.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
   - operator-manual/resource_actions.md
   - operator-manual/custom_tools.md
   - operator-manual/custom-styles.md
+  - operator-manual/ui-customization.md
   - operator-manual/metrics.md
   - operator-manual/web_based_terminal.md
   - operator-manual/config-management-plugins.md


### PR DESCRIPTION
this is the documentation for the new feature introduced in https://github.com/argoproj/argo-cd/pull/12080.

i didn't mention UI view extensions as I couldn't find it yet in the other docs

Signed-off-by: Alex Eftimie <alex.eftimie@getyourguide.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

