### PR TITLE
fix: remove Egress NetworkPolicy for argocd-redis and argocd-redis-ha-haproxy - 2.10

### DIFF
--- a/docs/operator-manual/upgrading/2.8-2.9.md
+++ b/docs/operator-manual/upgrading/2.8-2.9.md
@@ -3,3 +3,56 @@
 ## Upgraded Kustomize Version
 
 Note that bundled Kustomize version has been upgraded from 5.1.0 to 5.2.1.
+
+## Egress NetworkPolicy for `argocd-redis` and `argocd-redis-ha-haproxy`
+
+Starting with Argo CD 2.9.16, the NetworkPolicy for the `argocd-redis` and `argocd-redis-ha-haproxy` dropped Egress restrictions. This change was made
+to allow access to the Kubernetes API to create a secret to secure Redis access.
+
+To retain similar networking restrictions as before 2.9.16, you can add an Egress rule to allow access only to the
+Kubernetes API and access needed by Redis itself. The Egress rule for Kubernetes access will depend entirely on your
+Kubernetes setup. The access for Redis itself can be allowed by adding the following to the
+`argocd-redis-network-policy` NetworkPolicy:
+
+```diff
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: argocd-redis-network-policy
+spec:
+  policyTypes:
+  - Ingress
++  - Egress
++  egress:
++  - ports:
++    - port: 53
++      protocol: UDP
++    - port: 53
++      protocol: TCP
+```
+
+```diff
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: argocd-redis-ha-haproxy
+spec:
+  policyTypes:
+  - Ingress
++  - Egress
++  egress:
++  - ports:
++    - port: 6379
++      protocol: TCP
++    - port: 26379
++      protocol: TCP
++    to:
++    - podSelector:
++        matchLabels:
++          app.kubernetes.io/name: argocd-redis-ha
++  - ports:
++    - port: 53
++      protocol: UDP
++    - port: 53
++      protocol: TCP
+```

--- a/docs/operator-manual/upgrading/2.9-2.10.md
+++ b/docs/operator-manual/upgrading/2.9-2.10.md
@@ -14,3 +14,56 @@ before enabling `managedNamespaceMetadata` on an existing namespace.
 ## Upgraded Helm Version
 
 Note that bundled Helm version has been upgraded from 3.13.2 to 3.14.3.
+
+## Egress NetworkPolicy for `argocd-redis` and `argocd-redis-ha-haproxy`
+
+Starting with Argo CD 2.10.11, the NetworkPolicy for the `argocd-redis` and `argocd-redis-ha-haproxy` dropped Egress restrictions. This change was made
+to allow access to the Kubernetes API to create a secret to secure Redis access.
+
+To retain similar networking restrictions as before 2.10.11, you can add an Egress rule to allow access only to the
+Kubernetes API and access needed by Redis itself. The Egress rule for Kubernetes access will depend entirely on your
+Kubernetes setup. The access for Redis itself can be allowed by adding the following to the
+`argocd-redis-network-policy` NetworkPolicy:
+
+```diff
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: argocd-redis-network-policy
+spec:
+  policyTypes:
+  - Ingress
++  - Egress
++  egress:
++  - ports:
++    - port: 53
++      protocol: UDP
++    - port: 53
++      protocol: TCP
+```
+
+```diff
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: argocd-redis-ha-haproxy
+spec:
+  policyTypes:
+  - Ingress
++  - Egress
++  egress:
++  - ports:
++    - port: 6379
++      protocol: TCP
++    - port: 26379
++      protocol: TCP
++    to:
++    - podSelector:
++        matchLabels:
++          app.kubernetes.io/name: argocd-redis-ha
++  - ports:
++    - port: 53
++      protocol: UDP
++    - port: 53
++      protocol: TCP
+```

--- a/manifests/base/redis/argocd-redis-network-policy.yaml
+++ b/manifests/base/redis/argocd-redis-network-policy.yaml
@@ -8,7 +8,6 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
-  - Egress
   ingress:
   - from:
     - podSelector:
@@ -23,9 +22,3 @@ spec:
     ports:
     - protocol: TCP
       port: 6379
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -21819,12 +21819,6 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-network-policy
 spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
   ingress:
   - from:
     - podSelector:
@@ -21844,7 +21838,6 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
-  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
+++ b/manifests/ha/base/redis-ha/argocd-redis-ha-proxy-network-policy.yaml
@@ -8,7 +8,6 @@ spec:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
   policyTypes:
   - Ingress
-  - Egress
   ingress:
   - from:
     - podSelector:
@@ -25,18 +24,4 @@ spec:
       protocol: TCP
     - port: 26379
       protocol: TCP
-  egress:
-  - to:
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: argocd-redis-ha
-    ports:
-    - port: 6379
-      protocol: TCP
-    - port: 26379
-      protocol: TCP
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
+

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -24022,21 +24022,6 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-ha-proxy-network-policy
 spec:
-  egress:
-  - ports:
-    - port: 6379
-      protocol: TCP
-    - port: 26379
-      protocol: TCP
-    to:
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: argocd-redis-ha
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
   ingress:
   - from:
     - podSelector:
@@ -24058,7 +24043,6 @@ spec:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
   policyTypes:
   - Ingress
-  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -3307,21 +3307,6 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-ha-proxy-network-policy
 spec:
-  egress:
-  - ports:
-    - port: 6379
-      protocol: TCP
-    - port: 26379
-      protocol: TCP
-    to:
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: argocd-redis-ha
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
   ingress:
   - from:
     - podSelector:
@@ -3343,7 +3328,6 @@ spec:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
   policyTypes:
   - Ingress
-  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -22860,12 +22860,6 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-network-policy
 spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
   ingress:
   - from:
     - podSelector:
@@ -22885,7 +22879,6 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
-  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -2145,12 +2145,6 @@ kind: NetworkPolicy
 metadata:
   name: argocd-redis-network-policy
 spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
   ingress:
   - from:
     - podSelector:
@@ -2170,7 +2164,6 @@ spec:
       app.kubernetes.io/name: argocd-redis
   policyTypes:
   - Ingress
-  - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
Cherry-picked fix: remove Egress NetworkPolicy for argocd-redis and argocd-redis-ha-haproxy (https://github.com/argoproj/argo-cd/pull/18367)