### PR TITLE
fix: `make verify-kube-connect` broken on arm64 architectures. #12617

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -11,7 +11,7 @@ FROM docker.io/library/golang:1.19 as golang
 
 FROM docker.io/library/registry:2.8 as registry
 
-FROM docker.io/bitnami/kubectl:1.24.8 as kubectl
+FROM docker.io/bitnami/kubectl:1.26@sha256:625467eb8c3a3d60232923404941c32e787eb9003e644d0fa8258b0efa7f6a7f as kubectl
 
 FROM ubuntu:22.04
 


### PR DESCRIPTION
Replace the `bitnami/kubectl` version in order to support both `amd64` along with `arm64` system architectures.
This is done according to [this issue](https://github.com/bitnami/containers/issues/19130) in the [bitnami/containers](https://github.com/bitnami/containers) repository.
The [image I propose using](https://hub.docker.com/layers/bitnami/kubectl/1.26/images/sha256-17fa84851a8b07abd4db95661eb0d3af0f14a5831f415a3a8b533c1ac5dbfc77?context=explore) supports both amd64 and arm64, instead of just amd64.

Fixes #12617.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

