### PR TITLE
fix: set readOnlyRootFilesystem to true for redis and ha-proxy (#13315)

### DIFF
--- a/manifests/base/redis/argocd-redis-deployment.yaml
+++ b/manifests/base/redis/argocd-redis-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         ports:
         - containerPort: 6379
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -16795,6 +16795,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/manifests/ha/base/redis-ha/overlays/deployment-containers-securityContext.yaml
+++ b/manifests/ha/base/redis-ha/overlays/deployment-containers-securityContext.yaml
@@ -1,6 +1,7 @@
 - op: add
   path: /spec/template/spec/initContainers/0/securityContext
   value:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -10,6 +11,7 @@
 - op: add
   path: /spec/template/spec/containers/0/securityContext
   value:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:

--- a/manifests/ha/base/redis-ha/overlays/statefulset-containers-securityContext.yaml
+++ b/manifests/ha/base/redis-ha/overlays/statefulset-containers-securityContext.yaml
@@ -1,6 +1,7 @@
 - op: add
   path: /spec/template/spec/initContainers/0/securityContext
   value:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -10,6 +11,7 @@
 - op: add
   path: /spec/template/spec/containers/0/securityContext
   value:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -19,6 +21,7 @@
 - op: add
   path: /spec/template/spec/containers/1/securityContext
   value:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -28,6 +31,7 @@
 - op: add
   path: /spec/template/spec/containers/2/securityContext
   value:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -18181,6 +18181,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -18201,6 +18202,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -19077,6 +19079,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -19125,6 +19128,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -19152,6 +19156,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -19180,6 +19185,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1841,6 +1841,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -1861,6 +1862,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -2737,6 +2739,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -2785,6 +2788,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -2812,6 +2816,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -2840,6 +2845,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -17295,6 +17295,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -955,6 +955,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 999


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/13315

This PR sets `readOnlyRootFilesystem` to true for redis and ha-proxy thus improving the default security configuration in line with other workloads.

There does not seem to be any impact to those containers, although I would love for others to test it as well.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
