### PR TITLE
chore: upgrade controller-gen from 0.4.1 to 0.14.0

### DIFF
--- a/docs/operator-manual/upgrading/2.11-2.12.md
+++ b/docs/operator-manual/upgrading/2.11-2.12.md
@@ -1,0 +1,30 @@
+# v2.11 to 2.12
+
+## Server-Side Apply Management of ApplicationSet Fields
+
+### Summary
+
+If you are using server-side apply with multiple field managers to manage a single `selector` or `labelSelector` field 
+in an ApplicationSet, that field management must be changed to be atomic starting with 2.12. 
+
+### Details
+
+Argo CD 2.12 upgraded its controller-gen version from 0.4.1 to 0.14.0. As part of that change, several ApplicationSet
+CRD fields now have `x-kubernetes-map-type: atomic`.
+
+Each of the affected fields is a label selector with two child keys: `matchLabels` and `matchExpressions`.
+
+Prior to this change, two field managers could manage the `matchLabels` and `matchExpressions` fields independently.
+Starting with the 2.12 CRD, a single field manager must manage both of those fields. This behavior is in line with the
+upstream behavior of the label selector struct.
+
+See the [Kubernetes server-side apply merge strategy docs](https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy)
+for more information about the fields' behavior.
+
+The affected ApplicationSet fields are the following (jq selector syntax):
+
+* `.spec.generators[].selector`
+* `.spec.generators[].cluster.selector`
+* `.spec.generators[].clusterDecisionResource.labelSelector`
+* `.spec.generators[].matrix.generators[].selector`
+* `.spec.generators[].merge.generators[].selector`

--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -37,6 +37,8 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
+* [v2.11 to v2.12](./2.11-2.12.md)
+* [v2.10 to v2.11](./2.10-2.11.md)
 * [v2.9 to v2.10](./2.9-2.10.md)
 * [v2.8 to v2.9](./2.8-2.9.md)
 * [v2.7 to v2.8](./2.7-2.8.md)

--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -28,7 +28,6 @@ func getCustomResourceDefinitions() map[string]*extensionsobj.CustomResourceDefi
 	crdYamlBytes, err := exec.Command(
 		"controller-gen",
 		"paths=./pkg/apis/application/...",
-		"crd:trivialVersions=true",
 		"crd:crdVersions=v1",
 		"output:crd:stdout",
 	).Output()

--- a/hack/installers/install-codegen-go-tools.sh
+++ b/hack/installers/install-codegen-go-tools.sh
@@ -45,7 +45,7 @@ go_mod_install k8s.io/code-generator/cmd/lister-gen
 go_mod_install k8s.io/kube-openapi/cmd/openapi-gen
 
 # controller-gen is run by ./hack/gen-crd-spec to generate the CRDs
-go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
+go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 
 # swagger cli is used to generate swagger docs
 go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -35,14 +35,19 @@ spec:
         description: Application is a definition of Application resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -140,22 +145,21 @@ spec:
                       type: object
                     type: array
                   revision:
-                    description: Revision is the revision (Git) or chart version (Helm)
-                      which to sync the application to If omitted, will use the revision
-                      specified in app spec.
+                    description: |-
+                      Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                      If omitted, will use the revision specified in app spec.
                     type: string
                   revisions:
-                    description: Revisions is the list of revision (Git) or chart
-                      version (Helm) which to sync each source in sources field for
-                      the application to If omitted, will use the revision specified
-                      in app spec.
+                    description: |-
+                      Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                      If omitted, will use the revision specified in app spec.
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Source overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     properties:
                       chart:
                         description: Chart is a Helm chart name, and must be specified
@@ -476,18 +480,18 @@ spec:
                           Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the revision of the source
-                          to sync the application to. In case of Git, this can be
-                          commit, tag, or branch. If omitted, will equal to HEAD.
+                        description: |-
+                          TargetRevision defines the revision of the source to sync the application to.
+                          In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
                           In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
                     type: object
                   sources:
-                    description: Sources overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Sources overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     items:
                       description: ApplicationSource contains all required information
                         about the source of an application
@@ -815,11 +819,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -838,10 +841,10 @@ spec:
                           the sync.
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                       hook:
@@ -849,10 +852,10 @@ spec:
                           perform the sync. This is the default strategy
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                     type: object
@@ -873,9 +876,9 @@ spec:
                       not set.
                     type: string
                   namespace:
-                    description: Namespace specifies the target namespace for the
-                      application's resources. The namespace will only be set for
-                      namespace-scoped resources that have not set a value for .metadata.namespace
+                    description: |-
+                      Namespace specifies the target namespace for the application's resources.
+                      The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
                     description: Server specifies the URL of the target cluster's
@@ -904,10 +907,9 @@ spec:
                     kind:
                       type: string
                     managedFieldsManagers:
-                      description: ManagedFieldsManagers is a list of trusted managers.
-                        Fields mutated by those managers will take precedence over
-                        the desired state defined in the SCM and won't be displayed
-                        in diffs
+                      description: |-
+                        ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                        desired state defined in the SCM and won't be displayed in diffs
                       items:
                         type: string
                       type: array
@@ -934,18 +936,17 @@ spec:
                   type: object
                 type: array
               project:
-                description: Project is a reference to the project this application
-                  belongs to. The empty string means that application belongs to the
-                  'default' project.
+                description: |-
+                  Project is a reference to the project this application belongs to.
+                  The empty string means that application belongs to the 'default' project.
                 type: string
               revisionHistoryLimit:
-                description: RevisionHistoryLimit limits the number of items kept
-                  in the application's revision history, which is used for informational
-                  purposes as well as for rollbacks to previous versions. This should
-                  only be changed in exceptional circumstances. Setting to zero will
-                  store no history. This will reduce storage used. Increasing will
-                  increase the space used to store the history, so we do not recommend
-                  increasing it. Default is 10.
+                description: |-
+                  RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.
+                  This should only be changed in exceptional circumstances.
+                  Setting to zero will store no history. This will reduce storage used.
+                  Increasing will increase the space used to store the history, so we do not recommend increasing it.
+                  Default is 10.
                 format: int64
                 type: integer
               source:
@@ -1264,10 +1265,10 @@ spec:
                       that contains the application manifests
                     type: string
                   targetRevision:
