### PR TITLE
feat: Add meta.Duration as known type for diffing (issue #6008)

### DIFF
--- a/docs/user-guide/diffing.md
+++ b/docs/user-guide/diffing.md
@@ -181,4 +181,7 @@ data:
       type: core/v1/PodSpec
 ```
 
-The list of supported Kubernetes types is available in [diffing_known_types.txt](https://raw.githubusercontent.com/argoproj/argo-cd/master/util/argo/normalizers/diffing_known_types.txt)
+The list of supported Kubernetes types is available in [diffing_known_types.txt](https://raw.githubusercontent.com/argoproj/argo-cd/master/util/argo/normalizers/diffing_known_types.txt) and additionally:
+
+* `core/Quantity`
+* `meta/v1/duration`

--- a/util/argo/normalizers/knowntypes_normalizer.go
+++ b/util/argo/normalizers/knowntypes_normalizer.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -31,6 +32,9 @@ type knownTypesNormalizer struct {
 func init() {
 	knownTypes["core/Quantity"] = func() interface{} {
 		return &resource.Quantity{}
+	}
+	knownTypes["meta/v1/Duration"] = func() interface{} {
+		return &metav1.Duration{}
 	}
 }
 

--- a/util/argo/normalizers/knowntypes_normalizer_test.go
+++ b/util/argo/normalizers/knowntypes_normalizer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/argoproj/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
@@ -226,6 +227,33 @@ spec:
 		return
 	}
 	assert.Equal(t, "1250M", ram)
+}
+
+func TestNormalize_Duration(t *testing.T) {
+	cert := mustUnmarshalYAML(`
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-cert
+spec:
+  duration: 8760h
+`)
+	normalizer, err := NewKnownTypesNormalizer(map[string]v1alpha1.ResourceOverride{
+		"cert-manager.io/Certificate": {
+			KnownTypeFields: []v1alpha1.KnownTypeField{{
+				Type:  "meta/v1/Duration",
+				Field: "spec.duration",
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, normalizer.Normalize(cert))
+
+	duration, ok, err := unstructured.NestedFieldNoCopy(cert.Object, "spec", "duration")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "8760h0m0s", duration)
 }
 
 func TestFieldDoesNotExist(t *testing.T) {


### PR DESCRIPTION
So that this can be used for custom resources. The motivation for this
is issue #6008: with this change one should be able to use the known
type to ensure equal durations don't present a diff, e,g. via adding to
`argocd-cm`:

    data:
      resource.customizations.knownTypeFields.cert-manager.io_Certificate: |
        - field: spec.duration
          type: meta/v1/Duration

This change is based on 5b464c996bd5ebc1d39bb013af3bed34415d77d2, though
I've included the API version in the type path to be consistent with the
generated type (i.e. `meta/v1/Duration` and not `meta/Duration`).

For documentation I've just manually listed the extra types that aren't
auto-generated, though this requires having to keep this list and the
code in-sync but this is probably not a big issue since the number of
extra types is not frequently changed.

In the tests I've used `require.*` methods since I find this simpler
than `if !assert.Blah(...) { return }` which the other tests in this
file are using.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. **Note**: I've noted the related issue, but I'm not sure if this is sufficient to close that.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. **N/A**: nothing to expose
* [x] Does this PR require documentation updates?
* []x I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
