### PR TITLE
chore: improve codegen error output

### DIFF
--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -117,6 +118,10 @@ func removeDescription(v interface{}) {
 
 func checkErr(err error) {
 	if err != nil {
+		var execError *exec.ExitError
+		if errors.As(err, &execError) {
+			fmt.Println(string(execError.Stderr))
+		}
 		panic(err)
 	}
 }


### PR DESCRIPTION
The codegen `checkErr` function currently hides any stderr output from a failed command. This change prints stderr for the failed command.