### PR TITLE
fix: revert registry change (#18327)

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -1091,7 +1091,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -1115,7 +1115,7 @@ spec:
           mountPath: /data
       containers:
       - name: haproxy
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         securityContext: 
           allowPrivilegeEscalation: false
@@ -1219,7 +1219,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
       - name: config-init
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -1258,7 +1258,7 @@ spec:
 
       containers:
       - name: redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         command:
           - redis-server
@@ -1321,7 +1321,7 @@ spec:
               - /bin/sh
               - /readonly-config/trigger-failover-if-master.sh
       - name: sentinel
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         command:
           - redis-sentinel
@@ -1378,7 +1378,7 @@ spec:
           {}
 
       - name: split-brain-fix
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         command:
           - sh

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -14,6 +14,7 @@ redis-ha:
     IPv6:
       enabled: false
     image:
+      repository: haproxy
       tag: 2.6.14-alpine
     containerSecurityContext: null
     timeout:
@@ -23,6 +24,7 @@ redis-ha:
     metrics:
       enabled: true
   image:
+    repository: redis
     tag: 7.0.14-alpine
   containerSecurityContext: null
   sentinel:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -22850,7 +22850,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -22905,7 +22905,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:
@@ -23916,7 +23916,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -23976,7 +23976,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -24034,7 +24034,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
@@ -24069,7 +24069,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1971,7 +1971,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -2026,7 +2026,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: haproxy:2.6.14-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:
@@ -3037,7 +3037,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3097,7 +3097,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -3155,7 +3155,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         name: split-brain-fix
         resources: {}
@@ -3190,7 +3190,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/redis:7.0.14-alpine
+        image: redis:7.0.14-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:


### PR DESCRIPTION
Revert redis-ha chart upstream change which changed registries for a couple images: https://github.com/DandyDeveloper/charts/pull/214/files

I'll leave the registry change in place for 2.12 and just document it.

Fixes https://github.com/argoproj/argo-cd/issues/18327