### PR TITLE
fix: Use math.MaxInt (instead of math.MaxInt64) to fix builds on 32bit platforms

### DIFF
--- a/util/http/http.go
+++ b/util/http/http.go
@@ -30,7 +30,7 @@ const (
 
 // max number of chunks a cookie can be broken into. To be compatible with
 // widest range of browsers, you shouldn't create more than 30 cookies per domain
-var maxCookieNumber = env.ParseNumFromEnv(common.EnvMaxCookieNumber, 20, 0, math.MaxInt64)
+var maxCookieNumber = env.ParseNumFromEnv(common.EnvMaxCookieNumber, 20, 0, math.MaxInt)
 
 // MakeCookieMetadata generates a string representing a Web cookie.  Yum!
 func MakeCookieMetadata(key, value string, flags ...string) ([]string, error) {


### PR DESCRIPTION
Just a fix of the wrong type