### PR TITLE
chore(deps): upgrade haproxy to 2.6.14-alpine

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -1071,7 +1071,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: haproxy:2.6.12-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -1089,7 +1089,7 @@ spec:
           mountPath: /data
       containers:
       - name: haproxy
-        image: haproxy:2.6.12-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         securityContext: 
           null

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -11,7 +11,7 @@ redis-ha:
     IPv6:
       enabled: false
     image:
-      tag: 2.6.12-alpine
+      tag: 2.6.14-alpine
     containerSecurityContext: null
     timeout:
       server: 6m

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -19853,7 +19853,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.6.12-alpine
+      - image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -19890,7 +19890,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.6.12-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1881,7 +1881,7 @@ spec:
                 app.kubernetes.io/name: argocd-redis-ha-haproxy
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: haproxy:2.6.12-alpine
+      - image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -1918,7 +1918,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: haproxy:2.6.12-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:


### PR DESCRIPTION
2.6.12 has a high-severity CVE.