### PR TITLE
fix(repo-server): excess git requests, add shared cache lock on revisions (Issue #14725)

### DIFF
--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -44,6 +44,7 @@ argocd-repo-server [flags]
       --redisdb int                                    Redis database.
       --repo-cache-expiration duration                 Cache expiration for repo state, incl. app lists, app details, manifest generation, revision meta-data (default 24h0m0s)
       --revision-cache-expiration duration             Cache expiration for cached revision (default 3m0s)
+      --revision-cache-lock-timeout duration           Cache TTL for locks to prevent duplicate requests on revisions, set to 0 to disable (default 10s)
       --sentinel stringArray                           Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
       --sentinelmaster string                          Redis sentinel master group name. (default "master")
       --streamed-manifest-max-extracted-size string    Maximum size of streamed manifest archives when extracted (default "1G")

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -93,6 +93,7 @@ argocd-server [flags]
       --repo-server-timeout-seconds int                 Repo server RPC call timeout seconds. (default 60)
       --request-timeout string                          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
       --revision-cache-expiration duration              Cache expiration for cached revision (default 3m0s)
+      --revision-cache-lock-timeout duration            Cache TTL for locks to prevent duplicate requests on revisions, set to 0 to disable (default 10s)
       --rootpath string                                 Used if Argo CD is running behind reverse proxy under subpath different from /
       --sentinel stringArray                            Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
       --sentinelmaster string                           Redis sentinel master group name. (default "master")

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -174,6 +174,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: reposerver.disable.helm.manifest.max.extracted.size
                 optional: true
+          - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
+            valueFrom:
+              configMapKeyRef:
+                key: reposerver.revision.cache.lock.timeout
+                name: argocd-cmd-params-cm
+                optional: true
           - name: ARGOCD_GIT_MODULES_ENABLED
             valueFrom:
               configMapKeyRef:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -21484,6 +21484,12 @@ spec:
               key: reposerver.disable.helm.manifest.max.extracted.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.revision.cache.lock.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_GIT_MODULES_ENABLED
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -23083,6 +23083,12 @@ spec:
               key: reposerver.disable.helm.manifest.max.extracted.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.revision.cache.lock.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_GIT_MODULES_ENABLED
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2204,6 +2204,12 @@ spec:
               key: reposerver.disable.helm.manifest.max.extracted.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.revision.cache.lock.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_GIT_MODULES_ENABLED
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -22129,6 +22129,12 @@ spec:
               key: reposerver.disable.helm.manifest.max.extracted.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.revision.cache.lock.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_GIT_MODULES_ENABLED
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1250,6 +1250,12 @@ spec:
               key: reposerver.disable.helm.manifest.max.extracted.size
               name: argocd-cmd-params-cm
               optional: true
+        - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: reposerver.revision.cache.lock.timeout
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_GIT_MODULES_ENABLED
           valueFrom:
             configMapKeyRef:

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/text"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -24,11 +25,15 @@ import (
 )
 
 var ErrCacheMiss = cacheutil.ErrCacheMiss
+var ErrCacheKeyLocked = cacheutil.ErrCacheKeyLocked
+
+const RevisionCacheLockTimeout = 10 * time.Second
 
 type Cache struct {
-	cache                   *cacheutil.Cache
-	repoCacheExpiration     time.Duration
-	revisionCacheExpiration time.Duration
+	cache                    *cacheutil.Cache
+	repoCacheExpiration      time.Duration
+	revisionCacheExpiration  time.Duration
+	revisionCacheLockTimeout time.Duration
 }
 
 // ClusterRuntimeInfo holds cluster runtime information
@@ -39,8 +44,8 @@ type ClusterRuntimeInfo interface {
 	GetKubeVersion() string
 }
 
-func NewCache(cache *cacheutil.Cache, repoCacheExpiration time.Duration, revisionCacheExpiration time.Duration) *Cache {
-	return &Cache{cache, repoCacheExpiration, revisionCacheExpiration}
+func NewCache(cache *cacheutil.Cache, repoCacheExpiration time.Duration, revisionCacheExpiration time.Duration, revisionCacheLockTimeout time.Duration) *Cache {
+	return &Cache{cache, repoCacheExpiration, revisionCacheExpiration, revisionCacheLockTimeout}
 }
 
 func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*Cache, error) {
@@ -57,7 +62,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*
 		if err != nil {
 			return nil, fmt.Errorf("error adding cache flags to cmd: %w", err)
 		}
-		return NewCache(cache, repoCacheExpiration, revisionCacheExpiration), nil
+		return NewCache(cache, repoCacheExpiration, revisionCacheExpiration, RevisionCacheLockTimeout), nil
 	}
 }
 
