### PR TITLE
ci(lint): create .golangci.yaml and bump golangci-lint version

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -109,8 +109,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
-          version: v1.54.0
-          args: --enable gofmt --timeout 10m --exclude SA5011 --verbose --max-issues-per-linter 0 --max-same-issues 0
+          version: v1.58.2
+          args: --verbose
 
   test-go:
     name: Run unit tests for Go packages

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,10 @@
+issues:
+  exclude:
+    - SA5011
+  max-issues-per-linter: 0
+  max-same-issues: 0
+linters:
+  enable:
+    - gofmt
+run:
+  timeout: 50m

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ lint-local:
 	golangci-lint --version
 	# NOTE: If you get a "Killed" OOM message, try reducing the value of GOGC
 	# See https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-	GOGC=$(ARGOCD_LINT_GOGC) GOMAXPROCS=2 golangci-lint run --enable gofmt --fix --verbose --timeout 3000s --max-issues-per-linter 0 --max-same-issues 0
+	GOGC=$(ARGOCD_LINT_GOGC) GOMAXPROCS=2 golangci-lint run --fix --verbose
 
 .PHONY: lint-ui
 lint-ui: test-tools-image

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0
+GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2


### PR DESCRIPTION
create .golangci.yaml instead of using command line arguments.
It allows to mutualise configuration between workflow and Makefile

Bump golangci-lint version to 1.58.2