### PR TITLE
feat: Enhance ArgoCD CLI: Dynamic Repo Server Retrieval with --core and --refresh Flags

### DIFF
--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/controller"
 	"github.com/argoproj/argo-cd/v2/controller/cache"
 	"github.com/argoproj/argo-cd/v2/controller/metrics"
+	"github.com/argoproj/argo-cd/v2/controller/sharding"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
@@ -437,5 +438,5 @@ func reconcileApplications(
 }
 
 func newLiveStateCache(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) cache.LiveStateCache {
-	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, kubeutil.NewKubectl(), server, func(managedByApp map[string]bool, ref apiv1.ObjectReference) {}, nil, argo.NewResourceTracking())
+	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, kubeutil.NewKubectl(), server, func(managedByApp map[string]bool, ref apiv1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
 }

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -276,8 +276,8 @@ func NewReconcileCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command 
 					printLine("Repo server is not provided, trying to port-forward to argocd-repo-server pod.")
 					overrides := clientcmd.ConfigOverrides{}
 					repoServerName := clientOpts.RepoServerName
-					repoServererviceLabelSelector := common.LabelKeyComponentRepoServer + "=" + common.LabelValueComponentRepoServer
-					repoServerServices, err := kubeClientset.CoreV1().Services(namespace).List(context.Background(), v1.ListOptions{LabelSelector: repoServererviceLabelSelector})
+					repoServerServiceLabelSelector := common.LabelKeyComponentRepoServer + "=" + common.LabelValueComponentRepoServer
+					repoServerServices, err := kubeClientset.CoreV1().Services(namespace).List(context.Background(), v1.ListOptions{LabelSelector: repoServerServiceLabelSelector})
 					errors.CheckError(err)
 					if len(repoServerServices.Items) > 0 {
 						if repoServerServicelabel, ok := repoServerServices.Items[0].Labels[common.LabelKeyAppName]; ok && repoServerServicelabel != "" {

--- a/common/common.go
+++ b/common/common.go
@@ -188,6 +188,9 @@ const (
 	// AnnotationKeyAppSkipReconcile tells the Application to skip the Application controller reconcile.
 	// Skip reconcile when the value is "true" or any other string values that can be strconv.ParseBool() to be true.
 	AnnotationKeyAppSkipReconcile = "argocd.argoproj.io/skip-reconcile"
+
+	LabelKeyComponentRepoServer   = "app.kubernetes.io/component"
+	LabelValueComponentRepoServer = "repo-server"
 )
 
 // Environment variables for tuning and debugging Argo CD

--- a/common/common.go
+++ b/common/common.go
@@ -188,8 +188,9 @@ const (
 	// AnnotationKeyAppSkipReconcile tells the Application to skip the Application controller reconcile.
 	// Skip reconcile when the value is "true" or any other string values that can be strconv.ParseBool() to be true.
 	AnnotationKeyAppSkipReconcile = "argocd.argoproj.io/skip-reconcile"
-
-	LabelKeyComponentRepoServer   = "app.kubernetes.io/component"
+	// LabelKeyComponentRepoServer is the label key to identify the component as repo-server
+	LabelKeyComponentRepoServer = "app.kubernetes.io/component"
+	// LabelValueComponentRepoServer is the label value for the repo-server component
 	LabelValueComponentRepoServer = "repo-server"
 )
 

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -437,7 +437,11 @@ func (c *liveStateCache) getCluster(server string) (clustercache.ClusterCache, e
 		return nil, fmt.Errorf("error getting cluster: %w", err)
 	}
 
-	if !c.canHandleCluster(cluster) && c.clusterSharding == nil {
+	if c.clusterSharding == nil {
+		return nil, fmt.Errorf("unable to handle cluster %s: cluster sharding is not configured", cluster.Server)
+	}
+
+	if !c.canHandleCluster(cluster) {
 		return nil, fmt.Errorf("controller is configured to ignore cluster %s", cluster.Server)
 	}
 

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -437,7 +437,7 @@ func (c *liveStateCache) getCluster(server string) (clustercache.ClusterCache, e
 		return nil, fmt.Errorf("error getting cluster: %w", err)
 	}
 
-	if !c.canHandleCluster(cluster) {
+	if !c.canHandleCluster(cluster) && c.clusterSharding == nil {
 		return nil, fmt.Errorf("controller is configured to ignore cluster %s", cluster.Server)
 	}
 

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -21,6 +21,7 @@ argocd-repo-server [flags]
       --disable-helm-manifest-max-extracted-size       Disable maximum size of helm manifest archives when extracted
       --disable-tls                                    Disable TLS on the gRPC endpoint
       --helm-manifest-max-extracted-size string        Maximum size of helm manifest archives when extracted (default "1G")
+      --helm-registry-max-index-size string            Maximum size of registry index file (default "1G")
   -h, --help                                           help for argocd-repo-server
       --logformat string                               Set the logging format. One of: text|json (default "text")
       --loglevel string                                Set the logging level. One of: debug|info|warn|error (default "info")


### PR DESCRIPTION
### Description

When using the ArgoCD CLI client with the --core and --refresh flags, it's essential to provide the `repo-server-name` argument for the default ArgoCD instance deployed with operators. However, in some cases, users might forget to specify this argument, leading to errors. 

**Current Behavior:**
Running the command `argocd app list --core` or `argocd admin app get-reconcile-results --refresh text.txt `  without providing the repo-server-name flag results in a default value of `argocd-repo-server`. This default value is not valid for ArgoCD installations with an operator. The actual repo server name is derived from the ArgoCD CR name, such as example-argocd-repo-server if the CR name is example-argocd. Consequently, an error occurs due to the mismatch between the default and actual repo server name.


**How to Reproduce the Issue:**
To reproduce the issue:

```
1. Install ArgoCD with an operator.
2. Configure the ArgoCD CustomResource (CR) name, e.g., example-argocd.
3. kubectl config set-context --current --namespace <some-namespace-where-argocd-is-deployed>
4. Execute the `argocd app list --core` command without specifying the repo-server-name flag.
```

**You will encounter the following issue:**

`FATA[0000] cannot find pod with selector: [app.kubernetes.io/name=argocd-repo-server] - use the --{component}-name flag in this command or set the environmental variable (Refer to https://argo-cd.readthedocs.io/en/stable/user-guide/environment-variables), to change the Argo CD component name in the CLI `

### Fix:
This pull request enhances the ArgoCD CLI by dynamically fetching the correct repo server name instead of relying solely on a default value. It queries the ArgoCD component services with the label `app.kubernetes.io/component=repo-server` and updates the repo server name accordingly. If the service query fails, it falls back to the default value. This ensures compatibility with ArgoCD installations using operators and improves overall reliability.

Additionally, this pull request addresses a bug documented in [issue #17602](https://github.com/argoproj/argo-cd/issues/17602)

**Output after fix:**

![image](https://github.com/argoproj/argo-cd/assets/44372157/f89a8e06-5737-4d7b-9176-4df63d65ec44)



<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