-                    description: TargetRevision defines the revision of the source
-                      to sync the application to. In case of Git, this can be commit,
-                      tag, or branch. If omitted, will equal to HEAD. In case of Helm,
-                      this is a semver tag for the Chart's version.
+                    description: |-
+                      TargetRevision defines the revision of the source to sync the application to.
+                      In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                      In case of Helm, this is a semver tag for the Chart's version.
                     type: string
                 required:
                 - repoURL
@@ -1596,10 +1597,10 @@ spec:
                         that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the revision of the source
-                        to sync the application to. In case of Git, this can be commit,
-                        tag, or branch. If omitted, will equal to HEAD. In case of
-                        Helm, this is a semver tag for the Chart's version.
+                      description: |-
+                        TargetRevision defines the revision of the source to sync the application to.
+                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                        In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -2092,11 +2093,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -2438,11 +2438,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -2454,9 +2453,9 @@ spec:
                   type: object
                 type: array
               observedAt:
-                description: 'ObservedAt indicates when the application state was
-                  updated without querying latest git state Deprecated: controller
-                  no longer updates ObservedAt field'
+                description: |-
+                  ObservedAt indicates when the application state was updated without querying latest git state
+                  Deprecated: controller no longer updates ObservedAt field
                 format: date-time
                 type: string
               operationState:
@@ -2569,22 +2568,21 @@ spec:
                               type: object
                             type: array
                           revision:
-                            description: Revision is the revision (Git) or chart version
-                              (Helm) which to sync the application to If omitted,
-                              will use the revision specified in app spec.
+                            description: |-
+                              Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                              If omitted, will use the revision specified in app spec.
                             type: string
                           revisions:
-                            description: Revisions is the list of revision (Git) or
-                              chart version (Helm) which to sync each source in sources
-                              field for the application to If omitted, will use the
-                              revision specified in app spec.
+                            description: |-
+                              Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                              If omitted, will use the revision specified in app spec.
                             items:
                               type: string
                             type: array
                           source:
-                            description: Source overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Source overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             properties:
                               chart:
                                 description: Chart is a Helm chart name, and must
@@ -2927,19 +2925,18 @@ spec:
                                   (Git or Helm) that contains the application manifests
                                 type: string
                               targetRevision:
-                                description: TargetRevision defines the revision of
-                                  the source to sync the application to. In case of
-                                  Git, this can be commit, tag, or branch. If omitted,
-                                  will equal to HEAD. In case of Helm, this is a semver
-                                  tag for the Chart's version.
+                                description: |-
+                                  TargetRevision defines the revision of the source to sync the application to.
+                                  In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                  In case of Helm, this is a semver tag for the Chart's version.
                                 type: string
                             required:
                             - repoURL
                             type: object
                           sources:
-                            description: Sources overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Sources overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             items:
                               description: ApplicationSource contains all required
                                 information about the source of an application
@@ -3290,11 +3287,10 @@ spec:
                                     (Git or Helm) that contains the application manifests
                                   type: string
                                 targetRevision:
-                                  description: TargetRevision defines the revision
-                                    of the source to sync the application to. In case
-                                    of Git, this can be commit, tag, or branch. If
-                                    omitted, will equal to HEAD. In case of Helm,
-                                    this is a semver tag for the Chart's version.
+                                  description: |-
+                                    TargetRevision defines the revision of the source to sync the application to.
+                                    In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                    In case of Helm, this is a semver tag for the Chart's version.
                                   type: string
                               required:
                               - repoURL
@@ -3315,11 +3311,10 @@ spec:
                                   to perform the sync.
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                               hook:
@@ -3327,11 +3322,10 @@ spec:
                                   to perform the sync. This is the default strategy
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                             type: object
@@ -3375,9 +3369,9 @@ spec:
                               description: Group specifies the API group of the resource
                               type: string
                             hookPhase:
-                              description: HookPhase contains the state of any operation
-                                associated with this resource OR hook This can also
-                                contain values for non-hook resources.
+                              description: |-
+                                HookPhase contains the state of any operation associated with this resource OR hook
+                                This can also contain values for non-hook resources.
                               type: string
                             hookType:
                               description: HookType specifies the type of the hook.
@@ -3762,11 +3756,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4117,11 +4110,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -4148,8 +4140,9 @@ spec:
                 description: Resources is a list of Kubernetes resources managed by
                   this application
                 items:
-                  description: 'ResourceStatus holds the current sync and health status
-                    of a resource TODO: describe members of this type'
+                  description: |-
+                    ResourceStatus holds the current sync and health status of a resource
+                    TODO: describe members of this type
                   properties:
                     group:
                       type: string
@@ -4232,10 +4225,9 @@ spec:
                               if Server is not set.
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
+                            description: |-
+                              Namespace specifies the target namespace for the application's resources.
+                              The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                             type: string
                           server:
                             description: Server specifies the URL of the target cluster's
@@ -4264,10 +4256,9 @@ spec:
                             kind:
                               type: string
                             managedFieldsManagers:
-                              description: ManagedFieldsManagers is a list of trusted
-                                managers. Fields mutated by those managers will take
-                                precedence over the desired state defined in the SCM
-                                and won't be displayed in diffs
+                              description: |-
+                                ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                                desired state defined in the SCM and won't be displayed in diffs
                               items:
                                 type: string
                               type: array
@@ -4613,11 +4604,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4968,11 +4958,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -5069,6 +5058,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -5665,6 +5655,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         template:
                           properties:
                             metadata:
@@ -7427,6 +7418,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -8023,6 +8015,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -11888,6 +11881,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         template:
@@ -12484,6 +12478,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -13080,6 +13075,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -16945,6 +16941,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         mergeKeys:
@@ -19645,6 +19642,7 @@ spec:
                             type: string
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 type: array
               goTemplate:
