### PR TITLE
fix: Pass logger to differ in diff command

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -50,6 +50,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/grpc"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"
+	logutils "github.com/argoproj/argo-cd/v2/util/log"
 	"github.com/argoproj/argo-cd/v2/util/manifeststream"
 	"github.com/argoproj/argo-cd/v2/util/templates"
 	"github.com/argoproj/argo-cd/v2/util/text/label"
@@ -1309,6 +1310,7 @@ func findandPrintDiff(ctx context.Context, app *argoappv1.Application, proj *arg
 			WithDiffSettings(app.Spec.IgnoreDifferences, overrides, ignoreAggregatedRoles).
 			WithTracking(argoSettings.AppLabelKey, argoSettings.TrackingMethod).
 			WithNoCache().
+			WithLogger(logutils.NewLogrusLogger(logutils.NewWithCurrentConfig())).
 			Build()
 		errors.CheckError(err)
 		diffRes, err := argodiff.StateDiff(item.live, item.target, diffConfig)


### PR DESCRIPTION
So that log messages are propagated up, this caused issues for me when trying to diagnose an issue linked to issue #17811. I've just copied the approach used e.g. in `controller/appcontroller.go` when calling `argodiff.NewDiffConfigBuilder`.

Sample output before this change:

    $ argocd --loglevel debug --server argocd-system.dev.aws.uw.systems app diff dev-enablement/dev-enablement

    ===== apps/Deployment dev-enablement/go-docs ======
    272c272
    <             cpu: "0"
    ---
    >             cpu: 0m
    275c275
    <             cpu: "0"
    ---
    >             cpu: 0m

Output with this change:

    $ argocd --loglevel debug --server argocd-system.dev.aws.uw.systems app diff dev-enablement/dev-enablement
    INFO[0000] Could not unmarshal to object of type apps/v1, Kind=Deployment: json: unknown field "restartPolicy"
    INFO[0000] Could not unmarshal to object of type apps/v1, Kind=Deployment: json: unknown field "restartPolicy"

    ===== apps/Deployment dev-enablement/go-docs ======
    272c272
    <             cpu: "0"
    ---
    >             cpu: 0m
    275c275
    <             cpu: "0"
    ---
    >             cpu: 0m
    INFO[0000] Could not create new object of type argoproj.io/v1alpha1, Kind=Application: no kind "Application" is registered for version "argoproj.io/v1alpha1" in scheme "pkg/runtime/scheme.go:100"
    INFO[0000] Could not create new object of type argoproj.io/v1alpha1, Kind=Application: no kind "Application" is registered for version "argoproj.io/v1alpha1" in scheme "pkg/runtime/scheme.go:100"
    INFO[0000] Could not create new object of type traefik.containo.us/v1alpha1, Kind=IngressRoute: no kind "IngressRoute" is registered for version "traefik.containo.us/v1alpha1" in scheme "pkg/runtime/scheme.go:100"
    INFO[0000] Could not create new object of type traefik.containo.us/v1alpha1, Kind=IngressRoute: no kind "IngressRoute" is registered for version "traefik.containo.us/v1alpha1" in scheme "pkg/runtime/scheme.go:100"
    INFO[0000] Could not create new object of type traefik.containo.us/v1alpha1, Kind=IngressRoute: no kind "IngressRoute" is registered for version "traefik.containo.us/v1alpha1" in scheme "pkg/runtime/scheme.go:100"
    INFO[0000] Could not create new object of type traefik.containo.us/v1alpha1, Kind=IngressRoute: no kind "IngressRoute" is registered for version "traefik.containo.us/v1alpha1" in scheme "pkg/runtime/scheme.go:100"

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. **(b)** this is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue. **N/A**
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. **N/A**
* [x] Does this PR require documentation updates? **N/A**
* [x] I've updated documentation as required by this PR. **N/A**
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged. **N/A**
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves. **N/A**
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
