### PR TITLE
chore: code clean for hack known_types.go

### DIFF
--- a/hack/known_types/main.go
+++ b/hack/known_types/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"go/importer"
+	"go/token"
 	"go/types"
 	"os"
 	"strings"
@@ -36,15 +37,16 @@ func newCommand() *cobra.Command {
 			packagePath := args[1]
 			outputPath := args[2]
 
-			// nolint:staticcheck
-			imprt := importer.For("source", nil)
+			if !strings.HasPrefix(packagePath, packagePrefix) {
+				return fmt.Errorf("package must be under %s", packagePrefix)
+			}
+
+			imprt := importer.ForCompiler(token.NewFileSet(), "source", nil)
 			pkg, err := imprt.Import(packagePath)
 			if err != nil {
 				return err
 			}
-			if !strings.HasPrefix(packagePath, packagePrefix) {
-				return fmt.Errorf("package must be under %s", packagePrefix)
-			}
+
 			shortPackagePath := strings.TrimPrefix(packagePath, packagePrefix)
 
 			var mapItems []string


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

update Deprecated codes , and other tiny codes for the if condition .```if !strings.HasPrefix(packagePath, packagePrefix) {```
[Deprecated: Use ForCompiler, which populates a FileSet with the positions of objects created by the importer.](https://pkg.go.dev/go/importer#For)