### PR TITLE
fix: broken Git file generator caching (fixes #13440)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules/
 .kube/
 ./test/cmp/*.sock
 .envrc.remote
+.*.swp
 
 # ignore built binaries
 cmd/argocd/argocd

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -317,26 +317,30 @@ func (c *Cache) SetRevisionChartDetails(repoURL, chart, revision string, item *a
 	return c.cache.SetItem(revisionChartDetailsKey(repoURL, chart, revision), item, c.repoCacheExpiration, false)
 }
 
-func gitDataKey(gitObject, repoURL, revision string) string {
-	return fmt.Sprintf("%s|%s|%s", gitObject, repoURL, revision)
+func gitFilesKey(repoURL, revision, pattern string) string {
+	return fmt.Sprintf("gitfiles|%s|%s|%s", repoURL, revision, pattern)
 }
 
-func (c *Cache) SetGitFiles(repoURL, revision string, files map[string][]byte) error {
-	return c.cache.SetItem(gitDataKey(gitfiles, repoURL, revision), &files, c.repoCacheExpiration, false)
+func (c *Cache) SetGitFiles(repoURL, revision, pattern string, files map[string][]byte) error {
+	return c.cache.SetItem(gitFilesKey(repoURL, revision, pattern), &files, c.repoCacheExpiration, false)
 }
 
-func (c *Cache) GetGitFiles(repoURL, revision string) (map[string][]byte, error) {
+func (c *Cache) GetGitFiles(repoURL, revision, pattern string) (map[string][]byte, error) {
 	var item map[string][]byte
-	return item, c.cache.GetItem(gitDataKey(gitfiles, repoURL, revision), &item)
+	return item, c.cache.GetItem(gitFilesKey(repoURL, revision, pattern), &item)
+}
+
+func gitDirectoriesKey(repoURL, revision string) string {
+	return fmt.Sprintf("gitdirs|%s|%s", repoURL, revision)
 }
 
 func (c *Cache) SetGitDirectories(repoURL, revision string, directories []string) error {
-	return c.cache.SetItem(gitDataKey(gitdir, repoURL, revision), &directories, c.repoCacheExpiration, false)
+	return c.cache.SetItem(gitDirectoriesKey(repoURL, revision), &directories, c.repoCacheExpiration, false)
 }
 
 func (c *Cache) GetGitDirectories(repoURL, revision string) ([]string, error) {
 	var item []string
-	return item, c.cache.GetItem(gitDataKey(gitdir, repoURL, revision), &item)
+	return item, c.cache.GetItem(gitDirectoriesKey(repoURL, revision), &item)
 }
 
 func (cmr *CachedManifestResponse) shallowCopy() *CachedManifestResponse {

--- a/reposerver/cache/types.go
+++ b/reposerver/cache/types.go
@@ -1,6 +1,0 @@
-package cache
-
-const (
-	gitdir   = "gitdirs"
-	gitfiles = "gitfiles"
-)


### PR DESCRIPTION
The Git file generator currently assumes that only a single Git file generator will ever exist for any repository. If multiple generators exist the cache will always return the results of the first file search that randomly happened to all subsequent searches.

This PR adds the search pattern to the Git file generator cache key in order to individualize cache entries for the Git file generator.

Note that `reposerver/cache/types.go` is deleted since it is no longer needed.

Fixes #13440

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.