### PR TITLE
fix:(appset) add a organizationNormalized template value for appset SCM provider (#14768)

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -301,6 +301,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [WooliesX](https://wooliesx.com.au/)
 1. [Woolworths Group](https://www.woolworthsgroup.com.au/)
 1. [WSpot](https://www.wspot.com.br/)
+1. [Wunderkind](https://wunderkind.co/)
 1. [Yieldlab](https://www.yieldlab.de/)
 1. [Youverify](https://youverify.co/)
 1. [Yubo](https://www.yubo.live/)

--- a/applicationset/generators/scm_provider.go
+++ b/applicationset/generators/scm_provider.go
@@ -203,15 +203,16 @@ func (g *SCMProviderGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha
 		}
 
 		params := map[string]interface{}{
-			"organization":     repo.Organization,
-			"repository":       repo.Repository,
-			"url":              repo.URL,
-			"branch":           repo.Branch,
-			"sha":              repo.SHA,
-			"short_sha":        repo.SHA[:shortSHALength],
-			"short_sha_7":      repo.SHA[:shortSHALength7],
-			"labels":           strings.Join(repo.Labels, ","),
-			"branchNormalized": utils.SanitizeName(repo.Branch),
+			"organization":           repo.Organization,
+			"repository":             repo.Repository,
+			"url":                    repo.URL,
+			"branch":                 repo.Branch,
+			"sha":                    repo.SHA,
+			"short_sha":              repo.SHA[:shortSHALength],
+			"short_sha_7":            repo.SHA[:shortSHALength7],
+			"labels":                 strings.Join(repo.Labels, ","),
+			"branchNormalized":       utils.SanitizeName(repo.Branch),
+			"organizationNormalized": utils.SanitizeName(repo.Organization),
 		}
 
 		err := appendTemplatedValues(appSetGenerator.SCMProvider.Values, params, applicationSetInfo.Spec.GoTemplate, applicationSetInfo.Spec.GoTemplateOptions)

--- a/applicationset/generators/scm_provider_test.go
+++ b/applicationset/generators/scm_provider_test.go
@@ -163,6 +163,35 @@ func TestSCMProviderGenerateParams(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Value Normalization",
+			repos: []*scm_provider.Repository{
+				{
+					Organization: "myorg/myteam",
+					Repository:   "repo4",
+					URL:          "git@github.com:myorg/repo3.git",
+					Branch:       "my/main",
+					SHA:          "0bc57212c3cbbec69d20b34c507284bd300def5b",
+					Labels:       []string{"prod", "staging"},
+				},
+			},
+			expected: []map[string]interface{}{
+				{
+					"organization":                  "myorg/myteam",
+					"organizationNormalized":        "myorg-myteam",
+					"repository":                    "repo3",
+					"url":                           "git@github.com:myorg/repo3.git",
+					"branch":                        "my/main",
+					"branchNormalized":              "my-main",
+					"sha":                           "0bc57212c3cbbec69d20b34c507284bd300def5b",
+					"short_sha":                     "0bc57212",
+					"short_sha_7":                   "0bc5721",
+					"labels":                        "prod,staging",
+					"values.foo":                    "bar",
+					"values.should_i_force_push_to": "main?",
+				},
+			},
+		},
 	}
 
 	for _, testCase := range cases {

--- a/docs/operator-manual/applicationset/Generators-SCM-Provider.md
+++ b/docs/operator-manual/applicationset/Generators-SCM-Provider.md
@@ -408,6 +408,7 @@ spec:
 * `short_sha_7`: The abbreviated Git commit SHA for the branch (7 chars or the length of the `sha` if it's shorter).
 * `labels`: A comma-separated list of repository labels.
 * `branchNormalized`: The value of `branch` normalized to contain only lowercase alphanumeric characters, '-' or '.'.
+* `organizationNormalized`: The value of `organization` normalized to contain only lowercase alphanumeric characters, '-' or '.'.
 
 ## Pass additional key-value pairs via `values` field
 
@@ -432,7 +433,7 @@ spec:
             secretName: mypassword
             key: password
       values:
-        name: "{{organization}}-{{repository}}"
+        name: "{{organizationNormalized}}-{{repository}}"
 
   template:
     metadata:


### PR DESCRIPTION
From the issue https://github.com/argoproj/argo-cd/issues/14768

This MR adds a organizationNormalized parameter to the SCM provider to ensure we can then use the Org name in templates

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Closes [14768]
