### PR TITLE
fix(api): respect all allowed audiences, regardless of check order

### DIFF
--- a/util/oidc/provider.go
+++ b/util/oidc/provider.go
@@ -135,7 +135,9 @@ func (p *providerImpl) Verify(tokenString string, argoSettings *settings.ArgoCDS
 			// to avoid logging irrelevant warnings: https://github.com/coreos/go-oidc/pull/406
 			tokenVerificationErrors[aud] = err
 		}
-		if len(tokenVerificationErrors) > 0 {
+		// If the most recent attempt encountered an error, and if we have collected multiple errors, switch to the
+		// other error type to gather more context.
+		if err != nil && len(tokenVerificationErrors) > 0 {
 			err = tokenVerificationError{errorsByAudience: tokenVerificationErrors}
 		}
 	}


### PR DESCRIPTION
This was a silly bug. In 2.11 I added logic to collect error messages so we'd have better logs about failed token verification.

But the error message collector forced an error message even when token validation _passed_ for one of the audiences. The behavior we want is that if _any_ allowed audience validates, the token is valid.

The test I added failed before and passes now, indicating that valid tokens will no longer be rejected based on order.