### PR TITLE
chore: use http constants instead of string

### DIFF
--- a/applicationset/services/pull_request/bitbucket_server_test.go
+++ b/applicationset/services/pull_request/bitbucket_server_test.go
@@ -158,7 +158,7 @@ func TestListPullRequestBasicAuth(t *testing.T) {
 
 func TestListResponseError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
 	svc, _ := NewBitbucketServiceNoAuth(context.Background(), ts.URL, "PROJECT", "REPO")

--- a/applicationset/services/scm_provider/bitbucket_cloud.go
+++ b/applicationset/services/scm_provider/bitbucket_cloud.go
@@ -29,7 +29,7 @@ func (c *ExtendedClient) GetContents(repo *Repository, path string) (bool, error
 	urlStr += fmt.Sprintf("/repositories/%s/%s/src/%s/%s?format=meta", c.owner, repo.Repository, repo.SHA, path)
 	body := strings.NewReader("")
 
-	req, err := http.NewRequest("GET", urlStr, body)
+	req, err := http.NewRequest(http.MethodGet, urlStr, body)
 	if err != nil {
 		return false, err
 	}

--- a/applicationset/services/scm_provider/bitbucket_server_test.go
+++ b/applicationset/services/scm_provider/bitbucket_server_test.go
@@ -347,7 +347,7 @@ func TestGetBranchesMissingDefault(t *testing.T) {
 		assert.Empty(t, r.Header.Get("Authorization"))
 		switch r.RequestURI {
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/branches/default":
-			http.Error(w, "Not found", 404)
+			http.Error(w, "Not found", http.StatusNotFound)
 		}
 		defaultHandler(t)(w, r)
 	}))
@@ -370,7 +370,7 @@ func TestGetBranchesErrorDefaultBranch(t *testing.T) {
 		assert.Empty(t, r.Header.Get("Authorization"))
 		switch r.RequestURI {
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/branches/default":
-			http.Error(w, "Internal server error", 500)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 		}
 		defaultHandler(t)(w, r)
 	}))
@@ -442,7 +442,7 @@ func TestListReposMissingDefaultBranch(t *testing.T) {
 		assert.Empty(t, r.Header.Get("Authorization"))
 		switch r.RequestURI {
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/branches/default":
-			http.Error(w, "Not found", 404)
+			http.Error(w, "Not found", http.StatusNotFound)
 		}
 		defaultHandler(t)(w, r)
 	}))
@@ -459,7 +459,7 @@ func TestListReposErrorDefaultBranch(t *testing.T) {
 		assert.Empty(t, r.Header.Get("Authorization"))
 		switch r.RequestURI {
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/branches/default":
-			http.Error(w, "Internal server error", 500)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 		}
 		defaultHandler(t)(w, r)
 	}))
