### PR TITLE
feat: changes git client to resolve semantic versioning tags

### DIFF
--- a/docs/user-guide/tracking_strategies.md
+++ b/docs/user-guide/tracking_strategies.md
@@ -25,14 +25,15 @@ Helm chart versions are [Semantic Versions](https://semver.org/). As a result, y
 
 ## Git
 
-For Git, all versions are Git references:
+For Git, all versions are Git references but tags [Semantic Versions](https://semver.org/) can also be used:
 
 | Use Case | How | Notes |
 |-|-|-|
 | Pin to a version (e.g. in production) | Either (a) tag the commit with (e.g. `v1.2.0`) and use that tag, or (b) using commit SHA. | See [commit pinning](#commit-pinning). |
-| Track patches (e.g. in pre-production) | Tag/re-tag the commit, e.g. (e.g. `v1.2`) and use that tag. | See [tag tracking](#tag-tracking) |
-| Track minor releases (e.g. in QA) | Re-tag the commit as (e.g. `v1`) and use that tag. | See [tag tracking](#tag-tracking) |
-| Use the latest (e.g. in local development) | Use `HEAD` or `master` (assuming `master` is your master branch). | See [HEAD / Branch Tracking](#head-branch-tracking) |
+| Track patches (e.g. in pre-production) | Use a range (e.g. `1.2.*` or `>=1.2.0 <1.3.0`)                                           | See [tag tracking](#tag-tracking) |
+| Track minor releases (e.g. in QA) | Use a range (e.g. `1.*` or `>=1.0.0 <2.0.0`)                                             | See [tag tracking](#tag-tracking) |
+| Use the latest (e.g. in local development) | Use `HEAD` or `master` (assuming `master` is your master branch).                        | See [HEAD / Branch Tracking](#head-branch-tracking) |
+| Use the latest including pre-releases | Use star range with `-0` suffix | `*-0` or `>=0.0.0-0` |
 
 
 ### HEAD / Branch Tracking
@@ -52,6 +53,9 @@ more stable, and less frequently updated, with some manual judgement of what con
 To redeploy an app, the user uses Git to change the meaning of a tag by retagging it to a
 different commit SHA. Argo CD will detect the new meaning of the tag when performing the
 comparison/sync.
+
+But if you're using semantic versioning you can set the constraint in your service revision
+and Argo CD will get the latest version following the constraint rules.
 
 ### Commit Pinning
 

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -1,0 +1,28 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
+
+	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
+)
+
+func TestGitSemverResolution(t *testing.T) {
+	Given(t).
+		RepoURLType(fixture.RepoURLTypeSSH).
+		Recurse().
+		CustomSSHKnownHostsAdded().
+		Revision("v0.1.*").
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeUnknown)).
+		When().
+		AddTag("v0.1.0").
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced))
+}

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -9,19 +9,31 @@ import (
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 )
 
-func TestGitSemverResolution(t *testing.T) {
+func TestGitSemverResolutionNotUsingConstraint(t *testing.T) {
 	Given(t).
-		RepoURLType(fixture.RepoURLTypeSSH).
-		Recurse().
+		Path("deployment").
 		CustomSSHKnownHostsAdded().
-		Revision("v0.1.*").
+		SSHRepoURLAdded(true).
+		RepoURLType(fixture.RepoURLTypeSSH).
+		Revision("v0.1.0").
 		When().
+		AddTag("v0.1.0").
 		CreateApp().
 		Sync().
 		Then().
-		Expect(SyncStatusIs(SyncStatusCodeUnknown)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced))
+}
+
+func TestGitSemverResolutionUsingConstraint(t *testing.T) {
+	Given(t).
+		Path("deployment").
+		CustomSSHKnownHostsAdded().
+		SSHRepoURLAdded(true).
+		RepoURLType(fixture.RepoURLTypeSSH).
+		Revision("v0.1.*").
 		When().
 		AddTag("v0.1.0").
+		CreateApp().
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced))

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -678,7 +678,7 @@ func (m *nativeGitClient) lsRemote(revision string) (string, error) {
 // only the for loop in this function will run, otherwise the lsRemote loop will try to resolve the revision.
 // Some examples to illustrate the actual behavior, if:
 // * The revision is "v0.1.*"/"0.1.*" or "v0.1.2"/"0.1.2" and there's a tag matching that constraint only this function loop will run;
-// * The revision is "v0.1.*"/"0.1.*" or "0.1.2"/"0.1.2" and there is no tag matching that constraint only this function loop will run;
+// * The revision is "v0.1.*"/"0.1.*" or "0.1.2"/"0.1.2" and there is no tag matching that constraint this function loop and lsRemote loop will run for backward compatibility;
 // * The revision is "custom-tag" only the lsRemote loop will run because that revision is an invalid semver;
 // * The revision is "master-branch" only the lsRemote loop will run because that revision is an invalid semver;
 func (m *nativeGitClient) resolveSemverRevision(revision string, refs []*plumbing.Reference) (string, error) {
@@ -714,7 +714,7 @@ func (m *nativeGitClient) resolveSemverRevision(revision string, refs []*plumbin
 	}
 
 	if maxVersionHash.IsZero() {
-		return "", fmt.Errorf("no version matching the semver revision were found")
+		return "", nil
 	}
 
 	return maxVersionHash.String(), nil

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -212,34 +212,85 @@ func TestCustomHTTPClient(t *testing.T) {
 func TestLsRemote(t *testing.T) {
 	clnt, err := NewClientExt("https://github.com/argoproj/argo-cd.git", "/tmp", NopCreds{}, false, false, "")
 	assert.NoError(t, err)
-	xpass := []string{
-		"HEAD",
-		"master",
-		"release-0.8",
-		"v0.8.0",
-		"4e22a3cb21fa447ca362a05a505a69397c8a0d44",
-		//"4e22a3c",
+
+	testCases := []struct {
+		name           string
+		revision       string
+		expectedCommit string
+	}{
+		{
+			name:     "should resolve symbolic link reference",
+			revision: "HEAD",
+		},
+		{
+			name:     "should resolve branch name",
+			revision: "master",
+		},
+		{
+			name:           "should resolve tag without semantic versioning",
+			revision:       "release-0.8",
+			expectedCommit: "ff87d8cb9e669d3738434733ecba3c6dd2c64d70",
+		},
+		{
+			name:           "should resolve a pined tag with semantic versioning",
+			revision:       "v0.8.0",
+			expectedCommit: "d7c04ae24c16f8ec611b0331596fbc595537abe9",
+		},
+		{
+			name:           "should resolve a range tag with semantic versioning",
+			revision:       "v0.8.*", // it should resolve to v0.8.2
+			expectedCommit: "e5eefa2b943ae14a3e4491d4e35ef082e1c2a3f4",
+		},
+		{
+			name:           "should resolve a conditional range tag with semantic versioning",
+			revision:       ">=v2.9.0 <2.10.4", // it should resolve to v2.10.3
+			expectedCommit: "0fd6344537eb948cff602824a1d060421ceff40e",
+		},
+		{
+			name:     "should resolve a star range tag with semantic versioning",
+			revision: "*",
+		},
+		{
+			name:     "should resolve a star range suffixed tag with semantic versioning",
+			revision: "*-0",
+		},
+		{
+			name:           "should resolve commit sha",
+			revision:       "4e22a3cb21fa447ca362a05a505a69397c8a0d44",
+			expectedCommit: "4e22a3cb21fa447ca362a05a505a69397c8a0d44",
+		},
 	}
-	for _, revision := range xpass {
-		commitSHA, err := clnt.LsRemote(revision)
-		assert.NoError(t, err)
-		assert.True(t, IsCommitSHA(commitSHA))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			commitSHA, err := clnt.LsRemote(tc.revision)
+			assert.NoError(t, err)
+			assert.True(t, IsCommitSHA(commitSHA))
+			if tc.expectedCommit != "" {
+				assert.Equal(t, tc.expectedCommit, commitSHA)
+			}
+		})
 	}
 
 	// We do not resolve truncated git hashes and return the commit as-is if it appears to be a commit
-	commitSHA, err := clnt.LsRemote("4e22a3c")
-	assert.NoError(t, err)
-	assert.False(t, IsCommitSHA(commitSHA))
-	assert.True(t, IsTruncatedCommitSHA(commitSHA))
+	t.Run("truncated commit", func(t *testing.T) {
+		commitSHA, err := clnt.LsRemote("4e22a3c")
+		assert.NoError(t, err)
+		assert.False(t, IsCommitSHA(commitSHA))
+		assert.True(t, IsTruncatedCommitSHA(commitSHA))
+	})
 
-	xfail := []string{
-		"unresolvable",
-		"4e22a3", // too short (6 characters)
-	}
-	for _, revision := range xfail {
-		_, err := clnt.LsRemote(revision)
-		assert.Error(t, err)
-	}
+	t.Run("unresolvable revisions", func(t *testing.T) {
+		xfail := []string{
+			"unresolvable",
+			"4e22a3", // too short (6 characters)
+		}
+
+		for _, revision := range xfail {
+			_, err := clnt.LsRemote(revision)
+			assert.ErrorContains(t, err, "Unable to resolve")
+		}
+	})
 }
 
 // Running this test requires git-lfs to be installed on your machine.

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -237,8 +237,18 @@ func TestLsRemote(t *testing.T) {
 			expectedCommit: "d7c04ae24c16f8ec611b0331596fbc595537abe9",
 		},
 		{
+			name:           "should resolve a pined tag with semantic versioning without the 'v' prefix",
+			revision:       "0.8.0",
+			expectedCommit: "d7c04ae24c16f8ec611b0331596fbc595537abe9",
+		},
+		{
 			name:           "should resolve a range tag with semantic versioning",
 			revision:       "v0.8.*", // it should resolve to v0.8.2
+			expectedCommit: "e5eefa2b943ae14a3e4491d4e35ef082e1c2a3f4",
+		},
+		{
+			name:           "should resolve a range tag with semantic versioning without the 'v' prefix",
+			revision:       "0.8.*", // it should resolve to v0.8.2
 			expectedCommit: "e5eefa2b943ae14a3e4491d4e35ef082e1c2a3f4",
 		},
 		{


### PR DESCRIPTION
Hi all, I'm creating this PR to make Argo CD able to resolve Semantic Version for Git revisions as it already have for Helm! I did this is an initial PR for the issue #5609 and I've made this way 'cause I think it's simpler to make one change at time, in the reference issue the proposed solution is to support four types of strategy based on `images updater` but I guess the current Git support for versioning **+** semantic versioning should be enough for the majority of the cases while maintaining backward compatibility with the people who already uses Argo.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Refs #5609
