### PR TITLE
feat(notification): add time format function

### DIFF
--- a/docs/operator-manual/notifications/functions.md
+++ b/docs/operator-manual/notifications/functions.md
@@ -12,6 +12,11 @@ Golang [Time](https://golang.org/pkg/time/#Time).
 
 Parses specified string using RFC3339 layout. Returns an instance of Golang [Time](https://golang.org/pkg/time/#Time).
 
+<hr>
+**`time.Format(val Time) string`**
+
+Formats specified Golang [Time] using RFC3339 layout. Returns a string.
+
 ### **strings**
 String related functions.
 

--- a/util/notification/expression/time/time.go
+++ b/util/notification/expression/time/time.go
@@ -6,8 +6,9 @@ import (
 
 func NewExprs() map[string]interface{} {
 	return map[string]interface{}{
-		"Parse": parse,
-		"Now":   now,
+		"Parse":  parse,
+		"Now":    now,
+		"Format": format,
 	}
 }
 
@@ -17,6 +18,10 @@ func parse(timestamp string) time.Time {
 		panic(err)
 	}
 	return res
+}
+
+func format(t time.Time) string {
+	return t.Format(time.RFC3339)
 }
 
 func now() time.Time {

--- a/util/notification/expression/time/time_test.go
+++ b/util/notification/expression/time/time_test.go
@@ -10,6 +10,7 @@ func TestNewTimeExprs(t *testing.T) {
 	funcs := []string{
 		"Parse",
 		"Now",
+		"Format",
 	}
 
 	for _, fn := range funcs {
@@ -17,4 +18,8 @@ func TestNewTimeExprs(t *testing.T) {
 		_, hasFunc := timeExprs[fn]
 		assert.True(t, hasFunc)
 	}
+}
+
+func TestTimeFormat(t *testing.T) {
+	assert.NotEmpty(t, format(now()))
 }


### PR DESCRIPTION
Add `time.format` function to render RFC3339 date string.

## use case

- send notification to elasticsearch
