### PR TITLE
fix: 'argocd-server-tls' Secret should be loaded from informer

### DIFF
--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -1444,7 +1444,7 @@ func (mgr *SettingsManager) updateSettingsFromSecret(settings *ArgoCDSettings, a
 // return values are nil, no external secret has been configured.
 func (mgr *SettingsManager) externalServerTLSCertificate() (*tls.Certificate, error) {
 	var cert tls.Certificate
-	secret, err := mgr.clientset.CoreV1().Secrets(mgr.namespace).Get(mgr.ctx, externalServerTLSSecretName, metav1.GetOptions{})
+	secret, err := mgr.secrets.Secrets(mgr.namespace).Get(externalServerTLSSecretName)
 	if err != nil {
 		if apierr.IsNotFound(err) {
 			return nil, nil


### PR DESCRIPTION
Argo CD is loading  `argocd-server-tls` Secret directly from Kubernetes although it is available in informer. This results in thousands of unnecessary k8s API calls and most likelly slows down reconciliation. 