### PR TITLE
chore(ci): fix release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,7 +114,7 @@ changelog:
     exclude:
       - '^test:'
       - '^.*?Bump(\([[:word:]]+\))?.+$'
-      - '^.*?[Bot](\([[:word:]]+\))?.+$'
+      - '^.*?\[Bot\](\([[:word:]]+\))?.+$'
 
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
I've tested on my fork, and I believe this will fix the problem of release notes not being generated.