### PR TITLE
feat: Include destination cluster in build environment (14957)

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1440,6 +1440,8 @@ func newEnv(q *apiclient.ManifestRequest, revision string) *v1alpha1.Env {
 	if len(shortRevision) > 7 {
 		shortRevision = shortRevision[:7]
 	}
+	appDest := v1alpha1.ApplicationDestination{Name: q.AppName, Namespace: q.Namespace}
+
 	return &v1alpha1.Env{
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAME", Value: q.AppName},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAMESPACE", Value: q.Namespace},
@@ -1448,6 +1450,8 @@ func newEnv(q *apiclient.ManifestRequest, revision string) *v1alpha1.Env {
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_REPO_URL", Value: q.Repo.Repo},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_PATH", Value: q.ApplicationSource.Path},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_TARGET_REVISION", Value: q.ApplicationSource.TargetRevision},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_CLUSTER_NAME", Value: appDest.Name},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_CLUSTER_SERVER", Value: appDest.Server},
 	}
 }
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1531,6 +1531,8 @@ func Test_newEnv(t *testing.T) {
 		&argoappv1.EnvEntry{Name: "ARGOCD_APP_SOURCE_REPO_URL", Value: "https://github.com/my-org/my-repo"},
 		&argoappv1.EnvEntry{Name: "ARGOCD_APP_SOURCE_PATH", Value: "my-path"},
 		&argoappv1.EnvEntry{Name: "ARGOCD_APP_SOURCE_TARGET_REVISION", Value: "my-target-revision"},
+		&argoappv1.EnvEntry{Name: "ARGOCD_APP_CLUSTER_NAME", Value: "my-cluster-name"},
+		&argoappv1.EnvEntry{Name: "ARGOCD_APP_CLUSTER_SERVER", Value: "https://kubernetes.default.svc"},
 	}, newEnv(&apiclient.ManifestRequest{
 		AppName:   "my-app-name",
 		Namespace: "my-namespace",


### PR DESCRIPTION
Include destination cluster in build environment. Fixes #14957 

It returns both `ARGOCD_APP_CLUSTER_NAME` and `ARGOCD_APP_CLUSTER_SERVER` with the assumption that the end user knows which one to use.