### PR TITLE
docs: fixed name of environment variable and config for applicationsets

### DIFF
--- a/docs/operator-manual/applicationset/Appset-Any-Namespace.md
+++ b/docs/operator-manual/applicationset/Appset-Any-Namespace.md
@@ -72,7 +72,7 @@ data:
     The allow-list only applies to SCM providers for which the user may configure a custom `api`. Where an SCM or PR
     generator does not accept a custom API URL, the provider is implicitly allowed.
 
-If you do not intend to allow users to use the SCM or PR generators, you can disable them entirely by setting the environment variable `ARGOCD_APPLICATIONSET_CONTROLLER_ALLOW_SCM_PROVIDERS` to argocd-cmd-params-cm `applicationsetcontroller.allow.scm.providers` to `false`.
+If you do not intend to allow users to use the SCM or PR generators, you can disable them entirely by setting the environment variable `ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_SCM_PROVIDERS` to argocd-cmd-params-cm `applicationsetcontroller.enable.scm.providers` to `false`.
 
 ### Overview
 


### PR DESCRIPTION
Fixed name of environment variable name and config map property enabling/disabling scm providers in applications sets in the documentation.

All yaml files in /manifests have the following section:
`            - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_SCM_PROVIDERS`
`              valueFrom:`
`                configMapKeyRef:`
`                  name: argocd-cmd-params-cm`
`                  key: applicationsetcontroller.enable.scm.providers`

This PR aligns documentation with manifests.

Checklist:
* this does not need to be in the release notes.
