### PR TITLE
docs(cmp): fix CMP param getter example (#16077)

### DIFF
--- a/examples/plugins/helm/get-parameters.sh
+++ b/examples/plugins/helm/get-parameters.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-yq e -o=json values.yaml | jq '{
+yq e -o=json values.yaml | jq '[{
   name: "helm-parameters",
   title: "Helm Parameters",
   collectionType: "map",
   map: [leaf_paths as $path | {"key": $path | join("."), "value": getpath($path)|tostring}] | from_entries
-}'
+}]'


### PR DESCRIPTION
CMP server expects a list of objects, not just a single object.

Closes https://github.com/argoproj/argo-cd/issues/16077