### PR TITLE
fix(ui): use name instead of title for CMP parameters

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -319,7 +319,7 @@ export const ApplicationParameters = (props: {
             const liveParam = app.spec.source.plugin?.parameters?.find(param => param.name === name);
             const pluginIcon =
                 announcement && liveParam ? 'This parameter has been provided by plugin, but is overridden in application manifest.' : 'This parameter is provided by the plugin.';
-            const isPluginPar = announcement ? true : false;
+            const isPluginPar = !!announcement;
             if ((announcement?.collectionType === undefined && liveParam?.map) || announcement?.collectionType === 'map') {
                 let liveParamMap;
                 if (liveParam) {
@@ -351,7 +351,7 @@ export const ApplicationParameters = (props: {
                         <FormField
                             field='spec.source.plugin.parameters'
                             componentProps={{
-                                name: announcement?.title ?? announcement?.name ?? name,
+                                name: announcement?.name ?? name,
                                 defaultVal: announcement?.map,
                                 isPluginPar,
                                 setAppParamsDeletedState
@@ -388,7 +388,7 @@ export const ApplicationParameters = (props: {
                         <FormField
                             field='spec.source.plugin.parameters'
                             componentProps={{
-                                name: announcement?.title ?? announcement?.name ?? name,
+                                name: announcement?.name ?? name,
                                 defaultVal: announcement?.array,
                                 isPluginPar,
                                 setAppParamsDeletedState
@@ -429,7 +429,7 @@ export const ApplicationParameters = (props: {
                         <FormField
                             field='spec.source.plugin.parameters'
                             componentProps={{
-                                name: announcement?.title ?? announcement?.name ?? name,
+                                name: announcement?.name ?? name,
                                 defaultVal: announcement?.string,
                                 isPluginPar,
                                 setAppParamsDeletedState


### PR DESCRIPTION
A CMP parameter `title` is meant to be a human-friendly label for the parameter in the UI.

The `title` is currently being used by the UI when writing parameters to the Application manifest. We should never use the title in the Application manifest. Instead we should always rely on the parameter `name`.