### PR TITLE
fix(security): don't allow app enumeration via RevisionChartDetails

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1376,7 +1376,7 @@ func (s *Server) RevisionChartDetails(ctx context.Context, q *application.Revisi
 		return nil, err
 	}
 	if a.Spec.Source.Chart == "" {
-		return nil, fmt.Errorf("no chart found for application: %v", a.Name)
+		return nil, fmt.Errorf("no chart found for application: %v", a.QualifiedName())
 	}
 	repo, err := s.db.GetRepository(ctx, a.Spec.Source.RepoURL)
 	if err != nil {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1371,17 +1371,12 @@ func (s *Server) RevisionMetadata(ctx context.Context, q *application.RevisionMe
 
 // RevisionChartDetails returns the helm chart metadata, as fetched from the reposerver
 func (s *Server) RevisionChartDetails(ctx context.Context, q *application.RevisionMetadataQuery) (*appv1.ChartDetails, error) {
-	appName := q.GetName()
-	appNs := s.appNamespaceOrDefault(q.GetAppNamespace())
-	a, err := s.appLister.Applications(appNs).Get(appName)
+	a, err := s.getApplicationEnforceRBACInformer(ctx, rbacpolicy.ActionGet, q.GetAppNamespace(), q.GetName())
 	if err != nil {
-		return nil, fmt.Errorf("error getting app by name: %w", err)
-	}
-	if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacpolicy.ActionGet, a.RBACName(s.ns)); err != nil {
-		return nil, fmt.Errorf("error enforcing claims: %w", err)
+		return nil, err
 	}
 	if a.Spec.Source.Chart == "" {
-		return nil, fmt.Errorf("no chart found for application: %v", appName)
+		return nil, fmt.Errorf("no chart found for application: %v", a.Name)
 	}
 	repo, err := s.db.GetRepository(ctx, a.Spec.Source.RepoURL)
 	if err != nil {


### PR DESCRIPTION
This endpoint was written before we had the fix in for app enumeration. I'm just applying the security fix to the additional endpoint.