### PR TITLE
fix: --file usage is broken for 'argocd proj create' command

### DIFF
--- a/cmd/util/project.go
+++ b/cmd/util/project.go
@@ -138,7 +138,10 @@ func readProjFromURI(fileURL string, proj *v1alpha1.AppProject) error {
 	} else {
 		err = config.UnmarshalRemoteFile(fileURL, &proj)
 	}
-	return fmt.Errorf("error reading proj from uri: %w", err)
+	if err != nil {
+		return fmt.Errorf("error reading proj from uri: %w", err)
+	}
+	return nil
 }
 
 func SetProjSpecOptions(flags *pflag.FlagSet, spec *v1alpha1.AppProjectSpec, projOpts *ProjectOpts) int {


### PR DESCRIPTION
PR fixes broken `argocd proj create` command. The command always fails when `--file` flag is used because `readProjFromURI` unconditionally returns error

/cherry-pick release-2.7
/cherry-pick  release-2.7