### PR TITLE
chore: fix non-deterministic test

### DIFF
--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -696,7 +696,7 @@ func TestSettingsManager_GetKustomizeBuildOptions(t *testing.T) {
 		})
 
 		got, err := settingsManager.GetKustomizeSettings()
-		assert.EqualError(t, err, "failed to add kustomize version from \"kustomize.version.v3.2.1\": found duplicate kustomize version: v3.2.1")
+		assert.ErrorContains(t, err, "found duplicate kustomize version: v3.2.1")
 		assert.Empty(t, got)
 	})
 


### PR DESCRIPTION
The test relied on an (unordered) map. This tests the part that doesn't rely on that map.