### PR TITLE
fix: implement filtering on cluster `List` API endpoint

### DIFF
--- a/docs/2.7-2.8.md
+++ b/docs/2.7-2.8.md
@@ -1,5 +1,0 @@
-# 2.7 to 2.8
-
-## Tini as entrypoint
-
-With the 2.8 release `entrypoint.sh` will be removed from the containers, because starting with 2.7, the implicit entrypoint is set to `tini` in the `Dockerfile` explicitly, and the kubernetes manifests has been updated to use it. Simply updating the containers without updating the deployment manifests will result in pod startup failures, as the old manifests are relying on `entrypoint.sh` instead of `tini`. Please make sure the manifests are updated properly before moving to 2.8.

--- a/docs/operator-manual/upgrading/2.7-2.8.md
+++ b/docs/operator-manual/upgrading/2.7-2.8.md
@@ -1,0 +1,18 @@
+# v2.7 to 2.8
+
+## Tini as entrypoint
+
+With the 2.8 release `entrypoint.sh` will be removed from the containers,
+because starting with 2.7, the implicit entrypoint is set to `tini` in the
+`Dockerfile` explicitly, and the kubernetes manifests has been updated to use
+it. Simply updating the containers without updating the deployment manifests
+will result in pod startup failures, as the old manifests are relying on
+`entrypoint.sh` instead of `tini`. Please make sure the manifests are updated
+properly before moving to 2.8.
+
+## Filtering applied to cluster `List` API endpoint
+
+Prior to `v2.8`, the `List` endpoint on the `ClusterService` did **not** filter
+clusters when responding, despite accepting query parameters. This bug has
+been addressed, and query parameters are now taken into account to filter the
+resulting list of clusters.

--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -37,6 +37,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
+* [v2.7 to v2.8](./2.7-2.8.md)
 * [v2.6 to v2.7](./2.6-2.7.md)
 * [v2.5 to v2.6](./2.5-2.6.md)
 * [v2.4 to v2.5](./2.4-2.5.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
     - operator-manual/server-commands/additional-configuration-method.md
   - Upgrading:
     - operator-manual/upgrading/overview.md
+    - operator-manual/upgrading/2.7-2.8.md
     - operator-manual/upgrading/2.6-2.7.md
     - operator-manual/upgrading/2.5-2.6.md
     - operator-manual/upgrading/2.4-2.5.md

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -56,8 +56,21 @@ func (s *Server) List(ctx context.Context, q *cluster.ClusterQuery) (*appv1.Clus
 		return nil, err
 	}
 
+	filteredItems := clusterList.Items
+
+	// Filter clusters by id
+	if filteredItems, err = filterClustersById(filteredItems, q.Id); err != nil {
+		return nil, err
+	}
+
+	// Filter clusters by name
+	filteredItems = filterClustersByName(filteredItems, q.Name)
+
+	// Filter clusters by server
+	filteredItems = filterClustersByServer(filteredItems, q.Server)
+
 	items := make([]appv1.Cluster, 0)
-	for _, clust := range clusterList.Items {
+	for _, clust := range filteredItems {
 		if s.enf.Enforce(ctx.Value("claims"), rbacpolicy.ResourceClusters, rbacpolicy.ActionGet, CreateClusterRBACObject(clust.Project, clust.Server)) {
 			items = append(items, clust)
 		}
@@ -69,8 +82,62 @@ func (s *Server) List(ctx context.Context, q *cluster.ClusterQuery) (*appv1.Clus
 	if err != nil {
 		return nil, err
 	}
-	clusterList.Items = items
-	return clusterList, nil
+
+	cl := *clusterList
+	cl.Items = items
+
+	return &cl, nil
+}
+
+func filterClustersById(clusters []appv1.Cluster, id *cluster.ClusterID) ([]appv1.Cluster, error) {
+	if id == nil {
+		return clusters, nil
+	}
+
+	var items []appv1.Cluster
+
+	switch id.Type {
+	case "name":
+		items = filterClustersByName(clusters, id.Value)
+	case "name_escaped":
+		nameUnescaped, err := url.QueryUnescape(id.Value)
+		if err != nil {
+			return nil, err
+		}
+		items = filterClustersByName(clusters, nameUnescaped)
+	default:
+		items = filterClustersByServer(clusters, id.Value)
+	}
+
+	return items, nil
+}
+
+func filterClustersByName(clusters []appv1.Cluster, name string) []appv1.Cluster {
+	if name == "" {
+		return clusters
+	}
+	items := make([]appv1.Cluster, 0)
+	for i := 0; i < len(clusters); i++ {
+		if clusters[i].Name == name {
+			items = append(items, clusters[i])
+			return items
+		}
+	}
+	return items
+}
+
+func filterClustersByServer(clusters []appv1.Cluster, server string) []appv1.Cluster {
+	if server == "" {
+		return clusters
+	}
+	items := make([]appv1.Cluster, 0)
+	for i := 0; i < len(clusters); i++ {
+		if clusters[i].Server == server {
+			items = append(items, clusters[i])
+			return items
+		}
+	}
+	return items
 }
 
 // Create creates a cluster


### PR DESCRIPTION
For known security reasons, the `Get` endpoint on the Clusters service returns a `403` rather than a `404` if a cluster is not found. This means that in order to determine the non-existence of a cluster API, users need to make use of the `List` endpoint (see [comment](https://github.com/argoproj/argo-cd/issues/13000#issuecomment-1483135268) related to workaround on the behaviour on the applications service). 

The application service implements filtering on List allowing the caller to effectively explicitly request a list consisting of a single application which makes this an effective workaround. However, at present, no form of filtering is applied on the cluster `List` API endpoint despite query parameters being available (see screenshot) below. This means that the same workaround for the clusters service is (_extremely_) inefficient as all clusters are returned on every call and the caller is left to iterate over all clusters. This PR addresses this issue by implementing filtering on this endpoint using the existing cluster query parameters (in the same manner as the [application service](https://github.com/argoproj/argo-cd/blob/03513ebeec3e70926f6c33328d11be5c99478c18/server/application/application.go#L211-L221).

![Screenshot from 2023-04-27 16-40-28](https://user-images.githubusercontent.com/878612/234897923-4eaa3d6b-8826-48e2-b9f3-80388f267f54.png)

Semi-related to #13000 (see [comment](https://github.com/argoproj/argo-cd/issues/13000#issuecomment-1507913979) here)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
