### PR TITLE
fix(ui): COPY JSON for ArgoCD version should include trailing newline argoproj#5117

### DIFF
--- a/ui/src/app/shared/components/version-info/version-info-panel.tsx
+++ b/ui/src/app/shared/components/version-info/version-info-panel.tsx
@@ -105,7 +105,7 @@ export class VersionPanel extends React.Component<VersionPanelProps, {copyState:
     }
 
     private async onCopy(version: VersionMessage): Promise<void> {
-        const stringifiedVersion = JSON.stringify(version, undefined, 4);
+        const stringifiedVersion = JSON.stringify(version, undefined, 4) + "\n";
         try {
             await navigator.clipboard.writeText(stringifiedVersion);
             this.setState({copyState: 'success'});

--- a/ui/src/app/shared/components/version-info/version-info-panel.tsx
+++ b/ui/src/app/shared/components/version-info/version-info-panel.tsx
@@ -105,7 +105,7 @@ export class VersionPanel extends React.Component<VersionPanelProps, {copyState:
     }
 
     private async onCopy(version: VersionMessage): Promise<void> {
-        const stringifiedVersion = JSON.stringify(version, undefined, 4) + "\n";
+        const stringifiedVersion = JSON.stringify(version, undefined, 4) + '\n';
         try {
             await navigator.clipboard.writeText(stringifiedVersion);
             this.setState({copyState: 'success'});


### PR DESCRIPTION
Fixes : argoproj#5117

Added a newline character to the copied JSON format of Argo CD version.

Demo:-
https://github.com/argoproj/argo-cd/assets/40431065/e6f9468d-79e7-4379-882e-bc7ec049b5a7

