### PR TITLE
why does kustomize does what it does

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -127,6 +127,9 @@ jobs:
         run: |
           git config --global user.name "John Doe"
           git config --global user.email "john.doe@example.com"
+      - name: echo PATH
+        run: |
+          echo $PATH
       - name: Download and vendor all required packages
         run: |
           go mod download

--- a/test/manifests_test.go
+++ b/test/manifests_test.go
@@ -15,6 +15,7 @@ import (
 func TestKustomizeVersion(t *testing.T) {
 	test.CIOnly(t)
 	out, err := argoexec.RunCommand("kustomize", argoexec.CmdOpts{}, "version")
+	fmt.Println(os.Getenv("PATH"))
 	assert.NoError(t, err)
 	assert.Contains(t, out, "Version:kustomize/v4", "kustomize should be version 4")
 }


### PR DESCRIPTION
Signed-off-by: Michael Crenshaw <350466+crenshaw-dev@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

