### PR TITLE
chore(ci): bump cosign version

### DIFF
--- a/.github/workflows/image-reuse.yaml
+++ b/.github/workflows/image-reuse.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
         with:
-          cosign-release: 'v2.0.0'
+          cosign-release: 'v2.0.2'
 
       - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0


### PR DESCRIPTION
The release pipeline is [failing](https://github.com/argoproj/argo-cd/actions/runs/6707820539/job/18228651268) because the installed cosign version doesn't match the expected version.