@@ -145,7 +150,12 @@ func (c *Cache) ListApps(repoUrl, revision string) (map[string]string, error) {
 }
 
 func (c *Cache) SetApps(repoUrl, revision string, apps map[string]string) error {
-	return c.cache.SetItem(listApps(repoUrl, revision), apps, c.repoCacheExpiration, apps == nil)
+	return c.cache.SetItem(
+		listApps(repoUrl, revision),
+		apps,
+		&cacheutil.CacheActionOpts{
+			Expiration: c.repoCacheExpiration,
+			Delete:     apps == nil})
 }
 
 func helmIndexRefsKey(repo string) string {
@@ -154,7 +164,14 @@ func helmIndexRefsKey(repo string) string {
 
 // SetHelmIndex stores helm repository index.yaml content to cache
 func (c *Cache) SetHelmIndex(repo string, indexData []byte) error {
-	return c.cache.SetItem(helmIndexRefsKey(repo), indexData, c.revisionCacheExpiration, false)
+	if indexData == nil {
+		// Logged as warning upstream
+		return fmt.Errorf("helm index data is nil, skipping cache")
+	}
+	return c.cache.SetItem(
+		helmIndexRefsKey(repo),
+		indexData,
+		&cacheutil.CacheActionOpts{Expiration: c.revisionCacheExpiration})
 }
 
 // GetHelmIndex retrieves helm repository index.yaml content from cache
@@ -172,21 +189,110 @@ func (c *Cache) SetGitReferences(repo string, references []*plumbing.Reference) 
 	for i := range references {
 		input = append(input, references[i].Strings())
 	}
-	return c.cache.SetItem(gitRefsKey(repo), input, c.revisionCacheExpiration, false)
+	return c.cache.SetItem(gitRefsKey(repo), input, &cacheutil.CacheActionOpts{Expiration: c.revisionCacheExpiration})
 }
 
-// GetGitReferences retrieves resolved Git repository references from cache
-func (c *Cache) GetGitReferences(repo string, references *[]*plumbing.Reference) error {
-	var input [][2]string
-	if err := c.cache.GetItem(gitRefsKey(repo), &input); err != nil {
-		return err
-	}
+// Converts raw cache items to plumbing.Reference objects
+func GitRefCacheItemToReferences(cacheItem [][2]string) *[]*plumbing.Reference {
 	var res []*plumbing.Reference
-	for i := range input {
-		res = append(res, plumbing.NewReferenceFromStrings(input[i][0], input[i][1]))
+	for i := range cacheItem {
+		// Skip empty data
+		if cacheItem[i][0] != "" || cacheItem[i][1] != "" {
+			res = append(res, plumbing.NewReferenceFromStrings(cacheItem[i][0], cacheItem[i][1]))
+		}
 	}
-	*references = res
-	return nil
+	return &res
+}
+
+// TryLockGitRefCache attempts to lock the key for the Git repository references if the key doesn't exist
+func (c *Cache) TryLockGitRefCache(repo string, lockId string) error {
+	// This try set with DisableOverwrite is important for making sure that only one process is able to claim ownership
+	// A normal get + set, or just set would cause ownership to go to whoever the last writer was, and during race conditions
+	// leads to duplicate requests
+	err := c.cache.SetItem(gitRefsKey(repo), [][2]string{{cacheutil.CacheLockedValue, lockId}}, &cacheutil.CacheActionOpts{
+		Expiration:       c.revisionCacheLockTimeout,
+		DisableOverwrite: true})
+	return err
+}
+
+// Retrieves the cache item for git repo references. Returns lockHolderId, references, error
+func (c *Cache) GetGitReferences(repo string) (string, *[]*plumbing.Reference, error) {
+	var input [][2]string
+	err := c.cache.GetItem(gitRefsKey(repo), &input)
+	if err == ErrCacheMiss {
+		// Expected
+		return "", nil, nil
+	} else if err == nil && len(input) > 0 && len(input[0]) > 0 {
+		if input[0][0] != cacheutil.CacheLockedValue {
+			// Valid value in cache, convert to plumbing.Reference and return
+			return "", GitRefCacheItemToReferences(input), nil
+		} else {
+			// The key lock is being held
+			return input[0][1], nil, nil
+		}
+	}
+	return "", nil, err
+}
+
+// GetOrLockGitReferences retrieves the git references if they exist, otherwise creates a lock and returns so the caller can populate the cache
+// Returns isLockOwner, localLockId, error
+func (c *Cache) GetOrLockGitReferences(repo string, references *[]*plumbing.Reference) (bool, string, error) {
+	myLockUUID, err := uuid.NewRandom()
+	if err != nil {
+		log.Debug("Error generating git references cache lock id: ", err)
+		return false, "", err
+	}
+	// We need to be able to identify that our lock was the successful one, otherwise we'll still have duplicate requests
+	myLockId := myLockUUID.String()
+	// Value matches the ttl on the lock in TryLockGitRefCache
+	waitUntil := time.Now().Add(c.revisionCacheLockTimeout)
+	// Wait only the maximum amount of time configured for the lock
+	for time.Now().Before(waitUntil) {
+		// Attempt to retrieve the key from local cache only
+		if _, cacheReferences, err := c.GetGitReferences(repo); err != nil || cacheReferences != nil {
+			if cacheReferences != nil {
+				*references = *cacheReferences
+			}
+			return false, myLockId, err
+		}
+		// Could not get key locally attempt to get the lock
+		err = c.TryLockGitRefCache(repo, myLockId)
+		if err != nil {
+			// Log but ignore this error since we'll want to retry, failing to obtain the lock should not throw an error
+			log.Errorf("Error attempting to acquire git references cache lock: %v", err)
+		}
+		// Attempt to retrieve the key again to see if we have the lock, or the key was populated
+		if lockOwner, cacheReferences, err := c.GetGitReferences(repo); err != nil || cacheReferences != nil {
+			if cacheReferences != nil {
+				// Someone else populated the key
+				*references = *cacheReferences
+			}
+			return false, myLockId, err
+		} else if lockOwner == myLockId {
+			// We have the lock, populate the key
+			return true, myLockId, nil
+		}
+		// Wait for lock, valid value, or timeout
+		time.Sleep(1 * time.Second)
+	}
+	// Timeout waiting for lock
+	log.Debug("Repository cache was unable to acquire lock or valid data within timeout")
+	return true, myLockId, nil
+}
+
+// UnlockGitReferences unlocks the key for the Git repository references if needed
+func (c *Cache) UnlockGitReferences(repo string, lockId string) error {
+	var input [][2]string
+	var err error
+	if err = c.cache.GetItem(gitRefsKey(repo), &input); err == nil &&
+		len(input) > 0 &&
+		len(input[0]) > 1 &&
+		input[0][0] == cacheutil.CacheLockedValue &&
+		input[0][1] == lockId {
+		// We have the lock, so remove it
+		return c.cache.SetItem(gitRefsKey(repo), input, &cacheutil.CacheActionOpts{Delete: true})
+	}
+	return err
 }
 
 // refSourceCommitSHAs is a list of resolved revisions for each ref source. This allows us to invalidate the cache
@@ -274,11 +380,19 @@ func (c *Cache) SetManifests(revision string, appSrc *appv1.ApplicationSource, s
 		res.CacheEntryHash = hash
 	}
 
-	return c.cache.SetItem(manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs), res, c.repoCacheExpiration, res == nil)
+	return c.cache.SetItem(
+		manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs),
+		res,
+		&cacheutil.CacheActionOpts{
+			Expiration: c.repoCacheExpiration,
+			Delete:     res == nil})
 }
 
 func (c *Cache) DeleteManifests(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, clusterInfo ClusterRuntimeInfo, namespace, trackingMethod, appLabelKey, appName string, refSourceCommitSHAs ResolvedRevisions) error {
-	return c.cache.SetItem(manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs), "", c.repoCacheExpiration, true)
+	return c.cache.SetItem(
+		manifestCacheKey(revision, appSrc, srcRefs, namespace, trackingMethod, appLabelKey, appName, clusterInfo, refSourceCommitSHAs),
+		"",
+		&cacheutil.CacheActionOpts{Delete: true})
 }
 
 func appDetailsCacheKey(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, trackingMethod appv1.TrackingMethod, refSourceCommitSHAs ResolvedRevisions) string {
@@ -293,7 +407,12 @@ func (c *Cache) GetAppDetails(revision string, appSrc *appv1.ApplicationSource, 
 }
 
 func (c *Cache) SetAppDetails(revision string, appSrc *appv1.ApplicationSource, srcRefs appv1.RefTargetRevisionMapping, res *apiclient.RepoAppDetailsResponse, trackingMethod appv1.TrackingMethod, refSourceCommitSHAs ResolvedRevisions) error {
-	return c.cache.SetItem(appDetailsCacheKey(revision, appSrc, srcRefs, trackingMethod, refSourceCommitSHAs), res, c.repoCacheExpiration, res == nil)
+	return c.cache.SetItem(
+		appDetailsCacheKey(revision, appSrc, srcRefs, trackingMethod, refSourceCommitSHAs),
+		res,
+		&cacheutil.CacheActionOpts{
+			Expiration: c.repoCacheExpiration,
+			Delete:     res == nil})
 }
 
 func revisionMetadataKey(repoURL, revision string) string {
@@ -306,7 +425,10 @@ func (c *Cache) GetRevisionMetadata(repoURL, revision string) (*appv1.RevisionMe
 }
 
 func (c *Cache) SetRevisionMetadata(repoURL, revision string, item *appv1.RevisionMetadata) error {
-	return c.cache.SetItem(revisionMetadataKey(repoURL, revision), item, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		revisionMetadataKey(repoURL, revision),
+		item,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func revisionChartDetailsKey(repoURL, chart, revision string) string {
@@ -319,7 +441,10 @@ func (c *Cache) GetRevisionChartDetails(repoURL, chart, revision string) (*appv1
 }
 
 func (c *Cache) SetRevisionChartDetails(repoURL, chart, revision string, item *appv1.ChartDetails) error {
-	return c.cache.SetItem(revisionChartDetailsKey(repoURL, chart, revision), item, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		revisionChartDetailsKey(repoURL, chart, revision),
+		item,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func gitFilesKey(repoURL, revision, pattern string) string {
@@ -327,7 +452,10 @@ func gitFilesKey(repoURL, revision, pattern string) string {
 }
 
 func (c *Cache) SetGitFiles(repoURL, revision, pattern string, files map[string][]byte) error {
-	return c.cache.SetItem(gitFilesKey(repoURL, revision, pattern), &files, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		gitFilesKey(repoURL, revision, pattern),
+		&files,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func (c *Cache) GetGitFiles(repoURL, revision, pattern string) (map[string][]byte, error) {
@@ -340,7 +468,10 @@ func gitDirectoriesKey(repoURL, revision string) string {
 }
 
 func (c *Cache) SetGitDirectories(repoURL, revision string, directories []string) error {
-	return c.cache.SetItem(gitDirectoriesKey(repoURL, revision), &directories, c.repoCacheExpiration, false)
+	return c.cache.SetItem(
+		gitDirectoriesKey(repoURL, revision),
+		&directories,
+		&cacheutil.CacheActionOpts{Expiration: c.repoCacheExpiration})
 }
 
 func (c *Cache) GetGitDirectories(repoURL, revision string) ([]string, error) {

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -52,7 +52,7 @@ func AddCacheFlagsToCmd(cmd *cobra.Command, opts ...cacheutil.Options) func() (*
 
 	cmd.Flags().DurationVar(&repoCacheExpiration, "repo-cache-expiration", env.ParseDurationFromEnv("ARGOCD_REPO_CACHE_EXPIRATION", 24*time.Hour, 0, math.MaxInt64), "Cache expiration for repo state, incl. app lists, app details, manifest generation, revision meta-data")
 	cmd.Flags().DurationVar(&revisionCacheExpiration, "revision-cache-expiration", env.ParseDurationFromEnv("ARGOCD_RECONCILIATION_TIMEOUT", 3*time.Minute, 0, math.MaxInt64), "Cache expiration for cached revision")
-	cmd.Flags().DurationVar(&revisionCacheExpiration, "revision-cache-lock-timeout", env.ParseDurationFromEnv("ARGOCD_REVISION_CACHE_LOCK_TIMEOUT", 10*time.Second, 0, math.MaxInt64), "Cache TTL for locks to prevent duplicate requests on revisions, set to 0 to disable")
+	cmd.Flags().DurationVar(&revisionCacheLockTimeout, "revision-cache-lock-timeout", env.ParseDurationFromEnv("ARGOCD_REVISION_CACHE_LOCK_TIMEOUT", 10*time.Second, 0, math.MaxInt64), "Cache TTL for locks to prevent duplicate requests on revisions, set to 0 to disable")
 
 	repoFactory := cacheutil.AddCacheFlagsToCmd(cmd, opts...)
 
@@ -230,7 +230,6 @@ func (c *Cache) GetGitReferences(repo string, references *[]*plumbing.Reference)
 		return "", err
 	// Value is set
 	case valueExists && input[0][0] != cacheutil.CacheLockedValue:
-		fmt.Printf("Input: %v\n", references)
 		*references = *GitRefCacheItemToReferences(input)
 		return "", nil
 	// Key is locked

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -227,6 +227,7 @@ func (c *Cache) GetGitReferences(repo string, references *[]*plumbing.Reference)
 	switch {
 	// Unexpected Error
 	case err != nil && err != ErrCacheMiss:
+		log.Errorf("Error attempting to retrieve git references from cache: %v", err)
 		return "", err
 	// Value is set
 	case valueExists && input[0][0] != cacheutil.CacheLockedValue:

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -223,7 +223,7 @@ func (c *Cache) TryLockGitRefCache(repo string, lockId string, references *[]*pl
 func (c *Cache) GetGitReferences(repo string, references *[]*plumbing.Reference) (string, error) {
 	var input [][2]string
 	err := c.cache.GetItem(gitRefsKey(repo), &input)
-	valueExists := input != nil && len(input) > 0 && len(input[0]) > 0
+	valueExists := len(input) > 0 && len(input[0]) > 0
 	switch {
 	// Unexpected Error
 	case err != nil && err != ErrCacheMiss:

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -82,7 +82,7 @@ func newCacheMocks() *repoCacheMocks {
 	return newCacheMocksWithOpts(1*time.Minute, 1*time.Minute, 10*time.Second)
 }
 
-func newCacheMocksWithOpts(repoCacheExpiration time.Duration, revisionCacheExpiration time.Duration, revisionCacheLockTimeout time.Duration) *repoCacheMocks {
+func newCacheMocksWithOpts(repoCacheExpiration, revisionCacheExpiration, revisionCacheLockTimeout time.Duration) *repoCacheMocks {
 	mockRepoCache := repositorymocks.NewMockRepoCache(&repositorymocks.MockCacheOptions{
 		RepoCacheExpiration:     1 * time.Minute,
 		RevisionCacheExpiration: 1 * time.Minute,

--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -49,7 +49,7 @@ func (c *Cache) GetItem(key string, item interface{}) error {
 }
 
 func (c *Cache) SetItem(key string, item interface{}, expiration time.Duration, delete bool) error {
-	return c.Cache.SetItem(key, item, expiration, delete)
+	return c.Cache.SetItem(key, item, &cacheutil.CacheActionOpts{Expiration: expiration, Delete: delete})
 }
 
 func appManagedResourcesKey(appName string) string {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -15,6 +15,7 @@ import (
 	certutil "github.com/argoproj/argo-cd/v2/util/cert"
 	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/redis/go-redis/v9"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -259,30 +260,43 @@ func (c *Cache) RenameItem(oldKey string, newKey string, expiration time.Duratio
 	return c.client.Rename(fmt.Sprintf("%s|%s", oldKey, common.CacheVersion), fmt.Sprintf("%s|%s", newKey, common.CacheVersion), expiration)
 }
 
-func (c *Cache) SetItem(key string, item interface{}, expiration time.Duration, delete bool) error {
-	key = fmt.Sprintf("%s|%s", key, common.CacheVersion)
-	if delete {
-		return c.client.Delete(key)
+func (c *Cache) generateFullKey(key string) string {
+	if key == "" {
+		log.Debug("Cache key is empty, this will result in key collisions if there is more than one empty key")
+	}
+	return fmt.Sprintf("%s|%s", key, common.CacheVersion)
+}
+
+// Sets or deletes an item in cache
+func (c *Cache) SetItem(key string, item interface{}, opts *CacheActionOpts) error {
+	if opts == nil {
+		opts = &CacheActionOpts{}
+	}
+	if item == nil {
+		return fmt.Errorf("cannot set nil item in cache")
+	}
+	fullKey := c.generateFullKey(key)
+	client := c.GetClient()
+	if opts.Delete {
+		return client.Delete(fullKey)
 	} else {
-		if item == nil {
-			return fmt.Errorf("cannot set item to nil for key %s", key)
-		}
-		return c.client.Set(&Item{Object: item, Key: key, Expiration: expiration})
+		return client.Set(&Item{Key: fullKey, Object: item, CacheActionOpts: *opts})
 	}
 }
 
 func (c *Cache) GetItem(key string, item interface{}) error {
+	key = c.generateFullKey(key)
 	if item == nil {
 		return fmt.Errorf("cannot get item into a nil for key %s", key)
 	}
-	key = fmt.Sprintf("%s|%s", key, common.CacheVersion)
-	return c.client.Get(key, item)
+	client := c.GetClient()
+	return client.Get(key, item)
 }
 
 func (c *Cache) OnUpdated(ctx context.Context, key string, callback func() error) error {
-	return c.client.OnUpdated(ctx, fmt.Sprintf("%s|%s", key, common.CacheVersion), callback)
+	return c.client.OnUpdated(ctx, c.generateFullKey(key), callback)
 }
 
 func (c *Cache) NotifyUpdated(key string) error {
-	return c.client.NotifyUpdated(fmt.Sprintf("%s|%s", key, common.CacheVersion))
+	return c.client.NotifyUpdated(c.generateFullKey(key))
 }

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -269,11 +269,11 @@ func (c *Cache) generateFullKey(key string) string {
 
 // Sets or deletes an item in cache
 func (c *Cache) SetItem(key string, item interface{}, opts *CacheActionOpts) error {
-	if opts == nil {
-		opts = &CacheActionOpts{}
-	}
 	if item == nil {
 		return fmt.Errorf("cannot set nil item in cache")
+	}
+	if opts == nil {
+		opts = &CacheActionOpts{}
 	}
 	fullKey := c.generateFullKey(key)
 	client := c.GetClient()

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -1,9 +1,13 @@
 package cache
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,33 +18,73 @@ func TestAddCacheFlagsToCmd(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, cache.client.(*redisCache).expiration)
 }
 
+func NewInMemoryRedis() (*redis.Client, func()) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	return redis.NewClient(&redis.Options{Addr: mr.Addr()}), mr.Close
+}
+
 func TestCacheClient(t *testing.T) {
+	clientRedis, stopRedis := NewInMemoryRedis()
+	defer stopRedis()
+	redisCache := NewRedisCache(clientRedis, 5*time.Second, RedisCompressionNone)
+	clientMemCache := NewInMemoryCache(60 * time.Second)
+	twoLevelClient := NewTwoLevelClient(redisCache, 5*time.Second)
+	// Run tests for both Redis and InMemoryCache
+	for _, client := range []CacheClient{clientMemCache, redisCache, twoLevelClient} {
+		cache := NewCache(client)
+		t.Run("SetItem", func(t *testing.T) {
+			err := cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 60 * time.Second, DisableOverwrite: true, Delete: false})
+			assert.NoError(t, err)
+			var output string
+			err = cache.GetItem("foo", &output)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", output)
+		})
+		t.Run("SetCacheItem W/Disable Overwrite", func(t *testing.T) {
+			err := cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 60 * time.Second, DisableOverwrite: true, Delete: false})
+			assert.NoError(t, err)
+			var output string
+			err = cache.GetItem("foo", &output)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", output)
+			err = cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 60 * time.Second, DisableOverwrite: true, Delete: false})
+			assert.NoError(t, err)
+			err = cache.GetItem("foo", &output)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", output, "output should not have changed with DisableOverwrite set to true")
+		})
+		t.Run("GetItem", func(t *testing.T) {
+			var val string
+			err := cache.GetItem("foo", &val)
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", val)
+		})
+		t.Run("DeleteItem", func(t *testing.T) {
+			err := cache.SetItem("foo", "bar", &CacheActionOpts{Expiration: 0, Delete: true})
+			assert.NoError(t, err)
+			var val string
+			err = cache.GetItem("foo", &val)
+			assert.Error(t, err)
+			assert.Empty(t, val)
+		})
+		t.Run("Check for nil items", func(t *testing.T) {
+			err := cache.SetItem("foo", nil, &CacheActionOpts{Expiration: 0, Delete: true})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot set nil item")
+			err = cache.GetItem("foo", nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot get item")
+		})
+	}
+}
+
+// Smoke test to ensure key changes aren't done accidentally
+func TestGenerateCacheKey(t *testing.T) {
 	client := NewInMemoryCache(60 * time.Second)
 	cache := NewCache(client)
-	t.Run("SetItem", func(t *testing.T) {
-		err := cache.SetItem("foo", "bar", 60*time.Second, false)
-		assert.NoError(t, err)
-	})
-	t.Run("GetItem", func(t *testing.T) {
-		var val string
-		err := cache.GetItem("foo", &val)
-		assert.NoError(t, err)
-		assert.Equal(t, "bar", val)
-	})
-	t.Run("DeleteItem", func(t *testing.T) {
-		err := cache.SetItem("foo", "bar", 0, true)
-		assert.NoError(t, err)
-		var val string
-		err = cache.GetItem("foo", &val)
-		assert.Error(t, err)
-		assert.Empty(t, val)
-	})
-	t.Run("Check for nil items", func(t *testing.T) {
-		err := cache.SetItem("foo", nil, 0, false)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot set item")
-		err = cache.GetItem("foo", nil)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot get item")
-	})
+	testKey := cache.generateFullKey("testkey")
+	assert.Equal(t, fmt.Sprintf("testkey|%s", common.CacheVersion), testKey)
 }

--- a/util/cache/client.go
+++ b/util/cache/client.go
@@ -7,10 +7,20 @@ import (
 )
 
 var ErrCacheMiss = errors.New("cache: key is missing")
+var ErrCacheKeyLocked = errors.New("cache: key is locked")
+var CacheLockedValue = "locked"
 
 type Item struct {
-	Key    string
-	Object interface{}
+	Key             string
+	Object          interface{}
+	CacheActionOpts CacheActionOpts
+}
+
+type CacheActionOpts struct {
+	// Delete item from cache
+	Delete bool
+	// Disable writing if key already exists (NX)
+	DisableOverwrite bool
 	// Expiration is the cache expiration time.
 	Expiration time.Duration
 }

--- a/util/cache/inmemory.go
+++ b/util/cache/inmemory.go
@@ -33,7 +33,12 @@ func (i *InMemoryCache) Set(item *Item) error {
 	if err != nil {
 		return err
 	}
-	i.memCache.Set(item.Key, buf, item.Expiration)
+	if item.CacheActionOpts.DisableOverwrite {
+		// go-redis doesn't throw an error on Set with NX, so absorbing here to keep the interface consistent
+		_ = i.memCache.Add(item.Key, buf, item.CacheActionOpts.Expiration)
+	} else {
+		i.memCache.Set(item.Key, buf, item.CacheActionOpts.Expiration)
+	}
 	return nil
 }
 

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -101,7 +101,7 @@ func (r *redisCache) Rename(oldKey string, newKey string, _ time.Duration) error
 }
 
 func (r *redisCache) Set(item *Item) error {
-	expiration := item.Expiration
+	expiration := item.CacheActionOpts.Expiration
 	if expiration == 0 {
 		expiration = r.expiration
 	}
@@ -115,6 +115,7 @@ func (r *redisCache) Set(item *Item) error {
 		Key:   r.getKey(item.Key),
 		Value: val,
 		TTL:   expiration,
+		SetNX: item.CacheActionOpts.DisableOverwrite,
 	})
 }
 

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -55,7 +55,8 @@ type Refs struct {
 
 type gitRefCache interface {
 	SetGitReferences(repo string, references []*plumbing.Reference) error
-	GetGitReferences(repo string, references *[]*plumbing.Reference) error
+	GetOrLockGitReferences(repo string, references *[]*plumbing.Reference) (updateCache bool, lockId string, err error)
+	UnlockGitReferences(repo string, lockId string) error
 }
 
 // Client is a generic git client interface
@@ -477,11 +478,28 @@ func (m *nativeGitClient) Checkout(revision string, submoduleEnabled bool) error
 }
 
 func (m *nativeGitClient) getRefs() ([]*plumbing.Reference, error) {
+	// Prevent an additional get call to cache if we know our state isn't stale
+	needsUnlock := true
 	if m.gitRefCache != nil && m.loadRefFromCache {
 		var res []*plumbing.Reference
-		if m.gitRefCache.GetGitReferences(m.repoURL, &res) == nil {
+		isLockOwner, localLockId, err := m.gitRefCache.GetOrLockGitReferences(m.repoURL, &res)
+		if !isLockOwner && err == nil {
+			// Valid value already in cache
 			return res, nil
+		} else if !isLockOwner && err != nil {
+			// Error getting value from cache
+			log.Debugf("Error getting git references from cache: %v", err)
+			return nil, err
 		}
+		// Defer a soft reset of the cache lock, if the value is set this call will be ignored
+		defer func() {
+			if needsUnlock {
+				err := m.gitRefCache.UnlockGitReferences(m.repoURL, localLockId)
+				if err != nil {
+					log.Debugf("Error unlocking git references from cache: %v", err)
+				}
+			}
+		}()
 	}
 
 	if m.OnLsRemote != nil {
@@ -508,6 +526,9 @@ func (m *nativeGitClient) getRefs() ([]*plumbing.Reference, error) {
 	if err == nil && m.gitRefCache != nil {
 		if err := m.gitRefCache.SetGitReferences(m.repoURL, res); err != nil {
 			log.Warnf("Failed to store git references to cache: %v", err)
+		} else {
+			// Since we successfully overwrote the lock with valid data, we don't need to unlock
+			needsUnlock = false
 		}
 		return res, nil
 	}

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -55,7 +56,7 @@ type Refs struct {
 
 type gitRefCache interface {
 	SetGitReferences(repo string, references []*plumbing.Reference) error
-	GetOrLockGitReferences(repo string, references *[]*plumbing.Reference) (updateCache bool, lockId string, err error)
+	GetOrLockGitReferences(repo string, lockId string, references *[]*plumbing.Reference) (string, error)
 	UnlockGitReferences(repo string, lockId string) error
 }
 
@@ -478,11 +479,19 @@ func (m *nativeGitClient) Checkout(revision string, submoduleEnabled bool) error
 }
 
 func (m *nativeGitClient) getRefs() ([]*plumbing.Reference, error) {
+	myLockUUID, err := uuid.NewRandom()
+	myLockId := ""
+	if err != nil {
+		log.Debug("Error generating git references cache lock id: ", err)
+	} else {
+		myLockId = myLockUUID.String()
+	}
 	// Prevent an additional get call to cache if we know our state isn't stale
 	needsUnlock := true
 	if m.gitRefCache != nil && m.loadRefFromCache {
 		var res []*plumbing.Reference
-		isLockOwner, localLockId, err := m.gitRefCache.GetOrLockGitReferences(m.repoURL, &res)
+		foundLockId, err := m.gitRefCache.GetOrLockGitReferences(m.repoURL, myLockId, &res)
+		isLockOwner := myLockId == foundLockId
 		if !isLockOwner && err == nil {
 			// Valid value already in cache
 			return res, nil
@@ -494,7 +503,7 @@ func (m *nativeGitClient) getRefs() ([]*plumbing.Reference, error) {
 		// Defer a soft reset of the cache lock, if the value is set this call will be ignored
 		defer func() {
 			if needsUnlock {
-				err := m.gitRefCache.UnlockGitReferences(m.repoURL, localLockId)
+				err := m.gitRefCache.UnlockGitReferences(m.repoURL, myLockId)
 				if err != nil {
 					log.Debugf("Error unlocking git references from cache: %v", err)
 				}

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -20,14 +20,23 @@ func runCmd(workingDir string, name string, args ...string) error {
 	return cmd.Run()
 }
 
-func Test_nativeGitClient_Fetch(t *testing.T) {
+func _createEmptyGitRepo() (string, error) {
 	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	if err != nil {
+		return tempDir, err
+	}
 
 	err = runCmd(tempDir, "git", "init")
-	require.NoError(t, err)
+	if err != nil {
+		return tempDir, err
+	}
 
 	err = runCmd(tempDir, "git", "commit", "-m", "Initial commit", "--allow-empty")
+	return tempDir, err
+}
+
+func Test_nativeGitClient_Fetch(t *testing.T) {
+	tempDir, err := _createEmptyGitRepo()
 	require.NoError(t, err)
 
 	client, err := NewClient(fmt.Sprintf("file://%s", tempDir), NopCreds{}, true, false, "")
@@ -41,13 +50,7 @@ func Test_nativeGitClient_Fetch(t *testing.T) {
 }
 
 func Test_nativeGitClient_Fetch_Prune(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-
-	err = runCmd(tempDir, "git", "init")
-	require.NoError(t, err)
-
-	err = runCmd(tempDir, "git", "commit", "-m", "Initial commit", "--allow-empty")
+	tempDir, err := _createEmptyGitRepo()
 	require.NoError(t, err)
 
 	client, err := NewClient(fmt.Sprintf("file://%s", tempDir), NopCreds{}, true, false, "")

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -398,9 +398,11 @@ func (a *ClientApp) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	sub := jwtutil.StringField(claims, "sub")
 	err = a.clientCache.Set(&cache.Item{
-		Key:        formatAccessTokenCacheKey(AccessTokenCachePrefix, sub),
-		Object:     encToken,
-		Expiration: getTokenExpiration(claims),
+		Key:    formatAccessTokenCacheKey(AccessTokenCachePrefix, sub),
+		Object: encToken,
+		CacheActionOpts: cache.CacheActionOpts{
+			Expiration: getTokenExpiration(claims),
+		},
 	})
 	if err != nil {
 		claimsJSON, _ := json.Marshal(claims)
@@ -654,9 +656,11 @@ func (a *ClientApp) GetUserInfo(actualClaims jwt.MapClaims, issuerURL, userInfoP
 	}
 
 	err = a.clientCache.Set(&cache.Item{
-		Key:        clientCacheKey,
-		Object:     encClaims,
-		Expiration: cacheExpiry,
+		Key:    clientCacheKey,
+		Object: encClaims,
+		CacheActionOpts: cache.CacheActionOpts{
+			Expiration: cacheExpiry,
+		},
 	})
 	if err != nil {
 		return claims, false, fmt.Errorf("couldn't put item to cache: %w", err)

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -71,6 +71,7 @@ func NewMockHandler(reactor *reactorDef, applicationNamespaces []string, objects
 		cacheClient,
 		1*time.Minute,
 		1*time.Minute,
+		10*time.Second,
 	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute, time.Minute), &mocks.ArgoDB{})
 }
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Additional Fixes #14725

Third part of a split of the https://github.com/argoproj/argo-cd/pull/16309 and follow-up to https://github.com/argoproj/argo-cd/pull/16410

Another piece of the fixes for #14725. This resolves the excess ls-remote requests that still occur in high application count environments due to the fact that all active processes get their cache invalidated at the same time. When this happens they all try to re-fetch the remotes at the same time and all miss the cache.

The solution is to add a soft cache level lock on the key, the first process to try and access that key on a miss will obtain the lock and attempt to refresh the cache.

This changed required adding the ability to use "set only if not exists" on the util/cache (redis NX or memcached add) interface. Without this option all of the processes could still end up in a position where they think they own the lock, so there are some minor changes to the util/cache interface:
- Adds a `DisableOverwrite` option to represent the NX/add during set option
- The `Item` struct now also contains options for the cache set actions. This allows passing `Delete` and `DisableOverwrite` in a shared options value and replaces the position of the current `delete` option in the SetItem call

This is the final major logic portion of the changes to remove all the excess git calls, but we can get some good performance improvements by also adding the two layer cache to the caching layer for revisions. So I'll be following up with another PR to add that. Most of the abstraction to prepare for that was handled as part of this PR.

Baseline without changes with 200 multi-source applications with a ref only source:
![Screenshot from 2023-11-18 18-24-30](https://github.com/argoproj/argo-cd/assets/20120766/3a6b49d8-eb07-4aa9-8e8a-728c53520c63)

With all the changes up to and including this PR under the same conditions:
![Screenshot from 2023-11-21 03-19-14](https://github.com/nromriell/argo-cd/assets/20120766/76706163-efba-43f4-83c8-892ff536a136)


Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
