### PR TITLE
fix: ApplicationSet deletes Application status

### DIFF
--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -218,6 +218,7 @@ func NewCommand() *cobra.Command {
 				SCMRootCAPath:              scmRootCAPath,
 				GlobalPreservedAnnotations: globalPreservedAnnotations,
 				GlobalPreservedLabels:      globalPreservedLabels,
+				Cache:                      mgr.GetCache(),
 			}).SetupWithManager(mgr, enableProgressiveSyncs, maxConcurrentReconciliations); err != nil {
 				log.Error(err, "unable to create controller", "controller", "ApplicationSet")
 				os.Exit(1)


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/15513

PR implements 2 applicationset controller changes that fixes https://github.com/argoproj/argo-cd/issues/15513:

* Appset reconciler updates application informer cache after updating the application. I believe stale informer data is a rootcase of the https://github.com/argoproj/argo-cd/issues/15513
* Appset reconciler modifies application using `patch` instead of `update` which guarantees it won't override status won't be touched.