### PR TITLE
docs: Document `ApplyOutOfSyncOnly` in application spec

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -189,6 +189,7 @@ spec:
     - PrunePropagationPolicy=foreground # Supported policies are background, foreground and orphan.
     - PruneLast=true # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
     - RespectIgnoreDifferences=true # When syncing changes, respect fields ignored by the ignoreDifferences configuration
+    - ApplyOutOfSyncOnly=true # Only sync out-of-sync resources, rather than applying every object in the application
     managedNamespaceMetadata: # Sets the metadata for the application namespace. Only valid if CreateNamespace=true (see above), otherwise it's a no-op.
       labels: # The labels to set on the application namespace
         any: label


### PR DESCRIPTION
I found this being used in an application I was working on but had a hard time discovering its meaning since it wasn't in the specification[1] though it was in the `sync-options` docs (see also baa0f2e39c45b86bedc3b3cca0878c0f77253529)

[1] https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/
[2] https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#selective-sync

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] ~Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or~ (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note). **No:** no release notes needed
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. **No:** no issue
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. **No:** not a new feature
*  [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. **No:** just docs changed
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. **No:** no new feature
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves. See PR description/commit body

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
