### PR TITLE
feat(deep-links): alias `application` as `app` for consistency with notifications engine (#14760)

### DIFF
--- a/docs/operator-manual/deep_links.md
+++ b/docs/operator-manual/deep_links.md
@@ -37,7 +37,7 @@ Each link in the list has five subfields:
 As mentioned earlier the links and conditions can be templated to use data from the resource, each category of links can access different types of data linked to that resource.
 Overall we have these 4 resources available for templating in the system:
 
-- `application`: this key is used to access the application resource data.
+- `app` or `application`: this key is used to access the application resource data.
 - `resource`: this key is used to access values for the actual k8s resource.
 - `cluster`: this key is used to access the related destination cluster data like name, server, namespaces etc.
 - `project`: this key is used to access the project resource data.
@@ -45,7 +45,7 @@ Overall we have these 4 resources available for templating in the system:
 The above resources are accessible in particular link categories, here's a list of resources available in each category:
 
 - `resource.links`: `resource`, `application`, `cluster` and `project`
-- `application.links`: `application` and `cluster`
+- `application.links`: `app`/`application` and `cluster`
 - `project.links`: `project`
 
 An example `argocd-cm.yaml` file with deep links and their variations :
@@ -60,16 +60,16 @@ An example `argocd-cm.yaml` file with deep links and their variations :
   # sample application level links
   application.links: |
     # pkg.go.dev/text/template is used for evaluating url templates
-    - url: https://mycompany.splunk.com?search={{.application.spec.destination.namespace}}&env={{.project.metadata.labels.env}}
+    - url: https://mycompany.splunk.com?search={{.app.spec.destination.namespace}}&env={{.project.metadata.labels.env}}
       title: Splunk
     # conditionally show link e.g. for specific project
     # github.com/antonmedv/expr is used for evaluation of conditions
-    - url: https://mycompany.splunk.com?search={{.application.spec.destination.namespace}}
+    - url: https://mycompany.splunk.com?search={{.app.spec.destination.namespace}}
       title: Splunk
       if: application.spec.project == "default"
-    - url: https://{{.application.metadata.annotations.splunkhost}}?search={{.application.spec.destination.namespace}}
+    - url: https://{{.app.metadata.annotations.splunkhost}}?search={{.app.spec.destination.namespace}}
       title: Splunk
-      if: application.metadata.annotations.splunkhost != ""
+      if: app.metadata.annotations.splunkhost != ""
   # sample resource level links
   resource.links: |
     - url: https://mycompany.splunk.com?search={{.resource.metadata.name}}&env={{.project.metadata.labels.env}}

--- a/server/deeplinks/deeplinks.go
+++ b/server/deeplinks/deeplinks.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/antonmedv/expr"
-	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v2/util/settings"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
 var sprigFuncMap = sprig.GenericFuncMap() // a singleton for better performance
@@ -27,6 +28,7 @@ func init() {
 const (
 	ResourceDeepLinkKey = "resource"
 	AppDeepLinkKey      = "application"
+	AppDeepLinkShortKey = "app"
 	ClusterDeepLinkKey  = "cluster"
 	ProjectDeepLinkKey  = "project"
 )
@@ -67,6 +69,7 @@ func CreateDeepLinksObject(resourceObj *unstructured.Unstructured, app *unstruct
 	}
 	if app != nil {
 		deeplinkObj[AppDeepLinkKey] = app.Object
+		deeplinkObj[AppDeepLinkShortKey] = app.Object
 	}
 	if cluster != nil {
 		deeplinkObj[ClusterDeepLinkKey] = cluster.Object

--- a/server/deeplinks/deeplinks_test.go
+++ b/server/deeplinks/deeplinks_test.go
@@ -5,15 +5,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v2/util/settings"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
 type deepLinkTC struct {
@@ -76,6 +77,22 @@ func TestDeepLinks(t *testing.T) {
 				Title:     "link",
 				URL:       "http://example.com/{{ .application.metadata.name }}&{{ .resource.data.key }}&{{ index .project.spec.sourceRepos 0}}&{{ .cluster.name }}",
 				Condition: pointer.String(`application.metadata.name == "test" && project.metadata.name == "test-project"`),
+			}},
+			outputLinks: []*application.LinkInfo{{
+				Title: pointer.String("link"),
+				Url:   pointer.String("http://example.com/test&value1&test-repo.git&test-cluster"),
+			}},
+			error: []string{},
+		},
+		{
+			appObj:      appObj,
+			resourceObj: resourceObj,
+			projectObj:  projectObj,
+			clusterObj:  clusterObj,
+			inputLinks: []settings.DeepLink{{
+				Title:     "link",
+				URL:       "http://example.com/{{ .app.metadata.name }}&{{ .resource.data.key }}&{{ index .project.spec.sourceRepos 0}}&{{ .cluster.name }}",
+				Condition: pointer.String(`app.metadata.name == "test" && project.metadata.name == "test-project"`),
 			}},
 			outputLinks: []*application.LinkInfo{{
 				Title: pointer.String("link"),


### PR DESCRIPTION
Closes #14760

Argo CD notifications templates use `app` instead of `application`: https://argocd-notifications.readthedocs.io/en/stable/templates/

This PR allows the user to choose either option.

I'm defaulting to `app` in the docs, for consistency with notifications engine.