### PR TITLE
chore: allow build of argocd-e2e-cluster image for remote tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,8 +18,10 @@ hack/
 docs/
 examples/
 .github/
-!test/fixture
 !test/container
+!test/e2e/testdata
+!test/fixture
+!test/remote
 !hack/installers
 !hack/gpg-wrapper.sh
 !hack/git-verify-wrapper.sh

--- a/test/remote/Makefile
+++ b/test/remote/Makefile
@@ -2,8 +2,8 @@ PWD=$(shell pwd)
 TEST_ROOT=$(shell realpath $(PWD)/../..)
 
 IMAGE_NAMESPACE?=
-IMAGE_NAME=argocd-e2e-cluster
-IMAGE_TAG=latest
+IMAGE_NAME?=argocd-e2e-cluster
+IMAGE_TAG?=latest
 ifneq (${IMAGE_NAMESPACE},)
 IMAGE_PREFIX=$(IMAGE_NAMESPACE)/
 else

--- a/test/remote/README.md
+++ b/test/remote/README.md
@@ -128,7 +128,7 @@ Run the tests
 In another shell, do a port-forward to the API server's service:
 
 ```shell
-kubectl -n argocd-e2e port-forward svc/argocd-server 443:4443
+kubectl -n argocd-e2e port-forward svc/argocd-server 4443:443
 ```
 
 Set Argo CD Server port:
@@ -140,7 +140,7 @@ export ARGOCD_SERVER=127.0.0.1:4443
 Set the admin password to use:
 
 ```shell
-export ARGOCD_E2E_ADMIN_PASSWORD=$(kubectl get secrets argocd-initial-admin-secret -o jsonpath='{.data.password}'|base64 -d)
+export ARGOCD_E2E_ADMIN_PASSWORD=$(kubectl -n argocd-e2e get secrets argocd-initial-admin-secret -o jsonpath='{.data.password}'|base64 -d)
 ```
 
 Run the tests


### PR DESCRIPTION
This pull request allows the `argocd-e2e-cluster` image to be created following [test/remote](https://github.com/argoproj/argo-cd/tree/master/test/remote) to allow the testing of Argo CD when deployed to an actual cluster.

Previously, these errors were seen when running `make image` in the test/remote directory:
```
Step 15/23 : COPY ./test/remote/entrypoint.sh /usr/local/bin
COPY failed: file not found in build context or excluded by .dockerignore: stat test/remote/entrypoint.sh: file does not exist

Step 18/23 : COPY ./test/e2e/testdata/ /app/config/testdata/
COPY failed: file not found in build context or excluded by .dockerignore: stat test/e2e/testdata/: file does not exist
```

Additionally, the Makefile in this directory is updated to allow the `argocd-e2e-cluster` image name and tag to be customized if needed, and corrected a few commands in README.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
