### PR TITLE
feat: Provide Edit support in Sources tab for multi-source app (#17588)

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters-source.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters-source.tsx
@@ -1,0 +1,112 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import {FormApi} from 'react-form';
+import {EditablePanelItem} from '../../../shared/components';
+import {EditableSection} from '../../../shared/components/editable-panel/editable-section';
+import {Consumer} from '../../../shared/context';
+import '../../../shared/components/editable-panel/editable-panel.scss';
+
+export interface ApplicationParametersPanelProps<T> {
+    floatingTitle?: string | React.ReactNode;
+    titleTop?: string | React.ReactNode;
+    titleBottom?: string | React.ReactNode;
+    index: number;
+    valuesTop?: T;
+    valuesBottom?: T;
+    validateTop?: (values: T) => any;
+    validateBottom?: (values: T) => any;
+    saveTop?: (input: T, query: {validate?: boolean}) => Promise<any>;
+    saveBottom?: (input: T, query: {validate?: boolean}) => Promise<any>;
+    itemsTop?: EditablePanelItem[];
+    itemsBottom?: EditablePanelItem[];
+    onModeSwitch?: () => any;
+    viewTop?: string | React.ReactNode;
+    viewBottom?: string | React.ReactNode;
+    editTop?: (formApi: FormApi) => React.ReactNode;
+    editBottom?: (formApi: FormApi) => React.ReactNode;
+    noReadonlyMode?: boolean;
+    collapsible?: boolean;
+}
+
+interface ApplicationParametersPanelState {
+    editTop: boolean;
+    editBottom: boolean;
+    savingTop: boolean;
+    savingBottom: boolean;
+}
+
+// Currently two editable sections, but can be modified to support N panels in general.  This should be part of a white-box, editable-panel.
+export class ApplicationParametersSource<T = {}> extends React.Component<ApplicationParametersPanelProps<T>, ApplicationParametersPanelState> {
+    constructor(props: ApplicationParametersPanelProps<T>) {
+        super(props);
+        this.state = {editTop: !!props.noReadonlyMode, editBottom: !!props.noReadonlyMode, savingTop: false, savingBottom: false};
+    }
+
+    public render() {
+        return (
+            <Consumer>
+                {ctx => (
+                    <div className={classNames({'editable-panel--disabled': this.state.savingTop})}>
+                        {this.props.floatingTitle && <div className='white-box--additional-top-space editable-panel__sticky-title'>{this.props.floatingTitle}</div>}
+                        <React.Fragment>
+                            <EditableSection
+                                uniqueId={'top_' + this.props.index}
+                                title={this.props.titleTop}
+                                view={this.props.viewTop}
+                                values={this.props.valuesTop}
+                                items={this.props.itemsTop}
+                                validate={this.props.validateTop}
+                                save={this.props.saveTop}
+                                onModeSwitch={() => this.onModeSwitch()}
+                                noReadonlyMode={this.props.noReadonlyMode}
+                                edit={this.props.editTop}
+                                collapsible={this.props.collapsible}
+                                ctx={ctx}
+                                isTopSection={true}
+                                disabledState={this.state.editTop || this.state.editTop === null}
+                                updateButtons={editClicked => {
+                                    this.setState({editBottom: editClicked});
+                                }}
+                            />
+                        </React.Fragment>
+                        {this.props.itemsTop && (
+                            <React.Fragment>
+                                <div className='row white-box__details-row'>
+                                    <p>&nbsp;</p>
+                                </div>
+                                <div className='white-box--no-padding editable-panel__divider' />
+                            </React.Fragment>
+                        )}
+                        <React.Fragment>
+                            <EditableSection
+                                uniqueId={'bottom_' + this.props.index}
+                                title={this.props.titleBottom}
+                                view={this.props.viewBottom}
+                                values={this.props.valuesBottom}
+                                items={this.props.itemsBottom}
+                                validate={this.props.validateBottom}
+                                save={this.props.saveBottom}
+                                onModeSwitch={() => this.onModeSwitch()}
+                                noReadonlyMode={this.props.noReadonlyMode}
+                                edit={this.props.editBottom}
+                                collapsible={this.props.collapsible}
+                                ctx={ctx}
+                                isTopSection={false}
+                                disabledState={this.state.editBottom || this.state.editBottom === null}
+                                updateButtons={editClicked => {
+                                    this.setState({editTop: editClicked});
+                                }}
+                            />
+                        </React.Fragment>
+                    </div>
+                )}
+            </Consumer>
+        );
+    }
+
+    private onModeSwitch() {
+        if (this.props.onModeSwitch) {
+            this.props.onModeSwitch();
+        }
+    }
+}

--- a/ui/src/app/applications/components/application-parameters/application-parameters.scss
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.scss
@@ -1,0 +1,80 @@
+@import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
+
+.application-parameters {
+    &__labels {
+        line-height: 28px;
+        display: flex;
+        align-items: center;
+        height: 100%;
+        flex-wrap: wrap;
+        padding-top: 0.5em;
+    }
+
+    &__label {
+        background-color: $argo-color-gray-5;
+        color: white;
+        border-radius: 5px;
+        padding: 4px;
+        line-height: 14px;
+        margin: 0.3em 0;
+        margin-right: 2px;
+    }
+
+    &__sort-icon {
+        cursor: pointer;
+        position: absolute;
+        font-size: 1.3em;
+        left: -1em;
+
+        &.fa-sort-up {
+            top: 10px;
+        }
+
+        &.fa-sort-down {
+            bottom: 10px;
+        }
+    }
+    &__remove-icon {
+        cursor: pointer;
+        position: absolute;
+        top: 1em;
+        right: 1em;
+    }
+
+    .argo-field {
+        line-height: 1.15;
+    }
+
+    .white-box__details p {
+        font-weight: 500;
+        @include themify($themes) {            
+            color: themed('text-1');
+        }
+    }
+
+    .white-box__details-row .row {
+        padding-left: 1em;
+        padding-right: 1em;
+    }
+
+    .white-box__details-row .row .columns:last-child {
+        padding-left: 1em;
+    }
+
+    .select {
+        padding-bottom: 0;
+    }
+
+    .row.application-retry-options {
+        .columns.application-retry-options__item{
+            padding-left: 0;
+            padding-right: 10px;
+        }
+
+        .argo-form-row__error-msg {
+            position: static;
+            line-height: 1;
+        }
+    }
+}

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -6,8 +6,6 @@ import {
     ArrayInputField,
     ArrayValueField,
     CheckboxField,
-    EditablePanel,
-    EditablePanelItem,
     Expandable,
     MapValueField,
     NameValueEditor,
@@ -18,7 +16,9 @@ import {
     Paginate,
     RevisionHelpIcon,
     Revision,
-    Repo
+    Repo,
+    EditablePanel,
+    EditablePanelItem
 } from '../../../shared/components';
 import * as models from '../../../shared/models';
 import {ApplicationSourceDirectory, Plugin} from '../../../shared/models';
@@ -27,9 +27,13 @@ import {ImageTagFieldEditor} from './kustomize';
 import * as kustomize from './kustomize-image';
 import {VarsInputField} from './vars-input-field';
 import {concatMaps} from '../../../shared/utils';
-import {getAppDefaultSource, helpTip} from '../utils';
+import {getAppDefaultSource} from '../utils';
 import * as jsYaml from 'js-yaml';
 import {RevisionFormField} from '../revision-form-field/revision-form-field';
+import classNames from 'classnames';
+import {ApplicationParametersSource} from './application-parameters-source';
+
+import './application-parameters.scss';
 
 const TextWithMetadataField = ReactFormField((props: {metadata: {value: string}; fieldApi: FieldApi; className: string}) => {
     const {
@@ -138,99 +142,267 @@ function getParamsEditableItems(
 export const ApplicationParameters = (props: {
     application: models.Application;
     details?: models.RepoAppDetails;
-    detailsList?: models.RepoAppDetails[];
     save?: (application: models.Application, query: {validate?: boolean}) => Promise<any>;
     noReadonlyMode?: boolean;
     pageNumber?: number;
     setPageNumber?: (x: number) => any;
+    collapsedSources?: boolean[];
+    handleCollapse?: (i: number, isCollapsed: boolean) => void;
 }) => {
     const app = cloneDeep(props.application);
     const source = getAppDefaultSource(app); // For source field
     const appSources = app?.spec.sources;
     const [removedOverrides, setRemovedOverrides] = React.useState(new Array<boolean>());
-
-    let attributes: EditablePanelItem[] = [];
-    const multipleAttributes = new Array<EditablePanelItem[]>();
-
+    const collapsible = props.collapsedSources !== undefined && props.handleCollapse !== undefined;
     const [appParamsDeletedState, setAppParamsDeletedState] = React.useState([]);
 
-    if (appSources && props.detailsList && props.detailsList.length > 1) {
-        for (let i: number = 0; i < props.detailsList.length; i++) {
-            multipleAttributes.push(
-                gatherDetails(props.detailsList[i], attributes, appSources[i], app, setRemovedOverrides, removedOverrides, appParamsDeletedState, setAppParamsDeletedState)
-            );
-            attributes = [];
-        }
-    } else {
-        // For source field. Delete this when source field is removed
-        attributes = gatherDetails(props.details, attributes, source, app, setRemovedOverrides, removedOverrides, appParamsDeletedState, setAppParamsDeletedState);
-    }
-
-    if (props.detailsList && props.detailsList.length > 1) {
+    if (app.spec.sources?.length > 0 && !props.details) {
         return (
-            <Paginate
-                showHeader={false}
-                data={multipleAttributes}
-                page={props.pageNumber}
-                preferencesKey={'5'}
-                onPageChange={page => {
-                    props.setPageNumber(page);
-                }}>
-                {data => {
-                    const listOfPanels: any[] = [];
-                    data.forEach(attr => {
-                        const repoAppDetails = props.detailsList[multipleAttributes.indexOf(attr)];
-                        listOfPanels.push(getEditablePanel(attr, repoAppDetails, multipleAttributes.indexOf(attr), app.spec.sources));
-                    });
-                    return listOfPanels;
-                }}
-            </Paginate>
+            <div className='application-parameters'>
+                <Paginate
+                    showHeader={false}
+                    data={app.spec.sources}
+                    page={props.pageNumber}
+                    preferencesKey={'5'}
+                    onPageChange={page => {
+                        props.setPageNumber(page);
+                    }}>
+                    {data => {
+                        const listOfPanels: JSX.Element[] = [];
+                        data.forEach(appSource => {
+                            const i = app.spec.sources.indexOf(appSource);
+                            listOfPanels.push(getEditablePanelForSources(i, appSource));
+                        });
+                        return listOfPanels;
+                    }}
+                </Paginate>
+            </div>
         );
     } else {
-        const v: models.ApplicationSource[] = new Array<models.ApplicationSource>();
-        v.push(app.spec.source);
-        return getEditablePanel(attributes, props.details, 0, v, true);
+        // For the other old/existings references of ApplicationParameters that have details already loaded. They are single source
+        let attributes: EditablePanelItem[] = [];
+        if (props.details) {
+            return getEditablePanel(
+                gatherDetails(0, props.details, attributes, source, app, setRemovedOverrides, removedOverrides, appParamsDeletedState, setAppParamsDeletedState, false),
+                props.details
+            );
+        } else {
+            // For single source field, for resource details where we have to do the load.
+            return (
+                <DataLoader input={app} load={application => getSingleSource(application)}>
+                    {(details: models.RepoAppDetails) => {
+                        attributes = [];
+                        const attr = gatherDetails(
+                            0,
+                            details,
+                            attributes,
+                            source,
+                            app,
+                            setRemovedOverrides,
+                            removedOverrides,
+                            appParamsDeletedState,
+                            setAppParamsDeletedState,
+                            false
+                        );
+                        return getEditablePanel(attr, details);
+                    }}
+                </DataLoader>
+            );
+        }
     }
 
-    function getEditablePanel(panel: EditablePanelItem[], repoAppDetails: models.RepoAppDetails, ind: number, sources: models.ApplicationSource[], isSingleSource?: boolean): any {
-        const src: models.ApplicationSource = sources[ind];
-        let descriptionCollapsed: string;
+    // Collapse button is separate
+    function getEditablePanelForSources(index: number, appSource: models.ApplicationSource): JSX.Element {
+        return (collapsible && props.collapsedSources[index] === undefined) || props.collapsedSources[index] ? (
+            <div
+                key={'app_params_collapsed_' + index}
+                className='settings-overview__redirect-panel'
+                style={{marginTop: 0}}
+                onClick={() => {
+                    const currentState = props.collapsedSources[index] !== undefined ? props.collapsedSources[index] : true;
+                    props.handleCollapse(index, !currentState);
+                }}>
+                <div className='editable-panel__collapsible-button'>
+                    <i className={`fa fa-angle-down filter__collapse`} />
+                </div>
+                <div className='settings-overview__redirect-panel__content'>
+                    <div className='settings-overview__redirect-panel__title'>Source {index + 1 + ': ' + appSource.repoURL}</div>
+                    <div className='settings-overview__redirect-panel__description'>
+                        {(appSource.path ? 'PATH=' + appSource.path : '') + (appSource.targetRevision ? (appSource.path ? ', ' : '') + 'REVISION=' + appSource.targetRevision : '')}
+                    </div>
+                </div>
+            </div>
+        ) : (
+            <div key={'app_params_expanded_' + index} className={classNames('white-box', 'editable-panel')} style={{marginBottom: '18px', paddingBottom: '20px'}}>
+                <div key={'app_params_panel_' + index} className='white-box__details'>
+                    {collapsible && (
+                        <React.Fragment>
+                            <div className='editable-panel__collapsible-button'>
+                                <i
+                                    className={`fa fa-angle-up filter__collapse`}
+                                    onClick={() => {
+                                        props.handleCollapse(index, !props.collapsedSources[index]);
+                                    }}
+                                />
+                            </div>
+                        </React.Fragment>
+                    )}
+                    <DataLoader input={app} load={application => getSourceFromSources(application, index)}>
+                        {(details: models.RepoAppDetails) => getEditablePanelForOneSource(details, index, source)}
+                    </DataLoader>
+                </div>
+            </div>
+        );
+    }
+
+    function getEditablePanel(items: EditablePanelItem[], repoAppDetails: models.RepoAppDetails): any {
+        return (
+            <div className='application-parameters'>
+                <EditablePanel
+                    save={
+                        props.save &&
+                        (async (input: models.Application) => {
+                            const updatedSrc = input.spec.source;
+
+                            function isDefined(item: any) {
+                                return item !== null && item !== undefined;
+                            }
+                            function isDefinedWithVersion(item: any) {
+                                return item !== null && item !== undefined && item.match(/:/);
+                            }
+                            if (updatedSrc.helm && updatedSrc.helm.parameters) {
+                                updatedSrc.helm.parameters = updatedSrc.helm.parameters.filter(isDefined);
+                            }
+                            if (updatedSrc.kustomize && updatedSrc.kustomize.images) {
+                                updatedSrc.kustomize.images = updatedSrc.kustomize.images.filter(isDefinedWithVersion);
+                            }
+
+                            let params = input.spec?.source?.plugin?.parameters;
+                            if (params) {
+                                for (const param of params) {
+                                    if (param.map && param.array) {
+                                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                        // @ts-ignore
+                                        param.map = param.array.reduce((acc, {name, value}) => {
+                                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                            // @ts-ignore
+                                            acc[name] = value;
+                                            return acc;
+                                        }, {});
+                                        delete param.array;
+                                    }
+                                }
+                                params = params.filter(param => !appParamsDeletedState.includes(param.name));
+                                input.spec.source.plugin.parameters = params;
+                            }
+                            if (input.spec.source.helm && input.spec.source.helm.valuesObject) {
+                                input.spec.source.helm.valuesObject = jsYaml.load(input.spec.source.helm.values); // Deserialize json
+                                input.spec.source.helm.values = '';
+                            }
+                            await props.save(input, {});
+                            setRemovedOverrides(new Array<boolean>());
+                        })
+                    }
+                    values={((repoAppDetails.plugin || app?.spec?.source?.plugin) && cloneDeep(app)) || app}
+                    validate={updatedApp => {
+                        const errors = {} as any;
+
+                        for (const fieldPath of ['spec.source.directory.jsonnet.tlas', 'spec.source.directory.jsonnet.extVars']) {
+                            const invalid = ((getNestedField(updatedApp, fieldPath) || []) as Array<models.JsonnetVar>).filter(item => !item.name && !item.code);
+                            errors[fieldPath] = invalid.length > 0 ? 'All fields must have name' : null;
+                        }
+
+                        if (updatedApp.spec.source.helm && updatedApp.spec.source.helm.values) {
+                            const parsedValues = jsYaml.load(updatedApp.spec.source.helm.values);
+                            errors['spec.source.helm.values'] = typeof parsedValues === 'object' ? null : 'Values must be a map';
+                        }
+
+                        return errors;
+                    }}
+                    onModeSwitch={
+                        repoAppDetails.plugin &&
+                        (() => {
+                            setAppParamsDeletedState([]);
+                        })
+                    }
+                    title={repoAppDetails.type.toLocaleUpperCase()}
+                    items={items as EditablePanelItem[]}
+                    noReadonlyMode={props.noReadonlyMode}
+                    hasMultipleSources={false}
+                />
+            </div>
+        );
+    }
+
+    function getEditablePanelForOneSource(repoAppDetails: models.RepoAppDetails, ind: number, src: models.ApplicationSource): any {
         let floatingTitle: string;
-        if (sources.length > 1) {
-            if (repoAppDetails.type === 'Directory') {
-                floatingTitle = 'TYPE=' + repoAppDetails.type + ', URL=' + src.repoURL;
-                descriptionCollapsed =
-                    'TYPE=' + repoAppDetails.type + (src.path ? ', PATH=' + src.path : '' + (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : ''));
-            } else if (repoAppDetails.type === 'Helm') {
-                floatingTitle = 'TYPE=' + repoAppDetails.type + ', URL=' + src.repoURL + (src.chart ? ', CHART=' + src.chart + ':' + src.targetRevision : '');
-                descriptionCollapsed =
-                    'TYPE=' +
-                    repoAppDetails.type +
-                    (src.chart ? ', CHART=' + src.chart + ':' + src.targetRevision : '') +
-                    (src.path ? ', PATH=' + src.path : '') +
-                    (src.helm && src.helm.valueFiles ? ', VALUES=' + src.helm.valueFiles[0] : '');
-            } else if (repoAppDetails.type === 'Kustomize') {
-                floatingTitle = 'TYPE=' + repoAppDetails.type + ', URL=' + src.repoURL;
-                descriptionCollapsed = 'TYPE=' + repoAppDetails.type + ', VERSION=' + src.kustomize.version + (src.path ? ', PATH=' + src.path : '');
-            } else if (repoAppDetails.type === 'Plugin') {
-                floatingTitle =
-                    'TYPE=' +
-                    repoAppDetails.type +
-                    ', URL=' +
-                    src.repoURL +
-                    (src.path ? ', PATH=' + src.path : '') +
-                    (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
-                descriptionCollapsed =
-                    'TYPE=' + repoAppDetails.type + '' + (src.path ? ', PATH=' + src.path : '') + (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
-            }
+        const lowerPanelAttributes: EditablePanelItem[] = [];
+        const upperPanelAttributes: EditablePanelItem[] = [];
+
+        const upperPanel = gatherCoreSourceDetails(ind, upperPanelAttributes, appSources[ind], app);
+        const lowerPanel = gatherDetails(
+            ind,
+            repoAppDetails,
+            lowerPanelAttributes,
+            appSources[ind],
+            app,
+            setRemovedOverrides,
+            removedOverrides,
+            appParamsDeletedState,
+            setAppParamsDeletedState,
+            true
+        );
+
+        if (repoAppDetails.type === 'Directory') {
+            floatingTitle =
+                'Source ' +
+                (ind + 1) +
+                ': TYPE=' +
+                repoAppDetails.type +
+                ', URL=' +
+                src.repoURL +
+                (repoAppDetails.path ? ', PATH=' + repoAppDetails.path : '') +
+                (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
+        } else if (repoAppDetails.type === 'Helm') {
+            floatingTitle =
+                'Source ' +
+                (ind + 1) +
+                ': TYPE=' +
+                repoAppDetails.type +
+                ', URL=' +
+                src.repoURL +
+                (src.chart ? ', CHART=' + src.chart + ':' + src.targetRevision : '') +
+                (src.path ? ', PATH=' + src.path : '') +
+                (src.targetRevision ? ', REVISION=' + src.targetRevision : '');
+        } else if (repoAppDetails.type === 'Kustomize') {
+            floatingTitle =
+                'Source ' +
+                (ind + 1) +
+                ': TYPE=' +
+                repoAppDetails.type +
+                ', URL=' +
+                src.repoURL +
+                (repoAppDetails.path ? ', PATH=' + repoAppDetails.path : '') +
+                (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
+        } else if (repoAppDetails.type === 'Plugin') {
+            floatingTitle =
+                'Source ' +
+                (ind + 1) +
+                ': TYPE=' +
+                repoAppDetails.type +
+                ', URL=' +
+                src.repoURL +
+                (repoAppDetails.path ? ', PATH=' + repoAppDetails.path : '') +
+                (src.targetRevision ? ', TARGET REVISION=' + src.targetRevision : '');
         }
         return (
-            <EditablePanel
-                key={ind}
-                save={
+            <ApplicationParametersSource
+                index={ind}
+                saveTop={props.save}
+                saveBottom={
                     props.save &&
                     (async (input: models.Application) => {
-                        const updatedSrc = isSingleSource ? input.spec.source : input.spec.sources[ind];
+                        const updatedSrc = input.spec.sources[ind];
 
                         function isDefined(item: any) {
                             return item !== null && item !== undefined;
@@ -246,7 +418,7 @@ export const ApplicationParameters = (props: {
                             updatedSrc.kustomize.images = updatedSrc.kustomize.images.filter(isDefinedWithVersion);
                         }
 
-                        let params = input.spec?.source?.plugin?.parameters;
+                        let params = input.spec?.sources[ind]?.plugin?.parameters;
                         if (params) {
                             for (const param of params) {
                                 if (param.map && param.array) {
@@ -263,32 +435,40 @@ export const ApplicationParameters = (props: {
                             }
 
                             params = params.filter(param => !appParamsDeletedState.includes(param.name));
-                            input.spec.source.plugin.parameters = params;
+                            updatedSrc.plugin.parameters = params;
                         }
-                        if (input.spec.source.helm && input.spec.source.helm.valuesObject) {
-                            input.spec.source.helm.valuesObject = jsYaml.load(input.spec.source.helm.values); // Deserialize json
-                            input.spec.source.helm.values = '';
+                        if (updatedSrc.helm && updatedSrc.helm.valuesObject) {
+                            updatedSrc.helm.valuesObject = jsYaml.load(updatedSrc.helm.values); // Deserialize json
+                            updatedSrc.helm.values = '';
                         }
+
                         await props.save(input, {});
                         setRemovedOverrides(new Array<boolean>());
                     })
                 }
-                values={
-                    app?.spec?.source
-                        ? ((props.details.plugin || app?.spec?.source?.plugin) && cloneDeep(app)) || app
-                        : ((repoAppDetails.plugin || app?.spec?.sources[ind]?.plugin) && cloneDeep(app)) || app
-                }
-                validate={updatedApp => {
+                valuesTop={(app?.spec?.sources && (repoAppDetails.plugin || app?.spec?.sources[ind]?.plugin) && cloneDeep(app)) || app}
+                valuesBottom={(app?.spec?.sources && (repoAppDetails.plugin || app?.spec?.sources[ind]?.plugin) && cloneDeep(app)) || app}
+                validateTop={updatedApp => {
+                    const errors = [] as any;
+                    const repoURL = updatedApp.spec.sources[ind].repoURL;
+                    if (repoURL === null || repoURL.length === 0) {
+                        errors['spec.sources[' + ind + '].repoURL'] = 'The source repo URL cannot be empty';
+                    } else {
+                        errors['spec.sources[' + ind + '].repoURL'] = null;
+                    }
+                    return errors;
+                }}
+                validateBottom={updatedApp => {
                     const errors = {} as any;
 
-                    for (const fieldPath of ['spec.source.directory.jsonnet.tlas', 'spec.source.directory.jsonnet.extVars']) {
+                    for (const fieldPath of ['spec.sources[' + ind + '].directory.jsonnet.tlas', 'spec.sources[' + ind + '].directory.jsonnet.extVars']) {
                         const invalid = ((getNestedField(updatedApp, fieldPath) || []) as Array<models.JsonnetVar>).filter(item => !item.name && !item.code);
                         errors[fieldPath] = invalid.length > 0 ? 'All fields must have name' : null;
                     }
 
-                    if (updatedApp.spec.source.helm && updatedApp.spec.source.helm.values) {
-                        const parsedValues = jsYaml.load(updatedApp.spec.source.helm.values);
-                        errors['spec.source.helm.values'] = typeof parsedValues === 'object' ? null : 'Values must be a map';
+                    if (updatedApp.spec.sources[ind].helm?.values) {
+                        const parsedValues = jsYaml.load(updatedApp.spec.sources[ind].helm.values);
+                        errors['spec.sources[' + ind + '].helm.values'] = typeof parsedValues === 'object' ? null : 'Values must be a map';
                     }
 
                     return errors;
@@ -299,43 +479,33 @@ export const ApplicationParameters = (props: {
                         setAppParamsDeletedState([]);
                     })
                 }
-                title={repoAppDetails.type.toLocaleUpperCase()}
-                titleCollapsed={src.repoURL}
-                floatingTitle={floatingTitle}
-                items={panel as EditablePanelItem[]}
+                titleBottom={repoAppDetails.type.toLocaleUpperCase()}
+                titleTop={'SOURCE ' + (ind + 1)}
+                floatingTitle={floatingTitle ? floatingTitle : null}
+                itemsBottom={lowerPanel as EditablePanelItem[]}
+                itemsTop={upperPanel as EditablePanelItem[]}
                 noReadonlyMode={props.noReadonlyMode}
-                collapsible={sources.length > 1}
-                collapsed={true}
-                collapsedDescription={descriptionCollapsed}
-                hasMultipleSources={app.spec.sources && app.spec.sources.length > 0}
+                collapsible={collapsible}
             />
         );
     }
 };
 
-function gatherDetails(
-    repoDetails: models.RepoAppDetails,
-    attributes: EditablePanelItem[],
-    source: models.ApplicationSource,
-    app: models.Application,
-    setRemovedOverrides: any,
-    removedOverrides: any,
-    appParamsDeletedState: any[],
-    setAppParamsDeletedState: any
-): EditablePanelItem[] {
+function gatherCoreSourceDetails(i: number, attributes: EditablePanelItem[], source: models.ApplicationSource, app: models.Application): EditablePanelItem[] {
     const hasMultipleSources = app.spec.sources && app.spec.sources.length > 0;
     // eslint-disable-next-line no-prototype-builtins
     const isHelm = source.hasOwnProperty('chart');
+    const repoUrlField = 'spec.sources[' + i + '].repoURL';
+    const sourcesPathField = 'spec.sources[' + i + '].path';
+    const refField = 'spec.sources[' + i + '].ref';
+    const chartField = 'spec.sources[' + i + '].chart';
+    const revisionField = 'spec.sources[' + i + '].targetRevision';
+    // For single source apps using the source field, these fields are shown in the Summary tab.
     if (hasMultipleSources) {
         attributes.push({
             title: 'REPO URL',
             view: <Repo url={source.repoURL} />,
-            edit: (formApi: FormApi) =>
-                hasMultipleSources ? (
-                    helpTip('REPO URL is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
-                ) : (
-                    <FormField formApi={formApi} field='spec.source.repoURL' component={Text} />
-                )
+            edit: (formApi: FormApi) => <FormField formApi={formApi} field={repoUrlField} component={Text} />
         });
         if (isHelm) {
             attributes.push({
@@ -345,59 +515,51 @@ function gatherDetails(
                         {source.chart}:{source.targetRevision}
                     </span>
                 ),
-                edit: (formApi: FormApi) =>
-                    hasMultipleSources ? (
-                        helpTip('CHART is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
-                    ) : (
-                        <DataLoader input={{repoURL: source.repoURL}} load={src => services.repos.charts(src.repoURL).catch(() => new Array<models.HelmChart>())}>
-                            {(charts: models.HelmChart[]) => (
-                                <div className='row'>
-                                    <div className='columns small-8'>
-                                        <FormField
-                                            formApi={formApi}
-                                            field='spec.source.chart'
-                                            component={AutocompleteField}
-                                            componentProps={{
-                                                items: charts.map(chart => chart.name),
-                                                filterSuggestions: true
-                                            }}
-                                        />
-                                    </div>
-                                    <DataLoader
-                                        input={{charts, chart: source.chart}}
-                                        load={async data => {
-                                            const chartInfo = data.charts.find(chart => chart.name === data.chart);
-                                            return (chartInfo && chartInfo.versions) || new Array<string>();
-                                        }}>
-                                        {(versions: string[]) => (
-                                            <div className='columns small-4'>
-                                                <FormField
-                                                    formApi={formApi}
-                                                    field='spec.source.targetRevision'
-                                                    component={AutocompleteField}
-                                                    componentProps={{
-                                                        items: versions
-                                                    }}
-                                                />
-                                                <RevisionHelpIcon type='helm' top='0' />
-                                            </div>
-                                        )}
-                                    </DataLoader>
+                edit: (formApi: FormApi) => (
+                    <DataLoader input={{repoURL: source.repoURL}} load={src => services.repos.charts(src.repoURL).catch(() => new Array<models.HelmChart>())}>
+                        {(charts: models.HelmChart[]) => (
+                            <div className='row'>
+                                <div className='columns small-8'>
+                                    <FormField
+                                        formApi={formApi}
+                                        field={chartField}
+                                        component={AutocompleteField}
+                                        componentProps={{
+                                            items: charts.map(chart => chart.name),
+                                            filterSuggestions: true
+                                        }}
+                                    />
                                 </div>
-                            )}
-                        </DataLoader>
-                    )
+                                <DataLoader
+                                    input={{charts, chart: source.chart}}
+                                    load={async data => {
+                                        const chartInfo = data.charts.find(chart => chart.name === data.chart);
+                                        return (chartInfo && chartInfo.versions) || new Array<string>();
+                                    }}>
+                                    {(versions: string[]) => (
+                                        <div className='columns small-4'>
+                                            <FormField
+                                                formApi={formApi}
+                                                field={revisionField}
+                                                component={AutocompleteField}
+                                                componentProps={{
+                                                    items: versions
+                                                }}
+                                            />
+                                            <RevisionHelpIcon type='helm' top='0' />
+                                        </div>
+                                    )}
+                                </DataLoader>
+                            </div>
+                        )}
+                    </DataLoader>
+                )
             });
         } else {
             attributes.push({
                 title: 'TARGET REVISION',
                 view: <Revision repoUrl={source.repoURL} revision={source.targetRevision || 'HEAD'} />,
-                edit: (formApi: FormApi) =>
-                    hasMultipleSources ? (
-                        helpTip('TARGET REVISION is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
-                    ) : (
-                        <RevisionFormField helpIconTop={'0'} hideLabel={true} formApi={formApi} repoURL={source.repoURL} />
-                    )
+                edit: (formApi: FormApi) => <RevisionFormField helpIconTop={'0'} hideLabel={true} formApi={formApi} repoURL={source.repoURL} fieldValue={revisionField} />
             });
             attributes.push({
                 title: 'PATH',
@@ -406,20 +568,30 @@ function gatherDetails(
                         {processPath(source.path)}
                     </Revision>
                 ),
-                edit: (formApi: FormApi) =>
-                    hasMultipleSources ? (
-                        helpTip('PATH is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
-                    ) : (
-                        <FormField formApi={formApi} field='spec.source.path' component={Text} />
-                    )
+                edit: (formApi: FormApi) => <FormField formApi={formApi} field={sourcesPathField} component={Text} />
             });
             attributes.push({
                 title: 'REF',
-                view: source.ref,
-                edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.ref' component={Text} />
+                view: <span>{source.ref}</span>,
+                edit: (formApi: FormApi) => <FormField formApi={formApi} field={refField} component={Text} />
             });
         }
     }
+    return attributes;
+}
+
+function gatherDetails(
+    ind: number,
+    repoDetails: models.RepoAppDetails,
+    attributes: EditablePanelItem[],
+    source: models.ApplicationSource,
+    app: models.Application,
+    setRemovedOverrides: any,
+    removedOverrides: any,
+    appParamsDeletedState: any[],
+    setAppParamsDeletedState: any,
+    isMultiSource: boolean
+): EditablePanelItem[] {
     if (repoDetails.type === 'Kustomize' && repoDetails.kustomize) {
         attributes.push({
             title: 'VERSION',
@@ -428,7 +600,12 @@ function gatherDetails(
                 <DataLoader load={() => services.authService.settings()}>
                     {settings =>
                         ((settings.kustomizeVersions || []).length > 0 && (
-                            <FormField formApi={formApi} field='spec.source.kustomize.version' component={AutocompleteField} componentProps={{items: settings.kustomizeVersions}} />
+                            <FormField
+                                formApi={formApi}
+                                field={isMultiSource ? 'spec.sources[' + ind + '].kustomize.version' : 'spec.source.kustomize.version'}
+                                component={AutocompleteField}
+                                componentProps={{items: settings.kustomizeVersions}}
+                            />
                         )) || <span>default</span>
                     }
                 </DataLoader>
@@ -438,19 +615,25 @@ function gatherDetails(
         attributes.push({
             title: 'NAME PREFIX',
             view: source.kustomize && source.kustomize.namePrefix,
-            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.kustomize.namePrefix' component={Text} />
+            edit: (formApi: FormApi) => (
+                <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].kustomize.namePrefix' : 'spec.source.kustomize.namePrefix'} component={Text} />
+            )
         });
 
         attributes.push({
             title: 'NAME SUFFIX',
             view: source.kustomize && source.kustomize.nameSuffix,
-            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.kustomize.nameSuffix' component={Text} />
+            edit: (formApi: FormApi) => (
+                <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].kustomize.nameSuffix' : 'spec.source.kustomize.nameSuffix'} component={Text} />
+            )
         });
 
         attributes.push({
             title: 'NAMESPACE',
-            view: app.spec.source.kustomize && app.spec.source.kustomize.namespace,
-            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.kustomize.namespace' component={Text} />
+            view: source.kustomize && source.kustomize.namespace,
+            edit: (formApi: FormApi) => (
+                <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].kustomize.namespace' : 'spec.source.kustomize.namespace'} component={Text} />
+            )
         });
 
         const srcImages = ((repoDetails && repoDetails.kustomize && repoDetails.kustomize.images) || []).map(val => kustomize.parse(val));
@@ -467,7 +650,7 @@ function gatherDetails(
                 getParamsEditableItems(
                     app,
                     'IMAGES',
-                    'spec.source.kustomize.images',
+                    isMultiSource ? 'spec.sources[' + ind + '].kustomize.images' : 'spec.source.kustomize.images',
                     removedOverrides,
                     setRemovedOverrides,
                     distinct(imagesByName.keys(), overridesByName.keys()).map(name => {
@@ -493,7 +676,7 @@ function gatherDetails(
             edit: (formApi: FormApi) => (
                 <FormField
                     formApi={formApi}
-                    field='spec.source.helm.valueFiles'
+                    field={isMultiSource ? 'spec.sources[' + ind + '].helm.valueFiles' : 'spec.source.helm.valueFiles'}
                     component={TagsInputField}
                     componentProps={{
                         options: repoDetails.helm.valueFiles,
@@ -518,7 +701,7 @@ function gatherDetails(
                 return (
                     <div>
                         <pre>
-                            <FormField formApi={formApi} field='spec.source.helm.values' component={TextArea} />
+                            <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].helm.values' : 'spec.source.helm.values'} component={TextArea} />
                         </pre>
                     </div>
                 );
@@ -532,7 +715,7 @@ function gatherDetails(
             getParamsEditableItems(
                 app,
                 'PARAMETERS',
-                'spec.source.helm.parameters',
+                isMultiSource ? 'spec.sources[' + ind + '].helm.parameters' : 'spec.source.helm.parameters',
                 removedOverrides,
                 setRemovedOverrides,
                 distinct(paramsByName.keys(), overridesByName.keys()).map(name => {
@@ -555,7 +738,7 @@ function gatherDetails(
             getParamsEditableItems(
                 app,
                 'PARAMETERS',
-                'spec.source.helm.parameters',
+                isMultiSource ? 'spec.sources[' + ind + '].helm.parameters' : 'spec.source.helm.parameters',
                 removedOverrides,
                 setRemovedOverrides,
                 distinct(fileParamsByName.keys(), fileOverridesByName.keys()).map(name => {
@@ -577,7 +760,12 @@ function gatherDetails(
             edit: (formApi: FormApi) => (
                 <DataLoader load={() => services.authService.plugins()}>
                     {(plugins: Plugin[]) => (
-                        <FormField formApi={formApi} field='spec.source.plugin.name' component={FormSelect} componentProps={{options: plugins.map(p => p.name)}} />
+                        <FormField
+                            formApi={formApi}
+                            field={isMultiSource ? 'spec.sources[' + ind + '].plugin.name' : 'spec.source.plugin.name'}
+                            component={FormSelect}
+                            componentProps={{options: plugins.map(p => p.name)}}
+                        />
                     )}
                 </DataLoader>
             )
@@ -593,7 +781,9 @@ function gatherDetails(
                     ))}
                 </div>
             ),
-            edit: (formApi: FormApi) => <FormField field='spec.source.plugin.env' formApi={formApi} component={ArrayInputField} />
+            edit: (formApi: FormApi) => (
+                <FormField field={isMultiSource ? 'spec.sources[' + ind + '].plugin.env' : 'spec.source.plugin.env'} formApi={formApi} component={ArrayInputField} />
+            )
         });
         const parametersSet = new Set<string>();
         if (repoDetails?.plugin?.parametersAnnouncement) {
@@ -645,7 +835,7 @@ function gatherDetails(
                     ),
                     edit: (formApi: FormApi) => (
                         <FormField
-                            field='spec.source.plugin.parameters'
+                            field={isMultiSource ? 'spec.sources[' + ind + '].plugin.parameters' : 'spec.source.plugin.parameters'}
                             componentProps={{
                                 name: announcement?.name ?? name,
                                 defaultVal: announcement?.map,
@@ -682,7 +872,7 @@ function gatherDetails(
                     ),
                     edit: (formApi: FormApi) => (
                         <FormField
-                            field='spec.source.plugin.parameters'
+                            field={isMultiSource ? 'spec.sources[' + ind + '].plugin.parameters' : 'spec.source.plugin.parameters'}
                             componentProps={{
                                 name: announcement?.name ?? name,
                                 defaultVal: announcement?.array,
@@ -723,7 +913,7 @@ function gatherDetails(
                     ),
                     edit: (formApi: FormApi) => (
                         <FormField
-                            field='spec.source.plugin.parameters'
+                            field={isMultiSource ? 'spec.sources[' + ind + '].plugin.parameters' : 'spec.source.plugin.parameters'}
                             componentProps={{
                                 name: announcement?.name ?? name,
                                 defaultVal: announcement?.string,
@@ -739,10 +929,11 @@ function gatherDetails(
         });
     } else if (repoDetails.type === 'Directory') {
         const directory = source.directory || ({} as ApplicationSourceDirectory);
+        const fieldValue = isMultiSource ? 'spec.sources[' + ind + '].directory.recurse' : 'spec.source.directory.recurse';
         attributes.push({
             title: 'DIRECTORY RECURSE',
             view: (!!directory.recurse).toString(),
-            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.directory.recurse' component={CheckboxField} />
+            edit: (formApi: FormApi) => <FormField formApi={formApi} field={fieldValue} component={CheckboxField} />
         });
         attributes.push({
             title: 'TOP-LEVEL ARGUMENTS',
@@ -751,7 +942,13 @@ function gatherDetails(
                     {i.name}='{i.value}' {i.code && 'code'}
                 </label>
             )),
-            edit: (formApi: FormApi) => <FormField field='spec.source.directory.jsonnet.tlas' formApi={formApi} component={VarsInputField} />
+            edit: (formApi: FormApi) => (
+                <FormField
+                    field={isMultiSource ? 'spec.sources[' + ind + '].directory.jsonnet.tlas' : 'spec.source.directory.jsonnet.tlas'}
+                    formApi={formApi}
+                    component={VarsInputField}
+                />
+            )
         });
         attributes.push({
             title: 'EXTERNAL VARIABLES',
@@ -760,20 +957,56 @@ function gatherDetails(
                     {i.name}='{i.value}' {i.code && 'code'}
                 </label>
             )),
-            edit: (formApi: FormApi) => <FormField field='spec.source.directory.jsonnet.extVars' formApi={formApi} component={VarsInputField} />
+            edit: (formApi: FormApi) => (
+                <FormField
+                    field={isMultiSource ? 'spec.sources[' + ind + '].directory.jsonnet.extVars' : 'spec.source.directory.jsonnet.extVars'}
+                    formApi={formApi}
+                    component={VarsInputField}
+                />
+            )
         });
 
         attributes.push({
             title: 'INCLUDE',
             view: directory && directory.include,
-            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.directory.include' component={Text} />
+            edit: (formApi: FormApi) => (
+                <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].directory.include' : 'spec.source.directory.include'} component={Text} />
+            )
         });
 
         attributes.push({
             title: 'EXCLUDE',
             view: directory && directory.exclude,
-            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.directory.exclude' component={Text} />
+            edit: (formApi: FormApi) => (
+                <FormField formApi={formApi} field={isMultiSource ? 'spec.sources[' + ind + '].directory.exclude' : 'spec.source.directory.exclude'} component={Text} />
+            )
         });
     }
     return attributes;
+}
+
+// For Sources field. Get one source with index i from the list
+async function getSourceFromSources(app: models.Application, i: number) {
+    const sources: models.ApplicationSource[] = app.spec.sources;
+    if (sources && i < sources.length) {
+        const aSource = sources[i];
+        const repoDetail = await services.repos.appDetails(aSource, app.metadata.name, app.spec.project, i, 0).catch(() => ({
+            type: 'Directory' as models.AppSourceType,
+            path: aSource.path
+        }));
+        return repoDetail;
+    }
+    return null;
+}
+
+// Delete when source field is removed
+async function getSingleSource(app: models.Application) {
+    if (app.spec.source) {
+        const repoDetail = await services.repos.appDetails(getAppDefaultSource(app), app.metadata.name, app.spec.project, 0, 0).catch(() => ({
+            type: 'Directory' as models.AppSourceType,
+            path: getAppDefaultSource(app).path
+        }));
+        return repoDetail;
+    }
+    return null;
 }

--- a/ui/src/app/applications/components/application-summary/application-summary.tsx
+++ b/ui/src/app/applications/components/application-summary/application-summary.tsx
@@ -31,7 +31,6 @@ import {EditAnnotations} from './edit-annotations';
 
 import './application-summary.scss';
 import {DeepLinks} from '../../../shared/components/deep-links';
-import {ExternalLinks} from '../application-urls';
 
 function swap(array: any[], a: number, b: number) {
     array = array.slice();
@@ -174,12 +173,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
         !hasMultipleSources && {
             title: 'REPO URL',
             view: <Repo url={source.repoURL} />,
-            edit: (formApi: FormApi) =>
-                hasMultipleSources ? (
-                    helpTip('REPO URL is not editable for applications with multiple sources. You can edit them in the "Manifest" tab.')
-                ) : (
-                    <FormField formApi={formApi} field='spec.source.repoURL' component={Text} />
-                )
+            edit: (formApi: FormApi) => <FormField formApi={formApi} field='spec.source.repoURL' component={Text} />
         },
         ...(!hasMultipleSources
             ? isHelm
@@ -269,12 +263,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
             view: app.spec.revisionHistoryLimit,
             edit: (formApi: FormApi) => (
                 <div style={{position: 'relative'}}>
-                    <FormField
-                        formApi={formApi}
-                        field='spec.revisionHistoryLimit'
-                        componentProps={{style: {paddingRight: '1em', width: '97%'}, placeholder: '10'}}
-                        component={NumberField}
-                    />
+                    <FormField formApi={formApi} field='spec.revisionHistoryLimit' componentProps={{style: {paddingRight: '1em'}, placeholder: '10'}} component={NumberField} />
                     <div style={{position: 'absolute', right: '0', top: '0'}}>
                         <HelpIcon
                             title='This limits the number of items kept in the apps revision history.
@@ -344,19 +333,20 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
             )
         }
     ];
-    const urls = ExternalLinks(app.status.summary.externalURLs);
+
+    const urls = app.status.summary.externalURLs || [];
     if (urls.length > 0) {
         attributes.push({
             title: 'URLs',
             view: (
                 <React.Fragment>
-                    {urls.map((url, i) => {
-                        return (
-                            <a key={i} href={url.ref} target='__blank'>
-                                {url.title} &nbsp;
+                    {urls
+                        .map(item => item.split('|'))
+                        .map((parts, i) => (
+                            <a key={i} href={parts.length > 1 ? parts[1] : parts[0]} target='__blank'>
+                                {parts[0]} &nbsp;
                             </a>
-                        );
-                    })}
+                        ))}
                 </React.Fragment>
             )
         });
@@ -495,6 +485,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
         <div className='application-summary'>
             <EditablePanel
                 save={updateApp}
+                view={hasMultipleSources ? <>This is a multi-source app, see the Sources tab for repository URLs and source-related information.</> : <></>}
                 validate={input => ({
                     'spec.project': !input.spec.project && 'Project name is required',
                     'spec.destination.server': !input.spec.destination.server && input.spec.destination.hasOwnProperty('server') && 'Cluster server is required',
@@ -511,7 +502,7 @@ export const ApplicationSummary = (props: ApplicationSummaryProps) => {
                         <div className='white-box__details'>
                             <p>SYNC POLICY</p>
                             <div className='row white-box__details-row'>
-                                <div className='columns small-3'>{(app.spec.syncPolicy && app.spec.syncPolicy.automated && <span>AUTOMATED</span>) || <span>MANUAL</span>}</div>
+                                <div className='columns small-3'>{(app.spec.syncPolicy && app.spec.syncPolicy.automated && <span>AUTOMATED</span>) || <span>NONE</span>}</div>
                                 <div className='columns small-9'>
                                     {(app.spec.syncPolicy && app.spec.syncPolicy.automated && (
                                         <button className='argo-button argo-button--base' onClick={() => unsetAutoSync(ctx)}>

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -5,7 +5,7 @@ import {EventsList, YamlEditor} from '../../../shared/components';
 import * as models from '../../../shared/models';
 import {ErrorBoundary} from '../../../shared/components/error-boundary/error-boundary';
 import {Context} from '../../../shared/context';
-import {Application, ApplicationTree, AppSourceType, Event, RepoAppDetails, ResourceNode, State, SyncStatuses} from '../../../shared/models';
+import {Application, ApplicationTree, Event, ResourceNode, State, SyncStatuses} from '../../../shared/models';
 import {services} from '../../../shared/services';
 import {ResourceTabExtension} from '../../../shared/services/extensions-service';
 import {NodeInfo, SelectNode} from '../application-details/application-details';
@@ -41,6 +41,12 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
     const selectedNodeInfo = NodeInfo(new URLSearchParams(appContext.history.location.search).get('node'));
     const selectedNodeKey = selectedNodeInfo.key;
     const [pageNumber, setPageNumber] = React.useState(0);
+    const [collapsedSources, setCollapsedSources] = React.useState(new Array<boolean>()); // For Sources tab to save collapse states
+    const handleCollapse = (i: number, isCollapsed: boolean) => {
+        const v = collapsedSources.slice();
+        v[i] = isCollapsed;
+        setCollapsedSources(v);
+    };
 
     const getResourceTabs = (
         node: ResourceNode,
@@ -162,21 +168,17 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
                 content: <ApplicationSummary app={application} updateApp={(app, query: {validate?: boolean}) => updateApp(app, query)} />
             },
             {
-                title: 'SOURCES',
-                key: 'sources',
+                title: application.spec.sources === undefined ? 'PARAMETERS' : 'SOURCES',
+                key: 'parameters',
                 content: (
-                    <DataLoader key='appDetails' input={application} load={app => getSources(app)}>
-                        {(details: RepoAppDetails[]) => (
-                            <ApplicationParameters
-                                save={(app: models.Application, query: {validate?: boolean}) => updateApp(app, query)}
-                                application={application}
-                                details={details[0]}
-                                detailsList={details}
-                                pageNumber={pageNumber}
-                                setPageNumber={setPageNumber}
-                            />
-                        )}
-                    </DataLoader>
+                    <ApplicationParameters
+                        save={(app: models.Application, query: {validate?: boolean}) => updateApp(app, query)}
+                        application={application}
+                        pageNumber={pageNumber}
+                        setPageNumber={setPageNumber}
+                        collapsedSources={collapsedSources}
+                        handleCollapse={handleCollapse}
+                    />
                 )
             },
             {
@@ -366,32 +368,3 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
         </div>
     );
 };
-
-// Maintain compatibility with single source field. Remove else block when source field is removed
-async function getSources(app: models.Application) {
-    const listOfDetails = new Array<RepoAppDetails & {type: AppSourceType; path: string}>();
-    const sources: models.ApplicationSource[] = app.spec.sources;
-    if (sources) {
-        const length = sources.length;
-        for (let i = 0; i < length; i++) {
-            const aSource = sources[i];
-            const repoDetail = await services.repos.appDetails(aSource, app.metadata.name, app.spec.project, i, 0).catch(() => ({
-                type: 'Directory' as AppSourceType,
-                path: aSource.path
-            }));
-            if (repoDetail) {
-                listOfDetails.push(repoDetail);
-            }
-        }
-        return listOfDetails;
-    } else {
-        const repoDetail = await services.repos.appDetails(AppUtils.getAppDefaultSource(app), app.metadata.name, app.spec.project, 0, 0).catch(() => ({
-            type: 'Directory' as AppSourceType,
-            path: AppUtils.getAppDefaultSource(app).path
-        }));
-        if (repoDetail) {
-            listOfDetails.push(repoDetail);
-        }
-        return listOfDetails;
-    }
-}

--- a/ui/src/app/applications/components/revision-form-field/revision-form-field.tsx
+++ b/ui/src/app/applications/components/revision-form-field/revision-form-field.tsx
@@ -10,6 +10,7 @@ interface RevisionFormFieldProps {
     helpIconTop?: string;
     hideLabel?: boolean;
     repoURL: string;
+    fieldValue?: string;
 }
 
 export class RevisionFormField extends React.PureComponent<RevisionFormFieldProps, {filterType: string}> {
@@ -49,7 +50,7 @@ export class RevisionFormField extends React.PureComponent<RevisionFormFieldProp
                                 <FormField
                                     formApi={this.props.formApi}
                                     label={this.props.hideLabel ? undefined : 'Revision'}
-                                    field='spec.source.targetRevision'
+                                    field={this.props.fieldValue ? this.props.fieldValue : 'spec.source.targetRevision'}
                                     component={AutocompleteField}
                                     componentProps={{
                                         items: revisions,

--- a/ui/src/app/shared/components/editable-panel/editable-panel.scss
+++ b/ui/src/app/shared/components/editable-panel/editable-panel.scss
@@ -13,6 +13,21 @@
         right: 3em;
     }
 
+    &__divider {
+        position: relative;
+        border-top: 2px solid lightgray;
+        padding-top: 8px;
+    }
+
+    &__buttons-relative {
+        position: relative;
+        justify-content: right;        
+    }
+
+    &__buttons-relative-button {
+        margin-left: 8px;
+    }
+
     &__collapsible-button {
         position: absolute;
         top: 30px;

--- a/ui/src/app/shared/components/editable-panel/editable-section.tsx
+++ b/ui/src/app/shared/components/editable-panel/editable-section.tsx
@@ -1,0 +1,164 @@
+import {ErrorNotification, NotificationType} from 'argo-ui';
+import * as React from 'react';
+import {Form, FormApi} from 'react-form';
+import {ContextApis} from '../../context';
+import {EditablePanelItem} from './editable-panel';
+import {Spinner} from '../spinner';
+
+export interface EditableSectionProps<T> {
+    title?: string | React.ReactNode;
+    uniqueId: string;
+    values: T;
+    validate?: (values: T) => any;
+    save?: (input: T, query: {validate?: boolean}) => Promise<any>;
+    items: EditablePanelItem[];
+    onModeSwitch?: () => any;
+    noReadonlyMode?: boolean;
+    view?: string | React.ReactNode;
+    edit?: (formApi: FormApi) => React.ReactNode;
+    collapsible?: boolean;
+    ctx: ContextApis;
+    isTopSection?: boolean;
+    disabledState?: boolean;
+    updateButtons?: (pressed: boolean) => void;
+}
+
+interface EditableSectionState {
+    isEditing: boolean;
+    isSaving: boolean;
+}
+
+// Similar to editable-panel but it should be part of a white-box, editable-panel HOC and it can be reused one after another
+export class EditableSection<T = {}> extends React.Component<EditableSectionProps<T>, EditableSectionState> {
+    private formApi: FormApi;
+
+    constructor(props: EditableSectionProps<T>) {
+        super(props);
+        this.state = {isEditing: !!props.noReadonlyMode, isSaving: false};
+    }
+
+    public UNSAFE_componentWillReceiveProps(nextProps: EditableSectionProps<T>) {
+        if (this.formApi && JSON.stringify(this.props.values) !== JSON.stringify(nextProps.values)) {
+            if (nextProps.noReadonlyMode) {
+                this.formApi.setAllValues(nextProps.values);
+            }
+        }
+    }
+
+    public render() {
+        return (
+            <div key={this.props.uniqueId}>
+                {!this.props.noReadonlyMode && this.props.save && (
+                    <div
+                        key={this.props.uniqueId + '__panel__buttons'}
+                        className={this.props.isTopSection ? 'editable-panel__buttons' : 'row white-box__details-row editable-panel__buttons-relative'}
+                        style={{
+                            top: this.props.isTopSection ? '25px' : '',
+                            right: this.props.isTopSection ? (this.props.collapsible ? '4.5em' : '3.5em') : this.props.collapsible ? '1.0em' : '0em'
+                        }}>
+                        {!this.state.isEditing && (
+                            <button
+                                key={'edit_button_' + this.props.uniqueId}
+                                onClick={() => {
+                                    this.setState({isEditing: true});
+                                    this.props.updateButtons(true);
+                                    this.props.onModeSwitch();
+                                }}
+                                disabled={this.props.disabledState}
+                                className='argo-button argo-button--base'>
+                                Edit
+                            </button>
+                        )}
+                        {this.state.isEditing && (
+                            <div key={'buttons_' + this.props.uniqueId} className={!this.props.isTopSection ? 'editable-panel__buttons-relative-button' : ''}>
+                                <React.Fragment key={'fragment_' + this.props.uniqueId}>
+                                    <button
+                                        key={'save_button_' + this.props.uniqueId}
+                                        disabled={this.state.isSaving}
+                                        onClick={() => !this.state.isSaving && this.formApi.submitForm(null)}
+                                        className='argo-button argo-button--base'>
+                                        <Spinner show={this.state.isSaving} style={{marginRight: '5px'}} />
+                                        Save
+                                    </button>{' '}
+                                    <button
+                                        key={'cancel_button_' + this.props.uniqueId}
+                                        onClick={() => {
+                                            this.setState({isEditing: false});
+                                            this.props.updateButtons(false);
+                                            this.props.onModeSwitch();
+                                        }}
+                                        className='argo-button argo-button--base-o'>
+                                        Cancel
+                                    </button>
+                                </React.Fragment>
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {this.props.title && (
+                    <div className='row white-box__details-row'>
+                        <p>{this.props.title}</p>
+                    </div>
+                )}
+
+                {(!this.state.isEditing && (
+                    <React.Fragment key={'read_' + this.props.uniqueId}>
+                        {this.props.view}
+                        {this.props.items
+                            .filter(item => item.view)
+                            .map(item => (
+                                <React.Fragment key={'read_' + this.props.uniqueId + '_' + (item.key || item.title)}>
+                                    {item.before}
+                                    <div className='row white-box__details-row'>
+                                        <div className='columns small-3'>{item.customTitle || item.title}</div>
+                                        <div className='columns small-9'>{item.view}</div>
+                                    </div>
+                                </React.Fragment>
+                            ))}
+                    </React.Fragment>
+                )) || (
+                    <Form
+                        getApi={api => (this.formApi = api)}
+                        formDidUpdate={async form => {
+                            if (this.props.noReadonlyMode && this.props.save) {
+                                await this.props.save(form.values as any, {});
+                            }
+                        }}
+                        onSubmit={async input => {
+                            try {
+                                this.setState({isSaving: true});
+                                await this.props.save(input as any, {});
+                                this.setState({isEditing: false, isSaving: false});
+                                this.props.onModeSwitch();
+                            } catch (e) {
+                                this.props.ctx.notifications.show({
+                                    content: <ErrorNotification title='Unable to save changes' e={e} />,
+                                    type: NotificationType.Error
+                                });
+                            } finally {
+                                this.setState({isSaving: false});
+                            }
+                        }}
+                        defaultValues={this.props.values}
+                        validateError={this.props.validate}>
+                        {api => (
+                            <React.Fragment key={'edit_' + this.props.uniqueId}>
+                                {this.props.edit && this.props.edit(api)}
+                                {this.props.items?.map(item => (
+                                    <React.Fragment key={'edit_' + this.props.uniqueId + '_' + (item.key || item.title)}>
+                                        {item.before}
+                                        <div className='row white-box__details-row'>
+                                            <div className='columns small-3'>{(item.titleEdit && item.titleEdit(api)) || item.customTitle || item.title}</div>
+                                            <div className='columns small-9'>{(item.edit && item.edit(api)) || item.view}</div>
+                                        </div>
+                                    </React.Fragment>
+                                ))}
+                            </React.Fragment>
+                        )}
+                    </Form>
+                )}
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
Fixes  https://github.com/argoproj/argo-cd/issues/17588

This PR builds upon https://github.com/argoproj/argo-cd/pull/17275

This PR adds/enables the "Edit" button to the Source and Parameter sections of each collapsible panel under the new Sources tab added from https://github.com/argoproj/argo-cd/pull/17275.  

There are a few noteworthy design points to this:
- Two Edit buttons are added.  One for the 'core' source information including Repo URL, path, etc.  See the discussion in the proposal as to why two edit buttons are needed
- The repo details are not loaded until the source panel is expanded.  This will reduce 'flickering' if all repo sources were loaded at once, and if the UI needs to be updated if underlying data is changed. This will also help with performance.

<img width="675" alt="LoadingOneSource" src="https://github.com/argoproj/argo-cd/assets/7726022/9b10a0c2-22de-4962-b75d-f03bd348ad5b">

- The collapse state of each source panel is 'remembered' if the user traverses the Resource details tabs.  It is also recalled if the details sliding panel is closed and opened back up again
- The existing support for the single source field can be easily removed with minimal changes.  Did not want to change the behavior of that.  
- Validation of a field seems to be broken (even without this change, and on single source apps).  It appears there needs to be a change in the argo UI.  I added new validation for just the repo URL to show that the validation works:

<img width="785" alt="Screenshot 2024-03-26 at 4 20 05 PM" src="https://github.com/argoproj/argo-cd/assets/7726022/0b4dbd8f-a2f5-43e8-8922-445b589722a6">

Testing:
- I tested multiple source apps with 2, 3 and 4 sources.  I edited and changed the repo URL or path, and subsequently, the parameters ( the bottom panel) changes to reflect the new source type
- I tested modifying and saving Helm parameter values changes, and the override behavior looks the same compared to using a single source app.
- After saving, the source panel may 'load' several times (due to model changes), but I think that is probably acceptable.
- If you are in Edit mode, and wait for some time, the page will refresh and will kick you out of edit mode. This is similar behavior to what is happening currently with single source apps.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
