### PR TITLE
fix(notification): slack template escape quotes

### DIFF
--- a/notifications_catalog/install.yaml
+++ b/notifications_catalog/install.yaml
@@ -44,7 +44,7 @@ data:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -72,7 +72,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]
@@ -123,7 +123,7 @@ data:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -147,7 +147,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]
@@ -198,7 +198,7 @@ data:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -226,7 +226,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]
@@ -277,7 +277,7 @@ data:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -305,7 +305,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]
@@ -360,7 +360,7 @@ data:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -384,7 +384,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]
@@ -434,7 +434,7 @@ data:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -462,7 +462,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]

--- a/notifications_catalog/templates/app-deployed.yaml
+++ b/notifications_catalog/templates/app-deployed.yaml
@@ -29,7 +29,7 @@ slack:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -56,7 +56,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]

--- a/notifications_catalog/templates/app-health-degraded.yaml
+++ b/notifications_catalog/templates/app-health-degraded.yaml
@@ -25,7 +25,7 @@ slack:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -48,7 +48,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]

--- a/notifications_catalog/templates/app-sync-failed.yaml
+++ b/notifications_catalog/templates/app-sync-failed.yaml
@@ -25,7 +25,7 @@ slack:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -52,7 +52,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]

--- a/notifications_catalog/templates/app-sync-running.yaml
+++ b/notifications_catalog/templates/app-sync-running.yaml
@@ -25,7 +25,7 @@ slack:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -51,7 +51,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]

--- a/notifications_catalog/templates/app-sync-status-unknown.yaml
+++ b/notifications_catalog/templates/app-sync-status-unknown.yaml
@@ -30,7 +30,7 @@ slack:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -52,7 +52,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]

--- a/notifications_catalog/templates/app-sync-succeeded.yaml
+++ b/notifications_catalog/templates/app-sync-succeeded.yaml
@@ -25,7 +25,7 @@ slack:
           {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": {{$c.message | quote}},
             "short": true
           }
           {{end}}
@@ -52,7 +52,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}"
+            "value": {{$c.message | quote}}
           }
         {{end}}
         ]


### PR DESCRIPTION
### Component: notification

Fix notification controller error 

```
Failed to notify recipient {slack XXXX} defined in resource XXXX: failed to unmarshal attachments '[{"
```

Because message can contain double-quote, this can break JSON.