### PR TITLE
fix: cert-manager.io/certificate health.lua for consistent issuing (Issue #16523)

### DIFF
--- a/resource_customizations/cert-manager.io/Certificate/health.lua
+++ b/resource_customizations/cert-manager.io/Certificate/health.lua
@@ -2,7 +2,7 @@ local hs = {}
 if obj.status ~= nil then
   if obj.status.conditions ~= nil then
 
-    -- Always Handle Issueing First to ensure consistent behaviour
+    -- Always Handle Issuing First to ensure consistent behaviour
     for i, condition in ipairs(obj.status.conditions) do
       if condition.type == "Issuing" and condition.status == "True" then
         hs.status = "Progressing"

--- a/resource_customizations/cert-manager.io/Certificate/health.lua
+++ b/resource_customizations/cert-manager.io/Certificate/health.lua
@@ -1,12 +1,17 @@
 local hs = {}
 if obj.status ~= nil then
   if obj.status.conditions ~= nil then
+
+    -- Always Handle Issueing First to ensure consistent behaviour
     for i, condition in ipairs(obj.status.conditions) do
       if condition.type == "Issuing" and condition.status == "True" then
         hs.status = "Progressing"
         hs.message = condition.message
         return hs
       end
+    end
+
+    for i, condition in ipairs(obj.status.conditions) do
       if condition.type == "Ready" and condition.status == "False" then
         hs.status = "Degraded"
         hs.message = condition.message

--- a/resource_customizations/cert-manager.io/Certificate/health_test.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/health_test.yaml
@@ -8,6 +8,10 @@ tests:
     message: Issuing certificate as Secret does not exist
   inputPath: testdata/progressing_issuing.yaml
 - healthStatus:
+    status: Progressing
+    message: Issuing certificate as Secret does not exist
+  inputPath: testdata/progressing_issuing_last.yaml
+- healthStatus:
     status: Degraded
     message: 'Resource validation failed: spec.acme.config: Required value: no ACME
       solver configuration specified for domain "cd.apps.argoproj.io"'

--- a/resource_customizations/cert-manager.io/Certificate/testdata/progressing_issuing_last.yaml
+++ b/resource_customizations/cert-manager.io/Certificate/testdata/progressing_issuing_last.yaml
@@ -1,0 +1,36 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  creationTimestamp: '2018-11-07T00:06:12Z'
+  generation: 1
+  name: test-cert
+  namespace: argocd
+  resourceVersion: '64763033'
+  selfLink: /apis/cert-manager.io/v1alpha2/namespaces/argocd/certificates/test-cert
+  uid: e6cfba50-314d-11e9-be3f-42010a800011
+spec:
+  acme:
+    config:
+      - domains:
+          - cd.apps.argoproj.io
+        http01:
+          ingress: http01
+  commonName: cd.apps.argoproj.io
+  dnsNames:
+    - cd.apps.argoproj.io
+  issuerRef:
+    kind: Issuer
+    name: argo-cd-issuer
+  secretName: test-secret
+status:
+  conditions:
+    - lastTransitionTime: '2021-09-15T02:10:00Z'
+      message: Issuing certificate as Secret does not exist
+      reason: DoesNotExist
+      status: 'False'
+      type: Ready
+    - lastTransitionTime: '2021-09-15T02:10:00Z'
+      message: Issuing certificate as Secret does not exist
+      reason: DoesNotExist
+      status: 'True'
+      type: Issuing


### PR DESCRIPTION
Fixes [ISSUE #16523]

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->


The health of a cert-manager.io/certificate is not always consistent within ArgoCD when Issuing and Ready states both exist. This occurs because the `Ready: False` state may come first or second in the status conditions. 

Example Degraded
```
status:
  conditions:
    - lastTransitionTime: '2023-12-01T11:15:28Z'
      message: Issuing certificate as Secret does not exist
      observedGeneration: 1
      reason: DoesNotExist
      status: 'False'
      type: Ready
    - lastTransitionTime: '2023-12-01T11:15:28Z'
      message: Issuing certificate as Secret does not exist
      observedGeneration: 1
      reason: DoesNotExist
      status: 'True'
      type: Issuing
  nextPrivateKeySecretName: certtest-81-vg977
```

Example Issuing
```
status:
  conditions:
    - lastTransitionTime: '2023-12-01T11:15:28Z'
      message: Issuing certificate as Secret does not exist
      observedGeneration: 1
      reason: DoesNotExist
      status: 'True'
      type: Issuing
    - lastTransitionTime: '2023-12-01T11:15:28Z'
      message: Issuing certificate as Secret does not exist
      observedGeneration: 1
      reason: DoesNotExist
      status: 'False'
      type: Ready
  nextPrivateKeySecretName: certtest-82-f4r27
```

This PR checks for Issuing first and places the resource health into 'Progressing' state if True before considering the Ready status.


I've also add a new test case for this. With the previous health check that test case would be in a Degraded state.
