### PR TITLE
feat(health): Add custom health check for AnsibleJob resource

### DIFF
--- a/resource_customizations/tower.ansible.com/AnsibleJob/health.lua
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/health.lua
@@ -1,0 +1,25 @@
+hs = {}
+if obj.status ~= nil then
+  if obj.status.ansibleJobResult ~= nil then
+    jobstatus = obj.status.ansibleJobResult.status
+    if jobstatus == "successful" then
+      hs.status = "Healthy"
+      hs.message = jobstatus .. " job - " .. obj.status.ansibleJobResult.url
+      return hs
+    end
+    if jobstatus == "failed" or jobstatus == "error" or jobstatus == "canceled" then
+      hs.status = "Degraded"
+      hs.message = jobstatus .. " job - " .. obj.status.ansibleJobResult.url
+      return hs
+    end
+    if jobstatus == "new" or jobstatus == "pending" or jobstatus == "waiting" or jobstatus == "running" then
+      hs.status = "Progressing"
+      hs.message = jobstatus .. " job - " .. obj.status.ansibleJobResult.url
+      return hs
+    end
+  end
+end
+
+hs.status = "Progressing"
+hs.message = "Waiting for AnsibleJob"
+return hs

--- a/resource_customizations/tower.ansible.com/AnsibleJob/health_test.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/health_test.yaml
@@ -1,0 +1,37 @@
+tests:
+- healthStatus:
+    status: Progressing
+    message: Waiting for AnsibleJob
+  inputPath: testdata/progressing_noStatus.yaml
+- healthStatus:
+    status: Progressing
+    message: 'new job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/progressing_new.yaml
+- healthStatus:
+    status: Progressing
+    message: 'pending job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/progressing_pending.yaml
+- healthStatus:
+    status: Progressing
+    message: 'running job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/progressing_running.yaml
+- healthStatus:
+    status: Progressing
+    message: 'waiting job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/progressing_waiting.yaml
+- healthStatus:
+    status: Degraded
+    message: 'canceled job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/degraded_canceled.yaml
+- healthStatus:
+    status: Degraded
+    message: 'error job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/degraded_error.yaml
+- healthStatus:
+    status: Degraded
+    message: 'failed job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/degraded_failed.yaml
+- healthStatus:
+    status: Healthy
+    message: 'successful job - https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1'
+  inputPath: testdata/healthy.yaml

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/degraded_canceled.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/degraded_canceled.yaml
@@ -1,0 +1,27 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    elapsed: "5.21"
+    failed: false
+    finished: "2023-06-27T20:22:40.116381Z"
+    started: "2023-06-27T20:22:34.906399Z"
+    status: canceled
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/degraded_error.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/degraded_error.yaml
@@ -1,0 +1,27 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    elapsed: "5.21"
+    failed: true
+    finished: "2023-06-27T20:22:40.116381Z"
+    started: "2023-06-27T20:22:34.906399Z"
+    status: error
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/degraded_failed.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/degraded_failed.yaml
@@ -1,0 +1,27 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    elapsed: "5.21"
+    failed: true
+    finished: "2023-06-27T20:22:40.116381Z"
+    started: "2023-06-27T20:22:34.906399Z"
+    status: failed
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/healthy.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/healthy.yaml
@@ -1,0 +1,27 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    elapsed: "5.21"
+    failed: false
+    finished: "2023-06-27T20:22:40.116381Z"
+    started: "2023-06-27T20:22:34.906399Z"
+    status: successful
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_new.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_new.yaml
@@ -1,0 +1,25 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    failed: false
+    started: "2023-06-27T20:22:34.906399Z"
+    status: new
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_noStatus.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_noStatus.yaml
@@ -1,0 +1,17 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_pending.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_pending.yaml
@@ -1,0 +1,25 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    failed: false
+    started: "2023-06-27T20:22:34.906399Z"
+    status: pending
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_running.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_running.yaml
@@ -1,0 +1,25 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    failed: false
+    started: "2023-06-27T20:22:34.906399Z"
+    status: running
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1

--- a/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_waiting.yaml
+++ b/resource_customizations/tower.ansible.com/AnsibleJob/testdata/progressing_waiting.yaml
@@ -1,0 +1,25 @@
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+  creationTimestamp: "2023-06-27T20:22:22Z"
+  generateName: prehook-test-
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: ansible-hooks
+    tower_job_id: "1"
+  name: prehook-test-dfcff01-presync-1687897341
+  namespace: argocd
+  resourceVersion: "6536518"
+  uid: 09fa0d39-a170-4c37-a3b0-6e140e029868
+spec:
+  job_template_name: Demo Job Template
+  tower_auth_secret: toweraccess
+status:
+  ansibleJobResult:
+    changed: true
+    failed: false
+    started: "2023-06-27T20:22:34.906399Z"
+    status: waiting
+    url: https://argocd.test.ansiblejob.custom.health.com/#/jobs/playbook/1


### PR DESCRIPTION
This PR adds the custom health check for AnsibleJob resource (https://github.com/ansible/awx-resource-operator)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.