### PR TITLE
docs: Converted italic text to normal text

### DIFF
--- a/docs/operator-manual/app-any-namespace.md
+++ b/docs/operator-manual/app-any-namespace.md
@@ -20,7 +20,7 @@ Some manual steps will need to be performed by the Argo CD administrator in orde
 
 ### Cluster-scoped Argo CD installation
 
-This feature can only be enabled and used when your Argo CD is installed as a cluster-wide instance, so it has permissions to list and manipulate resources on a cluster scope. It will *not* work with an Argo CD installed in namespace-scoped mode.
+This feature can only be enabled and used when your Argo CD is installed as a cluster-wide instance, so it has permissions to list and manipulate resources on a cluster scope. It will not work with an Argo CD installed in namespace-scoped mode.
 
 ### Switch resource tracking method
 


### PR DESCRIPTION
_Issue : The word 'not' written in italic_ 

**ISSUE DETAILS**
To see the issue , go to this link "https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/"
In Prerequisites section ,the word 'not' is unnecessarily written in italic. It should be written in normal text to maintain the uniformity.

<img width="1280" alt="argocd_word_in_italic" src="https://github.com/argoproj/argo-cd/assets/102309095/deada287-48ba-4276-8fe3-23058167bcc6">
