### PR TITLE
chore: pin mkdocs Python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,3 +5,7 @@ mkdocs:
 python:
   install:
     - requirements: docs/requirements.txt
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"


### PR DESCRIPTION
Following this: https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

To avoid this: https://readthedocs.org/projects/argo-cd/builds/19855696/