### PR TITLE
chore: add SLSA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 **Releases:**
 [![Release Version](https://img.shields.io/github/v/release/argoproj/argo-cd?label=argo-cd)](https://github.com/argoproj/argo-cd/releases/latest)
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/argo-cd)](https://artifacthub.io/packages/helm/argo/argo-cd)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 **Code:** 
 [![Integration tests](https://github.com/argoproj/argo-cd/workflows/Integration%20tests/badge.svg?branch=master)](https://github.com/argoproj/argo-cd/actions?query=workflow%3A%22Integration+tests%22)


### PR DESCRIPTION
The wonderful folks over at Chainguard have diligently published a SLSA (Supply-chain Levels for Software Artifacts) assessment commissioned by the CNCF.  The findings of the assessment substantiate that Argo CD has met the requirements for SLSA (v0.1) Level 3. This PR Adds the SLSA Level 3 badge. The assessment can be found here (https://github.com/argoproj/argoproj/blob/master/docs/software_supply_chain_slsa_assessment_chainguard_2023.pdf).