### PR TITLE
docs: Fix wrong link to non existing page for applicationset reference

### DIFF
--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -66,7 +66,7 @@ See [Web-based Terminal](web_based_terminal.md) for more info.
 
 #### The `applicationsets` resource
 
-[ApplicationSets](applicationset) provide a declarative way to automatically create/update/delete Applications.
+[ApplicationSets](applicationset/index.md) provide a declarative way to automatically create/update/delete Applications.
 
 Granting `applicationsets, create` effectively grants the ability to create Applications. While it doesn't allow the 
 user to create Applications directly, they can create Applications via an ApplicationSet.


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.

I've found a dead link within the RBAC docs which should reference to the applicationset/index.md but lead to nowhere.