### PR TITLE
docs: update release doc and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,12 +9,6 @@ assignees: ''
 Target RC1 date: ___. __, ____
 Target GA date: ___. __, ____
 
- - [ ] Create new section in the [Release Planning doc](https://docs.google.com/document/d/1trJIomcgXcfvLw0aYnERrFWfPjQOfYMDJOCh1S8nMBc/edit?usp=sharing)
- - [ ] Schedule a Release Planning meeting roughly two weeks before the scheduled Release freeze date by adding it to the community calendar (or delegate this task to someone with write access to the community calendar)
-     - [ ] Include Zoom link in the invite
- - [ ] Post in #argo-cd and #argo-contributors one week before the meeting
- - [ ] Post again one hour before the meeting
- - [ ] At the meeting, remove issues/PRs from the project's column for that release which have not been “claimed” by at least one Approver (add it to the next column if Approver requests that)
  - [ ] 1wk before feature freeze post in #argo-contributors that PRs must be merged by DD-MM-YYYY to be included in the release - ask approvers to drop items from milestone they can’t merge
  - [ ] At least two days before RC1 date, draft RC blog post and submit it for review (or delegate this task)
  - [ ] Cut RC1 (or delegate this task to an Approver and coordinate timing)

--- a/docs/developer-guide/release-process-and-cadence.md
+++ b/docs/developer-guide/release-process-and-cadence.md
@@ -6,14 +6,15 @@
 
 These are the upcoming releases dates:
 
-| Release | Release Planning Meeting | Release Candidate 1   | General Availability | Release Champion                                      | Checklist                                                     |
-|---------|--------------------------|-----------------------|----------------------|-------------------------------------------------------|---------------------------------------------------------------|
-| v2.6    | Monday, Dec. 12, 2022    | Monday, Dec. 19, 2022 | Monday, Feb. 6, 2023 | [William Tam](https://github.com/wtam2018)            | [checklist](https://github.com/argoproj/argo-cd/issues/11563) |
-| v2.7    | Monday, Mar. 6, 2023     | Monday, Mar. 20, 2023 | Monday, May. 1, 2023 | [Pavel Kostohrys](https://github.com/pasha-codefresh) | [checklist](https://github.com/argoproj/argo-cd/issues/12762) |
-| v2.8    | Monday, Jun. 20, 2023    | Monday, Jun. 26, 2023 | Monday, Aug. 7, 2023 | [Keith Chong](https://github.com/keithchong)          | [checklist](https://github.com/argoproj/argo-cd/issues/13742) |
-| v2.9    | Monday, Sep. 4, 2023     | Monday, Sep. 18, 2023 | Monday, Nov. 6, 2023 | [Leonardo Almeida](https://github.com/leoluz)         | [checklist](https://github.com/argoproj/argo-cd/issues/14078) |
-| v2.10   | Monday, Dec. 4, 2023     | Monday, Dec. 18, 2023 | Monday, Feb. 5, 2024 | 
-
+| Release | Release Candidate 1   | General Availability | Release Champion                                      | Checklist                                                     |
+|---------|-----------------------|----------------------|-------------------------------------------------------|---------------------------------------------------------------|
+| v2.6    | Monday, Dec. 19, 2022 | Monday, Feb. 6, 2023 | [William Tam](https://github.com/wtam2018)            | [checklist](https://github.com/argoproj/argo-cd/issues/11563) |
+| v2.7    | Monday, Mar. 20, 2023 | Monday, May 1, 2023  | [Pavel Kostohrys](https://github.com/pasha-codefresh) | [checklist](https://github.com/argoproj/argo-cd/issues/12762) |
+| v2.8    | Monday, Jun. 26, 2023 | Monday, Aug. 7, 2023 | [Keith Chong](https://github.com/keithchong)          | [checklist](https://github.com/argoproj/argo-cd/issues/13742) |
+| v2.9    | Monday, Sep. 18, 2023 | Monday, Nov. 6, 2023 | [Leonardo Almeida](https://github.com/leoluz)         | [checklist](https://github.com/argoproj/argo-cd/issues/14078) |
+| v2.10   | Monday, Dec. 18, 2023 | Monday, Feb. 5, 2024 | 
+| v2.11   | Monday, Mar. 18, 2024 | Monday, May 6, 2024  | 
+| v2.12   | Monday, Jun. 17, 2024 | Monday, Aug. 5, 2024 | 
 
 Actual release dates might differ from the plan by a few days.
 
@@ -22,8 +23,8 @@ Actual release dates might differ from the plan by a few days.
 #### Minor Releases (e.g. 2.x.0)
 
 A minor Argo CD release occurs four times a year, once every three months. Each General Availability (GA) release is
-preceded by several Release Candidates (RCs). The first RC is released three weeks before the scheduled GA date. This
-effectively means that there is a three-week feature freeze.
+preceded by several Release Candidates (RCs). The first RC is released seven weeks before the scheduled GA date. This
+effectively means that there is a seven-week feature freeze.
 
 These are the approximate release dates:
 
@@ -39,17 +40,6 @@ Dates may be shifted slightly to accommodate holidays. Those shifts should be mi
 Argo CD patch releases occur on an as-needed basis. Only the three most recent minor versions are eligible for patch
 releases. Versions older than the three most recent minor versions are considered EOL and will not receive bug fixes or
 security updates.
-
-#### Minor Release Planning Meeting
-
-Roughly two weeks before the RC date, there will be a meeting to discuss which features are planned for the RC. This meeting is
-for contributors to advocate for certain features. Features which have at least one approver (besides the contributor)
-who can assure they will review/merge by the RC date will be included in the release milestone. All other features will
-be dropped from the milestone (and potentially shifted to the next one).
-
-Since not everyone will be able to attend the meeting, there will be a meeting doc. Contributors can add their feature
-to a table, and Approvers can add their name to the table. Features with a corresponding approver will remain in the
-release milestone.
 
 #### Release Champion
 


### PR DESCRIPTION
I think the release planning meeting is too heavy-weight. Instead, we should use the contributors' meeting to tidy up the planning project.