### PR TITLE
fix(utils): avoid invalid trims of resource tracking labels #17809

### DIFF
--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -2,6 +2,7 @@ package argo
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -155,6 +156,12 @@ func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, v
 		}
 		if len(val) > LabelMaxLength {
 			val = val[:LabelMaxLength]
+			// Trim the string until the last valid alphanumeric character
+			reg := regexp.MustCompile(`[^a-z0-9A-Z]*$`)
+			match := reg.FindString(val)
+			if match != "" {
+				val = strings.TrimRight(val, match)
+			}
 		}
 		err = argokube.SetAppInstanceLabel(un, key, val)
 		if err != nil {

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -62,6 +62,21 @@ func TestSetAppInstanceAnnotationAndLabel(t *testing.T) {
 	assert.Equal(t, "my-app", app)
 }
 
+func TestSetAppInstanceAnnotationAndLabelTrimming(t *testing.T) {
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
+	assert.Nil(t, err)
+
+	var obj unstructured.Unstructured
+	err = yaml.Unmarshal(yamlBytes, &obj)
+	assert.Nil(t, err)
+
+	rt := NewResourceTracking()
+	err = rt.SetAppInstance(&obj, common.LabelKeyAppInstance, "this-is-a-very-long-resource-name-needs-to-be-sanitized-to-not-be-invalid", "", TrackingMethodAnnotationAndLabel)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "this-is-a-very-long-resource-name-needs-to-be-sanitized-to-not", obj.GetLabels()[common.LabelKeyAppInstance])
+}
+
 func TestSetAppInstanceAnnotationNotFound(t *testing.T) {
 	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

This implements a sanitization on trimmed labels, as trimming to 63 characters can produce labels ending with `_`, `.` and `-`. Those labels are invalid and the resource can't be created on Kubernetes.
Fixes #17809 
