### PR TITLE
fix(cmp): send sigterm to cmp commands before sigkill to allow for potential cleanup (#9180)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,6 +469,11 @@ start-e2e-local: mod-vendor-local dep-ui-local cli-local
 clean-debug:
 	-find ${CURRENT_DIR} -name debug.test -exec rm -f {} +
 
+.PHONY: clean-test
+clean-test:
+	rm -rf ${CURRENT_DIR}/test-results
+	rm -rf ${CURRENT_DIR}/coverage.out
+
 .PHONY: clean
 clean: clean-debug
 	-rm -rf ${CURRENT_DIR}/dist

--- a/Makefile
+++ b/Makefile
@@ -469,11 +469,6 @@ start-e2e-local: mod-vendor-local dep-ui-local cli-local
 clean-debug:
 	-find ${CURRENT_DIR} -name debug.test -exec rm -f {} +
 
-.PHONY: clean-test
-clean-test:
-	rm -rf ${CURRENT_DIR}/test-results
-	rm -rf ${CURRENT_DIR}/coverage.out
-
 .PHONY: clean
 clean: clean-debug
 	-rm -rf ${CURRENT_DIR}/dist

--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -97,6 +97,14 @@ func runCommand(ctx context.Context, command Command, path string, env []string)
 		<-ctx.Done()
 		// Kill by group ID to make sure child processes are killed. The - tells `kill` that it's a group ID.
 		// Since we didn't set Pgid in SysProcAttr, the group ID is the same as the process ID. https://pkg.go.dev/syscall#SysProcAttr
+
+		// Sending a TERM signal first to allow any potential cleanup if needed, and then sending a KILL signal
+		_ = sysCallTerm(-cmd.Process.Pid)
+
+		// modify cleanup timeout to allow process to cleanup
+		cleanupTimeout := 5 * time.Second 
+		time.Sleep(cleanupTimeout)
+
 		_ = sysCallKill(-cmd.Process.Pid)
 	}()
 

--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -102,7 +102,7 @@ func runCommand(ctx context.Context, command Command, path string, env []string)
 		_ = sysCallTerm(-cmd.Process.Pid)
 
 		// modify cleanup timeout to allow process to cleanup
-		cleanupTimeout := 5 * time.Second 
+		cleanupTimeout := 5 * time.Second
 		time.Sleep(cleanupTimeout)
 
 		_ = sysCallKill(-cmd.Process.Pid)

--- a/cmpserver/plugin/plugin_test.go
+++ b/cmpserver/plugin/plugin_test.go
@@ -378,7 +378,7 @@ func TestRunCommandContextTimeoutWithCleanup(t *testing.T) {
 	// This command sleeps for 4 seconds which is currently less than the 5 second delay between SIGTERM and SIGKILL signal and then exits successfully.
 	command := Command{
 		Command: []string{"sh", "-c"},
-		Args:    []string{`(trap 'echo "cleanup completed"; exit' SIGTERM; sleep 4)`},
+		Args:    []string{`(trap 'echo "cleanup completed"; exit' TERM; sleep 4)`},
 	}
 
 	before := time.Now()
@@ -387,7 +387,6 @@ func TestRunCommandContextTimeoutWithCleanup(t *testing.T) {
 
 	assert.Error(t, err) // The command should time out, causing an error.
 	assert.Less(t, after.Sub(before), 1*time.Second)
-
 	// The command should still have completed the cleanup after termination.
 	assert.Contains(t, output, "cleanup completed")
 }

--- a/cmpserver/plugin/plugin_test.go
+++ b/cmpserver/plugin/plugin_test.go
@@ -369,6 +369,29 @@ func TestRunCommandEmptyCommand(t *testing.T) {
 	assert.ErrorContains(t, err, "Command is empty")
 }
 
+// TestRunCommandContextTimeoutWithGracefulTermination makes sure that the process is given enough time to cleanup before sending SIGKILL.
+func TestRunCommandContextTimeoutWithGracefulTermination(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
+	defer cancel()
+
+	// Use a subshell so there's a child command.
+	// This command sleeps for 4 seconds which is currently less than the 5 second delay between SIGTERM and SIGKILL signal and then exits successfully.
+	command := Command{
+		Command: []string{"sh", "-c"},
+		Args:    []string{"sleep 4 && echo 'cleanup completed'"},
+	}
+
+	before := time.Now()
+	output, err := runCommand(ctx, command, "", []string{})
+	after := time.Now()
+
+	assert.Error(t, err) // The command should time out, causing an error.
+	assert.Less(t, after.Sub(before), 1*time.Second)
+
+	// The command should still have completed the cleanup after termination.
+	assert.Contains(t, output, "cleanup completed")
+}
+
 func Test_getParametersAnnouncement_empty_command(t *testing.T) {
 	staticYAML := `
 - name: static-a

--- a/cmpserver/plugin/plugin_test.go
+++ b/cmpserver/plugin/plugin_test.go
@@ -370,7 +370,7 @@ func TestRunCommandEmptyCommand(t *testing.T) {
 }
 
 // TestRunCommandContextTimeoutWithGracefulTermination makes sure that the process is given enough time to cleanup before sending SIGKILL.
-func TestRunCommandContextTimeoutWithGracefulTermination(t *testing.T) {
+func TestRunCommandContextTimeoutWithCleanup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
 	defer cancel()
 
@@ -378,7 +378,7 @@ func TestRunCommandContextTimeoutWithGracefulTermination(t *testing.T) {
 	// This command sleeps for 4 seconds which is currently less than the 5 second delay between SIGTERM and SIGKILL signal and then exits successfully.
 	command := Command{
 		Command: []string{"sh", "-c"},
-		Args:    []string{"sleep 4 && echo 'cleanup completed'"},
+		Args:    []string{`(trap 'echo "cleanup completed"; exit' SIGTERM; sleep 4)`},
 	}
 
 	before := time.Now()

--- a/cmpserver/plugin/plugin_unix.go
+++ b/cmpserver/plugin/plugin_unix.go
@@ -14,3 +14,7 @@ func newSysProcAttr(setpgid bool) *syscall.SysProcAttr {
 func sysCallKill(pid int) error {
 	return syscall.Kill(pid, syscall.SIGKILL)
 }
+
+func sysCallTerm(pid int) error {
+	return syscall.Kill(pid, syscall.SIGTERM)
+}


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/9180

I'm not sure if the tini entrypoint fixes this issue but I've added a fix as @kklimonda-fn suggested by sending sigterm before sigkill and waiting for about 5seconds.

The fix for this seems rather simple, but @crenshaw-dev I saw that you wanted a unit test to test if the signal was received by the command correctly, I am trying to craft a UT for this. 
I tried one with the shell trapping the received SIGTERM signal and subsequently echoing a message which can then be captured and checked but this doesn't seem to work. I'll try a different way to make it.

If you have any other suggestions for ways to write this UT which won't be flaky it would be helpful.

**Note: Not ready to merge yet**