### PR TITLE
chore: PR title checker, uses less permissive permissions

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,14 @@
+{
+    "LABEL": {
+      "name": "title needs formatting",
+      "color": "EEEEEE"
+    },
+    "CHECKS": {
+      "regexp": "^(feat|fix|docs|test|ci|chore|\[Bot\]).*:.+$"
+    },
+    "MESSAGES": {
+      "success": "PR title is valid",
+      "failure": "PR title is invalid",
+      "notice": "PR Title needs to pass regex '^(feat|fix|docs|test|ci|chore|\[Bot\]).*:.+$"
+    }
+  }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@ Checklist:
 
 * [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
 * [ ] The title of the PR states what changed and the related issues number (used for the release note).
+* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
 * [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
 * [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
 * [ ] Does this PR require documentation updates?

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -2,15 +2,11 @@ name: "Lint PR"
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+    types: [opened, edited, reopened, synchronize]
 
 # IMPORTANT: No checkout actions, scripts, or builds should be added to this workflow. Permissions should always be used
-# with extreme caution.
-permissions:
-  contents: read
+# with extreme caution. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+permissions: {}
 
 # PR updates can happen in quick succession leading to this
 # workflow being trigger a number of times. This limits it
@@ -18,24 +14,16 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+
 jobs:
-  main:
+  validate:
     permissions:
-      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
-      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
-    name: Validate PR title
+      contents: read
+      pull-requests: read
+    name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      # IMPORTANT: Carefully review changes when updating this action. Using the pull_request_target event requires caution.
-      - uses: amannn/action-semantic-pull-request@b6bca70dcd3e56e896605356ce09b76f7e1e0d39 # v5.1.0
+      - uses: thehanimo/pr-title-checker@cdafc664bf9b25678d4e6df76ff67b2fe21bb5d2 # v1.3.7
         with:
-          types: |
-            feat
-            fix
-            docs
-            test
-            ci
-            chore
-            [Bot] docs
-        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          configuration_path: ".github/pr-title-checker-config.json"

--- a/docs/developer-guide/toolchain-guide.md
+++ b/docs/developer-guide/toolchain-guide.md
@@ -53,7 +53,7 @@ The following read will help you to submit a PR that meets the standards of our 
 
 Please use a meaningful and concise title for your PR. This will help us to pick PRs for review quickly, and the PR title will also end up in the Changelog.
 
-We use the [Semantic PR title checker](https://github.com/zeke/semantic-pull-requests) to categorize your PR into one of the following categories:
+We use [PR title checker](https://github.com/marketplace/actions/pr-title-checker) to categorize your PR into one of the following categories:
 
 * `fix` - Your PR contains one or more code bug fixes
 * `feat` - Your PR contains a new feature


### PR DESCRIPTION
This PR uses a PR title checker that uses less permissive permissions. In particular the old workflow would give `statuses: write` permissions using the [`on.pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event trigger that has potential security consequences.

This should also help bump up our overall OpenSSF Scorecard score.