### PR TITLE
fix: setting spec.SyncPolicy crashes 'argocd appset get' output (#12424)

### DIFF
--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -343,16 +343,19 @@ func printAppSetSummaryTable(appSet *arogappsetv1.ApplicationSet) {
 	fmt.Printf(printOpFmtStr, "Path:", source.Path)
 	printAppSourceDetails(&source)
 
-	var syncPolicy string
-	if appSet.Spec.SyncPolicy != nil && appSet.Spec.Template.Spec.SyncPolicy.Automated != nil {
-		syncPolicy = "Automated"
-		if appSet.Spec.Template.Spec.SyncPolicy.Automated.Prune {
-			syncPolicy += " (Prune)"
+	var (
+		syncPolicyStr string
+		syncPolicy = appSet.Spec.Template.Spec.SyncPolicy
+	)
+	if syncPolicy != nil && syncPolicy.Automated != nil {
+		syncPolicyStr = "Automated"
+		if syncPolicy.Automated.Prune {
+			syncPolicyStr += " (Prune)"
 		}
 	} else {
-		syncPolicy = "<none>"
+		syncPolicyStr = "<none>"
 	}
-	fmt.Printf(printOpFmtStr, "SyncPolicy:", syncPolicy)
+	fmt.Printf(printOpFmtStr, "SyncPolicy:", syncPolicyStr)
 
 }
 

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -67,4 +69,125 @@ func TestPrintApplicationSetTable(t *testing.T) {
 	assert.NoError(t, err)
 	expectation := "NAME      NAMESPACE  PROJECT  SYNCPOLICY  CONDITIONS\napp-name             default  nil         [{ResourcesUpToDate  <nil> True }]\napp-name             default  nil         [{ResourcesUpToDate  <nil> True }]\n"
 	assert.Equal(t, expectation, output)
+}
+
+func TestPrintAppSetSummaryTable(t *testing.T) {
+	baseAppSet := &arogappsetv1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-name",
+		},
+		Spec: arogappsetv1.ApplicationSetSpec{
+			Generators: []arogappsetv1.ApplicationSetGenerator{
+				arogappsetv1.ApplicationSetGenerator{
+					Git: &arogappsetv1.GitGenerator{
+						RepoURL:  "https://github.com/argoproj/argo-cd.git",
+						Revision: "head",
+						Directories: []arogappsetv1.GitDirectoryGeneratorItem{
+							arogappsetv1.GitDirectoryGeneratorItem{
+								Path: "applicationset/examples/git-generator-directory/cluster-addons/*",
+							},
+						},
+					},
+				},
+			},
+			Template: arogappsetv1.ApplicationSetTemplate{
+				Spec: v1alpha1.ApplicationSpec{
+					Project: "default",
+				},
+			},
+		},
+		Status: arogappsetv1.ApplicationSetStatus{
+			Conditions: []arogappsetv1.ApplicationSetCondition{
+				arogappsetv1.ApplicationSetCondition{
+					Status: v1alpha1.ApplicationSetConditionStatusTrue,
+					Type:   arogappsetv1.ApplicationSetConditionResourcesUpToDate,
+				},
+			},
+		},
+	}
+
+	appsetSpecSyncPolicy := baseAppSet.DeepCopy()
+	appsetSpecSyncPolicy.Spec.SyncPolicy = &arogappsetv1.ApplicationSetSyncPolicy{
+		PreserveResourcesOnDeletion: true,
+	}
+
+	appSetTemplateSpecSyncPolicy := baseAppSet.DeepCopy()
+	appSetTemplateSpecSyncPolicy.Spec.Template.Spec.SyncPolicy = &arogappsetv1.SyncPolicy{
+		Automated: &arogappsetv1.SyncPolicyAutomated{
+			SelfHeal: true,
+		},
+	}
+
+	appSetBothSyncPolicies := baseAppSet.DeepCopy()
+	appSetBothSyncPolicies.Spec.SyncPolicy = &arogappsetv1.ApplicationSetSyncPolicy{
+		PreserveResourcesOnDeletion: true,
+	}
+	appSetBothSyncPolicies.Spec.Template.Spec.SyncPolicy = &arogappsetv1.SyncPolicy{
+		Automated: &arogappsetv1.SyncPolicyAutomated{
+			SelfHeal: true,
+		},
+	}
+
+	for _, tt := range []struct {
+		name           string
+		appSet         *arogappsetv1.ApplicationSet
+		expectedOutput string
+	}{
+		{
+			name:   "appset with only spec.syncPolicy set",
+			appSet: appsetSpecSyncPolicy,
+			expectedOutput: `Name:               app-name
+Project:            default
+Server:             
+Namespace:          
+Repo:               
+Target:             
+Path:               
+SyncPolicy:         <none>
+`,
+		},
+		{
+			name:   "appset with only spec.template.spec.syncPolicy set",
+			appSet: appSetTemplateSpecSyncPolicy,
+			expectedOutput: `Name:               app-name
+Project:            default
+Server:             
+Namespace:          
+Repo:               
+Target:             
+Path:               
+SyncPolicy:         Automated
+`,
+		},
+		{
+			name:   "appset with both spec.SyncPolicy and spec.template.spec.syncPolicy set",
+			appSet: appSetBothSyncPolicies,
+			expectedOutput: `Name:               app-name
+Project:            default
+Server:             
+Namespace:          
+Repo:               
+Target:             
+Path:               
+SyncPolicy:         Automated
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStdout := os.Stdout
+			defer func() {
+				os.Stdout = oldStdout
+			}()
+
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			printAppSetSummaryTable(tt.appSet)
+			w.Close()
+
+			out, err := ioutil.ReadAll(r)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedOutput, string(out))
+		})
+	}
 }


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

Fixes: #12424

Previously we didn't explicitly check for the presence of `spec.template.spec.SyncPolicy` before accessing its `.Automated` struct variable which led to a nil pointer dereference issue.