### PR TITLE
docs: Fix app patch doc

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2452,12 +2452,11 @@ func NewApplicationPatchCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 	command := cobra.Command{
 		Use:   "patch APPNAME",
 		Short: "Patch application",
-		Long: `Examples:
-	# Update an application's source path using json patch
-	argocd app patch myapplication --patch='[{"op": "replace", "path": "/spec/source/path", "value": "newPath"}]' --type json
+		Example: `  # Update an application's source path using json patch
+  argocd app patch myapplication --patch='[{"op": "replace", "path": "/spec/source/path", "value": "newPath"}]' --type json
 
-	# Update an application's repository target revision using merge patch
-	argocd app patch myapplication --patch '{"spec": { "source": { "targetRevision": "master" } }}' --type merge`,
+  # Update an application's repository target revision using merge patch
+  argocd app patch myapplication --patch '{"spec": { "source": { "targetRevision": "master" } }}' --type merge`,
 		Run: func(c *cobra.Command, args []string) {
 			ctx := c.Context()
 

--- a/docs/user-guide/commands/argocd_app_patch.md
+++ b/docs/user-guide/commands/argocd_app_patch.md
@@ -2,17 +2,18 @@
 
 Patch application
 
-### Synopsis
-
-Examples:
-	# Update an application's source path using json patch
-	argocd app patch myapplication --patch='[{"op": "replace", "path": "/spec/source/path", "value": "newPath"}]' --type json
-
-	# Update an application's repository target revision using merge patch
-	argocd app patch myapplication --patch '{"spec": { "source": { "targetRevision": "master" } }}' --type merge
-
 ```
 argocd app patch APPNAME [flags]
+```
+
+### Examples
+
+```
+  # Update an application's source path using json patch
+  argocd app patch myapplication --patch='[{"op": "replace", "path": "/spec/source/path", "value": "newPath"}]' --type json
+
+  # Update an application's repository target revision using merge patch
+  argocd app patch myapplication --patch '{"spec": { "source": { "targetRevision": "master" } }}' --type merge
 ```
 
 ### Options


### PR DESCRIPTION
The doc currently looks a bit messed up on the docs site:
![Screenshot from 2023-01-27 13-37-06](https://user-images.githubusercontent.com/6567012/215099964-4373ee85-4a74-4977-b5d9-ef7f1c6c251c.png)

This PR fixes that and aligns the page with other command reference docs (I copied the structure used in the app create doc)

Signed-off-by: Lawrence Carvalho <lacarvalho91@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

