### PR TITLE
fix: surface errors when compressing files

### DIFF
--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -109,11 +109,11 @@ func SendRepoStream(ctx context.Context, appPath, repoPath string, sender Stream
 func GetCompressedRepoAndMetadata(repoPath string, appPath string, env []string, excludedGlobs []string, opt *senderOption) (*os.File, *pluginclient.AppStreamRequest, error) {
 	// compress all files in appPath in tgz
 	tgz, filesWritten, checksum, err := tgzstream.CompressFiles(repoPath, nil, excludedGlobs)
-	if filesWritten == 0 {
-		return nil, nil, fmt.Errorf("no files to send")
-	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("error compressing repo files: %w", err)
+	}
+	if filesWritten == 0 {
+		return nil, nil, fmt.Errorf("no files to send")
 	}
 	if opt != nil && opt.tarDoneChan != nil {
 		opt.tarDoneChan <- true

--- a/util/manifeststream/stream.go
+++ b/util/manifeststream/stream.go
@@ -40,11 +40,11 @@ type RepoStreamReceiver interface {
 // SendApplicationManifestQueryWithFiles compresses a folder and sends it over the stream
 func SendApplicationManifestQueryWithFiles(ctx context.Context, stream ApplicationStreamSender, appName string, appNs string, dir string, inclusions []string) error {
 	f, filesWritten, checksum, err := tgzstream.CompressFiles(dir, inclusions, nil)
-	if filesWritten == 0 {
-		return fmt.Errorf("no files to send")
-	}
 	if err != nil {
 		return fmt.Errorf("failed to compress files: %w", err)
+	}
+	if filesWritten == 0 {
+		return fmt.Errorf("no files to send")
 	}
 
 	err = stream.Send(&applicationpkg.ApplicationManifestQueryWithFilesWrapper{


### PR DESCRIPTION
`CompressFiles` returns `filesWritten == 0` for all cases where `err != nil`, but when `err != nil`, the fact that no files were written isn't the most interesting bit of information. i.e. we're hiding the actual error in many cases.

This change will pass up the error message if there is one. If there isn't an error, we throw a new error if no files were written.