### PR TITLE
fix: rewrite Host header in dex round tripper

### DIFF
--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -123,6 +123,7 @@ type DexRewriteURLRoundTripper struct {
 func (s DexRewriteURLRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.URL.Host = s.DexURL.Host
 	r.URL.Scheme = s.DexURL.Scheme
+	r.Host = s.DexURL.Host
 	return s.T.RoundTrip(r)
 }
 

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -429,5 +429,7 @@ func Test_DexReverseProxy(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = rt.RoundTrip(req)
 		assert.NoError(t, err)
+		target, _ := url.Parse(server.URL)
+		assert.Equal(t, req.Host, target.Host)
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/3975

> In Istio, HTTP traffic is routed to a [cluster](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/terminology) based on Host header. Dex reverse proxy does not rewrite Host header, so traffic does not get routed to argocd-dex-server cluster and no cluster-level configuration (e.g. mTLS) is applied. Because of this, request to dex-server fails in environments where strict mTLS is enabled or where [outbound traffic policy](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-OutboundTrafficPolicy-Mode) is set to REGISTRY_ONLY.


PR #6183 didn't fix the issue because I missed that we also have to rewrite host header in `DexRewriteURLRoundTripper` and screwed up my testing somehow. This time I tested it more thoroughly and looks like this should finally fix the problem. 


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
