### PR TITLE
fix: evaluate all possible refresh reasons for multi-source apps (#12379)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1474,6 +1474,13 @@ func resourceStatusKey(res appv1.ResourceStatus) string {
 	return strings.Join([]string{res.Group, res.Kind, res.Namespace, res.Name}, "/")
 }
 
+func currentSourceEqualsSyncedSource(app *appv1.Application) bool {
+	if app.Spec.HasMultipleSources() {
+		return app.Spec.Sources.Equals(app.Status.Sync.ComparedTo.Sources)
+	}
+	return app.Spec.Source.Equals(app.Status.Sync.ComparedTo.Source)
+}
+
 // needRefreshAppStatus answers if application status needs to be refreshed.
 // Returns true if application never been compared, has changed or comparison result has expired.
 // Additionally returns whether full refresh was requested or not.
@@ -1492,14 +1499,12 @@ func (ctrl *ApplicationController) needRefreshAppStatus(app *appv1.Application, 
 		refreshType = requestedType
 		reason = fmt.Sprintf("%s refresh requested", refreshType)
 	} else {
-		if app.Spec.HasMultipleSources() {
-			if (len(app.Spec.Sources) != len(app.Status.Sync.ComparedTo.Sources)) || !reflect.DeepEqual(app.Spec.Sources, app.Status.Sync.ComparedTo.Sources) {
-				reason = "atleast one of the spec.sources differs"
-				compareWith = CompareWithLatestForceResolve
-			}
-		} else if !app.Spec.Source.Equals(app.Status.Sync.ComparedTo.Source) {
+		if !currentSourceEqualsSyncedSource(app) {
 			reason = "spec.source differs"
 			compareWith = CompareWithLatestForceResolve
+			if app.Spec.HasMultipleSources() {
+				reason = "at least one of the spec.sources differs"
+			}
 		} else if hardExpired || softExpired {
 			// The commented line below mysteriously crashes if app.Status.ReconciledAt is nil
 			// reason = fmt.Sprintf("comparison expired. reconciledAt: %v, expiry: %v", app.Status.ReconciledAt, statusRefreshTimeout)

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -209,6 +209,55 @@ status:
         repoURL: https://github.com/argoproj/argocd-example-apps.git
 `
 
+var fakeMultiSourceApp = `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  uid: "123"
+  name: my-app
+  namespace: ` + test.FakeArgoCDNamespace + `
+spec:
+  destination:
+    namespace: ` + test.FakeDestNamespace + `
+    server: https://localhost:6443
+  project: default
+  sources:
+  - path: some/path
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+  - path: some/other/path
+    repoURL: https://github.com/argoproj/argocd-example-apps-fake.git
+  syncPolicy:
+    automated: {}
+status:
+  operationState:
+    finishedAt: 2018-09-21T23:50:29Z
+    message: successfully synced
+    operation:
+      sync:
+        revisions:
+        - HEAD
+        - HEAD
+    phase: Succeeded
+    startedAt: 2018-09-21T23:50:25Z
+    syncResult:
+      resources:
+      - kind: RoleBinding
+        message: |-
+          rolebinding.rbac.authorization.k8s.io/always-outofsync reconciled
+          rolebinding.rbac.authorization.k8s.io/always-outofsync configured
+        name: always-outofsync
+        namespace: default
+        status: Synced
+      revisions: 
+      - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      sources:
+      - path: some/path
+        repoURL: https://github.com/argoproj/argocd-example-apps.git
+      - path: some/other/path
+        repoURL: https://github.com/argoproj/argocd-example-apps-fake.git
+`
+
 var fakeAppWithDestName = `
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -261,6 +310,10 @@ data:
 
 func newFakeApp() *argoappv1.Application {
 	return createFakeApp(fakeApp)
+}
+
+func newFakeMultiSourceApp() *argoappv1.Application {
+	return createFakeApp(fakeMultiSourceApp)
 }
 
 func newFakeAppWithDestMismatch() *argoappv1.Application {
@@ -857,101 +910,133 @@ func TestSetOperationStateOnDeletedApp(t *testing.T) {
 }
 
 func TestNeedRefreshAppStatus(t *testing.T) {
-	ctrl := newFakeController(&fakeData{apps: []runtime.Object{}})
-
-	app := newFakeApp()
-	now := metav1.Now()
-	app.Status.ReconciledAt = &now
-	app.Status.Sync = argoappv1.SyncStatus{
-		Status: argoappv1.SyncStatusCodeSynced,
-		ComparedTo: argoappv1.ComparedTo{
-			Source:      app.Spec.GetSource(),
-			Destination: app.Spec.Destination,
+	testCases := []struct {
+		name string
+		app  *argoappv1.Application
+	}{
+		{
+			name: "single-source app",
+			app:  newFakeApp(),
+		},
+		{
+			name: "multi-source app",
+			app:  newFakeMultiSourceApp(),
 		},
 	}
 
-	// no need to refresh just reconciled application
-	needRefresh, _, _ := ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
-	assert.False(t, needRefresh)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := newFakeController(&fakeData{apps: []runtime.Object{}})
+			app := tc.app
+			now := metav1.Now()
+			app.Status.ReconciledAt = &now
 
-	// refresh app using the 'deepest' requested comparison level
-	ctrl.requestAppRefresh(app.Name, CompareWithRecent.Pointer(), nil)
-	ctrl.requestAppRefresh(app.Name, ComparisonWithNothing.Pointer(), nil)
+			app.Status.Sync = argoappv1.SyncStatus{
+				Status: argoappv1.SyncStatusCodeSynced,
+				ComparedTo: argoappv1.ComparedTo{
+					Destination: app.Spec.Destination,
+				},
+			}
 
-	needRefresh, refreshType, compareWith := ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
-	assert.True(t, needRefresh)
-	assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
-	assert.Equal(t, CompareWithRecent, compareWith)
+			if app.Spec.HasMultipleSources() {
+				app.Status.Sync.ComparedTo.Sources = app.Spec.Sources
+			} else {
+				app.Status.Sync.ComparedTo.Source = app.Spec.GetSource()
+			}
 
-	// refresh application which status is not reconciled using latest commit
-	app.Status.Sync = argoappv1.SyncStatus{Status: argoappv1.SyncStatusCodeUnknown}
+			// no need to refresh just reconciled application
+			needRefresh, _, _ := ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
+			assert.False(t, needRefresh)
 
-	needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
-	assert.True(t, needRefresh)
-	assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
-	assert.Equal(t, CompareWithLatestForceResolve, compareWith)
+			// refresh app using the 'deepest' requested comparison level
+			ctrl.requestAppRefresh(app.Name, CompareWithRecent.Pointer(), nil)
+			ctrl.requestAppRefresh(app.Name, ComparisonWithNothing.Pointer(), nil)
 
-	{
-		// refresh app using the 'latest' level if comparison expired
-		app := app.DeepCopy()
-		ctrl.requestAppRefresh(app.Name, CompareWithRecent.Pointer(), nil)
-		reconciledAt := metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour))
-		app.Status.ReconciledAt = &reconciledAt
-		needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Minute, 2*time.Hour)
-		assert.True(t, needRefresh)
-		assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
-		assert.Equal(t, CompareWithLatestForceResolve, compareWith)
-	}
+			needRefresh, refreshType, compareWith := ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
+			assert.True(t, needRefresh)
+			assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
+			assert.Equal(t, CompareWithRecent, compareWith)
 
-	{
-		// refresh app using the 'latest' level if comparison expired for hard refresh
-		app := app.DeepCopy()
-		app.Status.Sync = argoappv1.SyncStatus{
-			Status: argoappv1.SyncStatusCodeSynced,
-			ComparedTo: argoappv1.ComparedTo{
-				Source:      app.Spec.GetSource(),
-				Destination: app.Spec.Destination,
-			},
-		}
-		ctrl.requestAppRefresh(app.Name, CompareWithRecent.Pointer(), nil)
-		reconciledAt := metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour))
-		app.Status.ReconciledAt = &reconciledAt
-		needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 2*time.Hour, 1*time.Minute)
-		assert.True(t, needRefresh)
-		assert.Equal(t, argoappv1.RefreshTypeHard, refreshType)
-		assert.Equal(t, CompareWithLatest, compareWith)
-	}
+			// refresh application which status is not reconciled using latest commit
+			app.Status.Sync = argoappv1.SyncStatus{Status: argoappv1.SyncStatusCodeUnknown}
 
-	{
-		app := app.DeepCopy()
-		// execute hard refresh if app has refresh annotation
-		reconciledAt := metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour))
-		app.Status.ReconciledAt = &reconciledAt
-		app.Annotations = map[string]string{
-			v1alpha1.AnnotationKeyRefresh: string(argoappv1.RefreshTypeHard),
-		}
-		needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
-		assert.True(t, needRefresh)
-		assert.Equal(t, argoappv1.RefreshTypeHard, refreshType)
-		assert.Equal(t, CompareWithLatestForceResolve, compareWith)
-	}
+			needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
+			assert.True(t, needRefresh)
+			assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
+			assert.Equal(t, CompareWithLatestForceResolve, compareWith)
 
