### PR TITLE
feat: plugins as services

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -219,6 +219,7 @@ Currently, the following organizations are **officially** using Argo CD:
 1. [PGS](https://www.pgs.com)
 1. [Pigment](https://www.gopigment.com/)
 1. [Pipefy](https://www.pipefy.com/)
+1. [Pipekit](https://www.pipekit.io)
 1. [Pismo](https://pismo.io/)
 1. [Platform9 Systems](https://platform9.com/)
 1. [Polarpoint.io](https://polarpoint.io)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -992,7 +992,7 @@ func getLocalObjects(ctx context.Context, app *argoappv1.Application, proj *argo
 func getLocalObjectsString(ctx context.Context, app *argoappv1.Application, proj *argoappv1.AppProject, local, localRepoRoot, appLabelKey, kubeVersion string, apiVersions []string, kustomizeOptions *argoappv1.KustomizeOptions,
 	trackingMethod string) []string {
 	source := app.Spec.GetSource()
-	res, err := repository.GenerateManifests(ctx, local, localRepoRoot, source.TargetRevision, &repoapiclient.ManifestRequest{
+	res, err := repository.GenerateManifests(ctx, nil, local, localRepoRoot, source.TargetRevision, &repoapiclient.ManifestRequest{
 		Repo:               &argoappv1.Repository{Repo: source.RepoURL},
 		AppLabelKey:        appLabelKey,
 		AppName:            app.Name,
@@ -1004,7 +1004,7 @@ func getLocalObjectsString(ctx context.Context, app *argoappv1.Application, proj
 		TrackingMethod:     trackingMethod,
 		ProjectName:        proj.Name,
 		ProjectSourceRepos: proj.Spec.SourceRepos,
-	}, true, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
+	}, true, &git.NoopCredsStore{}, resource.MustParse("0"), nil, nil)
 	errors.CheckError(err)
 
 	return res.Manifests

--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -23,6 +23,7 @@ type PluginConfig struct {
 
 type PluginConfigSpec struct {
 	Version          string     `json:"version"`
+	ListenAddress    string     `json:"listenAddress,omitempty"`
 	Init             Command    `json:"init,omitempty"`
 	Generate         Command    `json:"generate"`
 	Discover         Discover   `json:"discover"`
@@ -93,13 +94,17 @@ func ValidatePluginConfig(config PluginConfig) error {
 	return nil
 }
 
-func (cfg *PluginConfig) Address() string {
+// Returns the listen address and whether this is a tcp or unix address
+func (cfg *PluginConfig) Address() (string, string) {
 	var address string
+	if cfg.Spec.ListenAddress != "" {
+		return cfg.Spec.ListenAddress, `tcp`
+	}
 	pluginSockFilePath := common.GetPluginSockFilePath()
 	if cfg.Spec.Version != "" {
 		address = fmt.Sprintf("%s/%s-%s.sock", pluginSockFilePath, cfg.Metadata.Name, cfg.Spec.Version)
 	} else {
 		address = fmt.Sprintf("%s/%s.sock", pluginSockFilePath, cfg.Metadata.Name)
 	}
-	return address
+	return address, `unix`
 }

--- a/cmpserver/server.go
+++ b/cmpserver/server.go
@@ -83,13 +83,17 @@ func (a *ArgoCDCMPServer) Run() {
 	config := a.initConstants.PluginConfig
 
 	// Listen on the socket address
-	_ = os.Remove(config.Address())
-	listener, err := net.Listen("unix", config.Address())
+	address, addressType := config.Address()
+	if addressType == `unix` {
+		_ = os.Remove(address)
+	}
+	listener, err := net.Listen(addressType, address)
+
 	errors.CheckError(err)
 	log.Infof("argocd-cmp-server %s serving on %s", common.GetVersion(), listener.Addr())
 
 	signal.Notify(a.stopCh, syscall.SIGINT, syscall.SIGTERM)
-	go a.Shutdown(config.Address())
+	go a.Shutdown(address)
 
 	grpcServer, err := a.CreateGRPC()
 	errors.CheckError(err)

--- a/docs/operator-manual/config-management-plugins.md
+++ b/docs/operator-manual/config-management-plugins.md
@@ -19,9 +19,10 @@ The following sections will describe how to create, install, and use plugins. Ch
 
 ## Installing a config management plugin
 
-### Sidecar plugin
+### Sidecar or services plugin
 
-An operator can configure a plugin tool via a sidecar to repo-server. The following changes are required to configure a new plugin:
+An operator can configure a plugin tool via a sidecar to repo-server, or as a kubernetes service in the same cluster
+as Argo CD. The following changes are required to configure a new plugin:
 
 #### Write the plugin configuration file
 
@@ -37,6 +38,10 @@ spec:
   # The version of your plugin. Optional. If specified, the Application's spec.source.plugin.name field
   # must be <plugin name>-<plugin version>.
   version: v1.0
+  # The listen address is where your plugin server will listen for connections. Optional. If not given it will listen
+  # on a unix socket, and this is the correct configuration for a sidecar plugin.
+  # To run as a service configure this to listen appropriately for incoming connections and specify a port number.
+  listenAddress: 0.0.0.0:8080
   # The init command runs in the Application source directory at the beginning of each manifest generation. The init
   # command can output anything. A non-zero status code will fail manifest generation.
   init:
@@ -54,18 +59,18 @@ spec:
       - |
         echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$ARGOCD_ENV_FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"
   # The discovery config is applied to a repository. If every configured discovery tool matches, then the plugin may be
-  # used to generate manifests for Applications using the repository. If the discovery config is omitted then the plugin 
-  # will not match any application but can still be invoked explicitly by specifying the plugin name in the app spec. 
-  # Only one of fileName, find.glob, or find.command should be specified. If multiple are specified then only the 
+  # used to generate manifests for Applications using the repository. If the discovery config is omitted then the plugin
+  # will not match any application but can still be invoked explicitly by specifying the plugin name in the app spec.
+  # Only one of fileName, find.glob, or find.command should be specified. If multiple are specified then only the
   # first (in that order) is evaluated.
   discover:
-    # fileName is a glob pattern (https://pkg.go.dev/path/filepath#Glob) that is applied to the Application's source 
+    # fileName is a glob pattern (https://pkg.go.dev/path/filepath#Glob) that is applied to the Application's source
     # directory. If there is a match, this plugin may be used for the Application.
     fileName: "./subdir/s*.yaml"
     find:
       # This does the same thing as fileName, but it supports double-start (nested directory) glob patterns.
       glob: "**/Chart.yaml"
-      # The find command runs in the repository's root directory. To match, it must exit with status code 0 _and_ 
+      # The find command runs in the repository's root directory. To match, it must exit with status code 0 _and_
       # produce non-empty output to standard out.
       command: [sh, -c, find . -name env.yaml]
   # The parameters config describes what parameters the UI should display for an Application. It is up to the user to
@@ -73,7 +78,7 @@ spec:
   # inform the "Parameters" tab in the App Details page of the UI.
   parameters:
     # Static parameter announcements are sent to the UI for _all_ Applications handled by this plugin.
-    # Think of the `string`, `array`, and `map` values set here as "defaults". It is up to the plugin author to make 
+    # Think of the `string`, `array`, and `map` values set here as "defaults". It is up to the plugin author to make
     # sure that these default values actually reflect the plugin's behavior if the user doesn't explicitly set different
     # values for those parameters.
     static:
@@ -116,13 +121,13 @@ spec:
 ```
 
 !!! note
-    While the ConfigManagementPlugin _looks like_ a Kubernetes object, it is not actually a custom resource. 
+    While the ConfigManagementPlugin _looks like_ a Kubernetes object, it is not actually a custom resource.
     It only follows kubernetes-style spec conventions.
 
 The `generate` command must print a valid Kubernetes YAML or JSON object stream to stdout. Both `init` and `generate` commands are executed inside the application source directory.
 
 The `discover.fileName` is used as [glob](https://pkg.go.dev/path/filepath#Glob) pattern to determine whether an
-application repository is supported by the plugin or not. 
+application repository is supported by the plugin or not.
 
 ```yaml
   discover:
@@ -134,11 +139,12 @@ If `discover.fileName` is not provided, the `discover.find.command` is executed 
 application repository is supported by the plugin or not. The `find` command should return a non-error exit code
 and produce output to stdout when the application source type is supported.
 
-#### Place the plugin configuration file in the sidecar
+#### Place the plugin configuration file in the plugin's runtime environment
 
-Argo CD expects the plugin configuration file to be located at `/home/argocd/cmp-server/config/plugin.yaml` in the sidecar.
+Argo CD expects the plugin configuration file to be located at `/home/argocd/cmp-server/config/plugin.yaml` in the sidecar
+or pod behind your service.
 
-If you use a custom image for the sidecar, you can add the file directly to that image.
+If you use a custom image for the plugin, you can add the file directly to that image.
 
 ```dockerfile
 WORKDIR /home/argocd/cmp-server/config/
@@ -146,7 +152,7 @@ COPY plugin.yaml ./
 ```
 
 If you use a stock image for the sidecar or would rather maintain the plugin configuration in a ConfigMap, just nest the
-plugin config file in a ConfigMap under the `plugin.yaml` key and mount the ConfigMap in the sidecar (see next section).
+plugin config file in a ConfigMap under the `plugin.yaml` key and mount the ConfigMap in the container (see next section).
 
 ```yaml
 apiVersion: v1
@@ -169,10 +175,11 @@ data:
         fileName: "./subdir/s*.yaml"
 ```
 
-#### Register the plugin sidecar
+#### Register the plugin as a sidecar
 
-To install a plugin, patch argocd-repo-server to run the plugin container as a sidecar, with argocd-cmp-server as its 
-entrypoint. You can use either off-the-shelf or custom-built plugin image as sidecar image. For example:
+To install a plugin as a sidecar, patch argocd-repo-server to run the plugin container as a sidecar, with
+argocd-cmp-server as its entrypoint. You can use either off-the-shelf or custom-built plugin image as sidecar image.
+For example:
 
 ```yaml
 containers:
@@ -191,7 +198,7 @@ containers:
     - mountPath: /home/argocd/cmp-server/config/plugin.yaml
       subPath: plugin.yaml
       name: my-plugin-config
-    # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps 
+    # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps
     # mitigate path traversal attacks.
     - mountPath: /tmp
       name: cmp-tmp
@@ -201,18 +208,172 @@ volumes:
   name: my-plugin-config
 - emptyDir: {}
   name: cmp-tmp
-``` 
+```
 
 !!! important "Double-check these items"
     1. Make sure to use `/var/run/argocd/argocd-cmp-server` as an entrypoint. The `argocd-cmp-server` is a lightweight GRPC service that allows Argo CD to interact with the plugin.
     2. Make sure that sidecar container is running as user 999.
     3. Make sure that plugin configuration file is present at `/home/argocd/cmp-server/config/plugin.yaml`. It can either be volume mapped via configmap or baked into image.
 
+#### Register the plugin as a service
+
+Argo CD needs to have access to the cluster to discover services. To do this it uses the service account token to gain access
+to the cluster. It also needs a Role or ClusterRole bound to that service account to access the namespace(s) that it the
+services are in. By default (no configuration) the services are looked for in the same namespace as the argocd-repo-server. You can set
+ARGOCD_SERVICE_PLUGINS_NAMESPACE to the name of a namespace to change it to look in a different namespace. To look in all
+namespaces set ARGOCD_SERVICE_PLUGINS_NAMESPACE to '*'.
+
+!!! Ensure that:
+    1. The argocd-repo-server deployment has `automountServiceAccountToken: true`
+	2. The argocd-repo-server's service account has a role binding allowing `get`, `list` and `watch` on services.
+
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-repo-server-getsvcs
+  namespace: argocd
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - services
+  verbs:
+    - get
+    - list
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd
+```
+
+or for cluster wide
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-repo-server-getsvcs
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - services
+  verbs:
+    - get
+    - list
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd
+```
+
+To install a plugin as a service, deploy something running your code. This would usually be a deployment, but Argo CD doesn't
+actually care what is behind the service. You can use either off-the-shelf or custom-built plugin image as sidecar image. This should
+follow the same rules as for a sidecar.
+
+To advertise the service to Argo CD you must provide a service with the label `argocd.argoproj.io/plugin: true`. Each port in the
+service will be treated as a separate plugin, and the name of the port is the name of the plugin, which will be used by applications
+which specify their plugin by name.
+
+This might look like:
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myplugin
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/plugin: "true"
+spec:
+  ports:
+  - name: myplugin
+    port: 8080
+    protocol: TCP
+    targetPort: cmp
+  selector:
+    k8s-app: myplugin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: myplugin
+  name: myplugin
+  namespace: argocd
+spec:
+  selector:
+    matchLabels:
+      k8s-app: myplugin
+  template:
+    metadata:
+      labels:
+        k8s-app: myplugin
+    spec:
+      containers:
+      - name: myplugin
+        image: myrepo/myplugin:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: cmp
+          protocol: TCP
+```
+
+!!! important "Double-check these items"
+    1. Make sure to use `argocd-cmp-server` as an entrypoint from the same version of Argo CD. The `argocd-cmp-server` is a lightweight GRPC service that allows Argo CD to interact with the plugin.
+    2. Make sure that sidecar container is running as user 999.
+    3. Make sure that plugin configuration file is present at `/home/argocd/cmp-server/config/plugin.yaml`. It can either be volume mapped via configmap or baked into image.
+	4. The **service** has the label `argocd.argoproj.io/plugin: "true"`
+	5. If you are calling the plugin by name that the **port** name is what you use to call it.
+
+If you'd like to disable this feature do not provide a service account token.
+
+#### Choosing between sidecar and service plugins
+
+If you are debugging your plugin, choose a service to start with. You can then restart the deployments behind the service without
+needing to restart Argo CD. You could also easilly develop in an in cluster development environment this way. If you want to develop
+locally and your cluster can reach your local machine you could even develop using an ExternalName service.
+
+For large mono-repos then sidecars will continue to work where services will take longer to transfer the state to the plugin. Argo CD
+doesn't condone large repos anyway. Because the network traffic between the repo-server and the plugin is over a unix socket it is by
+default more secure.
+
+Services allow independent scaling, even using HPAs, installation and upgrading at runtime, and work more like normal services.
+You can add monitoring to both types, but it feels more natural with a service. If you are making your plugin available for public
+consumption you can provide separate deployment manifests (yaml/kustomize/helm chart) to allow easier adoption. Plugin repository
+downtime is less serious in this case; with a sidecar if any one of the containers in the pod is unavailable then your pod will not
+start/restart. You can grant specific cluster permissions to your plugin without granting them to the rest of the repo server.
+
 ### Using environment variables in your plugin
 
 Plugin commands have access to
 
-1. The system environment variables of the sidecar
+1. The system environment variables of the container
 2. [Standard build environment variables](../user-guide/build-environment.md)
 3. Variables in the Application spec (References to system and build variables will get interpolated in the variables' values):
 
@@ -226,9 +387,9 @@ Plugin commands have access to
                   value: bar
                 - name: REV
                   value: test-$ARGOCD_APP_REVISION
-    
-    Before reaching the `init.command`, `generate.command`, and `discover.find.command` commands, Argo CD prefixes all 
-    user-supplied environment variables (#3 above) with `ARGOCD_ENV_`. This prevents users from directly setting 
+
+    Before reaching the `init.command`, `generate.command`, and `discover.find.command` commands, Argo CD prefixes all
+    user-supplied environment variables (#3 above) with `ARGOCD_ENV_`. This prevents users from directly setting
     potentially-sensitive environment variables.
 
 4. Parameters in the Application spec:
@@ -244,43 +405,43 @@ Plugin commands have access to
                - name: helm-parameters
                  map:
                    image.tag: v1.2.3
-   
+
     The parameters are available as JSON in the `ARGOCD_APP_PARAMETERS` environment variable. The example above would
     produce this JSON:
-   
+
         [{"name": "values-files", "array": ["values-dev.yaml"]}, {"name": "helm-parameters", "map": {"image.tag": "v1.2.3"}}]
-   
+
     !!! note
         Parameter announcements, even if they specify defaults, are _not_ sent to the plugin in `ARGOCD_APP_PARAMETERS`.
         Only parameters explicitly set in the Application spec are sent to the plugin. It is up to the plugin to apply
         the same defaults as the ones announced to the UI.
-   
+
     The same parameters are also available as individual environment variables. The names of the environment variables
     follows this convention:
-   
+
            - name: some-string-param
              string: some-string-value
            # PARAM_SOME_STRING_PARAM=some-string-value
-           
+
            - name: some-array-param
              value: [item1, item2]
            # PARAM_SOME_ARRAY_PARAM_0=item1
            # PARAM_SOME_ARRAY_PARAM_1=item2
-           
+
            - name: some-map-param
              map:
                image.tag: v1.2.3
            # PARAM_SOME_MAP_PARAM_IMAGE_TAG=v1.2.3
-   
-!!! warning "Sanitize/escape user input" 
+
+!!! warning "Sanitize/escape user input"
     As part of Argo CD's manifest generation system, config management plugins are treated with a level of trust. Be
     sure to escape user input in your plugin to prevent malicious input from causing unwanted behavior.
 
 ## Using a config management plugin with an Application
 
 You may leave the `name` field
-empty in the `plugin` section for the plugin to be automatically matched with the Application based on its discovery rules. If you do mention the name make sure 
-it is either `<metadata.name>-<spec.version>` if version is mentioned in the `ConfigManagementPlugin` spec or else just `<metadata.name>`. When name is explicitly 
+empty in the `plugin` section for the plugin to be automatically matched with the Application based on its discovery rules. If you do mention the name make sure
+it is either `<metadata.name>-<spec.version>` if version is mentioned in the `ConfigManagementPlugin` spec or else just `<metadata.name>`. When name is explicitly
 specified only that particular plugin will be used iff its discovery pattern/command matches the provided application repo.
 
 ```yaml
@@ -309,22 +470,22 @@ If you don't need to set any environment variables, you can set an empty plugin 
 
 !!! important
     If your CMP command runs too long, the command will be killed, and the UI will show an error. The CMP server
-    respects the timeouts set by the `server.repo.server.timeout.seconds` and `controller.repo.server.timeout.seconds` 
+    respects the timeouts set by the `server.repo.server.timeout.seconds` and `controller.repo.server.timeout.seconds`
     items in `argocd-cm`. Increase their values from the default of 60s.
 
     Each CMP command will also independently timeout on the `ARGOCD_EXEC_TIMEOUT` set for the CMP sidecar. The default
     is 90s. So if you increase the repo server timeout greater than 90s, be sure to set `ARGOCD_EXEC_TIMEOUT` on the
     sidecar.
-    
+
 !!! note
     Each Application can only have one config management plugin configured at a time. If you're converting an existing
-    plugin configured through the `argocd-cm` ConfigMap to a sidecar, make sure to update the plugin name to either `<metadata.name>-<spec.version>` 
-    if version was mentioned in the `ConfigManagementPlugin` spec or else just use `<metadata.name>`. You can also remove the name altogether 
+    plugin configured through the `argocd-cm` ConfigMap to a sidecar, make sure to update the plugin name to either `<metadata.name>-<spec.version>`
+    if version was mentioned in the `ConfigManagementPlugin` spec or else just use `<metadata.name>`. You can also remove the name altogether
     and let the automatic discovery to identify the plugin.
 !!! note
     If a CMP renders blank manfiests, and `prune` is set to `true`, Argo CD will automatically remove resources. CMP plugin authors should ensure errors are part of the exit code. Commonly something like `kustomize build . | cat` won't pass errors because of the pipe. Consider setting `set -o pipefail` so anything piped will pass errors on failure.
 
-## Debugging a CMP
+## Debugging a CMP as a sidecar
 
 If you are actively developing a sidecar-installed CMP, keep a few things in mind:
 
@@ -338,6 +499,9 @@ If you are actively developing a sidecar-installed CMP, keep a few things in min
 4. Verify your sidecar has started properly by viewing the Pod and seeing that two containers are running `kubectl get pod -l app.kubernetes.io/component=repo-server -n argocd`
 5. Write log message to stderr and set the `--loglevel=info` flag in the sidecar. This will print everything written to stderr, even on successfull command execution.
 
+## Debugging a CMP as a service
+
+If you are actively developing a services based CMP then things should be more familiar than as a sidecar. You still need to bare in mind that CMP errors are cached by the repo-server in Redis. Restarting the repo-server Pod will not clear the cache. Always do a "Hard Refresh" when actively developing a CMP so you have the latest output.
 
 ### Other Common Errors
 | Error Message | Cause |
@@ -402,7 +566,7 @@ spec:
     The `lockRepo` key is not relevant for sidecar plugins, because sidecar plugins do not share a single source repo
     directory when generating manifests.
 
-Next, we need to decide how this yaml is going to be added to the sidecar. We can either bake the yaml directly into the image, or we can mount it from a ConfigMap. 
+Next, we need to decide how this yaml is going to be added to the sidecar. We can either bake the yaml directly into the image, or we can mount it from a ConfigMap.
 
 If using a ConfigMap, our example would look like this:
 
@@ -431,14 +595,14 @@ Then this would be mounted in our plugin sidecar.
 
 ### Write discovery rules for your plugin
 
-Sidecar plugins can use either discovery rules or a plugin name to match Applications to plugins. If the discovery rule is omitted 
+Sidecar plugins can use either discovery rules or a plugin name to match Applications to plugins. If the discovery rule is omitted
 then you have to explicitly specify the plugin by name in the app spec or else that particular plugin will not match any app.
 
-If you want to use discovery instead of the plugin name to match applications to your plugin, write rules applicable to 
-your plugin [using the instructions above](#1-write-the-plugin-configuration-file) and add them to your configuration 
+If you want to use discovery instead of the plugin name to match applications to your plugin, write rules applicable to
+your plugin [using the instructions above](#1-write-the-plugin-configuration-file) and add them to your configuration
 file.
 
-To use the name instead of discovery, update the name in your application manifest to `<metadata.name>-<spec.version>` 
+To use the name instead of discovery, update the name in your application manifest to `<metadata.name>-<spec.version>`
 if version was mentioned in the `ConfigManagementPlugin` spec or else just use `<metadata.name>`. For example:
 
 ```yaml

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -16,7 +16,6 @@ spec:
         app.kubernetes.io/name: argocd-repo-server
     spec:
       serviceAccountName: argocd-repo-server
-      automountServiceAccountToken: false
       containers:
       - name: argocd-repo-server
         image: quay.io/argoproj/argocd:latest

--- a/manifests/base/repo-server/argocd-repo-server-role-binding.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd

--- a/manifests/base/repo-server/argocd-repo-server-role.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-repo-server-getsvcs
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - services
+  verbs:
+    - get
+    - list
+    - watch

--- a/manifests/base/repo-server/kustomization.yaml
+++ b/manifests/base/repo-server/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - argocd-repo-server-deployment.yaml
 - argocd-repo-server-service.yaml
 - argocd-repo-server-network-policy.yaml
+- argocd-repo-server-role.yaml
+- argocd-repo-server-role-binding.yaml

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -20671,6 +20671,20 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-repo-server-getsvcs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -20721,6 +20735,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-applicationset-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -21184,7 +21211,6 @@ spec:
                   app.kubernetes.io/part-of: argocd
               topologyKey: kubernetes.io/hostname
             weight: 5
-      automountServiceAccountToken: false
       containers:
       - args:
         - /usr/local/bin/argocd-repo-server

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -20805,6 +20805,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: argocd-repo-server-getsvcs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
@@ -21102,6 +21116,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha-haproxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22783,7 +22810,6 @@ spec:
               matchLabels:
                 app.kubernetes.io/name: argocd-repo-server
             topologyKey: kubernetes.io/hostname
-      automountServiceAccountToken: false
       containers:
       - args:
         - /usr/local/bin/argocd-repo-server

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -283,6 +283,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: argocd-repo-server-getsvcs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
@@ -419,6 +433,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-ha-haproxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -2049,7 +2076,6 @@ spec:
               matchLabels:
                 app.kubernetes.io/name: argocd-repo-server
             topologyKey: kubernetes.io/hostname
-      automountServiceAccountToken: false
       containers:
       - args:
         - /usr/local/bin/argocd-repo-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -20764,6 +20764,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: argocd-repo-server-getsvcs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
@@ -21029,6 +21043,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-notifications-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -21829,7 +21856,6 @@ spec:
                   app.kubernetes.io/part-of: argocd
               topologyKey: kubernetes.io/hostname
             weight: 5
-      automountServiceAccountToken: false
       containers:
       - args:
         - /usr/local/bin/argocd-repo-server

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -242,6 +242,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: argocd-repo-server-getsvcs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
@@ -346,6 +360,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-notifications-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-repo-server-getsvcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-repo-server-getsvcs
+subjects:
+- kind: ServiceAccount
+  name: argocd-repo-server
+  namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1095,7 +1122,6 @@ spec:
                   app.kubernetes.io/part-of: argocd
               topologyKey: kubernetes.io/hostname
             weight: 5
-      automountServiceAccountToken: false
       containers:
       - args:
         - /usr/local/bin/argocd-repo-server

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -91,6 +91,7 @@ type Service struct {
 	newGitClient              func(rawRepoURL string, root string, creds git.Creds, insecure bool, enableLfs bool, proxy string, opts ...git.ClientOpts) (git.Client, error)
 	newHelmClient             func(repoURL string, creds helm.Creds, enableOci bool, proxy string, opts ...helm.ClientOpts) helm.Client
 	initConstants             RepoServerInitConstants
+	discoverer                *discovery.Discoverer
 	// now is usually just time.Now, but may be replaced by unit tests for testing purposes
 	now func() time.Time
 }
@@ -119,6 +120,7 @@ func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initCo
 	repoLock := NewRepositoryLock()
 	gitRandomizedPaths := io.NewRandomizedTempPaths(rootDir)
 	helmRandomizedPaths := io.NewRandomizedTempPaths(rootDir)
+	discoverer := discovery.New()
 	return &Service{
 		parallelismLimitSemaphore: parallelismLimitSemaphore,
 		repoLock:                  repoLock,
@@ -135,6 +137,7 @@ func NewService(metricsServer *metrics.MetricsServer, cache *cache.Cache, initCo
 		gitRepoPaths:       gitRandomizedPaths,
 		chartPaths:         helmRandomizedPaths,
 		gitRepoInitializer: directoryPermissionInitializer,
+		discoverer:         &discoverer,
 		rootDir:            rootDir,
 	}
 }
@@ -220,7 +223,7 @@ func (s *Service) ListApps(ctx context.Context, q *apiclient.ListAppsRequest) (*
 	}
 
 	defer io.Close(closer)
-	apps, err := discovery.Discover(ctx, gitClient.Root(), gitClient.Root(), q.EnabledSourceTypes, s.initConstants.CMPTarExcludedGlobs)
+	apps, err := discovery.Discover(ctx, s.discoverer, gitClient.Root(), gitClient.Root(), q.EnabledSourceTypes, s.initConstants.CMPTarExcludedGlobs)
 	if err != nil {
 		return nil, fmt.Errorf("error discovering applications: %w", err)
 	}
@@ -232,24 +235,16 @@ func (s *Service) ListApps(ctx context.Context, q *apiclient.ListAppsRequest) (*
 	return &res, nil
 }
 
-// ListPlugins lists the contents of a GitHub repo
+// ListPlugins returns a list of cmp v2 plugins running as sidecar or services to reposerver
 func (s *Service) ListPlugins(ctx context.Context, _ *empty.Empty) (*apiclient.PluginList, error) {
-	pluginSockFilePath := common.GetPluginSockFilePath()
-
-	sockFiles, err := os.ReadDir(pluginSockFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get plugins from dir %v, error=%w", pluginSockFilePath, err)
-	}
-
+	pluginNames, err := s.discoverer.GetPluginNames()
 	var plugins []*apiclient.PluginInfo
-	for _, file := range sockFiles {
-		if file.Type() == os.ModeSocket {
-			plugins = append(plugins, &apiclient.PluginInfo{Name: strings.TrimSuffix(file.Name(), ".sock")})
-		}
+	for _, name := range pluginNames {
+		plugins = append(plugins, &apiclient.PluginInfo{Name: name})
 	}
 
 	res := apiclient.PluginList{Items: plugins}
-	return &res, nil
+	return &res, err
 }
 
 type operationSettings struct {
@@ -794,7 +789,7 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 			}
 		}
 
-		manifestGenResult, err = GenerateManifests(ctx, opContext.appPath, repoRoot, commitSHA, q, false, s.gitCredsStore, s.initConstants.MaxCombinedDirectoryManifestsSize, s.gitRepoPaths, WithCMPTarDoneChannel(ch.tarDoneCh), WithCMPTarExcludedGlobs(s.initConstants.CMPTarExcludedGlobs))
+		manifestGenResult, err = GenerateManifests(ctx, s.discoverer, opContext.appPath, repoRoot, commitSHA, q, false, s.gitCredsStore, s.initConstants.MaxCombinedDirectoryManifestsSize, s.gitRepoPaths, WithCMPTarDoneChannel(ch.tarDoneCh), WithCMPTarExcludedGlobs(s.initConstants.CMPTarExcludedGlobs))
 	}
 	refSourceCommitSHAs := make(map[string]string)
 	if len(repoRefs) > 0 {
@@ -1365,13 +1360,13 @@ func WithCMPTarExcludedGlobs(excludedGlobs []string) GenerateManifestOpt {
 }
 
 // GenerateManifests generates manifests from a path. Overrides are applied as a side effect on the given ApplicationSource.
-func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, q *apiclient.ManifestRequest, isLocal bool, gitCredsStore git.CredsStore, maxCombinedManifestQuantity resource.Quantity, gitRepoPaths io.TempPaths, opts ...GenerateManifestOpt) (*apiclient.ManifestResponse, error) {
+func GenerateManifests(ctx context.Context, discoverer *discovery.Discoverer, appPath, repoRoot, revision string, q *apiclient.ManifestRequest, isLocal bool, gitCredsStore git.CredsStore, maxCombinedManifestQuantity resource.Quantity, gitRepoPaths io.TempPaths, opts ...GenerateManifestOpt) (*apiclient.ManifestResponse, error) {
 	opt := newGenerateManifestOpt(opts...)
 	var targetObjs []*unstructured.Unstructured
 
 	resourceTracking := argo.NewResourceTracking()
 
-	appSourceType, err := GetAppSourceType(ctx, q.ApplicationSource, appPath, repoRoot, q.AppName, q.EnabledSourceTypes, opt.cmpTarExcludedGlobs)
+	appSourceType, err := GetAppSourceType(ctx, discoverer, q.ApplicationSource, appPath, repoRoot, q.AppName, q.EnabledSourceTypes, opt.cmpTarExcludedGlobs)
 	if err != nil {
 		return nil, fmt.Errorf("error getting app source type: %w", err)
 	}
@@ -1397,9 +1392,9 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 			pluginName = q.ApplicationSource.Plugin.Name
 		}
 		// if pluginName is provided it has to be `<metadata.name>-<spec.version>` or just `<metadata.name>` if plugin version is empty
-		targetObjs, err = runConfigManagementPluginSidecars(ctx, appPath, repoRoot, pluginName, env, q, opt.cmpTarDoneCh, opt.cmpTarExcludedGlobs)
+		targetObjs, err = runConfigManagementPluginSidecars(ctx, discoverer, appPath, repoRoot, pluginName, env, q, opt.cmpTarDoneCh, opt.cmpTarExcludedGlobs)
 		if err != nil {
-			err = fmt.Errorf("plugin sidecar failed. %s", err.Error())
+			err = fmt.Errorf("plugin sidecar/service failed. %s", err.Error())
 		}
 	case v1alpha1.ApplicationSourceTypeDirectory:
 		var directory *v1alpha1.ApplicationSourceDirectory
@@ -1534,7 +1529,7 @@ func mergeSourceParameters(source *v1alpha1.ApplicationSource, path, appName str
 }
 
 // GetAppSourceType returns explicit application source type or examines a directory and determines its application source type
-func GetAppSourceType(ctx context.Context, source *v1alpha1.ApplicationSource, appPath, repoPath, appName string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (v1alpha1.ApplicationSourceType, error) {
+func GetAppSourceType(ctx context.Context, discoverer *discovery.Discoverer, source *v1alpha1.ApplicationSource, appPath, repoPath, appName string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (v1alpha1.ApplicationSourceType, error) {
 	err := mergeSourceParameters(source, appPath, appName)
 	if err != nil {
 		return "", fmt.Errorf("error while parsing source parameters: %v", err)
@@ -1551,7 +1546,7 @@ func GetAppSourceType(ctx context.Context, source *v1alpha1.ApplicationSource, a
 		}
 		return *appSourceType, nil
 	}
-	appType, err := discovery.AppType(ctx, appPath, repoPath, enableGenerateManifests, tarExcludedGlobs)
+	appType, err := discovery.AppType(ctx, discoverer, appPath, repoPath, enableGenerateManifests, tarExcludedGlobs)
 	if err != nil {
 		return "", fmt.Errorf("error getting app source type: %v", err)
 	}
@@ -1898,7 +1893,7 @@ func getPluginParamEnvs(envVars []string, plugin *v1alpha1.ApplicationSourcePlug
 	return env, nil
 }
 
-func runConfigManagementPluginSidecars(ctx context.Context, appPath, repoPath, pluginName string, envVars *v1alpha1.Env, q *apiclient.ManifestRequest, tarDoneCh chan<- bool, tarExcludedGlobs []string) ([]*unstructured.Unstructured, error) {
+func runConfigManagementPluginSidecars(ctx context.Context, discoverer *discovery.Discoverer, appPath, repoPath, pluginName string, envVars *v1alpha1.Env, q *apiclient.ManifestRequest, tarDoneCh chan<- bool, tarExcludedGlobs []string) ([]*unstructured.Unstructured, error) {
 	// compute variables.
 	env, err := getPluginEnvs(envVars, q)
 	if err != nil {
@@ -1906,7 +1901,7 @@ func runConfigManagementPluginSidecars(ctx context.Context, appPath, repoPath, p
 	}
 
 	// detect config management plugin server
-	conn, cmpClient, err := discovery.DetectConfigManagementPlugin(ctx, appPath, repoPath, pluginName, env, tarExcludedGlobs)
+	conn, cmpClient, err := discoverer.DetectConfigManagementPlugin(ctx, appPath, repoPath, pluginName, env, tarExcludedGlobs)
 	if err != nil {
 		return nil, err
 	}
@@ -1963,7 +1958,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 			return err
 		}
 
-		appSourceType, err := GetAppSourceType(ctx, q.Source, opContext.appPath, repoRoot, q.AppName, q.EnabledSourceTypes, s.initConstants.CMPTarExcludedGlobs)
+		appSourceType, err := GetAppSourceType(ctx, s.discoverer, q.Source, opContext.appPath, repoRoot, q.AppName, q.EnabledSourceTypes, s.initConstants.CMPTarExcludedGlobs)
 		if err != nil {
 			return err
 		}
@@ -1980,7 +1975,7 @@ func (s *Service) GetAppDetails(ctx context.Context, q *apiclient.RepoServerAppD
 				return err
 			}
 		case v1alpha1.ApplicationSourceTypePlugin:
-			if err := populatePluginAppDetails(ctx, res, opContext.appPath, repoRoot, q, s.gitCredsStore, s.initConstants.CMPTarExcludedGlobs); err != nil {
+			if err := populatePluginAppDetails(ctx, res, opContext.appPath, repoRoot, q, s.gitCredsStore, s.discoverer, s.initConstants.CMPTarExcludedGlobs); err != nil {
 				return fmt.Errorf("failed to populate plugin app details: %w", err)
 			}
 		}
@@ -2139,7 +2134,7 @@ func populateKustomizeAppDetails(res *apiclient.RepoAppDetailsResponse, q *apicl
 	return nil
 }
 
-func populatePluginAppDetails(ctx context.Context, res *apiclient.RepoAppDetailsResponse, appPath string, repoPath string, q *apiclient.RepoServerAppDetailsQuery, store git.CredsStore, tarExcludedGlobs []string) error {
+func populatePluginAppDetails(ctx context.Context, res *apiclient.RepoAppDetailsResponse, appPath string, repoPath string, q *apiclient.RepoServerAppDetailsQuery, store git.CredsStore, discoverer *discovery.Discoverer, tarExcludedGlobs []string) error {
 	res.Plugin = &apiclient.PluginAppSpec{}
 
 	envVars := []string{
@@ -2159,7 +2154,7 @@ func populatePluginAppDetails(ctx context.Context, res *apiclient.RepoAppDetails
 		pluginName = q.Source.Plugin.Name
 	}
 	// detect config management plugin server (sidecar)
-	conn, cmpClient, err := discovery.DetectConfigManagementPlugin(ctx, appPath, repoPath, pluginName, env, tarExcludedGlobs)
+	conn, cmpClient, err := discoverer.DetectConfigManagementPlugin(ctx, appPath, repoPath, pluginName, env, tarExcludedGlobs)
 	if err != nil {
 		return fmt.Errorf("failed to detect CMP for app: %w", err)
 	}

--- a/reposerver/repository/repository.proto
+++ b/reposerver/repository/repository.proto
@@ -283,8 +283,8 @@ service RepoServerService {
     rpc ListApps(ListAppsRequest) returns (AppList) {
     }
 
-    // ListPlugins returns a list of cmp v2 plugins running as sidecar to reposerver
-    rpc ListPlugins(google.protobuf.Empty) returns (PluginList) {
+	// ListPlugins returns a list of cmp v2 plugins running as sidecar or services to reposerver
+	rpc ListPlugins(google.protobuf.Empty) returns (PluginList) {
     }
 
     // Generate manifest for application in specified repo name and revision

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -207,7 +207,7 @@ func TestGenerateYamlManifestInDir(t *testing.T) {
 	assert.Equal(t, countOfManifests, len(res1.Manifests))
 
 	// this will test concatenated manifests to verify we split YAMLs correctly
-	res2, err := GenerateManifests(context.Background(), "./testdata/concatenated", "/", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
+	res2, err := GenerateManifests(context.Background(), nil, "./testdata/concatenated", "/", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(res2.Manifests))
 }
@@ -264,7 +264,7 @@ func Test_GenerateManifests_NoOutOfBoundsAccess(t *testing.T) {
 
 			q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &argoappv1.ApplicationSource{}, ProjectName: "something",
 				ProjectSourceRepos: []string{"*"}}
-			res, err := GenerateManifests(context.Background(), repoDir, "", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
+			res, err := GenerateManifests(context.Background(), nil, repoDir, "", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
 			require.Error(t, err)
 			assert.NotContains(t, err.Error(), mustNotContain)
 			assert.Contains(t, err.Error(), "illegal filepath")
@@ -280,7 +280,7 @@ func TestGenerateManifests_MissingSymlinkDestination(t *testing.T) {
 
 	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &argoappv1.ApplicationSource{}, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"}}
-	_, err = GenerateManifests(context.Background(), repoDir, "", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
+	_, err = GenerateManifests(context.Background(), nil, repoDir, "", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
 	require.NoError(t, err)
 }
 
@@ -1448,15 +1448,15 @@ func TestGenerateNullList(t *testing.T) {
 }
 
 func TestIdentifyAppSourceTypeByAppDirWithKustomizations(t *testing.T) {
-	sourceType, err := GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yaml", "./testdata", "testapp", map[string]bool{}, []string{})
+	sourceType, err := GetAppSourceType(context.Background(), nil, &argoappv1.ApplicationSource{}, "./testdata/kustomization_yaml", "./testdata", "testapp", map[string]bool{}, []string{})
 	assert.Nil(t, err)
 	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
 
-	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yml", "./testdata", "testapp", map[string]bool{}, []string{})
+	sourceType, err = GetAppSourceType(context.Background(), nil, &argoappv1.ApplicationSource{}, "./testdata/kustomization_yml", "./testdata", "testapp", map[string]bool{}, []string{})
 	assert.Nil(t, err)
 	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
 
-	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/Kustomization", "./testdata", "testapp", map[string]bool{}, []string{})
+	sourceType, err = GetAppSourceType(context.Background(), nil, &argoappv1.ApplicationSource{}, "./testdata/Kustomization", "./testdata", "testapp", map[string]bool{}, []string{})
 	assert.Nil(t, err)
 	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
 }
@@ -1468,7 +1468,7 @@ func TestGenerateFromUTF16(t *testing.T) {
 		ProjectName:        "something",
 		ProjectSourceRepos: []string{"*"},
 	}
-	res1, err := GenerateManifests(context.Background(), "./testdata/utf-16", "/", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
+	res1, err := GenerateManifests(context.Background(), nil, "./testdata/utf-16", "/", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(res1.Manifests))
 }

--- a/server/settings/settings.go
+++ b/server/settings/settings.go
@@ -163,7 +163,7 @@ func (s *Server) plugins(ctx context.Context) ([]*settingspkg.Plugin, error) {
 
 	pluginList, err := client.ListPlugins(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list sidecar plugins from reposerver: %w", err)
+		return nil, fmt.Errorf("failed to list sidecar and service plugins from reposerver: %w", err)
 	}
 
 	var out []*settingspkg.Plugin

--- a/util/app/discovery/discovery.go
+++ b/util/app/discovery/discovery.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/argoproj/argo-cd/v2/util/io/files"
-
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	log "github.com/sirupsen/logrus"
 
@@ -19,6 +17,29 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/kustomize"
 )
+
+type Discoverer struct {
+	pluginService *pluginService
+}
+
+func New() Discoverer {
+	ps := newPluginService()
+	return Discoverer{
+		pluginService: ps,
+	}
+}
+
+func (d *Discoverer) GetPluginNames() ([]string, error) {
+	plugins, err := d.pluginService.getAllPlugins()
+	pluginNames := make([]string, len(plugins))
+	if err != nil {
+		return pluginNames, err
+	}
+	for i := range plugins {
+		pluginNames[i] = plugins[i].name
+	}
+	return pluginNames, nil
+}
 
 func IsManifestGenerationEnabled(sourceType v1alpha1.ApplicationSourceType, enableGenerateManifests map[string]bool) bool {
 	if enableGenerateManifests == nil {
@@ -31,20 +52,22 @@ func IsManifestGenerationEnabled(sourceType v1alpha1.ApplicationSourceType, enab
 	return enabled
 }
 
-func Discover(ctx context.Context, appPath, repoPath string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (map[string]string, error) {
+func Discover(ctx context.Context, discoverer *Discoverer, appPath, repoPath string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (map[string]string, error) {
 	apps := make(map[string]string)
 
-	// Check if it is CMP
-	conn, _, err := DetectConfigManagementPlugin(ctx, appPath, repoPath, "", []string{}, tarExcludedGlobs)
-	if err == nil {
-		// Found CMP
-		io.Close(conn)
+	// Check if it is CMP. When running from the CLI this won't work, so we don't try.
+	if discoverer != nil {
+		conn, _, err := discoverer.DetectConfigManagementPlugin(ctx, appPath, repoPath, "", []string{}, tarExcludedGlobs)
+		if err == nil {
+			// Found CMP
+			io.Close(conn)
 
-		apps["."] = string(v1alpha1.ApplicationSourceTypePlugin)
-		return apps, nil
+			apps["."] = string(v1alpha1.ApplicationSourceTypePlugin)
+			return apps, nil
+		}
 	}
 
-	err = filepath.Walk(appPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(appPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -67,8 +90,8 @@ func Discover(ctx context.Context, appPath, repoPath string, enableGenerateManif
 	return apps, err
 }
 
-func AppType(ctx context.Context, appPath, repoPath string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (string, error) {
-	apps, err := Discover(ctx, appPath, repoPath, enableGenerateManifests, tarExcludedGlobs)
+func AppType(ctx context.Context, discoverer *Discoverer, appPath, repoPath string, enableGenerateManifests map[string]bool, tarExcludedGlobs []string) (string, error) {
+	apps, err := Discover(ctx, discoverer, appPath, repoPath, enableGenerateManifests, tarExcludedGlobs)
 	if err != nil {
 		return "", err
 	}
@@ -85,34 +108,33 @@ func AppType(ctx context.Context, appPath, repoPath string, enableGenerateManife
 // check cmpSupports()
 // if supported return conn for the cmp-server
 
-func DetectConfigManagementPlugin(ctx context.Context, appPath, repoPath, pluginName string, env []string, tarExcludedGlobs []string) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, error) {
+func (d *Discoverer) DetectConfigManagementPlugin(ctx context.Context, appPath, repoPath, pluginName string, env []string, tarExcludedGlobs []string) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, error) {
 	var conn io.Closer
 	var cmpClient pluginclient.ConfigManagementPluginServiceClient
 	var connFound bool
 
-	pluginSockFilePath := common.GetPluginSockFilePath()
-	log.WithFields(log.Fields{
-		common.SecurityField:    common.SecurityLow,
-		common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
-	}).Debugf("pluginSockFilePath is: %s", pluginSockFilePath)
-
 	if pluginName != "" {
 		// check if the given plugin supports the repo
-		conn, cmpClient, connFound = cmpSupports(ctx, pluginSockFilePath, appPath, repoPath, fmt.Sprintf("%v.sock", pluginName), env, tarExcludedGlobs, true)
-		if !connFound {
+		plugin, err := d.pluginService.getPluginByName(pluginName)
+		if plugin == nil {
 			return nil, nil, fmt.Errorf("couldn't find cmp-server plugin with name %q supporting the given repository", pluginName)
 		}
-	} else {
-		fileList, err := os.ReadDir(pluginSockFilePath)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Failed to list all plugins in dir, error=%w", err)
+			return nil, nil, fmt.Errorf("failed to find cmp-server plugin with name %q, error=%w", pluginName, err)
 		}
-		for _, file := range fileList {
-			if file.Type() == os.ModeSocket {
-				conn, cmpClient, connFound = cmpSupports(ctx, pluginSockFilePath, appPath, repoPath, file.Name(), env, tarExcludedGlobs, false)
-				if connFound {
-					break
-				}
+		conn, cmpClient, connFound = cmpSupports(ctx, appPath, repoPath, plugin, env, tarExcludedGlobs, true)
+		if !connFound {
+			return nil, nil, fmt.Errorf("named cmp service %q not reachable", pluginName)
+		}
+	} else {
+		plugins, err := d.pluginService.getAllPlugins()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list all plugins, error=%w", err)
+		}
+		for _, plugin := range plugins {
+			conn, cmpClient, connFound = cmpSupports(ctx, appPath, repoPath, plugin, env, tarExcludedGlobs, false)
+			if connFound {
+				break
 			}
 		}
 		if !connFound {
@@ -142,26 +164,15 @@ func matchRepositoryCMP(ctx context.Context, appPath, repoPath string, client pl
 	return resp.GetIsSupported(), resp.GetIsDiscoveryEnabled(), nil
 }
 
-func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fileName string, env []string, tarExcludedGlobs []string, namedPlugin bool) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, bool) {
-	absPluginSockFilePath, err := filepath.Abs(pluginSockFilePath)
-	if err != nil {
-		log.Errorf("error getting absolute path for plugin socket dir %v, %v", pluginSockFilePath, err)
-		return nil, nil, false
-	}
-	address := filepath.Join(absPluginSockFilePath, fileName)
-	if !files.Inbound(address, absPluginSockFilePath) {
-		log.Errorf("invalid socket file path, %v is outside plugin socket dir %v", fileName, pluginSockFilePath)
-		return nil, nil, false
-	}
-
-	cmpclientset := pluginclient.NewConfigManagementPluginClientSet(address)
+func cmpSupports(ctx context.Context, appPath, repoPath string, plugin *plugin, env []string, tarExcludedGlobs []string, namedPlugin bool) (io.Closer, pluginclient.ConfigManagementPluginServiceClient, bool) {
+	cmpclientset := pluginclient.NewConfigManagementPluginClientSet(plugin.address, plugin.pluginType.clientSetType())
 
 	conn, cmpClient, err := cmpclientset.NewConfigManagementPluginClient()
 	if err != nil {
 		log.WithFields(log.Fields{
 			common.SecurityField:    common.SecurityMedium,
 			common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
-		}).Errorf("error dialing to cmp-server for plugin %s, %v", fileName, err)
+		}).Errorf("error dialing to cmp-server for plugin %s, %v", plugin.address, err)
 		return nil, nil, false
 	}
 
@@ -183,7 +194,7 @@ func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fil
 		log.WithFields(log.Fields{
 			common.SecurityField:    common.SecurityLow,
 			common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
-		}).Debugf("Reponse from socket file %s does not support %v", fileName, repoPath)
+		}).Debugf("Reponse from socket file %s does not support %v", plugin.address, repoPath)
 		io.Close(conn)
 		return nil, nil, false
 	}

--- a/util/app/discovery/discovery_test.go
+++ b/util/app/discovery/discovery_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDiscover(t *testing.T) {
-	apps, err := Discover(context.Background(), "./testdata", "./testdata", map[string]bool{}, []string{})
+	apps, err := Discover(context.Background(), nil, "./testdata", "./testdata", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"foo": "Kustomize",
@@ -19,15 +19,15 @@ func TestDiscover(t *testing.T) {
 }
 
 func TestAppType(t *testing.T) {
-	appType, err := AppType(context.Background(), "./testdata/foo", "./testdata", map[string]bool{}, []string{})
+	appType, err := AppType(context.Background(), nil, "./testdata/foo", "./testdata", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Kustomize", appType)
 
-	appType, err = AppType(context.Background(), "./testdata/baz", "./testdata", map[string]bool{}, []string{})
+	appType, err = AppType(context.Background(), nil, "./testdata/baz", "./testdata", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Helm", appType)
 
-	appType, err = AppType(context.Background(), "./testdata", "./testdata", map[string]bool{}, []string{})
+	appType, err = AppType(context.Background(), nil, "./testdata", "./testdata", map[string]bool{}, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 }
@@ -37,15 +37,15 @@ func TestAppType_Disabled(t *testing.T) {
 		string(v1alpha1.ApplicationSourceTypeKustomize): false,
 		string(v1alpha1.ApplicationSourceTypeHelm):      false,
 	}
-	appType, err := AppType(context.Background(), "./testdata/foo", "./testdata", enableManifestGeneration, []string{})
+	appType, err := AppType(context.Background(), nil, "./testdata/foo", "./testdata", enableManifestGeneration, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 
-	appType, err = AppType(context.Background(), "./testdata/baz", "./testdata", enableManifestGeneration, []string{})
+	appType, err = AppType(context.Background(), nil, "./testdata/baz", "./testdata", enableManifestGeneration, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 
-	appType, err = AppType(context.Background(), "./testdata", "./testdata", enableManifestGeneration, []string{})
+	appType, err = AppType(context.Background(), nil, "./testdata", "./testdata", enableManifestGeneration, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 }

--- a/util/app/discovery/plugin.go
+++ b/util/app/discovery/plugin.go
@@ -1,0 +1,130 @@
+package discovery
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	pluginclient "github.com/argoproj/argo-cd/v2/cmpserver/apiclient"
+	"github.com/argoproj/argo-cd/v2/common"
+	log "github.com/sirupsen/logrus"
+	informerscorev1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+type pluginType int
+
+const (
+	sidecar pluginType = iota
+	service
+)
+
+type pluginService struct {
+	servicePlugins []*plugin
+	serviceMutex   sync.RWMutex
+	informer       *informerscorev1.ServiceInformer
+}
+
+type plugin struct {
+	name       string
+	pluginType pluginType
+	address    string
+	owner      string
+}
+
+func (p *pluginType) clientSetType() pluginclient.ClientType {
+	switch *p {
+	case sidecar:
+		return pluginclient.Sidecar
+	case service:
+		return pluginclient.Service
+	default:
+		log.Debugf("Unexpected pluginType %d", *p)
+		return pluginclient.Sidecar
+	}
+}
+
+func kubernetesClient() (*kubernetes.Clientset, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+func newPluginService() *pluginService {
+	ps := pluginService{
+		servicePlugins: make([]*plugin, 0),
+	}
+	c, err := kubernetesClient()
+	if err == nil {
+		go ps.serviceWatcher(c)
+	} else {
+		// This is fine if this is what the user wants
+		log.Warnf("Unable to uses plugins from services, ensure service account token is mounted (%s)", err)
+	}
+	return &ps
+}
+
+func (s *pluginService) getServicePlugins() ([]*plugin, error) {
+	return s.servicePlugins, nil
+}
+
+func (s *pluginService) getSidecarPlugins() ([]*plugin, error) {
+	plugins := make([]*plugin, 0)
+	pluginSockFilePath := common.GetPluginSockFilePath()
+	log.WithFields(log.Fields{
+		common.SecurityField:    common.SecurityLow,
+		common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
+	}).Debugf("pluginSockFilePath is: %s", pluginSockFilePath)
+
+	fileList, err := os.ReadDir(pluginSockFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list all plugins in dir, error=%w", err)
+	}
+	for _, file := range fileList {
+		if file.Type() == os.ModeSocket {
+			name, foundSock := strings.CutSuffix(file.Name(), `.sock`)
+			if foundSock {
+				plugins = append(plugins, &plugin{
+					name:       name,
+					pluginType: sidecar,
+					address:    filepath.Join(pluginSockFilePath, file.Name()),
+					owner:      file.Name(),
+				})
+			}
+		}
+	}
+	return plugins, nil
+}
+
+func (s *pluginService) getAllPlugins() ([]*plugin, error) {
+	s.serviceMutex.RLock()
+	defer s.serviceMutex.RUnlock()
+	servicePlugins, err := s.getServicePlugins()
+	if err != nil {
+		return nil, err
+	}
+	sidecarPlugins, err := s.getSidecarPlugins()
+	if err != nil {
+		return nil, err
+	}
+	return append(sidecarPlugins, servicePlugins...), nil
+}
+
+// Gets a plugin by name or returns nil if no such plugin
+func (s *pluginService) getPluginByName(name string) (*plugin, error) {
+	plugins, err := s.getAllPlugins()
+	if err != nil {
+		return nil, err
+	}
+	for _, plugin := range plugins {
+		if name == plugin.name {
+			return plugin, nil
+		}
+	}
+	return nil, nil
+}

--- a/util/app/discovery/services.go
+++ b/util/app/discovery/services.go
@@ -1,0 +1,121 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"slices"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+func (s *pluginService) namespace() string {
+	ns := os.Getenv("ARGOCD_SERVICE_PLUGINS_NAMESPACE")
+
+	switch ns {
+	case `*`:
+		return corev1.NamespaceAll
+	case "":
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		configOverrides := &clientcmd.ConfigOverrides{}
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+		namespace, _, err := kubeConfig.Namespace()
+		if err != nil {
+			log.Warnf("Error getting default namespace %s. Got %s", err, namespace)
+		}
+		return namespace
+	default:
+		return ns
+	}
+}
+
+func (s *pluginService) serviceWatcher(c *kubernetes.Clientset) {
+	//	labelOptions := informers.WithTweakListOptions()
+	factory := informers.NewFilteredSharedInformerFactory(c, 10*time.Minute, s.namespace(),
+		func(opts *metav1.ListOptions) {
+			opts.LabelSelector = "argocd.argoproj.io/plugin=true"
+		})
+
+	informer := factory.Core().V1().Services()
+	s.informer = &informer
+
+	_, err := informer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    s.svcAdd,
+			UpdateFunc: s.svcUpdate,
+			DeleteFunc: s.svcDelete,
+		},
+	)
+	if err != nil {
+		log.Errorf("Failed to initialise plugin services watcher, plugins as services will not work: %s", err)
+		return
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	informer.Informer().Run(ctx.Done())
+}
+
+func (s *pluginService) svcAdd(obj interface{}) {
+	svc := obj.(*corev1.Service)
+	log.Infof("Adding plugin service %s", namespacedName(svc))
+	s.serviceMutex.Lock()
+	defer s.serviceMutex.Unlock()
+	s.addFromService(svc)
+}
+
+func (s *pluginService) svcDelete(obj interface{}) {
+	svc := obj.(*corev1.Service)
+	log.Infof("Deleting plugin service %s", namespacedName(svc))
+	s.serviceMutex.Lock()
+	defer s.serviceMutex.Unlock()
+	s.deleteByOwner(namespacedName(svc).String())
+}
+
+func (s *pluginService) svcUpdate(_ interface{}, new interface{}) {
+	svc := new.(*corev1.Service)
+	log.Infof("Updating plugin service %s", namespacedName(svc))
+	s.serviceMutex.Lock()
+	defer s.serviceMutex.Unlock()
+	// Simple delete all and add them all again logic
+	s.deleteByOwner(namespacedName(svc).String())
+	s.addFromService(svc)
+}
+
+func namespacedName(svc *corev1.Service) types.NamespacedName {
+	return types.NamespacedName{Name: svc.ObjectMeta.Name, Namespace: svc.ObjectMeta.Namespace}
+}
+
+func (s *pluginService) deleteByOwner(owner string) {
+	// You must have the rw lock to call this
+	for i, svc := range s.servicePlugins {
+		if svc.owner == owner {
+			s.servicePlugins = slices.Delete(
+				s.servicePlugins, i, i+1)
+		}
+	}
+}
+
+func (s *pluginService) addFromService(svc *corev1.Service) {
+	// You must have the rw lock to call this
+	for _, port := range svc.Spec.Ports {
+		s.servicePlugins = append(s.servicePlugins, &plugin{
+			name:       port.Name,
+			pluginType: service,
+			address: fmt.Sprintf("%s.%s.svc.cluster.local:%d",
+				svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, port.Port),
+			owner: namespacedName(svc).String(),
+		})
+	}
+}


### PR DESCRIPTION
This commit makes the repo server able to use cmp plugins via kubernetes services.

It implements #14132 - read that for details

Some discussion points for this PR:
* Plugin name: Currently determined by the **port** name in the service. One service can have many ports, and this feels somewhat useful, so I chose the port name. My guess is the correct thing to do is add another gRPC call, which could also return the parameters (future UI work could then expose them for those people who use it to create apps). We'd then query on first noticing and then poll every 30 seconds. I'd like feedback on whether this is the right approach and desired - if so I'll add it.
* We cache the service list, but not the sidecar list. I'm assuming some plugins could take time to initialise, so may not have created a socket file in time for a cache at startup approach. It would be trivial to switch though.
* SA Token + role + rolebindings in the repo server: I've added it as default mounted now because it makes service plugins just work. Happy not to do this though.
* Namespace configuration for where to find services is via en environment variable. I didn't originally propose it, but I think it's the right approach now.
* No tests written yet whilst we ascertain what we want.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

