### PR TITLE
fix: preserve escape codes in repo url of git webhook payload

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -321,7 +321,7 @@ func getWebUrlRegex(webURL string) (*regexp.Regexp, error) {
 	}
 
 	regexEscapedHostname := regexp.QuoteMeta(urlObj.Hostname())
-	regexEscapedPath := regexp.QuoteMeta(urlObj.Path[1:])
+	regexEscapedPath := regexp.QuoteMeta(urlObj.EscapedPath()[1:])
 	regexpStr := fmt.Sprintf(`(?i)^(http://|https://|%s@|ssh://(%s@)?)%s(:[0-9]+|)[:/]%s(\.git)?$`,
 		usernameRegex, usernameRegex, regexEscapedHostname, regexEscapedPath)
 	repoRegexp, err := regexp.Compile(regexpStr)

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -670,6 +670,7 @@ func Test_getWebUrlRegex(t *testing.T) {
 		{true, "https://example.com/org/repo", "ssh://user-name@example.com/org/repo", "valid usernames with hyphens in repo should match"},
 		{false, "https://example.com/org/repo", "ssh://-user-name@example.com/org/repo", "invalid usernames with hyphens in repo should not match"},
 		{true, "https://example.com:443/org/repo", "GIT@EXAMPLE.COM:22:ORG/REPO", "matches aren't case-sensitive"},
+		{true, "https://example.com/org/repo%20", "https://example.com/org/repo%20", "escape codes in path are preserved"},
 	}
 	for _, testCase := range tests {
 		testCopy := testCase


### PR DESCRIPTION
Fixes #17349

Azure DevOps projects can have space characters in their name. 
This PR ensures escape codes are preserved when handling git push webhook so the URL in the payload can match the Application sources.