### PR TITLE
chore: upgrade redis to 7.0.8 to avoid several CVEs

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -426,7 +426,7 @@ jobs:
         run: |
           docker pull ghcr.io/dexidp/dex:v2.35.3
           docker pull argoproj/argo-cd-ci-builder:v1.0.0
-          docker pull redis:7.0.7-alpine
+          docker pull redis:7.0.8-alpine
       - name: Create target directory for binaries in the build-process
         run: |
           mkdir -p dist

--- a/manifests/base/redis/argocd-redis-deployment.yaml
+++ b/manifests/base/redis/argocd-redis-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: argocd-redis        
       containers:
       - name: redis
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: Always
         args:
         - "--save"

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -15639,7 +15639,7 @@ spec:
         - ""
         - --appendonly
         - "no"
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -1179,7 +1179,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
       - name: config-init
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -1206,7 +1206,7 @@ spec:
 
       containers:
       - name: redis
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         command:
         - redis-server
@@ -1256,7 +1256,7 @@ spec:
               - /bin/sh
               - /readonly-config/trigger-failover-if-master.sh
       - name: sentinel
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         command:
           - redis-sentinel
@@ -1300,7 +1300,7 @@ spec:
           {}
 
       - name: split-brain-fix
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         command:
           - sh

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -18,7 +18,7 @@ redis-ha:
       client: 6m
     checkInterval: 3s
   image:
-    tag: 7.0.7-alpine
+    tag: 7.0.8-alpine
   containerSecurityContext: null
   sentinel:
     bind: "0.0.0.0"

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -17868,7 +17868,7 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -17921,7 +17921,7 @@ spec:
         - /data/conf/sentinel.conf
         command:
         - redis-sentinel
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -17973,7 +17973,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
@@ -18002,7 +18002,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2672,7 +2672,7 @@ spec:
         - /data/conf/redis.conf
         command:
         - redis-server
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -2725,7 +2725,7 @@ spec:
         - /data/conf/sentinel.conf
         command:
         - redis-sentinel
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -2777,7 +2777,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
@@ -2806,7 +2806,7 @@ spec:
           value: 40000915ab58c3fa8fd888fb8b24711944e6cbb4
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -16117,7 +16117,7 @@ spec:
         - ""
         - --appendonly
         - "no"
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -921,7 +921,7 @@ spec:
         - ""
         - --appendonly
         - "no"
-        image: redis:7.0.7-alpine
+        image: redis:7.0.8-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/redis:7.0.5 as redis
+FROM docker.io/library/redis:7.0.8-alpine as redis
 
 # There are libraries we will want to copy from here in the final stage of the
 # build, but the COPY directive does not have a way to determine system


### PR DESCRIPTION
This PR fixes several CVEs found in the recent Snyk Scan for Redis.

CVE-2022-4450
CVE-2022-4450
CVE-2023-0216
CVE-2023-0217
CVE-2023-0286
CVE-2023-0286
