### PR TITLE
feat: make git requests configurable

### DIFF
--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -154,6 +154,10 @@ data:
   reposerver.streamed.manifest.max.extracted.size: "1G"
   # Enable git submodule support
   reposerver.enable.git.submodule: "true"
+  # Number of concurrent git ls-remote requests. Any value less than 1 means no limit.
+  reposerver.git.lsremote.parallelism.limit: "0"
+  # Git requests timeout.
+  reposerver.git.request.timeout: "15s"
 
   # Disable TLS on the HTTP endpoint
   dexserver.disable.tls: "false"

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -168,6 +168,18 @@ spec:
                 key: reposerver.enable.git.submodule
                 name: argocd-cmd-params-cm
                 optional: true
+          - name: ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT
+            valueFrom:
+              configMapKeyRef:
+                key: reposerver.git.lsremote.parallelism.limit
+                name: argocd-cmd-params-cm
+                optional: true
+          - name: ARGOCD_GIT_REQUEST_TIMEOUT
+            valueFrom:
+              configMapKeyRef:
+                key: reposerver.git.request.timeout
+                name: argocd-cmd-params-cm
+                optional: true
           - name: HELM_CACHE_HOME
             value: /helm-working-dir
           - name: HELM_CONFIG_HOME

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -21042,6 +21042,18 @@ spec:
               key: reposerver.enable.git.submodule
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.lsremote.parallelism.limit
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_GIT_REQUEST_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.request.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -22528,6 +22528,18 @@ spec:
               key: reposerver.enable.git.submodule
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.lsremote.parallelism.limit
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_GIT_REQUEST_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.request.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2184,6 +2184,18 @@ spec:
               key: reposerver.enable.git.submodule
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.lsremote.parallelism.limit
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_GIT_REQUEST_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.request.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -21574,6 +21574,18 @@ spec:
               key: reposerver.enable.git.submodule
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.lsremote.parallelism.limit
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_GIT_REQUEST_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.request.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1230,6 +1230,18 @@ spec:
               key: reposerver.enable.git.submodule
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.lsremote.parallelism.limit
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_GIT_REQUEST_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.git.request.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: HELM_CACHE_HOME
           value: /helm-working-dir
         - name: HELM_CONFIG_HOME

--- a/reposerver/metrics/githandlers.go
+++ b/reposerver/metrics/githandlers.go
@@ -36,6 +36,8 @@ func NewGitClientEventHandlers(metricsServer *MetricsServer) git.EventHandlers {
 			startTime := time.Now()
 			metricsServer.IncGitRequest(repo, GitRequestTypeLsRemote)
 			if lsRemoteParallelismLimitSemaphore != nil {
+				// The `Acquire` method returns either `nil` or error of the provided context. The
+				// context.Background() is never canceled, so it is safe to ignore the error.
 				_ = lsRemoteParallelismLimitSemaphore.Acquire(context.Background(), 1)
 			}
 			return func() {

--- a/reposerver/metrics/githandlers.go
+++ b/reposerver/metrics/githandlers.go
@@ -1,10 +1,26 @@
 package metrics
 
 import (
+	"context"
+	"math"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
+	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/git"
 )
+
+var (
+	lsRemoteParallelismLimit          = env.ParseInt64FromEnv("ARGOCD_GIT_LS_REMOTE_PARALLELISM_LIMIT", 0, 0, math.MaxInt64)
+	lsRemoteParallelismLimitSemaphore *semaphore.Weighted
+)
+
+func init() {
+	if lsRemoteParallelismLimit > 0 {
+		lsRemoteParallelismLimitSemaphore = semaphore.NewWeighted(lsRemoteParallelismLimit)
+	}
+}
 
 // NewGitClientEventHandlers creates event handlers that update Git related metrics
 func NewGitClientEventHandlers(metricsServer *MetricsServer) git.EventHandlers {
@@ -19,7 +35,13 @@ func NewGitClientEventHandlers(metricsServer *MetricsServer) git.EventHandlers {
 		OnLsRemote: func(repo string) func() {
 			startTime := time.Now()
 			metricsServer.IncGitRequest(repo, GitRequestTypeLsRemote)
+			if lsRemoteParallelismLimitSemaphore != nil {
+				_ = lsRemoteParallelismLimitSemaphore.Acquire(context.Background(), 1)
+			}
 			return func() {
+				if lsRemoteParallelismLimitSemaphore != nil {
+					lsRemoteParallelismLimitSemaphore.Release(1)
+				}
 				metricsServer.ObserveGitRequestDuration(repo, GitRequestTypeLsRemote, time.Since(startTime))
 			}
 		},

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -174,6 +174,10 @@ func NewClientExt(rawRepoURL string, root string, creds Creds, insecure bool, en
 	return client, nil
 }
 
+var (
+	gitClientTimeout = env.ParseDurationFromEnv("ARGOCD_GIT_REQUEST_TIMEOUT", 15*time.Second, 0, math.MaxInt64)
+)
+
 // Returns a HTTP client object suitable for go-git to use using the following
 // pattern:
 //   - If insecure is true, always returns a client with certificate verification
@@ -185,8 +189,8 @@ func NewClientExt(rawRepoURL string, root string, creds Creds, insecure bool, en
 func GetRepoHTTPClient(repoURL string, insecure bool, creds Creds, proxyURL string) *http.Client {
 	// Default HTTP client
 	var customHTTPClient = &http.Client{
-		// 15 second timeout
-		Timeout: 15 * time.Second,
+		// 15 second timeout by default
+		Timeout: gitClientTimeout,
 		// don't follow redirect
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse


### PR DESCRIPTION
PR introduces an `ARGOCD_GIT_REQUEST_TIMEOUT` env variable that allows configuring git request timeouts (currently 15s by default)  