### PR TITLE
fix: handle annotations for resources with ':' in the name (#15101)

### DIFF
--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -180,8 +180,10 @@ func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceVal
 	var appInstanceValue AppInstanceValue
 	parts := strings.Split(value, ":")
 	appInstanceValue.ApplicationName = parts[0]
-	if len(parts) != 3 {
+	if len(parts) < 2 {
 		return nil, WrongResourceTrackingFormat
+	} else if len(parts) > 3 {
+		parts = []string{parts[0], parts[1], strings.Join(parts[2:], ":")}
 	}
 	groupParts := strings.Split(parts[1], "/")
 	if len(groupParts) != 2 {

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -180,7 +180,7 @@ func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceVal
 	var appInstanceValue AppInstanceValue
 	parts := strings.SplitN(value, ":", 3)
 	appInstanceValue.ApplicationName = parts[0]
-	if len(parts) < 2 {
+	if len(parts) != 3 {
 		return nil, WrongResourceTrackingFormat
 	}
 	groupParts := strings.Split(parts[1], "/")

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -178,12 +178,10 @@ func (rt *resourceTracking) BuildAppInstanceValue(value AppInstanceValue) string
 // ParseAppInstanceValue parse resource tracking id from format <application-name>:<group>/<kind>:<namespace>/<name> to struct
 func (rt *resourceTracking) ParseAppInstanceValue(value string) (*AppInstanceValue, error) {
 	var appInstanceValue AppInstanceValue
-	parts := strings.Split(value, ":")
+	parts := strings.SplitN(value, ":", 3)
 	appInstanceValue.ApplicationName = parts[0]
 	if len(parts) < 2 {
 		return nil, WrongResourceTrackingFormat
-	} else if len(parts) > 3 {
-		parts = []string{parts[0], parts[1], strings.Join(parts[2:], ":")}
 	}
 	groupParts := strings.Split(parts[1], "/")
 	if len(groupParts) != 2 {

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -89,6 +89,19 @@ func TestParseAppInstanceValue(t *testing.T) {
 	assert.Equal(t, appInstanceValue.Name, "<name>")
 }
 
+func TestParseAppInstanceValueColon(t *testing.T) {
+	resourceTracking := NewResourceTracking()
+	appInstanceValue, err := resourceTracking.ParseAppInstanceValue("app:<group>/<kind>:<namespace>/<name>:<colon>")
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	assert.Equal(t, appInstanceValue.ApplicationName, "app")
+	assert.Equal(t, appInstanceValue.Group, "<group>")
+	assert.Equal(t, appInstanceValue.Kind, "<kind>")
+	assert.Equal(t, appInstanceValue.Namespace, "<namespace>")
+	assert.Equal(t, appInstanceValue.Name, "<name>:<colon>")
+}
+
 func TestParseAppInstanceValueWrongFormat1(t *testing.T) {
 	resourceTracking := NewResourceTracking()
 	_, err := resourceTracking.ParseAppInstanceValue("app")


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
This change adds logic for handling annotations for resources that have a `:` in the name. While this is an illegal character for most names it is allowed in RBAC resources. This causes them to fail the annotation check and Argo CD does not clean them up with cascading delete.

Fixes [#15101]
