### PR TITLE
docs: fix upgrade instructions

### DIFF
--- a/docs/operator-manual/upgrading/2.8-2.9.md
+++ b/docs/operator-manual/upgrading/2.8-2.9.md
@@ -1,2 +1,5 @@
 # v2.8 to 2.9
 
+## Upgraded Kustomize Version
+
+Note that bundled Kustomize version has been upgraded from 5.1.0 to 5.2.1.

--- a/docs/operator-manual/upgrading/2.8-2.9.md
+++ b/docs/operator-manual/upgrading/2.8-2.9.md
@@ -1,12 +1,2 @@
 # v2.8 to 2.9
 
-## `managedNamespaceMetadata` no longer preserves client-side-applied labels or annotations
-
-Argo CD 2.9 upgraded kubectl from 1.24 to 1.26. This upgrade introduced a change where client-side-applied labels and
-annotations are no longer preserved when using a server-side kubectl apply. This change affects the
-`managedNamespaceMetadata` field of the `Application` CRD. Previously, labels and annotations applied via a client-side
-apply would be preserved when `managedNamespaceMetadata` was enabled. Now, those existing labels and annotation will be
-removed.
-
-To avoid unexpected behavior, follow the [client-side to server-side resource upgrade guide](https://kubernetes.io/docs/reference/using-api/server-side-apply/#upgrading-from-client-side-apply-to-server-side-apply)
-before enabling `managedNamespaceMetadata` on an existing namespace.

--- a/docs/operator-manual/upgrading/2.9-2.10.md
+++ b/docs/operator-manual/upgrading/2.9-2.10.md
@@ -1,4 +1,4 @@
-# 2.9 to 2.10
+# v2.9 to 2.10
 
 ## `managedNamespaceMetadata` no longer preserves client-side-applied labels or annotations
 

--- a/docs/operator-manual/upgrading/2.9-2.10.md
+++ b/docs/operator-manual/upgrading/2.9-2.10.md
@@ -1,0 +1,12 @@
+# 2.9 to 2.10
+
+## `managedNamespaceMetadata` no longer preserves client-side-applied labels or annotations
+
+Argo CD 2.10 upgraded kubectl from 1.24 to 1.26. This upgrade introduced a change where client-side-applied labels and
+annotations are no longer preserved when using a server-side kubectl apply. This change affects the
+`managedNamespaceMetadata` field of the `Application` CRD. Previously, labels and annotations applied via a client-side
+apply would be preserved when `managedNamespaceMetadata` was enabled. Now, those existing labels and annotation will be
+removed.
+
+To avoid unexpected behavior, follow the [client-side to server-side resource upgrade guide](https://kubernetes.io/docs/reference/using-api/server-side-apply/#upgrading-from-client-side-apply-to-server-side-apply)
+before enabling `managedNamespaceMetadata` on an existing namespace.

--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -37,6 +37,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
+* [v2.9 to v2.10](./2.9-2.10.md)
 * [v2.8 to v2.9](./2.8-2.9.md)
 * [v2.7 to v2.8](./2.7-2.8.md)
 * [v2.6 to v2.7](./2.6-2.7.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,8 @@ nav:
     - operator-manual/server-commands/additional-configuration-method.md
   - Upgrading:
     - operator-manual/upgrading/overview.md
+    - operator-manual/upgrading/2.9-2.10.md
+    - operator-manual/upgrading/2.8-2.9.md
     - operator-manual/upgrading/2.7-2.8.md
     - operator-manual/upgrading/2.6-2.7.md
     - operator-manual/upgrading/2.5-2.6.md


### PR DESCRIPTION
The managedNamespaceMetadata change didn't make it into 2.9.