-	{
-		app := app.DeepCopy()
-		// ensure that CompareWithLatest level is used if application source has changed
-		ctrl.requestAppRefresh(app.Name, ComparisonWithNothing.Pointer(), nil)
-		// sample app source change
-		app.Spec.Source.Helm = &argoappv1.ApplicationSourceHelm{
-			Parameters: []argoappv1.HelmParameter{{
-				Name:  "foo",
-				Value: "bar",
-			}},
-		}
+			t.Run("refresh app using the 'latest' level if comparison expired", func(t *testing.T) {
+				app := app.DeepCopy()
+				ctrl.requestAppRefresh(app.Name, CompareWithRecent.Pointer(), nil)
+				reconciledAt := metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour))
+				app.Status.ReconciledAt = &reconciledAt
+				needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Minute, 2*time.Hour)
+				assert.True(t, needRefresh)
+				assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
+				assert.Equal(t, CompareWithLatestForceResolve, compareWith)
+			})
 
-		needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
-		assert.True(t, needRefresh)
-		assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
-		assert.Equal(t, CompareWithLatestForceResolve, compareWith)
+			t.Run("refresh app using the 'latest' level if comparison expired for hard refresh", func(t *testing.T) {
+				app := app.DeepCopy()
+				app.Status.Sync = argoappv1.SyncStatus{
+					Status: argoappv1.SyncStatusCodeSynced,
+					ComparedTo: argoappv1.ComparedTo{
+						Destination: app.Spec.Destination,
+					},
+				}
+				if app.Spec.HasMultipleSources() {
+					app.Status.Sync.ComparedTo.Sources = app.Spec.Sources
+				} else {
+					app.Status.Sync.ComparedTo.Source = app.Spec.GetSource()
+				}
+				ctrl.requestAppRefresh(app.Name, CompareWithRecent.Pointer(), nil)
+				reconciledAt := metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour))
+				app.Status.ReconciledAt = &reconciledAt
+				needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 2*time.Hour, 1*time.Minute)
+				assert.True(t, needRefresh)
+				assert.Equal(t, argoappv1.RefreshTypeHard, refreshType)
+				assert.Equal(t, CompareWithLatest, compareWith)
+			})
+
+			t.Run("execute hard refresh if app has refresh annotation", func(t *testing.T) {
+				app := app.DeepCopy()
+				reconciledAt := metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour))
+				app.Status.ReconciledAt = &reconciledAt
+				app.Annotations = map[string]string{
+					v1alpha1.AnnotationKeyRefresh: string(argoappv1.RefreshTypeHard),
+				}
+				needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
+				assert.True(t, needRefresh)
+				assert.Equal(t, argoappv1.RefreshTypeHard, refreshType)
+				assert.Equal(t, CompareWithLatestForceResolve, compareWith)
+			})
+
+			t.Run("ensure that CompareWithLatest level is used if application source has changed", func(t *testing.T) {
+				app := app.DeepCopy()
+				ctrl.requestAppRefresh(app.Name, ComparisonWithNothing.Pointer(), nil)
+				// sample app source change
+				if app.Spec.HasMultipleSources() {
+					app.Spec.Sources[0].Helm = &argoappv1.ApplicationSourceHelm{
+						Parameters: []argoappv1.HelmParameter{{
+							Name:  "foo",
+							Value: "bar",
+						}},
+					}
+				} else {
+					app.Spec.Source.Helm = &argoappv1.ApplicationSourceHelm{
+						Parameters: []argoappv1.HelmParameter{{
+							Name:  "foo",
+							Value: "bar",
+						}},
+					}
+				}
+
+				needRefresh, refreshType, compareWith = ctrl.needRefreshAppStatus(app, 1*time.Hour, 2*time.Hour)
+				assert.True(t, needRefresh)
+				assert.Equal(t, argoappv1.RefreshTypeNormal, refreshType)
+				assert.Equal(t, CompareWithLatestForceResolve, compareWith)
+			})
+		})
 	}
 }
 

