### PR TITLE
chore: inform user when a plugin's name is required

### DIFF
--- a/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
+++ b/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
@@ -44,7 +44,7 @@ func NewCommand() *cobra.Command {
 			config, err := plugin.ReadPluginConfig(configFilePath)
 			errors.CheckError(err)
 
-			if config.Spec.Discover.FileName == "" && config.Spec.Discover.Find.Glob == "" && len(config.Spec.Discover.Find.Command.Command) == 0 {
+			if !config.Spec.Discover.IsDefined() {
 				name := config.Metadata.Name
 				if config.Spec.Version != "" {
 					name = name + "-" + config.Spec.Version

--- a/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
+++ b/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
@@ -44,6 +44,14 @@ func NewCommand() *cobra.Command {
 			config, err := plugin.ReadPluginConfig(configFilePath)
 			errors.CheckError(err)
 
+			if config.Spec.Discover.FileName == "" && config.Spec.Discover.Find.Glob == "" && len(config.Spec.Discover.Find.Command.Command) == 0 {
+				name := config.Metadata.Name
+				if config.Spec.Version != "" {
+					name = name + "-" + config.Spec.Version
+				}
+				log.Infof("No discovery configuration is defined for plugin %s. To use this plugin, specify %q in the Application's spec.source.plugin.name field.", config.Metadata.Name, name)
+			}
+
 			if otlpAddress != "" {
 				var closer func()
 				var err error

--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -29,10 +29,14 @@ type PluginConfigSpec struct {
 	Parameters Parameters `yaml:"parameters"`
 }
 
-//Discover holds find and fileName
+// Discover holds find and fileName
 type Discover struct {
 	Find     Find   `json:"find"`
 	FileName string `json:"fileName"`
+}
+
+func (d Discover) IsDefined() bool {
+	return d.FileName != "" || d.Find.Glob == "" || len(d.Find.Command.Command) > 0
 }
 
 // Command holds binary path and arguments list


### PR DESCRIPTION
If no discovery rules are set, then the user must specify the plugin's name.

This change helps inform the plugin author of that fact.

Helps solve problems like this: https://cloud-native.slack.com/archives/C01TSERG0KZ/p1677665085430139