### PR TITLE
fix: adds WebSocket ping to interactive terminal (#14191)

### DIFF
--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
@@ -227,6 +228,10 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer session.Done()
+
+	// send pings across the WebSocket channel at regular intervals to keep it alive through
+	// load balancers which may close an idle connection after some period of time
+	go session.StartKeepalives(time.Second * 5)
 
 	if isValidShell(s.allowedShells, shell) {
 		cmd := []string{shell}

--- a/server/application/websocket.go
+++ b/server/application/websocket.go
@@ -51,6 +51,23 @@ func (t *terminalSession) Done() {
 	close(t.doneChan)
 }
 
+func (t *terminalSession) StartKeepalives(dur time.Duration) {
+	ticker := time.NewTicker(dur)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			err := t.Ping()
+			if err != nil {
+				log.Errorf("ping error: %v", err)
+				return
+			}
+		case <-t.doneChan:
+			return
+		}
+	}
+}
+
 // Next called in a loop from remotecommand as long as the process is running
 func (t *terminalSession) Next() *remotecommand.TerminalSize {
 	select {
@@ -84,6 +101,17 @@ func (t *terminalSession) Read(p []byte) (int, error) {
 	default:
 		return copy(p, EndOfTransmission), fmt.Errorf("unknown message type %s", msg.Operation)
 	}
+}
+
+// Ping called periodically to ensure connection stays alive through load balancers
+func (t *terminalSession) Ping() error {
+	t.writeLock.Lock()
+	err := t.wsConn.WriteMessage(websocket.PingMessage, []byte("ping"))
+	t.writeLock.Unlock()
+	if err != nil {
+		log.Errorf("ping message err: %v", err)
+	}
+	return err
 }
 
 // Write called from remotecommand whenever there is any output


### PR DESCRIPTION
This adds a WebSocket ping message on a 5-second interval, sent from the server to the client. This ensures that the interactive terminal will remain open and won't be closed by load balancers that are reaping idle connections.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