--- a/controller/state.go
+++ b/controller/state.go
@@ -471,7 +471,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *ap
 		failedToLoadObjs = true
 	}
 
-	logCtx.Debugf("Retrieved lived manifests")
+	logCtx.Debugf("Retrieved live manifests")
 
 	// filter out all resources which are not permitted in the application project
 	for k, v := range liveObjByKey {

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -188,7 +188,7 @@ func (s ApplicationSources) Equals(other ApplicationSources) bool {
 		return false
 	}
 	for i := range s {
-		if !s[i].Equals((other)[i]) {
+		if !s[i].Equals(other[i]) {
 			return false
 		}
 	}

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -183,6 +183,18 @@ type ApplicationSource struct {
 // ApplicationSources contains list of required information about the sources of an application
 type ApplicationSources []ApplicationSource
 
+func (s ApplicationSources) Equals(other ApplicationSources) bool {
+	if len(s) != len(other) {
+		return false
+	}
+	for i := range s {
+		if !s[i].Equals((other)[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (a *ApplicationSpec) GetSource() ApplicationSource {
 	// if Application has multiple sources, return the first source in sources
 	if a.HasMultipleSources() {

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -3,11 +3,12 @@ package e2e
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	. "github.com/argoproj/argo-cd/v2/util/argo"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMultiSourceAppCreation(t *testing.T) {
@@ -42,7 +43,8 @@ func TestMultiSourceAppCreation(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		When().Refresh(RefreshTypeNormal).Then().
+		// Since it's auto-synced, we shouldn't have to manually refresh to see that things are synced.
+		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
 			statusByName := map[string]SyncStatusCode{}

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -43,7 +43,8 @@ func TestMultiSourceAppCreation(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		// Since it's auto-synced, we shouldn't have to manually refresh to see that things are synced.
+		When().Sync().Then().
+		Expect(Success("")).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
@@ -98,7 +99,9 @@ func TestMultiSourceAppWithHelmExternalValueFiles(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		When().Refresh(RefreshTypeNormal).Then().
+		When().Sync().Then().
+		Expect(Success("")).
+		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
 			statusByName := map[string]SyncStatusCode{}
@@ -146,7 +149,9 @@ func TestMultiSourceAppWithSourceOverride(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		When().Refresh(RefreshTypeNormal).Then().
+		When().Sync().Then().
+		Expect(Success("")).
+		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
 			statusByName := map[string]SyncStatusCode{}

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -42,6 +42,7 @@ func TestMultiSourceAppCreation(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
+		Timeout(60).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
@@ -95,6 +96,7 @@ func TestMultiSourceAppWithHelmExternalValueFiles(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
+		Timeout(60).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
@@ -142,6 +144,7 @@ func TestMultiSourceAppWithSourceOverride(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
+		Timeout(60).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -42,7 +42,7 @@ func TestMultiSourceAppCreation(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		Timeout(60).
+		Given().Timeout(60).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
@@ -96,7 +96,7 @@ func TestMultiSourceAppWithHelmExternalValueFiles(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		Timeout(60).
+		Given().Timeout(60).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
@@ -144,7 +144,7 @@ func TestMultiSourceAppWithSourceOverride(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		Timeout(60).
+		Given().Timeout(60).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -25,7 +25,6 @@ func TestMultiSourceAppCreation(t *testing.T) {
 		When().
 		CreateMultiSourceAppFromFile().
 		Then().
-		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
 			assert.Equal(t, Name(), app.Name)
 			for i, source := range app.Spec.GetSources() {
@@ -79,7 +78,6 @@ func TestMultiSourceAppWithHelmExternalValueFiles(t *testing.T) {
 		When().
 		CreateMultiSourceAppFromFile().
 		Then().
-		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
 			assert.Equal(t, Name(), app.Name)
 			for i, source := range app.Spec.GetSources() {
@@ -127,7 +125,6 @@ func TestMultiSourceAppWithSourceOverride(t *testing.T) {
 		When().
 		CreateMultiSourceAppFromFile().
 		Then().
-		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
 			assert.Equal(t, Name(), app.Name)
 			for i, source := range app.Spec.GetSources() {

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -43,8 +43,6 @@ func TestMultiSourceAppCreation(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		When().Sync().Then().
-		Expect(Success("")).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
@@ -99,8 +97,6 @@ func TestMultiSourceAppWithHelmExternalValueFiles(t *testing.T) {
 			assert.Contains(t, output, Name())
 		}).
 		Expect(Success("")).
-		When().Sync().Then().
-		Expect(Success("")).
 		When().Wait().Then().
 		Expect(Success("")).
 		And(func(app *Application) {
@@ -148,8 +144,6 @@ func TestMultiSourceAppWithSourceOverride(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Contains(t, output, Name())
 		}).
-		Expect(Success("")).
-		When().Sync().Then().
 		Expect(Success("")).
 		When().Wait().Then().
 		Expect(Success("")).

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -157,11 +157,6 @@ func (a *Actions) CreateMultiSourceAppFromFile(flags ...string) *Actions {
 				Server:    a.context.destServer,
 				Namespace: fixture.DeploymentNamespace(),
 			},
-			SyncPolicy: &SyncPolicy{
-				Automated: &SyncPolicyAutomated{
-					SelfHeal: true,
-				},
-			},
 		},
 	}
 

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -365,6 +365,17 @@ func (a *Actions) DeleteBySelector(selector string) *Actions {
 	return a
 }
 
+func (a *Actions) Wait(args ...string) *Actions {
+	a.context.t.Helper()
+	args = append([]string{"app", "wait"}, args...)
+	if a.context.name != "" {
+		args = append(args, a.context.AppQualifiedName())
+	}
+	args = append(args, "--timeout", fmt.Sprintf("%v", a.context.timeout))
+	a.runCli(args...)
+	return a
+}
+
 func (a *Actions) SetParamInSettingConfigMap(key, value string) *Actions {
 	fixture.SetParamInSettingConfigMap(key, value)
 	return a

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -157,6 +157,11 @@ func (a *Actions) CreateMultiSourceAppFromFile(flags ...string) *Actions {
 				Server:    a.context.destServer,
 				Namespace: fixture.DeploymentNamespace(),
 			},
+			SyncPolicy: &SyncPolicy{
+				Automated: &SyncPolicyAutomated{
+					SelfHeal: true,
+				},
+			},
 		},
 	}
 

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -86,11 +86,6 @@ func (c *Consequences) resource(kind, name, namespace string) ResourceStatus {
 	}
 }
 
-func (c *Consequences) Timeout(timeout int) *Consequences {
-	c.timeout = timeout
-	return c
-}
-
 func (c *Consequences) AndCLIOutput(block func(output string, err error)) *Consequences {
 	c.context.t.Helper()
 	block(c.actions.lastOutput, c.actions.lastError)


### PR DESCRIPTION
The way the "should we refresh the app" logic is currently written, if it's a multi-source app where the sources haven't changed, we just quit.

But there are three other possible reasons the app might need refreshing:
* last refresh is expired
* the destination has changed
* the controller itself has requested a refresh (this is the one we're missing on sync)

I gotta think about how to test this...

Fixes https://github.com/argoproj/argo-cd/issues/12379