### PR TITLE
docs: fix list format

### DIFF
--- a/docs/proposals/feature-bounties.md
+++ b/docs/proposals/feature-bounties.md
@@ -31,6 +31,7 @@ This proposal is experimental, meaning after trying a single bounty, we will rev
 
 #### Creating a Bounty
 A bounty is a special proposal created under `docs/proposals/feature-bounties`. 
+
 * A bounty proposal may only be created by an existing Argo maintainer.
 * The proposal document must be reviewed in regular maintainer meetings and an invitation for feedback will provide 7-days to comment.
 * Bounty should have approval with [lazy-consensus](https://community.apache.org/committers/lazyConsensus.html)


### PR DESCRIPTION
The newline makes sure the list is rendered as a list.