### PR TITLE
fix: Gitlab scm_provider - don't create transport from scratch (#15424)

### DIFF
--- a/applicationset/services/pull_request/gitea.go
+++ b/applicationset/services/pull_request/gitea.go
@@ -26,11 +26,13 @@ func NewGiteaService(ctx context.Context, token, url, owner, repo string, insecu
 	if insecure {
 		cookieJar, _ := cookiejar.New(nil)
 
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 		httpClient = &http.Client{
 			Jar: cookieJar,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}}
+			Transport: tr,
+		}
 	}
 	client, err := gitea.NewClient(url, gitea.SetToken(token), gitea.SetHTTPClient(httpClient))
 	if err != nil {

--- a/applicationset/services/pull_request/gitea.go
+++ b/applicationset/services/pull_request/gitea.go
@@ -30,7 +30,7 @@ func NewGiteaService(ctx context.Context, token, url, owner, repo string, insecu
 		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		httpClient = &http.Client{
-			Jar: cookieJar,
+			Jar:       cookieJar,
 			Transport: tr,
 		}
 	}

--- a/applicationset/services/pull_request/gitlab.go
+++ b/applicationset/services/pull_request/gitlab.go
@@ -32,9 +32,9 @@ func NewGitLabService(ctx context.Context, token, url, project string, labels []
 		token = os.Getenv("GITLAB_TOKEN")
 	}
 
-	tr := &http.Transport{
-		TLSClientConfig: utils.GetTlsConfig(scmRootCAPath, insecure),
-	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = utils.GetTlsConfig(scmRootCAPath, insecure)
+
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = tr
 

--- a/applicationset/services/scm_provider/gitea.go
+++ b/applicationset/services/scm_provider/gitea.go
@@ -27,11 +27,13 @@ func NewGiteaProvider(ctx context.Context, owner, token, url string, allBranches
 	if insecure {
 		cookieJar, _ := cookiejar.New(nil)
 
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 		httpClient = &http.Client{
 			Jar: cookieJar,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}}
+			Transport: tr,
+		}
 	}
 	client, err := gitea.NewClient(url, gitea.SetToken(token), gitea.SetHTTPClient(httpClient))
 	if err != nil {

--- a/applicationset/services/scm_provider/gitea.go
+++ b/applicationset/services/scm_provider/gitea.go
@@ -31,7 +31,7 @@ func NewGiteaProvider(ctx context.Context, owner, token, url string, allBranches
 		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		httpClient = &http.Client{
-			Jar: cookieJar,
+			Jar:       cookieJar,
 			Transport: tr,
 		}
 	}

--- a/applicationset/services/scm_provider/gitlab.go
+++ b/applicationset/services/scm_provider/gitlab.go
@@ -30,9 +30,9 @@ func NewGitlabProvider(ctx context.Context, organization string, token string, u
 	}
 	var client *gitlab.Client
 
-	tr := &http.Transport{
-		TLSClientConfig: utils.GetTlsConfig(scmRootCAPath, insecure),
-	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = utils.GetTlsConfig(scmRootCAPath, insecure)
+
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = tr
 


### PR DESCRIPTION
Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Since ArgoCD 2.8.0, the Gitlab scm_provider seems to ignore proxy settings of pod argocd-applicationset-controller.

Instead of creating an `http.Transport` from scratch, this PR aims at cloning the default one to inherit from proxy settings read from environment variables.

Closes #15424

Antoine