### PR TITLE
fix: manifest missing rbac rules for applicationset leader ellection (#14369)

### DIFF
--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SRCROOT="$( CDPATH='' cd -- "$(dirname "$0")/.." && pwd -P )"
+SRCROOT="$(git rev-parse --show-toplevel)"
 AUTOGENMSG="# This is an auto-generated file. DO NOT EDIT"
 
 KUSTOMIZE=kustomize

--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
@@ -63,3 +63,42 @@ rules:
       - get
       - list
       - watch
+
+  # argocd-applicationset-controller leader election rules
+  # TODO: Remove configmaps related rules once `LeaderElectionResourceLock` is set to `leases`
+  #   - Either explicitly in `cmd/argocd-applicationset-controller/commands/applicationset_controller.go`
+  #   - Or if `sigs.k8s.io/controller-runtime` is upgraded to `>=v0.12.0` where this is the new default
+
+  # Create with resourceNames fails
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  # Limit updates to specific lock
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      # Defined in `cmd/argocd-applicationset-controller/commands/applicationset_controller.go`
+      - 58ac56fa.applicationsets.argoproj.io
+    verbs:
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      # Defined in `cmd/argocd-applicationset-controller/commands/applicationset_controller.go`
+      - 58ac56fa.applicationsets.argoproj.io
+    verbs:
+      - get
+      - update

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -18516,6 +18516,35 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -18552,6 +18552,35 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -175,6 +175,35 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -18543,6 +18543,35 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -166,6 +166,35 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - 58ac56fa.applicationsets.argoproj.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Closes #14369

Manifest is missing required RBAC rules required for the leader election feature of applicationset-controller (`applicationsetcontroller.enable.leader.election=true`)

The resource name is hardcoded in [cmd/argocd-applicationset-controller/commands/applicationset_controller.go](https://github.com/argoproj/argo-cd/blob/e2e0da7fcc4e6a5cf040117a3af9c15a7d0c267f/cmd/argocd-applicationset-controller/commands/applicationset_controller.go#L118C9-L118C9)
`LeaderElectionID = "58ac56fa.applicationsets.argoproj.io"`

Create of resource with `resourceNames` resulted in permission error. Therefore extra rules without resourceNames.

Tested
```
minikube start
kubectl create namespace argocd && kubectl apply -n argocd -f manifests/install.yaml
kubectl -n argocd patch configmaps argocd-cmd-params-cm -p '{"data": {"applicationsetcontroller.enable.leader.election": "true"}}'
kubectl -n argocd rollout restart deployment argocd-applicationset-controller
kubectl -n argocd rollout status deployment argocd-applicationset-controller

kubectl -n argocd logs -l app.kubernetes.io/name=argocd-applicationset-controller
time="2023-07-07T11:06:05Z" level=info msg="ArgoCD ApplicationSet Controller is starting" built="2023-07-06T23:53:41Z" commit=03026997d1a30befd89ae90e5f319304d8b25b84 namespace=argocd version=v2.9.0+0302699
time="2023-07-07T11:06:06Z" level=info msg="Starting configmap/secret informers"
time="2023-07-07T11:06:06Z" level=info msg="Configmap/secret informer synced"
time="2023-07-07T11:06:06Z" level=info msg="Starting manager"
time="2023-07-07T11:06:06Z" level=info msg="Starting webhook server"
I0707 11:06:06.615472       8 leaderelection.go:248] attempting to acquire leader lease argocd/58ac56fa.applicationsets.argoproj.io...
I0707 11:06:07.719032       8 leaderelection.go:258] successfully acquired lease argocd/58ac56fa.applicationsets.argoproj.io

kubectl -n argocd get configmaps,leases.coordination.k8s.io 58ac56fa.applicationsets.argoproj.io
NAME                                             DATA   AGE
configmap/58ac56fa.applicationsets.argoproj.io   0      2m11s

NAME                                                             HOLDER                                                                                   AGE
lease.coordination.k8s.io/58ac56fa.applicationsets.argoproj.io   argocd-applicationset-controller-58f5d6c9bc-rsxbh_90aeeb4d-8506-4855-9916-d081b668e4c8   2m10s
```

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
