### PR TITLE
docs(webhook): include installation instructions on Triggers and Templates page

### DIFF
--- a/docs/operator-manual/notifications/catalog.md
+++ b/docs/operator-manual/notifications/catalog.md
@@ -1,4 +1,9 @@
 # Triggers and Templates Catalog
+## Getting Started
+* Install Triggers and Templates from the catalog
+  ```bash
+  kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/notifications_catalog/install.yaml
+  ```
 ## Triggers
 |          NAME          |                          DESCRIPTION                          |                      TEMPLATE                       |
 |------------------------|---------------------------------------------------------------|-----------------------------------------------------|

--- a/hack/gen-catalog/main.go
+++ b/hack/gen-catalog/main.go
@@ -118,6 +118,13 @@ func newDocsCommand() *cobra.Command {
 
 func generateBuiltInTriggersDocs(out io.Writer, triggers map[string][]triggers.Condition, templates map[string]services.Notification) {
 	_, _ = fmt.Fprintln(out, "# Triggers and Templates Catalog")
+
+	_, _ = fmt.Fprintln(out, "## Getting Started")
+	_, _ = fmt.Fprintln(out, "* Install Triggers and Templates from the catalog")
+	_, _ = fmt.Fprintln(out, "  ```bash")
+	_, _ = fmt.Fprintln(out, "  kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/notifications_catalog/install.yaml")
+	_, _ = fmt.Fprintln(out, "  ```")
+
 	_, _ = fmt.Fprintln(out, "## Triggers")
 
 	w := tablewriter.NewWriter(out)


### PR DESCRIPTION
closes https://github.com/argoproj-labs/argocd-notifications/issues/324

The intent of this commit is to clarify that the catalog must be installed and provide a breadcrumb to the configuration source.