### PR TITLE
fix: better repo path sanitization

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -2772,3 +2772,11 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		})
 	}
 }
+
+func Test_getRepoSanitizerRegex(t *testing.T) {
+	r := getRepoSanitizerRegex("/tmp/_argocd-repo")
+	msg := r.ReplaceAllString("error message containing /tmp/_argocd-repo/SENSITIVE and other stuff", "<path to cached source>")
+	assert.Equal(t, "error message containing <path to cached source> and other stuff", msg)
+	msg = r.ReplaceAllString("error message containing /tmp/_argocd-repo/SENSITIVE/with/trailing/path and other stuff", "<path to cached source>")
+	assert.Equal(t, "error message containing <path to cached source>/with/trailing/path and other stuff", msg)
+}


### PR DESCRIPTION
This fixes two problems:

1. We currently only sanitize sensitive paths from error messages if the path ends with a `/` - but they don't always end with a `/`, particularly in the case of errors related to Helm charts.
2. Replacing with a `.` leads to confusing messages like ".values.yaml not found". The user thinks "wat the hek, I don't have a file called .values.yaml." So now we'll replace with the more meaningful "\<path to cached source>".