### PR TITLE
docs: add explanation for duplicate key comparison error

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -225,3 +225,7 @@ resource.customizations.health.bitnami.com_SealedSecret: |
   hs.message = "Controller doesn't report resource status"
   return hs
 ```
+
+## My syncs are failing with a ComparisonError `The order in patch list … doesn't match $setElementOrder list: …`
+The YAML file from where this error comes from has a duplicate key, value pair
+


### PR DESCRIPTION
Adds a faq entry for the behaviour described in https://github.com/argoproj/argo-cd/issues/4071

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

