### PR TITLE
docs: Added example of using build env vars in your Kustomized App

### DIFF
--- a/docs/user-guide/kustomize.md
+++ b/docs/user-guide/kustomize.md
@@ -143,6 +143,34 @@ argocd app set <appName> --kustomize-version v3.5.4
 
 Kustomize apps have access to the [standard build environment](build-environment.md) which can be used in combination with a [config managment plugin](../operator-manual/config-management-plugins.md) to alter the rendered manifests.
 
+You can use these build environment variables in your Argo CD Application manifests. You can enable this by setting `.spec.source.kustomize.commonAnnotationsEnvsubst` to `true` in your Application manifest.
+
+For example, the following Application manifest will set the `app-source` annotation to the name of the Application:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook-app
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    namespace: demo
+    server: https://kubernetes.default.svc
+  source:
+    path: kustomize-guestbook
+    repoURL: https://github.com/argoproj/argocd-example-apps
+    targetRevision: HEAD
+    kustomize:
+      commonAnnotationsEnvsubst: true
+      commonAnnotations:
+        app-source: ${ARGOCD_APP_NAME}
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+```
+
 ## Kustomizing Helm charts
 
 It's possible to [render Helm charts with Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/chart.md).


### PR DESCRIPTION
Closes: #16010

Added example of using build env vars in your Kustomized App, which should clear up some confusion.