### PR TITLE
fix(application-controller): Fix panic error when trying to scale application controller shards 

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -219,7 +219,7 @@ func getClusterFilter(kubeClient *kubernetes.Clientset, settingsMgr *settings.Se
 	appControllerDeployment, err := kubeClient.AppsV1().Deployments(settingsMgr.GetNamespace()).Get(context.Background(), applicationControllerName, metav1.GetOptions{})
 
 	// if the application controller deployment was not found, the Get() call returns an empty Deployment object. So, set the variable to nil explicitly
-	if kubeerrors.IsNotFound(err) {
+	if err != nil && kubeerrors.IsNotFound(err) {
 		appControllerDeployment = nil
 	}
 

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -214,8 +214,12 @@ func NewApplicationController(
 	readinessHealthCheck := func(r *http.Request) error {
 		applicationControllerName := env.StringFromEnv(common.EnvAppControllerName, common.DefaultApplicationControllerName)
 		appControllerDeployment, err := deploymentInformer.Lister().Deployments(settingsMgr.GetNamespace()).Get(applicationControllerName)
-		if !kubeerrors.IsNotFound(err) {
-			return fmt.Errorf("error retrieving Application Controller Deployment: %s", err)
+		if err != nil {
+			if kubeerrors.IsNotFound(err) {
+				appControllerDeployment = nil
+			} else {
+				return fmt.Errorf("error retrieving Application Controller Deployment: %s", err)
+			}
 		}
 		if appControllerDeployment != nil {
 			if appControllerDeployment.Spec.Replicas != nil && int(*appControllerDeployment.Spec.Replicas) <= 0 {

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -208,7 +208,7 @@ func NewApplicationController(
 		},
 	})
 
-	factory := informers.NewSharedInformerFactory(ctrl.kubeClientset, defaultDeploymentInformerResyncDuration)
+	factory := informers.NewSharedInformerFactoryWithOptions(ctrl.kubeClientset, defaultDeploymentInformerResyncDuration, informers.WithNamespace(settingsMgr.GetNamespace()))
 	deploymentInformer := factory.Apps().V1().Deployments()
 
 	readinessHealthCheck := func(r *http.Request) error {

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -152,8 +152,9 @@ func StripCRLFCharacter(input string) string {
 func (db *db) GetApplicationControllerReplicas() int {
 	// get the replicas from application controller deployment, if the application controller deployment does not exist, check for environment variable
 	applicationControllerName := env.StringFromEnv(common.EnvAppControllerName, common.DefaultApplicationControllerName)
-	appControllerDeployment, _ := db.kubeclientset.AppsV1().Deployments(db.settingsMgr.GetNamespace()).Get(context.Background(), applicationControllerName, metav1.GetOptions{})
-	if appControllerDeployment != nil {
+	appControllerDeployment, err := db.kubeclientset.AppsV1().Deployments(db.settingsMgr.GetNamespace()).Get(context.Background(), applicationControllerName, metav1.GetOptions{})
+
+	if err == nil && appControllerDeployment.Spec.Replicas != nil {
 		return int(*appControllerDeployment.Spec.Replicas)
 	}
 	return env.ParseNumFromEnv(common.EnvControllerReplicas, 0, 0, math.MaxInt32)


### PR DESCRIPTION
Fix panic error when trying to scale up the replicas of the application controller. Since the error is ignored when trying to get the `Deployments`

```
appControllerDeployment, _ := db.kubeclientset.AppsV1().Deployments(db.settingsMgr.GetNamespace()).Get(context.Background(), applicationControllerName, metav1.GetOptions{})
```

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
