### PR TITLE
feat(appset): add key title to PR generator (#16447)

### DIFF
--- a/applicationset/controllers/template/template_test.go
+++ b/applicationset/controllers/template/template_test.go
@@ -254,6 +254,7 @@ func TestGenerateAppsUsingPullRequestGenerator(t *testing.T) {
 			params: []map[string]interface{}{
 				{
 					"number":                                "1",
+					"title":                                 "title1",
 					"branch":                                "branch1",
 					"branch_slug":                           "branchSlug1",
 					"head_sha":                              "089d92cbf9ff857a39e6feccd32798ca700fb958",

--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -97,6 +97,7 @@ func (g *PullRequestGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha
 
 		paramMap := map[string]interface{}{
 			"number":             strconv.Itoa(pull.Number),
+			"title":              pull.Title,
 			"branch":             pull.Branch,
 			"branch_slug":        slug.Make(pull.Branch),
 			"target_branch":      pull.TargetBranch,

--- a/applicationset/generators/pull_request_test.go
+++ b/applicationset/generators/pull_request_test.go
@@ -30,6 +30,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 					[]*pullrequest.PullRequest{
 						{
 							Number:       1,
+							Title:        "title1",
 							Branch:       "branch1",
 							TargetBranch: "master",
 							HeadSHA:      "089d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -41,6 +42,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"number":             "1",
+					"title":              "title1",
 					"branch":             "branch1",
 					"branch_slug":        "branch1",
 					"target_branch":      "master",
@@ -59,6 +61,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 					[]*pullrequest.PullRequest{
 						{
 							Number:       2,
+							Title:        "title2",
 							Branch:       "feat/areally+long_pull_request_name_to_test_argo_slugification_and_branch_name_shortening_feature",
 							TargetBranch: "feat/anotherreally+long_pull_request_name_to_test_argo_slugification_and_branch_name_shortening_feature",
 							HeadSHA:      "9b34ff5bd418e57d58891eb0aa0728043ca1e8be",
@@ -70,6 +73,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"number":             "2",
+					"title":              "title2",
 					"branch":             "feat/areally+long_pull_request_name_to_test_argo_slugification_and_branch_name_shortening_feature",
 					"branch_slug":        "feat-areally-long-pull-request-name-to-test-argo",
 					"target_branch":      "feat/anotherreally+long_pull_request_name_to_test_argo_slugification_and_branch_name_shortening_feature",
@@ -88,6 +92,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 					[]*pullrequest.PullRequest{
 						{
 							Number:       1,
+							Title:        "title1",
 							Branch:       "a-very-short-sha",
 							TargetBranch: "master",
 							HeadSHA:      "abcd",
@@ -99,6 +104,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"number":             "1",
+					"title":              "title1",
 					"branch":             "a-very-short-sha",
 					"branch_slug":        "a-very-short-sha",
 					"target_branch":      "master",
@@ -128,6 +134,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 					[]*pullrequest.PullRequest{
 						{
 							Number:       1,
+							Title:        "title1",
 							Branch:       "branch1",
 							TargetBranch: "master",
 							HeadSHA:      "089d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -140,6 +147,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"number":             "1",
+					"title":              "title1",
 					"branch":             "branch1",
 					"branch_slug":        "branch1",
 					"target_branch":      "master",
@@ -165,6 +173,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 					[]*pullrequest.PullRequest{
 						{
 							Number:       1,
+							Title:        "title1",
 							Branch:       "branch1",
 							TargetBranch: "master",
 							HeadSHA:      "089d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -177,6 +186,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"number":             "1",
+					"title":              "title1",
 					"branch":             "branch1",
 					"branch_slug":        "branch1",
 					"target_branch":      "master",

--- a/applicationset/services/pull_request/azure_devops.go
+++ b/applicationset/services/pull_request/azure_devops.go
@@ -95,6 +95,7 @@ func (a *AzureDevOpsService) List(ctx context.Context) ([]*PullRequest, error) {
 		if *pr.Repository.Name == a.repo {
 			pullRequests = append(pullRequests, &PullRequest{
 				Number:  *pr.PullRequestId,
+				Title:   *pr.Title,
 				Branch:  strings.Replace(*pr.SourceRefName, "refs/heads/", "", 1),
 				HeadSHA: *pr.LastMergeSourceCommit.CommitId,
 				Labels:  azureDevOpsLabels,

--- a/applicationset/services/pull_request/azure_devops_test.go
+++ b/applicationset/services/pull_request/azure_devops_test.go
@@ -56,12 +56,14 @@ func TestListPullRequest(t *testing.T) {
 	teamProject := "myorg_project"
 	repoName := "myorg_project_repo"
 	pr_id := 123
+	pr_title := "feat(123)"
 	pr_head_sha := "cd4973d9d14a08ffe6b641a89a68891d6aac8056"
 	ctx := context.Background()
 
 	pullRequestMock := []git.GitPullRequest{
 		{
 			PullRequestId: createIntPtr(pr_id),
+			Title:         createStringPtr(pr_title),
 			SourceRefName: createStringPtr("refs/heads/feature-branch"),
 			LastMergeSourceCommit: &git.GitCommitRef{
 				CommitId: createStringPtr(pr_head_sha),
@@ -95,6 +97,7 @@ func TestListPullRequest(t *testing.T) {
 	assert.Len(t, list, 1)
 	assert.Equal(t, "feature-branch", list[0].Branch)
 	assert.Equal(t, pr_head_sha, list[0].HeadSHA)
+	assert.Equal(t, "feat(123)", list[0].Title)
 	assert.Equal(t, pr_id, list[0].Number)
 }
 

--- a/applicationset/services/pull_request/bitbucket_cloud.go
+++ b/applicationset/services/pull_request/bitbucket_cloud.go
@@ -17,6 +17,7 @@ type BitbucketCloudService struct {
 
 type BitbucketCloudPullRequest struct {
 	ID     int                             `json:"id"`
+	Title  string                          `json:"title"`
 	Source BitbucketCloudPullRequestSource `json:"source"`
 }
 
@@ -129,6 +130,7 @@ func (b *BitbucketCloudService) List(_ context.Context) ([]*PullRequest, error) 
 	for _, pull := range pulls {
 		pullRequests = append(pullRequests, &PullRequest{
 			Number:  pull.ID,
+			Title:   pull.Title,
 			Branch:  pull.Source.Branch.Name,
 			HeadSHA: pull.Source.Commit.Hash,
 		})

--- a/applicationset/services/pull_request/bitbucket_cloud_test.go
+++ b/applicationset/services/pull_request/bitbucket_cloud_test.go
@@ -27,6 +27,7 @@ func defaultHandlerCloud(t *testing.T) func(http.ResponseWriter, *http.Request) 
 					"values": [
 						{
 							"id": 101,
+							"title": "feat(foo-bar)",
 							"source": {
 								"branch": {
 									"name": "feature/foo-bar"
@@ -86,6 +87,7 @@ func TestListPullRequestBearerTokenCloud(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, pullRequests, 1)
 	assert.Equal(t, 101, pullRequests[0].Number)
+	assert.Equal(t, "feat(foo-bar)", pullRequests[0].Title)
 	assert.Equal(t, "feature/foo-bar", pullRequests[0].Branch)
 	assert.Equal(t, "1a8dd249c04a", pullRequests[0].HeadSHA)
 }
@@ -102,6 +104,7 @@ func TestListPullRequestNoAuthCloud(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, pullRequests, 1)
 	assert.Equal(t, 101, pullRequests[0].Number)
+	assert.Equal(t, "feat(foo-bar)", pullRequests[0].Title)
 	assert.Equal(t, "feature/foo-bar", pullRequests[0].Branch)
 	assert.Equal(t, "1a8dd249c04a", pullRequests[0].HeadSHA)
 }
@@ -118,6 +121,7 @@ func TestListPullRequestBasicAuthCloud(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, pullRequests, 1)
 	assert.Equal(t, 101, pullRequests[0].Number)
+	assert.Equal(t, "feat(foo-bar)", pullRequests[0].Title)
 	assert.Equal(t, "feature/foo-bar", pullRequests[0].Branch)
 	assert.Equal(t, "1a8dd249c04a", pullRequests[0].HeadSHA)
 }
@@ -136,6 +140,7 @@ func TestListPullRequestPaginationCloud(t *testing.T) {
 				"values": [
 					{
 						"id": 101,
+						"title": "feat(101)",
 						"source": {
 							"branch": {
 								"name": "feature-101"
@@ -148,6 +153,7 @@ func TestListPullRequestPaginationCloud(t *testing.T) {
 					},
 					{
 						"id": 102,
+						"title": "feat(102)",
 						"source": {
 							"branch": {
 								"name": "feature-102"
@@ -169,6 +175,7 @@ func TestListPullRequestPaginationCloud(t *testing.T) {
 				"values": [
 					{
 						"id": 103,
+						"title": "feat(103)",
 						"source": {
 							"branch": {
 								"name": "feature-103"
@@ -196,16 +203,19 @@ func TestListPullRequestPaginationCloud(t *testing.T) {
 	assert.Len(t, pullRequests, 3)
 	assert.Equal(t, PullRequest{
 		Number:  101,
+		Title:   "feat(101)",
 		Branch:  "feature-101",
 		HeadSHA: "1a8dd249c04a",
 	}, *pullRequests[0])
 	assert.Equal(t, PullRequest{
 		Number:  102,
+		Title:   "feat(102)",
 		Branch:  "feature-102",
 		HeadSHA: "4cf807e67a6d",
 	}, *pullRequests[1])
 	assert.Equal(t, PullRequest{
 		Number:  103,
+		Title:   "feat(103)",
 		Branch:  "feature-103",
 		HeadSHA: "6344d9623e3b",
 	}, *pullRequests[2])
@@ -309,6 +319,7 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 				"values": [
 					{
 						"id": 101,
+						"title": "feat(101)",
 						"source": {
 							"branch": {
 								"name": "feature-101"
@@ -321,6 +332,7 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 					},
 					{
 						"id": 200,
+						"title": "feat(200)",
 						"source": {
 							"branch": {
 								"name": "feature-200"
@@ -342,6 +354,7 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 				"values": [
 					{
 						"id": 102,
+						"title": "feat(102)",
 						"source": {
 							"branch": {
 								"name": "feature-102"
@@ -374,11 +387,13 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 	assert.Len(t, pullRequests, 2)
 	assert.Equal(t, PullRequest{
 		Number:  101,
+		Title:   "feat(101)",
 		Branch:  "feature-101",
 		HeadSHA: "1a8dd249c04a",
 	}, *pullRequests[0])
 	assert.Equal(t, PullRequest{
 		Number:  102,
+		Title:   "feat(102)",
 		Branch:  "feature-102",
 		HeadSHA: "6344d9623e3b",
 	}, *pullRequests[1])
@@ -395,6 +410,7 @@ func TestListPullRequestBranchMatchCloud(t *testing.T) {
 	assert.Len(t, pullRequests, 1)
 	assert.Equal(t, PullRequest{
 		Number:  102,
+		Title:   "feat(102)",
 		Branch:  "feature-102",
 		HeadSHA: "6344d9623e3b",
 	}, *pullRequests[0])

--- a/applicationset/services/pull_request/bitbucket_server.go
+++ b/applicationset/services/pull_request/bitbucket_server.go
@@ -78,6 +78,7 @@ func (b *BitbucketService) List(_ context.Context) ([]*PullRequest, error) {
 		for _, pull := range pulls {
 			pullRequests = append(pullRequests, &PullRequest{
 				Number:       pull.ID,
+				Title:        pull.Title,
 				Branch:       pull.FromRef.DisplayID, // ID: refs/heads/main DisplayID: main
 				TargetBranch: pull.ToRef.DisplayID,
 				HeadSHA:      pull.FromRef.LatestCommit, // This is not defined in the official docs, but works in practice

--- a/applicationset/services/pull_request/bitbucket_server_test.go
+++ b/applicationset/services/pull_request/bitbucket_server_test.go
@@ -26,6 +26,7 @@ func defaultHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 					"values": [
 						{
 							"id": 101,
+							"title": "feat(ABC) : 123",
 							"toRef": {
 								"latestCommit": "5b766e3564a3453808f3cd3dd3f2e5fad8ef0e7a",
 								"displayId": "master",
@@ -61,6 +62,7 @@ func TestListPullRequestNoAuth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, pullRequests, 1)
 	assert.Equal(t, 101, pullRequests[0].Number)
+	assert.Equal(t, "feat(ABC) : 123", pullRequests[0].Title)
 	assert.Equal(t, "feature-ABC-123", pullRequests[0].Branch)
 	assert.Equal(t, "master", pullRequests[0].TargetBranch)
 	assert.Equal(t, "cb3cf2e4d1517c83e720d2585b9402dbef71f992", pullRequests[0].HeadSHA)
@@ -79,6 +81,7 @@ func TestListPullRequestPagination(t *testing.T) {
 					"values": [
 						{
 							"id": 101,
+							"title": "feat(101)",
 							"toRef": {
 								"latestCommit": "5b766e3564a3453808f3cd3dd3f2e5fad8ef0e7a",
 								"displayId": "master",
@@ -92,6 +95,7 @@ func TestListPullRequestPagination(t *testing.T) {
 						},
 						{
 							"id": 102,
+							"title": "feat(102)",
 							"toRef": {
 								"latestCommit": "5b766e3564a3453808f3cd3dd3f2e5fad8ef0e7a",
 								"displayId": "branch",
@@ -114,6 +118,7 @@ func TestListPullRequestPagination(t *testing.T) {
 				"values": [
 					{
 						"id": 200,
+						"title": "feat(200)",
 						"toRef": {
 							"latestCommit": "5b766e3564a3453808f3cd3dd3f2e5fad8ef0e7a",
 							"displayId": "master",
@@ -143,6 +148,7 @@ func TestListPullRequestPagination(t *testing.T) {
 	assert.Len(t, pullRequests, 3)
 	assert.Equal(t, PullRequest{
 		Number:       101,
+		Title:        "feat(101)",
 		Branch:       "feature-101",
 		TargetBranch: "master",
 		HeadSHA:      "ab3cf2e4d1517c83e720d2585b9402dbef71f992",
@@ -150,6 +156,7 @@ func TestListPullRequestPagination(t *testing.T) {
 	}, *pullRequests[0])
 	assert.Equal(t, PullRequest{
 		Number:       102,
+		Title:        "feat(102)",
 		Branch:       "feature-102",
 		TargetBranch: "branch",
 		HeadSHA:      "bb3cf2e4d1517c83e720d2585b9402dbef71f992",
@@ -157,6 +164,7 @@ func TestListPullRequestPagination(t *testing.T) {
 	}, *pullRequests[1])
 	assert.Equal(t, PullRequest{
 		Number:       200,
+		Title:        "feat(200)",
 		Branch:       "feature-200",
 		TargetBranch: "master",
 		HeadSHA:      "cb3cf2e4d1517c83e720d2585b9402dbef71f992",
@@ -195,6 +203,7 @@ func TestListPullRequestBearerAuth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, pullRequests, 1)
 	assert.Equal(t, 101, pullRequests[0].Number)
+	assert.Equal(t, "feat(ABC) : 123", pullRequests[0].Title)
 	assert.Equal(t, "feature-ABC-123", pullRequests[0].Branch)
 	assert.Equal(t, "cb3cf2e4d1517c83e720d2585b9402dbef71f992", pullRequests[0].HeadSHA)
 }
@@ -274,6 +283,7 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 					"values": [
 						{
 							"id": 101,
+							"title": "feat(101)",
 							"toRef": {
 								"latestCommit": "5b766e3564a3453808f3cd3dd3f2e5fad8ef0e7a",
 								"displayId": "master",
@@ -287,6 +297,7 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 						},
 						{
 							"id": 102,
+							"title": "feat(102)",
 							"toRef": {
 								"latestCommit": "5b766e3564a3453808f3cd3dd3f2e5fad8ef0e7a",
 								"displayId": "branch",
@@ -309,6 +320,7 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 				"values": [
 					{
 						"id": 200,
+						"title": "feat(200)",
 						"toRef": {
 							"latestCommit": "5b766e3564a3453808f3cd3dd3f2e5fad8ef0e7a",
 							"displayId": "master",
@@ -343,6 +355,7 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 	assert.Len(t, pullRequests, 2)
 	assert.Equal(t, PullRequest{
 		Number:       101,
+		Title:        "feat(101)",
 		Branch:       "feature-101",
 		TargetBranch: "master",
 		HeadSHA:      "ab3cf2e4d1517c83e720d2585b9402dbef71f992",
@@ -350,6 +363,7 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 	}, *pullRequests[0])
 	assert.Equal(t, PullRequest{
 		Number:       102,
+		Title:        "feat(102)",
 		Branch:       "feature-102",
 		TargetBranch: "branch",
 		HeadSHA:      "bb3cf2e4d1517c83e720d2585b9402dbef71f992",
@@ -368,6 +382,7 @@ func TestListPullRequestBranchMatch(t *testing.T) {
 	assert.Len(t, pullRequests, 1)
 	assert.Equal(t, PullRequest{
 		Number:       102,
+		Title:        "feat(102)",
 		Branch:       "feature-102",
 		TargetBranch: "branch",
 		HeadSHA:      "bb3cf2e4d1517c83e720d2585b9402dbef71f992",

--- a/applicationset/services/pull_request/gitea.go
+++ b/applicationset/services/pull_request/gitea.go
@@ -57,6 +57,7 @@ func (g *GiteaService) List(ctx context.Context) ([]*PullRequest, error) {
 	for _, pr := range prs {
 		list = append(list, &PullRequest{
 			Number:       int(pr.Index),
+			Title:        pr.Title,
 			Branch:       pr.Head.Ref,
 			TargetBranch: pr.Base.Ref,
 			HeadSHA:      pr.Head.Sha,

--- a/applicationset/services/pull_request/gitea_test.go
+++ b/applicationset/services/pull_request/gitea_test.go
@@ -256,6 +256,7 @@ func TestGiteaList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, prs, 1)
 	assert.Equal(t, 1, prs[0].Number)
+	assert.Equal(t, "add an empty file", prs[0].Title)
 	assert.Equal(t, "test", prs[0].Branch)
 	assert.Equal(t, "main", prs[0].TargetBranch)
 	assert.Equal(t, "7bbaf62d92ddfafd9cc8b340c619abaec32bc09f", prs[0].HeadSHA)

--- a/applicationset/services/pull_request/github.go
+++ b/applicationset/services/pull_request/github.go
@@ -66,6 +66,7 @@ func (g *GithubService) List(ctx context.Context) ([]*PullRequest, error) {
 			}
 			pullRequests = append(pullRequests, &PullRequest{
 				Number:       *pull.Number,
+				Title:        *pull.Title,
 				Branch:       *pull.Head.Ref,
 				TargetBranch: *pull.Base.Ref,
 				HeadSHA:      *pull.Head.SHA,

--- a/applicationset/services/pull_request/gitlab.go
+++ b/applicationset/services/pull_request/gitlab.go
@@ -81,6 +81,7 @@ func (g *GitLabService) List(ctx context.Context) ([]*PullRequest, error) {
 		for _, mr := range mrs {
 			pullRequests = append(pullRequests, &PullRequest{
 				Number:       mr.IID,
+				Title:        mr.Title,
 				Branch:       mr.SourceBranch,
 				TargetBranch: mr.TargetBranch,
 				HeadSHA:      mr.SHA,

--- a/applicationset/services/pull_request/gitlab_test.go
+++ b/applicationset/services/pull_request/gitlab_test.go
@@ -80,6 +80,7 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, prs, 1)
 	assert.Equal(t, 15442, prs[0].Number)
+	assert.Equal(t, "Draft: Use structured logging for DB load balancer", prs[0].Title)
 	assert.Equal(t, "use-structured-logging-for-db-load-balancer", prs[0].Branch)
 	assert.Equal(t, "master", prs[0].TargetBranch)
 	assert.Equal(t, "2fc4e8b972ff3208ec63b6143e34ad67ff343ad7", prs[0].HeadSHA)

--- a/applicationset/services/pull_request/interface.go
+++ b/applicationset/services/pull_request/interface.go
@@ -8,6 +8,8 @@ import (
 type PullRequest struct {
 	// Number is a number that will be the ID of the pull request.
 	Number int
+	// Title of the pull request.
+	Title string
 	// Branch is the name of the branch from which the pull request originated.
 	Branch string
 	// TargetBranch is the name of the target branch of the pull request.

--- a/applicationset/services/pull_request/utils_test.go
+++ b/applicationset/services/pull_request/utils_test.go
@@ -20,6 +20,7 @@ func TestFilterBranchMatchBadRegexp(t *testing.T) {
 		[]*PullRequest{
 			{
 				Number:       1,
+				Title:        "PR branch1",
 				Branch:       "branch1",
 				TargetBranch: "master",
 				HeadSHA:      "089d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -42,24 +43,28 @@ func TestFilterBranchMatch(t *testing.T) {
 		[]*PullRequest{
 			{
 				Number:       1,
+				Title:        "PR one",
 				Branch:       "one",
 				TargetBranch: "master",
 				HeadSHA:      "189d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       2,
+				Title:        "PR two",
 				Branch:       "two",
 				TargetBranch: "master",
 				HeadSHA:      "289d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       3,
+				Title:        "PR three",
 				Branch:       "three",
 				TargetBranch: "master",
 				HeadSHA:      "389d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       4,
+				Title:        "PR four",
 				Branch:       "four",
 				TargetBranch: "master",
 				HeadSHA:      "489d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -84,24 +89,28 @@ func TestFilterTargetBranchMatch(t *testing.T) {
 		[]*PullRequest{
 			{
 				Number:       1,
+				Title:        "PR one",
 				Branch:       "one",
 				TargetBranch: "master",
 				HeadSHA:      "189d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       2,
+				Title:        "PR two",
 				Branch:       "two",
 				TargetBranch: "branch1",
 				HeadSHA:      "289d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       3,
+				Title:        "PR three",
 				Branch:       "three",
 				TargetBranch: "branch2",
 				HeadSHA:      "389d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       4,
+				Title:        "PR four",
 				Branch:       "four",
 				TargetBranch: "branch3",
 				HeadSHA:      "489d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -126,24 +135,28 @@ func TestMultiFilterOr(t *testing.T) {
 		[]*PullRequest{
 			{
 				Number:       1,
+				Title:        "PR one",
 				Branch:       "one",
 				TargetBranch: "master",
 				HeadSHA:      "189d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       2,
+				Title:        "PR two",
 				Branch:       "two",
 				TargetBranch: "master",
 				HeadSHA:      "289d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       3,
+				Title:        "PR three",
 				Branch:       "three",
 				TargetBranch: "master",
 				HeadSHA:      "389d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       4,
+				Title:        "PR four",
 				Branch:       "four",
 				TargetBranch: "master",
 				HeadSHA:      "489d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -173,24 +186,28 @@ func TestMultiFilterOrWithTargetBranchFilter(t *testing.T) {
 		[]*PullRequest{
 			{
 				Number:       1,
+				Title:        "PR one",
 				Branch:       "one",
 				TargetBranch: "master",
 				HeadSHA:      "189d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       2,
+				Title:        "PR two",
 				Branch:       "two",
 				TargetBranch: "branch1",
 				HeadSHA:      "289d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       3,
+				Title:        "PR three",
 				Branch:       "three",
 				TargetBranch: "branch2",
 				HeadSHA:      "389d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       4,
+				Title:        "PR four",
 				Branch:       "four",
 				TargetBranch: "branch3",
 				HeadSHA:      "489d92cbf9ff857a39e6feccd32798ca700fb958",
@@ -221,12 +238,14 @@ func TestNoFilters(t *testing.T) {
 		[]*PullRequest{
 			{
 				Number:       1,
+				Title:        "PR one",
 				Branch:       "one",
 				TargetBranch: "master",
 				HeadSHA:      "189d92cbf9ff857a39e6feccd32798ca700fb958",
 			},
 			{
 				Number:       2,
+				Title:        "PR two",
 				Branch:       "two",
 				TargetBranch: "master",
 				HeadSHA:      "289d92cbf9ff857a39e6feccd32798ca700fb958",

--- a/docs/operator-manual/applicationset/Generators-Pull-Request.md
+++ b/docs/operator-manual/applicationset/Generators-Pull-Request.md
@@ -404,6 +404,7 @@ spec:
 ```
 
 * `number`: The ID number of the pull request.
+* `title`: The title of the pull request.
 * `branch`: The name of the branch of the pull request head.
 * `branch_slug`: The branch name will be cleaned to be conform to the DNS label standard as defined in [RFC 1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names), and truncated to 50 characters to give room to append/suffix-ing it with 13 more characters.
 * `target_branch`: The name of the target branch of the pull request.

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -2666,6 +2666,7 @@ func githubPullMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request
 			_, err := io.WriteString(w, `[
   {
     "number": 1,
+    "title": "title1",
     "labels": [
       {
         "name": "preview"


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Closes #16447 

### Change
Add a new key `title` for all SCMaaS providers on generator `pullRequest`.

### Why
Adding the `title` allow to filter PRs by title.
Which is a must for SCMaaS like `bitbucket` that do not support labels.
(`branch` filtering is not an alternative to labels because branch names are "immutable")

Example (see `crenshaw-dev`'s comment https://github.com/argoproj/argo-cd/issues/16447#issuecomment-1836350117 ):
```yaml
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: preview
  namespace: argocd
spec:
  goTemplate: true
  goTemplateOptions: ["missingkey=error"]
  generators:
  - matrix:
      generators:
      - pullRequest:
            bitbucketServer:
              project: project-name
              repo: repo-name
              api: https://bitbucket.example.com
              basicAuth:
                // ...
       - list:
            elements:
            - titleMatches: '{{ regexMatch ".*[PREVIEW].*" .title }}'
    selector:
      matchLabels:
       titleMatches: "true"
template:
  // ...
```

------

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.


<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
