### PR TITLE
docs: Update docs for azure workload identity cluster setup

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -929,7 +929,9 @@ If your AKS cluster utilizes the [Mutating Admission Webhook](https://azure.gith
 
 2. **Create Federated Identity Credential**: Generate an Azure federated identity credential for the `argocd-application-controller` and `argocd-server` service accounts. Refer to the [Federated Identity Credential](https://azure.github.io/azure-workload-identity/docs/topics/federated-identity-credential.html) documentation for detailed instructions.
 
-3. **Set the AZURE_CLIENT_ID**: Update the `AZURE_CLIENT_ID` in the cluster secret to match the client id of the newly created federated identity credential.
+3. **Add Annotations to Service Account** Add `"azure.workload.identity/client-id": "$CLIENT_ID"` and `"azure.workload.identity/tenant-id": "$TENANT_ID"` annotations to the `argocd-application-controller` and `argocd-server` service accounts using the details from the federated credential.
+
+4. **Set the AZURE_CLIENT_ID**: Update the `AZURE_CLIENT_ID` in the cluster secret to match the client id of the newly created federated identity credential.
 
 
 ```yaml


### PR DESCRIPTION
Adds a missing step to the docs for declarative setup of an AKS cluster using workload identity for adding annotations to the service accounts.