### PR TITLE
fix: warn instead of error on failure to get plugin app details

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1992,7 +1992,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 			}
 		case v1alpha1.ApplicationSourceTypePlugin:
 			if err := populatePluginAppDetails(ctx, res, opContext.appPath, repoRoot, q, s.gitCredsStore, s.initConstants.CMPTarExcludedGlobs); err != nil {
-				return fmt.Errorf("failed to populate plugin app details: %w", err)
+				log.Warnf("failed to populate plugin app details - this is expected if the app is meant to use an argocd-cm plugin: %v", err)
 			}
 		}
 		_ = s.cache.SetAppDetails(revision, q.Source, q.RefSources, res, v1alpha1.TrackingMethod(q.TrackingMethod), nil)


### PR DESCRIPTION
We don't actually know that this is an error. If the app is meant to use an argocd-cm plugin, there won't be a corresponding sidecar plugin to populate the app details.

Unfortunately in this part of the code we don't have a list of configured plugins, so we can't verify whether the error is a real problem. Adding that information would require an API change (adding a `plugins` parameter), which we shouldn't do in a minor release series.

Instead we should just log a warning which will let argocd-cm plugins work and still preserve debug info for when sidecar plugins fail.

This problem goes away in 2.8, which does not support argocd-cm plugins.

Fixes https://github.com/argoproj/argo-cd/issues/14432