### PR TITLE
fix: unstable integration test

### DIFF
--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -2447,10 +2447,8 @@ func TestNamespacedDisableManifestGeneration(t *testing.T) {
 			assert.Equal(t, app.Status.SourceType, ApplicationSourceTypeKustomize)
 		}).
 		When().
-		And(func(app *Application) {
-			time.Sleep(3 * time.Second)
-		}).
 		And(func() {
+			time.Sleep(3 * time.Second)
 			SetEnableManifestGeneration(map[ApplicationSourceType]bool{
 				ApplicationSourceTypeKustomize: false,
 			})

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -2447,6 +2447,9 @@ func TestNamespacedDisableManifestGeneration(t *testing.T) {
 			assert.Equal(t, app.Status.SourceType, ApplicationSourceTypeKustomize)
 		}).
 		When().
+		And(func(app *Application) {
+			time.Sleep(3 * time.Second)
+		}).
 		And(func() {
 			SetEnableManifestGeneration(map[ApplicationSourceType]bool{
 				ApplicationSourceTypeKustomize: false,


### PR DESCRIPTION
Closes [ISSUE #15868]

# Description
Integration tests are often failed with follows error. 
It fails with the same error and the same test every time.
```
	Error:      	Not equal: 
       	            	expected: "Kustomize"
       	            	actual  : "Directory"        	            	
       	            	Diff:
       	            	--- Expected
       	            	+++ Actual
       	            	@@ -1,2 +1,2 @@
       	            	-(v1alpha1.ApplicationSourceType) (len=9) "Kustomize"
       	            	+(v1alpha1.ApplicationSourceType) (len=9) "Directory"        	            	 
    	Test:       	TestNamespacedDisableManifestGeneration
```

Test is here.
https://github.com/argoproj/argo-cd/blob/master/test/e2e/app_management_ns_test.go#L2437C14-L2437C14

I'm guessing `SetEnableManifestGeneration` isn't worked with some reason.
may be too short with just wait time of the when() func.
I'd like to see behavior when wait more before change `ApplicationSourceTypeKustomize`.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->