@@ -20363,22 +20361,28 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: 'AppProject provides a logical grouping of applications, providing
-          controls for: * where the apps may deploy to (cluster whitelist) * what
-          may be deployed (repository whitelist, resource whitelist/blacklist) * who
-          can access these applications (roles, OIDC group claims bindings) * and
-          what they can do (RBAC policies) * automation access to these roles (JWT
-          tokens)'
+        description: |-
+          AppProject provides a logical grouping of applications, providing controls for:
+          * where the apps may deploy to (cluster whitelist)
+          * what may be deployed (repository whitelist, resource whitelist/blacklist)
+          * who can access these applications (roles, OIDC group claims bindings)
+          * and what they can do (RBAC policies)
+          * automation access to these roles (JWT tokens)
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -20389,9 +20393,9 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20406,9 +20410,9 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20435,9 +20439,9 @@ spec:
                         not set.
                       type: string
                     namespace:
-                      description: Namespace specifies the target namespace for the
-                        application's resources. The namespace will only be set for
-                        namespace-scoped resources that have not set a value for .metadata.namespace
+                      description: |-
+                        Namespace specifies the target namespace for the application's resources.
+                        The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                       type: string
                     server:
                       description: Server specifies the URL of the target cluster's
@@ -20450,9 +20454,9 @@ spec:
                 description: NamespaceResourceBlacklist contains list of blacklisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20467,9 +20471,9 @@ spec:
                 description: NamespaceResourceWhitelist contains list of whitelisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string

--- a/manifests/crds/application-crd.yaml
+++ b/manifests/crds/application-crd.yaml
@@ -34,14 +34,19 @@ spec:
         description: Application is a definition of Application resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -139,22 +144,21 @@ spec:
                       type: object
                     type: array
                   revision:
-                    description: Revision is the revision (Git) or chart version (Helm)
-                      which to sync the application to If omitted, will use the revision
-                      specified in app spec.
+                    description: |-
+                      Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                      If omitted, will use the revision specified in app spec.
                     type: string
                   revisions:
-                    description: Revisions is the list of revision (Git) or chart
-                      version (Helm) which to sync each source in sources field for
-                      the application to If omitted, will use the revision specified
-                      in app spec.
+                    description: |-
+                      Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                      If omitted, will use the revision specified in app spec.
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Source overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     properties:
                       chart:
                         description: Chart is a Helm chart name, and must be specified
@@ -475,18 +479,18 @@ spec:
                           Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the revision of the source
-                          to sync the application to. In case of Git, this can be
-                          commit, tag, or branch. If omitted, will equal to HEAD.
+                        description: |-
+                          TargetRevision defines the revision of the source to sync the application to.
+                          In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
                           In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
                     type: object
                   sources:
-                    description: Sources overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Sources overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     items:
                       description: ApplicationSource contains all required information
                         about the source of an application
@@ -814,11 +818,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -837,10 +840,10 @@ spec:
                           the sync.
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                       hook:
@@ -848,10 +851,10 @@ spec:
                           perform the sync. This is the default strategy
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                     type: object
@@ -872,9 +875,9 @@ spec:
                       not set.
                     type: string
                   namespace:
-                    description: Namespace specifies the target namespace for the
-                      application's resources. The namespace will only be set for
-                      namespace-scoped resources that have not set a value for .metadata.namespace
+                    description: |-
+                      Namespace specifies the target namespace for the application's resources.
+                      The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
                     description: Server specifies the URL of the target cluster's
@@ -903,10 +906,9 @@ spec:
                     kind:
                       type: string
                     managedFieldsManagers:
-                      description: ManagedFieldsManagers is a list of trusted managers.
-                        Fields mutated by those managers will take precedence over
-                        the desired state defined in the SCM and won't be displayed
-                        in diffs
+                      description: |-
+                        ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                        desired state defined in the SCM and won't be displayed in diffs
                       items:
                         type: string
                       type: array
@@ -933,18 +935,17 @@ spec:
                   type: object
                 type: array
               project:
-                description: Project is a reference to the project this application
-                  belongs to. The empty string means that application belongs to the
-                  'default' project.
+                description: |-
+                  Project is a reference to the project this application belongs to.
+                  The empty string means that application belongs to the 'default' project.
                 type: string
               revisionHistoryLimit:
-                description: RevisionHistoryLimit limits the number of items kept
-                  in the application's revision history, which is used for informational
-                  purposes as well as for rollbacks to previous versions. This should
-                  only be changed in exceptional circumstances. Setting to zero will
-                  store no history. This will reduce storage used. Increasing will
-                  increase the space used to store the history, so we do not recommend
-                  increasing it. Default is 10.
+                description: |-
+                  RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.
+                  This should only be changed in exceptional circumstances.
+                  Setting to zero will store no history. This will reduce storage used.
+                  Increasing will increase the space used to store the history, so we do not recommend increasing it.
+                  Default is 10.
                 format: int64
                 type: integer
               source:
@@ -1263,10 +1264,10 @@ spec:
                       that contains the application manifests
                     type: string
                   targetRevision:
-                    description: TargetRevision defines the revision of the source
-                      to sync the application to. In case of Git, this can be commit,
-                      tag, or branch. If omitted, will equal to HEAD. In case of Helm,
-                      this is a semver tag for the Chart's version.
+                    description: |-
+                      TargetRevision defines the revision of the source to sync the application to.
+                      In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                      In case of Helm, this is a semver tag for the Chart's version.
                     type: string
                 required:
                 - repoURL
@@ -1595,10 +1596,10 @@ spec:
                         that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the revision of the source
-                        to sync the application to. In case of Git, this can be commit,
-                        tag, or branch. If omitted, will equal to HEAD. In case of
-                        Helm, this is a semver tag for the Chart's version.
+                      description: |-
+                        TargetRevision defines the revision of the source to sync the application to.
+                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                        In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -2091,11 +2092,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -2437,11 +2437,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -2453,9 +2452,9 @@ spec:
                   type: object
                 type: array
               observedAt:
-                description: 'ObservedAt indicates when the application state was
-                  updated without querying latest git state Deprecated: controller
-                  no longer updates ObservedAt field'
+                description: |-
+                  ObservedAt indicates when the application state was updated without querying latest git state
+                  Deprecated: controller no longer updates ObservedAt field
                 format: date-time
                 type: string
               operationState:
@@ -2568,22 +2567,21 @@ spec:
                               type: object
                             type: array
                           revision:
-                            description: Revision is the revision (Git) or chart version
-                              (Helm) which to sync the application to If omitted,
-                              will use the revision specified in app spec.
+                            description: |-
+                              Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                              If omitted, will use the revision specified in app spec.
                             type: string
                           revisions:
