### PR TITLE
fix(controller): populate ignoreDifferences in sync status

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -950,7 +950,8 @@ func TestNeedRefreshAppStatus(t *testing.T) {
 			app.Status.Sync = v1alpha1.SyncStatus{
 				Status: v1alpha1.SyncStatusCodeSynced,
 				ComparedTo: v1alpha1.ComparedTo{
-					Destination: app.Spec.Destination,
+					Destination:       app.Spec.Destination,
+					IgnoreDifferences: app.Spec.IgnoreDifferences,
 				},
 			}
 
@@ -1019,7 +1020,8 @@ func TestNeedRefreshAppStatus(t *testing.T) {
 				app.Status.Sync = v1alpha1.SyncStatus{
 					Status: v1alpha1.SyncStatusCodeSynced,
 					ComparedTo: v1alpha1.ComparedTo{
-						Destination: app.Spec.Destination,
+						Destination:       app.Spec.Destination,
+						IgnoreDifferences: app.Spec.IgnoreDifferences,
 					},
 				}
 				if app.Spec.HasMultipleSources() {
@@ -1214,7 +1216,7 @@ func TestUpdateReconciledAt(t *testing.T) {
 	app := newFakeApp()
 	reconciledAt := metav1.NewTime(time.Now().Add(-1 * time.Second))
 	app.Status = v1alpha1.ApplicationStatus{ReconciledAt: &reconciledAt}
-	app.Status.Sync = v1alpha1.SyncStatus{ComparedTo: v1alpha1.ComparedTo{Source: app.Spec.GetSource(), Destination: app.Spec.Destination}}
+	app.Status.Sync = v1alpha1.SyncStatus{ComparedTo: v1alpha1.ComparedTo{Source: app.Spec.GetSource(), Destination: app.Spec.Destination, IgnoreDifferences: app.Spec.IgnoreDifferences}}
 	ctrl := newFakeController(&fakeData{
 		apps: []runtime.Object{app, &defaultProj},
 		manifestResponse: &apiclient.ManifestResponse{

--- a/controller/state.go
+++ b/controller/state.go
@@ -351,7 +351,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 		if hasMultipleSources {
 			return &comparisonResult{
 				syncStatus: &v1alpha1.SyncStatus{
-					ComparedTo: v1alpha1.ComparedTo{Destination: app.Spec.Destination, Sources: sources},
+					ComparedTo: v1alpha1.ComparedTo{Destination: app.Spec.Destination, Sources: sources, IgnoreDifferences: app.Spec.IgnoreDifferences},
 					Status:     v1alpha1.SyncStatusCodeUnknown,
 					Revisions:  revisions,
 				},
@@ -360,7 +360,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 		} else {
 			return &comparisonResult{
 				syncStatus: &v1alpha1.SyncStatus{
-					ComparedTo: v1alpha1.ComparedTo{Source: sources[0], Destination: app.Spec.Destination},
+					ComparedTo: v1alpha1.ComparedTo{Source: sources[0], Destination: app.Spec.Destination, IgnoreDifferences: app.Spec.IgnoreDifferences},
 					Status:     v1alpha1.SyncStatusCodeUnknown,
 					Revision:   revisions[0],
 				},
@@ -506,7 +506,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 
 	// restore comparison using cached diff result if previous comparison was performed for the same revision
 	revisionChanged := len(manifestInfos) != len(sources) || !reflect.DeepEqual(app.Status.Sync.Revisions, manifestRevisions)
-	specChanged := !reflect.DeepEqual(app.Status.Sync.ComparedTo, v1alpha1.ComparedTo{Source: app.Spec.GetSource(), Destination: app.Spec.Destination, Sources: sources})
+	specChanged := !reflect.DeepEqual(app.Status.Sync.ComparedTo, v1alpha1.ComparedTo{Source: app.Spec.GetSource(), Destination: app.Spec.Destination, Sources: sources, IgnoreDifferences: app.Spec.IgnoreDifferences})
 
 	_, refreshRequested := app.IsRefreshRequested()
 	noCache = noCache || refreshRequested || app.Status.Expired(m.statusRefreshTimeout) || specChanged || revisionChanged
@@ -647,8 +647,9 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 	if hasMultipleSources {
 		syncStatus = v1alpha1.SyncStatus{
 			ComparedTo: v1alpha1.ComparedTo{
-				Destination: app.Spec.Destination,
-				Sources:     sources,
+				Destination:       app.Spec.Destination,
+				Sources:           sources,
+				IgnoreDifferences: app.Spec.IgnoreDifferences,
 			},
 			Status:    syncCode,
 			Revisions: manifestRevisions,
@@ -656,8 +657,9 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 	} else {
 		syncStatus = v1alpha1.SyncStatus{
 			ComparedTo: v1alpha1.ComparedTo{
-				Destination: app.Spec.Destination,
-				Source:      app.Spec.GetSource(),
+				Destination:       app.Spec.Destination,
+				Source:            app.Spec.GetSource(),
+				IgnoreDifferences: app.Spec.IgnoreDifferences,
 			},
 			Status:   syncCode,
 			Revision: revision,


### PR DESCRIPTION
[This PR](https://github.com/argoproj/argo-cd/pull/12607) was incomplete. It correctly checks whether ignoreDifferences was changed since the last sync and requests a new sync if it wasn't. But it incorrectly fails to populate the ignoreDifferences field in the last sync state. So for any app with ignoreDifferences set, refreshes will be constantly requested.