### PR TITLE
fix: enforce content type header for API requests (#16860) (Cherry-pick release-2.7)

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/argoproj/pkg/stats"
@@ -60,6 +61,7 @@ func NewCommand() *cobra.Command {
 		repoServerAddress        string
 		dexServerAddress         string
 		disableAuth              bool
+		contentTypes             string
 		enableGZip               bool
 		tlsConfigCustomizerSrc   func() (tls.ConfigCustomizer, error)
 		cacheSrc                 func() (*servercache.Cache, error)
@@ -177,6 +179,7 @@ func NewCommand() *cobra.Command {
 				DexServerAddr:         dexServerAddress,
 				DexTLSConfig:          dexTlsConfig,
 				DisableAuth:           disableAuth,
+				ContentTypes:          strings.Split(contentTypes, ";"),
 				EnableGZip:            enableGZip,
 				TLSConfigCustomizer:   tlsConfigCustomizer,
 				Cache:                 cache,
@@ -225,6 +228,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&dexServerAddress, "dex-server", env.StringFromEnv("ARGOCD_SERVER_DEX_SERVER", common.DefaultDexServerAddr), "Dex server address")
 	command.Flags().BoolVar(&disableAuth, "disable-auth", env.ParseBoolFromEnv("ARGOCD_SERVER_DISABLE_AUTH", false), "Disable client authentication")
 	command.Flags().BoolVar(&enableGZip, "enable-gzip", env.ParseBoolFromEnv("ARGOCD_SERVER_ENABLE_GZIP", false), "Enable GZIP compression")
+	command.Flags().StringVar(&contentTypes, "api-content-types", "application/json", "Semicolon separated list of allowed content types for non GET api requests. Any content type is allowed if empty.")
 	command.AddCommand(cli.NewVersionCmd(cliName))
 	command.Flags().IntVar(&listenPort, "port", common.DefaultPortAPIServer, "Listen on given port")
 	command.Flags().IntVar(&metricsPort, "metrics-port", common.DefaultPortArgoCDAPIServerMetrics, "Start metrics on given port")

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -13,6 +13,7 @@ argocd-server [flags]
 ### Options
 
 ```
+      --api-content-types string                      Semicolon separated list of allowed content types for non GET api requests. Any content type is allowed if empty. (default "application/json")
       --app-state-cache-expiration duration           Cache expiration for app state (default 1h0m0s)
       --application-namespaces strings                List of additional namespaces where application resources can be managed in
       --as string                                     Username to impersonate for the operation

--- a/server/server.go
+++ b/server/server.go
@@ -200,6 +200,7 @@ type ArgoCDServer struct {
 
 type ArgoCDServerOpts struct {
 	DisableAuth           bool
+	ContentTypes          []string
 	EnableGZip            bool
 	Insecure              bool
 	StaticAssetsDir       string
@@ -960,6 +961,9 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 	if a.EnableGZip {
 		handler = compressHandler(handler)
 	}
+	if len(a.ContentTypes) > 0 {
+		handler = enforceContentTypes(handler, a.ContentTypes)
+	}
 	mux.Handle("/api/", handler)
 
 	terminal := application.NewHandler(a.appLister, a.Namespace, a.ApplicationNamespaces, a.db, a.enf, a.Cache, appResourceTreeFn, a.settings.ExecShells, *a.sessionMgr).
@@ -1024,6 +1028,20 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 	}
 	mux.Handle("/", assetsHandler)
 	return &httpS
+}
+
+func enforceContentTypes(handler http.Handler, types []string) http.Handler {
+	allowedTypes := map[string]bool{}
+	for _, t := range types {
+		allowedTypes[strings.ToLower(t)] = true
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet || allowedTypes[strings.ToLower(r.Header.Get("Content-Type"))] {
+			handler.ServeHTTP(w, r)
+		} else {
+			http.Error(w, "Invalid content type", http.StatusUnsupportedMediaType)
+		}
+	})
 }
 
 // registerExtensions will try to register all configured extensions

--- a/test/e2e/fixture/http.go
+++ b/test/e2e/fixture/http.go
@@ -28,6 +28,7 @@ func DoHttpRequest(method string, path string, data ...byte) (*http.Response, er
 		return nil, err
 	}
 	req.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: token})
+	req.Header.Set("Content-Type", "application/json")
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{

--- a/test/e2e/fixture/http.go
+++ b/test/e2e/fixture/http.go
@@ -2,6 +2,7 @@ package fixture
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -27,7 +28,14 @@ func DoHttpRequest(method string, path string, data ...byte) (*http.Response, er
 		return nil, err
 	}
 	req.AddCookie(&http.Cookie{Name: common.AuthCookieName, Value: token})
-	return http.DefaultClient.Do(req)
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: IsRemote()},
+		},
+	}
+
+	return httpClient.Do(req)
 }
 
 // DoHttpJsonRequest executes a http request against the Argo CD API server and unmarshals the response body as JSON


### PR DESCRIPTION
Cherry-pick content-type enforcement PR: https://github.com/argoproj/argo-cd/pull/16860