### PR TITLE
fix(kustomize): no concurrent processing if Kustomize patches are used

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -555,7 +555,8 @@ func (k *ApplicationSourceKustomize) AllowsConcurrentProcessing() bool {
 		len(k.CommonAnnotations) == 0 &&
 		k.NamePrefix == "" &&
 		k.Namespace == "" &&
-		k.NameSuffix == ""
+		k.NameSuffix == "" &&
+		len(k.Patches) == 0
 }
 
 // IsZero returns true when the Kustomize options are considered empty

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3002,6 +3002,16 @@ func TestSourceAllowsConcurrentProcessing_KustomizeParams(t *testing.T) {
 
 		assert.False(t, src.AllowsConcurrentProcessing())
 	})
+
+	t.Run("Has Patches", func(t *testing.T) {
+		src := ApplicationSource{Path: ".", Kustomize: &ApplicationSourceKustomize{
+			Patches: KustomizePatches{{
+				Path: "test",
+			}},
+		}}
+
+		assert.False(t, src.AllowsConcurrentProcessing())
+	})
 }
 
 func TestUnSetCascadedDeletion(t *testing.T) {


### PR DESCRIPTION
The patches feature makes on-disk changes which should block concurrent processing for Kustomize apps.