### PR TITLE
chore: rename source-indexes to source-positions

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -730,9 +730,9 @@ func getServer(app *argoappv1.Application) string {
 // NewApplicationSetCommand returns a new instance of an `argocd app set` command
 func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		appOpts      cmdutil.AppOptions
-		appNamespace string
-		sourceIndex  int
+		appOpts        cmdutil.AppOptions
+		appNamespace   string
+		sourcePosition int
 	)
 	var command = &cobra.Command{
 		Use:   "set APPNAME",
@@ -750,8 +750,8 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
   # Set and override application parameters with a parameter file
   argocd app set my-app --parameter-file path/to/parameter-file.yaml
 
-  # Set and override application parameters for a source at index 1 under spec.sources of app my-app. source-index starts at 1.
-  argocd app set my-app --source-index 1 --repo https://github.com/argoproj/argocd-example-apps.git
+  # Set and override application parameters for a source at index 1 under spec.sources of app my-app. source-position starts at 1.
+  argocd app set my-app --source-position 1 --repo https://github.com/argoproj/argocd-example-apps.git
 
   # Set application parameters and specify the namespace
   argocd app set my-app --parameter key1=value1 --parameter key2=value2 --namespace my-namespace
@@ -772,24 +772,24 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			errors.CheckError(err)
 
 			if app.Spec.HasMultipleSources() {
-				if sourceIndex <= 0 {
+				if sourcePosition <= 0 {
 					errors.CheckError(fmt.Errorf("Source index should be specified and greater than 0 for applications with multiple sources"))
 				}
-				if len(app.Spec.GetSources()) < sourceIndex {
+				if len(app.Spec.GetSources()) < sourcePosition {
 					errors.CheckError(fmt.Errorf("Source index should be less than the number of sources in the application"))
 				}
 			}
 
-			// sourceIndex startes with 1, thus, it needs to be decreased by 1 to find the correct index in the list of sources
-			sourceIndex = sourceIndex - 1
-			visited := cmdutil.SetAppSpecOptions(c.Flags(), &app.Spec, &appOpts, sourceIndex)
+			// sourcePosition startes with 1, thus, it needs to be decreased by 1 to find the correct index in the list of sources
+			sourcePosition = sourcePosition - 1
+			visited := cmdutil.SetAppSpecOptions(c.Flags(), &app.Spec, &appOpts, sourcePosition)
 			if visited == 0 {
 				log.Error("Please set at least one option to update")
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
 
-			setParameterOverrides(app, appOpts.Parameters, sourceIndex)
+			setParameterOverrides(app, appOpts.Parameters, sourcePosition)
 			_, err = appIf.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
 				Name:         &app.Name,
 				Spec:         &app.Spec,
@@ -799,7 +799,7 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().IntVar(&sourceIndex, "source-index", -1, "Index of the source from the list of sources of the app. Index starts at 1.")
+	command.Flags().IntVar(&sourcePosition, "source-position", -1, "Index of the source from the list of sources of the app. Index starts at 1.")
 	cmdutil.AddAppFlags(command, &appOpts)
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Set application parameters in namespace")
 	return command
@@ -836,7 +836,7 @@ func (o *unsetOpts) KustomizeIsZero() bool {
 // NewApplicationUnsetCommand returns a new instance of an `argocd app unset` command
 func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		sourceIndex int
+		sourcePosition int
 	)
 	appOpts := cmdutil.AppOptions{}
 	opts := unsetOpts{}
@@ -850,8 +850,8 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
   # Unset kustomize override suffix
   argocd app unset my-app --namesuffix
 
-  # Unset kustomize override suffix for source at index 1 under spec.sources of app my-app. source-index starts at 1.
-  argocd app unset my-app --source-index 1 --namesuffix
+  # Unset kustomize override suffix for source at index 1 under spec.sources of app my-app. source-position starts at 1.
+  argocd app unset my-app --source-position 1 --namesuffix
 
   # Unset parameter override
   argocd app unset my-app -p COMPONENT=PARAM`,
@@ -871,15 +871,15 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 			errors.CheckError(err)
 
 			if app.Spec.HasMultipleSources() {
-				if sourceIndex <= 0 {
+				if sourcePosition <= 0 {
 					errors.CheckError(fmt.Errorf("Source index should be specified and greater than 0 for applications with multiple sources"))
 				}
-				if len(app.Spec.GetSources()) < sourceIndex {
+				if len(app.Spec.GetSources()) < sourcePosition {
 					errors.CheckError(fmt.Errorf("Source index should be less than the number of sources in the application"))
 				}
 			}
 
-			source := app.Spec.GetSourcePtr(sourceIndex)
+			source := app.Spec.GetSourcePtr(sourcePosition)
 
 			updated, nothingToUnset := unset(source, opts)
 			if nothingToUnset {
@@ -890,7 +890,7 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 				return
 			}
 
-			cmdutil.SetAppSpecOptions(c.Flags(), &app.Spec, &appOpts, sourceIndex)
+			cmdutil.SetAppSpecOptions(c.Flags(), &app.Spec, &appOpts, sourcePosition)
 			_, err = appIf.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
 				Name:         &app.Name,
 				Spec:         &app.Spec,
@@ -914,7 +914,7 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 	command.Flags().StringArrayVar(&opts.pluginEnvs, "plugin-env", []string{}, "Unset plugin env variables (e.g --plugin-env name)")
 	command.Flags().BoolVar(&opts.passCredentials, "pass-credentials", false, "Unset passCredentials")
 	command.Flags().BoolVar(&opts.ref, "ref", false, "Unset ref on the source")
-	command.Flags().IntVar(&sourceIndex, "source-index", -1, "Index of the source from the list of sources of the app. Index starts at 1.")
+	command.Flags().IntVar(&sourcePosition, "source-position", -1, "Index of the source from the list of sources of the app. Index starts at 1.")
 	return command
 }
 
@@ -1126,7 +1126,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		localIncludes      []string
 		appNamespace       string
 		revisions          []string
-		sourceIndexes      []int64
+		sourcePositions    []int64
 	)
 	shortDesc := "Perform a diff against the target and live state."
 	var command = &cobra.Command{
@@ -1141,8 +1141,8 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				os.Exit(2)
 			}
 
-			if len(revisions) != len(sourceIndexes) {
-				errors.CheckError(fmt.Errorf("While using revisions and source-indexes, length of values for both flags should be same."))
+			if len(revisions) != len(sourcePositions) {
+				errors.CheckError(fmt.Errorf("While using revisions and source-positions, length of values for both flags should be same."))
 			}
 
 			clientset := headless.NewClientOrDie(clientOpts, c)
@@ -1163,12 +1163,12 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			argoSettings, err := settingsIf.Get(ctx, &settings.SettingsQuery{})
 			errors.CheckError(err)
 			diffOption := &DifferenceOption{}
-			if app.Spec.HasMultipleSources() && len(revisions) > 0 && len(sourceIndexes) > 0 {
+			if app.Spec.HasMultipleSources() && len(revisions) > 0 && len(sourcePositions) > 0 {
 
 				revisionSourceMappings := make(map[int64]string, 0)
-				for i, index := range sourceIndexes {
+				for i, index := range sourcePositions {
 					if index <= 0 {
-						errors.CheckError(fmt.Errorf("source-index cannot be less than or equal to 0. Index starts at 1."))
+						errors.CheckError(fmt.Errorf("source-position cannot be less than or equal to 0. Index starts at 1."))
 					}
 					revisionSourceMappings[index] = revisions[i]
 				}
@@ -1233,8 +1233,8 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().BoolVar(&serverSideGenerate, "server-side-generate", false, "Used with --local, this will send your manifests to the server for diffing")
 	command.Flags().StringArrayVar(&localIncludes, "local-include", []string{"*.yaml", "*.yml", "*.json"}, "Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path.")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only render the difference in namespace")
-	command.Flags().StringArrayVar(&revisions, "revisions", []string{}, "Show manifests at specific revisions for the index of sources in source-indexes")
-	command.Flags().Int64SliceVar(&sourceIndexes, "source-indexes", []int64{}, "List of source indexes. Default is empty array. Indexes start at 1.")
+	command.Flags().StringArrayVar(&revisions, "revisions", []string{}, "Show manifests at specific revisions for the index of sources in source-positions")
+	command.Flags().Int64SliceVar(&sourcePositions, "source-positions", []int64{}, "List of source indexes. Default is empty array. Indexes start at 1.")
 	return command
 }
 
@@ -2736,12 +2736,12 @@ func printOperationResult(opState *argoappv1.OperationState) {
 // NewApplicationManifestsCommand returns a new instance of an `argocd app manifests` command
 func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		source        string
-		revision      string
-		revisions     []string
-		sourceIndexes []int64
-		local         string
-		localRepoRoot string
+		source          string
+		revision        string
+		revisions       []string
+		sourcePositions []int64
+		local           string
+		localRepoRoot   string
 	)
 	var command = &cobra.Command{
 		Use:   "manifests APPNAME",
@@ -2754,7 +2754,7 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
   argocd app manifests my-app --revision 0.0.1
 
   # Get manifests for a multi-source application at specific revisions for specific sources
-  argocd app manifests my-app --revisions 0.0.1 --source-indexes 1 --revisions 0.0.2 --source-indexes 2
+  argocd app manifests my-app --revisions 0.0.1 --source-positions 1 --revisions 0.0.2 --source-positions 2
   		`),
 		Run: func(c *cobra.Command, args []string) {
 			ctx := c.Context()
@@ -2764,8 +2764,8 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 				os.Exit(1)
 			}
 
-			if len(revisions) != len(sourceIndexes) {
-				errors.CheckError(fmt.Errorf("While using revisions and source-indexes, length of values for both flags should be same."))
+			if len(revisions) != len(sourcePositions) {
+				errors.CheckError(fmt.Errorf("While using revisions and source-positions, length of values for both flags should be same."))
 			}
 
 			appName, appNs := argo.ParseFromQualifiedName(args[0], "")
@@ -2798,12 +2798,12 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 
 					proj := getProject(c, clientOpts, ctx, app.Spec.Project)
 					unstructureds = getLocalObjects(context.Background(), app, proj.Project, local, localRepoRoot, argoSettings.AppLabelKey, cluster.ServerVersion, cluster.Info.APIVersions, argoSettings.KustomizeOptions, argoSettings.TrackingMethod)
-				} else if len(revisions) > 0 && len(sourceIndexes) > 0 {
+				} else if len(revisions) > 0 && len(sourcePositions) > 0 {
 
 					revisionSourceMappings := make(map[int64]string, 0)
-					for i, index := range sourceIndexes {
+					for i, index := range sourcePositions {
 						if index <= 0 {
-							errors.CheckError(fmt.Errorf("source-index cannot be less than or equal to 0, Index starts at 1"))
+							errors.CheckError(fmt.Errorf("source-position cannot be less than or equal to 0, Index starts at 1"))
 						}
 						revisionSourceMappings[index] = revisions[i]
 					}
@@ -2859,8 +2859,8 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 	}
 	command.Flags().StringVar(&source, "source", "git", "Source of manifests. One of: live|git")
 	command.Flags().StringVar(&revision, "revision", "", "Show manifests at a specific revision")
-	command.Flags().StringArrayVar(&revisions, "revisions", []string{}, "Show manifests at specific revisions for the index of sources in source-indexes")
-	command.Flags().Int64SliceVar(&sourceIndexes, "source-indexes", []int64{}, "List of source indexes. Default is empty array. Indexes start at 1.")
+	command.Flags().StringArrayVar(&revisions, "revisions", []string{}, "Show manifests at specific revisions for the index of sources in source-positions")
+	command.Flags().Int64SliceVar(&sourcePositions, "source-positions", []int64{}, "List of source indexes. Default is empty array. Indexes start at 1.")
 	command.Flags().StringVar(&local, "local", "", "If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", ".", "Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'.")
 	return command
@@ -3040,11 +3040,11 @@ func NewApplicationAddSourceCommand(clientOpts *argocdclient.ClientOptions) *cob
 			if len(app.Spec.Sources) > 0 {
 				appSource, _ := cmdutil.ConstructSource(&argoappv1.ApplicationSource{}, appOpts, c.Flags())
 
-				// sourceIndex is the index at which new source will be appended to spec.Sources
-				sourceIndex := len(app.Spec.GetSources())
+				// sourcePosition is the index at which new source will be appended to spec.Sources
+				sourcePosition := len(app.Spec.GetSources())
 				app.Spec.Sources = append(app.Spec.Sources, *appSource)
 
-				setParameterOverrides(app, appOpts.Parameters, sourceIndex)
+				setParameterOverrides(app, appOpts.Parameters, sourcePosition)
 
 				_, err = appIf.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
 					Name:         &app.Name,
@@ -3068,14 +3068,14 @@ func NewApplicationAddSourceCommand(clientOpts *argocdclient.ClientOptions) *cob
 // NewApplicationRemoveSourceCommand returns a new instance of an `argocd app remove-source` command
 func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		sourceIndex  int
-		appNamespace string
+		sourcePosition int
+		appNamespace   string
 	)
 	command := &cobra.Command{
 		Use:   "remove-source APPNAME",
 		Short: "Remove a source from multiple sources application. Index starts with 1. Default value is -1.",
 		Example: `  # Remove the source at index 1 from application's sources. Index starts at 1.
-  argocd app remove-source myapplication --source-index 1`,
+  argocd app remove-source myapplication --source-position 1`,
 		Run: func(c *cobra.Command, args []string) {
 			ctx := c.Context()
 
@@ -3084,7 +3084,7 @@ func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *
 				os.Exit(1)
 			}
 
-			if sourceIndex <= 0 {
+			if sourcePosition <= 0 {
 				errors.CheckError(fmt.Errorf("Index value of source must be greater than 0"))
 			}
 
@@ -3109,11 +3109,11 @@ func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *
 				errors.CheckError(fmt.Errorf("Cannot remove the only source remaining in the app"))
 			}
 
-			if len(app.Spec.GetSources()) < sourceIndex {
-				errors.CheckError(fmt.Errorf("Application does not have source at %d\n", sourceIndex))
+			if len(app.Spec.GetSources()) < sourcePosition {
+				errors.CheckError(fmt.Errorf("Application does not have source at %d\n", sourcePosition))
 			}
 
-			app.Spec.Sources = append(app.Spec.Sources[:sourceIndex-1], app.Spec.Sources[sourceIndex:]...)
+			app.Spec.Sources = append(app.Spec.Sources[:sourcePosition-1], app.Spec.Sources[sourcePosition:]...)
 
 			_, err = appIf.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
 				Name:         &app.Name,
@@ -3126,6 +3126,6 @@ func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *
 		},
 	}
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Namespace of the target application where the source will be appended")
-	command.Flags().IntVar(&sourceIndex, "source-index", -1, "Index of the source from the list of sources of the app. Index starts from 1.")
+	command.Flags().IntVar(&sourcePosition, "source-position", -1, "Index of the source from the list of sources of the app. Index starts from 1.")
 	return command
 }

--- a/cmd/util/app_test.go
+++ b/cmd/util/app_test.go
@@ -174,12 +174,12 @@ func (f *appOptionsFixture) SetFlag(key, value string) error {
 	return err
 }
 
-func (f *appOptionsFixture) SetFlagWithSourceIndex(key, value string, index int) error {
+func (f *appOptionsFixture) SetFlagWithSourcePosition(key, value string, sourcePosition int) error {
 	err := f.command.Flags().Set(key, value)
 	if err != nil {
 		return err
 	}
-	_ = SetAppSpecOptions(f.command.Flags(), f.spec, f.options, index)
+	_ = SetAppSpecOptions(f.command.Flags(), f.spec, f.options, sourcePosition)
 	return err
 }
 
@@ -251,34 +251,34 @@ func newMultiSourceAppOptionsFixture() *appOptionsFixture {
 
 func Test_setAppSpecOptionsMultiSourceApp(t *testing.T) {
 	f := newMultiSourceAppOptionsFixture()
-	index := 0
-	index1 := 1
-	index2 := 2
+	sourcePosition := 0
+	sourcePosition1 := 1
+	sourcePosition2 := 2
 	t.Run("SyncPolicy", func(t *testing.T) {
-		assert.NoError(t, f.SetFlagWithSourceIndex("sync-policy", "automated", index1))
+		assert.NoError(t, f.SetFlagWithSourcePosition("sync-policy", "automated", sourcePosition1))
 		assert.NotNil(t, f.spec.SyncPolicy.Automated)
 
 		f.spec.SyncPolicy = nil
-		assert.NoError(t, f.SetFlagWithSourceIndex("sync-policy", "automatic", index1))
+		assert.NoError(t, f.SetFlagWithSourcePosition("sync-policy", "automatic", sourcePosition1))
 		assert.NotNil(t, f.spec.SyncPolicy.Automated)
 	})
-	t.Run("Helm - Index 0", func(t *testing.T) {
-		assert.NoError(t, f.SetFlagWithSourceIndex("helm-version", "v2", index))
+	t.Run("Helm - SourcePosition 0", func(t *testing.T) {
+		assert.NoError(t, f.SetFlagWithSourcePosition("helm-version", "v2", sourcePosition))
 		assert.Equal(t, len(f.spec.GetSources()), 2)
-		assert.Equal(t, f.spec.GetSources()[index].Helm.Version, "v2")
+		assert.Equal(t, f.spec.GetSources()[sourcePosition].Helm.Version, "v2")
 	})
 	t.Run("Kustomize", func(t *testing.T) {
-		assert.NoError(t, f.SetFlagWithSourceIndex("kustomize-replica", "my-deployment=2", index1))
-		assert.Equal(t, f.spec.Sources[index1-1].Kustomize.Replicas, v1alpha1.KustomizeReplicas{{Name: "my-deployment", Count: intstr.FromInt(2)}})
-		assert.NoError(t, f.SetFlagWithSourceIndex("kustomize-replica", "my-deployment=4", index2))
-		assert.Equal(t, f.spec.Sources[index2-1].Kustomize.Replicas, v1alpha1.KustomizeReplicas{{Name: "my-deployment", Count: intstr.FromInt(4)}})
+		assert.NoError(t, f.SetFlagWithSourcePosition("kustomize-replica", "my-deployment=2", sourcePosition1))
+		assert.Equal(t, f.spec.Sources[sourcePosition1-1].Kustomize.Replicas, v1alpha1.KustomizeReplicas{{Name: "my-deployment", Count: intstr.FromInt(2)}})
+		assert.NoError(t, f.SetFlagWithSourcePosition("kustomize-replica", "my-deployment=4", sourcePosition2))
+		assert.Equal(t, f.spec.Sources[sourcePosition2-1].Kustomize.Replicas, v1alpha1.KustomizeReplicas{{Name: "my-deployment", Count: intstr.FromInt(4)}})
 	})
 	t.Run("Helm", func(t *testing.T) {
-		assert.NoError(t, f.SetFlagWithSourceIndex("helm-version", "v2", index1))
-		assert.NoError(t, f.SetFlagWithSourceIndex("helm-version", "v3", index2))
+		assert.NoError(t, f.SetFlagWithSourcePosition("helm-version", "v2", sourcePosition1))
+		assert.NoError(t, f.SetFlagWithSourcePosition("helm-version", "v3", sourcePosition2))
 		assert.Equal(t, len(f.spec.GetSources()), 2)
-		assert.Equal(t, f.spec.GetSources()[index1-1].Helm.Version, "v2")
-		assert.Equal(t, f.spec.GetSources()[index2-1].Helm.Version, "v3")
+		assert.Equal(t, f.spec.GetSources()[sourcePosition1-1].Helm.Version, "v2")
+		assert.Equal(t, f.spec.GetSources()[sourcePosition2-1].Helm.Version, "v3")
 	})
 }
 

--- a/docs/user-guide/commands/argocd_app.md
+++ b/docs/user-guide/commands/argocd_app.md
@@ -91,7 +91,7 @@ argocd app [flags]
 * [argocd app manifests](argocd_app_manifests.md)	 - Print manifests of an application
 * [argocd app patch](argocd_app_patch.md)	 - Patch application
 * [argocd app patch-resource](argocd_app_patch-resource.md)	 - Patch resource in an application
-* [argocd app remove-source](argocd_app_remove-source.md)	 - Remove a source from multiple sources application. Index starts with 1. Default value is -1.
+* [argocd app remove-source](argocd_app_remove-source.md)	 - Remove a source from multiple sources application. Counting starts with 1. Default value is -1.
 * [argocd app resources](argocd_app_resources.md)	 - List resource of application
 * [argocd app rollback](argocd_app_rollback.md)	 - Rollback application to a previous deployed version by History ID, omitted will Rollback to the previous version
 * [argocd app set](argocd_app_set.md)	 - Set application parameters

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -27,9 +27,9 @@ argocd app diff APPNAME [flags]
       --local-repo-root string        Path to the repository root. Used together with --local allows setting the repository root (default "/")
       --refresh                       Refresh application data when retrieving
       --revision string               Compare live app to a particular revision
-      --revisions stringArray         Show manifests at specific revisions for the index of sources in source-positions
+      --revisions stringArray         Show manifests at specific revisions for source position in source-positions
       --server-side-generate          Used with --local, this will send your manifests to the server for diffing
-      --source-positions int64Slice   List of source indexes. Default is empty array. Indexes start at 1. (default [])
+      --source-positions int64Slice   List of source positions. Default is empty array. Counting start at 1. (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -18,18 +18,18 @@ argocd app diff APPNAME [flags]
 ### Options
 
 ```
-  -N, --app-namespace string        Only render the difference in namespace
-      --exit-code                   Return non-zero exit code when there is a diff (default true)
-      --hard-refresh                Refresh application data as well as target manifests cache
-  -h, --help                        help for diff
-      --local string                Compare live app to a local manifests
-      --local-include stringArray   Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path. (default [*.yaml,*.yml,*.json])
-      --local-repo-root string      Path to the repository root. Used together with --local allows setting the repository root (default "/")
-      --refresh                     Refresh application data when retrieving
-      --revision string             Compare live app to a particular revision
-      --revisions stringArray       Show manifests at specific revisions for the index of sources in source-indexes
-      --server-side-generate        Used with --local, this will send your manifests to the server for diffing
-      --source-indexes int64Slice   List of source indexes. Default is empty array. Indexes start at 1. (default [])
+  -N, --app-namespace string          Only render the difference in namespace
+      --exit-code                     Return non-zero exit code when there is a diff (default true)
+      --hard-refresh                  Refresh application data as well as target manifests cache
+  -h, --help                          help for diff
+      --local string                  Compare live app to a local manifests
+      --local-include stringArray     Used with --server-side-generate, specify patterns of filenames to send. Matching is based on filename and not path. (default [*.yaml,*.yml,*.json])
+      --local-repo-root string        Path to the repository root. Used together with --local allows setting the repository root (default "/")
+      --refresh                       Refresh application data when retrieving
+      --revision string               Compare live app to a particular revision
+      --revisions stringArray         Show manifests at specific revisions for the index of sources in source-positions
+      --server-side-generate          Used with --local, this will send your manifests to the server for diffing
+      --source-positions int64Slice   List of source indexes. Default is empty array. Indexes start at 1. (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_manifests.md
+++ b/docs/user-guide/commands/argocd_app_manifests.md
@@ -28,9 +28,9 @@ argocd app manifests APPNAME [flags]
       --local string                  If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.
       --local-repo-root string        Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'. (default ".")
       --revision string               Show manifests at a specific revision
-      --revisions stringArray         Show manifests at specific revisions for the index of sources in source-positions
+      --revisions stringArray         Show manifests at specific revisions for the source at position in source-positions
       --source string                 Source of manifests. One of: live|git (default "git")
-      --source-positions int64Slice   List of source indexes. Default is empty array. Indexes start at 1. (default [])
+      --source-positions int64Slice   List of source positions. Default is empty array. Counting start at 1. (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_manifests.md
+++ b/docs/user-guide/commands/argocd_app_manifests.md
@@ -18,19 +18,19 @@ argocd app manifests APPNAME [flags]
   argocd app manifests my-app --revision 0.0.1
   
   # Get manifests for a multi-source application at specific revisions for specific sources
-  argocd app manifests my-app --revisions 0.0.1 --source-indexes 1 --revisions 0.0.2 --source-indexes 2
+  argocd app manifests my-app --revisions 0.0.1 --source-positions 1 --revisions 0.0.2 --source-positions 2
 ```
 
 ### Options
 
 ```
-  -h, --help                        help for manifests
-      --local string                If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.
-      --local-repo-root string      Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'. (default ".")
-      --revision string             Show manifests at a specific revision
-      --revisions stringArray       Show manifests at specific revisions for the index of sources in source-indexes
-      --source string               Source of manifests. One of: live|git (default "git")
-      --source-indexes int64Slice   List of source indexes. Default is empty array. Indexes start at 1. (default [])
+  -h, --help                          help for manifests
+      --local string                  If set, show locally-generated manifests. Value is the absolute path to app manifests within the manifest repo. Example: '/home/username/apps/env/app-1'.
+      --local-repo-root string        Path to the local repository root. Used together with --local allows setting the repository root. Example: '/home/username/apps'. (default ".")
+      --revision string               Show manifests at a specific revision
+      --revisions stringArray         Show manifests at specific revisions for the index of sources in source-positions
+      --source string                 Source of manifests. One of: live|git (default "git")
+      --source-positions int64Slice   List of source indexes. Default is empty array. Indexes start at 1. (default [])
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_remove-source.md
+++ b/docs/user-guide/commands/argocd_app_remove-source.md
@@ -12,7 +12,7 @@ argocd app remove-source APPNAME [flags]
 
 ```
   # Remove the source at index 1 from application's sources. Index starts at 1.
-  argocd app remove-source myapplication --source-index 1
+  argocd app remove-source myapplication --source-position 1
 ```
 
 ### Options
@@ -20,7 +20,7 @@ argocd app remove-source APPNAME [flags]
 ```
   -N, --app-namespace string   Namespace of the target application where the source will be appended
   -h, --help                   help for remove-source
-      --source-index int       Index of the source from the list of sources of the app. Index starts from 1. (default -1)
+      --source-position int    Index of the source from the list of sources of the app. Index starts from 1. (default -1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_remove-source.md
+++ b/docs/user-guide/commands/argocd_app_remove-source.md
@@ -2,7 +2,7 @@
 
 ## argocd app remove-source
 
-Remove a source from multiple sources application. Index starts with 1. Default value is -1.
+Remove a source from multiple sources application. Counting starts with 1. Default value is -1.
 
 ```
 argocd app remove-source APPNAME [flags]
@@ -11,7 +11,7 @@ argocd app remove-source APPNAME [flags]
 ### Examples
 
 ```
-  # Remove the source at index 1 from application's sources. Index starts at 1.
+  # Remove the source at position 1 from application's sources. Counting starts at 1.
   argocd app remove-source myapplication --source-position 1
 ```
 
@@ -20,7 +20,7 @@ argocd app remove-source APPNAME [flags]
 ```
   -N, --app-namespace string   Namespace of the target application where the source will be appended
   -h, --help                   help for remove-source
-      --source-position int    Index of the source from the list of sources of the app. Index starts from 1. (default -1)
+      --source-position int    Position of the source from the list of sources of the app. Counting starts at 1. (default -1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -23,8 +23,8 @@ argocd app set APPNAME [flags]
   # Set and override application parameters with a parameter file
   argocd app set my-app --parameter-file path/to/parameter-file.yaml
   
-  # Set and override application parameters for a source at index 1 under spec.sources of app my-app. source-index starts at 1.
-  argocd app set my-app --source-index 1 --repo https://github.com/argoproj/argocd-example-apps.git
+  # Set and override application parameters for a source at index 1 under spec.sources of app my-app. source-position starts at 1.
+  argocd app set my-app --source-position 1 --repo https://github.com/argoproj/argocd-example-apps.git
   
   # Set application parameters and specify the namespace
   argocd app set my-app --parameter key1=value1 --parameter key2=value2 --namespace my-namespace
@@ -79,7 +79,7 @@ argocd app set APPNAME [flags]
       --revision string                            The tracking source branch, tag, commit or Helm chart version the application will sync to
       --revision-history-limit int                 How many items to keep in revision history (default 10)
       --self-heal                                  Set self healing when sync is automated
-      --source-index int                           Index of the source from the list of sources of the app. Index starts at 1. (default -1)
+      --source-position int                        Index of the source from the list of sources of the app. Index starts at 1. (default -1)
       --sync-option Prune=false                    Add or remove a sync option, e.g add Prune=false. Remove using `!` prefix, e.g. `!Prune=false`
       --sync-policy string                         Set the sync policy (one of: manual (aliases of manual: none), automated (aliases of automated: auto, automatic))
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -23,7 +23,7 @@ argocd app set APPNAME [flags]
   # Set and override application parameters with a parameter file
   argocd app set my-app --parameter-file path/to/parameter-file.yaml
   
-  # Set and override application parameters for a source at index 1 under spec.sources of app my-app. source-position starts at 1.
+  # Set and override application parameters for a source at position 1 under spec.sources of app my-app. source-position starts at 1.
   argocd app set my-app --source-position 1 --repo https://github.com/argoproj/argocd-example-apps.git
   
   # Set application parameters and specify the namespace
@@ -79,7 +79,7 @@ argocd app set APPNAME [flags]
       --revision string                            The tracking source branch, tag, commit or Helm chart version the application will sync to
       --revision-history-limit int                 How many items to keep in revision history (default 10)
       --self-heal                                  Set self healing when sync is automated
-      --source-position int                        Index of the source from the list of sources of the app. Index starts at 1. (default -1)
+      --source-position int                        Position of the source from the list of sources of the app. Counting starts at 1. (default -1)
       --sync-option Prune=false                    Add or remove a sync option, e.g add Prune=false. Remove using `!` prefix, e.g. `!Prune=false`
       --sync-policy string                         Set the sync policy (one of: manual (aliases of manual: none), automated (aliases of automated: auto, automatic))
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)

--- a/docs/user-guide/commands/argocd_app_unset.md
+++ b/docs/user-guide/commands/argocd_app_unset.md
@@ -17,8 +17,8 @@ argocd app unset APPNAME parameters [flags]
   # Unset kustomize override suffix
   argocd app unset my-app --namesuffix
 
-  # Unset kustomize override suffix for source at index 1 under spec.sources of app my-app. source-index starts at 1.
-  argocd app unset my-app --source-index 1 --namesuffix
+  # Unset kustomize override suffix for source at index 1 under spec.sources of app my-app. source-position starts at 1.
+  argocd app unset my-app --source-position 1 --namesuffix
 
   # Unset parameter override
   argocd app unset my-app -p COMPONENT=PARAM
@@ -40,7 +40,7 @@ argocd app unset APPNAME parameters [flags]
       --pass-credentials                Unset passCredentials
       --plugin-env stringArray          Unset plugin env variables (e.g --plugin-env name)
       --ref                             Unset ref on the source
-      --source-index int                Index of the source from the list of sources of the app. Index starts at 1. (default -1)
+      --source-position int             Index of the source from the list of sources of the app. Index starts at 1. (default -1)
       --values stringArray              Unset one or more Helm values files
       --values-literal                  Unset literal Helm values block
 ```

--- a/docs/user-guide/commands/argocd_app_unset.md
+++ b/docs/user-guide/commands/argocd_app_unset.md
@@ -17,7 +17,7 @@ argocd app unset APPNAME parameters [flags]
   # Unset kustomize override suffix
   argocd app unset my-app --namesuffix
 
-  # Unset kustomize override suffix for source at index 1 under spec.sources of app my-app. source-position starts at 1.
+  # Unset kustomize override suffix for source at position 1 under spec.sources of app my-app. source-position starts at 1.
   argocd app unset my-app --source-position 1 --namesuffix
 
   # Unset parameter override
@@ -40,7 +40,7 @@ argocd app unset APPNAME parameters [flags]
       --pass-credentials                Unset passCredentials
       --plugin-env stringArray          Unset plugin env variables (e.g --plugin-env name)
       --ref                             Unset ref on the source
-      --source-position int             Index of the source from the list of sources of the app. Index starts at 1. (default -1)
+      --source-position int             Position of the source from the list of sources of the app. Counting starts at 1. (default -1)
       --values stringArray              Unset one or more Helm values files
       --values-literal                  Unset literal Helm values block
 ```


### PR DESCRIPTION
Based on recent discussion in contributors meeting, renaming `source-indexes` to `source-positions` in `argocd app` subcommands for multiple sources.



------
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
