### PR TITLE
chore: update k8s version in CI

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -361,7 +361,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        k3s-version: [v1.26.0, v1.25.4, v1.24.3, v1.23.3]
+        k3s-version: [v1.27.2, v1.26.0, v1.25.4, v1.24.3]
     needs: 
       - build-go
     env:


### PR DESCRIPTION

## What

I would like to update the k8s version used to run e2e tests.


## Why

ArgoCD 2.7 is quite recent, so I think it would make sense to have it tested on K8s 1.27.
Please let me know


