### PR TITLE
fix: BanzaiCloud KafkaCluster healthcheck to return Progressing during rolling update

### DIFF
--- a/resource_customizations/kafka.banzaicloud.io/KafkaCluster/health.lua
+++ b/resource_customizations/kafka.banzaicloud.io/KafkaCluster/health.lua
@@ -1,5 +1,10 @@
 local health_status = {}
 if obj.status ~= nil then
+  if obj.status.state == "ClusterRollingUpgrading" then
+    health_status.message = "Kafka Cluster is Rolling Upgrading."
+    health_status.status = "Progressing"
+    return health_status
+  end
   if obj.status.brokersState ~= nil then
     local numberBrokers = 0
     local healthyBrokers = 0
@@ -20,11 +25,6 @@ if obj.status ~= nil then
       if obj.status.cruiseControlTopicStatus == "CruiseControlTopicNotReady" or obj.status.cruiseControlTopicStatus == nil then
         if obj.status.state == "ClusterReconciling" then
           health_status.message = "Kafka Cluster is Reconciling."
-          health_status.status = "Progressing"
-          return health_status
-        end
-        if obj.status.state == "ClusterRollingUpgrading" then
-          health_status.message = "Kafka Cluster is Rolling Upgrading."
           health_status.status = "Progressing"
           return health_status
         end

--- a/resource_customizations/kafka.banzaicloud.io/KafkaCluster/health_test.yaml
+++ b/resource_customizations/kafka.banzaicloud.io/KafkaCluster/health_test.yaml
@@ -8,6 +8,10 @@ tests:
     message: "Waiting for KafkaCluster"
   inputPath: testdata/updating.yaml
 - healthStatus:
+    status: Progressing
+    message: "Kafka Cluster is Rolling Upgrading."
+  inputPath: testdata/rollingUpgrade.yaml
+- healthStatus:
     status: Degraded
     message: "Broker Config is out of Sync or CruiseControlState is not Ready"
   inputPath: testdata/degraded.yaml

--- a/resource_customizations/kafka.banzaicloud.io/KafkaCluster/testdata/rollingUpgrade.yaml
+++ b/resource_customizations/kafka.banzaicloud.io/KafkaCluster/testdata/rollingUpgrade.yaml
@@ -1,0 +1,48 @@
+apiVersion: kafka.banzaicloud.io/v1beta1
+kind: KafkaCluster
+metadata:
+  finalizers:
+  - finalizer.kafkaclusters.kafka.banzaicloud.io
+  - topics.kafkaclusters.kafka.banzaicloud.io
+  - users.kafkaclusters.kafka.banzaicloud.io
+  generation: 4
+  labels:
+    argocd.argoproj.io/instance: kafka-cluster
+    controller-tools.k8s.io: "1.0"
+    name: kafkacluster
+    namespace: kafka
+  name: kafkacluster
+  namespace: kafka
+  resourceVersion: "31935335"
+  selfLink: /apis/kafka.banzaicloud.io/v1beta1/namespaces/2269-kafka/kafkaclusters/kafkacluster
+  uid: c6affef0-651d-44c7-8bff-638961517c8d
+spec: {}
+status:
+  alertCount: 0
+  brokersState:
+    "0":
+      configurationState: ConfigInSync
+      gracefulActionState:
+        cruiseControlState: GracefulUpscaleSucceeded
+        errorMessage: CruiseControlTopicReady
+      rackAwarenessState: |
+        broker.rack=us-east-1,us-east-1c
+    "1":
+      configurationState: ConfigInSync
+      gracefulActionState:
+        cruiseControlState: GracefulUpscaleSucceeded
+        errorMessage: CruiseControlTopicReady
+      rackAwarenessState: |
+        broker.rack=us-east-1,us-east-1b
+    "2":
+      configurationState: ConfigOutOfSync
+      gracefulActionState:
+        cruiseControlState: GracefulUpscaleSucceeded
+        errorMessage: CruiseControlTopicReady
+      rackAwarenessState: |
+        broker.rack=us-east-1,us-east-1a
+  cruiseControlTopicStatus: CruiseControlTopicReady
+  rollingUpgradeStatus:
+    errorCount: 0
+    lastSuccess: ""
+  state: ClusterRollingUpgrading


### PR DESCRIPTION
Updates the Lua HealthCheck for kafka.banzaicloud.io/KafkaCluster. Previously, when syncing a KafkaCluster, it would go into "Degraded" state when the cluster is performing a rolling upgrade. This update sets the status to "Progressing" when the KafkaCluster state is "ClusterRollingUpgrading", regardless of the brokers' status (ConfigInSync/ConfigOutOfSync)

Fixes [#17993]

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
