### PR TITLE
docs: explicit that ArgoCD hooks replaces the Helm ones

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -25,6 +25,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Arctiq Inc.](https://www.arctiq.ca)
 1. [ARZ Allgemeines Rechenzentrum GmbH](https://www.arz.at/)
 1. [Axual B.V.](https://axual.com)
+1. [Back Market](https://www.backmarket.com)
 1. [Baloise](https://www.baloise.com)
 1. [BCDevExchange DevOps Platform](https://bcdevexchange.org/DevOpsPlatform)
 1. [Beat](https://thebeat.co/en/)

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -168,7 +168,7 @@ Argo CD supports many (most?) Helm hooks by mapping the Helm annotations onto Ar
 Unsupported hooks are ignored. In Argo CD, hooks are created by using `kubectl apply`, rather than `kubectl create`. This means that if the hook is named and already exists, it will not change unless you have annotated it with `before-hook-creation`.
 
 !!! warning "Helm hooks + ArgoCD hooks"
-    If you define some ArgoCD hooks in addition to the Helm ones, the Helm hooks will be ignored.   
+    If you define some Argo CD hooks in addition to the Helm ones, the Helm hooks will be ignored.   
 
 !!! warning "'install' vs 'upgrade' vs 'sync'"
     Argo CD cannot know if it is running a first-time "install" or an "upgrade" - every operation is a "sync'. This means that, by default, apps that have `pre-install` and `pre-upgrade` will have those hooks run at the same time.

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -167,6 +167,9 @@ Argo CD supports many (most?) Helm hooks by mapping the Helm annotations onto Ar
 
 Unsupported hooks are ignored. In Argo CD, hooks are created by using `kubectl apply`, rather than `kubectl create`. This means that if the hook is named and already exists, it will not change unless you have annotated it with `before-hook-creation`.
 
+!!! warning "Helm hooks + ArgoCD hooks"
+    If you define some ArgoCD hooks in addition to the Helm ones, the Helm hooks will be ignored.   
+
 !!! warning "'install' vs 'upgrade' vs 'sync'"
     Argo CD cannot know if it is running a first-time "install" or an "upgrade" - every operation is a "sync'. This means that, by default, apps that have `pre-install` and `pre-upgrade` will have those hooks run at the same time.
 


### PR DESCRIPTION
After digging a bit in the code, I've found this comment that confirms that if we define some ArgoCD hooks the Helm ones are ignored. https://github.com/argoproj/gitops-engine/blob/425d65e07695a741d90b248f2f365f6a4329c23d/pkg/sync/hook/hook.go#L36C2-L36C46

Obviously feel free to reword this. 

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
