### PR TITLE
feat(ui): use settings context

### DIFF
--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -4,7 +4,7 @@ import {useState} from 'react';
 import {EventsList, YamlEditor} from '../../../shared/components';
 import * as models from '../../../shared/models';
 import {ErrorBoundary} from '../../../shared/components/error-boundary/error-boundary';
-import {Context} from '../../../shared/context';
+import {AuthSettingsCtx, Context} from '../../../shared/context';
 import {Application, ApplicationTree, AppSourceType, Event, RepoAppDetails, ResourceNode, State, SyncStatuses} from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {ResourceTabExtension} from '../../../shared/services/extensions-service';
@@ -37,6 +37,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
     const {selectedNode, updateApp, application, isAppSelected, tree} = {...props};
     const [activeContainer, setActiveContainer] = useState();
     const appContext = React.useContext(Context);
+    const settingsContext = React.useContext(AuthSettingsCtx);
     const tab = new URLSearchParams(appContext.history.location.search).get('tab');
     const selectedNodeInfo = NodeInfo(new URLSearchParams(appContext.history.location.search).get('node'));
     const selectedNodeKey = selectedNodeInfo.key;
@@ -277,8 +278,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                             }
                         }
 
-                        const settings = await services.authService.settings();
-                        const execEnabled = settings.execEnabled;
+                        const execEnabled = settingsContext.execEnabled;
                         const logsAllowed = await services.accounts.canI('logs', 'get', application.spec.project + '/' + application.metadata.name);
                         const execAllowed = await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
                         const links = await services.applications.getResourceLinks(application.metadata.name, application.metadata.namespace, selectedNode).catch(() => null);

--- a/ui/src/app/shared/components/badge-panel/badge-panel.tsx
+++ b/ui/src/app/shared/components/badge-panel/badge-panel.tsx
@@ -1,14 +1,14 @@
-import {DataLoader, DropDownMenu} from 'argo-ui';
+import {DropDownMenu} from 'argo-ui';
 import * as React from 'react';
 
-import {services} from '../../../shared/services';
-import {Context} from '../../context';
+import {AuthSettingsCtx, Context} from '../../context';
 
 require('./badge-panel.scss');
 
 export const BadgePanel = ({app, project}: {app?: string; project?: string}) => {
     const [badgeType, setBadgeType] = React.useState('URL');
     const context = React.useContext(Context);
+    const settingsContext = React.useContext(AuthSettingsCtx);
     if (!app && !project) {
         throw new Error('Either app or project property must be specified');
     }
@@ -67,9 +67,9 @@ export const BadgePanel = ({app, project}: {app?: string; project?: string}) => 
         );
     }
 
-    return (
-        <DataLoader load={() => services.authService.settings()}>
-            {settings => (settings.statusBadgeEnabled && <div>{badgeContent(settings.statusBadgeRootUrl)}</div>) || null}
-        </DataLoader>
-    );
+    if (settingsContext.statusBadgeEnabled) {
+        return <div>{badgeContent(settingsContext.statusBadgeRootUrl)}</div>;
+    }
+
+    return null;
 };


### PR DESCRIPTION
A small improvement: use authSettings React context instead of doing extra HTTP calls to /settings API.

