### PR TITLE
fix: trigger ApplicationSet reconciliation for clusters matching cluster generators in matrix or merge generators

### DIFF
--- a/applicationset/controllers/clustereventhandler.go
+++ b/applicationset/controllers/clustereventhandler.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -46,7 +47,6 @@ type addRateLimitingInterface interface {
 }
 
 func (h *clusterSecretEventHandler) queueRelatedAppGenerators(q addRateLimitingInterface, object client.Object) {
-
 	// Check for label, lookup all ApplicationSets that might match the cluster, queue them all
 	if object.GetLabels()[generators.ArgoCDSecretTypeLabel] != generators.ArgoCDSecretTypeCluster {
 		return
@@ -73,6 +73,40 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(q addRateLimitingI
 				foundClusterGenerator = true
 				break
 			}
+
+			if generator.Matrix != nil {
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Matrix.Generators)
+				if err != nil {
+					h.Log.
+						WithFields(log.Fields{
+							"namespace": appSet.GetNamespace(),
+							"name":      appSet.GetName(),
+						}).
+						WithError(err).
+						Error("Unable to check if ApplicationSet matrix generators have cluster generator")
+				}
+				if ok {
+					foundClusterGenerator = true
+					break
+				}
+			}
+
+			if generator.Merge != nil {
+				ok, err := nestedGeneratorsHaveClusterGenerator(generator.Merge.Generators)
+				if err != nil {
+					h.Log.
+						WithFields(log.Fields{
+							"namespace": appSet.GetNamespace(),
+							"name":      appSet.GetName(),
+						}).
+						WithError(err).
+						Error("Unable to check if ApplicationSet merge generators have cluster generator")
+				}
+				if ok {
+					foundClusterGenerator = true
+					break
+				}
+			}
 		}
 		if foundClusterGenerator {
 
@@ -81,4 +115,43 @@ func (h *clusterSecretEventHandler) queueRelatedAppGenerators(q addRateLimitingI
 			q.Add(req)
 		}
 	}
+}
+
+// nestedGeneratorsHaveClusterGenerator iterate over provided nested generators to check if they have a cluster generator.
+func nestedGeneratorsHaveClusterGenerator(generators []argoprojiov1alpha1.ApplicationSetNestedGenerator) (bool, error) {
+	for _, generator := range generators {
+		if ok, err := nestedGeneratorHasClusterGenerator(generator); ok || err != nil {
+			return ok, err
+		}
+	}
+	return false, nil
+}
+
+// nestedGeneratorHasClusterGenerator checks if the provided generator has a cluster generator.
+func nestedGeneratorHasClusterGenerator(nested argoprojiov1alpha1.ApplicationSetNestedGenerator) (bool, error) {
+	if nested.Clusters != nil {
+		return true, nil
+	}
+
+	if nested.Matrix != nil {
+		nestedMatrix, err := argoprojiov1alpha1.ToNestedMatrixGenerator(nested.Matrix)
+		if err != nil {
+			return false, fmt.Errorf("unable to get nested matrix generator: %w", err)
+		}
+		if nestedMatrix != nil {
+			return nestedGeneratorsHaveClusterGenerator(nestedMatrix.ToMatrixGenerator().Generators)
+		}
+	}
+
+	if nested.Merge != nil {
+		nestedMerge, err := argoprojiov1alpha1.ToNestedMergeGenerator(nested.Merge)
+		if err != nil {
+			return false, fmt.Errorf("unable to get nested merge generator: %w", err)
+		}
+		if nestedMerge != nil {
+			return nestedGeneratorsHaveClusterGenerator(nestedMerge.ToMergeGenerator().Generators)
+		}
+	}
+
+	return false, nil
 }

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -163,7 +164,6 @@ func TestClusterEventHandler(t *testing.T) {
 				{NamespacedName: types.NamespacedName{Namespace: "another-namespace", Name: "my-app-set"}},
 			},
 		},
-
 		{
 			name: "non-argo cd secret should not match",
 			items: []argov1alpha1.ApplicationSet{
@@ -185,6 +185,348 @@ func TestClusterEventHandler(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-non-argocd-secret",
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "a matrix generator with a cluster generator should produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Matrix: &argov1alpha1.MatrixGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											Clusters: &argov1alpha1.ClusterGenerator{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "my-app-set"},
+			}},
+		},
+		{
+			name: "a matrix generator with non cluster generator should not match",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Matrix: &argov1alpha1.MatrixGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											List: &argov1alpha1.ListGenerator{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "a matrix generator with a nested matrix generator containing a cluster generator should produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Matrix: &argov1alpha1.MatrixGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											Matrix: &apiextensionsv1.JSON{
+												Raw: []byte(
+													`{
+														"generators": [
+														  {
+															"clusters": {
+															  "selector": {
+																"matchLabels": {
+																  "argocd.argoproj.io/secret-type": "cluster"
+																}
+															  }
+															}
+														  }
+														]
+													  }`,
+												),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "my-app-set"},
+			}},
+		},
+		{
+			name: "a matrix generator with a nested matrix generator containing non cluster generator should not match",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Matrix: &argov1alpha1.MatrixGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											Matrix: &apiextensionsv1.JSON{
+												Raw: []byte(
+													`{
+														"generators": [
+														  {
+															"list": {
+															  "elements": [
+																"a",
+																"b"
+															  ]
+															}
+														  }
+														]
+													  }`,
+												),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "a merge generator with a cluster generator should produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Merge: &argov1alpha1.MergeGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											Clusters: &argov1alpha1.ClusterGenerator{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "my-app-set"},
+			}},
+		},
+		{
+			name: "a matrix generator with non cluster generator should not match",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Merge: &argov1alpha1.MergeGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											List: &argov1alpha1.ListGenerator{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "a merge generator with a nested merge generator containing a cluster generator should produce a request",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Merge: &argov1alpha1.MergeGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											Merge: &apiextensionsv1.JSON{
+												Raw: []byte(
+													`{
+														"generators": [
+														  {
+															"clusters": {
+															  "selector": {
+																"matchLabels": {
+																  "argocd.argoproj.io/secret-type": "cluster"
+																}
+															  }
+															}
+														  }
+														]
+													  }`,
+												),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Namespace: "argocd", Name: "my-app-set"},
+			}},
+		},
+		{
+			name: "a merge generator with a nested merge generator containing non cluster generator should not match",
+			items: []argov1alpha1.ApplicationSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "my-app-set",
+						Namespace: "argocd",
+					},
+					Spec: argov1alpha1.ApplicationSetSpec{
+						Generators: []argov1alpha1.ApplicationSetGenerator{
+							{
+								Merge: &argov1alpha1.MergeGenerator{
+									Generators: []argov1alpha1.ApplicationSetNestedGenerator{
+										{
+											Merge: &apiextensionsv1.JSON{
+												Raw: []byte(
+													`{
+														"generators": [
+														  {
+															"list": {
+															  "elements": [
+																"a",
+																"b"
+															  ]
+															}
+														  }
+														]
+													  }`,
+												),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "argocd",
+					Name:      "my-secret",
+					Labels: map[string]string{
+						generators.ArgoCDSecretTypeLabel: generators.ArgoCDSecretTypeCluster,
+					},
 				},
 			},
 			expectedRequests: []reconcile.Request{},


### PR DESCRIPTION
This PR fixes #12542 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

