### PR TITLE
fix: enforce content type header for API requests (#16860)  (Cherry-pick release-2.9 )

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/argoproj/pkg/stats"
@@ -58,6 +59,7 @@ func NewCommand() *cobra.Command {
 		repoServerAddress        string
 		dexServerAddress         string
 		disableAuth              bool
+		contentTypes             string
 		enableGZip               bool
 		tlsConfigCustomizerSrc   func() (tls.ConfigCustomizer, error)
 		cacheSrc                 func() (*servercache.Cache, error)
@@ -177,6 +179,7 @@ func NewCommand() *cobra.Command {
 				DexServerAddr:         dexServerAddress,
 				DexTLSConfig:          dexTlsConfig,
 				DisableAuth:           disableAuth,
+				ContentTypes:          strings.Split(contentTypes, ";"),
 				EnableGZip:            enableGZip,
 				TLSConfigCustomizer:   tlsConfigCustomizer,
 				Cache:                 cache,
@@ -224,6 +227,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&repoServerAddress, "repo-server", env.StringFromEnv("ARGOCD_SERVER_REPO_SERVER", common.DefaultRepoServerAddr), "Repo server address")
 	command.Flags().StringVar(&dexServerAddress, "dex-server", env.StringFromEnv("ARGOCD_SERVER_DEX_SERVER", common.DefaultDexServerAddr), "Dex server address")
 	command.Flags().BoolVar(&disableAuth, "disable-auth", env.ParseBoolFromEnv("ARGOCD_SERVER_DISABLE_AUTH", false), "Disable client authentication")
+	command.Flags().StringVar(&contentTypes, "api-content-types", "application/json", "Semicolon separated list of allowed content types for non GET api requests. Any content type is allowed if empty.")
 	command.Flags().BoolVar(&enableGZip, "enable-gzip", env.ParseBoolFromEnv("ARGOCD_SERVER_ENABLE_GZIP", true), "Enable GZIP compression")
 	command.AddCommand(cli.NewVersionCmd(cliName))
 	command.Flags().StringVar(&listenHost, "address", env.StringFromEnv("ARGOCD_SERVER_LISTEN_ADDRESS", common.DefaultAddressAPIServer), "Listen on given address")

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -16,6 +16,7 @@ argocd-server [flags]
 
 ```
       --address string                                Listen on given address (default "0.0.0.0")
+      --api-content-types string                      Semicolon separated list of allowed content types for non GET api requests. Any content type is allowed if empty. (default "application/json")
       --app-state-cache-expiration duration           Cache expiration for app state (default 1h0m0s)
       --application-namespaces strings                List of additional namespaces where application resources can be managed in
       --as string                                     Username to impersonate for the operation

--- a/test/e2e/fixture/http.go
+++ b/test/e2e/fixture/http.go
@@ -28,6 +28,7 @@ func DoHttpRequest(method string, path string, data ...byte) (*http.Response, er
 		return nil, err
 	}
 	req.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: token})
+	req.Header.Set("Content-Type", "application/json")
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{

--- a/test/e2e/fixture/http.go
+++ b/test/e2e/fixture/http.go
@@ -2,6 +2,7 @@ package fixture
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -27,7 +28,14 @@ func DoHttpRequest(method string, path string, data ...byte) (*http.Response, er
 		return nil, err
 	}
 	req.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: token})
-	return http.DefaultClient.Do(req)
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: IsRemote()},
+		},
+	}
+
+	return httpClient.Do(req)
 }
 
 // DoHttpJsonRequest executes a http request against the Argo CD API server and unmarshals the response body as JSON


### PR DESCRIPTION
Cherry-pick content-type enforcement PR: https://github.com/argoproj/argo-cd/pull/16860