### PR TITLE
fix(ui): Fix jumpy "Source" panel when typing (issue #15961)

### DIFF
--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -13,6 +13,7 @@ import {RevisionFormField} from '../revision-form-field/revision-form-field';
 import {SetFinalizerOnApplication} from './set-finalizer-on-application';
 import './application-create-panel.scss';
 import {getAppDefaultSource} from '../utils';
+import { debounce } from 'lodash-es';
 
 const jsonMergePatch = require('json-merge-patch');
 
@@ -110,6 +111,7 @@ export const ApplicationCreatePanel = (props: {
     const [destFormat, setDestFormat] = React.useState('URL');
     const [retry, setRetry] = React.useState(false);
     const app = deepMerge(DEFAULT_APP, props.app || {});
+    const debouncedOnAppChanged = debounce(props.onAppChanged, 500);
 
     React.useEffect(() => {
         if (app?.spec?.destination?.name && app.spec.destination.name !== '') {
@@ -181,7 +183,7 @@ export const ApplicationCreatePanel = (props: {
                                             'Cluster name is required'
                                     })}
                                     defaultValues={app}
-                                    formDidUpdate={state => props.onAppChanged(state.values as any)}
+                                    formDidUpdate={state => debouncedOnAppChanged(state.values as any)}
                                     onSubmit={props.createApp}
                                     getApi={props.getFormApi}>
                                     {api => {
@@ -513,7 +515,7 @@ export const ApplicationCreatePanel = (props: {
                                         return (
                                             <form onSubmit={api.submitForm} role='form' className='width-control'>
                                                 {generalPanel()}
-
+                                                
                                                 {sourcePanel()}
 
                                                 {destinationPanel()}

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -111,7 +111,7 @@ export const ApplicationCreatePanel = (props: {
     const [destFormat, setDestFormat] = React.useState('URL');
     const [retry, setRetry] = React.useState(false);
     const app = deepMerge(DEFAULT_APP, props.app || {});
-    const debouncedOnAppChanged = debounce(props.onAppChanged, 500);
+    const debouncedOnAppChanged = debounce(props.onAppChanged, 800);
 
     React.useEffect(() => {
         if (app?.spec?.destination?.name && app.spec.destination.name !== '') {

--- a/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
+++ b/ui/src/app/applications/components/application-create-panel/application-create-panel.tsx
@@ -13,7 +13,7 @@ import {RevisionFormField} from '../revision-form-field/revision-form-field';
 import {SetFinalizerOnApplication} from './set-finalizer-on-application';
 import './application-create-panel.scss';
 import {getAppDefaultSource} from '../utils';
-import { debounce } from 'lodash-es';
+import {debounce} from 'lodash-es';
 
 const jsonMergePatch = require('json-merge-patch');
 
@@ -515,7 +515,7 @@ export const ApplicationCreatePanel = (props: {
                                         return (
                                             <form onSubmit={api.submitForm} role='form' className='width-control'>
                                                 {generalPanel()}
-                                                
+
                                                 {sourcePanel()}
 
                                                 {destinationPanel()}


### PR DESCRIPTION
Fixes #15961

This PR fixes an issue where each keystroke in the repo URL field of the "Source" panel for creating a new application triggers a call to the backend and component rerender, leading the component to feel "jumpy"

## Approach

### Investigation

- The `<ApplicationCreatePanel />` parent component has a `<Form />` child component with a prop `formDidUpdate` 
- The value of this prop is a function that updates the desired `app` data via calling `props.onAppChanged()`
- So, each time a keystroke is entered into a form field, `app` is updated
- As `app` is passed as a prop into the child component that renders the "Revision"/"Chart" field of the "Source" panel, every keystroke will cause this field to re-render

### Solution

- On the issue https://github.com/argoproj/argo-cd/issues/15961, the suggested approach is to update the UI logic to validate the git repo URL format to reduce jumpiness. The difficulty with this approach is that git supports [many URL formats](https://stackoverflow.com/questions/31801271/what-are-the-supported-git-url-formats) (e.g., `ssh`, `http`, `https`, `git`), and we would need to maintain this validation logic
- The alternative approach implemented in this PR is to debounce `props.onAppChanged()`
- In my testing, a debounce wait time of 800ms feels like the right balance between maintaining snappiness and preventing unnecessary re-renders

## Results

### Before

https://github.com/argoproj/argo-cd/assets/155603967/ccc09a76-38b8-48b1-8a90-329611886db4

#### Repo URL field

### After

#### Repo URL field

https://github.com/argoproj/argo-cd/assets/155603967/b51d5e33-2451-4069-ad1c-bb25889e191f

#### Creating a new app

https://github.com/argoproj/argo-cd/assets/155603967/a9d2ad32-1dd5-4866-bdaf-64dbec03a501

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
