### PR TITLE
remove invalid characters before markdown example

### DIFF
--- a/docs/operator-manual/applicationset/Progressive-Syncs.md
+++ b/docs/operator-manual/applicationset/Progressive-Syncs.md
@@ -53,7 +53,6 @@ Once a change is pushed, the following will happen in order.
 * 10% of all `env-prod` Applications will be updated at a time until all `env-prod` Applications have been updated.
 
 ```
----
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/docs/operator-manual/applicationset/Progressive-Syncs.md
+++ b/docs/operator-manual/applicationset/Progressive-Syncs.md
@@ -52,7 +52,7 @@ Once a change is pushed, the following will happen in order.
 * The rollout will wait for all `env-qa` Applications to be manually synced via the `argocd` CLI or by clicking the Sync button in the UI.
 * 10% of all `env-prod` Applications will be updated at a time until all `env-prod` Applications have been updated.
 
-```
+```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.

Missing language in markdown example prevent it from having syntax highlighting

![image](https://github.com/argoproj/argo-cd/assets/82411321/3bf30eab-0b8a-4416-8098-14594d4988a4)
