### PR TITLE
fix: Remove executable bit from default file mode

### DIFF
--- a/docs/operator-manual/upgrading/2.7-2.8.md
+++ b/docs/operator-manual/upgrading/2.7-2.8.md
@@ -65,3 +65,8 @@ p, role:action-runner, applications, action/argoproj.io/WorkflowTemplate/create-
 p, role:action-runner, applications, action/argoproj.io/CronWorkflow/create-workflow, *, allow
 p, role:action-runner, applications, action/batch/CronJob/create-job, *, allow
 ```
+
+## Change default file open mode
+
+In version 2.7, the CMP plugin was changed to open Git/Helm files with all executable bits set (unless `preserveFileMode` was specified).  
+Version 2.8 removes the executable bits in cases where they are not necessary.

--- a/util/io/files/tar.go
+++ b/util/io/files/tar.go
@@ -90,13 +90,12 @@ func Untgz(dstPath string, r io.Reader, maxSize int64, preserveFileMode bool) er
 			return fmt.Errorf("illegal filepath in archive: %s", target)
 		}
 
-		var mode os.FileMode = 0755
-		if preserveFileMode {
-			mode = os.FileMode(header.Mode)
-		}
-
 		switch header.Typeflag {
 		case tar.TypeDir:
+			var mode os.FileMode = 0755
+			if preserveFileMode {
+				mode = os.FileMode(header.Mode)
+			}
 			err := os.MkdirAll(target, mode)
 			if err != nil {
 				return fmt.Errorf("error creating nested folders: %w", err)
@@ -118,6 +117,11 @@ func Untgz(dstPath string, r io.Reader, maxSize int64, preserveFileMode bool) er
 				return fmt.Errorf("error creating symlink: %s", err)
 			}
 		case tar.TypeReg:
+			var mode os.FileMode = 0644
+			if preserveFileMode {
+				mode = os.FileMode(header.Mode)
+			}
+
 			err := os.MkdirAll(filepath.Dir(target), 0755)
 			if err != nil {
 				return fmt.Errorf("error creating nested folders: %w", err)

--- a/util/io/files/tar_test.go
+++ b/util/io/files/tar_test.go
@@ -216,7 +216,7 @@ func TestUntgz(t *testing.T) {
 
 		scriptFileInfo, err := os.Stat(path.Join(destDir, "script.sh"))
 		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0755), scriptFileInfo.Mode())
+		assert.Equal(t, os.FileMode(0644), scriptFileInfo.Mode())
 	})
 }
 


### PR DESCRIPTION
`Untgz` unnecessarily calls `os.OpenFile` with a file mode which has all executable bits set.
This PR removes the executable bits.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.