### PR TITLE
fix: Add more context to the sync failed  message when resource kind  doesn't exist 

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -56,7 +56,7 @@ func (m *appStateManager) getGVKParser(server string) (*managedfields.GvkParser,
 	return cluster.GetGVKParser(), nil
 }
 
-func (m *appStateManager) getAPIResourceVersion(server string, kind string) (*[]kube.APIResourceInfo, error) {
+func (m *appStateManager) getAPIResourceVersion(server string) (*[]kube.APIResourceInfo, error) {
 	_, apiResources, err := m.liveStateCache.GetVersionsInfo(server)
 
 	if err != nil {
@@ -334,7 +334,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 	for _, res := range resState {
 
 		err := argo.FormatSyncMsg(&res, func(kind string) (*[]kube.APIResourceInfo, error) {
-			return m.getAPIResourceVersion(app.Spec.Destination.Server, kind)
+			return m.getAPIResourceVersion(app.Spec.Destination.Server)
 		})
 
 		if err != nil {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -325,20 +325,20 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 
 	var apiVersion []kube.APIResourceInfo
 	for _, res := range resState {
-
-		err := argo.FormatSyncMsg(&res, func() ([]kube.APIResourceInfo, error) {
-
+		augmentedMsg, err := argo.AugmentSyncMsg(res, func() ([]kube.APIResourceInfo, error) {
 			if apiVersion == nil {
 				_, apiVersion, err = m.liveStateCache.GetVersionsInfo(app.Spec.Destination.Server)
 				if err != nil {
-					return nil, fmt.Errorf("failed to fetch resource of given kind %s from the target cluster", res.ResourceKey.Kind)
+					return nil, fmt.Errorf("failed to get version info from the target cluster %q", app.Spec.Destination.Server)
 				}
 			}
 			return apiVersion, nil
 		})
 
 		if err != nil {
-			log.Errorf("show the original message since: %v", err)
+			log.Errorf("using the original message since: %v", err)
+		} else {
+			res.Message = augmentedMsg
 		}
 
 		state.SyncResult.Resources = append(state.SyncResult.Resources, &v1alpha1.ResourceResult{

--- a/test/e2e/api_versions_test.go
+++ b/test/e2e/api_versions_test.go
@@ -1,0 +1,57 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
+)
+
+func TestAppSyncWrongVersion(t *testing.T) {
+	// Make sure the error messages are good when there are group or version mismatches between CRDs and resources.
+	ctx := Given(t)
+	ctx.
+		Path("crd-version-differences").
+		When().
+		CreateApp().
+		// Install CRD and one instance of it on v1alpha1
+		AppSet("--directory-include", "crd-v1alpha1.yaml").
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		When().
+		AppSet("--directory-include", "crd-v1alpha2-instance.yaml").
+		IgnoreErrors(). // Ignore errors because we are testing the error message.
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
+		When().
+		DoNotIgnoreErrors().
+		Get().
+		Then().
+		// Technically it's a "success" because we're just doing a "get," but the get output contains the error message.
+		Expect(SuccessRegex(`The Kubernetes API could not find version "v1alpha2" of argoproj\.io/Dummy for requested resource [a-z0-9-]+/dummy-crd-instance\. Version "v1alpha1" of argoproj\.io/Dummy is installed on the destination cluster\.`)).
+		When().
+		AppSet("--directory-include", "crd-wronggroup-instance.yaml", "--directory-exclude", "crd-v1alpha2-instance.yaml").
+		IgnoreErrors(). // Ignore errors because we are testing the error message.
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
+		When().
+		DoNotIgnoreErrors().
+		Get().
+		Then().
+		Expect(SuccessRegex(`The Kubernetes API could not find version "v1alpha1" of wrong\.group/Dummy for requested resource [a-z0-9-]+/dummy-crd-instance-wronggroup\. Version "v1alpha1" of argoproj\.io/Dummy is installed on the destination cluster\.`)).
+		When().
+		AppSet("--directory-include", "crd-does-not-exist-instance.yaml", "--directory-exclude", "crd-wronggroup-instance.yaml").
+		IgnoreErrors(). // Ignore errors because we are testing the error message.
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
+		When().
+		DoNotIgnoreErrors().
+		Get().
+		Then().
+		// Not the best error message, but good enough.
+		Expect(Success(`DoesNotExist.argoproj.io "" not found`))
+}

--- a/test/e2e/api_versions_test.go
+++ b/test/e2e/api_versions_test.go
@@ -30,7 +30,7 @@ func TestAppSyncWrongVersion(t *testing.T) {
 		Get().
 		Then().
 		// Technically it's a "success" because we're just doing a "get," but the get output contains the error message.
-		Expect(SuccessRegex(`The Kubernetes API could not find version "v1alpha2" of argoproj\.io/Dummy for requested resource [a-z0-9-]+/dummy-crd-instance\. Version "v1alpha1" of argoproj\.io/Dummy is installed on the destination cluster\.`)).
+		Expect(SuccessRegex(`The Kubernetes API could not find version "v1alpha2" of argoproj\.io/Fake for requested resource [a-z0-9-]+/fake-crd-instance\. Version "v1alpha1" of argoproj\.io/Fake is installed on the destination cluster\.`)).
 		When().
 		AppSet("--directory-include", "crd-wronggroup-instance.yaml", "--directory-exclude", "crd-v1alpha2-instance.yaml").
 		IgnoreErrors(). // Ignore errors because we are testing the error message.
@@ -41,7 +41,7 @@ func TestAppSyncWrongVersion(t *testing.T) {
 		DoNotIgnoreErrors().
 		Get().
 		Then().
-		Expect(SuccessRegex(`The Kubernetes API could not find version "v1alpha1" of wrong\.group/Dummy for requested resource [a-z0-9-]+/dummy-crd-instance-wronggroup\. Version "v1alpha1" of argoproj\.io/Dummy is installed on the destination cluster\.`)).
+		Expect(SuccessRegex(`The Kubernetes API could not find version "v1alpha1" of wrong\.group/Fake for requested resource [a-z0-9-]+/fake-crd-instance-wronggroup\. Version "v1alpha1" of argoproj\.io/Fake is installed on the destination cluster\.`)).
 		When().
 		AppSet("--directory-include", "crd-does-not-exist-instance.yaml", "--directory-exclude", "crd-wronggroup-instance.yaml").
 		IgnoreErrors(). // Ignore errors because we are testing the error message.

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -353,6 +353,12 @@ func (a *Actions) Refresh(refreshType RefreshType) *Actions {
 	return a
 }
 
+func (a *Actions) Get() *Actions {
+	a.context.t.Helper()
+	a.runCli("app", "get", a.context.AppQualifiedName())
+	return a
+}
+
 func (a *Actions) Delete(cascade bool) *Actions {
 	a.context.t.Helper()
 	a.runCli("app", "delete", a.context.AppQualifiedName(), fmt.Sprintf("--cascade=%v", cascade), "--yes")

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -299,13 +299,24 @@ func NamespacedEvent(namespace string, reason string, message string) Expectatio
 	return event(namespace, reason, message)
 }
 
-// asserts that the last command was successful
-func Success(message string) Expectation {
+// Success asserts that the last command was successful and that the output contains the given message.
+func Success(message string, matchers ...func(string, string) bool) Expectation {
+	if len(matchers) == 0 {
+		matchers = append(matchers, strings.Contains)
+	}
+	match := func(actual, expected string) bool {
+		for i := range matchers {
+			if !matchers[i](actual, expected) {
+				return false
+			}
+		}
+		return true
+	}
 	return func(c *Consequences) (state, string) {
 		if c.actions.lastError != nil {
 			return failed, "error"
 		}
-		if !strings.Contains(c.actions.lastOutput, message) {
+		if !match(c.actions.lastOutput, message) {
 			return failed, fmt.Sprintf("output did not contain '%s'", message)
 		}
 		return succeeded, fmt.Sprintf("no error and output contained '%s'", message)
@@ -342,6 +353,13 @@ func Error(message, err string, matchers ...func(string, string) bool) Expectati
 // ErrorRegex asserts that the last command was an error that matches given regex epxression
 func ErrorRegex(messagePattern, err string) Expectation {
 	return Error(messagePattern, err, func(actual, expected string) bool {
+		return regexp.MustCompile(expected).MatchString(actual)
+	})
+}
+
+// SuccessRegex asserts that the last command was successful and output matches given regex expression
+func SuccessRegex(messagePattern string) Expectation {
+	return Success(messagePattern, func(actual, expected string) bool {
 		return regexp.MustCompile(expected).MatchString(actual)
 	})
 }

--- a/test/e2e/testdata/crd-version-differences/crd-does-not-exist-instance.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-does-not-exist-instance.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: DoesNotExist
+metadata:
+  name: dummy-crd-instance-doesnotexist
+spec:
+  cpu: 2000m
+  memory: 32Mi

--- a/test/e2e/testdata/crd-version-differences/crd-v1alpha1.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-v1alpha1.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dummies.argoproj.io
+spec:
+  conversion:
+    strategy: None
+  group: argoproj.io
+  names:
+    kind: Dummy
+    listKind: DummyList
+    plural: dummies
+    singular: dummy
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                cpu:
+                  type: string
+                memory:
+                  type: string

--- a/test/e2e/testdata/crd-version-differences/crd-v1alpha1.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-v1alpha1.yaml
@@ -1,16 +1,16 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: dummies.argoproj.io
+  name: fakes.argoproj.io
 spec:
   conversion:
     strategy: None
   group: argoproj.io
   names:
-    kind: Dummy
-    listKind: DummyList
-    plural: dummies
-    singular: dummy
+    kind: Fake
+    listKind: FakeList
+    plural: fakes
+    singular: fake
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/test/e2e/testdata/crd-version-differences/crd-v1alpha2-instance.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-v1alpha2-instance.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha2
+kind: Dummy
+metadata:
+  name: dummy-crd-instance
+spec:
+  cpu: 2000m
+  memory: 32Mi

--- a/test/e2e/testdata/crd-version-differences/crd-v1alpha2-instance.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-v1alpha2-instance.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha2
-kind: Dummy
+kind: Fake
 metadata:
-  name: dummy-crd-instance
+  name: fake-crd-instance
 spec:
   cpu: 2000m
   memory: 32Mi

--- a/test/e2e/testdata/crd-version-differences/crd-wronggroup-instance.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-wronggroup-instance.yaml
@@ -1,0 +1,7 @@
+apiVersion: wrong.group/v1alpha1
+kind: Dummy
+metadata:
+  name: dummy-crd-instance-wronggroup
+spec:
+  cpu: 2000m
+  memory: 32Mi

--- a/test/e2e/testdata/crd-version-differences/crd-wronggroup-instance.yaml
+++ b/test/e2e/testdata/crd-version-differences/crd-wronggroup-instance.yaml
@@ -1,7 +1,7 @@
 apiVersion: wrong.group/v1alpha1
-kind: Dummy
+kind: Fake
 metadata:
-  name: dummy-crd-instance-wronggroup
+  name: fake-crd-instance-wronggroup
 spec:
   cpu: 2000m
   memory: 32Mi

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -70,10 +70,6 @@ func getAPIResourceInfo(kind string, apiVersFn func() ([]kube.APIResourceInfo, e
 		}
 	}
 
-	if resource == nil {
-		return nil, fmt.Errorf("no matching resource found of kind: %s", kind)
-	}
-
 	return resource, nil
 }
 

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -44,9 +44,11 @@ func FormatSyncMsg(res *common.ResourceSyncResult, apiVersFn func() ([]kube.APIR
 		if err != nil {
 			return err
 		}
-		res.Message = fmt.Sprintf("The server could not find requested resource %s. Make sure the CRD is installed on the destination cluster, "+
-			"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind: %s is %s",
-			res.ResourceKey.Name, resource.GroupKind.Kind, resource.GroupVersionResource.Version)
+		if resource == nil {
+			res.Message = fmt.Sprintf("The Kubernetes API could not find %s/%s for requested resource %s/%s. Make sure the %q CRD is installed on the destination cluster.", res.ResourceKey.Group, res.ResourceKey.Kind, res.ResourceKey.Namespace, res.ResourceKey.Name, res.ResourceKey.Kind)
+		} else {
+			res.Message = fmt.Sprintf("The Kubernetes API could not find version %q of %s/%s for requested resource %s/%s. Version %q of %s/%s is installed on the destination cluster.", res.Version, res.ResourceKey.Group, res.ResourceKey.Kind, res.ResourceKey.Namespace, res.ResourceKey.Name, resource.GroupVersionResource.Version, resource.GroupKind.Group, resource.GroupKind.Kind)"
+		}
 	}
 
 	return nil

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -65,7 +65,7 @@ func FormatSyncMsg(res *common.ResourceSyncResult, f func(kind string) (*[]kube.
 	switch res.Message {
 	case "the server could not find the requested resource":
 		res.Message = fmt.Sprintf("The server could not find resource %s. Make sure the CRD is installed on the destination cluster, "+
-			"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind `%s` is %s",
+			"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind: %s is %s",
 			res.ResourceKey.Name, resource.GroupKind.Kind, resource.GroupVersionResource.Version)
 	}
 

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -46,7 +46,7 @@ func AugmentSyncMsg(res common.ResourceSyncResult, apiResourceInfoGetter func() 
 		if resource == nil {
 			res.Message = fmt.Sprintf("The Kubernetes API could not find %s/%s for requested resource %s/%s. Make sure the %q CRD is installed on the destination cluster.", res.ResourceKey.Group, res.ResourceKey.Kind, res.ResourceKey.Namespace, res.ResourceKey.Name, res.ResourceKey.Kind)
 		} else {
-			res.Message = fmt.Sprintf("The Kubernetes API could not find version %q of %s/%s for requested resource %s/%s. Version %q of %s/%s is installed on the destination cluster.", res.Version, res.ResourceKey.Group, res.ResourceKey.Kind, res.ResourceKey.Namespace, res.ResourceKey.Name, resource.GroupVersionResource.Version, resource.GroupKind.Group, resource.GroupKind.Kind)"
+			res.Message = fmt.Sprintf("The Kubernetes API could not find version %q of %s/%s for requested resource %s/%s. Version %q of %s/%s is installed on the destination cluster.", res.Version, res.ResourceKey.Group, res.ResourceKey.Kind, res.ResourceKey.Namespace, res.ResourceKey.Name, resource.GroupVersionResource.Version, resource.GroupKind.Group, resource.GroupKind.Kind)
 		}
 	}
 

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -1469,7 +1469,7 @@ func TestFormatSyncMsg(t *testing.T) {
 			name: "match specific k8s error",
 			msg:  "the server could not find the requested resource",
 			expectedMessage: "The server could not find resource deployment-resource. Make sure the CRD is installed on the destination cluster, " +
-				"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind `Deployment` is v1beta1",
+				"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind: Deployment is v1beta1",
 			mockFn: mockAPIResourcesFn,
 		},
 		{

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -1513,7 +1513,6 @@ func TestFormatSyncMsg(t *testing.T) {
 				res.ResourceKey.Kind = tt.kind
 			}
 			err := FormatSyncMsg(res, tt.mockFn)
-			fmt.Println(err)
 			if res.ResourceKey.Kind == "Volume" {
 				assert.NotNil(t, err)
 			} else {

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -1468,7 +1468,7 @@ func TestFormatSyncMsg(t *testing.T) {
 		{
 			name: "match specific k8s error",
 			msg:  "the server could not find the requested resource",
-			expectedMessage: "The server could not find resource deployment-resource. Make sure the CRD is installed on the destination cluster, " +
+			expectedMessage: "The server could not find requested resource deployment-resource. Make sure the CRD is installed on the destination cluster, " +
 				"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind: Deployment is v1beta1",
 			mockFn: mockAPIResourcesFn,
 		},

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -1466,22 +1466,22 @@ func TestFormatSyncMsg(t *testing.T) {
 		mockFn          func(string) (*[]kube.APIResourceInfo, error)
 	}{
 		{
-			name: "match_specific_k8s_error",
+			name: "match specific k8s error",
 			msg:  "the server could not find the requested resource",
-			expectedMessage: fmt.Sprintf("The server could not find resource deployment-resource. Make sure the CRD is installed on the destination cluster, " +
-				"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind `Deployment` is v1beta1"),
+			expectedMessage: "The server could not find resource deployment-resource. Make sure the CRD is installed on the destination cluster, " +
+				"and that the requested CRD version is available. Currently, the installed API version for the corresponding Kind `Deployment` is v1beta1",
 			mockFn: mockAPIResourcesFn,
 		},
 		{
-			name:            "no_match_random_k8s_error",
+			name:            "any random k8s msg",
 			msg:             "random message from k8s",
-			expectedMessage: fmt.Sprintf("random message from k8s"),
+			expectedMessage: "random message from k8s",
 			mockFn:          mockAPIResourcesFn,
 		},
 		{
-			name:            "no_resource_kind_match",
+			name:            "resource doesn't exist in the target cluster",
 			kind:            "Volume",
-			expectedMessage: fmt.Sprintf("random message from k8s"),
+			expectedMessage: "random message from k8s",
 			mockFn: func(string) (*[]kube.APIResourceInfo, error) {
 				return &[]kube.APIResourceInfo{
 					{
@@ -1498,8 +1498,8 @@ func TestFormatSyncMsg(t *testing.T) {
 			},
 		},
 		{
-			name:            "api_resource_nil",
-			expectedMessage: fmt.Sprintf("random message from k8s"),
+			name:            "API Resource is empty",
+			expectedMessage: "random message from k8s",
 			mockFn: func(string) (*[]kube.APIResourceInfo, error) {
 				return nil, errors.New("random message from k8s")
 			},


### PR DESCRIPTION
This PR enriches the Kubernetes error message to include a more user-friendly message. When the user gets the error message `the server could not find the requested resource`. This error message is not sufficient to indicate that the API version changed in the target cluster. The PR would provide more context to the error message on the relevant API version 