### PR TITLE
chore: typo in documentation comment

### DIFF
--- a/docs/operator-manual/application.yaml
+++ b/docs/operator-manual/application.yaml
@@ -119,7 +119,7 @@ spec:
         extVars:
         - name: foo
           value: bar
-          # You can use "code to determine if the value is either string (false, the default) or Jsonnet code (if code is true).
+          # You can use "code" to determine if the value is either string (false, the default) or Jsonnet code (if code is true).
         - code: true
           name: baz
           value: "true"


### PR DESCRIPTION
Just a simple typo in the documentation. 