### PR TITLE
test: bump k8s versions for e2e tests (#15765)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -362,7 +362,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s-version: [v1.27.2, v1.26.0, v1.25.4, v1.24.3]
+        k3s-version: [v1.28.2, v1.27.6, v1.26.9, v1.25.14]
     needs: 
       - build-go
     env:


### PR DESCRIPTION
Closes #15765

I think we should cherry-pick this back to release-2.9.