### PR TITLE
docs: use compliant name in Generators-List.md

### DIFF
--- a/docs/operator-manual/applicationset/Generators-List.md
+++ b/docs/operator-manual/applicationset/Generators-List.md
@@ -61,7 +61,7 @@ The List generator can also dynamically generate its elements based on a yaml/js
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: elementsYaml
+  name: elements-yaml
   namespace: argocd
 spec:
   goTemplate: true


### PR DESCRIPTION
s/elementsYaml/elements-yaml/

Fixes issue:

```
The ApplicationSet "elementsYaml" is invalid: metadata.name: Invalid value: "elementsYaml": a lowercase
RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and
end with an alphanumeric character (e.g. 'example.com', regex used for validation is
'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```
