### PR TITLE
docs: add golang upgrade note for 2.5

### DIFF
--- a/docs/operator-manual/upgrading/2.4-2.5.md
+++ b/docs/operator-manual/upgrading/2.4-2.5.md
@@ -197,3 +197,8 @@ response and will therefore fail to create/update the Application.
 To solve the issue, upgrade the CLI to at least 2.5.16, or 2.6.7.
 
 CLIs older than 2.5.0-rc1 are unaffected.
+
+## Golang upgrade in 2.5.20
+
+In 2.5.20, we upgrade the Golang version used to build Argo CD from 1.18 to 1.19. If you use Argo CD as a library, you
+may need to upgrade your Go version.


### PR DESCRIPTION
Note to accompany golang upgrade for 2.5 releases.