### PR TITLE
fix: return nil if reading application set was successful

### DIFF
--- a/cmd/util/applicationset.go
+++ b/cmd/util/applicationset.go
@@ -61,6 +61,6 @@ func readAppset(yml []byte, appsets *[]*argoprojiov1alpha1.ApplicationSet) error
 		*appsets = append(*appsets, &appset)
 
 	}
-
-	return fmt.Errorf("error reading app set: %w", err)
+	// we reach here if there is no error found while reading the Application Set
+	return nil
 }


### PR DESCRIPTION
Fix the return statement. We need to send nil instead of a formatted error. (Discussion is slack [thread](https://cloud-native.slack.com/archives/C01TSERG0KZ/p1675258511753459))


Signed-off-by: ishitasequeira <ishiseq29@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

