### PR TITLE
fix: update rbac validation to support applications in different namespaces

### DIFF
--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3082,6 +3082,64 @@ func TestOrphanedResourcesMonitorSettings_IsWarn(t *testing.T) {
 	assert.True(t, settings.IsWarn())
 }
 
+func Test_isValidPolicy(t *testing.T) {
+	policyTests := []struct {
+		name    string
+		policy  string
+		isValid bool
+	}{
+		{
+			name:    "policy with full wildcard",
+			policy:  "some-project/*",
+			isValid: true,
+		},
+		{
+			name:    "policy with full wildcard namespace and application",
+			policy:  "some-project/*/*",
+			isValid: true,
+		},
+		{
+			name:    "policy with wildcard namespace and specified application",
+			policy:  "some-project/*/some-application",
+			isValid: true,
+		},
+		{
+			name:    "policy with specified namespace and wildcard application",
+			policy:  "some-project/some-namespace/*",
+			isValid: true,
+		},
+		{
+			name:    "policy with wildcard prefix namespace and specified application",
+			policy:  "some-project/some-name*/some-application",
+			isValid: true,
+		},
+		{
+			name:    "policy with specified namespace and wildcard prefixed application",
+			policy:  "some-project/some-namespace/some-app*",
+			isValid: true,
+		},
+		{
+			name:    "policy with valid namespace and application",
+			policy:  "some-project/some-namespace/some-application",
+			isValid: true,
+		},
+		{
+			name:    "policy with invalid namespace character",
+			policy:  "some-project/some~namespace/some-application",
+			isValid: false,
+		},
+		{
+			name:    "policy with invalid application character",
+			policy:  "some-project/some-namespace/some^application",
+			isValid: false,
+		},
+	}
+
+	for _, policyTest := range policyTests {
+		assert.Equal(t, policyTest.isValid, isValidObject("some-project", policyTest.policy), policyTest.name)
+	}
+}
+
 func Test_validatePolicy_projIsNotRegex(t *testing.T) {
 	// Make sure the "." in "some.project" isn't treated as the regex wildcard.
 	err := validatePolicy("some.project", "org-admin", "p, proj:some.project:org-admin, applications, *, some-project/*, allow")

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3094,7 +3094,7 @@ func Test_isValidPolicy(t *testing.T) {
 			isValid: true,
 		},
 		{
-			name:    "policy with specified project",
+			name:    "policy with specified project and application",
 			policy:  "some-project/some-application",
 			isValid: true,
 		},

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3094,6 +3094,11 @@ func Test_isValidPolicy(t *testing.T) {
 			isValid: true,
 		},
 		{
+			name:    "policy with specified project",
+			policy:  "some-project/some-application",
+			isValid: true,
+		},
+		{
 			name:    "policy with full wildcard namespace and application",
 			policy:  "some-project/*/*",
 			isValid: true,

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -585,7 +585,7 @@ p, role:admin, projects, update, *, allow`)
 		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(projWithRole), enforcer, sync.NewKeyLock(), nil, nil, projInformer, settingsMgr, argoDB)
 		request := &project.ProjectUpdateRequest{Project: projWithRole}
 		_, err := projectServer.Update(context.Background(), request)
-		assert.Contains(t, err.Error(), "object must be of form 'test/*' or 'test/<APPNAME>'")
+		assert.Contains(t, err.Error(), "object must be of form 'test/*', 'test[/<NAMESPACE>]/<APPNAME>' or 'test/<APPNAME>'")
 	})
 
 	t.Run("TestValidateProjectIncorrectProjectInRoleFailure", func(t *testing.T) {


### PR DESCRIPTION
When attempting to create a policy that allows or denies privileges for an application within a namespace you get the following error:

```
FATA[0000] rpc error: code = InvalidArgument desc = invalid policy rule 'p, proj:my-project:my-role, applications, get, my-project/my-namespace/app-prefix-*, allow': object must be of form 'my-project/*' or 'my-project/<APPNAME>', not 'my-project/my-namespace/app-prefix-*'
```

However, if you don't use the `project/namespace/application` format in the policy you don't get the appropriate privileges access the api:

```
➜  project-scratch-space k get appproject my-project -o=jsonpath='{.spec.roles}' | jq .
[
  {
    "name": "my-role",
    "policies": [
      "p, proj:my-project:my-role, applications, get, my-project/my-deployment-1, allow"
    ]
  }
]
➜  project-scratch-space curl -s -H "Authorization: Bearer <token>" "http://localhost:8080/api/v1/applications/my-deployment-1?appNamespace=my-namespace" | jq .
{
  "error": "permission denied",
  "code": 7,
  "message": "permission denied"
}
```

Update the regex validation of the policy object to include the namespace format.

With the namespace specified the appropriate information is returned:

```
➜  project-scratch-space k get appproject my-project -o=jsonpath='{.spec.roles}' | jq .
[
  {
    "name": "my-role",
    "policies": [
      "p, proj:my-project:my-role, applications, get, my-project/my-namespace/my-deployment-1, allow"
    ]
  }
]
➜  project-scratch-space curl -s -H "Authorization: Bearer <token>" "http://localhost:8080/api/v1/applications/my-deployment-1?appNamespace=my-namespace" | jq .
{
  "metadata": {
    "name": "my-deployment-1",
    "namespace": "my-namespace",
    "uid": "5894e229-7d87-4437-9d97-4e14515cec2d",
    "resourceVersion": "34648",
    "generation": 111,
    ... snip ...
    "controllerNamespace": "argocd"
  }
}
```

Fixes #15333

I looked to update the documentation for this, but based on what I saw it seems like the docs seem to indicate that this is the way it should work to begin with.  Though if I missed something, I'd be happy to update any documentation that needs it.

https://github.com/argoproj/argo-cd/blob/4abc9929281296122db0eace1607583187dd9944/docs/operator-manual/app-any-namespace.md#L136

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