@@ -516,17 +516,17 @@ func TestBitbucketServerHasPath(t *testing.T) {
 			_, err = io.WriteString(w, `{"type":"FILE"}`)
 
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/browse/anotherpkg/missing.txt?at=main&limit=100&type=true":
-			http.Error(w, "The path \"anotherpkg/missing.txt\" does not exist at revision \"main\"", 404)
+			http.Error(w, "The path \"anotherpkg/missing.txt\" does not exist at revision \"main\"", http.StatusNotFound)
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/browse/notathing?at=main&limit=100&type=true":
-			http.Error(w, "The path \"notathing\" does not exist at revision \"main\"", 404)
+			http.Error(w, "The path \"notathing\" does not exist at revision \"main\"", http.StatusNotFound)
 
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/browse/return-redirect?at=main&limit=100&type=true":
-			http.Redirect(w, r, "http://"+r.Host+"/rest/api/1.0/projects/PROJECT/repos/REPO/browse/redirected?at=main&limit=100&type=true", 301)
+			http.Redirect(w, r, "http://"+r.Host+"/rest/api/1.0/projects/PROJECT/repos/REPO/browse/redirected?at=main&limit=100&type=true", http.StatusMovedPermanently)
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/browse/redirected?at=main&limit=100&type=true":
 			_, err = io.WriteString(w, `{"type":"DIRECTORY"}`)
 
 		case "/rest/api/1.0/projects/PROJECT/repos/REPO/browse/unauthorized-response?at=main&limit=100&type=true":
-			http.Error(w, "Authentication failed", 401)
+			http.Error(w, "Authentication failed", http.StatusUnauthorized)
 
 		default:
 			t.Fail()

--- a/applicationset/services/scm_provider/gitea.go
+++ b/applicationset/services/scm_provider/gitea.go
@@ -47,7 +47,7 @@ func NewGiteaProvider(ctx context.Context, owner, token, url string, allBranches
 func (g *GiteaProvider) GetBranches(ctx context.Context, repo *Repository) ([]*Repository, error) {
 	if !g.allBranches {
 		branch, status, err := g.client.GetRepoBranch(g.owner, repo.Repository, repo.Branch)
-		if status.StatusCode == 404 {
+		if status.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("got 404 while getting default branch %q for repo %q - check your repo config: %w", repo.Branch, repo.Repository, err)
 		}
 		if err != nil {

--- a/applicationset/services/scm_provider/gitea_test.go
+++ b/applicationset/services/scm_provider/gitea_test.go
@@ -247,7 +247,7 @@ func giteaMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 			_, err := io.WriteString(w, testdata.ReposGiteaGoSdkContentsGiteaResponse)
 			require.NoError(t, err)
 		case "/api/v1/repos/gitea/go-sdk/contents/notathing?ref=master":
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 			_, err := io.WriteString(w, `{"errors":["object does not exist [id: , rel_path: notathing]"],"message":"GetContentsOrList","url":"https://gitea.com/api/swagger"}`)
 			require.NoError(t, err)
 		default:

--- a/applicationset/services/scm_provider/github.go
+++ b/applicationset/services/scm_provider/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/google/go-github/v35/github"
@@ -123,7 +124,7 @@ func (g *GithubProvider) listBranches(ctx context.Context, repo *Repository) ([]
 		if err != nil {
 			var githubErrorResponse *github.ErrorResponse
 			if errors.As(err, &githubErrorResponse) {
-				if githubErrorResponse.Response.StatusCode == 404 {
+				if githubErrorResponse.Response.StatusCode == http.StatusNotFound {
 					// Default branch doesn't exist, so the repo is empty.
 					return []github.Branch{}, nil
 				}

--- a/applicationset/services/scm_provider/github_test.go
+++ b/applicationset/services/scm_provider/github_test.go
@@ -196,7 +196,7 @@ func githubMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 				t.Fail()
 			}
 		default:
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 }

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -133,7 +133,7 @@ func (h *WebhookHandler) Handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Infof("Webhook processing failed: %s", err)
 		status := http.StatusBadRequest
-		if r.Method != "POST" {
+		if r.Method != http.MethodPost {
 			status = http.StatusMethodNotAllowed
 		}
 		http.Error(w, fmt.Sprintf("Webhook processing failed: %s", html.EscapeString(err.Error())), status)

--- a/applicationset/webhook/webhook_test.go
+++ b/applicationset/webhook/webhook_test.go
@@ -177,7 +177,7 @@ func TestWebhookHandler(t *testing.T) {
 			h, err := NewWebhookHandler(namespace, set, fc, mockGenerators())
 			assert.Nil(t, err)
 
-			req := httptest.NewRequest("POST", "/api/webhook", nil)
+			req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 			req.Header.Set(test.headerKey, test.headerValue)
 			eventJSON, err := os.ReadFile(filepath.Join("testdata", test.payloadFile))
 			assert.NoError(t, err)

--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -207,7 +207,7 @@ func runTest(t *testing.T, cfg TestMetricServerConfig) {
 		metricsServ.registry.MustRegister(collector)
 	}
 
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	assert.NoError(t, err)
 	rr := httptest.NewRecorder()
 	metricsServ.Handler.ServeHTTP(rr, req)
@@ -337,7 +337,7 @@ argocd_app_sync_total{dest_server="https://localhost:6443",name="my-app",namespa
 	metricsServ.IncSync(fakeApp, &argoappv1.OperationState{Phase: common.OperationSucceeded})
 	metricsServ.IncSync(fakeApp, &argoappv1.OperationState{Phase: common.OperationSucceeded})
 
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	assert.NoError(t, err)
 	rr := httptest.NewRecorder()
 	metricsServ.Handler.ServeHTTP(rr, req)
@@ -391,7 +391,7 @@ argocd_app_reconcile_count{dest_server="https://localhost:6443",namespace="argoc
 	fakeApp := newFakeApp(fakeApp)
 	metricsServ.IncReconcile(fakeApp, 5*time.Second)
 
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	assert.NoError(t, err)
 	rr := httptest.NewRecorder()
 	metricsServ.Handler.ServeHTTP(rr, req)
@@ -415,7 +415,7 @@ argocd_app_sync_total{dest_server="https://localhost:6443",name="my-app",namespa
 argocd_app_sync_total{dest_server="https://localhost:6443",name="my-app",namespace="argocd",phase="Succeeded",project="important-project"} 2
 `
 
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	assert.NoError(t, err)
 	rr := httptest.NewRecorder()
 	metricsServ.Handler.ServeHTTP(rr, req)
@@ -426,7 +426,7 @@ argocd_app_sync_total{dest_server="https://localhost:6443",name="my-app",namespa
 	err = metricsServ.SetExpiration(time.Second)
 	assert.NoError(t, err)
 	time.Sleep(2 * time.Second)
-	req, err = http.NewRequest("GET", "/metrics", nil)
+	req, err = http.NewRequest(http.MethodGet, "/metrics", nil)
 	assert.NoError(t, err)
 	rr = httptest.NewRecorder()
 	metricsServ.Handler.ServeHTTP(rr, req)

--- a/hack/gen-resources/generators/repo_generator.go
+++ b/hack/gen-resources/generators/repo_generator.go
@@ -33,7 +33,7 @@ func NewRepoGenerator(clientSet *kubernetes.Clientset) Generator {
 
 func fetchRepos(token string, page int) ([]Repo, error) {
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", fmt.Sprintf("https://api.github.com/repos/argoproj/argocd-example-apps/forks?per_page=100&page=%v", page), nil)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("https://api.github.com/repos/argoproj/argocd-example-apps/forks?per_page=100&page=%v", page), nil)
 	req.Header.Set("Authorization", token)
 	resp, err := client.Do(req)
 	if err != nil {

--- a/server/application/terminal_test.go
+++ b/server/application/terminal_test.go
@@ -213,7 +213,7 @@ func TestTerminalHandler_ServeHTTP_empty_params(t *testing.T) {
 					paramsArray = append(paramsArray, key+"="+value)
 				}
 				paramsString := strings.Join(paramsArray, "&")
-				request := httptest.NewRequest("GET", "https://argocd.example.com/api/v1/terminal?"+paramsString, nil)
+				request := httptest.NewRequest(http.MethodGet, "https://argocd.example.com/api/v1/terminal?"+paramsString, nil)
 				recorder := httptest.NewRecorder()
 				handler.ServeHTTP(recorder, request)
 				response := recorder.Result()
@@ -225,7 +225,7 @@ func TestTerminalHandler_ServeHTTP_empty_params(t *testing.T) {
 
 func TestTerminalHandler_ServeHTTP_disallowed_namespace(t *testing.T) {
 	handler := terminalHandler{namespace: "argocd", enabledNamespaces: []string{"allowed"}}
-	request := httptest.NewRequest("GET", "https://argocd.example.com/api/v1/terminal?pod=valid&container=valid&appName=valid&projectName=valid&namespace=test&appNamespace=disallowed", nil)
+	request := httptest.NewRequest(http.MethodGet, "https://argocd.example.com/api/v1/terminal?pod=valid&container=valid&appName=valid&projectName=valid&namespace=test&appNamespace=disallowed", nil)
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, request)
 	response := recorder.Result()

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -61,7 +61,7 @@ var (
 func TestHandlerFeatureIsEnabled(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(&testApp), settingsMgr, "default")
-	req, err := http.NewRequest("GET", "/api/badge?name=testApp", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=testApp", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -113,7 +113,7 @@ func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
 		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), tt.namespace)
 		handler := NewHandler(appclientset.NewSimpleClientset(&testProject, tt.testApp[0], tt.testApp[1]), settingsMgr, tt.namespace)
 		rr := httptest.NewRecorder()
-		req, err := http.NewRequest("GET", tt.apiEndPoint, nil)
+		req, err := http.NewRequest(http.MethodGet, tt.apiEndPoint, nil)
 		assert.NoError(t, err)
 		handler.ServeHTTP(rr, req)
 		assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
@@ -177,7 +177,7 @@ func createApplications(appCombo, projectName []string, namespace string) []*v1a
 func TestHandlerFeatureIsEnabledRevisionIsEnabled(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(&testApp), settingsMgr, "default")
-	req, err := http.NewRequest("GET", "/api/badge?name=testApp&revision=true", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=testApp&revision=true", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -200,7 +200,7 @@ func TestHandlerRevisionIsEnabledNoOperationState(t *testing.T) {
 
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(app), settingsMgr, "default")
-	req, err := http.NewRequest("GET", "/api/badge?name=testApp&revision=true", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=testApp&revision=true", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -223,7 +223,7 @@ func TestHandlerRevisionIsEnabledShortCommitSHA(t *testing.T) {
 
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(&argoCDCm, &argoCDSecret), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(app), settingsMgr, "default")
-	req, err := http.NewRequest("GET", "/api/badge?name=testApp&revision=true", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=testApp&revision=true", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -240,7 +240,7 @@ func TestHandlerFeatureIsDisabled(t *testing.T) {
 
 	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCmDisabled, &argoCDSecret), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(&testApp), settingsMgr, "default")
-	req, err := http.NewRequest("GET", "/api/badge?name=testApp", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=testApp", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()

--- a/server/logout/logout_test.go
+++ b/server/logout/logout_test.go
@@ -251,17 +251,17 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 	invalidHeader := make(map[string][]string)
 	invalidHeader["Cookie"] = []string{"argocd.token=" + invalidToken}
 
-	oidcRequest, err := http.NewRequest("GET", "http://localhost:4000/api/logout", nil)
+	oidcRequest, err := http.NewRequest(http.MethodGet, "http://localhost:4000/api/logout", nil)
 	assert.NoError(t, err)
 	oidcRequest.Header = oidcTokenHeader
-	nonoidcRequest, err := http.NewRequest("GET", "http://localhost:4000/api/logout", nil)
+	nonoidcRequest, err := http.NewRequest(http.MethodGet, "http://localhost:4000/api/logout", nil)
 	assert.NoError(t, err)
 	nonoidcRequest.Header = nonOidcTokenHeader
 	assert.NoError(t, err)
-	requestWithInvalidToken, err := http.NewRequest("GET", "http://localhost:4000/api/logout", nil)
+	requestWithInvalidToken, err := http.NewRequest(http.MethodGet, "http://localhost:4000/api/logout", nil)
 	assert.NoError(t, err)
 	requestWithInvalidToken.Header = invalidHeader
-	invalidRequest, err := http.NewRequest("GET", "http://localhost:4000/api/logout", nil)
+	invalidRequest, err := http.NewRequest(http.MethodGet, "http://localhost:4000/api/logout", nil)
 	assert.NoError(t, err)
 
 	tests := []struct {

--- a/server/server_norace_test.go
+++ b/server/server_norace_test.go
@@ -111,7 +111,7 @@ func Test_StaticHeaders(t *testing.T) {
 
 		client := http.Client{}
 		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", s.ListenPort)
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		assert.NoError(t, err)
 		resp, err := client.Do(req)
 		assert.NoError(t, err)
@@ -140,7 +140,7 @@ func Test_StaticHeaders(t *testing.T) {
 
 		client := http.Client{}
 		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", s.ListenPort)
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		assert.NoError(t, err)
 		resp, err := client.Do(req)
 		assert.NoError(t, err)
@@ -172,7 +172,7 @@ func Test_StaticHeaders(t *testing.T) {
 
 		client := http.Client{}
 		url := fmt.Sprintf("http://127.0.0.1:%d/test.html", s.ListenPort)
-		req, err := http.NewRequest("GET", url, nil)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		assert.NoError(t, err)
 		resp, err := client.Do(req)
 		assert.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -518,7 +518,7 @@ func dexMockHandler(t *testing.T, url string) func(http.ResponseWriter, *http.Re
 				t.Fail()
 			}
 		default:
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 }

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -971,7 +971,7 @@ func githubSCMMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request)
 				t.Fail()
 			}
 		default:
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 }
@@ -1279,7 +1279,7 @@ func githubPullMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request
 				t.Fail()
 			}
 		default:
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 }

--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -75,7 +75,7 @@ func NewDexHTTPReverseProxy(serverAddr string, baseHRef string, tlsConfig *DexTL
 	}
 
 	proxy.ModifyResponse = func(resp *http.Response) error {
-		if resp.StatusCode == 500 {
+		if resp.StatusCode == http.StatusInternalServerError {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return err

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -425,7 +425,7 @@ func Test_DexReverseProxy(t *testing.T) {
 		defer server.Close()
 		rt := NewDexRewriteURLRoundTripper(server.URL, http.DefaultTransport)
 		assert.NotNil(t, rt)
-		req, err := http.NewRequest("GET", "/", bytes.NewBuffer([]byte("")))
+		req, err := http.NewRequest(http.MethodGet, "/", bytes.NewBuffer([]byte("")))
 		assert.NoError(t, err)
 		_, err = rt.RoundTrip(req)
 		assert.NoError(t, err)

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -198,7 +198,7 @@ func TestCustomHTTPClient(t *testing.T) {
 				assert.Nil(t, cert.PrivateKey)
 			}
 		}
-		req, err := http.NewRequest("GET", "http://proxy-from-env:7878", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://proxy-from-env:7878", nil)
 		assert.Nil(t, err)
 		proxy, err := transport.Proxy(req)
 		assert.Nil(t, err)

--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -45,14 +45,14 @@ func TestHealthCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Was expecting status code 200 from health check, but got %d instead", resp.StatusCode)
 	}
 
 	sentinel = true
 
 	resp, _ = http.Get(server + "/healthz")
-	if resp.StatusCode != 503 {
+	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("Was expecting status code 503 from health check, but got %d instead", resp.StatusCode)
 	}
 

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -286,7 +286,7 @@ func (c *nativeHelmChart) loadRepoIndex() ([]byte, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", indexURL, nil)
+	req, err := http.NewRequest(http.MethodGet, indexURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (c *nativeHelmChart) loadRepoIndex() ([]byte, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("failed to get index: " + resp.Status)
 	}
 	return io.ReadAll(resp.Body)
@@ -453,7 +453,7 @@ func sanitizeLog(input string) string {
 }
 
 func (c *nativeHelmChart) getTagsFromUrl(tagsURL string) ([]byte, string, error) {
-	req, err := http.NewRequest("GET", tagsURL, nil)
+	req, err := http.NewRequest(http.MethodGet, tagsURL, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed create request: %v", err)
 	}
@@ -486,7 +486,7 @@ func (c *nativeHelmChart) getTagsFromUrl(tagsURL string) ([]byte, string, error)
 		}
 	}()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		data, err := io.ReadAll(resp.Body)
 		var responseExcerpt string
 		if err != nil {

--- a/util/http/http_test.go
+++ b/util/http/http_test.go
@@ -56,7 +56,7 @@ func (rt TestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 
 func TestTransportWithHeader(t *testing.T) {
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", "/foo", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/foo", nil)
 	req.Header.Set("Bar", "req_1")
 	req.Header.Set("Foo", "req_1")
 

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -97,7 +97,7 @@ func (p *fakeProvider) Verify(_ string, _ *settings.ArgoCDSettings) (*gooidc.IDT
 func TestHandleCallback(t *testing.T) {
 	app := ClientApp{provider: &fakeProvider{}}
 
-	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
 	req.Form = url.Values{
 		"error":             []string{"login-failed"},
 		"error_description": []string{"<script>alert('hello')</script>"},
@@ -129,7 +129,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com")
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("GET", "https://argocd.example.com/auth/login", nil)
+		req := httptest.NewRequest(http.MethodGet, "https://argocd.example.com/auth/login", nil)
 
 		w := httptest.NewRecorder()
 
@@ -169,7 +169,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com")
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("GET", "https://argocd.example.com/auth/login", nil)
+		req := httptest.NewRequest(http.MethodGet, "https://argocd.example.com/auth/login", nil)
 
 		w := httptest.NewRecorder()
 
@@ -216,7 +216,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 	w := httptest.NewRecorder()
 
-	req := httptest.NewRequest("GET", "https://argocd.example.com/auth/login", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://argocd.example.com/auth/login", nil)
 
 	app.HandleLogin(w, req)
 
@@ -225,7 +225,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 	state := redirectUrl.Query()["state"]
 
-	req = httptest.NewRequest("GET", fmt.Sprintf("https://argocd.example.com/auth/callback?state=%s&code=abc", state), nil)
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://argocd.example.com/auth/callback?state=%s&code=abc", state), nil)
 	for _, cookie := range w.Result().Cookies() {
 		req.AddCookie(cookie)
 	}
@@ -257,7 +257,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com")
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("GET", "https://argocd.example.com/auth/callback", nil)
+		req := httptest.NewRequest(http.MethodGet, "https://argocd.example.com/auth/callback", nil)
 
 		w := httptest.NewRecorder()
 
@@ -297,7 +297,7 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 		app, err := NewClientApp(cdSettings, dexTestServer.URL, nil, "https://argocd.example.com")
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("GET", "https://argocd.example.com/auth/callback", nil)
+		req := httptest.NewRequest(http.MethodGet, "https://argocd.example.com/auth/callback", nil)
 
 		w := httptest.NewRecorder()
 
@@ -413,7 +413,7 @@ func TestGenerateAppState(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("VerifyAppState_Successful", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		for _, cookie := range generateResponse.Result().Cookies() {
 			req.AddCookie(cookie)
 		}
@@ -424,7 +424,7 @@ func TestGenerateAppState(t *testing.T) {
 	})
 
 	t.Run("VerifyAppState_Failed", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		for _, cookie := range generateResponse.Result().Cookies() {
 			req.AddCookie(cookie)
 		}
@@ -457,7 +457,7 @@ func TestGenerateAppState_XSS(t *testing.T) {
 		state, err := app.generateAppState(expectedReturnURL, generateResponse)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		for _, cookie := range generateResponse.Result().Cookies() {
 			req.AddCookie(cookie)
 		}
@@ -473,7 +473,7 @@ func TestGenerateAppState_XSS(t *testing.T) {
 		state, err := app.generateAppState(expectedReturnURL, generateResponse)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		for _, cookie := range generateResponse.Result().Cookies() {
 			req.AddCookie(cookie)
 		}
@@ -491,7 +491,7 @@ func TestGenerateAppState_NoReturnURL(t *testing.T) {
 	key, err := cdSettings.GetServerEncryptionKey()
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	encrypted, err := crypto.Encrypt([]byte("123"), key)
 	require.NoError(t, err)
 

--- a/util/proxy/proxy_test.go
+++ b/util/proxy/proxy_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -37,7 +38,7 @@ func TestGetCallBack(t *testing.T) {
 		proxyEnv := "http://proxy:8888"
 		os.Setenv("http_proxy", "http://proxy:8888")
 		defer os.Unsetenv("http_proxy")
-		url, err := GetCallback("")(httptest.NewRequest("GET", proxyEnv, nil))
+		url, err := GetCallback("")(httptest.NewRequest(http.MethodGet, proxyEnv, nil))
 		assert.Nil(t, err)
 		assert.Equal(t, proxyEnv, url.String())
 	})

--- a/util/swagger/swagger_test.go
+++ b/util/swagger/swagger_test.go
@@ -52,7 +52,7 @@ func TestSwaggerUI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Was expecting status code 200 from swagger-ui, but got %d instead", resp.StatusCode)
 	}
 }

--- a/util/test/testutil.go
+++ b/util/test/testutil.go
@@ -131,7 +131,7 @@ func dexMockHandler(t *testing.T, url string) func(http.ResponseWriter, *http.Re
 }`, url))
 			require.NoError(t, err)
 		default:
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 }
@@ -184,7 +184,7 @@ func oidcMockHandler(t *testing.T, url string) func(http.ResponseWriter, *http.R
 			_, err = io.WriteString(w, string(out))
 			require.NoError(t, err)
 		default:
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 }

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -439,7 +439,7 @@ func (a *ArgoCDWebhookHandler) Handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Infof("Webhook processing failed: %s", err)
 		status := http.StatusBadRequest
-		if r.Method != "POST" {
+		if r.Method != http.MethodPost {
 			status = http.StatusMethodNotAllowed
 		}
 		http.Error(w, fmt.Sprintf("Webhook processing failed: %s", html.EscapeString(err.Error())), status)

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -74,7 +74,7 @@ func NewMockHandler(reactor *reactorDef, objects ...runtime.Object) *ArgoCDWebho
 func TestGitHubCommitEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
 	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
 	assert.NoError(t, err)
@@ -127,7 +127,7 @@ func TestGitHubCommitEvent_MultiSource_Refresh(t *testing.T) {
 			},
 		},
 	})
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
 	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestGitHubCommitEvent_MultiSource_Refresh(t *testing.T) {
 func TestGitHubTagEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
 	eventJSON, err := os.ReadFile("testdata/github-tag-event.json")
 	assert.NoError(t, err)
@@ -160,7 +160,7 @@ func TestGitHubTagEvent(t *testing.T) {
 func TestGitHubPingEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "ping")
 	eventJSON, err := os.ReadFile("testdata/github-ping-event.json")
 	assert.NoError(t, err)
@@ -176,7 +176,7 @@ func TestGitHubPingEvent(t *testing.T) {
 func TestBitbucketServerRepositoryReferenceChangedEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-Event-Key", "repo:refs_changed")
 	eventJSON, err := os.ReadFile("testdata/bitbucket-server-event.json")
 	assert.NoError(t, err)
@@ -195,7 +195,7 @@ func TestBitbucketServerRepositoryDiagnosticPingEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
 	eventJSON := "{\"test\": true}"
-	req := httptest.NewRequest("POST", "/api/webhook", bytes.NewBufferString(eventJSON))
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", bytes.NewBufferString(eventJSON))
 	req.Header.Set("X-Event-Key", "diagnostics:ping")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
@@ -208,7 +208,7 @@ func TestBitbucketServerRepositoryDiagnosticPingEvent(t *testing.T) {
 func TestGogsPushEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-Gogs-Event", "push")
 	eventJSON, err := os.ReadFile("testdata/gogs-event.json")
 	assert.NoError(t, err)
@@ -224,7 +224,7 @@ func TestGogsPushEvent(t *testing.T) {
 func TestGitLabPushEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-Gitlab-Event", "Push Hook")
 	eventJSON, err := os.ReadFile("testdata/gitlab-event.json")
 	assert.NoError(t, err)
@@ -240,7 +240,7 @@ func TestGitLabPushEvent(t *testing.T) {
 func TestInvalidMethod(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("GET", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
@@ -254,7 +254,7 @@ func TestInvalidMethod(t *testing.T) {
 func TestInvalidEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)
@@ -268,7 +268,7 @@ func TestInvalidEvent(t *testing.T) {
 func TestUnknownEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-Unknown-Event", "push")
 	w := httptest.NewRecorder()
 	h.Handler(w, req)


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

