### PR TITLE
fix(action): Add missing owner references and annotation to the create-job action (#16606)

### DIFF
--- a/resource_customizations/batch/CronJob/actions/create-job/action.lua
+++ b/resource_customizations/batch/CronJob/actions/create-job/action.lua
@@ -38,12 +38,18 @@ if job.metadata == nil then
 end
 job.metadata.name = obj.metadata.name .. "-" ..os.date("!%Y%m%d%H%M")
 job.metadata.namespace = obj.metadata.namespace
+if job.metadata.annotations == nil then
+  job.metadata.annotations = {}
+end
+job.metadata.annotations['cronjob.kubernetes.io/instantiate'] = "manual"
 
 local ownerRef = {}
 ownerRef.apiVersion = obj.apiVersion
 ownerRef.kind = obj.kind
 ownerRef.name = obj.metadata.name
 ownerRef.uid = obj.metadata.uid
+ownerRef.blockOwnerDeletion = true
+ownerRef.controller = true
 job.metadata.ownerReferences = {}
 job.metadata.ownerReferences[1] = ownerRef
 

--- a/resource_customizations/batch/CronJob/actions/testdata/job.yaml
+++ b/resource_customizations/batch/CronJob/actions/testdata/job.yaml
@@ -8,6 +8,7 @@
       labels:
         my: label
       annotations:
+        cronjob.kubernetes.io/instantiate: manual
         my: annotation
     spec:
       ttlSecondsAfterFinished: 100


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. - `doesn't need to be updated`
* [x] Does this PR require documentation updates? - `No`
* [ ] I've updated documentation as required by this PR. - `No documents to update`
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. - `Have updated the existing unit test to include the added annotation`
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
Closes #16606

When we trigger action "Create Job" it is expected to perform as `kubectl create job --from=<CRON_JOB_NAME>` command. The jobs created should be correctly owned by the CronJob so that the `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` fields work as intended. This PR fixes the issue mentioned above. It also adds an annotation that the kubectl command above adds to jobs created from a cronjob.