### PR TITLE
fix: stop using mixed rxjs versions in Argo CD UI

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -54,7 +54,8 @@
   "resolutions": {
     "@types/react": "^16.9.3",
     "@types/react-dom": "^16.8.2",
-    "normalize-url": "4.3.0"
+    "normalize-url": "4.3.0",
+    "rxjs": "6.6.7"
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/ui/src/app/applications/components/applications-list/applications-list.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-list.tsx
@@ -114,7 +114,7 @@ const ViewPref = ({children}: {children: (pref: AppsListPreferences & {page: num
                                     .filter(item => !!item);
                             }
                             if (params.get('autoSync') != null) {
-                                viewPref.autosyncFilter = params
+                                viewPref.autoSyncFilter = params
                                     .get('autoSync')
                                     .split(',')
                                     .filter(item => !!item);

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8187,19 +8187,12 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.6:
+rxjs@6.6.7, rxjs@^6.6.6, rxjs@^7.5.5:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
-
-rxjs@^7.5.5:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
-  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
-  dependencies:
-    tslib "^2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -9183,11 +9176,6 @@ tslib@^2.0.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
-tslib@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslint-config-prettier@^1.18.0:
   version "1.18.0"


### PR DESCRIPTION
The rxjs library was upgraded to 7.x in argo-ui but in argocd-ui still uses 6.x. So as a result we are using both version. I cannot explain why build is not failing, but VSCode is showing errors:

<img width="1519" alt="image" src="https://user-images.githubusercontent.com/426437/222276724-e1b271b6-2593-49cf-affd-cd3df4537b0e.png">

PR overrides rxjs version to 6.x (it is not that easy to upgrade to 7.x) which makes VSCode usable again and reduces js bundle size by ~100kb:

before:

```
ui git:(master) ls -lah dist/app/main.faae1c5b3a1f8bc33b6f.js                                                                                                        (k3d-akuity/default)
-rw-r--r--  1 alexmt  staff   5.1M Mar  1 14:08 dist/app/main.faae1c5b3a1f8bc33b6f.js
```

after:
```
ls -lah dist/app/main.45675ccc95492ebf352f.js                                                                                               (k3d-akuity/default)
-rw-r--r--  1 alexmt  staff   5.0M Mar  1 14:12 dist/app/main.45675ccc95492ebf352f.js
```