### PR TITLE
docs: fixes a markdown typo in USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -277,7 +277,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [Trendyol](https://www.trendyol.com/)
 1. [tru.ID](https://tru.id)
 1. [Trusting Social](https://trustingsocial.com/)
-1. [Twilio Segment] (https://segment.com/)
+1. [Twilio Segment](https://segment.com/)
 1. [Twilio SendGrid](https://sendgrid.com)
 1. [tZERO](https://www.tzero.com/)
 1. [U.S. Veterans Affairs Department](https://www.va.gov/) 


### PR DESCRIPTION
This removes the whitespace between the link text and the link URL.

Incorrectly rendered markdown -
![CleanShot 2023-09-05 at 14 15 53](https://github.com/argoproj/argo-cd/assets/7345249/05a4be39-e360-4fe3-8744-e29c413d61ce)


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
This does not need to be in the release notes.
* [x] Optional. My organization is added to USERS.md.


<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
