### PR TITLE
fix(ui): Stop using the deprecated url format for gitlab instances

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -269,6 +269,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [ungleich.ch](https://ungleich.ch/)
 1. [Unifonic Inc](https://www.unifonic.com/)
 1. [Universidad Mesoamericana](https://www.umes.edu.gt/)
+1. [Urbantz](https://urbantz.com/)
 1. [Vectra](https://www.vectra.ai)
 1. [Veepee](https://www.veepee.com)
 1. [Viaduct](https://www.viaduct.ai/)

--- a/ui/src/app/shared/components/urls.test.ts
+++ b/ui/src/app/shared/components/urls.test.ts
@@ -35,7 +35,7 @@ test('gitlab.com', () => {
         'git@gitlab.com:alex_collins/private-repo.git',
         'b1fe9426ead684d7af16958920968342ee295c1f',
         'https://gitlab.com/alex_collins/private-repo',
-        'https://gitlab.com/alex_collins/private-repo/commit/b1fe9426ead684d7af16958920968342ee295c1f');
+        'https://gitlab.com/alex_collins/private-repo/-/commit/b1fe9426ead684d7af16958920968342ee295c1f');
 });
 
 test('bitbucket.org', () => {

--- a/ui/src/app/shared/components/urls.ts
+++ b/ui/src/app/shared/components/urls.ts
@@ -39,6 +39,12 @@ export function revisionUrl(url: string, revision: string, forPath: boolean): st
         urlSubPath = isSHA(revision) && !forPath ? 'commits' : 'src';
     }
 
+    // Gitlab changed the way urls to commit look like
+    // Ref: https://docs.gitlab.com/ee/update/deprecations.html#legacy-urls-replaced-or-removed
+    if (parsed.source === 'gitlab.com') {
+        urlSubPath = '-/' + urlSubPath;
+    }
+
     if (!supportedSource(parsed)) {
         return null;
     }


### PR DESCRIPTION
The legacy URLs format has been deprecated since february 2023 and now gitlab is make these urls invalid.

Ref: https://docs.gitlab.com/ee/update/deprecations.html#legacy-urls-replaced-or-removed

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
