### PR TITLE
Allow users to template and render Application's resources fully locally

### DIFF
--- a/docs/operator-manual/deep_links.md
+++ b/docs/operator-manual/deep_links.md
@@ -60,7 +60,7 @@ An example `argocd-cm.yaml` file with deep links and their variations :
   # sample application level links
   application.links: |
     # pkg.go.dev/text/template is used for evaluating url templates
-    - url: https://mycompany.splunk.com?search={{.application.spec.destination.namespace}}&env={{.project.metadata.label.env}}
+    - url: https://mycompany.splunk.com?search={{.application.spec.destination.namespace}}&env={{.project.metadata.labels.env}}
       title: Splunk
     # conditionally show link e.g. for specific project
     # github.com/antonmedv/expr is used for evaluation of conditions
@@ -72,7 +72,7 @@ An example `argocd-cm.yaml` file with deep links and their variations :
       if: application.metadata.annotations.splunkhost != ""
   # sample resource level links
   resource.links: |
-    - url: https://mycompany.splunk.com?search={{.resource.metadata.name}}&env={{.project.metadata.label.env}}
+    - url: https://mycompany.splunk.com?search={{.resource.metadata.name}}&env={{.project.metadata.labels.env}}
       title: Splunk
       if: resource.kind == "Pod" || resource.kind == "Deployment"
 ```


### PR DESCRIPTION
This PR is an attempt to make the `argocd app manifests` command run completely local, a pre-rendered file with app objects is required for correct operation.
I hope, this PR should close [#11129](https://github.com/argoproj/argo-cd/issues/11129) 

example command run:
`argocd app manifests my-app-name --local-app-manifest /repo/my-app/application/my-app.yaml --local /repo/my-app/manifests --local-repo-root /repo/my-app`

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
