### PR TITLE
fix(repo-server): excess git requests, short-circuit GenerateManifests ref only

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -510,6 +510,7 @@ func (s *Service) GenerateManifest(ctx context.Context, q *apiclient.ManifestReq
 
 	// Skip this path for ref only sources
 	if q.HasMultipleSources && q.ApplicationSource.Path == "" && q.ApplicationSource.Chart == "" && q.ApplicationSource.Ref != "" {
+		log.Debugf("Skipping manifest generation for ref only source for application: %s", q.AppName)
 		_, revision, err := s.newClientResolveRevision(q.Repo, q.Revision, git.WithCache(s.cache, !q.NoRevisionCache && !q.NoCache))
 		res = &apiclient.ManifestResponse{
 			Revision: revision,

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -510,7 +510,7 @@ func (s *Service) GenerateManifest(ctx context.Context, q *apiclient.ManifestReq
 
 	// Skip this path for ref only sources
 	if q.HasMultipleSources && q.ApplicationSource.Path == "" && q.ApplicationSource.Chart == "" && q.ApplicationSource.Ref != "" {
-		log.Debugf("Skipping manifest generation for ref only source for application: %s", q.AppName)
+		log.Debugf("Skipping manifest generation for ref only source for application: %s and ref %s", q.AppName, q.ApplicationSource.Ref)
 		_, revision, err := s.newClientResolveRevision(q.Repo, q.Revision, git.WithCache(s.cache, !q.NoRevisionCache && !q.NoCache))
 		res = &apiclient.ManifestResponse{
 			Revision: revision,

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -507,6 +507,16 @@ func resolveReferencedSources(hasMultipleSources bool, source *v1alpha1.Applicat
 func (s *Service) GenerateManifest(ctx context.Context, q *apiclient.ManifestRequest) (*apiclient.ManifestResponse, error) {
 	var res *apiclient.ManifestResponse
 	var err error
+
+	// Skip this path for ref only sources
+	if q.HasMultipleSources && q.ApplicationSource.Path == "" && q.ApplicationSource.Chart == "" && q.ApplicationSource.Ref != "" {
+		_, revision, err := s.newClientResolveRevision(q.Repo, q.Revision, git.WithCache(s.cache, !q.NoRevisionCache && !q.NoCache))
+		res = &apiclient.ManifestResponse{
+			Revision: revision,
+		}
+		return res, err
+	}
+
 	cacheFn := func(cacheKey string, refSourceCommitSHAs cache.ResolvedRevisions, firstInvocation bool) (bool, error) {
 		ok, resp, err := s.getManifestCacheEntry(cacheKey, q, refSourceCommitSHAs, firstInvocation)
 		res = resp

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -337,6 +337,62 @@ func TestGenerateManifests_EmptyCache(t *testing.T) {
 	gitMocks.AssertCalled(t, "Fetch", mock.Anything)
 }
 
+// Test that when Generate manifest is called with a source that is ref only it does not try to generate manifests or hit the manifest cache
+// but it does resolve and cache the revision
+func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
+	lsremoteCalled := false
+	dir := t.TempDir()
+	repopath := fmt.Sprintf("%s/tmprepo", dir)
+	repoRemote := fmt.Sprintf("file://%s", repopath)
+	cacheMocks := newCacheMocks()
+	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
+	service := NewService(metrics.NewMetricsServer(), cacheMocks.cache, RepoServerInitConstants{ParallelismLimit: 1}, argo.NewResourceTracking(), &git.NoopCredsStore{}, repopath)
+	service.newGitClient = func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (client git.Client, e error) {
+		opts = append(opts, git.WithEventHandlers(git.EventHandlers{
+			// Primary check, we want to make sure ls-remote is not called when the item is in cache
+			OnLsRemote: func(repo string) func() {
+				return func() {
+					lsremoteCalled = true
+				}
+			},
+			OnFetch: func(repo string) func() {
+				return func() {
+					assert.Fail(t, "Fetch should not be called from GenerateManifest when the source is ref only")
+				}
+			},
+		}))
+		gitClient, err := git.NewClientExt(rawRepoURL, root, creds, insecure, enableLfs, proxy, opts...)
+		return gitClient, err
+	}
+	revision := initGitRepo(t, newGitRepoOptions{
+		path:           repopath,
+		createPath:     true,
+		remote:         repoRemote,
+		addEmptyCommit: true,
+	})
+	src := argoappv1.ApplicationSource{RepoURL: repoRemote, TargetRevision: "HEAD", Ref: "test-ref"}
+	repo := &argoappv1.Repository{
+		Repo: repoRemote,
+	}
+	q := apiclient.ManifestRequest{
+		Repo:               repo,
+		Revision:           "HEAD",
+		HasMultipleSources: true,
+		ApplicationSource:  &src,
+		ProjectName:        "default",
+		ProjectSourceRepos: []string{"*"},
+	}
+	_, err := service.GenerateManifest(context.Background(), &q)
+	assert.NoError(t, err)
+	cacheMocks.mockCache.AssertCacheCalledTimes(t, &repositorymocks.CacheCallCounts{
+		ExternalSets: 1,
+		ExternalGets: 1})
+	assert.True(t, lsremoteCalled, "ls-remote should be called when the source is ref only")
+	var revisions [][2]string
+	assert.NoError(t, cacheMocks.cacheutilCache.GetItem(fmt.Sprintf("git-refs|%s", repoRemote), &revisions))
+	assert.ElementsMatch(t, [][2]string{{"refs/heads/main", revision}, {"HEAD", "ref: refs/heads/main"}}, revisions)
+}
+
 // Test that calling manifest generation on source helm reference helm files that when the revision is cached it does not call ls-remote
 func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 	dir := t.TempDir()
@@ -2758,7 +2814,7 @@ func initGitRepo(t *testing.T, options newGitRepoOptions) (revision string) {
 		assert.NoError(t, os.Mkdir(options.path, 0755))
 	}
 
-	cmd := exec.Command("git", "init", options.path)
+	cmd := exec.Command("git", "init", "-b", "main", options.path)
 	cmd.Dir = options.path
 	assert.NoError(t, cmd.Run())
 


### PR DESCRIPTION
Partially Fixes #14725

Second part of a split of the https://github.com/argoproj/argo-cd/pull/16309 and follow-up to https://github.com/argoproj/argo-cd/pull/16410. Continues the fixes required to remove the excess git requests when using multi-source and ref sources.

Issue:
When `GenerateManifest` is called with a ref only source manifest generation is still run, and since there are no manifests this is always considered a manifest cache miss causing an excess number of fetch requests to the git server

Changes:
Short-circuit calls to `GenerateManifest` when it is a ref only source, however as part of the short circuit still resolve the references if they are not already in cache, this can help prevent additional calls to ls-remote when `GenerateManifest` is called with a related manifest generating source 

Impact:
This PR should greatly reduce the number of fetch calls made to git for multi-source applications with a ref only source. Some minor improvements to ls-remote should be observed as well since we skip unnecessary git util calls.

There is one additional item (race condition fix) along with a performance improvement (move to two level-cache) that will be included in follow-up PRs to finish up the reduction of ls-remote calls

Baseline v2.9.0 with 200 multi-source applications with a ref only source:
![Screenshot from 2023-11-18 18-24-30](https://github.com/argoproj/argo-cd/assets/20120766/3a6b49d8-eb07-4aa9-8e8a-728c53520c63)

With the changes in the first PR under the same conditions:
![Screenshot from 2023-11-21 00-43-54](https://github.com/argoproj/argo-cd/assets/20120766/66a87d87-8f4c-429e-a6b9-f3a1e9dbd2b1)

With the changes from the first PR and this PR under the same conditions:
![Screenshot from 2023-11-21 01-23-41](https://github.com/nromriell/argo-cd/assets/20120766/a7a974f0-538b-4efe-b23d-dfebcce2ac29)


Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] Optional. My organization is added to USERS.md.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
