### PR TITLE
fix!: disable rate limiting completely by default

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -220,7 +220,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&shardingAlgorithm, "sharding-method", env.StringFromEnv(common.EnvControllerShardingAlgorithm, common.DefaultShardingAlgorithm), "Enables choice of sharding method. Supported sharding methods are : [legacy, round-robin] ")
 	// global queue rate limit config
 	command.Flags().Int64Var(&workqueueRateLimit.BucketSize, "wq-bucket-size", env.ParseInt64FromEnv("WORKQUEUE_BUCKET_SIZE", 500, 1, math.MaxInt64), "Set Workqueue Rate Limiter Bucket Size, default 500")
-	command.Flags().Int64Var(&workqueueRateLimit.BucketQPS, "wq-bucket-qps", env.ParseInt64FromEnv("WORKQUEUE_BUCKET_QPS", 50, 1, math.MaxInt64), "Set Workqueue Rate Limiter Bucket QPS, default 50")
+	command.Flags().Float64Var(&workqueueRateLimit.BucketQPS, "wq-bucket-qps", env.ParseFloat64FromEnv("WORKQUEUE_BUCKET_QPS", math.MaxFloat64, 1, math.MaxFloat64), "Set Workqueue Rate Limiter Bucket QPS, default set to MaxFloat64 which disables the bucket limiter")
 	// individual item rate limit config
 	// when WORKQUEUE_FAILURE_COOLDOWN is 0 per item rate limiting is disabled(default)
 	command.Flags().DurationVar(&workqueueRateLimit.FailureCoolDown, "wq-cooldown-ns", time.Duration(env.ParseInt64FromEnv("WORKQUEUE_FAILURE_COOLDOWN_NS", 0, 0, (24*time.Hour).Nanoseconds())), "Set Workqueue Per Item Rate Limiter Cooldown duration in ns, default 0(per item rate limiter disabled)")

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -267,13 +267,13 @@ The final rate limiter uses a combination of both and calculates the final backo
 
 ### Global rate limits
 
-  This is enabled by default, it is a simple bucket based rate limiter that limits the number of items that can be queued per second.
+  This is disabled by default, it is a simple bucket based rate limiter that limits the number of items that can be queued per second.
 This is useful to prevent a large number of apps from being queued at the same time.
 
 To configure the bucket limiter you can set the following environment variables:
 
   * `WORKQUEUE_BUCKET_SIZE` - The number of items that can be queued in a single burst. Defaults to 500.
-  * `WORKQUEUE_BUCKET_QPS` - The number of items that can be queued per second. Defaults to 50.
+  * `WORKQUEUE_BUCKET_QPS` - The number of items that can be queued per second. Defaults to MaxFloat64, which disables the limiter.
 
 ### Per item rate limits
 

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -77,7 +77,7 @@ argocd-application-controller [flags]
       --username string                        Username for basic authentication to the API server
       --wq-backoff-factor float                Set Workqueue Per Item Rate Limiter Backoff Factor, default is 1.5 (default 1.5)
       --wq-basedelay-ns duration               Set Workqueue Per Item Rate Limiter Base Delay duration in nanoseconds, default 1000000 (1ms) (default 1ms)
-      --wq-bucket-qps int                      Set Workqueue Rate Limiter Bucket QPS, default 50 (default 50)
+      --wq-bucket-qps float                    Set Workqueue Rate Limiter Bucket QPS, default set to MaxFloat64 which disables the bucket limiter (default 1.7976931348623157e+308)
       --wq-bucket-size int                     Set Workqueue Rate Limiter Bucket Size, default 500 (default 500)
       --wq-cooldown-ns duration                Set Workqueue Per Item Rate Limiter Cooldown duration in ns, default 0(per item rate limiter disabled)
       --wq-maxdelay-ns duration                Set Workqueue Per Item Rate Limiter Max Delay duration in nanoseconds, default 1000000000 (1s) (default 1s)

--- a/pkg/ratelimiter/ratelimiter.go
+++ b/pkg/ratelimiter/ratelimiter.go
@@ -11,7 +11,7 @@ import (
 
 type AppControllerRateLimiterConfig struct {
 	BucketSize      int64
-	BucketQPS       int64
+	BucketQPS       float64
 	FailureCoolDown time.Duration
 	BaseDelay       time.Duration
 	MaxDelay        time.Duration
@@ -22,7 +22,8 @@ func GetDefaultAppRateLimiterConfig() *AppControllerRateLimiterConfig {
 	return &AppControllerRateLimiterConfig{
 		// global queue rate limit config
 		500,
-		50,
+		// when WORKQUEUE_BUCKET_QPS is MaxFloat64 global bucket limiting is disabled(default)
+		math.MaxFloat64,
 		// individual item rate limit config
 		// when WORKQUEUE_FAILURE_COOLDOWN is 0 per item rate limiting is disabled(default)
 		0,


### PR DESCRIPTION
Related https://github.com/argoproj/argo-cd/issues/17257

This PR disabled the bucket limiter by default, setting the QPS(r) value to MaxFloat64 according to documentation of the limiter should ignore the bucket size completely [refer here](https://cs.opensource.google/go/x/time/+/refs/tags/v0.5.0:rate/rate.go;l=35-38)

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
