### PR TITLE
chore: Update log level to warn when in-cluster svr addr is disabled but internal addr is used

### DIFF
--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -78,7 +78,7 @@ func (db *db) ListClusters(ctx context.Context) (*appv1.ClusterList, error) {
 				hasInClusterCredentials = true
 				clusterList.Items = append(clusterList.Items, *cluster)
 			} else {
-				log.Errorf("failed to add cluster %q to cluster list: in-cluster server address is disabled in Argo CD settings", cluster.Name)
+				log.Warnf("failed to add cluster %q to cluster list: in-cluster server address is disabled in Argo CD settings", cluster.Name)
 			}
 		} else {
 			clusterList.Items = append(clusterList.Items, *cluster)


### PR DESCRIPTION
These are sometimes intentional and should not be treated as errors.