### PR TITLE
fix(ui): soften readiness gate failure message (#13972)

### DIFF
--- a/ui/src/app/applications/components/application-node-info/application-node-info.tsx
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.tsx
@@ -275,7 +275,7 @@ export const ApplicationNodeInfo = (props: {
         if (!props.live?.status?.containerStatuses?.length) {
             return null;
         }
-        if (props.live?.status.containerStatuses.some((containerStatus: {ready: boolean}) => !containerStatus.ready)) {
+        if (props.live?.status?.containerStatuses?.some((containerStatus: {ready: boolean}) => !containerStatus.ready)) {
             return null;
         }
 

--- a/ui/src/app/applications/components/application-node-info/application-node-info.tsx
+++ b/ui/src/app/applications/components/application-node-info/application-node-info.tsx
@@ -9,16 +9,9 @@ import * as models from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {ResourceTreeNode} from '../application-resource-tree/application-resource-tree';
 import {ApplicationResourcesDiff} from '../application-resources-diff/application-resources-diff';
-import {
-    ComparisonStatusIcon,
-    formatCreationTimestamp,
-    getPodReadinessGatesState,
-    getPodReadinessGatesState as _getPodReadinessGatesState,
-    getPodStateReason,
-    HealthStatusIcon
-} from '../utils';
+import {ComparisonStatusIcon, formatCreationTimestamp, getPodReadinessGatesState, getPodStateReason, HealthStatusIcon} from '../utils';
 import './application-node-info.scss';
-import {ReadinessGatesFailedWarning} from './readiness-gates-failed-warning';
+import {ReadinessGatesNotPassedWarning} from './readiness-gates-not-passed-warning';
 
 const RenderContainerState = (props: {container: any}) => {
     const state = (props.container.state?.waiting && 'waiting') || (props.container.state?.terminated && 'terminated') || (props.container.state?.running && 'running');
@@ -278,6 +271,14 @@ export const ApplicationNodeInfo = (props: {
     }
 
     const readinessGatesState = React.useMemo(() => {
+        // If containers are not ready then readiness gate status is not important.
+        if (!props.live?.status?.containerStatuses?.length) {
+            return null;
+        }
+        if (props.live?.status.containerStatuses.some((containerStatus: {ready: boolean}) => !containerStatus.ready)) {
+            return null;
+        }
+
         if (props.live && props.node?.kind === 'Pod') {
             return getPodReadinessGatesState(props.live);
         }
@@ -287,7 +288,7 @@ export const ApplicationNodeInfo = (props: {
 
     return (
         <div>
-            {Boolean(readinessGatesState) && <ReadinessGatesFailedWarning readinessGatesState={readinessGatesState} />}
+            {Boolean(readinessGatesState) && <ReadinessGatesNotPassedWarning readinessGatesState={readinessGatesState} />}
             <div className='white-box'>
                 <div className='white-box__details'>
                     {attributes.map(attr => (

--- a/ui/src/app/applications/components/application-node-info/readiness-gates-not-passed-warning.scss
+++ b/ui/src/app/applications/components/application-node-info/readiness-gates-not-passed-warning.scss
@@ -3,7 +3,7 @@
 .white-box {
     &__readiness-gates-alert {
         padding: 20px;
-        border-left: 6px solid $argo-status-failed-color !important;
+        border-left: 6px solid $argo-status-warning-color !important;
 
         ul {
             margin-bottom: 0;

--- a/ui/src/app/applications/components/application-node-info/readiness-gates-not-passed-warning.tsx
+++ b/ui/src/app/applications/components/application-node-info/readiness-gates-not-passed-warning.tsx
@@ -1,29 +1,29 @@
 import * as React from 'react';
 import {selectPostfix} from '../utils';
 
-import './readiness-gates-failed-warning.scss';
+import './readiness-gates-not-passed-warning.scss';
 
-export interface ReadinessGatesFailedWarningProps {
+export interface ReadinessGatesNotPassedWarningProps {
     readinessGatesState: {
         nonExistingConditions: string[];
-        failedConditions: string[];
+        notPassedConditions: string[];
     };
 }
 
-export const ReadinessGatesFailedWarning = ({readinessGatesState}: ReadinessGatesFailedWarningProps) => {
-    if (readinessGatesState.failedConditions.length > 0 || readinessGatesState.nonExistingConditions.length > 0) {
+export const ReadinessGatesNotPassedWarning = ({readinessGatesState}: ReadinessGatesNotPassedWarningProps) => {
+    if (readinessGatesState.notPassedConditions.length > 0 || readinessGatesState.nonExistingConditions.length > 0) {
         return (
             <div className='white-box white-box__readiness-gates-alert'>
-                <h5>Readiness Gates Failing: </h5>
+                <h5>Readiness Gates Not Passing: </h5>
                 <ul>
-                    {readinessGatesState.failedConditions.length > 0 && (
+                    {readinessGatesState.notPassedConditions.length > 0 && (
                         <li>
-                            The status of pod readiness gate{selectPostfix(readinessGatesState.failedConditions, '', 's')}{' '}
-                            {readinessGatesState.failedConditions
+                            The status of pod readiness gate{selectPostfix(readinessGatesState.notPassedConditions, '', 's')}{' '}
+                            {readinessGatesState.notPassedConditions
                                 .map(t => `"${t}"`)
                                 .join(', ')
                                 .trim()}{' '}
-                            {selectPostfix(readinessGatesState.failedConditions, 'is', 'are')} False.
+                            {selectPostfix(readinessGatesState.notPassedConditions, 'is', 'are')} False.
                         </li>
                     )}
                     {readinessGatesState.nonExistingConditions.length > 0 && (

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -946,11 +946,12 @@ export function getPodStateReason(pod: appModels.State): {message: string; reaso
     return {reason, message, netContainerStatuses};
 }
 
-export const getPodReadinessGatesState = (pod: appModels.State): {nonExistingConditions: string[]; failedConditions: string[]} => {
+export const getPodReadinessGatesState = (pod: appModels.State): {nonExistingConditions: string[]; notPassedConditions: string[]} => {
+    // if pod does not have readiness gates then return empty status
     if (!pod.spec?.readinessGates?.length) {
         return {
             nonExistingConditions: [],
-            failedConditions: []
+            notPassedConditions: []
         };
     }
 
@@ -989,7 +990,7 @@ export const getPodReadinessGatesState = (pod: appModels.State): {nonExistingCon
 
     return {
         nonExistingConditions,
-        failedConditions
+        notPassedConditions: failedConditions
     };
 };
 


### PR DESCRIPTION
Two changes: 
* Don't show the message until all containers are ready (because readiness gates don't matter if the containers aren't ready)
* Soften the warning text and presentation ("not passing" instead of "failure", yellow border instead of red)

![image](https://github.com/argoproj/argo-cd/assets/350466/ee1c6985-ade0-4c45-9677-8fdf6a4cef70)


Fixes #13972 