### PR TITLE
fix: oras-go client should fallback to docker config if no credentials specified

### DIFF
--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -361,7 +361,7 @@ func TestGetTagsFromURLEnvironmentAuthentication(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			client := NewClient(testCase.repoURL, Creds{
 				InsecureSkipVerify: true,
-			}, true, "")
+			}, true, "", "")
 
 			tags, err := client.GetTags("mychart", true)
 

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -326,14 +326,14 @@ func TestGetTagsFromURLEnvironmentAuthentication(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	serverURL, err := url.Parse(server.URL)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")
 	t.Setenv("DOCKER_CONFIG", tempDir)
 
 	config := fmt.Sprintf(`{"auths":{"%s":{"auth":"Zm9vOmJhcg=="}}}`, server.URL)
-	assert.NoError(t, os.WriteFile(configPath, []byte(config), 0666))
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0666))
 
 	testCases := []struct {
 		name    string
@@ -365,7 +365,7 @@ func TestGetTagsFromURLEnvironmentAuthentication(t *testing.T) {
 
 			tags, err := client.GetTags("mychart", true)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.ElementsMatch(t, tags.Tags, []string{
 				"2.8.0",
 				"2.8.0-prerelease",

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -333,7 +333,7 @@ func TestGetTagsFromURLEnvironmentAuthentication(t *testing.T) {
 	t.Setenv("DOCKER_CONFIG", tempDir)
 
 	config := fmt.Sprintf(`{"auths":{"%s":{"auth":"Zm9vOmJhcg=="}}}`, server.URL)
-	require.NoError(t, os.WriteFile(configPath, []byte(config), 0666))
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o666))
 
 	testCases := []struct {
 		name    string


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes https://github.com/argoproj/argo-cd/issues/20122

I'm using https://github.com/argoproj/argo-cd/issues/17279 to authenticate to Google Artifact Registry as a helm registry using workload identity. Unlike https://github.com/argoproj/argo-cd/issues/10218, the other solution does not require installing ESO. This works in general since `helm template` can get creds via the `$HOME/.docker/config.json`. However, if you need to use `targetRevision: *` with your application, this ends up using the oras-go client here which is only configured for static credentials.

This change adds a backwards compatible change where if both the username and password is not configured, it will use the oras-go credentials package to get the docker config from the environment and use that to get credentials.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
