### PR TITLE
fix: Argo CD app is out of sync right after sync

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1356,7 +1356,7 @@ func (ctrl *ApplicationController) processRequestedAppOperation(app *appv1.Appli
 		// sync/health information
 		if _, err := cache.MetaNamespaceKeyFunc(app); err == nil {
 			// force app refresh with using CompareWithLatest comparison type and trigger app reconciliation loop
-			ctrl.requestAppRefresh(app.QualifiedName(), CompareWithLatest.Pointer(), nil)
+			ctrl.requestAppRefresh(app.QualifiedName(), CompareWithLatestForceResolve.Pointer(), nil)
 		} else {
 			logCtx.Warnf("Fails to requeue application: %v", err)
 		}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -1718,6 +1718,36 @@ func TestProcessRequestedAppOperation_HasRetriesTerminated(t *testing.T) {
 	assert.Equal(t, string(synccommon.OperationFailed), phase)
 }
 
+func TestProcessRequestedAppOperation_Successful(t *testing.T) {
+	app := newFakeApp()
+	app.Spec.Project = "default"
+	app.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{},
+	}
+	ctrl := newFakeController(&fakeData{
+		apps: []runtime.Object{app, &defaultProj},
+		manifestResponses: []*apiclient.ManifestResponse{{
+			Manifests: []string{},
+		}},
+	}, nil)
+	fakeAppCs := ctrl.applicationClientset.(*appclientset.Clientset)
+	receivedPatch := map[string]interface{}{}
+	fakeAppCs.PrependReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		if patchAction, ok := action.(kubetesting.PatchAction); ok {
+			assert.NoError(t, json.Unmarshal(patchAction.GetPatch(), &receivedPatch))
+		}
+		return true, &v1alpha1.Application{}, nil
+	})
+
+	ctrl.processRequestedAppOperation(app)
+
+	phase, _, _ := unstructured.NestedString(receivedPatch, "status", "operationState", "phase")
+	assert.Equal(t, string(synccommon.OperationSucceeded), phase)
+	ok, level := ctrl.isRefreshRequested(ctrl.toAppKey(app.Name))
+	assert.True(t, ok)
+	assert.Equal(t, CompareWithLatestForceResolve, level)
+}
+
 func TestGetAppHosts(t *testing.T) {
 	app := newFakeApp()
 	data := &fakeData{


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/18153


PR ensures that controller requests reconciling application using most recent resolved revision after sync . Otherwise app might stay out of sync as described in https://github.com/argoproj/argo-cd/issues/18153