### PR TITLE
chore: use openssf scorecard and enable badge

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,62 @@
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: "39 9 * * 2"
+  push:
+    branches: ["main"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge. (Upcoming feature)
+      id-token: write
+      # Needs for private repositories.
+      contents: read
+      actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) Read-only PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecards on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@3ebbd71c74ef574dbc558c82f70e52732c8b44fe # v2.2.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -5,7 +5,11 @@ on:
   schedule:
     - cron: "39 9 * * 2"
   push:
-    branches: ["main"]
+    branches: ["master"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -13,7 +17,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -22,6 +26,7 @@ jobs:
       # Needs for private repositories.
       contents: read
       actions: read
+    if: github.repository == 'argoproj/argo-cd'
 
     steps:
       - name: "Checkout code"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Integration tests](https://github.com/argoproj/argo-cd/workflows/Integration%20tests/badge.svg?branch=master)](https://github.com/argoproj/argo-cd/actions?query=workflow%3A%22Integration+tests%22)
 [![codecov](https://codecov.io/gh/argoproj/argo-cd/branch/master/graph/badge.svg)](https://codecov.io/gh/argoproj/argo-cd)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4486/badge)](https://bestpractices.coreinfrastructure.org/projects/4486)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/argoproj/argo-cd/badge)](https://api.securityscorecards.dev/projects/github.com/argoproj/argo-cd)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fargoproj%2Fargo-cd.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fargoproj%2Fargo-cd?ref=badge_shield)
 
 **Social:**


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

[OpenSSF Scorecard](https://github.com/ossf/scorecard#openssf-scorecard) can be used to help improve and maintain security best practices.  Remediation steps and how to improve our score will be listed under the Security tab under the Code Scanning section.   Argo CD is already included in the weekly scan of over 1 million projects. Currently Argo CD has an impressive score of `8.7`. A current score can be checked by making a simple api request using the following command.
```bash
curl https://api.securityscorecards.dev/projects/github.com/argoproj/argo-cd | jq 
```
Current OpenSSF scorecard scores for graduated projects

|Project      |Score |Has a badge on GitHub |
|--------------|-----|-------|
|argo-cd       | 8.7 |
|argo-rollouts | 7.4 |
|argo-events   | 7.0 |
|argo-workflows| 8.3 |
|-----------------------|------|
|containerD    | 7.6 |
|coreDNS       | 6.9 |
|envoy         | 8.4 |
|etcd          | 7.5 | * |
|fluentd       | 5.9 |
|flux          | 9.0 |
|harbor        | 7.8 |
|helm          | 8.0 |
|jaeger        | 7.3 |
|kubernets     | 6.7 |
|linkerd       | 8.6 |
|OPA           | 8.6 |
|prometheus    | 7.3 |
|rook          | 7.4 |
|spiffe        | 6.1 |
|sprire        | 6.8 |
|tuf           | 9.2 | * |
|tikv          | 6.7 |
|vitess        | 7.5 |


