### PR TITLE
feat: webhook should use 'rename' to copy app manifests of previous commit

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -6,11 +6,12 @@ import (
 	"math"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/pkg/ratelimiter"
 	"github.com/argoproj/pkg/stats"
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/controller/sharding"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
+	"github.com/argoproj/argo-cd/v2/pkg/ratelimiter"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
@@ -31,8 +33,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/settings"
 	"github.com/argoproj/argo-cd/v2/util/tls"
 	"github.com/argoproj/argo-cd/v2/util/trace"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -227,8 +227,10 @@ func NewCommand() *cobra.Command {
 	command.Flags().Float64Var(&workqueueRateLimit.BackoffFactor, "wq-backoff-factor", env.ParseFloat64FromEnv("WORKQUEUE_BACKOFF_FACTOR", 1.5, 0, math.MaxFloat64), "Set Workqueue Per Item Rate Limiter Backoff Factor, default is 1.5")
 	command.Flags().BoolVar(&enableDynamicClusterDistribution, "dynamic-cluster-distribution-enabled", env.ParseBoolFromEnv(common.EnvEnableDynamicClusterDistribution, false), "Enables dynamic cluster distribution.")
 	command.Flags().BoolVar(&serverSideDiff, "server-side-diff-enabled", env.ParseBoolFromEnv(common.EnvServerSideDiff, false), "Feature flag to enable ServerSide diff. Default (\"false\")")
-	cacheSource = appstatecache.AddCacheFlagsToCmd(&command, func(client *redis.Client) {
-		redisClient = client
+	cacheSource = appstatecache.AddCacheFlagsToCmd(&command, cacheutil.Options{
+		OnClientCreated: func(client *redis.Client) {
+			redisClient = client
+		},
 	})
 	return &command
 }

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -210,8 +210,10 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&helmManifestMaxExtractedSize, "helm-manifest-max-extracted-size", env.StringFromEnv("ARGOCD_REPO_SERVER_HELM_MANIFEST_MAX_EXTRACTED_SIZE", "1G"), "Maximum size of helm manifest archives when extracted")
 	command.Flags().BoolVar(&disableManifestMaxExtractedSize, "disable-helm-manifest-max-extracted-size", env.ParseBoolFromEnv("ARGOCD_REPO_SERVER_DISABLE_HELM_MANIFEST_MAX_EXTRACTED_SIZE", false), "Disable maximum size of helm manifest archives when extracted")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(&command)
-	cacheSrc = reposervercache.AddCacheFlagsToCmd(&command, func(client *redis.Client) {
-		redisClient = client
+	cacheSrc = reposervercache.AddCacheFlagsToCmd(&command, cacheutil.Options{
+		OnClientCreated: func(client *redis.Client) {
+			redisClient = client
+		},
 	})
 	return &command
 }

--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -18,8 +18,10 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
+	reposervercache "github.com/argoproj/argo-cd/v2/reposerver/cache"
 	"github.com/argoproj/argo-cd/v2/server"
 	servercache "github.com/argoproj/argo-cd/v2/server/cache"
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	"github.com/argoproj/argo-cd/v2/util/cli"
 	"github.com/argoproj/argo-cd/v2/util/dex"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -64,6 +66,7 @@ func NewCommand() *cobra.Command {
 		enableGZip               bool
 		tlsConfigCustomizerSrc   func() (tls.ConfigCustomizer, error)
 		cacheSrc                 func() (*servercache.Cache, error)
+		repoServerCacheSrc       func() (*reposervercache.Cache, error)
 		frameOptions             string
 		contentSecurityPolicy    string
 		repoServerPlaintext      bool
@@ -104,6 +107,8 @@ func NewCommand() *cobra.Command {
 			tlsConfigCustomizer, err := tlsConfigCustomizerSrc()
 			errors.CheckError(err)
 			cache, err := cacheSrc()
+			errors.CheckError(err)
+			repoServerCache, err := repoServerCacheSrc()
 			errors.CheckError(err)
 
 			kubeclientset := kubernetes.NewForConfigOrDie(config)
@@ -183,6 +188,7 @@ func NewCommand() *cobra.Command {
 				EnableGZip:            enableGZip,
 				TLSConfigCustomizer:   tlsConfigCustomizer,
 				Cache:                 cache,
+				RepoServerCache:       repoServerCache,
 				XFrameOptions:         frameOptions,
 				ContentSecurityPolicy: contentSecurityPolicy,
 				RedisClient:           redisClient,
@@ -254,8 +260,11 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringSliceVar(&applicationNamespaces, "application-namespaces", env.StringsFromEnv("ARGOCD_APPLICATION_NAMESPACES", []string{}, ","), "List of additional namespaces where application resources can be managed in")
 	command.Flags().BoolVar(&enableProxyExtension, "enable-proxy-extension", env.ParseBoolFromEnv("ARGOCD_SERVER_ENABLE_PROXY_EXTENSION", false), "Enable Proxy Extension feature")
 	tlsConfigCustomizerSrc = tls.AddTLSFlagsToCmd(command)
-	cacheSrc = servercache.AddCacheFlagsToCmd(command, func(client *redis.Client) {
-		redisClient = client
+	cacheSrc = servercache.AddCacheFlagsToCmd(command, cacheutil.Options{
+		OnClientCreated: func(client *redis.Client) {
+			redisClient = client
+		},
 	})
+	repoServerCacheSrc = reposervercache.AddCacheFlagsToCmd(command, cacheutil.Options{FlagPrefix: "repo-server-"})
 	return command
 }

--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -78,6 +78,12 @@ func (c *forwardCacheClient) Set(item *cache.Item) error {
 	})
 }
 
+func (c *forwardCacheClient) Rename(oldKey string, newKey string, expiration time.Duration) error {
+	return c.doLazy(func(client cache.CacheClient) error {
+		return client.Rename(oldKey, newKey, expiration)
+	})
+}
+
 func (c *forwardCacheClient) Get(key string, obj interface{}) error {
 	return c.doLazy(func(client cache.CacheClient) error {
 		return client.Get(key, obj)

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -25,73 +25,86 @@ argocd-server [flags]
 ### Options
 
 ```
-      --address string                                Listen on given address (default "0.0.0.0")
-      --app-state-cache-expiration duration           Cache expiration for app state (default 1h0m0s)
-      --application-namespaces strings                List of additional namespaces where application resources can be managed in
-      --as string                                     Username to impersonate for the operation
-      --as-group stringArray                          Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --as-uid string                                 UID to impersonate for the operation
-      --basehref string                               Value for base href in index.html. Used if Argo CD is running behind reverse proxy under subpath different from / (default "/")
-      --certificate-authority string                  Path to a cert file for the certificate authority
-      --client-certificate string                     Path to a client certificate file for TLS
-      --client-key string                             Path to a client key file for TLS
-      --cluster string                                The name of the kubeconfig cluster to use
-      --connection-status-cache-expiration duration   Cache expiration for cluster/repo connection status (default 1h0m0s)
-      --content-security-policy value                 Set Content-Security-Policy header in HTTP responses to value. To disable, set to "". (default "frame-ancestors 'self';")
-      --context string                                The name of the kubeconfig context to use
-      --default-cache-expiration duration             Cache expiration default (default 24h0m0s)
-      --dex-server string                             Dex server address (default "argocd-dex-server:5556")
-      --dex-server-plaintext                          Use a plaintext client (non-TLS) to connect to dex server
-      --dex-server-strict-tls                         Perform strict validation of TLS certificates when connecting to dex server
-      --disable-auth                                  Disable client authentication
-      --disable-compression                           If true, opt-out of response compression for all requests to the server
-      --enable-gzip                                   Enable GZIP compression (default true)
-      --enable-proxy-extension                        Enable Proxy Extension feature
-      --gloglevel int                                 Set the glog logging level
-  -h, --help                                          help for argocd-server
-      --insecure                                      Run server without TLS
-      --insecure-skip-tls-verify                      If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                             Path to a kube config. Only required if out-of-cluster
-      --logformat string                              Set the logging format. One of: text|json (default "text")
-      --login-attempts-expiration duration            Cache expiration for failed login attempts (default 24h0m0s)
-      --loglevel string                               Set the logging level. One of: debug|info|warn|error (default "info")
-      --metrics-address string                        Listen for metrics on given address (default "0.0.0.0")
-      --metrics-port int                              Start metrics on given port (default 8083)
-  -n, --namespace string                              If present, the namespace scope for this CLI request
-      --oidc-cache-expiration duration                Cache expiration for OIDC state (default 3m0s)
-      --otlp-address string                           OpenTelemetry collector address to send traces to
-      --otlp-attrs strings                            List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)
-      --otlp-headers stringToString                   List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2) (default [])
-      --otlp-insecure                                 OpenTelemetry collector insecure mode (default true)
-      --password string                               Password for basic authentication to the API server
-      --port int                                      Listen on given port (default 8080)
-      --proxy-url string                              If provided, this URL will be used to connect via proxy
-      --redis string                                  Redis server hostname and port (e.g. argocd-redis:6379). 
-      --redis-ca-certificate string                   Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
-      --redis-client-certificate string               Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
-      --redis-client-key string                       Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                         Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
-      --redis-insecure-skip-tls-verify                Skip Redis server certificate validation.
-      --redis-use-tls                                 Use TLS when connecting to Redis. 
-      --redisdb int                                   Redis database.
-      --repo-server string                            Repo server address (default "argocd-repo-server:8081")
-      --repo-server-plaintext                         Use a plaintext client (non-TLS) to connect to repository server
-      --repo-server-strict-tls                        Perform strict validation of TLS certificates when connecting to repo server
-      --repo-server-timeout-seconds int               Repo server RPC call timeout seconds. (default 60)
-      --request-timeout string                        The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --rootpath string                               Used if Argo CD is running behind reverse proxy under subpath different from /
-      --sentinel stringArray                          Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
-      --sentinelmaster string                         Redis sentinel master group name. (default "master")
-      --server string                                 The address and port of the Kubernetes API server
-      --staticassets string                           Directory path that contains additional static assets (default "/shared/app")
-      --tls-server-name string                        If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --tlsciphers string                             The list of acceptable ciphers to be used when establishing TLS connections. Use 'list' to list available ciphers. (default "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_256_GCM_SHA384")
-      --tlsmaxversion string                          The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.3")
-      --tlsminversion string                          The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.2")
-      --token string                                  Bearer token for authentication to the API server
-      --user string                                   The name of the kubeconfig user to use
-      --username string                               Username for basic authentication to the API server
-      --x-frame-options value                         Set X-Frame-Options header in HTTP responses to value. To disable, set to "". (default "sameorigin")
+      --address string                                  Listen on given address (default "0.0.0.0")
+      --app-state-cache-expiration duration             Cache expiration for app state (default 1h0m0s)
+      --application-namespaces strings                  List of additional namespaces where application resources can be managed in
+      --as string                                       Username to impersonate for the operation
+      --as-group stringArray                            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                                   UID to impersonate for the operation
+      --basehref string                                 Value for base href in index.html. Used if Argo CD is running behind reverse proxy under subpath different from / (default "/")
+      --certificate-authority string                    Path to a cert file for the certificate authority
+      --client-certificate string                       Path to a client certificate file for TLS
+      --client-key string                               Path to a client key file for TLS
+      --cluster string                                  The name of the kubeconfig cluster to use
+      --connection-status-cache-expiration duration     Cache expiration for cluster/repo connection status (default 1h0m0s)
+      --content-security-policy value                   Set Content-Security-Policy header in HTTP responses to value. To disable, set to "". (default "frame-ancestors 'self';")
+      --context string                                  The name of the kubeconfig context to use
+      --default-cache-expiration duration               Cache expiration default (default 24h0m0s)
+      --dex-server string                               Dex server address (default "argocd-dex-server:5556")
+      --dex-server-plaintext                            Use a plaintext client (non-TLS) to connect to dex server
+      --dex-server-strict-tls                           Perform strict validation of TLS certificates when connecting to dex server
+      --disable-auth                                    Disable client authentication
+      --disable-compression                             If true, opt-out of response compression for all requests to the server
+      --enable-gzip                                     Enable GZIP compression (default true)
+      --enable-proxy-extension                          Enable Proxy Extension feature
+      --gloglevel int                                   Set the glog logging level
+  -h, --help                                            help for argocd-server
+      --insecure                                        Run server without TLS
+      --insecure-skip-tls-verify                        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                               Path to a kube config. Only required if out-of-cluster
+      --logformat string                                Set the logging format. One of: text|json (default "text")
+      --login-attempts-expiration duration              Cache expiration for failed login attempts (default 24h0m0s)
+      --loglevel string                                 Set the logging level. One of: debug|info|warn|error (default "info")
+      --metrics-address string                          Listen for metrics on given address (default "0.0.0.0")
+      --metrics-port int                                Start metrics on given port (default 8083)
+  -n, --namespace string                                If present, the namespace scope for this CLI request
+      --oidc-cache-expiration duration                  Cache expiration for OIDC state (default 3m0s)
+      --otlp-address string                             OpenTelemetry collector address to send traces to
+      --otlp-attrs strings                              List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)
+      --otlp-headers stringToString                     List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2) (default [])
+      --otlp-insecure                                   OpenTelemetry collector insecure mode (default true)
+      --password string                                 Password for basic authentication to the API server
+      --port int                                        Listen on given port (default 8080)
+      --proxy-url string                                If provided, this URL will be used to connect via proxy
+      --redis string                                    Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string                     Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string                 Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string                         Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress string                           Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-insecure-skip-tls-verify                  Skip Redis server certificate validation.
+      --redis-use-tls                                   Use TLS when connecting to Redis. 
+      --redisdb int                                     Redis database.
+      --repo-cache-expiration duration                  Cache expiration for repo state, incl. app lists, app details, manifest generation, revision meta-data (default 24h0m0s)
+      --repo-server string                              Repo server address (default "argocd-repo-server:8081")
+      --repo-server-default-cache-expiration duration   Cache expiration default (default 24h0m0s)
+      --repo-server-plaintext                           Use a plaintext client (non-TLS) to connect to repository server
+      --repo-server-redis string                        Redis server hostname and port (e.g. argocd-redis:6379). 
+      --repo-server-redis-ca-certificate string         Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --repo-server-redis-client-certificate string     Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --repo-server-redis-client-key string             Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --repo-server-redis-compress string               Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --repo-server-redis-insecure-skip-tls-verify      Skip Redis server certificate validation.
+      --repo-server-redis-use-tls                       Use TLS when connecting to Redis. 
+      --repo-server-redisdb int                         Redis database.
+      --repo-server-sentinel stringArray                Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
+      --repo-server-sentinelmaster string               Redis sentinel master group name. (default "master")
+      --repo-server-strict-tls                          Perform strict validation of TLS certificates when connecting to repo server
+      --repo-server-timeout-seconds int                 Repo server RPC call timeout seconds. (default 60)
+      --request-timeout string                          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --revision-cache-expiration duration              Cache expiration for cached revision (default 3m0s)
+      --rootpath string                                 Used if Argo CD is running behind reverse proxy under subpath different from /
+      --sentinel stringArray                            Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
+      --sentinelmaster string                           Redis sentinel master group name. (default "master")
+      --server string                                   The address and port of the Kubernetes API server
+      --staticassets string                             Directory path that contains additional static assets (default "/shared/app")
+      --tls-server-name string                          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --tlsciphers string                               The list of acceptable ciphers to be used when establishing TLS connections. Use 'list' to list available ciphers. (default "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_256_GCM_SHA384")
+      --tlsmaxversion string                            The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.3")
+      --tlsminversion string                            The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.2")
+      --token string                                    Bearer token for authentication to the API server
+      --user string                                     The name of the kubeconfig user to use
+      --username string                                 Username for basic authentication to the API server
+      --x-frame-options value                           Set X-Frame-Options header in HTTP responses to value. To disable, set to "". (default "sameorigin")
 ```
 
 ### SEE ALSO

--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
 
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -33,7 +32,7 @@ func NewCache(
 	return &Cache{cache, connectionStatusCacheExpiration, oidcCacheExpiration, loginAttemptsExpiration}
 }
 
-func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) func() (*Cache, error) {
+func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*Cache, error) {
 	var connectionStatusCacheExpiration time.Duration
 	var oidcCacheExpiration time.Duration
 	var loginAttemptsExpiration time.Duration

--- a/server/server.go
+++ b/server/server.go
@@ -213,6 +213,7 @@ type ArgoCDServerOpts struct {
 	AppClientset          appclientset.Interface
 	RepoClientset         repoapiclient.Clientset
 	Cache                 *servercache.Cache
+	RepoServerCache       *repocache.Cache
 	RedisClient           *redis.Client
 	TLSConfigCustomizer   tlsutil.ConfigCustomizer
 	XFrameOptions         string
@@ -1028,7 +1029,7 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 
 	// Webhook handler for git events (Note: cache timeouts are hardcoded because API server does not write to cache and not really using them)
 	argoDB := db.NewDB(a.Namespace, a.settingsMgr, a.KubeClientset)
-	acdWebhookHandler := webhook.NewHandler(a.Namespace, a.ArgoCDServerOpts.ApplicationNamespaces, a.AppClientset, a.settings, a.settingsMgr, repocache.NewCache(a.Cache.GetCache(), 24*time.Hour, 3*time.Minute), a.Cache, argoDB)
+	acdWebhookHandler := webhook.NewHandler(a.Namespace, a.ArgoCDServerOpts.ApplicationNamespaces, a.AppClientset, a.settings, a.settingsMgr, a.RepoServerCache, a.Cache, argoDB)
 
 	mux.HandleFunc("/api/webhook", acdWebhookHandler.Handler)
 

--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
 
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -29,7 +28,7 @@ func NewCache(cache *cacheutil.Cache, appStateCacheExpiration time.Duration) *Ca
 	return &Cache{cache, appStateCacheExpiration}
 }
 
-func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) func() (*Cache, error) {
+func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*Cache, error) {
 	var appStateCacheExpiration time.Duration
 
 	cmd.Flags().DurationVar(&appStateCacheExpiration, "app-state-cache-expiration", env.ParseDurationFromEnv("ARGOCD_APP_STATE_CACHE_EXPIRATION", 1*time.Hour, 0, 10*time.Hour), "Cache expiration for app state")

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"time"
 
 	"crypto/tls"
 	"crypto/x509"
 
-	"github.com/redis/go-redis/v9"
-	"github.com/spf13/cobra"
-
 	"github.com/argoproj/argo-cd/v2/common"
 	certutil "github.com/argoproj/argo-cd/v2/util/cert"
 	"github.com/argoproj/argo-cd/v2/util/env"
+	"github.com/redis/go-redis/v9"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -77,8 +77,52 @@ func buildFailoverRedisClient(sentinelMaster, password, username string, redisDB
 	return client
 }
 
+type Options struct {
+	FlagPrefix      string
+	OnClientCreated func(client *redis.Client)
+}
+
+func (o *Options) callOnClientCreated(client *redis.Client) {
+	if o.OnClientCreated != nil {
+		o.OnClientCreated(client)
+	}
+}
+
+func (o *Options) getEnvPrefix() string {
+	return strings.Replace(strings.ToUpper(o.FlagPrefix), "-", "_", -1)
+}
+
+func mergeOptions(opts ...Options) Options {
+	var result Options
+	for _, o := range opts {
+		if o.FlagPrefix != "" {
+			result.FlagPrefix = o.FlagPrefix
+		}
+		if o.OnClientCreated != nil {
+			result.OnClientCreated = o.OnClientCreated
+		}
+	}
+	return result
+}
+
+func getFlagVal[T any](cmd *cobra.Command, o Options, name string, getVal func(name string) (T, error)) func() T {
+	return func() T {
+		var res T
+		var err error
+		if o.FlagPrefix != "" && cmd.Flags().Changed(o.FlagPrefix+name) {
+			res, err = getVal(o.FlagPrefix + name)
+		} else {
+			res, err = getVal(name)
+		}
+		if err != nil {
+			panic(err)
+		}
+		return res
+	}
+}
+
 // AddCacheFlagsToCmd adds flags which control caching to the specified command
-func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) func() (*Cache, error) {
+func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...Options) func() (*Cache, error) {
 	redisAddress := ""
 	sentinelAddresses := make([]string, 0)
 	sentinelMaster := ""
@@ -89,20 +133,44 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 	redisUseTLS := false
 	insecureRedis := false
 	compressionStr := ""
+	opt := mergeOptions(opts...)
 	var defaultCacheExpiration time.Duration
 
-	cmd.Flags().StringVar(&redisAddress, "redis", env.StringFromEnv("REDIS_SERVER", ""), "Redis server hostname and port (e.g. argocd-redis:6379). ")
-	cmd.Flags().IntVar(&redisDB, "redisdb", env.ParseNumFromEnv("REDISDB", 0, 0, math.MaxInt32), "Redis database.")
-	cmd.Flags().StringArrayVar(&sentinelAddresses, "sentinel", []string{}, "Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). ")
-	cmd.Flags().StringVar(&sentinelMaster, "sentinelmaster", "master", "Redis sentinel master group name.")
-	cmd.Flags().DurationVar(&defaultCacheExpiration, "default-cache-expiration", env.ParseDurationFromEnv("ARGOCD_DEFAULT_CACHE_EXPIRATION", 24*time.Hour, 0, math.MaxInt64), "Cache expiration default")
-	cmd.Flags().BoolVar(&redisUseTLS, "redis-use-tls", false, "Use TLS when connecting to Redis. ")
-	cmd.Flags().StringVar(&redisClientCertificate, "redis-client-certificate", "", "Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).")
-	cmd.Flags().StringVar(&redisClientKey, "redis-client-key", "", "Path to Redis client key (e.g. /etc/certs/redis/client.crt).")
-	cmd.Flags().BoolVar(&insecureRedis, "redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
-	cmd.Flags().StringVar(&redisCACertificate, "redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
-	cmd.Flags().StringVar(&compressionStr, CLIFlagRedisCompress, env.StringFromEnv("REDIS_COMPRESSION", string(RedisCompressionGZip)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none)")
+	cmd.Flags().StringVar(&redisAddress, opt.FlagPrefix+"redis", env.StringFromEnv(opt.getEnvPrefix()+"REDIS_SERVER", ""), "Redis server hostname and port (e.g. argocd-redis:6379). ")
+	redisAddressSrc := getFlagVal(cmd, opt, "redis", cmd.Flags().GetString)
+	cmd.Flags().IntVar(&redisDB, opt.FlagPrefix+"redisdb", env.ParseNumFromEnv(opt.getEnvPrefix()+"REDISDB", 0, 0, math.MaxInt32), "Redis database.")
+	redisDBSrc := getFlagVal(cmd, opt, "redisdb", cmd.Flags().GetInt)
+	cmd.Flags().StringArrayVar(&sentinelAddresses, opt.FlagPrefix+"sentinel", []string{}, "Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). ")
+	sentinelAddressesSrc := getFlagVal(cmd, opt, "sentinel", cmd.Flags().GetStringArray)
+	cmd.Flags().StringVar(&sentinelMaster, opt.FlagPrefix+"sentinelmaster", "master", "Redis sentinel master group name.")
+	sentinelMasterSrc := getFlagVal(cmd, opt, "sentinelmaster", cmd.Flags().GetString)
+	cmd.Flags().DurationVar(&defaultCacheExpiration, opt.FlagPrefix+"default-cache-expiration", env.ParseDurationFromEnv("ARGOCD_DEFAULT_CACHE_EXPIRATION", 24*time.Hour, 0, math.MaxInt64), "Cache expiration default")
+	defaultCacheExpirationSrc := getFlagVal(cmd, opt, "default-cache-expiration", cmd.Flags().GetDuration)
+	cmd.Flags().BoolVar(&redisUseTLS, opt.FlagPrefix+"redis-use-tls", false, "Use TLS when connecting to Redis. ")
+	redisUseTLSSrc := getFlagVal(cmd, opt, "redis-use-tls", cmd.Flags().GetBool)
+	cmd.Flags().StringVar(&redisClientCertificate, opt.FlagPrefix+"redis-client-certificate", "", "Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).")
+	redisClientCertificateSrc := getFlagVal(cmd, opt, "redis-client-certificate", cmd.Flags().GetString)
+	cmd.Flags().StringVar(&redisClientKey, opt.FlagPrefix+"redis-client-key", "", "Path to Redis client key (e.g. /etc/certs/redis/client.crt).")
+	redisClientKeySrc := getFlagVal(cmd, opt, "redis-client-key", cmd.Flags().GetString)
+	cmd.Flags().BoolVar(&insecureRedis, opt.FlagPrefix+"redis-insecure-skip-tls-verify", false, "Skip Redis server certificate validation.")
+	insecureRedisSrc := getFlagVal(cmd, opt, "redis-insecure-skip-tls-verify", cmd.Flags().GetBool)
+	cmd.Flags().StringVar(&redisCACertificate, opt.FlagPrefix+"redis-ca-certificate", "", "Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.")
+	redisCACertificateSrc := getFlagVal(cmd, opt, "redis-ca-certificate", cmd.Flags().GetString)
+	cmd.Flags().StringVar(&compressionStr, opt.FlagPrefix+CLIFlagRedisCompress, env.StringFromEnv(opt.getEnvPrefix()+"REDIS_COMPRESSION", string(RedisCompressionGZip)), "Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none)")
+	compressionStrSrc := getFlagVal(cmd, opt, CLIFlagRedisCompress, cmd.Flags().GetString)
 	return func() (*Cache, error) {
+		redisAddress := redisAddressSrc()
+		redisDB := redisDBSrc()
+		sentinelAddresses := sentinelAddressesSrc()
+		sentinelMaster := sentinelMasterSrc()
+		defaultCacheExpiration := defaultCacheExpirationSrc()
+		redisUseTLS := redisUseTLSSrc()
+		redisClientCertificate := redisClientCertificateSrc()
+		redisClientKey := redisClientKeySrc()
+		insecureRedis := insecureRedisSrc()
+		redisCACertificate := redisCACertificateSrc()
+		compressionStr := compressionStrSrc()
+
 		var tlsConfig *tls.Config = nil
 		if redisUseTLS {
 			tlsConfig = &tls.Config{}
@@ -138,9 +206,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 		}
 		if len(sentinelAddresses) > 0 {
 			client := buildFailoverRedisClient(sentinelMaster, password, username, redisDB, maxRetries, tlsConfig, sentinelAddresses)
-			for i := range opts {
-				opts[i](client)
-			}
+			opt.callOnClientCreated(client)
 			return NewCache(NewRedisCache(client, defaultCacheExpiration, compression)), nil
 		}
 		if redisAddress == "" {
@@ -148,9 +214,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...func(client *redis.Client)) 
 		}
 
 		client := buildRedisClient(redisAddress, password, username, redisDB, maxRetries, tlsConfig)
-		for i := range opts {
-			opts[i](client)
-		}
+		opt.callOnClientCreated(client)
 		return NewCache(NewRedisCache(client, defaultCacheExpiration, compression)), nil
 	}
 }
@@ -166,6 +230,10 @@ func (c *Cache) GetClient() CacheClient {
 
 func (c *Cache) SetClient(client CacheClient) {
 	c.client = client
+}
+
+func (c *Cache) RenameItem(oldKey string, newKey string, expiration time.Duration) error {
+	return c.client.Rename(fmt.Sprintf("%s|%s", oldKey, common.CacheVersion), fmt.Sprintf("%s|%s", newKey, common.CacheVersion), expiration)
 }
 
 func (c *Cache) SetItem(key string, item interface{}, expiration time.Duration, delete bool) error {

--- a/util/cache/client.go
+++ b/util/cache/client.go
@@ -17,6 +17,7 @@ type Item struct {
 
 type CacheClient interface {
 	Set(item *Item) error
+	Rename(oldKey string, newKey string, expiration time.Duration) error
 	Get(key string, obj interface{}) error
 	Delete(key string) error
 	OnUpdated(ctx context.Context, key string, callback func() error) error

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -37,6 +37,16 @@ func (i *InMemoryCache) Set(item *Item) error {
 	return nil
 }
 
+func (i *InMemoryCache) Rename(oldKey string, newKey string, expiration time.Duration) error {
+	bufIf, found := i.memCache.Get(oldKey)
+	if !found {
+		return ErrCacheMiss
+	}
+	i.memCache.Set(newKey, bufIf, expiration)
+	i.memCache.Delete(oldKey)
+	return nil
+}
+
 // HasSame returns true if key with the same value already present in cache
 func (i *InMemoryCache) HasSame(key string, obj interface{}) (bool, error) {
 	var buf bytes.Buffer

--- a/util/cache/mocks/cacheclient.go
+++ b/util/cache/mocks/cacheclient.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
-	cache "github.com/argoproj/argo-cd/v2/util/cache"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/argoproj/argo-cd/v2/util/cache"
 )
 
 type MockCacheClient struct {
@@ -13,6 +14,14 @@ type MockCacheClient struct {
 	BaseCache  cache.CacheClient
 	ReadDelay  time.Duration
 	WriteDelay time.Duration
+}
+
+func (c *MockCacheClient) Rename(oldKey string, newKey string, expiration time.Duration) error {
+	args := c.Called(oldKey, newKey, expiration)
+	if len(args) > 0 && args.Get(0) != nil {
+		return args.Get(0).(error)
+	}
+	return c.BaseCache.Rename(oldKey, newKey, expiration)
 }
 
 func (c *MockCacheClient) Set(item *cache.Item) error {

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -95,6 +95,10 @@ func (r *redisCache) unmarshal(data []byte, obj interface{}) error {
 	return nil
 }
 
+func (r *redisCache) Rename(oldKey string, newKey string, _ time.Duration) error {
+	return r.client.Rename(context.TODO(), r.getKey(oldKey), r.getKey(newKey)).Err()
+}
+
 func (r *redisCache) Set(item *Item) error {
 	expiration := item.Expiration
 	if expiration == 0 {

--- a/util/cache/twolevelclient.go
+++ b/util/cache/twolevelclient.go
@@ -18,6 +18,14 @@ type twoLevelClient struct {
 	externalCache CacheClient
 }
 
+func (c *twoLevelClient) Rename(oldKey string, newKey string, expiration time.Duration) error {
+	err := c.inMemoryCache.Rename(oldKey, newKey, expiration)
+	if err != nil {
+		log.Warnf("Failed to move key '%s' in in-memory cache: %v", oldKey, err)
+	}
+	return c.externalCache.Rename(oldKey, newKey, expiration)
+}
+
 // Set stores the given value in both in-memory and external cache.
 // Skip storing the value in external cache if the same value already exists in memory to avoid requesting external cache.
 func (c *twoLevelClient) Set(item *Item) error {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -349,18 +349,12 @@ func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Appl
 		return fmt.Errorf("error getting ref sources: %w", err)
 	}
 	source := app.Spec.GetSource()
-	cache.LogDebugManifestCacheKeyFields("getting manifests cache", "webhook app revision changed", change.shaBefore, &source, refSources, &clusterInfo, app.Spec.Destination.Namespace, trackingMethod, appInstanceLabelKey, app.Name, nil)
+	cache.LogDebugManifestCacheKeyFields("moving manifests cache", "webhook app revision changed", change.shaBefore, &source, refSources, &clusterInfo, app.Spec.Destination.Namespace, trackingMethod, appInstanceLabelKey, app.Name, nil)
 
-	var cachedManifests cache.CachedManifestResponse
-	if err := a.repoCache.GetManifests(change.shaBefore, &source, refSources, &clusterInfo, app.Spec.Destination.Namespace, trackingMethod, appInstanceLabelKey, app.Name, &cachedManifests, nil); err != nil {
+	if err := a.repoCache.SetNewRevisionManifests(change.shaAfter, change.shaBefore, &source, refSources, &clusterInfo, app.Spec.Destination.Namespace, trackingMethod, appInstanceLabelKey, app.Name, nil); err != nil {
 		return err
 	}
 
-	cache.LogDebugManifestCacheKeyFields("setting manifests cache", "webhook app revision changed", change.shaAfter, &source, refSources, &clusterInfo, app.Spec.Destination.Namespace, trackingMethod, appInstanceLabelKey, app.Name, nil)
-
-	if err = a.repoCache.SetManifests(change.shaAfter, &source, refSources, &clusterInfo, app.Spec.Destination.Namespace, trackingMethod, appInstanceLabelKey, app.Name, &cachedManifests, nil); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
Related to https://github.com/argoproj/argo-cd/issues/14269

The [manifests path annotation](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#webhook-and-manifest-paths-annotation) feature implementation causes Redis high memory usage. After the Git repository receives a new commit, the webhook handler copies the manifest of multiple applications using the `get` & `set` Redis commands. As a result, it transfers a lot of data from and into Redis while leaving unnecessary copies of old manifests. 

The PR changes implementation to use `rename` command. It significantly reduces Redis traffic, improves webhook performance, and eliminates memory spikes.

