### PR TITLE
docs: 2 link fixes + hint 

### DIFF
--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -30,7 +30,7 @@ in one of the following ways:
 ## Authorization
 
 Authorization is performed by iterating the list of group membership in a user's JWT groups claims,
-and comparing each group against the roles/rules in the [RBAC](../rbac) policy. Any matched rule
+and comparing each group against the roles/rules in the [RBAC](../rbac.md) policy. Any matched rule
 permits access to the API request.
 
 ## TLS

--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -30,7 +30,7 @@ in one of the following ways:
 ## Authorization
 
 Authorization is performed by iterating the list of group membership in a user's JWT groups claims,
-and comparing each group against the roles/rules in the [RBAC](../rbac.md) policy. Any matched rule
+and comparing each group against the roles/rules in the [RBAC](../operator-manual/rbac.md) policy. Any matched rule
 permits access to the API request.
 
 ## TLS

--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -30,7 +30,7 @@ in one of the following ways:
 ## Authorization
 
 Authorization is performed by iterating the list of group membership in a user's JWT groups claims,
-and comparing each group against the roles/rules in the [RBAC](../operator-manual/rbac.md) policy. Any matched rule
+and comparing each group against the roles/rules in the [RBAC](./rbac.md) policy. Any matched rule
 permits access to the API request.
 
 ## TLS

--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -144,7 +144,7 @@ argocd cluster rm https://your-kubernetes-cluster-addr
 
 ## Cluster RBAC
 
-By default, Argo CD uses a [clusteradmin level role](https://github.com/argoproj/argo-cd/blob/master/manifests/base/application-controller/argocd-application-controller-role.yaml)
+By default, Argo CD uses a [clusteradmin level role](https://github.com/argoproj/argo-cd/blob/master/manifests/base/application-controller-roles/argocd-application-controller-role.yaml)
 in order to:
 
 1. watch & operate on cluster state


### PR DESCRIPTION
I fixed 2 links in the docs. 

---

Also there seem to be some words missing in this sentence, but I couldn't figure out what it's supposed to be: https://github.com/argoproj/argo-cd/blob/8631e7ef9be5b0da99457f12af0430d9ad873ac5/docs/operator-manual/cluster-bootstrapping.md#L59

My guess is either something like
> The sync policy *is set* to automated + prune, ... 

or 

> The sync policy *defaults* to automated + prune, ...
