### PR TITLE
fix: 'action.Disabled' visualization in argocd admin settings resource-overrides list-actions

### DIFF
--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -505,7 +505,7 @@ argocd admin settings resource-overrides action list /tmp/deploy.yaml --argocd-c
 				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 				_, _ = fmt.Fprintf(w, "NAME\tENABLED\n")
 				for _, action := range availableActions {
-					_, _ = fmt.Fprintf(w, "%s\t%s\n", action.Name, strconv.FormatBool(action.Disabled))
+					_, _ = fmt.Fprintf(w, "%s\t%s\n", action.Name, strconv.FormatBool(!action.Disabled))
 				}
 				_ = w.Flush()
 			})

--- a/cmd/argocd/commands/admin/settings_test.go
+++ b/cmd/argocd/commands/admin/settings_test.go
@@ -384,8 +384,8 @@ func TestResourceOverrideAction(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Contains(t, out, `NAME     ENABLED
-restart  false
-resume   false
+restart  true
+resume   true
 `)
 	})
 }


### PR DESCRIPTION
A quick fix to properly show the enabled state of a (custom) action when using `argocd admin settings resource-overrides list-actions`

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

