### PR TITLE
fix(appset): adjust NotIn operator behavior of AppSet Progressive Syncs to match documentation (#13501)

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -853,43 +853,19 @@ func (r *ApplicationSetReconciler) buildAppDependencyList(ctx context.Context, a
 
 			selected := true // default to true, assuming the current Application is a match for the given step matchExpression
 
-			allNotInMatched := true // needed to support correct AND behavior between multiple NotIn MatchExpressions
-			notInUsed := false      // since we default to allNotInMatched == true, track whether a NotIn expression was actually used
-
 			for _, matchExpression := range step.MatchExpressions {
 
-				if matchExpression.Operator == "In" {
-					if val, ok := app.Labels[matchExpression.Key]; ok {
-						valueMatched := labelMatchedExpression(val, matchExpression)
+				if val, ok := app.Labels[matchExpression.Key]; ok {
+					valueMatched := labelMatchedExpression(val, matchExpression)
 
-						if !valueMatched { // none of the matchExpression values was a match with the Application'ss labels
-							selected = false
-							break
-						}
-					} else {
-						selected = false // no matching label key with In means this Application will not be included in the current step
+					if !valueMatched { // none of the matchExpression values was a match with the Application'ss labels
+						selected = false
 						break
 					}
-				} else if matchExpression.Operator == "NotIn" {
-					notInUsed = true // a NotIn selector was used in this matchExpression
-					if val, ok := app.Labels[matchExpression.Key]; ok {
-						valueMatched := labelMatchedExpression(val, matchExpression)
-
-						if !valueMatched { // none of the matchExpression values was a match with the Application's labels
-							allNotInMatched = false
-						}
-					} else {
-						allNotInMatched = false // no matching label key with NotIn means this Application may still be included in the current step
-					}
-				} else { // handle invalid operator selection
-					log.Warnf("skipping AppSet rollingUpdate step Application selection for %q, invalid matchExpression operator provided: %q ", applicationSet.Name, matchExpression.Operator)
-					selected = false
+				} else if matchExpression.Operator == "In" {
+					selected = false // no matching label key with "In" operator means this Application will not be included in the current step
 					break
 				}
-			}
-
-			if notInUsed && allNotInMatched { // check if all NotIn Expressions matched, if so exclude this Application
-				selected = false
 			}
 
 			if selected {
@@ -907,11 +883,20 @@ func (r *ApplicationSetReconciler) buildAppDependencyList(ctx context.Context, a
 }
 
 func labelMatchedExpression(val string, matchExpression argov1alpha1.ApplicationMatchExpression) bool {
-	valueMatched := false
+	if matchExpression.Operator != "In" && matchExpression.Operator != "NotIn" {
+		log.Errorf("skipping AppSet rollingUpdate step Application selection, invalid matchExpression operator provided: %q ", matchExpression.Operator)
+		return false
+	}
+
+	// if operator == In, default to false
+	// if operator == NotIn, default to true
+	valueMatched := matchExpression.Operator == "NotIn"
+
 	for _, value := range matchExpression.Values {
 		if val == value {
-			valueMatched = true
-			break
+			// first "In" match returns true
+			// first "NotIn" match returns false
+			return matchExpression.Operator == "In"
 		}
 	}
 	return valueMatched


### PR DESCRIPTION
It's currently not reasonable to exclude sets of Applications in more complex RollingSync specifications. This PR addresses the limitation by changing the code's assumption of how multiple NotIn matchExpressions are used to eliminate Applications from a RollingSync step.

https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/
> All matchExpressions must be true for an Application to be selected (multiple expressions match with AND behavior).

This isn't working properly with multiple NotIn operators, it looks more like OR behavior with the older test case results.

This PR also simplifies the current logic used to build the Application step list.

Closes https://github.com/argoproj/argo-cd/issues/13501

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
