### PR TITLE
chore: delete unused code for admin-settings-rbac.

### DIFF
--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -292,11 +292,9 @@ func getPolicyFromConfigMap(cm *corev1.ConfigMap) (string, string, string) {
 	if !ok {
 		userPolicy = ""
 	}
-	if defaultRole == "" {
-		defaultRole, ok = cm.Data[rbac.ConfigMapPolicyDefaultKey]
-		if !ok {
-			defaultRole = ""
-		}
+	defaultRole, ok = cm.Data[rbac.ConfigMapPolicyDefaultKey]
+	if !ok {
+		defaultRole = ""
 	}
 
 	return userPolicy, defaultRole, cm.Data[rbac.ConfigMapMatchModeKey]


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

delete unused code for admin-settings-rbac.