### PR TITLE
docs: Add proper spacing to microsoft ad docs

### DIFF
--- a/docs/operator-manual/user-management/microsoft.md
+++ b/docs/operator-manual/user-management/microsoft.md
@@ -160,7 +160,7 @@
                p, role:org-admin, repositories, delete, *, allow
                g, "84ce98d1-e359-4f3b-85af-985b458de3c6", role:org-admin
 
-4. Mapping role from jwt token to argo
+4. Mapping role from jwt token to argo.  
    If you want to map the roles from the jwt token to match the default roles (readonly and admin) then you must change the scope variable in the rbac-configmap.
 
             policy.default: role:readonly


### PR DESCRIPTION
How it looks right now:  https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/microsoft/#configure-argo-to-use-the-new-azure-ad-app-registration

![image](https://github.com/argoproj/argo-cd/assets/11192971/7485b5fe-3535-4504-910b-e1d94e0f561e)

This PR will add proper spacing as intended. 