### PR TITLE
docs: add soft documentation for `ignoreMissingValueFiles`

### DIFF
--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -72,6 +72,22 @@ source:
     - values-production.yaml
 ```
 
+If Helm is passed a non-existing value file during template expansion, it will error out. Missing
+values files can be ignored (meaning, not passed to Helm) using the `--ignore-missing-value-files`. This can be
+particularly helpful to implement a [default/override
+pattern](https://github.com/argoproj/argo-cd/issues/7767#issue-1060611415) with [Application
+Sets](./application-set.md).
+
+In the declarative syntax:
+```yaml
+source:
+  helm:
+    valueFiles:
+    - values-common.yaml
+    - values-optional-override.yaml
+    ignoreMissingValueFiles: true
+```
+
 ## Values
 
 Argo CD supports the equivalent of a values file directly in the Application manifest using the `source.helm.valuesObject` key.


### PR DESCRIPTION
The Helm source has the ability to ignore missing values files since
99d1dcad0 (feat: added a new Helm option ignoreMissingValueFiles,
2022-01-03).
This is however not obvious from reading the user guide on Helm.

Document the parameters along with a reference to the use case which
motivated it.

This is a documentation followup of #8003


Should be cherry-picked into: #8003 is merged since v2.3.0 (git tag --contains 99d1dcad0), so:
- v2.3
- v2.4
- v2.5
- v2.6
- v2.7
- v2.8
- v2.9
- v2.10
- v2.11

But I guess some of them are out of support ^

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
