### PR TITLE
fix: correct discrepancies in generated swagger file

### DIFF
--- a/assets/swagger.json
+++ b/assets/swagger.json
@@ -5654,19 +5654,8 @@
     },
     "v1Time": {
       "description": "Time is a wrapper around time.Time which supports correct\nmarshaling to YAML and JSON.  Wrappers are provided for many\nof the factory methods that the time package offers.\n\n+protobuf.options.marshal=false\n+protobuf.as=Timestamp\n+protobuf.options.(gogoproto.goproto_stringer)=false",
-      "type": "object",
-      "properties": {
-        "nanos": {
-          "description": "Non-negative fractions of a second at nanosecond resolution. Negative\nsecond values with fractions must still have non-negative nanos values\nthat count forward in time. Must be from 0 to 999,999,999\ninclusive. This field may be limited in precision depending on context.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "seconds": {
-          "description": "Represents seconds of UTC time since Unix epoch\n1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to\n9999-12-31T23:59:59Z inclusive.",
-          "type": "string",
-          "format": "int64"
-        }
-      }
+      "type": "string",
+      "format": "date-time"
     },
     "v1alpha1AWSAuthConfig": {
       "type": "object",
@@ -8223,13 +8212,15 @@
             "$ref": "#/definitions/v1alpha1ResourceRef"
           }
         },
-        "resourceRef": {
-          "$ref": "#/definitions/v1alpha1ResourceRef"
-        },
         "resourceVersion": {
           "type": "string"
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/v1alpha1ResourceRef"
+        }
+      ]
     },
     "v1alpha1ResourceOverride": {
       "type": "object",

--- a/hack/generate-proto.sh
+++ b/hack/generate-proto.sh
@@ -118,7 +118,10 @@ EOF
       del(.definitions.v1alpha1OptionalArray) |
       .definitions.v1alpha1ApplicationSourcePluginParameter.properties.map = {"description":"Map is the value of a map type parameter.","type":"object","additionalProperties":{"type":"string"}} |
       del(.definitions.v1alpha1OptionalMap)
-    ' "${COMBINED_SWAGGER}" > "${SWAGGER_OUT}"
+    ' "${COMBINED_SWAGGER}" | \
+    jq '.definitions.v1Time.type = "string" | .definitions.v1Time.format = "date-time" | del(.definitions.v1Time.properties)' | \
+    jq '.definitions.v1alpha1ResourceNode.allOf = [{"$ref": "#/definitions/v1alpha1ResourceRef"}] | del(.definitions.v1alpha1ResourceNode.properties.resourceRef) ' \
+    > "${SWAGGER_OUT}"
 
     /bin/rm "${PRIMARY_SWAGGER}" "${COMBINED_SWAGGER}"
 }


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/4314

PR fixes discrepancies in generated swagger file for `v1.Time` and `v1alpha1.ResourceNode` types. Below is an example of generated java DTO for `ResourceNode` type ( it uses both problematic types)


```java
// generated using 
// swagger-codegen generate -i ~/go/src/github.com/argoproj/argo-cd/assets/swagger.json -l java


public class V1alpha1ResourceNode extends V1alpha1ResourceRef { // inherits V1alpha1ResourceRef instead of embedding
  @SerializedName("createdAt")
  private OffsetDateTime createdAt = null; // OpenAPI's date time type (org.threeten.bp.OffsetDateTime)

  @SerializedName("health")
  private V1alpha1HealthStatus health = null;

  @SerializedName("images")
  private List<String> images = null;

  @SerializedName("info")
  private List<V1alpha1InfoItem> info = null;

  @SerializedName("networkingInfo")
  private V1alpha1ResourceNetworkingInfo networkingInfo = null;

  @SerializedName("parentRefs")
  private List<V1alpha1ResourceRef> parentRefs = null;

  @SerializedName("resourceVersion")
  private String resourceVersion = null;
}
```