### PR TITLE
fix: fix broken helm repo alias/name support

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -935,14 +935,21 @@ func getHelmRepos(appPath string, repositories []*v1alpha1.Repository, helmRepoC
 	if err != nil {
 		return nil, err
 	}
+	reposByName := make(map[string]*v1alpha1.Repository)
 	reposByUrl := make(map[string]*v1alpha1.Repository)
 	for _, repo := range repositories {
 		reposByUrl[repo.Repo] = repo
+		if repo.Name != "" {
+			reposByName[repo.Name] = repo
+		}
 	}
 
 	repos := make([]helm.HelmRepository, 0)
 	for _, dep := range dependencies {
 		repo, ok := reposByUrl[dep.Repo]
+		if !ok && dep.Name != "" {
+			repo, ok = reposByName[dep.Name]
+		}
 		if !ok {
 			repo = &v1alpha1.Repository{Repo: dep.Repo, Name: dep.Name, EnableOCI: dep.EnableOCI}
 			if repositoryCredential := getRepoCredential(helmRepoCreds, dep.Repo); repositoryCredential != nil {
@@ -980,7 +987,11 @@ func getHelmDependencyRepos(appPath string) ([]*v1alpha1.Repository, error) {
 	}
 
 	for _, r := range d.Dependencies {
-		if u, err := url.Parse(r.Repository); err == nil && (u.Scheme == "https" || u.Scheme == "oci") {
+		if strings.HasPrefix(r.Repository, "@") {
+			repos = append(repos, &v1alpha1.Repository{
+				Name: r.Repository[1:],
+			})
+		} else if u, err := url.Parse(r.Repository); err == nil && (u.Scheme == "https" || u.Scheme == "oci") {
 			repo := &v1alpha1.Repository{
 				// trimming oci:// prefix since it is currently not supported by Argo CD (OCI repos just have no scheme)
 				Repo:      strings.TrimPrefix(r.Repository, "oci://"),

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1276,6 +1276,7 @@ func TestListApps(t *testing.T) {
 		"oci-dependencies":                  "Helm",
 		"out-of-bounds-values-file-link":    "Helm",
 		"values-files":                      "Helm",
+		"helm-with-dependencies":            "Helm",
 	}
 	assert.Equal(t, expectedApps, res.Apps)
 }
@@ -2602,7 +2603,7 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 	})
 }
 
-func TestOCIDependencies(t *testing.T) {
+func TestGetHelmRepos_OCIDependencies(t *testing.T) {
 	src := argoappv1.ApplicationSource{Path: "."}
 	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, HelmRepoCreds: []*argoappv1.RepoCreds{
 		{URL: "example.com", Username: "test", Password: "test", EnableOCI: true},
@@ -2615,6 +2616,22 @@ func TestOCIDependencies(t *testing.T) {
 	assert.Equal(t, helmRepos[0].Username, "test")
 	assert.Equal(t, helmRepos[0].EnableOci, true)
 	assert.Equal(t, helmRepos[0].Repo, "example.com")
+}
+
+func TestGetHelmRepo_NamedRepos(t *testing.T) {
+	src := argoappv1.ApplicationSource{Path: "."}
+	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, Repos: []*argoappv1.Repository{{
+		Name:     "custom-repo",
+		Repo:     "https://example.com",
+		Username: "test",
+	}}}
+
+	helmRepos, err := getHelmRepos("./testdata/helm-with-dependencies", q.Repos, q.HelmRepoCreds)
+	assert.Nil(t, err)
+
+	assert.Equal(t, len(helmRepos), 1)
+	assert.Equal(t, helmRepos[0].Username, "test")
+	assert.Equal(t, helmRepos[0].Repo, "https://example.com")
 }
 
 func Test_getResolvedValueFiles(t *testing.T) {

--- a/reposerver/repository/testdata/helm-with-dependencies/Chart.yaml
+++ b/reposerver/repository/testdata/helm-with-dependencies/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: helm-with-dependencies
+version: v1.0.0
+dependencies:
+  - name: helm
+    repository: "@custom-repo"
+    version: v1.0.0


### PR DESCRIPTION
PR fixes bug introduced by this [fix](https://github.com/argoproj/argo-cd/commit/ea3a67a9f36ecfdd76e45174c8ca5743a2069753). While parsing Chart.yaml repo server should take alias into account.