### PR TITLE
[Draft] feat: multiple policy configmap support enabled

### DIFF
--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -309,13 +309,26 @@ func getPolicyConfigMap(ctx context.Context, client kubernetes.Interface, namesp
 	if err != nil {
 		return nil, err
 	}
+
+	cmList, err := client.CoreV1().ConfigMaps(namespace).List(ctx, v1.ListOptions{
+		LabelSelector: common.ArgoCDRBACConfigMapLabelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range cmList.Items {
+		cm.Data[rbac.ConfigMapPolicyCSVKey] += fmt.Sprintf("\n# concenated rbac data fetched by label %s\n%s",
+			common.ArgoCDRBACConfigMapLabelSelector, v.Data[rbac.ConfigMapPolicyCSVKey])
+	}
+
 	return cm, nil
 }
 
 // checkPolicy checks whether given subject is allowed to execute specified
 // action against specified resource
 func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole, matchMode string, strict bool) bool {
-	enf := rbac.NewEnforcer(nil, "argocd", "argocd-rbac-cm", nil)
+	enf := rbac.NewEnforcer(nil, "argocd", common.ArgoCDRBACConfigMapName, nil)
 	enf.SetDefaultRole(defaultRole)
 	enf.SetMatchMode(matchMode)
 	if builtinPolicy != "" {
@@ -329,7 +342,8 @@ func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPoli
 			log.Fatalf("invalid user policy: %v", err)
 			return false
 		}
-		if err := enf.SetUserPolicy(userPolicy); err != nil {
+
+		if err := enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, userPolicy); err != nil {
 			log.Fatalf("could not set user policy: %v", err)
 			return false
 		}

--- a/common/common.go
+++ b/common/common.go
@@ -29,6 +29,7 @@ const (
 	ArgoCDNotificationsConfigMapName = "argocd-notifications-cm"
 	ArgoCDNotificationsSecretName    = "argocd-notifications-secret"
 	ArgoCDRBACConfigMapName          = "argocd-rbac-cm"
+	ArgoCDRBACConfigMapLabelSelector = "argocd.argoproj.io/cm-type=rbac"
 	// ArgoCDKnownHostsConfigMapName contains SSH known hosts data for connecting repositories. Will get mounted as volume to pods
 	ArgoCDKnownHostsConfigMapName = "argocd-ssh-known-hosts-cm"
 	// ArgoCDTLSCertsConfigMapName contains TLS certificate data for connecting repositories. Will get mounted as volume to pods

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -1269,7 +1269,7 @@ g, group-47, role:test2
 p, role:test3, applications, *, proj-20/*, allow
 g, group-49, role:test3
 `
-		_ = enf.SetUserPolicy(policy)
+		_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 	}
 	appServer := newTestAppServerWithEnforcerConfigure(f, t, objects...)
 

--- a/server/rbacpolicy/rbacpolicy_test.go
+++ b/server/rbacpolicy/rbacpolicy_test.go
@@ -54,7 +54,7 @@ func TestEnforceAllPolicies(t *testing.T) {
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableLog(true)
 	_ = enf.SetBuiltinPolicy(`p, alice, applications, create, my-proj/*, allow` + "\n" + `p, alice, logs, get, my-proj/*, allow` + "\n" + `p, alice, exec, create, my-proj/*, allow`)
-	_ = enf.SetUserPolicy(`p, bob, applications, create, my-proj/*, allow` + "\n" + `p, bob, logs, get, my-proj/*, allow` + "\n" + `p, bob, exec, create, my-proj/*, allow`)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, `p, bob, applications, create, my-proj/*, allow`+"\n"+`p, bob, logs, get, my-proj/*, allow`+"\n"+`p, bob, exec, create, my-proj/*, allow`)
 	rbacEnf := NewRBACPolicyEnforcer(enf, projLister)
 	enf.SetClaimsEnforcerFunc(rbacEnf.EnforceClaims)
 
@@ -128,7 +128,7 @@ func TestInvalidatedCache(t *testing.T) {
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableLog(true)
 	_ = enf.SetBuiltinPolicy(`p, alice, applications, create, my-proj/*, allow` + "\n" + `p, alice, logs, get, my-proj/*, allow` + "\n" + `p, alice, exec, create, my-proj/*, allow`)
-	_ = enf.SetUserPolicy(`p, bob, applications, create, my-proj/*, allow` + "\n" + `p, bob, logs, get, my-proj/*, allow` + "\n" + `p, bob, exec, create, my-proj/*, allow`)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, `p, bob, applications, create, my-proj/*, allow`+"\n"+`p, bob, logs, get, my-proj/*, allow`+"\n"+`p, bob, exec, create, my-proj/*, allow`)
 	rbacEnf := NewRBACPolicyEnforcer(enf, projLister)
 	enf.SetClaimsEnforcerFunc(rbacEnf.EnforceClaims)
 
@@ -143,7 +143,7 @@ func TestInvalidatedCache(t *testing.T) {
 	assert.True(t, enf.Enforce(claims, "exec", "create", "my-proj/my-app"))
 
 	_ = enf.SetBuiltinPolicy(`p, alice, applications, create, my-proj2/*, allow` + "\n" + `p, alice, logs, get, my-proj2/*, allow` + "\n" + `p, alice, exec, create, my-proj2/*, allow`)
-	_ = enf.SetUserPolicy(`p, bob, applications, create, my-proj2/*, allow` + "\n" + `p, bob, logs, get, my-proj2/*, allow` + "\n" + `p, bob, exec, create, my-proj2/*, allow`)
+	_ = enf.SetUserPolicy(common.ArgoCDConfigMapName, `p, bob, applications, create, my-proj2/*, allow`+"\n"+`p, bob, logs, get, my-proj2/*, allow`+"\n"+`p, bob, exec, create, my-proj2/*, allow`)
 	claims = jwt.MapClaims{"sub": "alice"}
 	assert.True(t, enf.Enforce(claims, "applications", "create", "my-proj2/my-app"))
 	assert.True(t, enf.Enforce(claims, "logs", "get", "my-proj2/my-app"))

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -455,7 +455,7 @@ func TestRepositoryServerGetAppDetails(t *testing.T) {
 		repoServerClient := mocks.RepoServerServiceClient{}
 		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
 		enforcer := newEnforcer(kubeclientset)
-		_ = enforcer.SetUserPolicy("p, role:readrepos, repositories, get, *, allow")
+		_ = enforcer.SetUserPolicy(common.ArgoCDConfigMapName, "p, role:readrepos, repositories, get, *, allow")
 		enforcer.SetDefaultRole("role:readrepos")
 
 		url := "https://test"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -191,7 +191,7 @@ func TestEnforceClaims(t *testing.T) {
 g, org2:team2, role:admin
 g, bob, role:admin
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 	allowed := []jwt.Claims{
 		jwt.MapClaims{"groups": []string{"org1:team1", "org2:team2"}},
 		jwt.RegisteredClaims{Subject: "admin"},

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"github.com/argoproj/argo-cd/v2/common"
 	"sort"
 	"strings"
 	"sync"
@@ -72,6 +73,8 @@ type Enforcer struct {
 	model              model.Model
 	defaultRole        string
 	matchMode          string
+	policyCache        map[string]string
+	policyLock         sync.Mutex
 }
 
 // cachedEnforcer holds the Casbin enforcer instances and optional custom project policy
@@ -169,6 +172,7 @@ func NewEnforcer(clientset kubernetes.Interface, namespace, configmap string, cl
 		model:              builtInModel,
 		claimsEnforcerFunc: claimsEnforcer,
 		enabled:            true,
+		policyCache:        make(map[string]string),
 	}
 }
 
@@ -326,10 +330,24 @@ func (e *Enforcer) SetBuiltinPolicy(policy string) error {
 	return e.LoadPolicy()
 }
 
+// buildPolicy merges all the user policies into one
+func (e *Enforcer) buildPolicy() string {
+	e.policyLock.Lock()
+	fullPolicy := ""
+	for _, policy := range e.policyCache {
+		fullPolicy = fmt.Sprintf("%s%s\n", fullPolicy, policy)
+	}
+	e.policyLock.Unlock()
+	return fullPolicy
+}
+
 // SetUserPolicy sets a user policy, augmenting the built-in policy
-func (e *Enforcer) SetUserPolicy(policy string) error {
+func (e *Enforcer) SetUserPolicy(policyName string, policy string) error {
+	e.policyLock.Lock()
+	e.policyCache[policyName] = policy
+	e.policyLock.Unlock()
 	e.invalidateCache(func() {
-		e.adapter.userDefinedPolicy = policy
+		e.adapter.userDefinedPolicy = e.buildPolicy()
 	})
 	return e.LoadPolicy()
 }
@@ -339,6 +357,15 @@ func (e *Enforcer) newInformer() cache.SharedIndexInformer {
 	tweakConfigMap := func(options *metav1.ListOptions) {
 		cmFieldSelector := fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", e.configmap))
 		options.FieldSelector = cmFieldSelector.String()
+	}
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	return v1.NewFilteredConfigMapInformer(e.clientset, e.namespace, defaultRBACSyncPeriod, indexers, tweakConfigMap)
+}
+
+// newAdditionalInformer returns an informer which watches updates on the rbac configmap
+func (e *Enforcer) newAdditionalInformer() cache.SharedIndexInformer {
+	tweakConfigMap := func(options *metav1.ListOptions) {
+		options.LabelSelector = common.ArgoCDRBACConfigMapLabelSelector
 	}
 	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
 	return v1.NewFilteredConfigMapInformer(e.clientset, e.namespace, defaultRBACSyncPeriod, indexers, tweakConfigMap)
@@ -357,8 +384,72 @@ func (e *Enforcer) RunPolicyLoader(ctx context.Context, onUpdated func(cm *apiv1
 			return err
 		}
 	}
+
+	go e.runAdditionalInformer(ctx)
 	e.runInformer(ctx, onUpdated)
 	return nil
+}
+
+func (e *Enforcer) runAdditionalInformer(ctx context.Context) {
+	cmInformer := e.newAdditionalInformer()
+	cmInformer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				if cm, ok := obj.(*apiv1.ConfigMap); ok {
+					err := e.syncAdditionalUpdate(cm)
+					if err != nil {
+						log.Error(err)
+					} else {
+						log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC Additional ConfigMap '%s' added", cm.Name)
+					}
+				}
+			},
+			UpdateFunc: func(old, new interface{}) {
+				oldCM := old.(*apiv1.ConfigMap)
+				newCM := new.(*apiv1.ConfigMap)
+				if oldCM.ResourceVersion == newCM.ResourceVersion {
+					return
+				}
+				err := e.syncAdditionalUpdate(newCM)
+				if err != nil {
+					log.Error(err)
+				} else {
+					log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC Additional ConfigMap '%s' updated", newCM.Name)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				cm := obj.(*apiv1.ConfigMap)
+				err := e.DeleteUserPolicy(cm.Name)
+				if err != nil {
+					log.Error(err)
+				} else {
+					log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC Additional ConfigMap '%s' deleted", cm.Name)
+				}
+			},
+		},
+	)
+	log.Info("Starting additional rbac config informer")
+	cmInformer.Run(ctx.Done())
+	log.Info("rbac additional configmap informer cancelled")
+}
+
+// DeleteUserPolicy deletes a user policy
+func (e *Enforcer) DeleteUserPolicy(policyName string) error {
+	e.policyLock.Lock()
+	delete(e.policyCache, policyName)
+	e.policyLock.Unlock()
+	e.invalidateCache(func() {
+		e.adapter.userDefinedPolicy = e.buildPolicy()
+	})
+	return e.LoadPolicy()
+}
+
+func (e *Enforcer) syncAdditionalUpdate(cm *apiv1.ConfigMap) error {
+	policyCSV, ok := cm.Data[ConfigMapPolicyCSVKey]
+	if !ok {
+		policyCSV = ""
+	}
+	return e.SetUserPolicy(cm.Name, policyCSV)
 }
 
 func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *apiv1.ConfigMap) error) {
@@ -371,7 +462,7 @@ func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *apiv1.Con
 					if err != nil {
 						log.Error(err)
 					} else {
-						log.Infof("RBAC ConfigMap '%s' added", e.configmap)
+						log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC ConfigMap '%s' added", cm.Name)
 					}
 				}
 			},
@@ -385,7 +476,7 @@ func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *apiv1.Con
 				if err != nil {
 					log.Error(err)
 				} else {
-					log.Infof("RBAC ConfigMap '%s' updated", e.configmap)
+					log.WithField(common.SecurityField, common.SecurityMedium).Infof("RBAC ConfigMap '%s' updated", newCM.Name)
 				}
 			},
 		},
@@ -432,10 +523,12 @@ func (e *Enforcer) syncUpdate(cm *apiv1.ConfigMap, onUpdated func(cm *apiv1.Conf
 	e.SetDefaultRole(cm.Data[ConfigMapPolicyDefaultKey])
 	e.SetMatchMode(cm.Data[ConfigMapMatchModeKey])
 	policyCSV := PolicyCSV(cm.Data)
+
 	if err := onUpdated(cm); err != nil {
 		return err
 	}
-	return e.SetUserPolicy(policyCSV)
+
+	return e.SetUserPolicy(cm.Name, policyCSV)
 }
 
 // ValidatePolicy verifies a policy string is acceptable to casbin

--- a/util/rbac/rbac_norace_test.go
+++ b/util/rbac/rbac_norace_test.go
@@ -5,6 +5,7 @@ package rbac
 
 import (
 	"context"
+	"github.com/argoproj/argo-cd/v2/common"
 	"testing"
 	"time"
 
@@ -78,7 +79,7 @@ p, trudy, applications/secrets, get, foo/obj, deny
 p, danny, applications, get, */obj, allow
 p, danny, applications, get, proj1/a*p1, allow
 `
-	_ = enf.SetUserPolicy(policy)
+	_ = enf.SetUserPolicy(common.ArgoCDRBACConfigMapName, policy)
 
 	// Verify the resource wildcard
 	assert.True(t, enf.Enforce("alice", "applications", "get", "foo/obj"))


### PR DESCRIPTION
Signed-off-by: bilalcaliskan [bilalcaliskan@protonmail.com](mailto:bilalcaliskan@protonmail.com)
Co-authored-by: notfromstatefarm <86763948+notfromstatefarm@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

This is the continuation PR of [#9976](https://github.com/argoproj/argo-cd/pull/9976) and fixes issue #8324. 

This PR implements the feature of `additional RBAC configmaps`. Any configmaps with the label `argocd.argoproj.io/cm-type=rbac` will be used and watched for changes. This will simplify of adding/managing RBAC rules on **large enterprise environments**.