### PR TITLE
docs: Change Generator docs for List Generator to note any key/value pairs can be used

### DIFF
--- a/docs/operator-manual/applicationset/Generators.md
+++ b/docs/operator-manual/applicationset/Generators.md
@@ -6,7 +6,7 @@ Generators are primarily based on the data source that they use to generate the 
 
 As of this writing there are nine generators:
 
-- [List generator](Generators-List.md): The List generator allows you to target Argo CD Applications to clusters based on a fixed list of cluster name/URL values.
+- [List generator](Generators-List.md): The List generator allows you to target Argo CD Applications to clusters based on a fixed list of any chosen key/value element pairs.
 - [Cluster generator](Generators-Cluster.md): The Cluster generator allows you to target Argo CD Applications to clusters, based on the list of clusters defined within (and managed by) Argo CD (which includes automatically responding to cluster addition/removal events from Argo CD).
 - [Git generator](Generators-Git.md): The Git generator allows you to create Applications based on files within a Git repository, or based on the directory structure of a Git repository.
 - [Matrix generator](Generators-Matrix.md): The Matrix generator may be used to combine the generated parameters of two separate generators.


### PR DESCRIPTION
This updates the Argo CD  Generator docs to reflect what the [List Generator doc](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-List/) notes, which is that Argo CD applicationSets are no longer limited to cluster/url value pairs:

> With the ApplicationSet v0.1.0 release, one could only specify url and cluster element fields (plus arbitrary values). As of ApplicationSet v0.2.0, any key/value element pair is supported (which is also fully backwards compatible with the v0.1.0 form)

Checklist:

* [x] (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.