### PR TITLE
feat: RBAC csv policy can be composed by multiple configmap keys

### DIFF
--- a/docs/operator-manual/argocd-rbac-cm.yaml
+++ b/docs/operator-manual/argocd-rbac-cm.yaml
@@ -19,6 +19,15 @@ data:
     # Grant all members of 'my-org:team-beta' admins
     g, my-org:team-beta, role:admin
 
+  # it is possible to provide additional entries in this configmap to compose the final policy csv.
+  # In this case the key must follow the pattern 'policy.<any string>.csv'. Argo CD will concatenate
+  # all additional policies it finds with this pattern below the main one ('policy.csv'). This is useful
+  # to allow composing policies in config management tools like Kustomize, Helm, etc.
+  policy.overlay.csv: |
+    p, role:tester, applications, *, */*, allow
+    p, role:tester, projects, *, *, allow
+    g, my-org:team-qa, role:tester
+
   # policy.default is the name of the default role which Argo CD will falls back to, when
   # authorizing API requests (optional). If omitted or empty, users may be still be able to login,
   # but will see no apps, projects, etc...

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -177,8 +177,13 @@ It is possible to provide additional entries in the `argocd-rbac-cm`
 configmap to compose the final policy csv. In this case the key must
 follow the pattern `policy.<any string>.csv`. Argo CD will concatenate
 all additional policies it finds with this pattern below the main one
-('policy.csv'). This is useful to allow composing policies in config
-management tools like Kustomize, Helm, etc.
+('policy.csv'). The order of additional provided policies are
+determined by the key string. Example: if two additional policies are
+provided with keys `policy.A.csv` and `policy.B.csv`, it will first
+concatenate `policy.A.csv` and then `policy.B.csv`.
+
+This is useful to allow composing policies in config management tools
+like Kustomize, Helm, etc.
 
 The example below shows how a Kustomize patch can be provided in an
 overlay to add additional configuration to an existing RBAC policy.

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -171,6 +171,31 @@ g, db-admins, role:staging-db-admins
 
 This example defines a *role* called `staging-db-admins` with *nine permissions* that allow that role to perform the *actions* (`create`/`delete`/`get`/`override`/`sync`/`update` applications, `get` logs, `create` exec and `get` appprojects) against `*` (all) objects in the `staging-db-admins` Argo CD AppProject.
 
+## Policy CSV Composition
+
+It is possible to provide additional entries in the `argocd-rbac-cm`
+configmap to compose the final policy csv. In this case the key must
+follow the pattern `policy.<any string>.csv`. Argo CD will concatenate
+all additional policies it finds with this pattern below the main one
+('policy.csv'). This is useful to allow composing policies in config
+management tools like Kustomize, Helm, etc.
+
+The example below shows how a Kustomize patch can be provided in an
+overlay to add additional configuration to an existing RBAC policy.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argocd
+data:
+  policy.tester-overlay.csv: |
+    p, role:tester, applications, *, */*, allow
+    p, role:tester, projects, *, *, allow
+    g, my-org:team-qa, role:tester
+```
+
 ## Anonymous Access
 
 The anonymous access to Argo CD can be enabled using `users.anonymous.enabled` field in `argocd-cm` (see [argocd-cm.yaml](argocd-cm.yaml)).

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -5,7 +5,6 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -402,14 +401,16 @@ func PolicyCSV(data map[string]string) string {
 		strBuilder.WriteString(p)
 	}
 	// append additional policies at the end of the csv
-	csvRegex := regexp.MustCompile(fmt.Sprintf("^%s.+$", ConfigMapPolicyCSVKey))
 	for key, value := range data {
-		if csvRegex.MatchString(key) {
+		if strings.HasPrefix(key, "policy.") &&
+			strings.HasSuffix(key, ".csv") &&
+			key != ConfigMapPolicyCSVKey {
+
 			strBuilder.WriteString("\n")
 			strBuilder.WriteString(value)
 		}
 	}
-	return strings.Trim(strBuilder.String(), "\n")
+	return strBuilder.String()
 }
 
 // syncUpdate updates the enforcer

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -82,6 +83,26 @@ func TestPolicyCSV(t *testing.T) {
 		assert.Regexp(t, "^policy1", policy)
 		assert.Contains(t, policy, "policy2")
 		assert.Contains(t, policy, "policy3")
+	})
+	t.Run("will return composed policy in a deterministic order", func(t *testing.T) {
+		// given
+		data := make(map[string]string)
+		data["UnrelatedKey"] = "unrelated value"
+		data["policy.B.csv"] = "policyb"
+		data["policy.A.csv"] = "policya"
+		data["policy.C.csv"] = "policyc"
+		data[ConfigMapPolicyCSVKey] = "policy1"
+
+		// when
+		policy := PolicyCSV(data)
+
+		// then
+		result := strings.Split(policy, "\n")
+		assert.Len(t, result, 4)
+		assert.Equal(t, "policy1", result[0])
+		assert.Equal(t, "policya", result[1])
+		assert.Equal(t, "policyb", result[2])
+		assert.Equal(t, "policyc", result[3])
 	})
 
 }

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -72,8 +72,8 @@ func TestPolicyCSV(t *testing.T) {
 		data := make(map[string]string)
 		data[ConfigMapPolicyCSVKey] = "policy1"
 		data["UnrelatedKey"] = "unrelated value"
-		data[fmt.Sprintf("%s.add1", ConfigMapPolicyCSVKey)] = "policy2"
-		data[fmt.Sprintf("%s.add2", ConfigMapPolicyCSVKey)] = "policy3"
+		data["policy.overlay1.csv"] = "policy2"
+		data["policy.overlay2.csv"] = "policy3"
 
 		// when
 		policy := PolicyCSV(data)


### PR DESCRIPTION
This PR adds support to provide multiple RBAC csv entries in `argocd-rbac-cm`.
Example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: argocd-rbac-cm
data:
  policy.default: role:readonly
  policy.csv: |
    g, group-admins, role:admin
    g, kubernetes:argocd-readonly, role:readonly
  policy.overlay1.csv: |
    p, role:tester, applications, *, */*, allow
    p, role:tester, projects, *, *, allow
    g, kubernetes:argocd-readonly, role:tester
  policy.overlay2.csv: |
    p, role:devops, applications, *, */*, allow
    p, role:devops, projects, *, *, allow
    g, group-devops, role:devops
```

This is useful to allow composing RBAC policies with multiple Kustomize overlays.

fix https://github.com/argoproj/argo-cd/issues/8324

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

