### PR TITLE
chore: add destination.name example

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -142,7 +142,10 @@ spec:
 
   # Destination cluster and namespace to deploy the application
   destination:
+    # cluster API URL
     server: https://kubernetes.default.svc
+    # or cluster name
+    # name: in-cluster
     # The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
     namespace: guestbook
 


### PR DESCRIPTION
I had trouble finding the documentation to use the cluster name for destination, instead of the full URL. This is really useful.

Use case: we manage multiple clusters, destination.name is a better way to set destination.

Signed-off-by: Thomas Decaux <ebuildy@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

