### PR TITLE
docs: managedFieldsManagers example in docs needs double-quotes

### DIFF
--- a/docs/user-guide/diffing.md
+++ b/docs/user-guide/diffing.md
@@ -60,8 +60,8 @@ To ignore fields owned by specific managers defined in your live resources:
 ```yaml
 spec:
   ignoreDifferences:
-  - group: *
-    kind: *
+  - group: "*"
+    kind: "*"
     managedFieldsManagers:
     - kube-controller-manager
 ```


### PR DESCRIPTION
Fixes #14323 

On <https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/#application-level-configuration> the managedFieldsManagers example should have double-quoted the `*` wildcards (e.g. `"*"`) because `*` is a YAML special character, and without this the examples cannot be parsed by ArgoCD (raising an error).
