### PR TITLE
docs: document matchExpressions field for appset cluster generator

### DIFF
--- a/docs/operator-manual/applicationset/Generators-Cluster.md
+++ b/docs/operator-manual/applicationset/Generators-Cluster.md
@@ -72,6 +72,12 @@ spec:
       selector:
         matchLabels:
           staging: true
+        # The cluster generator also supports matchExpressions.
+        #matchExpressions:
+        #  - key: staging
+        #    operator: In
+        #    values:
+        #      - "true"
   template:
   # (...)
 ```
@@ -104,6 +110,12 @@ spec:
       selector:
         matchLabels:
           argocd.argoproj.io/secret-type: cluster
+        # The cluster generator also supports matchExpressions.
+        #matchExpressions:
+        #  - key: staging
+        #    operator: In
+        #    values:
+        #      - "true"
 ```
 
 This selector will not match the default local cluster, since the default local cluster does not have a Secret (and thus does not have the `argocd.argoproj.io/secret-type` label on that secret). Any cluster selector that selects on that label will automatically exclude the default local cluster.


### PR DESCRIPTION
Signed-off-by: Michael Crenshaw <350466+crenshaw-dev@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

