### PR TITLE
fix(ui): Fix excessive padding on system level extension pages (issue #17929)

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -236,10 +236,7 @@ export class App extends React.Component<
                                                     ) : (
                                                         <DataLoader load={() => services.viewPreferences.getPreferences()}>
                                                             {pref => (
-                                                                <Layout
-                                                                    onVersionClick={() => this.setState({showVersionPanel: true})}
-                                                                    navItems={this.navItems}
-                                                                    pref={pref}>
+                                                                <Layout onVersionClick={() => this.setState({showVersionPanel: true})} navItems={this.navItems} pref={pref}>
                                                                     <Banner>
                                                                         <route.component {...routeProps} />
                                                                     </Banner>

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -26,7 +26,7 @@ const base = bases.length > 0 ? bases[0].getAttribute('href') || '/' : '/';
 export const history = createBrowserHistory({basename: base});
 requests.setBaseHRef(base);
 
-type Routes = {[path: string]: {component: React.ComponentType<RouteComponentProps<any>>; noLayout?: boolean; extension?: boolean}};
+type Routes = {[path: string]: {component: React.ComponentType<RouteComponentProps<any>>; noLayout?: boolean}};
 
 const routes: Routes = {
     '/login': {component: login.component as any, noLayout: true},
@@ -182,8 +182,7 @@ export class App extends React.Component<
                 </>
             );
             extendedRoutes[extension.path] = {
-                component: component as React.ComponentType<React.ComponentProps<any>>,
-                extension: true
+                component: component as React.ComponentType<React.ComponentProps<any>>
             };
         }
 

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -240,8 +240,7 @@ export class App extends React.Component<
                                                                 <Layout
                                                                     onVersionClick={() => this.setState({showVersionPanel: true})}
                                                                     navItems={this.navItems}
-                                                                    pref={pref}
-                                                                    isExtension={route.extension}>
+                                                                    pref={pref}>
                                                                     <Banner>
                                                                         <route.component {...routeProps} />
                                                                     </Banner>

--- a/ui/src/app/shared/components/layout/layout.scss
+++ b/ui/src/app/shared/components/layout/layout.scss
@@ -40,14 +40,4 @@
     &__content {
         width: 100%;
     }
-
-    &--extension {
-        .cd-layout__content--sb-expanded {
-            padding-left: $sidebar-width;
-        }
-
-        .cd-layout__content--sb-collapsed {
-            padding-left: $collapsed-sidebar-width;
-        }
-    }
 }

--- a/ui/src/app/shared/components/layout/layout.tsx
+++ b/ui/src/app/shared/components/layout/layout.tsx
@@ -9,7 +9,6 @@ export interface LayoutProps {
     onVersionClick?: () => void;
     children?: React.ReactNode;
     pref: ViewPreferences;
-    isExtension?: boolean;
 }
 
 const getBGColor = (theme: string): string => (theme === 'light' ? '#dee6eb' : '#100f0f');

--- a/ui/src/app/shared/components/layout/layout.tsx
+++ b/ui/src/app/shared/components/layout/layout.tsx
@@ -23,7 +23,7 @@ export const Layout = (props: LayoutProps) => {
 
     return (
         <div className={props.pref.theme ? 'theme-' + props.pref.theme : 'theme-light'}>
-            <div className={`cd-layout ${props.isExtension ? 'cd-layout--extension' : ''}`}>
+            <div className={'cd-layout'}>
                 <Sidebar onVersionClick={props.onVersionClick} navItems={props.navItems} pref={props.pref} />
                 <div className={`cd-layout__content ${props.pref.hideSidebar ? 'cd-layout__content--sb-collapsed' : 'cd-layout__content--sb-expanded'} custom-styles`}>
                     {props.children}


### PR DESCRIPTION
Fixes #17929

This PR fixes a bug where system level extension pages have excessive left padding

## Approach

### Investigation

- Per the original PR https://github.com/argoproj/argo-cd/pull/10758 that added system level extensions, we know the current amount of left padding has deviated from the intended design. Originally, left padding was specified by the CSS class `.cd-layout--extension`
- A subsequent PR https://github.com/argoproj/argo-cd/pull/13451 wraps system level extensions in the `<Page />` component. The `<Page />` component applies the `.sb-page-wrapper` CSS class, which applies the same left-padding amounts as `.cd-layout--extension`
- Therefore, the current amount of left padding is double the desired amount

### Solution

- Removed the CSS class `.cd-layout--extension`
- Removed the `isExtension` prop of `<Layout />` as it is no longer used anymore
- Removed the `extension` property of type `Routes` in `<App />` as it is also no longer used anymore

## Results

### Before

#### Sidebar open

<img width="1724" alt="image" src="https://github.com/argoproj/argo-cd/assets/155603967/c6c00465-35f9-4b8a-a978-ec043ede0e72">

#### Sidebar closed

<img width="1725" alt="image" src="https://github.com/argoproj/argo-cd/assets/155603967/da4d7d75-c7fc-402c-b5b5-bdf0d133618a">

### After

#### Sidebar open

<img width="1726" alt="image" src="https://github.com/argoproj/argo-cd/assets/155603967/7f3e656a-32d2-41d5-a571-71cf5cd54d32">

#### Sidebar closed

<img width="1725" alt="image" src="https://github.com/argoproj/argo-cd/assets/155603967/f2f1c84d-2940-41c6-8aea-b7813fe84bf1">

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
