### PR TITLE
chore: fix unit-tests

### DIFF
--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -433,17 +433,17 @@ func TestLsFiles(t *testing.T) {
 	expectedResult := []string{"a.yaml", "link.yaml", "subdir/b.yaml"}
 	lsResult, err := client.LsFiles("*.yaml", false)
 	assert.NoError(t, err)
-	assert.Equal(t, lsResult, expectedResult)
+	assert.Equal(t, expectedResult, lsResult)
 
 	// New and safer globbing, do not return symlinks resolving outside of the repo
 	expectedResult = []string{"a.yaml"}
 	lsResult, err = client.LsFiles("*.yaml", true)
 	assert.NoError(t, err)
-	assert.Equal(t, lsResult, expectedResult)
+	assert.Equal(t, expectedResult, lsResult)
 
 	// New globbing, do not return files outside of the repo
 	var nilResult []string
 	lsResult, err = client.LsFiles(filepath.Join(tmpDir2, "*.yaml"), true)
 	assert.NoError(t, err)
-	assert.Equal(t, lsResult, nilResult)
+	assert.Equal(t, nilResult, lsResult)
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
