### PR TITLE
fix: support specifying username/password for redis holding manifests in argocd-server

### DIFF
--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -199,6 +199,14 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...Options) func() (*Cache, err
 		}
 		password := os.Getenv(envRedisPassword)
 		username := os.Getenv(envRedisUsername)
+		if opt.FlagPrefix != "" {
+			if val := os.Getenv(opt.getEnvPrefix() + envRedisUsername); val != "" {
+				username = val
+			}
+			if val := os.Getenv(opt.getEnvPrefix() + envRedisPassword); val != "" {
+				password = val
+			}
+		}
 		maxRetries := env.ParseNumFromEnv(envRedisRetryCount, defaultRedisRetryCount, 0, math.MaxInt32)
 		compression, err := CompressionTypeFromString(compressionStr)
 		if err != nil {


### PR DESCRIPTION
Followup for https://github.com/argoproj/argo-cd/pull/16754

The PR introduced ability to configure location of Redis holding manifests in Argo CD API server. The missing bit was username/password of the separate redis. 