### PR TITLE
fix: data race for lazy OIDC provider initialization

### DIFF
--- a/util/oidc/provider.go
+++ b/util/oidc/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ type Provider interface {
 }
 
 type providerImpl struct {
+	sync.RWMutex
 	issuerURL      string
 	client         *http.Client
 	goOIDCProvider *gooidc.Provider
@@ -48,13 +50,21 @@ func NewOIDCProvider(issuerURL string, client *http.Client) Provider {
 
 // oidcProvider lazily initializes, memoizes, and returns the OIDC provider.
 func (p *providerImpl) provider() (*gooidc.Provider, error) {
-	if p.goOIDCProvider != nil {
-		return p.goOIDCProvider, nil
+	p.RLock()
+	var prov = p.goOIDCProvider
+	p.RUnlock()
+	if prov != nil {
+		return prov, nil
 	}
+	// We don't want to hold the lock during the call.
+	// Hence, this could be executed multiple times, but no harm.
 	prov, err := p.newGoOIDCProvider()
 	if err != nil {
 		return nil, err
 	}
+
+	p.Lock()
+	defer p.Unlock()
 	p.goOIDCProvider = prov
 	return p.goOIDCProvider, nil
 }


### PR DESCRIPTION
The ArgoCD server SSO configuration is shared state that gets potentially concurrently read and written to.  We are protecting it with an RWMutex to prevent the data race.  Since it's write-once and the read path is much more common, and there should be no contention.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [-] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [-] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [-] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [-] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [-] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
