### PR TITLE
docs: add documentation for child elements of path

### DIFF
--- a/docs/operator-manual/applicationset/GoTemplate.md
+++ b/docs/operator-manual/applicationset/GoTemplate.md
@@ -98,6 +98,7 @@ By activating Go Templating, `{{ .path }}` becomes an object. Therefore, some ch
 generators' templating:
 
 - `{{ path }}` becomes `{{ .path.path }}`
+- `{{ path.* }}` becomes `{{ .path.* }}`
 - `{{ path[n] }}` becomes `{{ index .path.segments n }}`
 
 Here is an example:

--- a/docs/operator-manual/applicationset/GoTemplate.md
+++ b/docs/operator-manual/applicationset/GoTemplate.md
@@ -98,7 +98,10 @@ By activating Go Templating, `{{ .path }}` becomes an object. Therefore, some ch
 generators' templating:
 
 - `{{ path }}` becomes `{{ .path.path }}`
-- `{{ path.* }}` becomes `{{ .path.* }}`
+- `{{ path.basename }}` becomes `{{ .path.basename }}`
+- `{{ path.basenameNormalized }}` becomes `{{ .path.basenameNormalized }}`
+- `{{ path.filename }}` becomes `{{ .path.filename }}`
+- `{{ path.filenameNormalized }}` becomes `{{ .path.filenameNormalized }}`
 - `{{ path[n] }}` becomes `{{ index .path.segments n }}`
 
 Here is an example:


### PR DESCRIPTION
When using go templating, the parent `{{ path }}` becomes `{{ .path.path }}, however, the other values are not at `{{ .path.path.* }}`, but at `{{ .path.* }}`.

This documentation update seeks to make this easier to understand since we just ran into this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
