### PR TITLE
fix: windows build

### DIFF
--- a/cmpserver/plugin/plugin_windows.go
+++ b/cmpserver/plugin/plugin_windows.go
@@ -14,3 +14,7 @@ func newSysProcAttr(setpgid bool) *syscall.SysProcAttr {
 func sysCallKill(pid int) error {
 	return nil
 }
+
+func sysCallTerm(pid int) error {
+	return nil
+}


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/pull/14960 introduced the new function for unix, but we need a windows equivalent for the windows build to pass.