### PR TITLE
fix(cli): pass redis compression to cluster stats and shards commands (#16060)

### DIFF
--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -211,7 +211,8 @@ func NewClusterShardsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
 
 	// parse all added flags and get the redis-compression flag that was added by parent command
-	command.Flags().Parse(os.Args[1:])
+	err := command.Flags().Parse(os.Args[1:])
+	errors.CheckError(err)
 	redisCompressionStr, _ = command.Flags().GetString(cacheutil.CLIFlagRedisCompress)
 	return &command
 }
@@ -492,7 +493,8 @@ func NewClusterStatsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
 
 	// parse all added flags and get the redis-compression flag that was added by parent command
-	command.Flags().Parse(os.Args[1:])
+	err := command.Flags().Parse(os.Args[1:])
+	errors.CheckError(err)
 	redisCompressionStr, _ = command.Flags().GetString(cacheutil.CLIFlagRedisCompress)
 	return &command
 }

--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -210,9 +210,10 @@ func NewClusterShardsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comm
 	command.Flags().BoolVar(&portForwardRedis, "port-forward-redis", true, "Automatically port-forward ha proxy redis from current namespace?")
 	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
 
-	// parse all added flags and get the redis-compression flag that was added by parent command
-	err := command.Flags().Parse(os.Args[1:])
-	errors.CheckError(err)
+	// parse all added flags so far to get the redis-compression flag that was added by AddCacheFlagsToCmd() above
+	// we can ignore unchecked error here as the command will be parsed again and checked when command.Execute() is run later
+	// nolint:errcheck
+	command.ParseFlags(os.Args[1:])
 	redisCompressionStr, _ = command.Flags().GetString(cacheutil.CLIFlagRedisCompress)
 	return &command
 }
@@ -492,9 +493,10 @@ func NewClusterStatsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 	command.Flags().BoolVar(&portForwardRedis, "port-forward-redis", true, "Automatically port-forward ha proxy redis from current namespace?")
 	cacheSrc = appstatecache.AddCacheFlagsToCmd(&command)
 
-	// parse all added flags and get the redis-compression flag that was added by parent command
-	err := command.Flags().Parse(os.Args[1:])
-	errors.CheckError(err)
+	// parse all added flags so far to get the redis-compression flag that was added by AddCacheFlagsToCmd() above
+	// we can ignore unchecked error here as the command will be parsed again and checked when command.Execute() is run later
+	// nolint:errcheck
+	command.ParseFlags(os.Args[1:])
 	redisCompressionStr, _ = command.Flags().GetString(cacheutil.CLIFlagRedisCompress)
 	return &command
 }

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -29,6 +29,11 @@ const (
 	defaultRedisRetryCount = 3
 )
 
+const (
+	// CLIFlagRedisCompress is a cli flag name to define the redis compression setting for data sent to redis
+	CLIFlagRedisCompress = "redis-compress"
+)
+
 func NewCache(client CacheClient) *Cache {
 	return &Cache{client}
 }
@@ -96,7 +101,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	cmd.Flags().StringVar(&redisClientKey, "redis-client-key", "", "Path to Redis client key (e.g. /etc/certs/redis/client.crt).")
 	cmd.Flags().BoolVar(&insecureRedis, "redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
 	cmd.Flags().StringVar(&redisCACertificate, "redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
-	cmd.Flags().StringVar(&compressionStr, "redis-compress", env.StringFromEnv("REDIS_COMPRESSION", string(RedisCompressionGZip)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none)")
+	cmd.Flags().StringVar(&compressionStr, CLIFlagRedisCompress, env.StringFromEnv("REDIS_COMPRESSION", string(RedisCompressionGZip)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none)")
 	return func() (*Cache, error) {
 		var tlsConfig *tls.Config = nil
 		if redisUseTLS {


### PR DESCRIPTION
Both `admin cluster stats` and `admin cluster shards` command still use hardcoded `RedisCompressionNone`. In case users are using Redis gzip compression, these commands return incorrect output. We should pass down the configuration from the `--redis-compress` flag (default gzip) to these subcommands.

Example bad output:
```
SERVER                                                                         SHARD  CONNECTION  NAMESPACES COUNT  APPS COUNT  RESOURCES COUNT
https://example-1-k8s.example.com                                              0                  10                 0           0
https://example-2-k8s.example.com                                              0                  10                 0           0
https://example-3-k8s.example.com                                              0                  10                 0           0
https://kubernetes.default.svc                                                 0                  5                  0           0
```

After the fix:
```
SERVER                                                                         SHARD  CONNECTION  NAMESPACES COUNT  APPS COUNT  RESOURCES COUNT
https://example-1-k8s.example.com                                              0      Successful  10                 201         4207
https://example-2-k8s.example.com                                              0      Successful  10                 172         2101
https://example-3-k8s.example.com                                              0      Successful  10                 108         889
https://kubernetes.default.svc                                                 0      Successful  5                  29          9877
```

The shard # number is still incorrect though, showing only `0` as the shard number. Most likely it's a regression introduced in https://github.com/argoproj/argo-cd/pull/13018
I will raise another PR later to address this.

Partially fixes: https://github.com/argoproj/argo-cd/issues/16060 (everything except the shard # number issue)

cc @clavinjune

Checklist:

* [x] ~~Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community,~~ (b) this is a bug fix, ~~or (c) this does not need to be in the release notes.~~
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates? N/A
* [ ] I've updated documentation as required by this PR. N/A
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