-                            description: Revisions is the list of revision (Git) or
-                              chart version (Helm) which to sync each source in sources
-                              field for the application to If omitted, will use the
-                              revision specified in app spec.
+                            description: |-
+                              Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                              If omitted, will use the revision specified in app spec.
                             items:
                               type: string
                             type: array
                           source:
-                            description: Source overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Source overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             properties:
                               chart:
                                 description: Chart is a Helm chart name, and must
@@ -2926,19 +2924,18 @@ spec:
                                   (Git or Helm) that contains the application manifests
                                 type: string
                               targetRevision:
-                                description: TargetRevision defines the revision of
-                                  the source to sync the application to. In case of
-                                  Git, this can be commit, tag, or branch. If omitted,
-                                  will equal to HEAD. In case of Helm, this is a semver
-                                  tag for the Chart's version.
+                                description: |-
+                                  TargetRevision defines the revision of the source to sync the application to.
+                                  In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                  In case of Helm, this is a semver tag for the Chart's version.
                                 type: string
                             required:
                             - repoURL
                             type: object
                           sources:
-                            description: Sources overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Sources overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             items:
                               description: ApplicationSource contains all required
                                 information about the source of an application
@@ -3289,11 +3286,10 @@ spec:
                                     (Git or Helm) that contains the application manifests
                                   type: string
                                 targetRevision:
-                                  description: TargetRevision defines the revision
-                                    of the source to sync the application to. In case
-                                    of Git, this can be commit, tag, or branch. If
-                                    omitted, will equal to HEAD. In case of Helm,
-                                    this is a semver tag for the Chart's version.
+                                  description: |-
+                                    TargetRevision defines the revision of the source to sync the application to.
+                                    In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                    In case of Helm, this is a semver tag for the Chart's version.
                                   type: string
                               required:
                               - repoURL
@@ -3314,11 +3310,10 @@ spec:
                                   to perform the sync.
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                               hook:
@@ -3326,11 +3321,10 @@ spec:
                                   to perform the sync. This is the default strategy
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                             type: object
@@ -3374,9 +3368,9 @@ spec:
                               description: Group specifies the API group of the resource
                               type: string
                             hookPhase:
-                              description: HookPhase contains the state of any operation
-                                associated with this resource OR hook This can also
-                                contain values for non-hook resources.
+                              description: |-
+                                HookPhase contains the state of any operation associated with this resource OR hook
+                                This can also contain values for non-hook resources.
                               type: string
                             hookType:
                               description: HookType specifies the type of the hook.
@@ -3761,11 +3755,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4116,11 +4109,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -4147,8 +4139,9 @@ spec:
                 description: Resources is a list of Kubernetes resources managed by
                   this application
                 items:
-                  description: 'ResourceStatus holds the current sync and health status
-                    of a resource TODO: describe members of this type'
+                  description: |-
+                    ResourceStatus holds the current sync and health status of a resource
+                    TODO: describe members of this type
                   properties:
                     group:
                       type: string
@@ -4231,10 +4224,9 @@ spec:
                               if Server is not set.
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
+                            description: |-
+                              Namespace specifies the target namespace for the application's resources.
+                              The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                             type: string
                           server:
                             description: Server specifies the URL of the target cluster's
@@ -4263,10 +4255,9 @@ spec:
                             kind:
                               type: string
                             managedFieldsManagers:
-                              description: ManagedFieldsManagers is a list of trusted
-                                managers. Fields mutated by those managers will take
-                                precedence over the desired state defined in the SCM
-                                and won't be displayed in diffs
+                              description: |-
+                                ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                                desired state defined in the SCM and won't be displayed in diffs
                               items:
                                 type: string
                               type: array
@@ -4612,11 +4603,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4967,11 +4957,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL

--- a/manifests/crds/applicationset-crd.yaml
+++ b/manifests/crds/applicationset-crd.yaml
@@ -61,6 +61,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -657,6 +658,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         template:
                           properties:
                             metadata:
@@ -2419,6 +2421,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -3015,6 +3018,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -6880,6 +6884,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         template:
@@ -7476,6 +7481,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -8072,6 +8078,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -11937,6 +11944,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         mergeKeys:
@@ -14637,6 +14645,7 @@ spec:
                             type: string
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 type: array
               goTemplate:

--- a/manifests/crds/appproject-crd.yaml
+++ b/manifests/crds/appproject-crd.yaml
@@ -20,22 +20,28 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: 'AppProject provides a logical grouping of applications, providing
-          controls for: * where the apps may deploy to (cluster whitelist) * what
-          may be deployed (repository whitelist, resource whitelist/blacklist) * who
-          can access these applications (roles, OIDC group claims bindings) * and
-          what they can do (RBAC policies) * automation access to these roles (JWT
-          tokens)'
+        description: |-
+          AppProject provides a logical grouping of applications, providing controls for:
+          * where the apps may deploy to (cluster whitelist)
+          * what may be deployed (repository whitelist, resource whitelist/blacklist)
+          * who can access these applications (roles, OIDC group claims bindings)
+          * and what they can do (RBAC policies)
+          * automation access to these roles (JWT tokens)
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -46,9 +52,9 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -63,9 +69,9 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -92,9 +98,9 @@ spec:
                         not set.
                       type: string
                     namespace:
-                      description: Namespace specifies the target namespace for the
-                        application's resources. The namespace will only be set for
-                        namespace-scoped resources that have not set a value for .metadata.namespace
+                      description: |-
+                        Namespace specifies the target namespace for the application's resources.
+                        The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                       type: string
                     server:
                       description: Server specifies the URL of the target cluster's
@@ -107,9 +113,9 @@ spec:
                 description: NamespaceResourceBlacklist contains list of blacklisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -124,9 +130,9 @@ spec:
                 description: NamespaceResourceWhitelist contains list of whitelisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -35,14 +35,19 @@ spec:
         description: Application is a definition of Application resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -140,22 +145,21 @@ spec:
                       type: object
                     type: array
                   revision:
-                    description: Revision is the revision (Git) or chart version (Helm)
-                      which to sync the application to If omitted, will use the revision
-                      specified in app spec.
+                    description: |-
+                      Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                      If omitted, will use the revision specified in app spec.
                     type: string
                   revisions:
