### PR TITLE
feat(cli): add project flag to avoid permission denied errors on 404

### DIFF
--- a/docs/user-guide/commands/argocd_app_delete-resource.md
+++ b/docs/user-guide/commands/argocd_app_delete-resource.md
@@ -18,6 +18,7 @@ argocd app delete-resource APPNAME [flags]
       --kind string            Kind
       --namespace string       Namespace
       --orphan                 Indicates whether to force delete the resource
+      --project string         The name of the application's project - specifying this allows the command to report "not found" instead of "permission denied" if the app does not exist
       --resource-name string   Name of resource
 ```
 

--- a/docs/user-guide/commands/argocd_app_patch-resource.md
+++ b/docs/user-guide/commands/argocd_app_patch-resource.md
@@ -18,6 +18,7 @@ argocd app patch-resource APPNAME [flags]
       --namespace string       Namespace
       --patch string           Patch
       --patch-type string      Which Patching strategy to use: 'application/json-patch+json', 'application/merge-patch+json', or 'application/strategic-merge-patch+json'. Defaults to 'application/merge-patch+json' (default "application/merge-patch+json")
+      --project string         The name of the application's project - specifying this allows the command to report "not found" instead of "permission denied" if the app does not exist
       --resource-name string   Name of resource
 ```
 

--- a/docs/user-guide/commands/argocd_app_resources.md
+++ b/docs/user-guide/commands/argocd_app_resources.md
@@ -11,9 +11,10 @@ argocd app resources APPNAME [flags]
 ### Options
 
 ```
-  -h, --help            help for resources
-      --orphaned        Lists only orphaned resources
-      --output string   Provides the tree view of the resources
+  -h, --help             help for resources
+      --orphaned         Lists only orphaned resources
+      --output string    Provides the tree view of the resources
+      --project string   The name of the application's project - specifying this allows the command to report "not found" instead of "permission denied" if the app does not exist
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
A while back, we changed the applicaiton API to require providing the project name in order to get 404 instead of "permission denied" for apps that do not exist.

This change adds the `--project` field to all the app resource CLI commands so that users can opt into getting the nicer error message.