### PR TITLE
fix: multi-source app breaks application parameters UI (#16910)

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -286,7 +286,7 @@ export const ApplicationParameters = (props: {
     } else if (props.details.type === 'Plugin') {
         attributes.push({
             title: 'NAME',
-            view: <div style={{marginTop: 15, marginBottom: 5}}>{ValueEditor(app.spec.source.plugin && app.spec.source.plugin.name, null)}</div>,
+            view: <div style={{marginTop: 15, marginBottom: 5}}>{ValueEditor(app.spec.source?.plugin?.name, null)}</div>,
             edit: (formApi: FormApi) => (
                 <DataLoader load={() => services.authService.plugins()}>
                     {(plugins: Plugin[]) => (
@@ -299,12 +299,11 @@ export const ApplicationParameters = (props: {
             title: 'ENV',
             view: (
                 <div style={{marginTop: 15}}>
-                    {app.spec.source.plugin &&
-                        (app.spec.source.plugin.env || []).map(val => (
-                            <span key={val.name} style={{display: 'block', marginBottom: 5}}>
-                                {NameValueEditor(val, null)}
-                            </span>
-                        ))}
+                    {(app.spec.source?.plugin?.env || []).map(val => (
+                        <span key={val.name} style={{display: 'block', marginBottom: 5}}>
+                            {NameValueEditor(val, null)}
+                        </span>
+                    ))}
                 </div>
             ),
             edit: (formApi: FormApi) => <FormField field='spec.source.plugin.env' formApi={formApi} component={ArrayInputField} />
@@ -315,7 +314,7 @@ export const ApplicationParameters = (props: {
                 parametersSet.add(announcement.name);
             }
         }
-        if (app.spec.source.plugin?.parameters) {
+        if (app.spec.source?.plugin?.parameters) {
             for (const appParameter of app.spec.source.plugin.parameters) {
                 parametersSet.add(appParameter.name);
             }
@@ -326,7 +325,7 @@ export const ApplicationParameters = (props: {
         }
         parametersSet.forEach(name => {
             const announcement = props.details.plugin.parametersAnnouncement?.find(param => param.name === name);
-            const liveParam = app.spec.source.plugin?.parameters?.find(param => param.name === name);
+            const liveParam = app.spec.source?.plugin?.parameters?.find(param => param.name === name);
             const pluginIcon =
                 announcement && liveParam ? 'This parameter has been provided by plugin, but is overridden in application manifest.' : 'This parameter is provided by the plugin.';
             const isPluginPar = !!announcement;


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/16910

As part of the original multi-source feature implementation, the Parameters tab shows the parameters related to the _first_ source. If you reverse the order of the two sources (from the bug issue) in the manifest yaml, then it doesn't blow up. It only happens with the sock-shop example. 

So with this fix, the parameters page will show the same contents as if the sock-shop example was created as a single source application. (It's a plugin still)

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).


