### PR TITLE
docs: Add traefik pending ingress solution

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,6 +36,15 @@ which might cause health check to return `Progressing` state instead of `Healthy
 As workaround Argo CD allows providing [health check](operator-manual/health.md) customization which overrides default
 behavior.
 
+If you are using Traefik for your Ingress, you can update the Traefik config to publish the loadBalancer IP using [publishedservice](https://doc.traefik.io/traefik/providers/kubernetes-ingress/#publishedservice), which will resolve this issue. 
+
+```yaml
+providers:
+  kubernetesIngress:
+    publishedService:
+      enabled: true
+```
+
 ## I forgot the admin password, how do I reset it?
 
 For Argo CD v1.8 and earlier, the initial password is set to the name of the server pod, as


### PR DESCRIPTION
There is a [known issue](https://argo-cd.readthedocs.io/en/latest/faq/#why-is-my-application-stuck-in-progressing-state) where argo will consider an Ingress pending until there is a loadBalancer IP assigned.

This PR provides sample traefik configuration to resolve this issue. 

Tested and confirmed on my cluster, Argo v2.9.0 and Traefik v3 beta.

![image](https://github.com/argoproj/argo-cd/assets/5771615/20c96cab-52de-476d-b8ff-39473d424725)



Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

