### PR TITLE
docs(cli): remove docs for non-existing `argocd admin` commands

### DIFF
--- a/cmd/argocd/commands/admin/admin.go
+++ b/cmd/argocd/commands/admin/admin.go
@@ -48,83 +48,8 @@ func NewAdminCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			c.HelpFunc()(c, args)
 		},
-		Example: `# List all clusters
-$ argocd admin cluster list
-
-# Add a new cluster
-$ argocd admin cluster add my-cluster --name my-cluster --in-cluster-context
-
-# Remove a cluster
-argocd admin cluster remove my-cluster
-
-# List all projects
-$ argocd admin project list
-
-# Create a new project
-$argocd admin project create my-project --src-namespace my-source-namespace --dest-namespace my-dest-namespace
-
-# Update a project
-$ argocd admin project update my-project --src-namespace my-updated-source-namespace --dest-namespace my-updated-dest-namespace
-
-# Delete a project
-$ argocd admin project delete my-project
-
-# List all settings
-$ argocd admin settings list
-
-# Get the current settings
-$ argocd admin settings get
-
-# Update settings
-$ argocd admin settings update --repository.resync --value 15
-
-# List all applications
-$ argocd admin app list
-
-# Get application details
-$ argocd admin app get my-app
-
-# Sync an application
-$ argocd admin app sync my-app
-
-# Pause an application
-$ argocd admin app pause my-app
-
-# Resume an application
-$ argocd admin app resume my-app
-
-# List all repositories
-$ argocd admin repo list
-
-# Add a repository
-$ argocd admin repo add https://github.com/argoproj/my-repo.git
-
-# Remove a repository
-$ argocd admin repo remove https://github.com/argoproj/my-repo.git
-
-# Import an application from a YAML file
-$ argocd admin app import -f my-app.yaml
-
-# Export an application to a YAML file
-$ argocd admin app export my-app -o my-exported-app.yaml
-
-# Access the Argo CD web UI
+		Example: `# Access the Argo CD web UI
 $ argocd admin dashboard
-
-# List notifications
-$ argocd admin notification list
-
-# Get notification details
-$ argocd admin notification get my-notification
-
-# Create a new notification
-$ argocd admin notification create my-notification -f notification-config.yaml
-
-# Update a notification
-$ argocd admin notification update my-notification -f updated-notification-config.yaml
-
-# Delete a notification
-$ argocd admin notification delete my-notification
 
 # Reset the initial admin password
 $ argocd admin initial-password reset

--- a/docs/user-guide/commands/argocd_admin.md
+++ b/docs/user-guide/commands/argocd_admin.md
@@ -11,83 +11,8 @@ argocd admin [flags]
 ### Examples
 
 ```
-# List all clusters
-$ argocd admin cluster list
-
-# Add a new cluster
-$ argocd admin cluster add my-cluster --name my-cluster --in-cluster-context
-
-# Remove a cluster
-argocd admin cluster remove my-cluster
-
-# List all projects
-$ argocd admin project list
-
-# Create a new project
-$argocd admin project create my-project --src-namespace my-source-namespace --dest-namespace my-dest-namespace
-
-# Update a project
-$ argocd admin project update my-project --src-namespace my-updated-source-namespace --dest-namespace my-updated-dest-namespace
-
-# Delete a project
-$ argocd admin project delete my-project
-
-# List all settings
-$ argocd admin settings list
-
-# Get the current settings
-$ argocd admin settings get
-
-# Update settings
-$ argocd admin settings update --repository.resync --value 15
-
-# List all applications
-$ argocd admin app list
-
-# Get application details
-$ argocd admin app get my-app
-
-# Sync an application
-$ argocd admin app sync my-app
-
-# Pause an application
-$ argocd admin app pause my-app
-
-# Resume an application
-$ argocd admin app resume my-app
-
-# List all repositories
-$ argocd admin repo list
-
-# Add a repository
-$ argocd admin repo add https://github.com/argoproj/my-repo.git
-
-# Remove a repository
-$ argocd admin repo remove https://github.com/argoproj/my-repo.git
-
-# Import an application from a YAML file
-$ argocd admin app import -f my-app.yaml
-
-# Export an application to a YAML file
-$ argocd admin app export my-app -o my-exported-app.yaml
-
 # Access the Argo CD web UI
 $ argocd admin dashboard
-
-# List notifications
-$ argocd admin notification list
-
-# Get notification details
-$ argocd admin notification get my-notification
-
-# Create a new notification
-$ argocd admin notification create my-notification -f notification-config.yaml
-
-# Update a notification
-$ argocd admin notification update my-notification -f updated-notification-config.yaml
-
-# Delete a notification
-$ argocd admin notification delete my-notification
 
 # Reset the initial admin password
 $ argocd admin initial-password reset


### PR DESCRIPTION
Looks like someone ChatGPT'ed a bunch of fake CLI docs for internet points. Removing the ones that don't actually exist.