### PR TITLE
chore: make `helm template` errors less verbose

### DIFF
--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -1,12 +1,14 @@
 package helm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -267,7 +269,8 @@ type TemplateOpts struct {
 }
 
 var (
-	re = regexp.MustCompile(`([^\\]),`)
+	re                 = regexp.MustCompile(`([^\\]),`)
+	apiVersionsRemover = regexp.MustCompile(`(--api-versions [^ ]+ )+`)
 )
 
 func cleanSetParameters(val string) string {
@@ -310,7 +313,16 @@ func (c *Cmd) template(chartPath string, opts *TemplateOpts) (string, error) {
 		args = append(args, "--include-crds")
 	}
 
-	return c.run(args...)
+	out, err := c.run(args...)
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "--api-versions") {
+			log.Debug(msg)
+			msg = apiVersionsRemover.ReplaceAllString(msg, "<api versions removed> ")
+		}
+		return "", errors.New(msg)
+	}
+	return out, nil
 }
 
 func (c *Cmd) Freestyle(args ...string) (string, error) {

--- a/util/helm/cmd_test.go
+++ b/util/helm/cmd_test.go
@@ -23,6 +23,18 @@ func TestCmd_template_kubeVersion(t *testing.T) {
 	assert.NotEmpty(t, s)
 }
 
+func TestCmd_template_noApiVersionsInError(t *testing.T) {
+	cmd, err := NewCmdWithVersion(".", HelmV3, false, "")
+	assert.NoError(t, err)
+	_, err = cmd.template("testdata/chart-does-not-exist", &TemplateOpts{
+		KubeVersion: "1.14",
+		APIVersions: []string{"foo", "bar"},
+	})
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "--api-version")
+	assert.ErrorContains(t, err, "<api versions removed> ")
+}
+
 func TestNewCmd_helmV3(t *testing.T) {
 	cmd, err := NewCmd(".", "v3", "")
 	assert.NoError(t, err)


### PR DESCRIPTION
`helm template` error messages are way too long, because they include all the `--api-version` arguments set on the call (see screenshot in 
https://github.com/argoproj/argo-cd/issues/6082). Those API versions are rarely (ever?) useful in debugging issues.

This PR replaces those flags in output with `<api versions removed>`. I added the full output to logs via `log.Debug`, just in case it proves useful in some cases.

The new output will look a bit like this;

> Unable to save changes: application spec for test is invalid: InvalidSpecError: Unable to generate manifests in helm-guestbook: rpc error: code = Unknown desc = `helm template . --name-template test --namespace default --kube-version 1.25 --set image.pullPolicy=Always --set replicaCount=blarn --values /var/folders/7c/whfc9xsj1z5g8jtc7t7z0cq80000gp/T/02157bae-04ed-4b9c-90e1-66d9690c6bb1 <api versions removed> --include-crds` failed exit status 1: Error: failed parsing --set data: unable to parse key: interface conversion: interface {} is string, not map[string]interface {}

There's still room for improvement, but it's much easier now to scan for the actual error.