### PR TITLE
fix: allow sync when multiple allow windows are present

### DIFF
--- a/docs/user-guide/sync_windows.md
+++ b/docs/user-guide/sync_windows.md
@@ -7,7 +7,7 @@ of both manual and automated syncs but allow an override for manual syncs which 
 in preventing automated syncs or if you need to temporarily override a window to perform a sync.
 
 The windows work in the following way. If there are no windows matching an application then all syncs are allowed. If there
-are any `allow` windows matching an application then syncs will only be allowed when there is an active `allow` windows. If there
+are any `allow` windows matching an application then syncs will only be allowed when there is an active `allow` window. If there
 are any `deny` windows matching an application then all syncs will be denied when the `deny` windows are active. If there is an
 active matching `allow` and an active matching `deny` then syncs will be denied as `deny` windows override `allow` windows. The
 UI and the CLI will both display the state of the sync windows. The UI has a panel which will display different colours depending

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2068,6 +2068,10 @@ func (w *SyncWindows) CanSync(isManual bool) bool {
 		}
 	}
 
+	if active.hasAllow() {
+		return true
+	}
+
 	inactiveAllows := w.InactiveAllows()
 	if inactiveAllows.HasWindows() {
 		if isManual && inactiveAllows.manualEnabled() {

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -2133,6 +2133,20 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		// then
 		assert.False(t, canSync)
 	})
+	t.Run("will allow auto sync with active-allow and inactive-allow", func(t *testing.T) {
+		// given
+		t.Parallel()
+		proj := newProjectBuilder().
+			withActiveAllowWindow(false).
+			withInactiveAllowWindow(false).
+			build()
+
+		// when
+		canSync := proj.Spec.SyncWindows.CanSync(false)
+
+		// then
+		assert.True(t, canSync)
+	})
 	t.Run("will deny manual sync with active-deny", func(t *testing.T) {
 		// given
 		t.Parallel()


### PR DESCRIPTION
The [sync window documentation](https://argo-cd.readthedocs.io/en/stable/user-guide/sync_windows/) states "If there are any `allow` windows matching an application then syncs will only be allowed when there is an active `allow` windows." However, the implementation appears to be that if there are multiple allow windows (e.g., allowing deploys from 9-5 on M-Th but only from 9-2 on F), then deploys will not be allowed if there are any inactive windows.

This adds a check after disallowing if a deny window is active but before disallowing if an allow window is inactive to allow if an allow window is active, regardless of any inactive allow windows.

This also fixes a typo in the referenced documentation (window vs windows).

Fixes #10425.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

