### PR TITLE
fix: Pod log container selector defaulting to first in list

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/container-selector.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/container-selector.tsx
@@ -28,7 +28,7 @@ export const ContainerSelector = ({
     if (containerNames.length <= 1) return <></>;
     return (
         <Tooltip content='Select a container to view logs'>
-            <select className='argo-field' onChange={e => onClickContainer(containerGroup(e.target.value), containerIndex(e.target.value), 'logs')}>
+            <select className='argo-field' value={containerName} onChange={e => onClickContainer(containerGroup(e.target.value), containerIndex(e.target.value), 'logs')}>
                 {containerNames.map(n => (
                     <option key={n} value={n}>
                         {n}


### PR DESCRIPTION
Fixes #13572

Without a value on the selector, it defaults to the first in the list, resulting in the incorrect container name being shown for the pod logs. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

