### PR TITLE
fix: Add button for wrapping lines in pod logs viewer

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -1,4 +1,4 @@
-import {DataLoader} from 'argo-ui';
+import {DataLoader, Tooltip} from 'argo-ui';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
@@ -159,6 +159,16 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                             <span>
                                 <FollowToggleButton follow={follow} setFollow={setFollow} />
                                 {follow && <AutoScrollButton scrollToBottom={scrollToBottom} setScrollToBottom={setScrollToBottom} />}
+                                <Tooltip content='Wrap Lines'>
+                                    <button
+                                        className={`argo-button argo-button--base${prefs.appDetails.wrapLines ? '' : '-o'}`}
+                                        onClick={() => {
+                                            const wrap = prefs.appDetails.wrapLines;
+                                            services.viewPreferences.updatePreferences({...prefs, appDetails: {...prefs.appDetails, wrapLines: !wrap}});
+                                        }}>
+                                        <i className='fa fa-paragraph' />
+                                    </button>
+                                </Tooltip>
                                 <ShowPreviousLogsToggleButton setPreviousLogs={setPreviousLogs} showPreviousLogs={previous} />
                                 <Spacer />
                                 <ContainerSelector containerGroups={containerGroups} containerName={containerName} onClickContainer={onClickContainer} />
@@ -189,7 +199,10 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                             onWheel={e => {
                                 if (e.deltaY < 0) setScrollToBottom(false);
                             }}>
-                            <AutoSizer>
+                            <AutoSizer
+                                style={{
+                                    whiteSpace: prefs.appDetails.wrapLines ? 'normal' : 'pre'
+                                }}>
                                 {({width, height}: {width: number; height: number}) => (
                                     <Grid
                                         cellRenderer={cellRenderer}

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -1,4 +1,4 @@
-import {DataLoader, Tooltip} from 'argo-ui';
+import {DataLoader} from 'argo-ui';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
@@ -27,6 +27,7 @@ import {PodNamesToggleButton} from './pod-names-toggle-button';
 import Ansi from 'ansi-to-react';
 import {AutoScrollButton} from './auto-scroll-button';
 import {GridCellProps} from 'react-virtualized/dist/es/Grid';
+import {WrapLinesButton} from './wrap-lines-button';
 
 export interface PodLogsProps {
     namespace: string;
@@ -159,16 +160,6 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                             <span>
                                 <FollowToggleButton follow={follow} setFollow={setFollow} />
                                 {follow && <AutoScrollButton scrollToBottom={scrollToBottom} setScrollToBottom={setScrollToBottom} />}
-                                <Tooltip content='Wrap Lines'>
-                                    <button
-                                        className={`argo-button argo-button--base${prefs.appDetails.wrapLines ? '' : '-o'}`}
-                                        onClick={() => {
-                                            const wrap = prefs.appDetails.wrapLines;
-                                            services.viewPreferences.updatePreferences({...prefs, appDetails: {...prefs.appDetails, wrapLines: !wrap}});
-                                        }}>
-                                        <i className='fa fa-paragraph' />
-                                    </button>
-                                </Tooltip>
                                 <ShowPreviousLogsToggleButton setPreviousLogs={setPreviousLogs} showPreviousLogs={previous} />
                                 <Spacer />
                                 <ContainerSelector containerGroups={containerGroups} containerName={containerName} onClickContainer={onClickContainer} />
@@ -186,6 +177,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                                 <PodNamesToggleButton viewPodNames={viewPodNames} setViewPodNames={setViewPodNames} />
                                 <TimestampsToggleButton setViewTimestamps={setViewTimestamps} viewTimestamps={viewTimestamps} timestamp={timestamp} />
                                 <DarkModeToggleButton prefs={prefs} />
+                                <WrapLinesButton prefs={prefs} />
                             </span>
                             <Spacer />
                             <span>

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -160,6 +160,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                             <span>
                                 <FollowToggleButton follow={follow} setFollow={setFollow} />
                                 {follow && <AutoScrollButton scrollToBottom={scrollToBottom} setScrollToBottom={setScrollToBottom} />}
+                                <WrapLinesButton prefs={prefs} />
                                 <ShowPreviousLogsToggleButton setPreviousLogs={setPreviousLogs} showPreviousLogs={previous} />
                                 <Spacer />
                                 <ContainerSelector containerGroups={containerGroups} containerName={containerName} onClickContainer={onClickContainer} />
@@ -177,7 +178,6 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                                 <PodNamesToggleButton viewPodNames={viewPodNames} setViewPodNames={setViewPodNames} />
                                 <TimestampsToggleButton setViewTimestamps={setViewTimestamps} viewTimestamps={viewTimestamps} timestamp={timestamp} />
                                 <DarkModeToggleButton prefs={prefs} />
-                                <WrapLinesButton prefs={prefs} />
                             </span>
                             <Spacer />
                             <span>

--- a/ui/src/app/applications/components/pod-logs-viewer/wrap-lines-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/wrap-lines-button.tsx
@@ -5,12 +5,12 @@ import {ToggleButton} from '../../../shared/components/toggle-button';
 // WrapLinesButton is a component that wraps log lines.
 export const WrapLinesButton = ({prefs}: {prefs: ViewPreferences}) => (
     <ToggleButton
-        title='WrapLines'
+        title='Wrap Lines'
         onToggle={() => {
             const wrap = prefs.appDetails.wrapLines;
             services.viewPreferences.updatePreferences({...prefs, appDetails: {...prefs.appDetails, wrapLines: !wrap}});
         }}
         toggled={prefs.appDetails.wrapLines}
-        icon='burrito'
+        icon='paragraph'
     />
 );

--- a/ui/src/app/applications/components/pod-logs-viewer/wrap-lines-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/wrap-lines-button.tsx
@@ -1,0 +1,16 @@
+import {services, ViewPreferences} from '../../../shared/services';
+import * as React from 'react';
+import {ToggleButton} from '../../../shared/components/toggle-button';
+
+// WrapLinesButton is a component that wraps log lines.
+export const WrapLinesButton = ({prefs}: {prefs: ViewPreferences}) => (
+    <ToggleButton
+        title='WrapLines'
+        onToggle={() => {
+            const wrap = prefs.appDetails.wrapLines;
+            services.viewPreferences.updatePreferences({...prefs, appDetails: {...prefs.appDetails, wrapLines: !wrap}});
+        }}
+        toggled={prefs.appDetails.wrapLines}
+        icon='burrito'
+    />
+);


### PR DESCRIPTION
This was added previously in https://github.com/argoproj/argo-cd/pull/6889. However, it was accidentally removed from refactoring in https://github.com/argoproj/argo-cd/pull/11030.