### PR TITLE
fix(appset): ensure appset don't attempt to remove application kind in patch requests

### DIFF
--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -78,6 +79,12 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f c
 			return a.Namespace == b.Namespace && a.Name == b.Name && a.Server == b.Server
 		},
 	)
+	// make sure updated object has the same apiVersion & kind as original object
+	if objKind, ok := obj.(schema.ObjectKind); ok {
+		if existingKind, ok := existing.(schema.ObjectKind); ok {
+			existingKind.SetGroupVersionKind(objKind.GroupVersionKind())
+		}
+	}
 
 	if equality.DeepEqual(existing, obj) {
 		return controllerutil.OperationResultNone, nil


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/15900

I was able to reproduce an issue only with the help of a debugger: request fails if patch body contains: `"kind": null` which happens only if `existingObj` does not have `kind/apiVersion` fields and `obj` has it. I suspect this is happening due to k8s bug: https://github.com/kubernetes/kubernetes/issues/80609 . Sometimes application is take from cache and it has apiVersion/kind and sometimes it is coming from API request without apiVersion/kind. 

PR ensures that `existingObj` has same  apiVersion/kind as `obj` so generated patch won't change apiVersion/kind