### PR TITLE
docs(github): comment out notational pieces of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
+<!--
 Note on DCO:
 
 If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
+-->
 
 Checklist:
 
@@ -14,8 +16,8 @@ Checklist:
 * [ ] Optional. My organization is added to USERS.md.
 * [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
 * [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
-* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
+* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
 * [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
 * [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
 
-Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
+<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->


### PR DESCRIPTION
### Summary

Comment out two notational sentences in the PR template

### Details

- the DCO and FAQ sentences are not filled out during PRs and are purely notational
  - comment them out with HTML comments, as is common practice
    - example from argo-helm in a near identical PR of mine: https://github.com/argoproj/argo-helm/pull/1969
      - copied this practice from other repos I maintain and from other repos before that
- these comments are still visible to the PR author, just not visible when rendered, keeping the PR more concise
  
Can see an example of what this looks like below vvv. If a maintainer clicks the edit button, will be able to see that the note is still there, just commented out and invisible when rendered.
  
### References

I just happened to stumble upon this while comparing Argo CD's docs to Argo Workflows (where I've been contributing often in recent times), figure I'd standardize this for Argo CD too.

<hr>

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [n/a] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [n/a] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [n/a] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [n/a] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [n/a] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
