### PR TITLE
feat: enable gzip compression in Redis by default (#13458)

### DIFF
--- a/cmd/argocd/commands/admin/dashboard.go
+++ b/cmd/argocd/commands/admin/dashboard.go
@@ -36,6 +36,6 @@ func NewDashboardCommand() *cobra.Command {
 	initialize.InitCommand(cmd)
 	cmd.Flags().IntVar(&port, "port", common.DefaultPortAPIServer, "Listen on given port")
 	cmd.Flags().StringVar(&address, "address", common.DefaultAddressAPIServer, "Listen on given address")
-	cmd.Flags().StringVar(&compressionStr, "redis-compress", env.StringFromEnv("REDIS_COMPRESSION", string(cache.RedisCompressionNone)), "Enable this if the application controller is configured with redis compression enabled. (possible values: none, gzip)")
+	cmd.Flags().StringVar(&compressionStr, "redis-compress", env.StringFromEnv("REDIS_COMPRESSION", string(cache.RedisCompressionGZip)), "Enable this if the application controller is configured with redis compression enabled. (possible values: gzip, none)")
 	return cmd
 }

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -14,8 +14,8 @@ data:
 
   # Redis server hostname and port (e.g. argocd-redis:6379)
   redis.server: "argocd-redis:6379"
-  # Enable compression for data sent to Redis with the required compression algorithm. (default 'none')
-  redis.compression: none
+  # Enable compression for data sent to Redis with the required compression algorithm. (default 'gzip')
+  redis.compression: gzip
   # Redis database
   redis.db:
 

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -46,7 +46,7 @@ argocd-application-controller [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
+      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -29,7 +29,7 @@ argocd-repo-server [flags]
       --redis-ca-certificate string                    Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string                Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                        Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                          Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
+      --redis-compress string                          Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
       --redis-insecure-skip-tls-verify                 Skip Redis server certificate validation.
       --redis-use-tls                                  Use TLS when connecting to Redis. 
       --redisdb int                                    Redis database.

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -52,7 +52,7 @@ argocd-server [flags]
       --redis-ca-certificate string                   Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string               Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                       Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                         Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
+      --redis-compress string                         Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
       --redis-insecure-skip-tls-verify                Skip Redis server certificate validation.
       --redis-use-tls                                 Use TLS when connecting to Redis. 
       --redisdb int                                   Redis database.

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -30,7 +30,7 @@ argocd admin cluster shards [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
+      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -30,7 +30,7 @@ argocd admin cluster stats [flags]
       --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
       --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip) (default "none")
+      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
       --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
       --redis-use-tls                         Use TLS when connecting to Redis. 
       --redisdb int                           Redis database.

--- a/docs/user-guide/commands/argocd_admin_dashboard.md
+++ b/docs/user-guide/commands/argocd_admin_dashboard.md
@@ -25,7 +25,7 @@ argocd admin dashboard [flags]
       --password string                Password for basic authentication to the API server
       --port int                       Listen on given port (default 8080)
       --proxy-url string               If provided, this URL will be used to connect via proxy
-      --redis-compress string          Enable this if the application controller is configured with redis compression enabled. (possible values: none, gzip) (default "none")
+      --redis-compress string          Enable this if the application controller is configured with redis compression enabled. (possible values: gzip, none) (default "gzip")
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
       --token string                   Bearer token for authentication to the API server

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -96,7 +96,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	cmd.Flags().StringVar(&redisClientKey, "redis-client-key", "", "Path to Redis client key (e.g. /etc/certs/redis/client.crt).")
 	cmd.Flags().BoolVar(&insecureRedis, "redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
 	cmd.Flags().StringVar(&redisCACertificate, "redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
-	cmd.Flags().StringVar(&compressionStr, "redis-compress", env.StringFromEnv("REDIS_COMPRESSION", string(RedisCompressionNone)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: none, gzip)")
+	cmd.Flags().StringVar(&compressionStr, "redis-compress", env.StringFromEnv("REDIS_COMPRESSION", string(RedisCompressionGZip)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none)")
 	return func() (*Cache, error) {
 		var tlsConfig *tls.Config = nil
 		if redisUseTLS {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f51a0a</samp>

This pull request changes the default value of the `redis-compress` flag from `none` to `gzip` in various commands and configuration files that interact with Redis. The purpose of this change is to enable gzip compression for data sent to Redis by default, which can improve performance and reduce memory usage.

Closes #13458