### PR TITLE
fix: invalid revision in re-used manifest cache

### DIFF
--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -354,6 +354,11 @@ func (c *Cache) GetManifests(revision string, appSrc *appv1.ApplicationSource, s
 	// The expected hash matches the actual hash, so remove the hash from the returned value
 	res.CacheEntryHash = ""
 
+	if res.ManifestResponse != nil {
+		// cached manifest response might be reused across different revisions, so we need to assume that the revision is the one we are looking for
+		res.ManifestResponse.Revision = revision
+	}
+
 	return nil
 }
 

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -124,11 +124,18 @@ func TestCache_GetManifests(t *testing.T) {
 		assert.Equal(t, ErrCacheMiss, err)
 	})
 	t.Run("expect cache hit", func(t *testing.T) {
-		err = cache.GetManifests("my-revision", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil)
+		err = cache.SetManifests(
+			"my-revision1", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value",
+			&CachedManifestResponse{ManifestResponse: &apiclient.ManifestResponse{SourceType: "my-source-type", Revision: "my-revision2"}}, nil)
 		assert.NoError(t, err)
-		assert.Equal(t, &CachedManifestResponse{ManifestResponse: &apiclient.ManifestResponse{SourceType: "my-source-type"}}, value)
+
+		err = cache.GetManifests("my-revision1", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "my-source-type", value.ManifestResponse.SourceType)
+		assert.Equal(t, "my-revision1", value.ManifestResponse.Revision)
 	})
-	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 8})
+	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 2, ExternalGets: 8})
 }
 
 func TestCache_GetAppDetails(t *testing.T) {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -302,7 +302,7 @@ func TestGenerateManifests_K8SAPIResetCache(t *testing.T) {
 		ProjectSourceRepos: []string{"*"},
 	}
 
-	cachedFakeResponse := &apiclient.ManifestResponse{Manifests: []string{"Fake"}}
+	cachedFakeResponse := &apiclient.ManifestResponse{Manifests: []string{"Fake"}, Revision: mock.Anything}
 
 	err := service.cache.SetManifests(mock.Anything, &src, q.RefSources, &q, "", "", "", "", &cache.CachedManifestResponse{ManifestResponse: cachedFakeResponse}, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
PR fixes the bug introduced by https://github.com/argoproj/argo-cd/pull/16754 

Argo CD webhook "moves" cached manifest in redis to the key that matches the new git revision however it does not take into account that cached value has old revision that is used by the application controller. PR fixes that caching layer to replace value of cached revision.