### PR TITLE
chore: add directories to dockerignore (used to speed up local dev)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,15 @@ cmd/**/debug
 debug.test
 coverage.out
 ui/node_modules/
+test-results/
+test/
+manifests/
+hack/
+docs/
+examples/
+.github/
+!hack/installers
+!hack/gpg-wrapper.sh
+!hack/git-verify-wrapper.sh
+!hack/tool-versions.sh
+!hack/install.sh


### PR DESCRIPTION
Add a bunch of directories to `.dockerignore` which are not required when doing the initial build of the Argo images. The background is that when developing locally, I use [Skaffold](https://skaffold.dev/) to incrementally rebuild the image on any changes (see #11980). When doing any changes to directories which do not strictly require a rebuild of the Docker image, Skaffold proceeds to rebuild the image. This PR just adds the directories which should not force a rebuild of the image. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

