### PR TITLE
fix(ui): log button behaviors (#15848)

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -1,7 +1,7 @@
 import {DataLoader} from 'argo-ui';
 import * as classNames from 'classnames';
 import * as React from 'react';
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useRef} from 'react';
 import {bufferTime, delay, retryWhen} from 'rxjs/operators';
 
 import {LogEntry} from '../../../shared/models';
@@ -83,6 +83,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
     const [highlight, setHighlight] = useState<RegExp>(matchNothing);
     const [scrollToBottom, setScrollToBottom] = useState(true);
     const [logs, setLogs] = useState<LogEntry[]>([]);
+    const logsContainerRef = useRef(null);
 
     useEffect(() => {
         if (viewPodNames) {
@@ -101,6 +102,15 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
     }
 
     useEffect(() => setScrollToBottom(true), [follow]);
+
+    useEffect(() => {
+        if (scrollToBottom) {
+            const element = logsContainerRef.current;
+            if (element) {
+                element.scrollTop = element.scrollHeight;
+            }
+        }
+    }, [logs, scrollToBottom]);
 
     useEffect(() => {
         setLogs([]);
@@ -125,6 +135,10 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
         return () => logsSource.unsubscribe();
     }, [applicationName, applicationNamespace, namespace, podName, group, kind, name, containerName, tail, follow, sinceSeconds, filter, previous]);
 
+    const handleScroll = (event: React.WheelEvent<HTMLDivElement>) => {
+        if (event.deltaY < 0) setScrollToBottom(false)
+    };
+
     const renderLog = (log: LogEntry, lineNum: number) =>
         // show the pod name if there are multiple pods, pad with spaces to align
         (viewPodNames ? (lineNum === 0 || logs[lineNum - 1].podName !== log.podName ? podColor(podName) + log.podName + reset : ' '.repeat(log.podName.length)) + ' ' : '') +
@@ -133,7 +147,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
         // show the log content, highlight the filter text
         log.content?.replace(highlight, (substring: string) => whiteOnYellow + substring + reset);
     const logsContent = (width: number, height: number, isWrapped: boolean) => (
-        <div style={{width, height, overflow: 'scroll'}}>
+        <div ref={logsContainerRef} onScroll={handleScroll} style={{width, height, overflow: 'scroll'}}>
             {logs.map((log, lineNum) => (
                 <pre key={lineNum} style={{whiteSpace: isWrapped ? 'normal' : 'pre'}} className='noscroll'>
                     <Ansi>{renderLog(log, lineNum)}</Ansi>
@@ -179,9 +193,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                         </div>
                         <div
                             className={classNames('pod-logs-viewer', {'pod-logs-viewer--inverted': prefs.appDetails.darkMode})}
-                            onWheel={e => {
-                                if (e.deltaY < 0) setScrollToBottom(false);
-                            }}>
+                            onWheel={handleScroll}>
                             <AutoSizer>{({width, height}: {width: number; height: number}) => logsContent(width, height, prefs.appDetails.wrapLines)}</AutoSizer>
                         </div>
                     </React.Fragment>

--- a/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/pod-logs-viewer.tsx
@@ -136,7 +136,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
     }, [applicationName, applicationNamespace, namespace, podName, group, kind, name, containerName, tail, follow, sinceSeconds, filter, previous]);
 
     const handleScroll = (event: React.WheelEvent<HTMLDivElement>) => {
-        if (event.deltaY < 0) setScrollToBottom(false)
+        if (event.deltaY < 0) setScrollToBottom(false);
     };
 
     const renderLog = (log: LogEntry, lineNum: number) =>
@@ -191,9 +191,7 @@ export const PodsLogsViewer = (props: PodLogsProps) => {
                                 <FullscreenButton {...props} />
                             </span>
                         </div>
-                        <div
-                            className={classNames('pod-logs-viewer', {'pod-logs-viewer--inverted': prefs.appDetails.darkMode})}
-                            onWheel={handleScroll}>
+                        <div className={classNames('pod-logs-viewer', {'pod-logs-viewer--inverted': prefs.appDetails.darkMode})} onWheel={handleScroll}>
                             <AutoSizer>{({width, height}: {width: number; height: number}) => logsContent(width, height, prefs.appDetails.wrapLines)}</AutoSizer>
                         </div>
                     </React.Fragment>


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
signed-off by: @ciiay yicai@redhat.com

Closes issue #15848 

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 84434ce</samp>

* Import `useRef` hook from React to create a reference to the logs container element ([link](https://github.com/argoproj/argo-cd/pull/16098/files?diff=unified&w=0#diff-2e021a2e2b744aff4648c3617ef5af0b74d30f9a3dd4e40dacb9248cdf2ef911L4-R4))
* Declare `logsContainerRef` variable to store the reference ([link](https://github.com/argoproj/argo-cd/pull/16098/files?diff=unified&w=0#diff-2e021a2e2b744aff4648c3617ef5af0b74d30f9a3dd4e40dacb9248cdf2ef911R86))
* Update `useEffect` hook to scroll the logs container element to the bottom if `scrollToBottom` state is true ([link](https://github.com/argoproj/argo-cd/pull/16098/files?diff=unified&w=0#diff-2e021a2e2b744aff4648c3617ef5af0b74d30f9a3dd4e40dacb9248cdf2ef911R107-R115))
* Define `handleScroll` function to handle the wheel event on the logs container element and set `scrollToBottom` state to false if user scrolls up ([link](https://github.com/argoproj/argo-cd/pull/16098/files?diff=unified&w=0#diff-2e021a2e2b744aff4648c3617ef5af0b74d30f9a3dd4e40dacb9248cdf2ef911R138-R141))
* Assign `logsContainerRef` to the `ref` prop and `handleScroll` to the `onScroll` prop of the logs container element ([link](https://github.com/argoproj/argo-cd/pull/16098/files?diff=unified&w=0#diff-2e021a2e2b744aff4648c3617ef5af0b74d30f9a3dd4e40dacb9248cdf2ef911L136-R150), [link](https://github.com/argoproj/argo-cd/pull/16098/files?diff=unified&w=0#diff-2e021a2e2b744aff4648c3617ef5af0b74d30f9a3dd4e40dacb9248cdf2ef911L180-R194))
* Remove `onWheel` prop from the logs container element since it is redundant with `onScroll` prop ([link](https://github.com/argoproj/argo-cd/pull/16098/files?diff=unified&w=0#diff-2e021a2e2b744aff4648c3617ef5af0b74d30f9a3dd4e40dacb9248cdf2ef911L180-R194))

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

Screenshot video

https://github.com/argoproj/argo-cd/assets/26255262/fa16d6d6-8a79-48ff-89ee-e9d0db6f89cc



