### PR TITLE
feat: add health-checks for snapshot volume

### DIFF
--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/health.lua
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/health.lua
@@ -1,0 +1,18 @@
+hs = {}
+
+if obj.status ~= nil and obj.status.readyToUse then
+  hs.status = "Healthy"
+  hs.message = "Ready to use"
+  return hs
+end
+
+if obj.status ~= nil and obj.status.error ~= nil then
+  hs.status = "Degraded"
+  hs.message = obj.status.error.message
+  return hs
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for status"
+
+return hs

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/health_test.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/health_test.yaml
@@ -1,0 +1,14 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "Waiting for status"
+  inputPath: testdata/initializing.yaml
+- healthStatus:
+    status: Healthy
+    message: "Ready to use"
+  inputPath: testdata/good.yaml
+- healthStatus:
+    status: Degraded
+    message: "VolumeSnapshotContent is dynamically provisioned while expecting a pre-provisioned one"
+  inputPath: testdata/bad.yaml
+

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/testdata/bad.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/testdata/bad.yaml
@@ -1,0 +1,14 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: data-04-06-2023
+spec:
+  source:
+    volumeSnapshotContentName: data-04-06-2023
+status:
+  error:
+    message: >-
+      VolumeSnapshotContent is dynamically provisioned while expecting a
+      pre-provisioned one
+    time: '2023-06-05T14:51:25Z'
+  readyToUse: false

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/testdata/good.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/testdata/good.yaml
@@ -1,0 +1,15 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  finalizers:
+    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
+    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
+status:
+  boundVolumeSnapshotContentName: snapcontent-7db10be0-424c-4ed2-9dfe-6c2120eae05b
+  creationTime: '2023-06-04T19:13:20Z'
+  readyToUse: true
+  restoreSize: 1Ti
+spec:
+  source:
+    persistentVolumeClaimName: mask-data-process-trcxk-mysql-data
+  volumeSnapshotClassName: azure-tools

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/testdata/initializing.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshot/testdata/initializing.yaml
@@ -1,0 +1,7 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: data-04-06-2023
+spec:
+  driver: disk.csi.azure.com
+status: {}

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/health.lua
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/health.lua
@@ -1,0 +1,18 @@
+hs = {}
+
+if obj.status ~= nil and obj.status.readyToUse then
+  hs.status = "Healthy"
+  hs.message = "Ready to use"
+  return hs
+end
+
+if obj.status ~= nil and obj.status.error ~= nil then
+  hs.status = "Degraded"
+  hs.message = obj.status.error.message
+  return hs
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for status"
+
+return hs

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/health_test.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/health_test.yaml
@@ -1,0 +1,13 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: "Waiting for status"
+  inputPath: testdata/initializing.yaml
+- healthStatus:
+    status: Healthy
+    message: "Ready to use"
+  inputPath: testdata/good.yaml
+- healthStatus:
+    status: Degraded
+    message: "Failed to check and update snapshot content"
+  inputPath: testdata/bad.yaml

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/testdata/bad.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/testdata/bad.yaml
@@ -1,0 +1,12 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: data-04-06-2023
+spec:
+  driver: disk.csi.azure.com
+status:
+  error:
+    message: >-
+      Failed to check and update snapshot content
+    time: '2023-06-05T15:44:50Z'
+  readyToUse: false

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/testdata/good.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/testdata/good.yaml
@@ -1,0 +1,20 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  creationTimestamp: '2023-06-04T19:13:19Z'
+  finalizers:
+    - snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection
+status:
+  creationTime: 1685906000388294100
+  readyToUse: true
+  restoreSize: 1099511627776
+  snapshotHandle: >-
+    /subscriptions/XXXXXX
+spec:
+  driver: disk.csi.azure.com
+  source:
+    volumeHandle: >-
+      /subscriptions/XXXXXX
+  volumeSnapshotClassName: azure-tools
+  volumeSnapshotRef:
+    apiVersion: snapshot.storage.k8s.io/v1

--- a/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/testdata/initializing.yaml
+++ b/resource_customizations/snapshot.storage.k8s.io/VolumeSnapshotContent/testdata/initializing.yaml
@@ -1,0 +1,7 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: data-04-06-2023
+spec:
+  driver: disk.csi.azure.com
+status: {}


### PR DESCRIPTION
Add 2 new resources health-check for:

- ``snapshot.storage.k8s.io``  ``VolumeSnapshot`` 
- ``snapshot.storage.k8s.io`` ``VolumeSnapshotContent``

Object status is similar between the 2 resources, so the code is 50% copy/paste.

Kubernetes documentation: https://kubernetes.io/docs/concepts/storage/volume-snapshots/