### PR TITLE
feat: support 'helm.sh/resource-policy: keep' helm annotation

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -53,6 +53,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/glob"
+	"github.com/argoproj/argo-cd/v2/util/helm"
 	logutils "github.com/argoproj/argo-cd/v2/util/log"
 	settings_util "github.com/argoproj/argo-cd/v2/util/settings"
 )
@@ -943,7 +944,9 @@ func (ctrl *ApplicationController) removeProjectFinalizer(proj *appv1.AppProject
 
 // shouldBeDeleted returns whether a given resource obj should be deleted on cascade delete of application app
 func (ctrl *ApplicationController) shouldBeDeleted(app *appv1.Application, obj *unstructured.Unstructured) bool {
-	return !kube.IsCRD(obj) && !isSelfReferencedApp(app, kube.GetObjectRef(obj)) && !resourceutil.HasAnnotationOption(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionDisableDeletion)
+	return !kube.IsCRD(obj) && !isSelfReferencedApp(app, kube.GetObjectRef(obj)) &&
+		!resourceutil.HasAnnotationOption(obj, synccommon.AnnotationSyncOptions, synccommon.SyncOptionDisableDeletion) &&
+		!resourceutil.HasAnnotationOption(obj, helm.ResourcePolicyAnnotation, helm.ResourcePolicyKeep)
 }
 
 func (ctrl *ApplicationController) getPermittedAppLiveObjects(app *appv1.Application, proj *appv1.AppProject, projectClusters func(project string) ([]*appv1.Cluster, error)) (map[kube.ResourceKey]*unstructured.Unstructured, error) {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1528,4 +1528,10 @@ func Test_syncDeleteOption(t *testing.T) {
 		delete := ctrl.shouldBeDeleted(app, cmObj)
 		assert.False(t, delete)
 	})
+	t.Run("with delete set to false object is retained", func(t *testing.T) {
+		cmObj := kube.MustToUnstructured(&cm)
+		cmObj.SetAnnotations(map[string]string{"helm.sh/resource-policy": "keep"})
+		delete := ctrl.shouldBeDeleted(app, cmObj)
+		assert.False(t, delete)
+	})
 }

--- a/docs/operator-manual/upgrading/2.6-2.7.md
+++ b/docs/operator-manual/upgrading/2.6-2.7.md
@@ -58,7 +58,7 @@ The manifests are now using [`tini` as entrypoint][3], instead of `entrypoint.sh
 
 ## Deep Links template updates
 
-Deep Links now allow you to access other values like `cluster`, `project`, `application` and `resource` in the url and condition templates for specific categories of links. 
+Deep Links now allow you to access other values like `cluster`, `project`, `application` and `resource` in the url and condition templates for specific categories of links.
 The templating syntax has also been updated to be prefixed with the type of resource you want to access for example previously if you had a `resource.links` config like :
 ```yaml
   resource.links: |
@@ -75,3 +75,9 @@ This would become :
 ```
 
 Read the full [documentation](../deep_links.md) to see all possible combinations of values accessible fo each category of links.
+
+## Support of `helm.sh/resource-policy` annotation
+
+Argo CD now supports the `helm.sh/resource-policy` annotation to control the deletion of resources. The behavior is the same as the behavior of
+`argocd.argoproj.io/sync-options: Delete=false` annotation: if the annotation is present and set to `keep`, the resource will not be deleted
+when the application is deleted.

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -119,6 +119,7 @@ Argo CD supports many (most?) Helm hooks by mapping the Helm annotations onto Ar
 | `helm.sh/hook-delete-policy` | Supported. See also `argocd.argoproj.io/hook-delete-policy`). |
 | `helm.sh/hook-delete-timeout` | No supported. Never used in Helm stable |
 | `helm.sh/hook-weight` | Supported as equivalent to `argocd.argoproj.io/sync-wave`. |
+| `helm.sh/resource-policy: keep` | Supported as equivalent to `argocd.argoproj.io/sync-options: Delete=false`. |
 
 Unsupported hooks are ignored. In Argo CD, hooks are created by using `kubectl apply`, rather than `kubectl create`. This means that if the hook is named and already exists, it will not change unless you have annotated it with `before-hook-creation`.
 

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -16,6 +16,11 @@ import (
 	pathutil "github.com/argoproj/argo-cd/v2/util/io/path"
 )
 
+const (
+	ResourcePolicyAnnotation = "helm.sh/resource-policy"
+	ResourcePolicyKeep       = "keep"
+)
+
 type HelmRepository struct {
 	Creds
 	Name      string


### PR DESCRIPTION
The v2.7 introduced `argocd.argoproj.io/sync-options: Delete=false` that prevents resource deletion. This PR expands the feature and supports `helm.sh/resource-policy: keep` annotation as well. 

Since Argo CD in general is trying to support [helm hooks](https://github.com/argoproj/argo-cd/blob/master/docs/user-guide/helm.md#helm-hooks), so it makes sense to support `helm.sh/resource-policy: keep` as well.