### PR TITLE
chore: enable bool-compare rule from testifylint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,21 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
+    - testifylint
     - unused
+linters-settings:
+  testifylint:
+    enable-all: true
+    disable:
+      - compares
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - float-compare
+      - go-require
+      - len
+      - nil-compare
+      - require-error
 run:
   timeout: 50m

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -223,10 +223,10 @@ func TestDefaultWaitOptions(t *testing.T) {
 		suspended: false,
 	}
 	opts := getWatchOpts(watch)
-	assert.Equal(t, true, opts.sync)
-	assert.Equal(t, true, opts.health)
-	assert.Equal(t, true, opts.operation)
-	assert.Equal(t, false, opts.suspended)
+	assert.True(t, opts.sync)
+	assert.True(t, opts.health)
+	assert.True(t, opts.operation)
+	assert.False(t, opts.suspended)
 }
 
 func TestOverrideWaitOptions(t *testing.T) {
@@ -237,10 +237,10 @@ func TestOverrideWaitOptions(t *testing.T) {
 		suspended: false,
 	}
 	opts := getWatchOpts(watch)
-	assert.Equal(t, true, opts.sync)
-	assert.Equal(t, false, opts.health)
-	assert.Equal(t, false, opts.operation)
-	assert.Equal(t, false, opts.suspended)
+	assert.True(t, opts.sync)
+	assert.False(t, opts.health)
+	assert.False(t, opts.operation)
+	assert.False(t, opts.suspended)
 }
 
 func TestFindRevisionHistoryWithoutPassedIdAndEmptyHistoryList(t *testing.T) {
@@ -1163,18 +1163,18 @@ func Test_unset(t *testing.T) {
 	assert.False(t, updated)
 	assert.False(t, nothingToUnset)
 
-	assert.Equal(t, true, helmSource.Helm.IgnoreMissingValueFiles)
+	assert.True(t, helmSource.Helm.IgnoreMissingValueFiles)
 	updated, nothingToUnset = unset(helmSource, unsetOpts{ignoreMissingValueFiles: true})
-	assert.Equal(t, false, helmSource.Helm.IgnoreMissingValueFiles)
+	assert.False(t, helmSource.Helm.IgnoreMissingValueFiles)
 	assert.True(t, updated)
 	assert.False(t, nothingToUnset)
 	updated, nothingToUnset = unset(helmSource, unsetOpts{ignoreMissingValueFiles: true})
 	assert.False(t, updated)
 	assert.False(t, nothingToUnset)
 
-	assert.Equal(t, true, helmSource.Helm.PassCredentials)
+	assert.True(t, helmSource.Helm.PassCredentials)
 	updated, nothingToUnset = unset(helmSource, unsetOpts{passCredentials: true})
-	assert.Equal(t, false, helmSource.Helm.PassCredentials)
+	assert.False(t, helmSource.Helm.PassCredentials)
 	assert.True(t, updated)
 	assert.False(t, nothingToUnset)
 	updated, nothingToUnset = unset(helmSource, unsetOpts{passCredentials: true})

--- a/cmd/util/app_test.go
+++ b/cmd/util/app_test.go
@@ -27,7 +27,7 @@ func Test_setHelmOpt(t *testing.T) {
 	t.Run("IgnoreMissingValueFiles", func(t *testing.T) {
 		src := v1alpha1.ApplicationSource{}
 		setHelmOpt(&src, helmOpts{ignoreMissingValueFiles: true})
-		assert.Equal(t, true, src.Helm.IgnoreMissingValueFiles)
+		assert.True(t, src.Helm.IgnoreMissingValueFiles)
 	})
 	t.Run("ReleaseName", func(t *testing.T) {
 		src := v1alpha1.ApplicationSource{}
@@ -57,12 +57,12 @@ func Test_setHelmOpt(t *testing.T) {
 	t.Run("HelmPassCredentials", func(t *testing.T) {
 		src := v1alpha1.ApplicationSource{}
 		setHelmOpt(&src, helmOpts{passCredentials: true})
-		assert.Equal(t, true, src.Helm.PassCredentials)
+		assert.True(t, src.Helm.PassCredentials)
 	})
 	t.Run("HelmSkipCrds", func(t *testing.T) {
 		src := v1alpha1.ApplicationSource{}
 		setHelmOpt(&src, helmOpts{skipCrds: true})
-		assert.Equal(t, true, src.Helm.SkipCrds)
+		assert.True(t, src.Helm.SkipCrds)
 	})
 }
 

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -995,7 +995,7 @@ func TestManifestGenErrorCacheByMinutesElapsed(t *testing.T) {
 
 			// 5) Ensure that the service no longer returns a cached copy of the last error
 			assert.True(t, err != nil && res == nil)
-			assert.True(t, !strings.HasPrefix(err.Error(), cachedManifestGenerationPrefix))
+			assert.False(t, strings.HasPrefix(err.Error(), cachedManifestGenerationPrefix))
 
 		})
 	}
@@ -1043,7 +1043,7 @@ func TestManifestGenErrorCacheRespectsNoCache(t *testing.T) {
 
 	// 3) Ensure that the cache returns a new generation attempt, rather than a previous cached error
 	assert.True(t, err != nil && res == nil)
-	assert.True(t, !strings.HasPrefix(err.Error(), cachedManifestGenerationPrefix))
+	assert.False(t, strings.HasPrefix(err.Error(), cachedManifestGenerationPrefix))
 
 	// 4) Call generateManifest
 	res, err = service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
@@ -3047,7 +3047,7 @@ func TestGetHelmRepos_OCIDependenciesWithHelmRepo(t *testing.T) {
 
 	assert.Equal(t, len(helmRepos), 1)
 	assert.Equal(t, helmRepos[0].Username, "test")
-	assert.Equal(t, helmRepos[0].EnableOci, true)
+	assert.True(t, helmRepos[0].EnableOci)
 	assert.Equal(t, helmRepos[0].Repo, "example.com/myrepo")
 }
 
@@ -3060,7 +3060,7 @@ func TestGetHelmRepos_OCIDependenciesWithRepo(t *testing.T) {
 
 	assert.Equal(t, len(helmRepos), 1)
 	assert.Equal(t, helmRepos[0].Username, "test")
-	assert.Equal(t, helmRepos[0].EnableOci, true)
+	assert.True(t, helmRepos[0].EnableOci)
 	assert.Equal(t, helmRepos[0].Repo, "example.com/myrepo")
 }
 

--- a/server/deeplinks/deeplinks_test.go
+++ b/server/deeplinks/deeplinks_test.go
@@ -169,6 +169,6 @@ func TestDeepLinks(t *testing.T) {
 		objs := CreateDeepLinksObject(tc.resourceObj, tc.appObj, tc.clusterObj, tc.projectObj)
 		output, err := EvaluateDeepLinksResponse(objs, tc.appObj.GetName(), tc.inputLinks)
 		assert.Equal(t, tc.error, err, strings.Join(err, ","))
-		assert.Equal(t, reflect.DeepEqual(output.Items, tc.outputLinks), true)
+		assert.True(t, reflect.DeepEqual(output.Items, tc.outputLinks))
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1190,7 +1190,7 @@ func TestOIDCConfigChangeDetection_SecretsChanged(t *testing.T) {
 	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
 
 	//Then
-	assert.Equal(t, result, true, "secrets have changed, expect interpolated OIDCConfig to change")
+	assert.True(t, result, "secrets have changed, expect interpolated OIDCConfig to change")
 }
 
 func TestOIDCConfigChangeDetection_ConfigChanged(t *testing.T) {
@@ -1222,7 +1222,7 @@ func TestOIDCConfigChangeDetection_ConfigChanged(t *testing.T) {
 	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
 
 	//Then
-	assert.Equal(t, result, true, "no error expected since OICD config created")
+	assert.True(t, result, "no error expected since OICD config created")
 }
 
 func TestOIDCConfigChangeDetection_ConfigCreated(t *testing.T) {
@@ -1242,7 +1242,7 @@ func TestOIDCConfigChangeDetection_ConfigCreated(t *testing.T) {
 	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
 
 	//Then
-	assert.Equal(t, result, true, "no error expected since new OICD config created")
+	assert.True(t, result, "no error expected since new OICD config created")
 }
 
 func TestOIDCConfigChangeDetection_ConfigDeleted(t *testing.T) {
@@ -1267,7 +1267,7 @@ func TestOIDCConfigChangeDetection_ConfigDeleted(t *testing.T) {
 	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
 
 	//Then
-	assert.Equal(t, result, true, "no error expected since OICD config deleted")
+	assert.True(t, result, "no error expected since OICD config deleted")
 }
 
 func TestOIDCConfigChangeDetection_NoChange(t *testing.T) {
@@ -1290,7 +1290,7 @@ func TestOIDCConfigChangeDetection_NoChange(t *testing.T) {
 	result := checkOIDCConfigChange(originalOIDCConfig, &argoSettings)
 
 	//Then
-	assert.Equal(t, result, false, "no error since no config change")
+	assert.False(t, result, "no error since no config change")
 }
 
 func TestIsMainJsBundle(t *testing.T) {

--- a/test/e2e/accounts_test.go
+++ b/test/e2e/accounts_test.go
@@ -34,7 +34,7 @@ func TestCreateAndUseAccount(t *testing.T) {
 		Login().
 		Then().
 		CurrentUser(func(user *session.GetUserInfoResponse, err error) {
-			assert.Equal(t, user.LoggedIn, true)
+			assert.True(t, user.LoggedIn)
 			assert.Equal(t, user.Username, ctx.GetName())
 		})
 }

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -135,13 +135,13 @@ func TestHelmIgnoreMissingValueFiles(t *testing.T) {
 		Then().
 		And(func(app *Application) {
 			assert.Equal(t, []string{"does-not-exist-values.yaml"}, app.Spec.GetSource().Helm.ValueFiles)
-			assert.Equal(t, false, app.Spec.GetSource().Helm.IgnoreMissingValueFiles)
+			assert.False(t, app.Spec.GetSource().Helm.IgnoreMissingValueFiles)
 		}).
 		When().
 		AppSet("--ignore-missing-value-files").
 		Then().
 		And(func(app *Application) {
-			assert.Equal(t, true, app.Spec.GetSource().Helm.IgnoreMissingValueFiles)
+			assert.True(t, app.Spec.GetSource().Helm.IgnoreMissingValueFiles)
 		}).
 		When().
 		Sync().
@@ -153,7 +153,7 @@ func TestHelmIgnoreMissingValueFiles(t *testing.T) {
 		AppUnSet("--ignore-missing-value-files").
 		Then().
 		And(func(app *Application) {
-			assert.Equal(t, false, app.Spec.GetSource().Helm.IgnoreMissingValueFiles)
+			assert.False(t, app.Spec.GetSource().Helm.IgnoreMissingValueFiles)
 		}).
 		When().
 		IgnoreErrors().

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -236,5 +236,5 @@ func TestResourceIdNormalizer_Normalize_ConfigHasOldLabel(t *testing.T) {
 }
 
 func TestIsOldTrackingMethod(t *testing.T) {
-	assert.Equal(t, true, IsOldTrackingMethod(string(TrackingMethodLabel)))
+	assert.True(t, IsOldTrackingMethod(string(TrackingMethodLabel)))
 }

--- a/util/buffered_context/buffered_context_test.go
+++ b/util/buffered_context/buffered_context_test.go
@@ -19,7 +19,7 @@ func TestWithEarlierDeadline_NoDeadline(t *testing.T) {
 	assert.Equal(t, ctx, bufferedCtx)
 
 	_, hasDeadline := bufferedCtx.Deadline()
-	assert.Equal(t, false, hasDeadline)
+	assert.False(t, hasDeadline)
 }
 
 func TestWithEarlierDeadline_WithDeadline(t *testing.T) {

--- a/util/cache/redis_hook_test.go
+++ b/util/cache/redis_hook_test.go
@@ -27,7 +27,7 @@ func Test_ReconnectCallbackHookCalled(t *testing.T) {
 
 	faultyDNSClient := NewRedisCache(faultyDNSRedisClient, 60*time.Second, RedisCompressionNone)
 	err = faultyDNSClient.Set(&Item{Key: "baz", Object: "foo"})
-	assert.Equal(t, called, true)
+	assert.True(t, called)
 	assert.Error(t, err)
 }
 
@@ -48,6 +48,6 @@ func Test_ReconnectCallbackHookNotCalled(t *testing.T) {
 	client := NewRedisCache(redisClient, 60*time.Second, RedisCompressionNone)
 
 	err = client.Set(&Item{Key: "foo", Object: "bar"})
-	assert.Equal(t, called, false)
+	assert.False(t, called)
 	assert.NoError(t, err)
 }

--- a/util/cert/cert_test.go
+++ b/util/cert/cert_test.go
@@ -308,15 +308,15 @@ func Test_SSHKnownHostsData_Tokenize(t *testing.T) {
 
 func Test_MatchHostName(t *testing.T) {
 	matchHostName := "foo.example.com"
-	assert.Equal(t, MatchHostName(matchHostName, "*"), true)
-	assert.Equal(t, MatchHostName(matchHostName, "*.example.com"), true)
-	assert.Equal(t, MatchHostName(matchHostName, "foo.*"), true)
-	assert.Equal(t, MatchHostName(matchHostName, "foo.*.com"), true)
-	assert.Equal(t, MatchHostName(matchHostName, "fo?.example.com"), true)
-	assert.Equal(t, MatchHostName(matchHostName, "foo?.example.com"), false)
-	assert.Equal(t, MatchHostName(matchHostName, "bar.example.com"), false)
-	assert.Equal(t, MatchHostName(matchHostName, "*.otherexample.com"), false)
-	assert.Equal(t, MatchHostName(matchHostName, "foo.otherexample.*"), false)
+	assert.True(t, MatchHostName(matchHostName, "*"))
+	assert.True(t, MatchHostName(matchHostName, "*.example.com"))
+	assert.True(t, MatchHostName(matchHostName, "foo.*"))
+	assert.True(t, MatchHostName(matchHostName, "foo.*.com"))
+	assert.True(t, MatchHostName(matchHostName, "fo?.example.com"))
+	assert.False(t, MatchHostName(matchHostName, "foo?.example.com"))
+	assert.False(t, MatchHostName(matchHostName, "bar.example.com"))
+	assert.False(t, MatchHostName(matchHostName, "*.otherexample.com"))
+	assert.False(t, MatchHostName(matchHostName, "foo.otherexample.*"))
 }
 
 func Test_SSHFingerprintSHA256(t *testing.T) {

--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -142,8 +142,8 @@ func TestCustomHTTPClient(t *testing.T) {
 	if client.Transport != nil {
 		transport := client.Transport.(*http.Transport)
 		assert.NotNil(t, transport.TLSClientConfig)
-		assert.Equal(t, true, transport.DisableKeepAlives)
-		assert.Equal(t, false, transport.TLSClientConfig.InsecureSkipVerify)
+		assert.True(t, transport.DisableKeepAlives)
+		assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
 		assert.NotNil(t, transport.TLSClientConfig.GetClientCertificate)
 		assert.Nil(t, transport.TLSClientConfig.RootCAs)
 		if transport.TLSClientConfig.GetClientCertificate != nil {
@@ -170,8 +170,8 @@ func TestCustomHTTPClient(t *testing.T) {
 	if client.Transport != nil {
 		transport := client.Transport.(*http.Transport)
 		assert.NotNil(t, transport.TLSClientConfig)
-		assert.Equal(t, true, transport.DisableKeepAlives)
-		assert.Equal(t, true, transport.TLSClientConfig.InsecureSkipVerify)
+		assert.True(t, transport.DisableKeepAlives)
+		assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 		assert.NotNil(t, transport.TLSClientConfig.GetClientCertificate)
 		assert.Nil(t, transport.TLSClientConfig.RootCAs)
 		if transport.TLSClientConfig.GetClientCertificate != nil {
@@ -203,8 +203,8 @@ func TestCustomHTTPClient(t *testing.T) {
 	if client.Transport != nil {
 		transport := client.Transport.(*http.Transport)
 		assert.NotNil(t, transport.TLSClientConfig)
-		assert.Equal(t, true, transport.DisableKeepAlives)
-		assert.Equal(t, false, transport.TLSClientConfig.InsecureSkipVerify)
+		assert.True(t, transport.DisableKeepAlives)
+		assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
 		assert.NotNil(t, transport.TLSClientConfig.RootCAs)
 	}
 }

--- a/util/grpc/errors_test.go
+++ b/util/grpc/errors_test.go
@@ -20,20 +20,20 @@ func Test_gitErrToGRPC(t *testing.T) {
 	defaultErrorMsg := "default error"
 	defaultError := gitErrToGRPC(errors.New(defaultErrorMsg))
 	_, ok = defaultError.(interface{ GRPCStatus() *status.Status })
-	assert.Equal(t, ok, false)
+	assert.False(t, ok)
 	assert.Equal(t, defaultError.Error(), defaultErrorMsg)
 
 	grpcErrorMsg := "grpc error"
 	grpcError := gitErrToGRPC(status.Errorf(codes.Unknown, grpcErrorMsg))
 	se, ok := grpcError.(interface{ GRPCStatus() *status.Status })
-	assert.Equal(t, ok, true)
+	assert.True(t, ok)
 	assert.Equal(t, se.GRPCStatus().Code(), codes.Unknown)
 	assert.Equal(t, se.GRPCStatus().Message(), grpcErrorMsg)
 
 	notFoundMsg := "repository not found"
 	notFound := gitErrToGRPC(status.Errorf(codes.NotFound, notFoundMsg))
 	se1, ok := notFound.(interface{ GRPCStatus() *status.Status })
-	assert.Equal(t, ok, true)
+	assert.True(t, ok)
 	assert.Equal(t, se1.GRPCStatus().Code(), codes.NotFound)
 	assert.Equal(t, se1.GRPCStatus().Message(), notFoundMsg)
 }

--- a/util/jwt/jwt_test.go
+++ b/util/jwt/jwt_test.go
@@ -62,9 +62,9 @@ func TestIssuedAtTime_Error_Missing(t *testing.T) {
 }
 
 func TestIsValid(t *testing.T) {
-	assert.Equal(t, true, IsValid("foo.bar.foo"))
-	assert.Equal(t, true, IsValid("foo.bar.foo.bar"))
-	assert.Equal(t, false, IsValid("foo.bar"))
-	assert.Equal(t, false, IsValid("foo"))
-	assert.Equal(t, false, IsValid(""))
+	assert.True(t, IsValid("foo.bar.foo"))
+	assert.True(t, IsValid("foo.bar.foo.bar"))
+	assert.False(t, IsValid("foo.bar"))
+	assert.False(t, IsValid("foo"))
+	assert.False(t, IsValid(""))
 }

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -394,10 +394,10 @@ func TestKustomizeLabelWithoutSelector(t *testing.T) {
 				obj := objs[0]
 				sl, found, err := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels")
 				assert.Nil(t, err)
-				assert.Equal(t, found, true)
+				assert.True(t, found)
 				tl, found, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "labels")
 				assert.Nil(t, err)
-				assert.Equal(t, found, true)
+				assert.True(t, found)
 				assert.Equal(t, tc.ExpectedMetadataLabels, obj.GetLabels())
 				assert.Equal(t, tc.ExpectedSelectorLabels, sl)
 				assert.Equal(t, tc.ExpectedTemplateLabels, tl)
@@ -478,13 +478,13 @@ func TestKustomizeBuildPatches(t *testing.T) {
 	obj := objs[0]
 	containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
 	assert.Nil(t, err)
-	assert.Equal(t, found, true)
+	assert.True(t, found)
 
 	ports, found, err := unstructured.NestedSlice(
 		containers[0].(map[string]interface{}),
 		"ports",
 	)
-	assert.Equal(t, found, true)
+	assert.True(t, found)
 	assert.Nil(t, err)
 
 	port, found, err := unstructured.NestedInt64(
@@ -492,7 +492,7 @@ func TestKustomizeBuildPatches(t *testing.T) {
 		"containerPort",
 	)
 
-	assert.Equal(t, found, true)
+	assert.True(t, found)
 	assert.Nil(t, err)
 	assert.Equal(t, port, int64(443))
 
@@ -500,7 +500,7 @@ func TestKustomizeBuildPatches(t *testing.T) {
 		containers[0].(map[string]interface{}),
 		"name",
 	)
-	assert.Equal(t, found, true)
+	assert.True(t, found)
 	assert.Nil(t, err)
 	assert.Equal(t, name, "test")
 }

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -159,7 +159,7 @@ func TestGetHealthScriptWithOverride(t *testing.T) {
 	}
 	script, useOpenLibs, err := vm.GetHealthScript(testObj)
 	assert.Nil(t, err)
-	assert.Equal(t, false, useOpenLibs)
+	assert.False(t, useOpenLibs)
 	assert.Equal(t, newHealthStatusFunction, script)
 }
 
@@ -176,7 +176,7 @@ func TestGetHealthScriptWithKindWildcardOverride(t *testing.T) {
 
 	script, useOpenLibs, err := vm.GetHealthScript(testObj)
 	assert.Nil(t, err)
-	assert.Equal(t, false, useOpenLibs)
+	assert.False(t, useOpenLibs)
 	assert.Equal(t, newHealthStatusFunction, script)
 }
 
@@ -193,7 +193,7 @@ func TestGetHealthScriptWithGroupWildcardOverride(t *testing.T) {
 
 	script, useOpenLibs, err := vm.GetHealthScript(testObj)
 	assert.Nil(t, err)
-	assert.Equal(t, false, useOpenLibs)
+	assert.False(t, useOpenLibs)
 	assert.Equal(t, newHealthStatusFunction, script)
 }
 
@@ -210,7 +210,7 @@ func TestGetHealthScriptWithGroupAndKindWildcardOverride(t *testing.T) {
 
 	script, useOpenLibs, err := vm.GetHealthScript(testObj)
 	assert.Nil(t, err)
-	assert.Equal(t, false, useOpenLibs)
+	assert.False(t, useOpenLibs)
 	assert.Equal(t, newHealthStatusFunction, script)
 }
 
@@ -219,7 +219,7 @@ func TestGetHealthScriptPredefined(t *testing.T) {
 	vm := VM{}
 	script, useOpenLibs, err := vm.GetHealthScript(testObj)
 	assert.Nil(t, err)
-	assert.Equal(t, true, useOpenLibs)
+	assert.True(t, useOpenLibs)
 	assert.NotEmpty(t, script)
 }
 
@@ -228,7 +228,7 @@ func TestGetHealthScriptNoPredefined(t *testing.T) {
 	vm := VM{}
 	script, useOpenLibs, err := vm.GetHealthScript(testObj)
 	assert.Nil(t, err)
-	assert.Equal(t, true, useOpenLibs)
+	assert.True(t, useOpenLibs)
 	assert.Equal(t, "", script)
 }
 

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -127,14 +127,14 @@ func TestInClusterServerAddressEnabled(t *testing.T) {
 	})
 	argoCDCM, err := settingsManager.getConfigMap()
 	assert.NoError(t, err)
-	assert.Equal(t, true, argoCDCM.Data[inClusterEnabledKey] == "true")
+	assert.True(t, argoCDCM.Data[inClusterEnabledKey] == "true")
 
 	_, settingsManager = fixtures(map[string]string{
 		"cluster.inClusterEnabled": "false",
 	})
 	argoCDCM, err = settingsManager.getConfigMap()
 	assert.NoError(t, err)
-	assert.Equal(t, false, argoCDCM.Data[inClusterEnabledKey] == "true")
+	assert.False(t, argoCDCM.Data[inClusterEnabledKey] == "true")
 }
 
 func TestInClusterServerAddressEnabledByDefault(t *testing.T) {
@@ -166,7 +166,7 @@ func TestInClusterServerAddressEnabledByDefault(t *testing.T) {
 	settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
 	settings, err := settingsManager.GetSettings()
 	assert.NoError(t, err)
-	assert.Equal(t, true, settings.InClusterEnabled)
+	assert.True(t, settings.InClusterEnabled)
 }
 
 func TestGetAppInstanceLabelKey(t *testing.T) {
@@ -182,7 +182,7 @@ func TestGetServerRBACLogEnforceEnableKeyDefaultFalse(t *testing.T) {
 	_, settingsManager := fixtures(nil)
 	serverRBACLogEnforceEnable, err := settingsManager.GetServerRBACLogEnforceEnable()
 	assert.NoError(t, err)
-	assert.Equal(t, false, serverRBACLogEnforceEnable)
+	assert.False(t, serverRBACLogEnforceEnable)
 }
 
 func TestGetIsIgnoreResourceUpdatesEnabled(t *testing.T) {
@@ -207,7 +207,7 @@ func TestGetServerRBACLogEnforceEnableKey(t *testing.T) {
 	})
 	serverRBACLogEnforceEnable, err := settingsManager.GetServerRBACLogEnforceEnable()
 	assert.NoError(t, err)
-	assert.Equal(t, true, serverRBACLogEnforceEnable)
+	assert.True(t, serverRBACLogEnforceEnable)
 }
 
 func TestGetResourceOverrides(t *testing.T) {
@@ -377,9 +377,9 @@ func TestGetResourceOverrides_with_splitted_keys(t *testing.T) {
 		assert.Equal(t, 1, len(overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreResourceUpdates.JSONPointers))
 		assert.Equal(t, "foo", overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].IgnoreResourceUpdates.JSONPointers[0])
 		assert.Equal(t, "foo\n", overrides["certmanager.k8s.io/Certificate"].HealthLua)
-		assert.Equal(t, true, overrides["certmanager.k8s.io/Certificate"].UseOpenLibs)
+		assert.True(t, overrides["certmanager.k8s.io/Certificate"].UseOpenLibs)
 		assert.Equal(t, "foo\n", overrides["cert-manager.io/Certificate"].HealthLua)
-		assert.Equal(t, false, overrides["cert-manager.io/Certificate"].UseOpenLibs)
+		assert.False(t, overrides["cert-manager.io/Certificate"].UseOpenLibs)
 		assert.Equal(t, "foo", overrides["apps/Deployment"].Actions)
 	})
 
@@ -432,8 +432,8 @@ func TestGetResourceOverrides_with_splitted_keys(t *testing.T) {
 		assert.Equal(t, "bar", overrides["admissionregistration.k8s.io/MutatingWebhookConfiguration"].HealthLua)
 		assert.Equal(t, "bar", overrides["certmanager.k8s.io/Certificate"].HealthLua)
 		assert.Equal(t, "bar", overrides["cert-manager.io/Certificate"].HealthLua)
-		assert.Equal(t, false, overrides["certmanager.k8s.io/Certificate"].UseOpenLibs)
-		assert.Equal(t, true, overrides["cert-manager.io/Certificate"].UseOpenLibs)
+		assert.False(t, overrides["certmanager.k8s.io/Certificate"].UseOpenLibs)
+		assert.True(t, overrides["cert-manager.io/Certificate"].UseOpenLibs)
 		assert.Equal(t, "bar", overrides["apps/Deployment"].Actions)
 		assert.Equal(t, "bar", overrides["Deployment"].Actions)
 		assert.Equal(t, "bar", overrides["iam-manager.k8s.io/Iamrole"].HealthLua)
@@ -764,7 +764,7 @@ func TestGetGoogleAnalytics(t *testing.T) {
 	ga, err := settingsManager.GetGoogleAnalytics()
 	assert.NoError(t, err)
 	assert.Equal(t, "123", ga.TrackingID)
-	assert.Equal(t, true, ga.AnonymizeUsers)
+	assert.True(t, ga.AnonymizeUsers)
 }
 
 func TestSettingsManager_GetHelp(t *testing.T) {
@@ -950,7 +950,7 @@ func TestGetOIDCConfig(t *testing.T) {
 
 	claim := oidcConfig.RequestedIDTokenClaims["groups"]
 	assert.NotNil(t, claim)
-	assert.Equal(t, true, claim.Essential)
+	assert.True(t, claim.Essential)
 }
 
 func TestRedirectURL(t *testing.T) {


### PR DESCRIPTION
Testifylint is a linter that helps follow testify best practices .
As there several rules that can generate a lot of changes it’s easier to review to apply them one after the other.

This one enables bool-compare rule 