### PR TITLE
 feat: add health-checks for Percona XtraDB cluster

### DIFF
--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health.lua
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health.lua
@@ -14,7 +14,7 @@ if obj.status ~= nil then
   end
 
   if obj.status.state == "paused" then
-    hs.status = "Degraded"
+    hs.status = "Unknown"
     hs.message = "Cluster is paused"
     return hs
   end
@@ -33,6 +33,6 @@ if obj.status ~= nil then
 
 end
 
-hs.status = "Progressing"
-hs.message = "Waiting for cluster state"
+hs.status = "Unknown"
+hs.message = "Cluster status is unknown. Ensure your ArgoCD is current and then check for/file a bug report: https://github.com/argoproj/argo-cd/issues"
 return hs

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health.lua
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health.lua
@@ -1,0 +1,38 @@
+hs = {}
+if obj.status ~= nil then
+
+  if obj.status.state == "initializing" then
+    hs.status = "Progressing"
+    hs.message = obj.status.ready .. "/" .. obj.status.size .. " node(s) are ready"
+    return hs
+  end
+
+  if obj.status.state == "ready" then
+    hs.status = "Healthy"
+    hs.message = obj.status.ready .. "/" .. obj.status.size .. " node(s) are ready"
+    return hs
+  end
+
+  if obj.status.state == "paused" then
+    hs.status = "Degraded"
+    hs.message = "Cluster is paused"
+    return hs
+  end
+
+  if obj.status.state == "stopping" then
+    hs.status = "Degraded"
+    hs.message = "Cluster is stopping (" .. obj.status.ready .. "/" .. obj.status.size .. " node(s) are ready)"
+    return hs
+  end
+
+  if obj.status.state == "error" then
+    hs.status = "Degraded"
+    hs.message = "Cluster is on error: " .. table.concat(obj.status.messages, ", ")
+    return hs
+  end
+
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for cluster state"
+return hs

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health_test.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health_test.yaml
@@ -1,0 +1,25 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "0/1 node(s) are ready"
+  inputPath: testdata/initializing.yaml
+- healthStatus:
+    status: Healthy
+    message: "1/1 node(s) are ready"
+  inputPath: testdata/ready.yaml
+- healthStatus:
+    status: Unknown
+    message: "Cluster is paused"
+  inputPath: testdata/paused.yaml
+- healthStatus:
+    status: Degraded
+    message: "Cluster is stopping (1/2 node(s) are ready)"
+  inputPath: testdata/stopping.yaml
+- healthStatus:
+    status: Degraded
+    message: "Cluster is on error: we lost node"
+  inputPath: testdata/error.yaml
+- healthStatus:
+    status: Unknown
+    message: "Cluster status is unknown. Ensure your ArgoCD is current and then check for/file a bug report: https://github.com/argoproj/argo-cd/issues"
+  inputPath: testdata/unknown.yaml

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/error.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/error.yaml
@@ -1,0 +1,24 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: quickstart
+spec: {}
+status:
+  backup: {}
+  haproxy: {}
+  host: pxc-mysql-pxc
+  logcollector: {}
+  observedGeneration: 1
+  pmm: {}
+  proxysql: {}
+  pxc:
+    image: ''
+    ready: 1
+    size: 2
+    status: error
+    version: 8.0.21-12.1
+  ready: 1
+  size: 2
+  state: error
+  messages:
+  - we lost node

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/initializing.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/initializing.yaml
@@ -1,0 +1,22 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: quickstart
+spec: {}
+status:
+  backup: {}
+  haproxy: {}
+  host: pxc-mysql-pxc
+  logcollector: {}
+  observedGeneration: 1
+  pmm: {}
+  proxysql: {}
+  pxc:
+    image: ''
+    ready: 0
+    size: 1
+    status: initializing
+    version: 8.0.21-12.1
+  ready: 0
+  size: 1
+  state: initializing

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/paused.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/paused.yaml
@@ -1,0 +1,22 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: quickstart
+spec: {}
+status:
+  backup: {}
+  haproxy: {}
+  host: pxc-mysql-pxc
+  logcollector: {}
+  observedGeneration: 1
+  pmm: {}
+  proxysql: {}
+  pxc:
+    image: ''
+    ready: 1
+    size: 1
+    status: paused
+    version: 8.0.21-12.1
+  ready: 1
+  size: 1
+  state: paused

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/ready.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/ready.yaml
@@ -1,0 +1,22 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: quickstart
+spec: {}
+status:
+  backup: {}
+  haproxy: {}
+  host: pxc-mysql-pxc
+  logcollector: {}
+  observedGeneration: 1
+  pmm: {}
+  proxysql: {}
+  pxc:
+    image: ''
+    ready: 1
+    size: 1
+    status: ready
+    version: 8.0.21-12.1
+  ready: 1
+  size: 1
+  state: ready

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/stopping.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/stopping.yaml
@@ -1,0 +1,22 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: quickstart
+spec: {}
+status:
+  backup: {}
+  haproxy: {}
+  host: pxc-mysql-pxc
+  logcollector: {}
+  observedGeneration: 1
+  pmm: {}
+  proxysql: {}
+  pxc:
+    image: ''
+    ready: 1
+    size: 2
+    status: stopping
+    version: 8.0.21-12.1
+  ready: 1
+  size: 2
+  state: stopping

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/unknown.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/unknown.yaml
@@ -1,0 +1,22 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: quickstart
+spec: {}
+status:
+  backup: {}
+  haproxy: {}
+  host: pxc-mysql-pxc
+  logcollector: {}
+  observedGeneration: 1
+  pmm: {}
+  proxysql: {}
+  pxc:
+    image: ''
+    ready: 1
+    size: 1
+    status: dontknow
+    version: 8.0.21-12.1
+  ready: 1
+  size: 1
+  state: dontknow


### PR DESCRIPTION
Add health checks for PXC xtrabDB cluster from Percona operator: https://docs.percona.com/percona-operator-for-mysql/


Todo: tests

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