-                    description: Revisions is the list of revision (Git) or chart
-                      version (Helm) which to sync each source in sources field for
-                      the application to If omitted, will use the revision specified
-                      in app spec.
+                    description: |-
+                      Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                      If omitted, will use the revision specified in app spec.
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Source overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     properties:
                       chart:
                         description: Chart is a Helm chart name, and must be specified
@@ -476,18 +480,18 @@ spec:
                           Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the revision of the source
-                          to sync the application to. In case of Git, this can be
-                          commit, tag, or branch. If omitted, will equal to HEAD.
+                        description: |-
+                          TargetRevision defines the revision of the source to sync the application to.
+                          In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
                           In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
                     type: object
                   sources:
-                    description: Sources overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Sources overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     items:
                       description: ApplicationSource contains all required information
                         about the source of an application
@@ -815,11 +819,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -838,10 +841,10 @@ spec:
                           the sync.
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                       hook:
@@ -849,10 +852,10 @@ spec:
                           perform the sync. This is the default strategy
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                     type: object
@@ -873,9 +876,9 @@ spec:
                       not set.
                     type: string
                   namespace:
-                    description: Namespace specifies the target namespace for the
-                      application's resources. The namespace will only be set for
-                      namespace-scoped resources that have not set a value for .metadata.namespace
+                    description: |-
+                      Namespace specifies the target namespace for the application's resources.
+                      The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
                     description: Server specifies the URL of the target cluster's
@@ -904,10 +907,9 @@ spec:
                     kind:
                       type: string
                     managedFieldsManagers:
-                      description: ManagedFieldsManagers is a list of trusted managers.
-                        Fields mutated by those managers will take precedence over
-                        the desired state defined in the SCM and won't be displayed
-                        in diffs
+                      description: |-
+                        ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                        desired state defined in the SCM and won't be displayed in diffs
                       items:
                         type: string
                       type: array
@@ -934,18 +936,17 @@ spec:
                   type: object
                 type: array
               project:
-                description: Project is a reference to the project this application
-                  belongs to. The empty string means that application belongs to the
-                  'default' project.
+                description: |-
+                  Project is a reference to the project this application belongs to.
+                  The empty string means that application belongs to the 'default' project.
                 type: string
               revisionHistoryLimit:
-                description: RevisionHistoryLimit limits the number of items kept
-                  in the application's revision history, which is used for informational
-                  purposes as well as for rollbacks to previous versions. This should
-                  only be changed in exceptional circumstances. Setting to zero will
-                  store no history. This will reduce storage used. Increasing will
-                  increase the space used to store the history, so we do not recommend
-                  increasing it. Default is 10.
+                description: |-
+                  RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.
+                  This should only be changed in exceptional circumstances.
+                  Setting to zero will store no history. This will reduce storage used.
+                  Increasing will increase the space used to store the history, so we do not recommend increasing it.
+                  Default is 10.
                 format: int64
                 type: integer
               source:
@@ -1264,10 +1265,10 @@ spec:
                       that contains the application manifests
                     type: string
                   targetRevision:
-                    description: TargetRevision defines the revision of the source
-                      to sync the application to. In case of Git, this can be commit,
-                      tag, or branch. If omitted, will equal to HEAD. In case of Helm,
-                      this is a semver tag for the Chart's version.
+                    description: |-
+                      TargetRevision defines the revision of the source to sync the application to.
+                      In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                      In case of Helm, this is a semver tag for the Chart's version.
                     type: string
                 required:
                 - repoURL
@@ -1596,10 +1597,10 @@ spec:
                         that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the revision of the source
-                        to sync the application to. In case of Git, this can be commit,
-                        tag, or branch. If omitted, will equal to HEAD. In case of
-                        Helm, this is a semver tag for the Chart's version.
+                      description: |-
+                        TargetRevision defines the revision of the source to sync the application to.
+                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                        In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -2092,11 +2093,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -2438,11 +2438,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -2454,9 +2453,9 @@ spec:
                   type: object
                 type: array
               observedAt:
-                description: 'ObservedAt indicates when the application state was
-                  updated without querying latest git state Deprecated: controller
-                  no longer updates ObservedAt field'
+                description: |-
+                  ObservedAt indicates when the application state was updated without querying latest git state
+                  Deprecated: controller no longer updates ObservedAt field
                 format: date-time
                 type: string
               operationState:
@@ -2569,22 +2568,21 @@ spec:
                               type: object
                             type: array
                           revision:
-                            description: Revision is the revision (Git) or chart version
-                              (Helm) which to sync the application to If omitted,
-                              will use the revision specified in app spec.
+                            description: |-
+                              Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                              If omitted, will use the revision specified in app spec.
                             type: string
                           revisions:
-                            description: Revisions is the list of revision (Git) or
-                              chart version (Helm) which to sync each source in sources
-                              field for the application to If omitted, will use the
-                              revision specified in app spec.
+                            description: |-
+                              Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                              If omitted, will use the revision specified in app spec.
                             items:
                               type: string
                             type: array
                           source:
-                            description: Source overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Source overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             properties:
                               chart:
                                 description: Chart is a Helm chart name, and must
@@ -2927,19 +2925,18 @@ spec:
                                   (Git or Helm) that contains the application manifests
                                 type: string
                               targetRevision:
-                                description: TargetRevision defines the revision of
-                                  the source to sync the application to. In case of
-                                  Git, this can be commit, tag, or branch. If omitted,
-                                  will equal to HEAD. In case of Helm, this is a semver
-                                  tag for the Chart's version.
+                                description: |-
+                                  TargetRevision defines the revision of the source to sync the application to.
+                                  In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                  In case of Helm, this is a semver tag for the Chart's version.
                                 type: string
                             required:
                             - repoURL
                             type: object
                           sources:
-                            description: Sources overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Sources overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             items:
                               description: ApplicationSource contains all required
                                 information about the source of an application
@@ -3290,11 +3287,10 @@ spec:
                                     (Git or Helm) that contains the application manifests
                                   type: string
                                 targetRevision:
