### PR TITLE
fix: when resource does not exist node menu and resource details shou…

### DIFF
--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -286,7 +286,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                         const execEnabled = settings.execEnabled;
                         const logsAllowed = await services.accounts.canI('logs', 'get', application.spec.project + '/' + application.metadata.name);
                         const execAllowed = await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
-                        const links = await services.applications.getResourceLinks(application.metadata.name, application.metadata.namespace, selectedNode);
+                        const links = await services.applications.getResourceLinks(application.metadata.name, application.metadata.namespace, selectedNode).catch(() => null);
                         return {controlledState, liveState, events, podState, execEnabled, execAllowed, logsAllowed, links};
                     }}>
                     {data => (

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -491,17 +491,20 @@ function getActionItems(
 
     const resourceActions = getResourceActionsMenuItems(resource, application.metadata, appContext);
 
-    const links = services.applications.getResourceLinks(application.metadata.name, application.metadata.namespace, resource).then(data => {
-        return (data.items || []).map(
-            link =>
-                ({
-                    title: link.title,
-                    iconClassName: `fa ${link.iconClass ? link.iconClass : 'fa-external-link'}`,
-                    action: () => window.open(link.url, '_blank'),
-                    tooltip: link.description
-                } as MenuItem)
-        );
-    });
+    const links = services.applications
+        .getResourceLinks(application.metadata.name, application.metadata.namespace, resource)
+        .then(data => {
+            return (data.items || []).map(
+                link =>
+                    ({
+                        title: link.title,
+                        iconClassName: `fa ${link.iconClass ? link.iconClass : 'fa-external-link'}`,
+                        action: () => window.open(link.url, '_blank'),
+                        tooltip: link.description
+                    } as MenuItem)
+            );
+        })
+        .catch(() => [] as MenuItem[]);
 
     return combineLatest(
         from([items]), // this resolves immediately


### PR DESCRIPTION


When a resource is "missing" the resource tree action items menu and the resource details sliding panel would not render properly due to an uncaught error from the `GetResourceLinks` API

Signed-off-by: Joshua Helton <jdoghelton@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

