### PR TITLE
fix: Disable keep alives for helm https connections (#13468) (cherry pick PR release 2.6)

### DIFF
--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -303,6 +303,7 @@ func (c *nativeHelmChart) loadRepoIndex() ([]byte, error) {
 	tr := &http.Transport{
 		Proxy:           proxy.GetCallback(c.proxy),
 		TLSClientConfig: tlsConf,
+		DisableKeepAlives: true,
 	}
 	client := http.Client{Transport: tr}
 	resp, err := client.Do(req)
@@ -471,6 +472,7 @@ func (c *nativeHelmChart) getTagsFromUrl(tagsURL string) ([]byte, string, error)
 	tr := &http.Transport{
 		Proxy:           proxy.GetCallback(c.proxy),
 		TLSClientConfig: tlsConf,
+		DisableKeepAlives: true,
 	}
 	client := http.Client{Transport: tr}
 	resp, err := client.Do(req)


### PR DESCRIPTION
PR already merged: https://github.com/argoproj/argo-cd/pull/13695

Was asked to open PR with the commit cherry picked for various release branches. This is for release-2.6