### PR TITLE
docs: redirect old CMP page to new one

### DIFF
--- a/docs/user-guide/config-management-plugins.md
+++ b/docs/user-guide/config-management-plugins.md
@@ -1,0 +1,3 @@
+# Config Management Plugins
+
+This page has been moved to the [operator manual](../operator-manual/config-management-plugins.md).


### PR DESCRIPTION
The page was moved, and things still link to the old page. Let's redirect.