### PR TITLE
chore: update VERSION on rc1 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -254,8 +254,8 @@ jobs:
           set -xue
           SOURCE_TAG=${{ github.ref_name }}
           VERSION_REF="${SOURCE_TAG#*v}"
-          if echo "$VERSION_REF" | grep -E -- '^[0-9]+\.[0-9]+\.0$';then
-            VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${VERSION_REF}")
+          if echo "$VERSION_REF" | grep -E -- '^[0-9]+\.[0-9]+\.0-rc1';then
+            VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${VERSION_REF%-rc1}")
             echo "Updating VERSION to: $VERSION"
             echo "UPDATE_VERSION=true" >> $GITHUB_ENV
             echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,6 +114,7 @@ changelog:
     exclude:
       - '^test:'
       - '^.*?Bump(\([[:word:]]+\))?.+$'
+      - '^.*?[Bot](\([[:word:]]+\))?.+$'
 
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
This PR updates the `VERSION` file on the main branch for a rc1 release.  We should change the version closer to a feature freeze.

Also excluded Snyk reports from the GitHub release notes.