### PR TITLE
fix(appset): normalize app spec before applying

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -596,6 +596,9 @@ func (r *ApplicationSetReconciler) createOrUpdateInCluster(ctx context.Context, 
 		appLog := log.WithFields(log.Fields{"app": generatedApp.Name, "appSet": applicationSet.Name})
 		generatedApp.Namespace = applicationSet.Namespace
 
+		// Normalize to avoid fighting with the application controller.
+		generatedApp.Spec = *argoutil.NormalizeApplicationSpec(&generatedApp.Spec)
+
 		found := &argov1alpha1.Application{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      generatedApp.Name,

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -856,7 +856,8 @@ func NormalizeApplicationSpec(spec *argoappv1.ApplicationSpec) *argoappv1.Applic
 		for _, source := range spec.Sources {
 			NormalizeSource(&source)
 		}
-	} else {
+	} else if spec.Source != nil {
+		// In practice, spec.Source should never be nil.
 		NormalizeSource(spec.Source)
 	}
 	return spec


### PR DESCRIPTION
The AppSet controller can get into a state where it fights with the application controller.

For example, try an appset like this:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: test
spec:
  generators:
    - git:
        repoURL: https://github.com/test/test
        directories:
          - path: '*'
  template:
    metadata:
      name: '{{path}}-dev'
    spec:
      project: test
      source:
        repoURL: https://github.intuit.com/test/test
        targetRevision: release/dev
        path: '{{path}}'
        directory:
          jsonnet: {}
      destination:
        server: https://test
        namespace: '{{path}}'
```

Note that the application controller logs a bunch of stuff like this:

```
time="2023-07-12T16:28:29Z" level=info msg="Normalized app spec: {\"spec\":{\"source\":{\"directory\":null}}}"
```

It's fighting with the appset controller.

This PR normalizes before applying so there's nothing to fight about.