### PR TITLE
docs: fix error in toolchain setup

### DIFF
--- a/docs/developer-guide/toolchain-guide.md
+++ b/docs/developer-guide/toolchain-guide.md
@@ -304,7 +304,7 @@ For installing the tools required to build and test Argo CD on your local system
 You can change the target location by setting the `BIN` environment before running the installer scripts. For example, you can install the binaries into `~/go/bin` (which should then be the first component in your `PATH` environment, i.e. `export PATH=~/go/bin:$PATH`):
 
 ```shell
-make BIN=~/go/bin install-tools-local
+BIN=~/go/bin make install-tools-local
 ```
 
 Additionally, you have to install at least the following tools via your OS's package manager (this list might not be always up-to-date):


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

When running `make BIN=~/go/bin install-tools-local`, the `~` is not expanded and ends up failing on the following command. This was the only error I noticed when getting argo-cd local environment ready from scratch.

```sudo install -m 0755 /tmp/helm/linux-arm64/helm ~/go/bin/helm```

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
