### PR TITLE
fix(ui): Update default and max count for maxCookieNumber

### DIFF
--- a/util/http/http.go
+++ b/util/http/http.go
@@ -18,8 +18,8 @@ import (
 const maxCookieLength = 4093
 
 // max number of chunks a cookie can be broken into. To be compatible with
-// widest range of browsers, we shouldn't create more than 30 cookies per domain
-var maxCookieNumber = env.ParseNumFromEnv(common.EnvMaxCookieNumber, 10, 0, 30)
+// widest range of browsers, you shouldn't create more than 30 cookies per domain
+var maxCookieNumber = env.ParseNumFromEnv(common.EnvMaxCookieNumber, 20, 0, math.MaxInt64)
 
 // MakeCookieMetadata generates a string representing a Web cookie.  Yum!
 func MakeCookieMetadata(key, value string, flags ...string) ([]string, error) {


### PR DESCRIPTION
In this PR I update default and max count for variable - maxCookieNumber

Default switch from 10 to 20, bc in [RFC 2109](https://www.ietf.org/rfc/rfc2109.txt) recommend:
```
      * at least 20 cookies per unique host or domain name
```

And switch max Cookies number from 30 to math.MaxInt64, bc:
- [RFC 2109](https://www.ietf.org/rfc/rfc2109.txt) don't have recomenration about MAX cookies count, only MIN. Ideally recommend have no limits on the number of cookies.
- I'm, as a ArgoCD administrator, want to be able to control limits for cookie.