### PR TITLE
fix: remove false positive for no-discovery cmp; log string, not bytes

### DIFF
--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -37,7 +37,7 @@ type Discover struct {
 }
 
 func (d Discover) IsDefined() bool {
-	return d.FileName != "" || d.Find.Glob == "" || len(d.Find.Command.Command) > 0
+	return d.FileName != "" || d.Find.Glob != "" || len(d.Find.Command.Command) > 0
 }
 
 // Command holds binary path and arguments list

--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -113,7 +113,7 @@ func runCommand(ctx context.Context, command Command, path string, env []string)
 	}
 	if len(output) == 0 {
 		log.WithFields(log.Fields{
-			"stderr":  stderr,
+			"stderr":  stderr.String(),
 			"command": command,
 		}).Warn("Plugin command returned zero output")
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a95bc7c</samp>

Fix a bug in plugin discovery and improve plugin command logging. The bug fix corrects a typo in `config.go` that caused incorrect plugin configuration detection. The logging improvement uses `stderr.String()` instead of `stderr` in `plugin.go` to show the error output of plugin commands.