### PR TITLE
chore(ci): update tested k8s versions

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -406,7 +406,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s-version: [v1.29.1, v1.28.6, v1.27.10, v1.26.13, v1.25.16]
+        k3s-version: [v1.30.1, v1.29.5, v1.28.10, v1.27.14]
     needs:
       - build-go
       - changes

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -406,7 +406,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s-version: [v1.30.1, v1.29.5, v1.28.10, v1.27.14]
+        k3s-version: [v1.30.0, v1.29.4, v1.28.9, v1.27.13]
     needs:
       - build-go
       - changes


### PR DESCRIPTION
Only test 4 versions, test only the latest versions.