### PR TITLE
feat(argodb): count app-controller Pods instead of getting from Deployment replicas

### DIFF
--- a/util/db/db.go
+++ b/util/db/db.go
@@ -151,6 +151,8 @@ func StripCRLFCharacter(input string) string {
 }
 
 // GetApplicationControllerReplicas gets the replicas of application controller pods
+// using the app.kubernetes.io/name label selector
+// if it couldn't get the number of pods, it uses the env var ARGOCD_CONTROLLER_REPLICAS
 func (db *db) GetApplicationControllerReplicas() int {
 	var appControllerReplicas int
 	appControllerName := env.StringFromEnv(common.EnvAppControllerName, common.DefaultApplicationControllerName)

--- a/util/db/db_test.go
+++ b/util/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -760,15 +760,38 @@ func TestGetApplicationControllerReplicas(t *testing.T) {
 	assert.Equal(t, int(expectedReplicas), replicas)
 
 	expectedReplicas = int32(3)
-	clientset = getClientset(nil, &appv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      common.ApplicationController,
-			Namespace: testNamespace,
+	clientset = getClientset(nil,
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-0", common.ApplicationController),
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					common.LabelKeyAppName: common.DefaultApplicationControllerName,
+				},
+			},
+			Spec: v1.PodSpec{},
 		},
-		Spec: appv1.DeploymentSpec{
-			Replicas: &expectedReplicas,
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-1", common.ApplicationController),
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					common.LabelKeyAppName: common.DefaultApplicationControllerName,
+				},
+			},
+			Spec: v1.PodSpec{},
 		},
-	})
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-2", common.ApplicationController),
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					common.LabelKeyAppName: common.DefaultApplicationControllerName,
+				},
+			},
+			Spec: v1.PodSpec{},
+		},
+	)
 	t.Setenv(common.EnvControllerReplicas, "2")
 	db = NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
 	replicas = db.GetApplicationControllerReplicas()


### PR DESCRIPTION
The `GetApplicationControllerReplicas` function of `util/db` uses using Deployment spec directly to get the number of app-controller replicas. We can actually count the number of app-controller Pods instead. 

There are several benefits:
- it's currently not backwards-compatible with StatefulSet app-controller setup. Counting the number of app-controller pods supports both Deployment and StatefulSet setups (or if anyone uses any other custom replication controllers).
- the CLI command `argocd admin cluster stats` and `argocd admin cluster shards` are using the function (via [this](https://github.com/argoproj/argo-cd/blob/9e0e8d5e8a055ccc93b0bfbedcfa2eee91aaf5d3/cmd/argocd/commands/admin/cluster.go#L125-L127)) to get app-controller replicas when calculating cluster statistics. This command currently doesn't work with StatefulSet setups. I'll raise a separate fix PR for the cli.
- we can (later) count and watch Pod statuses, preferably using lister/informer, to make sure only running pods are taken into account for counting replicas. I'll leave this to future PRs.

Required to fix https://github.com/argoproj/argo-cd/issues/16060

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
