### PR TITLE
Revert "chore(deps): bump library/registry from `f4e1b87` to `fb9c9ae` in /test/container"

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -10,7 +10,7 @@ FROM docker.io/library/node:21.7.1@sha256:b9ccc4aca32eebf124e0ca0fd573dacffba2b9
 
 FROM docker.io/library/golang:1.22.1@sha256:0b55ab82ac2a54a6f8f85ec8b943b9e470c39e32c109b766bbc1b801f3fa8d3b as golang
 
-FROM docker.io/library/registry:2.8@sha256:fb9c9aef62af3955f6014613456551c92e88a67dcf1fc51f5f91bcbd1832813f as registry
+FROM docker.io/library/registry:2.8@sha256:f4e1b878d4bc40a1f65532d68c94dcfbab56aa8cba1f00e355a206e7f6cc9111 as registry
 
 FROM docker.io/bitnami/kubectl:1.27@sha256:14ab746e857d96c105df4989cc2bf841292f2d143f7c60f9d7f549ae660eab43 as kubectl
 


### PR DESCRIPTION
Reverts argoproj/argo-cd#17554

We can't build using Golang 1.22 yet