### PR TITLE
docs: fix deep links docs formatting

### DIFF
--- a/docs/operator-manual/deep_links.md
+++ b/docs/operator-manual/deep_links.md
@@ -11,38 +11,42 @@ or individual resources (pods, services, etc.).
 ## Configuring Deep Links
 
 The configuration for Deep Links is present in `argocd-cm` as `<location>.links` fields where 
-`<location>` determines where it will be displayed. The possible values for `<location>` are :
-- `project` : all links under this field will show up in the project tab in the Argo CD UI
-- `application` : all links under this field will show up in the application summary tab
-- `resource` : all links under this field will show up in the resource (deployments, pods, services, etc.) summary tab
+`<location>` determines where it will be displayed. The possible values for `<location>` are:
 
-Each link in the list has five subfields :
-1. `title` : title/tag that will be displayed in the UI corresponding to that link
-2. `url` : the actual URL where the deep link will redirect to, this field can be templated to use data from the
+- `project`: all links under this field will show up in the project tab in the Argo CD UI
+- `application`: all links under this field will show up in the application summary tab
+- `resource`: all links under this field will show up in the resource (deployments, pods, services, etc.) summary tab
+
+Each link in the list has five subfields:
+
+1. `title`: title/tag that will be displayed in the UI corresponding to that link
+2. `url`: the actual URL where the deep link will redirect to, this field can be templated to use data from the
    corresponding application, project or resource objects (depending on where it is located). This uses [text/template](pkg.go.dev/text/template) pkg for templating
-3. `description` (optional) : a description for what the deep link is about
-4. `icon.class` (optional) : a font-awesome icon class to be used when displaying the links in dropdown menus
-5. `if` (optional) : a conditional statement that results in either `true` or `false`, it also has access to the same
+3. `description` (optional): a description for what the deep link is about
+4. `icon.class` (optional): a font-awesome icon class to be used when displaying the links in dropdown menus
+5. `if` (optional): a conditional statement that results in either `true` or `false`, it also has access to the same
    data as the `url` field. If the condition resolves to `true` the deep link will be displayed - else it will be hidden. If
    the field is omitted, by default the deep links will be displayed. This uses [antonmedv/expr](https://github.com/antonmedv/expr/tree/master/docs) for evaluating conditions
 
 !!!note
-   For resources of kind Secret the data fields are redacted but other fields are accessible for templating the deep links.
+    For resources of kind Secret the data fields are redacted but other fields are accessible for templating the deep links.
 
 !!!warning
-   Make sure to validate the url templates and inputs to prevent data leaks or possible generation of any malicious links.
+    Make sure to validate the url templates and inputs to prevent data leaks or possible generation of any malicious links.
 
 As mentioned earlier the links and conditions can be templated to use data from the resource, each category of links can access different types of data linked to that resource.
-Overall we have these 4 resources available for templating in the system :
-- `application` : this key is used to access the application resource data.
-- `resource` : this key is used to access values for the actual k8s resource.
-- `cluster` : this key is used to access the related destination cluster data like name, server, namespaces etc.
-- `project` : this key is used to access the project resource data.
+Overall we have these 4 resources available for templating in the system:
 
-The above resources are accessible in particular link categories, here's a list of resources available in each category :
-- `resource.links` : `resource`, `application`, `cluster` and `project`
-- `application.links` : `application` and `cluster`
-- `project.links` : `project`
+- `application`: this key is used to access the application resource data.
+- `resource`: this key is used to access values for the actual k8s resource.
+- `cluster`: this key is used to access the related destination cluster data like name, server, namespaces etc.
+- `project`: this key is used to access the project resource data.
+
+The above resources are accessible in particular link categories, here's a list of resources available in each category:
+
+- `resource.links`: `resource`, `application`, `cluster` and `project`
+- `application.links`: `application` and `cluster`
+- `project.links`: `project`
 
 An example `argocd-cm.yaml` file with deep links and their variations :
 


### PR DESCRIPTION
RTD rendered the previous format poorly. This looks nicer.