### PR TITLE
fix: Use CredsStore for GoogleCloudCreds

### DIFF
--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -202,7 +202,7 @@ func (repo *Repository) GetGitCreds(store git.CredsStore) git.Creds {
 		return git.NewGitHubAppCreds(repo.GithubAppId, repo.GithubAppInstallationId, repo.GithubAppPrivateKey, repo.GitHubAppEnterpriseBaseURL, repo.Repo, repo.TLSClientCertData, repo.TLSClientCertKey, repo.IsInsecure(), repo.Proxy, store)
 	}
 	if repo.GCPServiceAccountKey != "" {
-		return git.NewGoogleCloudCreds(repo.GCPServiceAccountKey)
+		return git.NewGoogleCloudCreds(repo.GCPServiceAccountKey, store)
 	}
 	return git.NopCreds{}
 }

--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -456,15 +456,16 @@ func (g GitHubAppCreds) GetClientCertKey() string {
 // GoogleCloudCreds to authenticate to Google Cloud Source repositories
 type GoogleCloudCreds struct {
 	creds *google.Credentials
+	store CredsStore
 }
 
-func NewGoogleCloudCreds(jsonData string) GoogleCloudCreds {
+func NewGoogleCloudCreds(jsonData string, store CredsStore) GoogleCloudCreds {
 	creds, err := google.CredentialsFromJSON(context.Background(), []byte(jsonData), "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		// Invalid JSON
 		log.Errorf("Failed reading credentials from JSON: %+v", err)
 	}
-	return GoogleCloudCreds{creds}
+	return GoogleCloudCreds{creds, store}
 }
 
 func (c GoogleCloudCreds) Environ() (io.Closer, []string, error) {
@@ -477,9 +478,13 @@ func (c GoogleCloudCreds) Environ() (io.Closer, []string, error) {
 		return NopCloser{}, nil, fmt.Errorf("failed to get access token from creds: %w", err)
 	}
 
-	env := []string{fmt.Sprintf("GIT_ASKPASS=%s", "git-ask-pass.sh"), fmt.Sprintf("GIT_USERNAME=%s", username), fmt.Sprintf("GIT_PASSWORD=%s", token)}
+	nonce := c.store.Add(username, token)
+	env := getGitAskPassEnv(nonce)
 
-	return NopCloser{}, env, nil
+	return argoioutils.NewCloser(func() error {
+		c.store.Remove(nonce)
+		return NopCloser{}.Close()
+	}), env, nil
 }
 
 func (c GoogleCloudCreds) getUsername() (string, error) {


### PR DESCRIPTION
git-ask-pass.sh is not longer supported for credentials

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Fixes #12390 