### PR TITLE
fix(ui): application details status panel has overlap on small screen

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.scss
+++ b/ui/src/app/applications/components/application-details/application-details.scss
@@ -13,6 +13,9 @@ $header: 120px;
         left: $sidebar-width;
         right: 0;
         z-index: 3;
+        @media screen and (max-width: map-get($breakpoints, xxlarge)) {
+            top: 150px;
+        }
         @media screen and (max-width: map-get($breakpoints, xlarge)) {
             top: 150px;
         }


### PR DESCRIPTION
Fix position of the element with class .application-details__status-panel on devices with screen size between 1200px and 1440px.

**Issue**

The `div..application-details__status-panel` has overlap with `div.page__top-bar` on screen with a size between 1200px and 1440px. 

**To Reproduce**

Open DevTools in chrome and resize the screen to 1220px.

**Expected behavior**

There should not be any overlap with this tool bars.

**Screenshots**

![image](https://github.com/argoproj/argo-cd/assets/4608564/a75911b2-9928-46c8-a55d-a9d8880286df)
Please ignore darkmode extension (same cold be reproduced in normal mode too)

**Version**

ArgoCD version: v2.8.6+6f7af53