### PR TITLE
fix: ensure repositories are correctly marked with `inherited` creds in CLI output

### DIFF
--- a/cmd/argocd/commands/repo.go
+++ b/cmd/argocd/commands/repo.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"text/tabwriter"
 
 	log "github.com/sirupsen/logrus"
@@ -250,15 +251,12 @@ func printRepoTable(repos appsv1.Repositories) {
 	_, _ = fmt.Fprintf(w, "TYPE\tNAME\tREPO\tINSECURE\tOCI\tLFS\tCREDS\tSTATUS\tMESSAGE\tPROJECT\n")
 	for _, r := range repos {
 		var hasCreds string
-		if !r.HasCredentials() {
-			hasCreds = "false"
+		if r.InheritedCreds {
+			hasCreds = "inherited"
 		} else {
-			if r.InheritedCreds {
-				hasCreds = "inherited"
-			} else {
-				hasCreds = "true"
-			}
+			hasCreds = strconv.FormatBool(r.HasCredentials())
 		}
+
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%v\t%v\t%v\t%s\t%s\t%s\t%s\n", r.Type, r.Name, r.Repo, r.IsInsecure(), r.EnableOCI, r.EnableLFS, hasCreds, r.ConnectionState.Status, r.ConnectionState.Message, r.Project)
 	}
 	_ = w.Flush()

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -163,6 +163,7 @@ func (s *Server) Get(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.R
 		GitHubAppEnterpriseBaseURL: repo.GitHubAppEnterpriseBaseURL,
 		Proxy:                      repo.Proxy,
 		Project:                    repo.Project,
+		InheritedCreds:             repo.InheritedCreds,
 	}
 
 	item.ConnectionState = s.getConnectionState(ctx, item.Repo, q.ForceRefresh)
@@ -196,6 +197,7 @@ func (s *Server) ListRepositories(ctx context.Context, q *repositorypkg.RepoQuer
 				Proxy:              repo.Proxy,
 				Project:            repo.Project,
 				ForceHttpBasicAuth: repo.ForceHttpBasicAuth,
+				InheritedCreds:     repo.InheritedCreds,
 			})
 		}
 	}

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -90,15 +90,16 @@ var (
 		},
 	}
 	fakeRepo = appsv1.Repository{
-		Repo:      "https://test",
-		Type:      "test",
-		Name:      "test",
-		Username:  "argo",
-		Insecure:  false,
-		EnableLFS: false,
-		EnableOCI: false,
-		Proxy:     "test",
-		Project:   "argocd",
+		Repo:           "https://test",
+		Type:           "test",
+		Name:           "test",
+		Username:       "argo",
+		Insecure:       false,
+		EnableLFS:      false,
+		EnableOCI:      false,
+		Proxy:          "test",
+		Project:        "argocd",
+		InheritedCreds: true,
 	}
 	guestbookApp = &appsv1.Application{
 		TypeMeta: metav1.TypeMeta{
@@ -206,6 +207,33 @@ func TestRepositoryServer(t *testing.T) {
 		})
 		assert.Nil(t, err)
 		assert.Equal(t, repo.Repo, url)
+	})
+
+	t.Run("Test_GetInherited", func(t *testing.T) {
+		repoServerClient := mocks.RepoServerServiceClient{}
+		repoServerClient.On("TestRepository", mock.Anything, mock.Anything).Return(&apiclient.TestRepositoryResponse{}, nil)
+		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
+
+		url := "https://test"
+		db := &dbmocks.ArgoDB{}
+		testRepo := &appsv1.Repository{
+			Repo:           url,
+			Type:           "git",
+			Username:       "foo",
+			InheritedCreds: true,
+		}
+		db.On("GetRepository", context.TODO(), url).Return(testRepo, nil)
+		db.On("RepositoryExists", context.TODO(), url).Return(true, nil)
+
+		s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, appLister, projInformer, testNamespace, settingsMgr)
+		repo, err := s.Get(context.TODO(), &repository.RepoQuery{
+			Repo: url,
+		})
+		assert.Nil(t, err)
+
+		testRepo.ConnectionState = repo.ConnectionState // overwrite connection state on our test object to simplify comparison below
+
+		assert.Equal(t, testRepo, repo)
 	})
 
 	t.Run("Test_GetWithErrorShouldReturn403", func(t *testing.T) {

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -92,6 +92,7 @@ type ACL struct {
 const (
 	RepoURLTypeFile                 = "file"
 	RepoURLTypeHTTPS                = "https"
+	RepoURLTypeHTTPSOrg             = "https-org"
 	RepoURLTypeHTTPSClientCert      = "https-cc"
 	RepoURLTypeHTTPSSubmodule       = "https-sub"
 	RepoURLTypeHTTPSSubmoduleParent = "https-par"
@@ -103,6 +104,8 @@ const (
 	RepoURLTypeHelmOCI              = "helm-oci"
 	GitUsername                     = "admin"
 	GitPassword                     = "password"
+	GithubAppID                     = "2978632978"
+	GithubAppInstallationID         = "7893789433789"
 	GpgGoodKeyID                    = "D56C4FCA57A46444"
 	HelmOCIRegistryURL              = "localhost:5000/myrepo"
 )
@@ -251,6 +254,7 @@ const (
 	EnvRepoURLTypeSSHSubmodule         = "ARGOCD_E2E_REPO_SSH_SUBMODULE"
 	EnvRepoURLTypeSSHSubmoduleParent   = "ARGOCD_E2E_REPO_SSH_SUBMODULE_PARENT"
 	EnvRepoURLTypeHTTPS                = "ARGOCD_E2E_REPO_HTTPS"
+	EnvRepoURLTypeHTTPSOrg             = "ARGOCD_E2E_REPO_HTTPS_ORG"
 	EnvRepoURLTypeHTTPSClientCert      = "ARGOCD_E2E_REPO_HTTPS_CLIENT_CERT"
 	EnvRepoURLTypeHTTPSSubmodule       = "ARGOCD_E2E_REPO_HTTPS_SUBMODULE"
 	EnvRepoURLTypeHTTPSSubmoduleParent = "ARGOCD_E2E_REPO_HTTPS_SUBMODULE_PARENT"
@@ -272,6 +276,9 @@ func RepoURL(urlType RepoURLType) string {
 	// Git server via HTTPS
 	case RepoURLTypeHTTPS:
 		return GetEnvWithDefault(EnvRepoURLTypeHTTPS, "https://localhost:9443/argo-e2e/testdata.git")
+	// Git "organisation" via HTTPS
+	case RepoURLTypeHTTPSOrg:
+		return GetEnvWithDefault(EnvRepoURLTypeHTTPSOrg, "https://localhost:9443/argo-e2e")
 	// Git server via HTTPS - Client Cert protected
 	case RepoURLTypeHTTPSClientCert:
 		return GetEnvWithDefault(EnvRepoURLTypeHTTPSClientCert, "https://localhost:9444/argo-e2e/testdata.git")


### PR DESCRIPTION
At present, the value of `InheritedCreds` is not propagated via the `Get`/`List` repository server API endpoints. This means that when running CLI commands `argocd repo [get|list]` the repo will always be displayed with `CREDS` shown as `false`. This PR ensures that the value of `InheritedCreds` is correctly returned by the API endpoints as well as addresses a slight logic flaw in the CLI code used to determine the correct value to display for the `CREDS` column.

Side note: when doing this work, I realised that since the API does not return sensitive information, using [`repo.HasCredentials()`](https://github.com/argoproj/argo-cd/blob/064c8da942c56bf45745d7bc1b9af8ded979aa61/pkg/apis/application/v1alpha1/repository_types.go#L109-L111) in the CLI will return false for all scenarios except when a username/password is used as the credentials for a repository. As such, there remains a bug in the CLI in that any repo that has been configured with explicit (sensitive) credentials (e.g. SSH private key) will still be displayed as `CREDS = false`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
