### PR TITLE
fix: health-checks for Elasticsearch

### DIFF
--- a/resource_customizations/elasticsearch.k8s.elastic.co/Elasticsearch/health.lua
+++ b/resource_customizations/elasticsearch.k8s.elastic.co/Elasticsearch/health.lua
@@ -17,7 +17,7 @@ if obj.status ~= nil then
             hs.message = "Elasticsearch Cluster status is Green"
             return hs
           elseif obj.status.health == "yellow" then
-            hs.status = "Degraded"
+            hs.status = "Progressing"
             hs.message = "Elasticsearch Cluster status is Yellow. Check the status of indices, replicas and shards"
             return hs
           elseif obj.status.health == "red" then

--- a/resource_customizations/elasticsearch.k8s.elastic.co/Elasticsearch/health_test.yaml
+++ b/resource_customizations/elasticsearch.k8s.elastic.co/Elasticsearch/health_test.yaml
@@ -4,7 +4,7 @@ tests:
     message: "Elasticsearch Cluster status is Green"
   inputPath: testdata/ready_green.yaml
 - healthStatus:
-    status: Degraded
+    status: Progressing
     message: "Elasticsearch Cluster status is Yellow. Check the status of indices, replicas and shards"
   inputPath: testdata/ready_yellow.yaml
 - healthStatus:


### PR DESCRIPTION
argocd application go to "degraged" state as soon as elasticsearch cluster health go to yellow state. Which is wrong, yellow state should not be considered as a broken state:

"when a new index is created, the cluster will go to yellow state, because replicas are not ready"

This can flood notifications with wrong alerts, because elasticsearch can create / move indices all the time (we got more than 10 wrong alerts per day).

To me, this is a bug on elasticsearch side (I mean cluster health check should wait a little time before changing color), but according discussion with elastic team at https://discuss.elastic.co/t/cluster-health-wrong-yellow-spikes-because-new-index/330124/6, this is normal, and yellow "spike" should not be considered as error.

The current argocd health check implementation is reporting error as soon as elasticsearch cluster health changes to yellow, I edit it to consider yellow state as "progressing" app state.

A better solution will be to add a kind a buffer, in order to give some time before the argocd application degrades.

Relate:
* https://github.com/argoproj/argo-cd/pull/6052