-                                  description: TargetRevision defines the revision
-                                    of the source to sync the application to. In case
-                                    of Git, this can be commit, tag, or branch. If
-                                    omitted, will equal to HEAD. In case of Helm,
-                                    this is a semver tag for the Chart's version.
+                                  description: |-
+                                    TargetRevision defines the revision of the source to sync the application to.
+                                    In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                    In case of Helm, this is a semver tag for the Chart's version.
                                   type: string
                               required:
                               - repoURL
@@ -3315,11 +3311,10 @@ spec:
                                   to perform the sync.
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                               hook:
@@ -3327,11 +3322,10 @@ spec:
                                   to perform the sync. This is the default strategy
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                             type: object
@@ -3375,9 +3369,9 @@ spec:
                               description: Group specifies the API group of the resource
                               type: string
                             hookPhase:
-                              description: HookPhase contains the state of any operation
-                                associated with this resource OR hook This can also
-                                contain values for non-hook resources.
+                              description: |-
+                                HookPhase contains the state of any operation associated with this resource OR hook
+                                This can also contain values for non-hook resources.
                               type: string
                             hookType:
                               description: HookType specifies the type of the hook.
@@ -3762,11 +3756,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4117,11 +4110,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -4148,8 +4140,9 @@ spec:
                 description: Resources is a list of Kubernetes resources managed by
                   this application
                 items:
-                  description: 'ResourceStatus holds the current sync and health status
-                    of a resource TODO: describe members of this type'
+                  description: |-
+                    ResourceStatus holds the current sync and health status of a resource
+                    TODO: describe members of this type
                   properties:
                     group:
                       type: string
@@ -4232,10 +4225,9 @@ spec:
                               if Server is not set.
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
+                            description: |-
+                              Namespace specifies the target namespace for the application's resources.
+                              The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                             type: string
                           server:
                             description: Server specifies the URL of the target cluster's
@@ -4264,10 +4256,9 @@ spec:
                             kind:
                               type: string
                             managedFieldsManagers:
-                              description: ManagedFieldsManagers is a list of trusted
-                                managers. Fields mutated by those managers will take
-                                precedence over the desired state defined in the SCM
-                                and won't be displayed in diffs
+                              description: |-
+                                ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                                desired state defined in the SCM and won't be displayed in diffs
                               items:
                                 type: string
                               type: array
@@ -4613,11 +4604,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4968,11 +4958,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -5069,6 +5058,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -5665,6 +5655,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         template:
                           properties:
                             metadata:
@@ -7427,6 +7418,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -8023,6 +8015,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -11888,6 +11881,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         template:
@@ -12484,6 +12478,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -13080,6 +13075,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -16945,6 +16941,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         mergeKeys:
@@ -19645,6 +19642,7 @@ spec:
                             type: string
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 type: array
               goTemplate:
@@ -20363,22 +20361,28 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: 'AppProject provides a logical grouping of applications, providing
-          controls for: * where the apps may deploy to (cluster whitelist) * what
-          may be deployed (repository whitelist, resource whitelist/blacklist) * who
-          can access these applications (roles, OIDC group claims bindings) * and
-          what they can do (RBAC policies) * automation access to these roles (JWT
-          tokens)'
+        description: |-
+          AppProject provides a logical grouping of applications, providing controls for:
+          * where the apps may deploy to (cluster whitelist)
+          * what may be deployed (repository whitelist, resource whitelist/blacklist)
+          * who can access these applications (roles, OIDC group claims bindings)
+          * and what they can do (RBAC policies)
+          * automation access to these roles (JWT tokens)
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -20389,9 +20393,9 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20406,9 +20410,9 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20435,9 +20439,9 @@ spec:
                         not set.
                       type: string
                     namespace:
-                      description: Namespace specifies the target namespace for the
-                        application's resources. The namespace will only be set for
-                        namespace-scoped resources that have not set a value for .metadata.namespace
+                      description: |-
+                        Namespace specifies the target namespace for the application's resources.
+                        The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                       type: string
                     server:
                       description: Server specifies the URL of the target cluster's
@@ -20450,9 +20454,9 @@ spec:
                 description: NamespaceResourceBlacklist contains list of blacklisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20467,9 +20471,9 @@ spec:
                 description: NamespaceResourceWhitelist contains list of whitelisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -35,14 +35,19 @@ spec:
         description: Application is a definition of Application resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -140,22 +145,21 @@ spec:
                       type: object
                     type: array
                   revision:
-                    description: Revision is the revision (Git) or chart version (Helm)
-                      which to sync the application to If omitted, will use the revision
-                      specified in app spec.
+                    description: |-
+                      Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                      If omitted, will use the revision specified in app spec.
                     type: string
                   revisions:
-                    description: Revisions is the list of revision (Git) or chart
-                      version (Helm) which to sync each source in sources field for
-                      the application to If omitted, will use the revision specified
-                      in app spec.
+                    description: |-
+                      Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                      If omitted, will use the revision specified in app spec.
                     items:
                       type: string
                     type: array
                   source:
-                    description: Source overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Source overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     properties:
                       chart:
                         description: Chart is a Helm chart name, and must be specified
@@ -476,18 +480,18 @@ spec:
                           Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the revision of the source
-                          to sync the application to. In case of Git, this can be
-                          commit, tag, or branch. If omitted, will equal to HEAD.
+                        description: |-
+                          TargetRevision defines the revision of the source to sync the application to.
+                          In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
                           In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
                     type: object
                   sources:
-                    description: Sources overrides the source definition set in the
-                      application. This is typically set in a Rollback operation and
-                      is nil during a Sync operation
+                    description: |-
+                      Sources overrides the source definition set in the application.
+                      This is typically set in a Rollback operation and is nil during a Sync operation
                     items:
                       description: ApplicationSource contains all required information
                         about the source of an application
@@ -815,11 +819,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -838,10 +841,10 @@ spec:
                           the sync.
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                       hook:
@@ -849,10 +852,10 @@ spec:
                           perform the sync. This is the default strategy
                         properties:
                           force:
-                            description: Force indicates whether or not to supply
-                              the --force flag to `kubectl apply`. The --force flag
-                              deletes and re-create the resource, when PATCH encounters
-                              conflict and has retried for 5 times.
+                            description: |-
+                              Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                              The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                              retried for 5 times.
                             type: boolean
                         type: object
                     type: object
