### PR TITLE
docs: document possibility to specify request timeout in plugin generator

### DIFF
--- a/docs/operator-manual/applicationset/Generators-Plugin.md
+++ b/docs/operator-manual/applicationset/Generators-Plugin.md
@@ -77,10 +77,12 @@ metadata:
 data:
   token: "$plugin.myplugin.token" # Alternatively $<some_K8S_secret>:plugin.myplugin.token
   baseUrl: "http://myplugin.plugin-ns.svc.cluster.local."
+  requestTimeout: "60"
 ```
 
 - `token`: Pre-shared token used to authenticate HTTP request (points to the right key you created in the `argocd-secret` Secret)
 - `baseUrl`: BaseUrl of the k8s service exposing your plugin in the cluster.
+- `requestTimeout`: Timeout of the request to the plugin in seconds (default: 30)
 
 ### Store credentials
 


### PR DESCRIPTION
In the [plugin generator code](https://github.com/argoproj/argo-cd/blob/74805d55f66da3bb496deb4503ebce429e0cc2dc/applicationset/generators/plugin.go#L101), I've found the possibility to manually set the timeout for a request to a plugin generator.
This feature isn't documented, though. With this PR it is.
