### PR TITLE
Testing k3s 1.23 with argocd 2.10.9

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -406,7 +406,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s-version: [v1.29.1, v1.28.6, v1.27.10, v1.26.13, v1.25.16]
+        k3s-version: [v1.23.17]
     needs:
       - build-go
       - changes


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Run E2E tests on Kubernetes 1.23.17 through Github Action to verify that ArgoCD 2.10.9 can run properly on this Kubernetes version.

Please do not review or ship this PR. It is solely meant to kick off the E2E tests.

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
