### PR TITLE
docs: update openunison authChainName

### DIFF
--- a/docs/operator-manual/user-management/openunison.md
+++ b/docs/operator-manual/user-management/openunison.md
@@ -19,7 +19,7 @@ metadata:
 spec:
   accessTokenSkewMillis: 120000
   accessTokenTimeToLive: 1200000
-  authChainName: LoginService
+  authChainName: login-service
   clientId: argocd
   codeLastMileKeyName: lastmile-oidc
   codeTokenSkewMilis: 60000


### PR DESCRIPTION
The [current](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/openunison/) Trust described for OpenUnison does not work, as the authChainName has changed: https://openunison.github.io/documentation/custom-sso/.  
This causes an annoying [NullPointerException](https://github.com/TremoloSecurity/OpenUnison/issues/759). This PR updates the documentation on OpenUnison to use the correct name.

