### PR TITLE
feat: option to use cluster-info endpoint for `cluster add` (#12625)

### DIFF
--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -541,6 +541,11 @@ func NewGenClusterConfigCommand(pathOpts *clientcmd.PathOptions) *cobra.Command 
 				return
 			}
 
+			if clusterOpts.InCluster && clusterOpts.ClusterEndpoint != "" {
+				log.Fatal("Can only use one of --in-cluster or --cluster-endpoint")
+				return
+			}
+
 			overrides := clientcmd.ConfigOverrides{
 				Context: *clstContext,
 			}
@@ -580,8 +585,12 @@ func NewGenClusterConfigCommand(pathOpts *clientcmd.PathOptions) *cobra.Command 
 			errors.CheckError(err)
 
 			clst := cmdutil.NewCluster(contextName, clusterOpts.Namespaces, clusterOpts.ClusterResources, conf, bearerToken, awsAuthConf, execProviderConf, labelsMap, annotationsMap)
-			if clusterOpts.InCluster {
+			if clusterOpts.InCluster || clusterOpts.ClusterEndpoint == string(cmdutil.KubeInternalEndpoint) {
 				clst.Server = argoappv1.KubernetesInternalAPIServerAddr
+			}
+			if clusterOpts.ClusterEndpoint == string(cmdutil.KubePublicEndpoint) {
+				// Ignore `kube-public` cluster endpoints, since this command is intended to run without invoking any network connections.
+				log.Warn("kube-public cluster endpoints are not supported. Falling back to the endpoint listed in the kubconfig context.")
 			}
 			if clusterOpts.Shard >= 0 {
 				clst.Shard = &clusterOpts.Shard

--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -585,7 +585,7 @@ func NewGenClusterConfigCommand(pathOpts *clientcmd.PathOptions) *cobra.Command 
 			errors.CheckError(err)
 
 			clst := cmdutil.NewCluster(contextName, clusterOpts.Namespaces, clusterOpts.ClusterResources, conf, bearerToken, awsAuthConf, execProviderConf, labelsMap, annotationsMap)
-			if clusterOpts.InCluster || clusterOpts.ClusterEndpoint == string(cmdutil.KubeInternalEndpoint) {
+			if clusterOpts.InClusterEndpoint() {
 				clst.Server = argoappv1.KubernetesInternalAPIServerAddr
 			}
 			if clusterOpts.ClusterEndpoint == string(cmdutil.KubePublicEndpoint) {

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -152,7 +152,7 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 				contextName = clusterOpts.Name
 			}
 			clst := cmdutil.NewCluster(contextName, clusterOpts.Namespaces, clusterOpts.ClusterResources, conf, managerBearerToken, awsAuthConf, execProviderConf, labelsMap, annotationsMap)
-			if clusterOpts.InCluster || clusterOpts.ClusterEndpoint == string(cmdutil.KubeInternalEndpoint) {
+			if clusterOpts.InClusterEndpoint() {
 				clst.Server = argoappv1.KubernetesInternalAPIServerAddr
 			} else if clusterOpts.ClusterEndpoint == string(cmdutil.KubePublicEndpoint) {
 				endpoint, err := cmdutil.GetKubePublicEndpoint(clientset)

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -93,8 +93,16 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 				cmdutil.PrintKubeContexts(configAccess)
 				os.Exit(1)
 			}
+
+			if clusterOpts.InCluster && clusterOpts.ClusterEndpoint != "" {
+				log.Fatal("Can only use one of --in-cluster or --cluster-endpoint")
+				return
+			}
+
 			contextName := args[0]
 			conf, err := getRestConfig(pathOpts, contextName)
+			errors.CheckError(err)
+			clientset, err := kubernetes.NewForConfig(conf)
 			errors.CheckError(err)
 			managerBearerToken := ""
 			var awsAuthConf *argoappv1.AWSAuthConfig
@@ -114,13 +122,10 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 				}
 			} else {
 				// Install RBAC resources for managing the cluster
-				clientset, err := kubernetes.NewForConfig(conf)
-				errors.CheckError(err)
 				if clusterOpts.ServiceAccount != "" {
 					managerBearerToken, err = clusterauth.GetServiceAccountBearerToken(clientset, clusterOpts.SystemNamespace, clusterOpts.ServiceAccount, common.BearerTokenTimeout)
 				} else {
 					isTerminal := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
-
 					if isTerminal && !skipConfirmation {
 						accessLevel := "cluster"
 						if len(clusterOpts.Namespaces) > 0 {
@@ -147,9 +152,18 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 				contextName = clusterOpts.Name
 			}
 			clst := cmdutil.NewCluster(contextName, clusterOpts.Namespaces, clusterOpts.ClusterResources, conf, managerBearerToken, awsAuthConf, execProviderConf, labelsMap, annotationsMap)
-			if clusterOpts.InCluster {
+			if clusterOpts.InCluster || clusterOpts.ClusterEndpoint == string(cmdutil.KubeInternalEndpoint) {
 				clst.Server = argoappv1.KubernetesInternalAPIServerAddr
+			} else if clusterOpts.ClusterEndpoint == string(cmdutil.KubePublicEndpoint) {
+				endpoint, err := cmdutil.GetKubePublicEndpoint(clientset)
+				if err != nil || len(endpoint) == 0 {
+					log.Warn("Failed to find the cluster endpoint from kube-public data. Falling back to the endpoint listed in the kubconfig context.")
+					log.Debugf("Get kube-public endpoint error: %v", err)
+					endpoint = clst.Server
+				}
+				clst.Server = endpoint
 			}
+
 			if clusterOpts.Shard >= 0 {
 				clst.Shard = &clusterOpts.Shard
 			}

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -157,8 +157,8 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 			} else if clusterOpts.ClusterEndpoint == string(cmdutil.KubePublicEndpoint) {
 				endpoint, err := cmdutil.GetKubePublicEndpoint(clientset)
 				if err != nil || len(endpoint) == 0 {
-					log.Warn("Failed to find the cluster endpoint from kube-public data. Falling back to the endpoint listed in the kubconfig context.")
-					log.Debugf("Get kube-public endpoint error: %v", err)
+					log.Warnf("Failed to find the cluster endpoint from kube-public data: %v", err)
+					log.Infof("Falling back to the endpoint '%s' as listed in the kubeconfig context", clst.Server)
 					endpoint = clst.Server
 				}
 				clst.Server = endpoint

--- a/cmd/util/cluster_test.go
+++ b/cmd/util/cluster_test.go
@@ -4,8 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
@@ -68,4 +74,110 @@ func Test_newCluster(t *testing.T) {
 	assert.Equal(t, "test-bearer-token", clusterWithBearerToken.Config.BearerToken)
 	assert.Nil(t, clusterWithBearerToken.Labels)
 	assert.Nil(t, clusterWithBearerToken.Annotations)
+}
+
+func TestGetKubePublicEndpoint(t *testing.T) {
+	cases := []struct {
+		name             string
+		clusterInfo      *corev1.ConfigMap
+		expectedEndpoint string
+		expectError      bool
+	}{
+		{
+			name: "has public endpoint",
+			clusterInfo: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-public",
+					Name:      "cluster-info",
+				},
+				Data: map[string]string{
+					"kubeconfig": kubeconfigFixture("https://test-cluster:6443"),
+				},
+			},
+			expectedEndpoint: "https://test-cluster:6443",
+		},
+		{
+			name:        "no cluster-info",
+			expectError: true,
+		},
+		{
+			name: "no kubeconfig in cluster-info",
+			clusterInfo: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-public",
+					Name:      "cluster-info",
+				},
+				Data: map[string]string{
+					"argo": "the project, not the movie",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "no clusters in cluster-info kubeconfig",
+			clusterInfo: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-public",
+					Name:      "cluster-info",
+				},
+				Data: map[string]string{
+					"kubeconfig": kubeconfigFixture(""),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "can't parse kubeconfig",
+			clusterInfo: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-public",
+					Name:      "cluster-info",
+				},
+				Data: map[string]string{
+					"kubeconfig": "this is not valid YAML",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := []runtime.Object{}
+			if tc.clusterInfo != nil {
+				objects = append(objects, tc.clusterInfo)
+			}
+			clientset := fake.NewSimpleClientset(objects...)
+			endpoint, err := GetKubePublicEndpoint(clientset)
+			if err != nil && !tc.expectError {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectError {
+				t.Error("expected error to be returned, received none")
+			}
+			if endpoint != tc.expectedEndpoint {
+				t.Errorf("expected endpoint %s, got %s", tc.expectedEndpoint, endpoint)
+			}
+		})
+	}
+
+}
+
+func kubeconfigFixture(endpoint string) string {
+	kubeconfig := &clientcmdapiv1.Config{}
+	if len(endpoint) > 0 {
+		kubeconfig.Clusters = []clientcmdapiv1.NamedCluster{
+			{
+				Name: "test-kube",
+				Cluster: clientcmdapiv1.Cluster{
+					Server: endpoint,
+				},
+			},
+		}
+	}
+	configYAML, err := yaml.Marshal(kubeconfig)
+	if err != nil {
+		return ""
+	}
+	return string(configYAML)
 }

--- a/docs/user-guide/commands/argocd_admin_cluster_generate-spec.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_generate-spec.md
@@ -13,6 +13,7 @@ argocd admin cluster generate-spec CONTEXT [flags]
       --aws-cluster-name string            AWS Cluster name if set then aws cli eks token command will be used to access cluster
       --aws-role-arn string                Optional AWS role arn. If set then AWS IAM Authenticator assumes a role to perform cluster operations instead of the default AWS credential provider chain.
       --bearer-token string                Authentication token that should be used to access K8S API server
+      --cluster-endpoint string            Cluster endpoint to use. Can be one of the following: 'kubeconfig', 'kube-public', or 'internal'.
       --cluster-resources                  Indicates if cluster level resources should be managed. The setting is used only if list of managed namespaces is not empty.
       --exec-command string                Command to run to provide client credentials to the cluster. You may need to build a custom ArgoCD image to ensure the command is available at runtime.
       --exec-command-api-version string    Preferred input version of the ExecInfo for the --exec-command executable

--- a/docs/user-guide/commands/argocd_cluster_add.md
+++ b/docs/user-guide/commands/argocd_cluster_add.md
@@ -12,6 +12,7 @@ argocd cluster add CONTEXT [flags]
       --annotation stringArray             Set metadata annotations (e.g. --annotation key=value)
       --aws-cluster-name string            AWS Cluster name if set then aws cli eks token command will be used to access cluster
       --aws-role-arn string                Optional AWS role arn. If set then AWS IAM Authenticator assumes a role to perform cluster operations instead of the default AWS credential provider chain.
+      --cluster-endpoint string            Cluster endpoint to use. Can be one of the following: 'kubeconfig', 'kube-public', or 'internal'.
       --cluster-resources                  Indicates if cluster level resources should be managed. The setting is used only if list of managed namespaces is not empty.
       --exec-command string                Command to run to provide client credentials to the cluster. You may need to build a custom ArgoCD image to ensure the command is available at runtime.
       --exec-command-api-version string    Preferred input version of the ExecInfo for the --exec-command executable


### PR DESCRIPTION
- Add option `--cluster-endpoint` to `cluster add` and `admin cluster`. commands, with values `kubeconfig`, `kube-public`, and `internal`.
- If kube-public is specified, use the endpoint published in the `kube-public/cluster-info` ConfigMap when adding a cluster to ArgoCD.
- Add check that makes the `--in-cluster` and `--cluster-endpoint` flags mutually exclusive.

Fixes #12625 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

