### PR TITLE
fix: avoid acquiring lock on two mutexes at the same time to prevent deadlock

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -488,10 +488,11 @@ func (c *liveStateCache) getSyncedCluster(server string) (clustercache.ClusterCa
 func (c *liveStateCache) invalidate(cacheSettings cacheSettings) {
 	log.Info("invalidating live state cache")
 	c.lock.Lock()
-	defer c.lock.Unlock()
-
 	c.cacheSettings = cacheSettings
-	for _, clust := range c.clusters {
+	clusters := c.clusters
+	c.lock.Unlock()
+
+	for _, clust := range clusters {
 		clust.Invalidate(clustercache.SetSettings(cacheSettings.clusterSettings))
 	}
 	log.Info("live state cache invalidated")


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/11458

PR fixes an almost identical bug that was fixed by https://github.com/argoproj/gitops-engine/pull/521. 

Deadlock is happening because we have two functions that acquire lock on two different mutexes in different order.

* [Mutex 1](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L195)
* [Mutex 2](https://github.com/argoproj/gitops-engine/blob/b4dd8b8c3976d03f9928a393c2447830a3ef7449/pkg/cache/cluster.go#L193)

Function 1 stack trace:
  * [liveStateCache.invalidate](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L488) - acquires [Mutex 1](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L195)
    * [clusterCache.Invalidate](https://github.com/argoproj/gitops-engine/blob/b4dd8b8c3976d03f9928a393c2447830a3ef7449/pkg/cache/cluster.go#L408) - acquires [Mutex 2](https://github.com/argoproj/gitops-engine/blob/b4dd8b8c3976d03f9928a393c2447830a3ef7449/pkg/cache/cluster.go#L193)


Function 2 stack trace:
  * [liveStateCache.getSyncedCluster](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#LL476C10-L476C42)
    *  [clusterCache.EnsureSynced](https://github.com/argoproj/gitops-engine/blob/b4dd8b8c3976d03f9928a393c2447830a3ef7449/pkg/cache/cluster.go#L806) - acquires [Mutex 2](https://github.com/argoproj/gitops-engine/blob/b4dd8b8c3976d03f9928a393c2447830a3ef7449/pkg/cache/cluster.go#L193)
        *  [clusterCache.newResource](https://github.com/argoproj/gitops-engine/blob/b4dd8b8c3976d03f9928a393c2447830a3ef7449/pkg/cache/cluster.go#LL361C3-L361C3)
            *  [SetPopulateResourceInfoHandler](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#LL424C6-L424C6) - acquires [Mutex 1](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L195)


So [liveStateCache.invalidate](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L488) waits for  [SetPopulateResourceInfoHandler](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#LL424C6-L424C6) and [SetPopulateResourceInfoHandler](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#LL424C6-L424C6) waits for  [liveStateCache.invalidate](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L488).

PR updates [liveStateCache.invalidate](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L488) to release  [Mutex 1](https://github.com/argoproj/argo-cd/blob/f8e016dea859ad43b82a4c12544546ef9d6dc9ce/controller/cache/cache.go#L195) before it locks [Mutex 2](https://github.com/argoproj/gitops-engine/blob/b4dd8b8c3976d03f9928a393c2447830a3ef7449/pkg/cache/cluster.go#L193)