### PR TITLE
fix: ManagedResources API should not return diff for hooks

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1486,7 +1486,7 @@ func (s *Server) ManagedResources(ctx context.Context, q *application.ResourcesQ
 	res := &application.ManagedResourcesResponse{}
 	for i := range items {
 		item := items[i]
-		if isMatchingResource(q, kube.ResourceKey{Name: item.Name, Namespace: item.Namespace, Kind: item.Kind, Group: item.Group}) {
+		if !item.Hook && isMatchingResource(q, kube.ResourceKey{Name: item.Name, Namespace: item.Namespace, Kind: item.Kind, Group: item.Group}) {
 			res.Items = append(res.Items, item)
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/3143

ManagedResources should just omit returns diffs for hooks.

Before:

<img width="1463" alt="image" src="https://github.com/argoproj/argo-cd/assets/426437/46071e4e-30c5-4782-9d92-da9978a42181">


After:

<img width="1518" alt="image" src="https://github.com/argoproj/argo-cd/assets/426437/aa4afdeb-a184-43e5-8096-e39f9095219a">
