### PR TITLE
docs: use service-name instead of service-id

### DIFF
--- a/docs/operator-manual/notifications/services/pagerduty_v2.md
+++ b/docs/operator-manual/notifications/services/pagerduty_v2.md
@@ -74,5 +74,5 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
-    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerdutyv2: "<serviceID for PagerDuty>"
+    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerdutyv2: "<service-name in serviceKeys>"
 ```


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [v] Does this PR require documentation updates?
* [v] I've updated documentation as required by this PR.
* [v] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [v] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [v] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

The pagerdutyv2 notification references the service-name defined under serviceKeys, not the ServiceID of PagerDuty. It appears that the PagerDuty V2 documentation may have been created from the [PagerDuty V1 documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/services/pagerduty/), incorporating outdated information in the process.