@@ -873,9 +876,9 @@ spec:
                       not set.
                     type: string
                   namespace:
-                    description: Namespace specifies the target namespace for the
-                      application's resources. The namespace will only be set for
-                      namespace-scoped resources that have not set a value for .metadata.namespace
+                    description: |-
+                      Namespace specifies the target namespace for the application's resources.
+                      The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
                   server:
                     description: Server specifies the URL of the target cluster's
@@ -904,10 +907,9 @@ spec:
                     kind:
                       type: string
                     managedFieldsManagers:
-                      description: ManagedFieldsManagers is a list of trusted managers.
-                        Fields mutated by those managers will take precedence over
-                        the desired state defined in the SCM and won't be displayed
-                        in diffs
+                      description: |-
+                        ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                        desired state defined in the SCM and won't be displayed in diffs
                       items:
                         type: string
                       type: array
@@ -934,18 +936,17 @@ spec:
                   type: object
                 type: array
               project:
-                description: Project is a reference to the project this application
-                  belongs to. The empty string means that application belongs to the
-                  'default' project.
+                description: |-
+                  Project is a reference to the project this application belongs to.
+                  The empty string means that application belongs to the 'default' project.
                 type: string
               revisionHistoryLimit:
-                description: RevisionHistoryLimit limits the number of items kept
-                  in the application's revision history, which is used for informational
-                  purposes as well as for rollbacks to previous versions. This should
-                  only be changed in exceptional circumstances. Setting to zero will
-                  store no history. This will reduce storage used. Increasing will
-                  increase the space used to store the history, so we do not recommend
-                  increasing it. Default is 10.
+                description: |-
+                  RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions.
+                  This should only be changed in exceptional circumstances.
+                  Setting to zero will store no history. This will reduce storage used.
+                  Increasing will increase the space used to store the history, so we do not recommend increasing it.
+                  Default is 10.
                 format: int64
                 type: integer
               source:
@@ -1264,10 +1265,10 @@ spec:
                       that contains the application manifests
                     type: string
                   targetRevision:
-                    description: TargetRevision defines the revision of the source
-                      to sync the application to. In case of Git, this can be commit,
-                      tag, or branch. If omitted, will equal to HEAD. In case of Helm,
-                      this is a semver tag for the Chart's version.
+                    description: |-
+                      TargetRevision defines the revision of the source to sync the application to.
+                      In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                      In case of Helm, this is a semver tag for the Chart's version.
                     type: string
                 required:
                 - repoURL
@@ -1596,10 +1597,10 @@ spec:
                         that contains the application manifests
                       type: string
                     targetRevision:
-                      description: TargetRevision defines the revision of the source
-                        to sync the application to. In case of Git, this can be commit,
-                        tag, or branch. If omitted, will equal to HEAD. In case of
-                        Helm, this is a semver tag for the Chart's version.
+                      description: |-
+                        TargetRevision defines the revision of the source to sync the application to.
+                        In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                        In case of Helm, this is a semver tag for the Chart's version.
                       type: string
                   required:
                   - repoURL
@@ -2092,11 +2093,10 @@ spec:
                             Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the revision of the
-                            source to sync the application to. In case of Git, this
-                            can be commit, tag, or branch. If omitted, will equal
-                            to HEAD. In case of Helm, this is a semver tag for the
-                            Chart's version.
+                          description: |-
+                            TargetRevision defines the revision of the source to sync the application to.
+                            In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                            In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
@@ -2438,11 +2438,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -2454,9 +2453,9 @@ spec:
                   type: object
                 type: array
               observedAt:
-                description: 'ObservedAt indicates when the application state was
-                  updated without querying latest git state Deprecated: controller
-                  no longer updates ObservedAt field'
+                description: |-
+                  ObservedAt indicates when the application state was updated without querying latest git state
+                  Deprecated: controller no longer updates ObservedAt field
                 format: date-time
                 type: string
               operationState:
@@ -2569,22 +2568,21 @@ spec:
                               type: object
                             type: array
                           revision:
-                            description: Revision is the revision (Git) or chart version
-                              (Helm) which to sync the application to If omitted,
-                              will use the revision specified in app spec.
+                            description: |-
+                              Revision is the revision (Git) or chart version (Helm) which to sync the application to
+                              If omitted, will use the revision specified in app spec.
                             type: string
                           revisions:
-                            description: Revisions is the list of revision (Git) or
-                              chart version (Helm) which to sync each source in sources
-                              field for the application to If omitted, will use the
-                              revision specified in app spec.
+                            description: |-
+                              Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+                              If omitted, will use the revision specified in app spec.
                             items:
                               type: string
                             type: array
                           source:
-                            description: Source overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Source overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             properties:
                               chart:
                                 description: Chart is a Helm chart name, and must
@@ -2927,19 +2925,18 @@ spec:
                                   (Git or Helm) that contains the application manifests
                                 type: string
                               targetRevision:
-                                description: TargetRevision defines the revision of
-                                  the source to sync the application to. In case of
-                                  Git, this can be commit, tag, or branch. If omitted,
-                                  will equal to HEAD. In case of Helm, this is a semver
-                                  tag for the Chart's version.
+                                description: |-
+                                  TargetRevision defines the revision of the source to sync the application to.
+                                  In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                  In case of Helm, this is a semver tag for the Chart's version.
                                 type: string
                             required:
                             - repoURL
                             type: object
                           sources:
-                            description: Sources overrides the source definition set
-                              in the application. This is typically set in a Rollback
-                              operation and is nil during a Sync operation
+                            description: |-
+                              Sources overrides the source definition set in the application.
+                              This is typically set in a Rollback operation and is nil during a Sync operation
                             items:
                               description: ApplicationSource contains all required
                                 information about the source of an application
@@ -3290,11 +3287,10 @@ spec:
                                     (Git or Helm) that contains the application manifests
                                   type: string
                                 targetRevision:
-                                  description: TargetRevision defines the revision
-                                    of the source to sync the application to. In case
-                                    of Git, this can be commit, tag, or branch. If
-                                    omitted, will equal to HEAD. In case of Helm,
-                                    this is a semver tag for the Chart's version.
+                                  description: |-
+                                    TargetRevision defines the revision of the source to sync the application to.
+                                    In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                    In case of Helm, this is a semver tag for the Chart's version.
                                   type: string
                               required:
                               - repoURL
