### PR TITLE
fix: `make verify-kube-connect` broken #12676

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,8 @@ hack/
 docs/
 examples/
 .github/
+!test/fixture/testrepos
+!test/container
 !hack/installers
 !hack/gpg-wrapper.sh
 !hack/git-verify-wrapper.sh

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/redis:7.0.8-alpine as redis
+FROM docker.io/library/redis:7.0.8@sha256:6a59f1cbb8d28ac484176d52c473494859a512ddba3ea62a547258cf16c9b3ae as redis
 
 # There are libraries we will want to copy from here in the final stage of the
 # build, but the COPY directive does not have a way to determine system


### PR DESCRIPTION
Fixes #12676.
- @34fathombelow Notice that I am using a different image than the one you used for Redis at #12627. I've checked that the openssl issue is resolved in the image I used [here](https://hub.docker.com/layers/library/redis/7.0.9/images/sha256-54043f92c16727f142fa93c377b279f91879abf974c244ce72099b35fefbd7b2?context=explore).
- I've excluded certain dependencies from the `.dockerignore` file.
- This continues happening due to insufficient testing that the local dev flow is functioning properly. I'll create an enhancement proposal: #12678.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

