### PR TITLE
fix: Refresh message is hidden (#11303)

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -48,7 +48,7 @@ $header: 120px;
     &__refreshing-label {
         color: $white-color;
         position: fixed;
-        top: $header + 100px;
+        margin-top: -20px;
         left: 50%;
         background-color: $argo-color-gray-7;
         border: 1px solid $argo-color-gray-5;


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

See https://github.com/argoproj/argo-cd/issues/11303
https://github.com/argoproj/argo-cd/pull/12327

With the above changes, when you click on the Refresh button the "Refreshing" message gets cut off.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 


With this fix, when you click on the Refresh button:

<img width="1113" alt="Screen Shot 2023-02-13 at 3 50 06 PM" src="https://user-images.githubusercontent.com/7726022/218572847-d6b52a15-47fc-469c-9441-a71975a2cb57.png">

<img width="1113" alt="Screen Shot 2023-02-13 at 3 50 21 PM" src="https://user-images.githubusercontent.com/7726022/218572885-4358f17a-cb00-459a-8aba-831c0cae44d9.png">
