### PR TITLE
docs: fix metrics labels name in notification monitoring

### DIFF
--- a/docs/operator-manual/notifications/grafana-dashboard.json
+++ b/docs/operator-manual/notifications/grafana-dashboard.json
@@ -60,7 +60,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(argocd_notifications_trigger_eval_total[$interval])) by (notifier)",
+          "expr": "sum(increase(argocd_notifications_trigger_eval_total[$interval])) by (name)",
           "refId": "A"
         }
       ],
@@ -146,7 +146,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(argocd_notifications_deliveries_total[$interval])) by (notifier)",
+          "expr": "sum(increase(argocd_notifications_deliveries_total[$interval])) by (service)",
           "refId": "A"
         }
       ],

--- a/docs/operator-manual/notifications/monitoring.md
+++ b/docs/operator-manual/notifications/monitoring.md
@@ -13,8 +13,8 @@ The following metrics are available:
  Number of delivered notifications.
  Labels:
 
-* `template` - notification template name 
-* `notifier` - notification service name
+* `trigger` - trigger name
+* `service` - notification service name
 * `succeeded` - flag that indicates if notification was successfully sent or failed
 
 ### `argocd_notifications_trigger_eval_total`


### PR DESCRIPTION
This PR fix notification documentation which use wrong labels name in `argocd_notifications_deliveries_total` metric
Possible labels are defined here https://github.com/argoproj/notifications-engine/blob/master/pkg/controller/metrics.go#L16

```
func NewMetricsRegistry(prefix string) *MetricsRegistry {
	deliveriesCounter := prometheus.NewCounterVec(
		prometheus.CounterOpts{
			Name: fmt.Sprintf("%s_notifications_deliveries_total", prefix),
			Help: "Number of delivered notifications.",
		},
		[]string{"trigger", "service", "succeeded"},
	)
     ...
}
```


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).