### PR TITLE
fix: api server fails to call dex with istio

### DIFF
--- a/manifests/base/dex/argocd-dex-server-service.yaml
+++ b/manifests/base/dex/argocd-dex-server-service.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   ports:
   - name: http
+    appProtocol: TCP
     protocol: TCP
     port: 5556
     targetPort: 5556

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -19769,7 +19769,8 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - appProtocol: TCP
+    name: http
     port: 5556
     protocol: TCP
     targetPort: 5556

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1275,7 +1275,8 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - appProtocol: TCP
+    name: http
     port: 5556
     protocol: TCP
     targetPort: 5556

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -18973,7 +18973,8 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - appProtocol: TCP
+    name: http
     port: 5556
     protocol: TCP
     targetPort: 5556

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -479,7 +479,8 @@ metadata:
   name: argocd-dex-server
 spec:
   ports:
-  - name: http
+  - appProtocol: TCP
+    name: http
     port: 5556
     protocol: TCP
     targetPort: 5556


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/10249

Istio is confused because dex's port name is `http`. There are two ways to fix it:

* Change name `https`, however some customers disables TLS for dex, so they would have to rename it back to `http`.
* Add `appProtocol: TCP` 

PR adds `appProtocol: TCP` since it is more universal fix