### PR TITLE
chore: upgrade haproxy to 2.6.9 to avoid multiple CVEs

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -1071,7 +1071,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: haproxy:2.6.2-alpine
+        image: haproxy:2.6.9-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -1089,7 +1089,7 @@ spec:
           mountPath: /data
       containers:
       - name: haproxy
-        image: haproxy:2.6.2-alpine
+        image: haproxy:2.6.9-alpine
         imagePullPolicy: IfNotPresent
         securityContext: 
           null

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -11,7 +11,7 @@ redis-ha:
     IPv6:
       enabled: false
     image:
-      tag: 2.6.2-alpine
+      tag: 2.6.9-alpine
     containerSecurityContext: null
     timeout:
       server: 6m

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -16992,7 +16992,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.6.2-alpine
+      - image: haproxy:2.6.9-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -17028,7 +17028,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.6.2-alpine
+        image: haproxy:2.6.9-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1796,7 +1796,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.6.2-alpine
+      - image: haproxy:2.6.9-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -1832,7 +1832,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.6.2-alpine
+        image: haproxy:2.6.9-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:


### PR DESCRIPTION
This PR fixes several CVEs found in the recent Snyk Scan for HAProxy.
CVE-2022-4450
CVE-2023-0215
CVE-2023-0286
 CVE-2022-4304
