### PR TITLE
fix(ci): do not fail fast on e2e test failures

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -361,6 +361,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
+        fail-fast: false
         k3s-version: [v1.27.2, v1.26.0, v1.25.4, v1.24.3]
     needs: 
       - build-go


### PR DESCRIPTION
e2e tests are flaking often. A flake in one version almost always kills all other running e2e tests by "failing fast." This means you have to re-run all e2e tests for a flake in just one version.

This change allows individual versions to succeed. It's how Rollouts does it: https://github.com/argoproj/argo-rollouts/blob/f650a1fd0ba7beb2125e1598410515edd572776f/.github/workflows/e2e.yaml#L38