### PR TITLE
test: wait longer after repo server restarted to avoid errors on s390x

### DIFF
--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -811,6 +811,8 @@ func RestartRepoServer() {
 		}
 		FailOnErr(Run("", "kubectl", "rollout", "restart", "deployment", workload))
 		FailOnErr(Run("", "kubectl", "rollout", "status", "deployment", workload))
+		// wait longer to avoid error on s390x
+		time.Sleep(10 * time.Second)
 	}
 }
 


### PR DESCRIPTION
Add a wait time 10 seconds after `repo server` is restarted to avoid `connection refused` error on s380x 
 in the following 7 cases:
```
TestCustomToolWithGitCreds
TestCustomToolWithGitCredsTemplate
TestHelmRepo
TestHelmWithDependencies
TestHelmRepoDiffLocal
TestCanAddAppFromClientCertRepoWithCredCfg 
TestCanAccessSSHRepo    
```

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