@@ -3315,11 +3311,10 @@ spec:
                                   to perform the sync.
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                               hook:
@@ -3327,11 +3322,10 @@ spec:
                                   to perform the sync. This is the default strategy
                                 properties:
                                   force:
-                                    description: Force indicates whether or not to
-                                      supply the --force flag to `kubectl apply`.
-                                      The --force flag deletes and re-create the resource,
-                                      when PATCH encounters conflict and has retried
-                                      for 5 times.
+                                    description: |-
+                                      Force indicates whether or not to supply the --force flag to `kubectl apply`.
+                                      The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+                                      retried for 5 times.
                                     type: boolean
                                 type: object
                             type: object
@@ -3375,9 +3369,9 @@ spec:
                               description: Group specifies the API group of the resource
                               type: string
                             hookPhase:
-                              description: HookPhase contains the state of any operation
-                                associated with this resource OR hook This can also
-                                contain values for non-hook resources.
+                              description: |-
+                                HookPhase contains the state of any operation associated with this resource OR hook
+                                This can also contain values for non-hook resources.
                               type: string
                             hookType:
                               description: HookType specifies the type of the hook.
@@ -3762,11 +3756,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4117,11 +4110,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -4148,8 +4140,9 @@ spec:
                 description: Resources is a list of Kubernetes resources managed by
                   this application
                 items:
-                  description: 'ResourceStatus holds the current sync and health status
-                    of a resource TODO: describe members of this type'
+                  description: |-
+                    ResourceStatus holds the current sync and health status of a resource
+                    TODO: describe members of this type
                   properties:
                     group:
                       type: string
@@ -4232,10 +4225,9 @@ spec:
                               if Server is not set.
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
+                            description: |-
+                              Namespace specifies the target namespace for the application's resources.
+                              The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                             type: string
                           server:
                             description: Server specifies the URL of the target cluster's
@@ -4264,10 +4256,9 @@ spec:
                             kind:
                               type: string
                             managedFieldsManagers:
-                              description: ManagedFieldsManagers is a list of trusted
-                                managers. Fields mutated by those managers will take
-                                precedence over the desired state defined in the SCM
-                                and won't be displayed in diffs
+                              description: |-
+                                ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the
+                                desired state defined in the SCM and won't be displayed in diffs
                               items:
                                 type: string
                               type: array
@@ -4613,11 +4604,10 @@ spec:
                               or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
+                            description: |-
+                              TargetRevision defines the revision of the source to sync the application to.
+                              In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                              In case of Helm, this is a semver tag for the Chart's version.
                             type: string
                         required:
                         - repoURL
@@ -4968,11 +4958,10 @@ spec:
                                 or Helm) that contains the application manifests
                               type: string
                             targetRevision:
-                              description: TargetRevision defines the revision of
-                                the source to sync the application to. In case of
-                                Git, this can be commit, tag, or branch. If omitted,
-                                will equal to HEAD. In case of Helm, this is a semver
-                                tag for the Chart's version.
+                              description: |-
+                                TargetRevision defines the revision of the source to sync the application to.
+                                In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
+                                In case of Helm, this is a semver tag for the Chart's version.
                               type: string
                           required:
                           - repoURL
@@ -5069,6 +5058,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         name:
                           type: string
                         requeueAfterSeconds:
@@ -5665,6 +5655,7 @@ spec:
                                 type: string
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         template:
                           properties:
                             metadata:
@@ -7427,6 +7418,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -8023,6 +8015,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -11888,6 +11881,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         template:
@@ -12484,6 +12478,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   name:
                                     type: string
                                   requeueAfterSeconds:
@@ -13080,6 +13075,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   template:
                                     properties:
                                       metadata:
@@ -16945,6 +16941,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         mergeKeys:
@@ -19645,6 +19642,7 @@ spec:
                             type: string
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 type: array
               goTemplate:
@@ -20363,22 +20361,28 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: 'AppProject provides a logical grouping of applications, providing
-          controls for: * where the apps may deploy to (cluster whitelist) * what
-          may be deployed (repository whitelist, resource whitelist/blacklist) * who
-          can access these applications (roles, OIDC group claims bindings) * and
-          what they can do (RBAC policies) * automation access to these roles (JWT
-          tokens)'
+        description: |-
+          AppProject provides a logical grouping of applications, providing controls for:
+          * where the apps may deploy to (cluster whitelist)
+          * what may be deployed (repository whitelist, resource whitelist/blacklist)
+          * who can access these applications (roles, OIDC group claims bindings)
+          * and what they can do (RBAC policies)
+          * automation access to these roles (JWT tokens)
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -20389,9 +20393,9 @@ spec:
                 description: ClusterResourceBlacklist contains list of blacklisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20406,9 +20410,9 @@ spec:
                 description: ClusterResourceWhitelist contains list of whitelisted
                   cluster level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20435,9 +20439,9 @@ spec:
                         not set.
                       type: string
                     namespace:
-                      description: Namespace specifies the target namespace for the
-                        application's resources. The namespace will only be set for
-                        namespace-scoped resources that have not set a value for .metadata.namespace
+                      description: |-
+                        Namespace specifies the target namespace for the application's resources.
+                        The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                       type: string
                     server:
                       description: Server specifies the URL of the target cluster's
@@ -20450,9 +20454,9 @@ spec:
                 description: NamespaceResourceBlacklist contains list of blacklisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string
@@ -20467,9 +20471,9 @@ spec:
                 description: NamespaceResourceWhitelist contains list of whitelisted
                   namespace level resources
                 items:
-                  description: GroupKind specifies a Group and a Kind, but does not
-                    force a version.  This is useful for identifying concepts during
-                    lookup stages without having partially valid types
+                  description: |-
+                    GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying
+                    concepts during lookup stages without having partially valid types
                   properties:
                     group:
                       type: string


### PR DESCRIPTION
controller-gen versions before 0.14.0 suffer from nil reference errors with go versions >= 1.22. 

Going ahead and bumping controller-gen to unblock a 1.22 upgrade.