### PR TITLE
chore: upgrade haproxy to 2.0.31 to avoid multiple CVEs

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -770,7 +770,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: haproxy:2.0.29-alpine
+        image: haproxy:2.0.31-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -790,7 +790,7 @@ spec:
         runAsUser: 1000
       containers:
       - name: haproxy
-        image: haproxy:2.0.29-alpine
+        image: haproxy:2.0.31-alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -9,7 +9,7 @@ redis-ha:
   haproxy:
     enabled: true
     image:
-      tag: 2.0.29-alpine
+      tag: 2.0.31-alpine
     timeout:
       server: 6m
       client: 6m

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10525,7 +10525,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.0.29-alpine
+      - image: haproxy:2.0.31-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -10554,7 +10554,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.0.29-alpine
+        image: haproxy:2.0.31-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1450,7 +1450,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.0.29-alpine
+      - image: haproxy:2.0.31-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -1479,7 +1479,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.0.29-alpine
+        image: haproxy:2.0.31-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         volumeMounts:


### PR DESCRIPTION
This PR fixes several CVEs found in the recent Snyk Scan for HAProxy.  Specifically for the release-2.4 branch since we use a different helm chart version for v2.4.x
CVE-2022-4450
CVE-2023-0215
CVE-2023-0286
 CVE-2022-4304
