### PR TITLE
fix: PerconaXtraDBCluster healthcheck (#16396)

### DIFF
--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health.lua
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/health.lua
@@ -27,7 +27,7 @@ if obj.status ~= nil then
 
   if obj.status.state == "error" then
     hs.status = "Degraded"
-    hs.message = "Cluster is on error: " .. table.concat(obj.status.messages, ", ")
+    hs.message = "Cluster is on error: " .. table.concat(obj.status.message, ", ")
     return hs
   end
 

--- a/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/error.yaml
+++ b/resource_customizations/pxc.percona.com/PerconaXtraDBCluster/testdata/error.yaml
@@ -12,7 +12,7 @@ status:
   pmm: {}
   proxysql: {}
   pxc:
-    image: ''
+    image: ""
     ready: 1
     size: 2
     status: error
@@ -20,5 +20,5 @@ status:
   ready: 1
   size: 2
   state: error
-  messages:
-  - we lost node
+  message:
+    - we lost node


### PR DESCRIPTION
The healthcheck for _pxc.percona.com/PerconaXtraDBCluster_ fails when the cluster is in _error_ state throwing
`<string>:30: bad argument #1 to concat (table expected, got nil)`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
Fixes #16396
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
