### PR TITLE
fix: OCI dependency url can't contain part of repository

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -2665,7 +2665,7 @@ func TestGetHelmRepos_OCIDependencies(t *testing.T) {
 	assert.Equal(t, len(helmRepos), 1)
 	assert.Equal(t, helmRepos[0].Username, "test")
 	assert.Equal(t, helmRepos[0].EnableOci, true)
-	assert.Equal(t, helmRepos[0].Repo, "example.com")
+	assert.Equal(t, helmRepos[0].Repo, "example.com/myrepo")
 }
 
 func TestGetHelmRepo_NamedRepos(t *testing.T) {

--- a/reposerver/repository/testdata/oci-dependencies/Chart.yaml
+++ b/reposerver/repository/testdata/oci-dependencies/Chart.yaml
@@ -2,5 +2,5 @@ name: my-chart
 version: 1.1.0
 dependencies:
 - name: my-dependency
-  repository: oci://example.com
+  repository: oci://example.com/myrepo
   version: '*'


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/14636

PR ensures that Argo CD uses registered OCI repo credentials when the helm chart references repo with the chart sub-path. 