### PR TITLE
fix(ui): add exec check to avoid API calls

### DIFF
--- a/ui/src/app/applications/components/application-details/application-resource-list.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.tsx
@@ -35,7 +35,7 @@ export const ApplicationResourceList = ({
     const view = searchParams.get('view');
 
     const ParentRefDetails = () => {
-        return (
+        return Object.keys(parentNode).length > 0 ? (
             <div className='resource-parent-node-info-title'>
                 <div>Parent Node Info</div>
                 <div className='resource-parent-node-info-title__label'>
@@ -47,6 +47,8 @@ export const ApplicationResourceList = ({
                     <div>{parentNode?.kind}</div>
                 </div>
             </div>
+        ) : (
+            <div />
         );
     };
     return (

--- a/ui/src/app/applications/components/application-details/application-resource-list.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.tsx
@@ -54,7 +54,7 @@ export const ApplicationResourceList = ({
             {/*Display only when the view is set to tree*/}
             {(view === 'tree' || view === 'network') && (
                 <div className='resource-details__header' style={{paddingTop: '20px'}}>
-                    <ParenRefDetails/>
+                    <ParenRefDetails />
                 </div>
             )}
             <div className='argo-table-list argo-table-list--clickable'>

--- a/ui/src/app/applications/components/application-details/application-resource-list.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.tsx
@@ -31,35 +31,43 @@ export const ApplicationResourceList = ({
         return null;
     }
     const parentNode = ((resources || []).length > 0 && (getResNode(tree.nodes, nodeKey(resources[0])) as ResourceNode)?.parentRefs?.[0]) || ({} as ResourceRef);
+    const searchParams = new URLSearchParams(window.location.search);
+    const view = searchParams.get('view');
 
+    const ParenRefDetails = () => {
+        return (
+            <div className='resource-parent-node-info-title'>
+                <div>Parent Node Info</div>
+                <div className='resource-parent-node-info-title__label'>
+                    <div>Name:</div>
+                    <div>{parentNode?.name}</div>
+                </div>
+                <div className='resource-parent-node-info-title__label'>
+                    <div>Kind:</div>
+                    <div>{parentNode?.kind}</div>
+                </div>
+            </div>
+        );
+    };
     return (
         <div>
-            <div className='resource-details__header' style={{paddingTop: '20px'}}>
-                {Object.keys(parentNode).length > 0 && (
-                    <div className='resource-parent-node-info-title'>
-                        <div> Parent Node Info</div>
-                        <div className='resource-parent-node-info-title__label'>
-                            <div>Name:</div>
-                            <div>{parentNode?.name}</div>
-                        </div>
-                        <div className='resource-parent-node-info-title__label'>
-                            <div>Kind:</div>
-                            <div> {parentNode?.kind}</div>
-                        </div>
-                    </div>
-                )}
-            </div>
+            {/*Display only when the view is set to tree*/}
+            {(view === 'tree' || view === 'network') && (
+                <div className='resource-details__header' style={{paddingTop: '20px'}}>
+                    <ParenRefDetails/>
+                </div>
+            )}
             <div className='argo-table-list argo-table-list--clickable'>
                 <div className='argo-table-list__head'>
                     <div className='row'>
                         <div className='columns small-1 xxxlarge-1' />
-                        <div className='columns small-2 xxxlarge-2'>NAME</div>
+                        <div className='columns small-2 xxxlarge-1'>NAME</div>
                         <div className='columns small-1 xxxlarge-1'>GROUP/KIND</div>
                         <div className='columns small-1 xxxlarge-1'>SYNC ORDER</div>
-                        <div className='columns small-2 xxxlarge-2'>NAMESPACE</div>
+                        <div className='columns small-2 xxxlarge-1'>NAMESPACE</div>
                         {(parentNode.kind === 'Rollout' || parentNode.kind === 'Deployment') && <div className='columns small-1 xxxlarge-1'>REVISION</div>}
-                        <div className='columns small-2 xxxlarge-2'>CREATED AT</div>
-                        <div className='columns small-2 xxxlarge-2'>STATUS</div>
+                        <div className='columns small-2 xxxlarge-1'>CREATED AT</div>
+                        <div className='columns small-2 xxxlarge-1'>STATUS</div>
                     </div>
                 </div>
                 {resources
@@ -79,7 +87,7 @@ export const ApplicationResourceList = ({
                                         <div>{ResourceLabel({kind: res.kind})}</div>
                                     </div>
                                 </div>
-                                <div className='columns small-2 xxxlarge-2'>
+                                <div className='columns small-2 xxxlarge-1'>
                                     {res.name}
                                     {res.kind === 'Application' && (
                                         <Consumer>
@@ -98,7 +106,7 @@ export const ApplicationResourceList = ({
                                 </div>
                                 <div className='columns small-1 xxxlarge-1'>{[res.group, res.kind].filter(item => !!item).join('/')}</div>
                                 <div className='columns small-1 xxxlarge-1'>{res.syncWave || '-'}</div>
-                                <div className='columns small-2 xxxlarge-2'>{res.namespace}</div>
+                                <div className='columns small-2 xxxlarge-1'>{res.namespace}</div>
                                 {res.kind === 'ReplicaSet' &&
                                     ((getResNode(tree.nodes, nodeKey(res)) as ResourceNode).info || [])
                                         .filter(tag => !tag.name.includes('Node'))
@@ -111,7 +119,7 @@ export const ApplicationResourceList = ({
                                             );
                                         })}
 
-                                <div className='columns small-2 xxxlarge-2'>
+                                <div className='columns small-2 xxxlarge-1'>
                                     {res.createdAt && (
                                         <span>
                                             <Moment fromNow={true} ago={true}>
@@ -121,7 +129,7 @@ export const ApplicationResourceList = ({
                                         </span>
                                     )}
                                 </div>
-                                <div className='columns small-2 xxxlarge-2'>
+                                <div className='columns small-2 xxxlarge-1'>
                                     {res.health && (
                                         <React.Fragment>
                                             <HealthStatusIcon state={res.health} /> {res.health.status} &nbsp;

--- a/ui/src/app/applications/components/application-details/application-resource-list.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.tsx
@@ -34,7 +34,7 @@ export const ApplicationResourceList = ({
     const searchParams = new URLSearchParams(window.location.search);
     const view = searchParams.get('view');
 
-    const ParenRefDetails = () => {
+    const ParentRefDetails = () => {
         return (
             <div className='resource-parent-node-info-title'>
                 <div>Parent Node Info</div>
@@ -51,10 +51,10 @@ export const ApplicationResourceList = ({
     };
     return (
         <div>
-            {/*Display only when the view is set to tree*/}
+            {/* Display only when the view is set to  or network */}
             {(view === 'tree' || view === 'network') && (
                 <div className='resource-details__header' style={{paddingTop: '20px'}}>
-                    <ParenRefDetails />
+                    <ParentRefDetails />
                 </div>
             )}
             <div className='argo-table-list argo-table-list--clickable'>

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -280,7 +280,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                         const settings = await services.authService.settings();
                         const execEnabled = settings.execEnabled;
                         const logsAllowed = await services.accounts.canI('logs', 'get', application.spec.project + '/' + application.metadata.name);
-                        const execAllowed = settings.execEnabled && await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
+                        const execAllowed = settings.execEnabled && (await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name));
                         const links = await services.applications.getResourceLinks(application.metadata.name, application.metadata.namespace, selectedNode).catch(() => null);
                         return {controlledState, liveState, events, podState, execEnabled, execAllowed, logsAllowed, links};
                     }}>

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -280,7 +280,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                         const settings = await services.authService.settings();
                         const execEnabled = settings.execEnabled;
                         const logsAllowed = await services.accounts.canI('logs', 'get', application.spec.project + '/' + application.metadata.name);
-                        const execAllowed = settings.execEnabled && (await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name));
+                        const execAllowed = execEnabled && (await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name));
                         const links = await services.applications.getResourceLinks(application.metadata.name, application.metadata.namespace, selectedNode).catch(() => null);
                         return {controlledState, liveState, events, podState, execEnabled, execAllowed, logsAllowed, links};
                     }}>

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -280,7 +280,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                         const settings = await services.authService.settings();
                         const execEnabled = settings.execEnabled;
                         const logsAllowed = await services.accounts.canI('logs', 'get', application.spec.project + '/' + application.metadata.name);
-                        const execAllowed = await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
+                        const execAllowed = settings.execEnabled && await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
                         const links = await services.applications.getResourceLinks(application.metadata.name, application.metadata.namespace, selectedNode).catch(() => null);
                         return {controlledState, liveState, events, podState, execEnabled, execAllowed, logsAllowed, links};
                     }}>

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -473,7 +473,7 @@ function getActionItems(
     const execAction = services.authService
         .settings()
         .then(async settings => {
-            const execAllowed = settings.execEnabled && await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
+            const execAllowed = settings.execEnabled && (await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name));
             if (resource.kind === 'Pod' && settings.execEnabled && execAllowed) {
                 return [
                     {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -473,7 +473,7 @@ function getActionItems(
     const execAction = services.authService
         .settings()
         .then(async settings => {
-            const execAllowed = await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
+            const execAllowed = settings.execEnabled && await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name);
             if (resource.kind === 'Pod' && settings.execEnabled && execAllowed) {
                 return [
                     {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -474,7 +474,7 @@ function getActionItems(
         .settings()
         .then(async settings => {
             const execAllowed = settings.execEnabled && (await services.accounts.canI('exec', 'create', application.spec.project + '/' + application.metadata.name));
-            if (resource.kind === 'Pod' && settings.execEnabled && execAllowed) {
+            if (resource.kind === 'Pod' && execAllowed) {
                 return [
                     {
                         title: 'Exec',


### PR DESCRIPTION
fixes https://github.com/argoproj/argo-cd/issues/16165

Along with this PR, fixing UI bug on the resource list when pod group is enabled and total pod count is grater than 15
UI displays Parent Node Ref details which shouldn't be displayed on this list view. Parent Ref details should only be displayed when the user clicks on the pod group on the tree view
<img width="1505" alt="Screenshot 2023-10-30 at 7 00 56 PM" src="https://github.com/argoproj/argo-cd/assets/11219262/aa8d8b9f-ab3b-49f6-91bf-34b967052304">
