### PR TITLE
chore: use ghcr for latest tag attestations

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,7 @@ jobs:
       ghcr_username: ${{ github.actor }}
       ghcr_password: ${{ secrets.GITHUB_TOKEN }}
 
-  build-and-publish-provenance:
+  build-and-publish-provenance: # Push attestations to GHCR, latest image is polluting quay.io
     needs: [build-and-publish]
     permissions:
       actions: read # for detecting the Github Actions environment.
@@ -87,11 +87,11 @@ jobs:
     # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.5.0
     with:
-      image: quay.io/argoproj/argocd
-      digest: ${{ needs.build-and-publish.outputs.image-digest }}
+      image: ghcr.io/argoproj/argo-cd/argocd
+      digest: ${{ needs.set-vars.outputs.image-tag }}
+      registry-username: ${{ github.actor }}
     secrets:
-      registry-username: ${{ secrets.RELEASE_QUAY_USERNAME }}
-      registry-password: ${{ secrets.RELEASE_QUAY_TOKEN }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
 
   Deploy:
     needs:


### PR DESCRIPTION
Currently during a `push` event to the `master` branch we are building attestations then attaching them to the latest tag on quay.io.  This is great for testing the attestation workflow but it is polluting the registry with attestations. This PR will instead test the attestations workflow and push attestations to ghcr.


![image](https://user-images.githubusercontent.com/76892343/228867878-fca03b6f-dfbc-463d-a9f1-9e91331e0aeb.png)

All `*.att` tags can be safely removed from quay.io registry **execpt** for the one selected in the image below, as that attestation is for v2.7.0-rc1. Notice how `sha256-3f18ffb6320ad3c4979e3958abe5a8ec991e3e225d0d86e1a346a13e5cb35b63.att` matches the image digest of the v2.7.0-rc1 tag.
![image](https://user-images.githubusercontent.com/76892343/228868540-8e4ccac1-73d2-4248-89da-ad86c6e8f86d.png)



  