### PR TITLE
feat: Default Application Filters (#15263)

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -326,6 +326,11 @@ data:
   # When you disable the switch (either add it to the configmap with a "false" value or do not add it to the configmap), no actual RBAC enforcement will take place.
   server.rbac.log.enforce.enable: "false"
 
+  # Application list selector limits what applications will be loaded by ArgoCD by default
+  # Provide there label selectors, separated by comma
+  # When empty - ArgoCD will load an unfiltered application list (default behavior)
+  server.application.list.selector: ""
+
   # exec.enabled indicates whether the UI exec feature is enabled. It is disabled by default.
   exec.enabled: "false"
 

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -247,7 +247,7 @@ func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*ap
 	selectorStr := q.GetSelector()
 	defaultApplicationListSelector, err := s.settingsMgr.GetServerDefaultApplicationListSelector()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read application deep links from configmap: %w", err)
+		return nil, fmt.Errorf("failed to read default application list selector from configmap: %w", err)
 	}
 	if defaultApplicationListSelector != "" {
 		if selectorStr == "" {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -244,7 +244,19 @@ func (s *Server) getApplicationEnforceRBACClient(ctx context.Context, action, pr
 
 // List returns list of applications
 func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*appv1.ApplicationList, error) {
-	selector, err := labels.Parse(q.GetSelector())
+	selectorStr := q.GetSelector()
+	defaultApplicationListSelector, err := s.settingsMgr.GetServerDefaultApplicationListSelector()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read application deep links from configmap: %w", err)
+	}
+	if defaultApplicationListSelector != "" {
+		if selectorStr == "" {
+			selectorStr = defaultApplicationListSelector
+		} else {
+			selectorStr = defaultApplicationListSelector + "," + selectorStr
+		}
+	}
+	selector, err := labels.Parse(selectorStr)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing the selector: %w", err)
 	}

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -492,9 +492,10 @@ const (
 	ResourceDeepLinks = "resource.links"
 	extensionConfig   = "extension.config"
 	// RespectRBAC is the key to configure argocd to respect rbac while watching for resources
-	RespectRBAC            = "resource.respectRBAC"
-	RespectRBACValueStrict = "strict"
-	RespectRBACValueNormal = "normal"
+	RespectRBAC                                  = "resource.respectRBAC"
+	RespectRBACValueStrict                       = "strict"
+	RespectRBACValueNormal                       = "normal"
+	settingsServerDefaultApplicationListSelector = "server.application.list.selector"
 )
 
 var (
@@ -777,6 +778,15 @@ func (mgr *SettingsManager) GetServerRBACLogEnforceEnable() (bool, error) {
 	}
 
 	return strconv.ParseBool(argoCDCM.Data[settingsServerRBACLogEnforceEnableKey])
+}
+
+func (mgr *SettingsManager) GetServerDefaultApplicationListSelector() (string, error) {
+	argoCDCM, err := mgr.getConfigMap()
+	if err != nil {
+		return "", fmt.Errorf("error retrieving argocd-cm: %w", err)
+	}
+
+	return argoCDCM.Data[settingsServerDefaultApplicationListSelector], nil
 }
 
 func (mgr *SettingsManager) GetDeepLinks(deeplinkType string) ([]DeepLink, error) {


### PR DESCRIPTION
The PR limits what applications to load in UI / cli.
It allows adding a default filter into `argocd-cm` ConfigMap so that server would always hide certain application types automatically.
It's based on the following proposal: https://github.com/argoproj/argo-cd/issues/15263
But without UI changes.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
