### PR TITLE
fix(cli): Show changed Secrets with argocd-cli app diff (#15825)

### DIFF
--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -8,7 +8,8 @@ Perform a diff against the target and live state.
 
 Perform a diff against the target and live state.
 Uses 'diff' to render the difference. KUBECTL_EXTERNAL_DIFF environment variable can be used to select your own diff tool.
-Returns the following exit codes: 2 on general errors, 1 when a diff is found, and 0 when no diff is found
+Returns the following exit codes: 2 on general errors, 1 when a diff is found, and 0 when no diff is found.
+Changes in Kubernetes Secrets will be reported, but their content will not be shown.
 
 ```
 argocd app diff APPNAME [flags]

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -799,14 +799,21 @@ func TestAppWithSecrets(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
+			// regular (server-side) diff should hide secret contents
 			diffOutput, err := RunCli("app", "diff", app.Name)
 			assert.Error(t, err)
 			assert.Contains(t, diffOutput, "username: ++++++++")
 			assert.Contains(t, diffOutput, "password: ++++++++++++")
+			assert.NotContains(t, diffOutput, "username: test-username")        // from "testdata/secrets/secrets.yaml"
+			assert.NotContains(t, diffOutput, "password: dGVzdC1wYXNzd29yZA==") // from "testdata/secrets/secrets.yaml"
 
-			// local diff should ignore secrets
-			diffOutput = FailOnErr(RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")).(string)
-			assert.Empty(t, diffOutput)
+			// local diff should also hide secrets
+			diffOutput, err = RunCli("app", "diff", app.Name, "--local", "testdata/secrets")
+			assert.Error(t, err)
+			assert.Contains(t, diffOutput, "username: ++++++++")
+			assert.Contains(t, diffOutput, "password: ++++++++++++")
+			assert.NotContains(t, diffOutput, "username: test-username")        // from "testdata/secrets/secrets.yaml"
+			assert.NotContains(t, diffOutput, "password: dGVzdC1wYXNzd29yZA==") // from "testdata/secrets/secrets.yaml
 
 			// ignore missing field and make sure diff shows no difference
 			app.Spec.IgnoreDifferences = []ResourceIgnoreDifferences{{


### PR DESCRIPTION
More than 4 years ago, the feature show changes of Kubernetes Secrets was removed from the `argocd app diff` command. I believe at the time the motivation for this was to avoid showing the *content* of Secrets on the command line (see https://github.com/argoproj/argo-cd/issues/1442 ).

Nowadays, the argocd-server component never replies with the content of a Secret, but instead simply flags the Secret as changed (this is currently exposed in the Argo CD Web UI).
However the CLI still has the left-over code that ignores Secret changes.

As discussed in https://github.com/argoproj/argo-cd/issues/15825 , this is an issue because:

* it is inconsistent between Argo CD Web UI and Argo CD CLI client (web UI flags changed Secrets, CLI completely ignores them)
* it is highly misleading for users because changed Secrets are not reported by the CLI.

Therefore, this PR reverts the behavior of *silently* not showing changed Secrets. It is safe to do this because the *content* of the changed Secrets are not shown to the user.

The tests have been updated to appropriately cover various edge cases.

Fixes https://github.com/argoproj/argo-cd/issues/15825

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
