### PR TITLE
fix(appset): preserve post-delete finalizers (#17181)

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -720,6 +721,17 @@ func (r *ApplicationSetReconciler) createOrUpdateInCluster(ctx context.Context, 
 						generatedApp.Labels = map[string]string{}
 					}
 					generatedApp.Labels[key] = state
+				}
+			}
+
+			// Preserve post-delete finalizers:
+			//   https://github.com/argoproj/argo-cd/issues/17181
+			for _, finalizer := range found.ObjectMeta.Finalizers {
+				if strings.HasPrefix(finalizer, argov1alpha1.PostDeleteFinalizerName) {
+					if generatedApp.Finalizers == nil {
+						generatedApp.Finalizers = []string{}
+					}
+					generatedApp.Finalizers = append(generatedApp.Finalizers, finalizer)
 				}
 			}
 

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -1281,6 +1281,71 @@ func TestCreateOrUpdateInCluster(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			name: "Ensure that argocd post-delete finalizers are preserved from an existing app",
+			appSet: v1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: v1alpha1.ApplicationSetSpec{
+					Template: v1alpha1.ApplicationSetTemplate{
+						Spec: v1alpha1.ApplicationSpec{
+							Project: "project",
+						},
+					},
+				},
+			},
+			existingApps: []v1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       application.ApplicationKind,
+						APIVersion: "argoproj.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "app1",
+						Namespace:       "namespace",
+						ResourceVersion: "2",
+						Finalizers: []string{
+							v1alpha1.PostDeleteFinalizerName,
+							v1alpha1.PostDeleteFinalizerName + "/mystage",
+						},
+					},
+					Spec: v1alpha1.ApplicationSpec{
+						Project: "project",
+					},
+				},
+			},
+			desiredApps: []v1alpha1.Application{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app1",
+					},
+					Spec: v1alpha1.ApplicationSpec{
+						Project: "project",
+					},
+				},
+			},
+			expected: []v1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       application.ApplicationKind,
+						APIVersion: "argoproj.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "app1",
+						Namespace:       "namespace",
+						ResourceVersion: "2",
+						Finalizers: []string{
+							v1alpha1.PostDeleteFinalizerName,
+							v1alpha1.PostDeleteFinalizerName + "/mystage",
+						},
+					},
+					Spec: v1alpha1.ApplicationSpec{
+						Project: "project",
+					},
+				},
+			},
 		},
 	} {
 


### PR DESCRIPTION
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

Fixes #17181 

Fix suggested by @alexmt:
> Application update replaces finalizers with the list of finalizers generated by the template. However [post-delete-finalizer.argocd.argoproj.io](http://post-delete-finalizer.argocd.argoproj.io/) and [post-delete-finalizer.argocd.argoproj.io/cleanup](http://post-delete-finalizer.argocd.argoproj.io/cleanup) are added dynamically and should not be touched. So the fix is to add special handling in the update method to preserve the post delete finalizers.