### PR TITLE
feat: PostDelete hook support

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/pkg/ratelimiter"
 	clustercache "github.com/argoproj/gitops-engine/pkg/cache"
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -59,6 +58,7 @@ import (
 
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/argoproj/argo-cd/v2/pkg/ratelimiter"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/errors"
@@ -884,11 +884,10 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 
 	if app.Operation != nil {
 		ctrl.processRequestedAppOperation(app)
-	} else if app.DeletionTimestamp != nil && app.CascadedDeletion() {
-		_, err = ctrl.finalizeApplicationDeletion(app, func(project string) ([]*appv1.Cluster, error) {
+	} else if app.DeletionTimestamp != nil {
+		if err = ctrl.finalizeApplicationDeletion(app, func(project string) ([]*appv1.Cluster, error) {
 			return ctrl.db.GetProjectClusters(context.Background(), project)
-		})
-		if err != nil {
+		}); err != nil {
 			ctrl.setAppCondition(app, appv1.ApplicationCondition{
 				Type:    appv1.ApplicationConditionDeletionError,
 				Message: err.Error(),
@@ -1023,65 +1022,69 @@ func (ctrl *ApplicationController) getPermittedAppLiveObjects(app *appv1.Applica
 	return objsMap, nil
 }
 
-func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Application, projectClusters func(project string) ([]*appv1.Cluster, error)) ([]*unstructured.Unstructured, error) {
+func (ctrl *ApplicationController) isValidDestination(app *appv1.Application) (bool, *argov1alpha.Cluster) {
+	// Validate the cluster using the Application destination's `name` field, if applicable,
+	// and set the Server field, if needed.
+	if err := argo.ValidateDestination(context.Background(), &app.Spec.Destination, ctrl.db); err != nil {
+		log.Warnf("Unable to validate destination of the Application being deleted: %v", err)
+		return false, nil
+	}
+
+	cluster, err := ctrl.db.GetCluster(context.Background(), app.Spec.Destination.Server)
+	if err != nil {
+		log.Warnf("Unable to locate cluster URL for Application being deleted: %v", err)
+		return false, nil
+	}
+	return true, cluster
+}
+
+func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Application, projectClusters func(project string) ([]*appv1.Cluster, error)) error {
 	logCtx := log.WithField("application", app.QualifiedName())
-	logCtx.Infof("Deleting resources")
 	// Get refreshed application info, since informer app copy might be stale
 	app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
 	if err != nil {
 		if !apierr.IsNotFound(err) {
 			logCtx.Errorf("Unable to get refreshed application info prior deleting resources: %v", err)
 		}
-		return nil, nil
+		return nil
 	}
 	proj, err := ctrl.getAppProj(app)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	// validDestination is true if the Application destination points to a cluster that is managed by Argo CD
-	// (and thus either a cluster secret exists for it, or it's local); validDestination is false otherwise.
-	validDestination := true
-
-	// Validate the cluster using the Application destination's `name` field, if applicable,
-	// and set the Server field, if needed.
-	if err := argo.ValidateDestination(context.Background(), &app.Spec.Destination, ctrl.db); err != nil {
-		log.Warnf("Unable to validate destination of the Application being deleted: %v", err)
-		validDestination = false
-	}
-
-	objs := make([]*unstructured.Unstructured, 0)
-	var cluster *appv1.Cluster
-
-	// Attempt to validate the destination via its URL
-	if validDestination {
-		if cluster, err = ctrl.db.GetCluster(context.Background(), app.Spec.Destination.Server); err != nil {
-			log.Warnf("Unable to locate cluster URL for Application being deleted: %v", err)
-			validDestination = false
+	isValid, cluster := ctrl.isValidDestination(app)
+	if !isValid {
+		app.UnSetCascadedDeletion()
+		app.UnSetPostDeleteFinalizer()
+		if err := ctrl.updateFinalizers(app); err != nil {
+			return err
 		}
+		logCtx.Infof("Resource entries removed from undefined cluster")
+		return nil
 	}
+	config := metrics.AddMetricsTransportWrapper(ctrl.metricsServer, app, cluster.RESTConfig())
 
-	if validDestination {
+	if app.CascadedDeletion() {
+		logCtx.Infof("Deleting resources")
 		// ApplicationDestination points to a valid cluster, so we may clean up the live objects
-
+		objs := make([]*unstructured.Unstructured, 0)
 		objsMap, err := ctrl.getPermittedAppLiveObjects(app, proj, projectClusters)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		for k := range objsMap {
 			// Wait for objects pending deletion to complete before proceeding with next sync wave
 			if objsMap[k].GetDeletionTimestamp() != nil {
 				logCtx.Infof("%d objects remaining for deletion", len(objsMap))
-				return objs, nil
+				return nil
 			}
 
 			if ctrl.shouldBeDeleted(app, objsMap[k]) {
 				objs = append(objs, objsMap[k])
 			}
 		}
-
-		config := metrics.AddMetricsTransportWrapper(ctrl.metricsServer, app, cluster.RESTConfig())
 
 		filteredObjs := FilterObjectsForDeletion(objs)
 
@@ -1096,12 +1099,12 @@ func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Applic
 			return ctrl.kubectl.DeleteResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 		})
 		if err != nil {
-			return objs, err
+			return err
 		}
 
 		objsMap, err = ctrl.getPermittedAppLiveObjects(app, proj, projectClusters)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		for k, obj := range objsMap {
@@ -1111,38 +1114,68 @@ func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Applic
 		}
 		if len(objsMap) > 0 {
 			logCtx.Infof("%d objects remaining for deletion", len(objsMap))
-			return objs, nil
+			return nil
 		}
-	}
-
-	if err := ctrl.cache.SetAppManagedResources(app.Name, nil); err != nil {
-		return objs, err
-	}
-
-	if err := ctrl.cache.SetAppResourcesTree(app.Name, nil); err != nil {
-		return objs, err
-	}
-
-	if err := ctrl.removeCascadeFinalizer(app); err != nil {
-		return objs, err
-	}
-
-	if validDestination {
 		logCtx.Infof("Successfully deleted %d resources", len(objs))
-	} else {
 		logCtx.Infof("Resource entries removed from undefined cluster")
+		app.UnSetCascadedDeletion()
+		return ctrl.updateFinalizers(app)
 	}
 
-	ctrl.projectRefreshQueue.Add(fmt.Sprintf("%s/%s", ctrl.namespace, app.Spec.GetProject()))
-	return objs, nil
+	if app.HasPostDeleteFinalizer() {
+		objsMap, err := ctrl.getPermittedAppLiveObjects(app, proj, projectClusters)
+		if err != nil {
+			return err
+		}
+
+		done, err := ctrl.executePostDeleteHooks(app, proj, objsMap, config, logCtx)
+		if err != nil {
+			return err
+		}
+		if !done {
+			return nil
+		}
+		app.UnSetPostDeleteFinalizer()
+		return ctrl.updateFinalizers(app)
+	}
+
+	if app.HasPostDeleteFinalizer("cleanup") {
+		objsMap, err := ctrl.getPermittedAppLiveObjects(app, proj, projectClusters)
+		if err != nil {
+			return err
+		}
+
+		done, err := ctrl.cleanupPostDeleteHooks(objsMap, config, logCtx)
+		if err != nil {
+			return err
+		}
+		if !done {
+			return nil
+		}
+		app.UnSetPostDeleteFinalizer("cleanup")
+		return ctrl.updateFinalizers(app)
+	}
+
+	if !app.CascadedDeletion() && !app.HasPostDeleteFinalizer() {
+		if err := ctrl.cache.SetAppManagedResources(app.Name, nil); err != nil {
+			return err
+		}
+
+		if err := ctrl.cache.SetAppResourcesTree(app.Name, nil); err != nil {
+			return err
+		}
+		ctrl.projectRefreshQueue.Add(fmt.Sprintf("%s/%s", ctrl.namespace, app.Spec.GetProject()))
+	}
+
+	return nil
 }
 
-func (ctrl *ApplicationController) removeCascadeFinalizer(app *appv1.Application) error {
+func (ctrl *ApplicationController) updateFinalizers(app *appv1.Application) error {
 	_, err := ctrl.getAppProj(app)
 	if err != nil {
 		return fmt.Errorf("error getting project: %w", err)
 	}
-	app.UnSetCascadedDeletion()
+
 	var patch []byte
 	patch, _ = json.Marshal(map[string]interface{}{
 		"metadata": map[string]interface{}{
@@ -1566,6 +1599,20 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 	app.Status.SourceTypes = compareResult.appSourceTypes
 	app.Status.ControllerNamespace = ctrl.namespace
 	patchMs = ctrl.persistAppStatus(origApp, &app.Status)
+	if (compareResult.hasPostDeleteHooks != app.HasPostDeleteFinalizer() || compareResult.hasPostDeleteHooks != app.HasPostDeleteFinalizer("cleanup")) &&
+		app.GetDeletionTimestamp() == nil {
+		if compareResult.hasPostDeleteHooks {
+			app.SetPostDeleteFinalizer()
+			app.SetPostDeleteFinalizer("cleanup")
+		} else {
+			app.UnSetPostDeleteFinalizer()
+			app.UnSetPostDeleteFinalizer("cleanup")
+		}
+
+		if err := ctrl.updateFinalizers(app); err != nil {
+			logCtx.Errorf("Failed to update finalizers: %v", err)
+		}
+	}
 	return
 }
 

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1117,7 +1117,6 @@ func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Applic
 			return nil
 		}
 		logCtx.Infof("Successfully deleted %d resources", len(objs))
-		logCtx.Infof("Resource entries removed from undefined cluster")
 		app.UnSetCascadedDeletion()
 		return ctrl.updateFinalizers(app)
 	}

--- a/controller/hook.go
+++ b/controller/hook.go
@@ -1,0 +1,148 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/argoproj/gitops-engine/pkg/sync/hook"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+
+	"github.com/argoproj/argo-cd/v2/util/lua"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+)
+
+var (
+	postDeleteHook  = "PostDelete"
+	postDeleteHooks = map[string]string{
+		"argocd.argoproj.io/hook": postDeleteHook,
+		"helm.sh/hook":            "post-delete",
+	}
+)
+
+func isHook(obj *unstructured.Unstructured) bool {
+	return hook.IsHook(obj) || isPostDeleteHook(obj)
+}
+
+func isPostDeleteHook(obj *unstructured.Unstructured) bool {
+	if obj == nil || obj.GetAnnotations() == nil {
+		return false
+	}
+	for k, v := range postDeleteHooks {
+		if val, ok := obj.GetAnnotations()[k]; ok && val == v {
+			return true
+		}
+	}
+	return false
+}
+
+func (ctrl *ApplicationController) executePostDeleteHooks(app *v1alpha1.Application, proj *v1alpha1.AppProject, liveObjs map[kube.ResourceKey]*unstructured.Unstructured, config *rest.Config, logCtx *log.Entry) (bool, error) {
+	appLabelKey, err := ctrl.settingsMgr.GetAppInstanceLabelKey()
+	if err != nil {
+		return false, err
+	}
+	var revisions []string
+	for _, src := range app.Spec.GetSources() {
+		revisions = append(revisions, src.TargetRevision)
+	}
+
+	targets, _, err := ctrl.appStateManager.GetRepoObjs(app, app.Spec.GetSources(), appLabelKey, revisions, false, false, false, proj)
+	if err != nil {
+		return false, err
+	}
+	runningHooks := map[kube.ResourceKey]*unstructured.Unstructured{}
+	for key, obj := range liveObjs {
+		if isPostDeleteHook(obj) {
+			runningHooks[key] = obj
+		}
+	}
+
+	expectedHook := map[kube.ResourceKey]*unstructured.Unstructured{}
+	for _, obj := range targets {
+		if obj.GetNamespace() == "" {
+			obj.SetNamespace(app.Spec.Destination.Namespace)
+		}
+		if !isPostDeleteHook(obj) {
+			continue
+		}
+		if runningHook := runningHooks[kube.GetResourceKey(obj)]; runningHook == nil {
+			expectedHook[kube.GetResourceKey(obj)] = obj
+		}
+	}
+	createdCnt := 0
+	for _, obj := range expectedHook {
+		_, err = ctrl.kubectl.CreateResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), obj, v1.CreateOptions{})
+		if err != nil {
+			return false, err
+		}
+		createdCnt++
+	}
+	if createdCnt > 0 {
+		logCtx.Infof("Created %d post-delete hooks", createdCnt)
+		return false, nil
+	}
+	resourceOverrides, err := ctrl.settingsMgr.GetResourceOverrides()
+	if err != nil {
+		return false, err
+	}
+	healthOverrides := lua.ResourceHealthOverrides(resourceOverrides)
+
+	progressingHooksCnt := 0
+	for _, obj := range runningHooks {
+		hookHealth, err := health.GetResourceHealth(obj, healthOverrides)
+		if err != nil {
+			return false, err
+		}
+		if hookHealth.Status == health.HealthStatusProgressing {
+			progressingHooksCnt++
+		}
+	}
+	if progressingHooksCnt > 0 {
+		logCtx.Infof("Waiting for %d post-delete hooks to complete", progressingHooksCnt)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ctrl *ApplicationController) cleanupPostDeleteHooks(liveObjs map[kube.ResourceKey]*unstructured.Unstructured, config *rest.Config, logCtx *log.Entry) (bool, error) {
+	resourceOverrides, err := ctrl.settingsMgr.GetResourceOverrides()
+	if err != nil {
+		return false, err
+	}
+	healthOverrides := lua.ResourceHealthOverrides(resourceOverrides)
+
+	pendingDeletionCount := 0
+	for _, obj := range liveObjs {
+		if !isPostDeleteHook(obj) {
+			continue
+		}
+		hookHealth, err := health.GetResourceHealth(obj, healthOverrides)
+		if err != nil {
+			return false, err
+		}
+		for _, policy := range hook.DeletePolicies(obj) {
+			if policy == common.HookDeletePolicyHookFailed && hookHealth.Status == health.HealthStatusDegraded || policy == common.HookDeletePolicyHookSucceeded && hookHealth.Status == health.HealthStatusHealthy {
+				pendingDeletionCount++
+				if obj.GetDeletionTimestamp() != nil {
+					continue
+				}
+				logCtx.Infof("Deleting post-delete hook %s/%s", obj.GetNamespace(), obj.GetName())
+				err = ctrl.kubectl.DeleteResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), v1.DeleteOptions{})
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+	}
+	if pendingDeletionCount > 0 {
+		logCtx.Infof("Waiting for %d post-delete hooks to be deleted", pendingDeletionCount)
+		return false, nil
+	}
+	return true, nil
+}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -283,6 +283,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		sync.WithInitialState(state.Phase, state.Message, initialResourcesRes, state.StartedAt),
 		sync.WithResourcesFilter(func(key kube.ResourceKey, target *unstructured.Unstructured, live *unstructured.Unstructured) bool {
 			return (len(syncOp.Resources) == 0 ||
+				isPostDeleteHook(target) ||
 				argo.ContainsSyncResource(key.Name, key.Namespace, schema.GroupVersionKind{Kind: key.Kind, Group: key.Group}, syncOp.Resources)) &&
 				m.isSelfReferencedObj(live, target, app.GetName(), appLabelKey, trackingMethod)
 		}),

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -210,7 +210,7 @@ is any normal Kubernetes resource annotated with the `helm.sh/hook` annotation.
 Argo CD supports many (most?) Helm hooks by mapping the Helm annotations onto Argo CD's own hook annotations:
 
 | Helm Annotation                 | Notes                                                                                         |
-| ------------------------------- | --------------------------------------------------------------------------------------------- |
+| ------------------------------- |-----------------------------------------------------------------------------------------------|
 | `helm.sh/hook: crd-install`     | Supported as equivalent to `argocd.argoproj.io/hook: PreSync`.                                |
 | `helm.sh/hook: pre-delete`      | Not supported. In Helm stable there are 3 cases used to clean up CRDs and 3 to clean-up jobs. |
 | `helm.sh/hook: pre-rollback`    | Not supported. Never used in Helm stable.                                                     |
@@ -218,7 +218,7 @@ Argo CD supports many (most?) Helm hooks by mapping the Helm annotations onto Ar
 | `helm.sh/hook: pre-upgrade`     | Supported as equivalent to `argocd.argoproj.io/hook: PreSync`.                                |
 | `helm.sh/hook: post-upgrade`    | Supported as equivalent to `argocd.argoproj.io/hook: PostSync`.                               |
 | `helm.sh/hook: post-install`    | Supported as equivalent to `argocd.argoproj.io/hook: PostSync`.                               |
-| `helm.sh/hook: post-delete`     | Not supported. Never used in Helm stable.                                                     |
+| `helm.sh/hook: post-delete`     | Supported as equivalent to `argocd.argoproj.io/hook: PostDelete`.                             |
 | `helm.sh/hook: post-rollback`   | Not supported. Never used in Helm stable.                                                     |
 | `helm.sh/hook: test-success`    | Not supported. No equivalent in Argo CD.                                                      |
 | `helm.sh/hook: test-failure`    | Not supported. No equivalent in Argo CD.                                                      |

--- a/docs/user-guide/resource_hooks.md
+++ b/docs/user-guide/resource_hooks.md
@@ -9,6 +9,8 @@ and after a Sync operation. Hooks can also be run if a Sync operation fails at a
 Kubernetes rolling update strategy.
 * Using a `PostSync` hook to run integration and health checks after a deployment.
 * Using a `SyncFail` hook to run clean-up or finalizer logic if a Sync operation fails. _`SyncFail` hooks are only available starting in v1.2_
+* Using a `PostDelete` hook to run clean-up or finalizer logic after an all Application resources are deleted. Please note that
+  `PostDelete` hooks are only deleted if delete policy matches to the aggregated deletion hooks status and not garbage collected after the application is deleted. 
 
 ## Usage
 

--- a/pkg/apis/application/v1alpha1/application_defaults.go
+++ b/pkg/apis/application/v1alpha1/application_defaults.go
@@ -9,6 +9,9 @@ const (
 	// ResourcesFinalizerName is the finalizer value which we inject to finalize deletion of an application
 	ResourcesFinalizerName string = "resources-finalizer.argocd.argoproj.io"
 
+	// PostDeleteFinalizerName is the finalizer that controls post-delete hooks execution
+	PostDeleteFinalizerName string = "post-delete-finalizer.argocd.argoproj.io"
+
 	// ForegroundPropagationPolicyFinalizer is the finalizer we inject to delete application with foreground propagation policy
 	ForegroundPropagationPolicyFinalizer string = "resources-finalizer.argocd.argoproj.io/foreground"
 

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2651,6 +2651,18 @@ func (app *Application) IsRefreshRequested() (RefreshType, bool) {
 	return refreshType, true
 }
 
+func (app *Application) HasPostDeleteFinalizer(stage ...string) bool {
+	return getFinalizerIndex(app.ObjectMeta, strings.Join(append([]string{PostDeleteFinalizerName}, stage...), "/")) > -1
+}
+
+func (app *Application) SetPostDeleteFinalizer(stage ...string) {
+	setFinalizer(&app.ObjectMeta, strings.Join(append([]string{PostDeleteFinalizerName}, stage...), "/"), true)
+}
+
+func (app *Application) UnSetPostDeleteFinalizer(stage ...string) {
+	setFinalizer(&app.ObjectMeta, strings.Join(append([]string{PostDeleteFinalizerName}, stage...), "/"), false)
+}
+
 // SetCascadedDeletion will enable cascaded deletion by setting the propagation policy finalizer
 func (app *Application) SetCascadedDeletion(finalizer string) {
 	setFinalizer(&app.ObjectMeta, finalizer, true)

--- a/test/e2e/hook_test.go
+++ b/test/e2e/hook_test.go
@@ -1,12 +1,14 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
@@ -46,6 +48,24 @@ func testHookSuccessful(t *testing.T, hookType HookType) {
 		Expect(ResourceHealthIs("Pod", "pod", health.HealthStatusHealthy)).
 		Expect(ResourceResultNumbering(2)).
 		Expect(ResourceResultIs(ResourceResult{Version: "v1", Kind: "Pod", Namespace: DeploymentNamespace(), Name: "hook", Message: "pod/hook created", HookType: hookType, HookPhase: OperationSucceeded, SyncPhase: SyncPhase(hookType)}))
+}
+
+func TestPostDeleteHook(t *testing.T) {
+	Given(t).
+		Path("post-delete-hook").
+		When().
+		CreateApp().
+		Refresh(RefreshTypeNormal).
+		Delete(true).
+		Then().
+		Expect(DoesNotExist()).
+		AndAction(func() {
+			hooks, err := KubeClientset.CoreV1().Pods(DeploymentNamespace()).List(context.Background(), metav1.ListOptions{})
+			CheckError(err)
+			assert.Len(t, hooks.Items, 1)
+			assert.Equal(t, "hook", hooks.Items[0].Name)
+		})
+
 }
 
 // make sure that that hooks do not appear in "argocd app diff"

--- a/test/e2e/testdata/post-delete-hook/hook.yaml
+++ b/test/e2e/testdata/post-delete-hook/hook.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PostDelete
+  name: hook
+spec:
+  containers:
+    - command:
+        - "true"
+      image: quay.io/argoprojlabs/argocd-e2e-container:0.1
+      imagePullPolicy: IfNotPresent
+      name: main
+  restartPolicy: Never


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/7575

PR introduces Post delete hooks support. Hooks are executed during application deletion after all resources as removed. Hooks respect deletion policies.

* [x] PostDelete hooks
* [x] Docs
* [x] Hooks delete policy
* [x] Tests



https://github.com/argoproj/argo-cd/assets/426437/038bc145-137d-46f5-a252-b10b976edbc7



