### PR TITLE
fix: Make selfHeal=true work when previous sync fails (#18442)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2252,19 +2252,17 @@ func (ctrl *ApplicationController) autoSync(app *appv1.Application, syncStatus *
 	// and parameter overrides are different from our most recent sync operation.
 	alreadyAttempted, lastAttemptedRevisions, lastAttemptedPhase := alreadyAttemptedSync(app, desiredRevisions, shouldCompareRevisions)
 	ts.AddCheckpoint("already_attempted_sync_ms")
+	// When selfHeal is enabled, a failed attempt at the same revision may still proceed into the self-heal path
 	if alreadyAttempted {
-		if !lastAttemptedPhase.Successful() {
-			logCtx.Warnf("Skipping auto-sync: failed previous sync attempt to %s and will not retry for %s", lastAttemptedRevisions, desiredRevisions)
-			message := fmt.Sprintf("Failed last sync attempt to %s: %s", lastAttemptedRevisions, app.Status.OperationState.Message)
-			return &appv1.ApplicationCondition{Type: appv1.ApplicationConditionSyncError, Message: message}, 0
-		}
 		if !app.Spec.SyncPolicy.Automated.GetSelfHeal() {
+			if !lastAttemptedPhase.Successful() {
+				logCtx.Warnf("Skipping auto-sync: failed previous sync attempt to %s and will not retry for %s", lastAttemptedRevisions, desiredRevisions)
+				message := fmt.Sprintf("Failed last sync attempt to %s: %s", lastAttemptedRevisions, app.Status.OperationState.Message)
+				return &appv1.ApplicationCondition{Type: appv1.ApplicationConditionSyncError, Message: message}, 0
+			}
 			logCtx.Infof("Skipping auto-sync: most recent sync already to %s", desiredRevisions)
 			return nil, 0
 		}
-		// Self heal will trigger a new sync operation when the desired state changes and cause the application to
-		// be OutOfSync when it was previously synced Successfully. This means SelfHeal should only ever be attempted
-		// when the revisions have not changed, and where the previous sync to these revision was successful
 		if app.Status.OperationState != nil && app.Status.OperationState.Operation.Sync != nil {
 			op.Sync.SelfHealAttemptsCount = app.Status.OperationState.Operation.Sync.SelfHealAttemptsCount
 		}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -714,6 +714,123 @@ func TestAutoSyncMultiSourceWithoutSelfHeal(t *testing.T) {
 	})
 }
 
+func TestSelfHeal(t *testing.T) {
+	// If the previous sync attempt failed and selfheal is set to true we should retry
+	t.Run("PreviousSyncOperationFailed", func(t *testing.T) {
+		app := newFakeApp()
+		app.Spec.SyncPolicy.Automated.SelfHeal = new(true)
+		app.Status.OperationState = &v1alpha1.OperationState{
+			Operation: v1alpha1.Operation{
+				Sync: &v1alpha1.SyncOperation{},
+			},
+			Phase: synccommon.OperationFailed,
+			SyncResult: &v1alpha1.SyncOperationResult{
+				Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				Source:   *app.Spec.Source.DeepCopy(),
+			},
+		}
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}
+		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, true)
+		assert.Nil(t, cond)
+		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Nil(t, app.Operation)
+	})
+
+	// Desired revision differs from the last operation's revision, so alreadyAttempted is false: this is a
+	// normal automated sync to a new commit, not the same-revision self-heal path from issue #18442.
+	t.Run("RevisionChangedAfterFailedSyncStartsNewAutoSync", func(t *testing.T) {
+		app := newFakeApp()
+		app.Spec.SyncPolicy.Automated.SelfHeal = new(true)
+		app.Status.OperationState = &v1alpha1.OperationState{
+			Operation: v1alpha1.Operation{
+				Sync: &v1alpha1.SyncOperation{},
+			},
+			Phase: synccommon.OperationFailed,
+			SyncResult: &v1alpha1.SyncOperationResult{
+				Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				Source:   *app.Spec.Source.DeepCopy(),
+			},
+		}
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		}
+		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, true)
+		assert.Nil(t, cond)
+		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.NotNil(t, app.Operation)
+		assert.NotNil(t, app.Operation.Sync)
+	})
+
+	// Same revision as the failed last sync (alreadyAttempted true): after selfHealTimeout has passed since
+	// FinishedAt, self-heal must initiate a targeted sync instead of returning SyncError or stalling forever.
+	t.Run("PreviousSyncOperationFailedSameRevisionStartsSelfHealWhenBackoffElapsed", func(t *testing.T) {
+		app := newFakeApp()
+		app.Spec.SyncPolicy.Automated.SelfHeal = new(true)
+		finishedAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+		app.Status.OperationState = &v1alpha1.OperationState{
+			FinishedAt: &finishedAt,
+			Operation: v1alpha1.Operation{
+				Sync: &v1alpha1.SyncOperation{},
+			},
+			Phase: synccommon.OperationFailed,
+			SyncResult: &v1alpha1.SyncOperationResult{
+				Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				Source:   *app.Spec.Source.DeepCopy(),
+			},
+		}
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}
+		resources := []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}
+		cond, _ := ctrl.autoSync(app, &syncStatus, resources, true)
+		assert.Nil(t, cond)
+		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, app.Operation)
+		require.NotNil(t, app.Operation.Sync)
+		assert.Equal(t, int64(1), app.Operation.Sync.SelfHealAttemptsCount)
+		require.Len(t, app.Operation.Sync.Resources, 1)
+		assert.Equal(t, "guestbook", app.Operation.Sync.Resources[0].Name)
+		assert.Equal(t, kube.DeploymentKind, app.Operation.Sync.Resources[0].Kind)
+	})
+
+	// If the previous sync attempt succeeded we should not return an error
+	t.Run("PreviousSyncOperationOk", func(t *testing.T) {
+		app := newFakeApp()
+		app.Spec.SyncPolicy.Automated.SelfHeal = new(true)
+		app.Status.OperationState = &v1alpha1.OperationState{
+			Operation: v1alpha1.Operation{
+				Sync: &v1alpha1.SyncOperation{},
+			},
+			Phase: synccommon.OperationSucceeded,
+			SyncResult: &v1alpha1.SyncOperationResult{
+				Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				Source:   *app.Spec.Source.DeepCopy(),
+			},
+		}
+		ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+		syncStatus := v1alpha1.SyncStatus{
+			Status:   v1alpha1.SyncStatusCodeOutOfSync,
+			Revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}
+		cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, true)
+		assert.Nil(t, cond)
+		app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Nil(t, app.Operation)
+	})
+}
+
 func TestAutoSyncNotAllowEmpty(t *testing.T) {
 	app := newFakeApp()
 	app.Spec.SyncPolicy.Automated.Prune = new(true)
@@ -917,6 +1034,32 @@ func TestAutoSyncIndicateError(t *testing.T) {
 	}
 	cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, true)
 	assert.NotNil(t, cond)
+	app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Nil(t, app.Operation)
+}
+
+// TestAutoSyncSkipAlreadySyncedRevision verifies that when selfHeal is false and the previous sync
+// to the same revision succeeded, auto-sync is silently skipped (no error, no new operation).
+func TestAutoSyncSkipAlreadySyncedRevision(t *testing.T) {
+	app := newFakeApp()
+	app.Status.OperationState = &v1alpha1.OperationState{
+		Operation: v1alpha1.Operation{
+			Sync: &v1alpha1.SyncOperation{},
+		},
+		Phase: synccommon.OperationSucceeded,
+		SyncResult: &v1alpha1.SyncOperationResult{
+			Revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Source:   *app.Spec.Source.DeepCopy(),
+		},
+	}
+	ctrl := newFakeController(t.Context(), &fakeData{apps: []runtime.Object{app}}, nil)
+	syncStatus := v1alpha1.SyncStatus{
+		Status:   v1alpha1.SyncStatusCodeOutOfSync,
+		Revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	cond, _ := ctrl.autoSync(app, &syncStatus, []v1alpha1.ResourceStatus{{Name: "guestbook", Kind: kube.DeploymentKind, Status: v1alpha1.SyncStatusCodeOutOfSync}}, true)
+	assert.Nil(t, cond)
 	app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(test.FakeArgoCDNamespace).Get(t.Context(), "my-app", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Nil(t, app.Operation)

--- a/test/e2e/app_autosync_ns_test.go
+++ b/test/e2e/app_autosync_ns_test.go
@@ -71,25 +71,20 @@ func TestNSAutoSyncSelfHealEnabled(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		When().
-		// app should be attempted to auto-synced once and marked with error after failed attempt detected
+		// app should be attempted to auto-synced and fail; with selfHeal enabled, the controller
+		// retries via self-heal instead of giving up with a SyncError condition
 		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": "badValue"}]`).
 		Refresh(RefreshTypeNormal).
 		Then().
 		Expect(OperationPhaseIs(OperationFailed)).
-		When().
-		// Trigger refresh again to make sure controller notices previously failed sync attempt before expectation timeout expires
-		Refresh(RefreshTypeNormal).
-		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
-		Expect(Condition(ApplicationConditionSyncError, "Failed last sync attempt")).
 		When().
-		// SyncError condition should be removed after successful sync
+		// Fix the bad value - self-heal allows the app to recover automatically
 		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": 1}]`).
 		Refresh(RefreshTypeNormal).
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		When().
-		// Trigger refresh twice to make sure controller notices successful attempt and removes condition
 		Refresh(RefreshTypeNormal).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).

--- a/test/e2e/app_autosync_test.go
+++ b/test/e2e/app_autosync_test.go
@@ -69,25 +69,20 @@ func TestAutoSyncSelfHealEnabled(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		When().
-		// app should be attempted to auto-synced once and marked with error after failed attempt detected
+		// app should be attempted to auto-synced and fail; with selfHeal enabled, the controller
+		// retries via self-heal instead of giving up with a SyncError condition
 		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": "badValue"}]`).
 		Refresh(RefreshTypeNormal).
 		Then().
 		Expect(OperationPhaseIs(OperationFailed)).
-		When().
-		// Trigger refresh again to make sure controller notices previously failed sync attempt before expectation timeout expires
-		Refresh(RefreshTypeNormal).
-		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
-		Expect(Condition(ApplicationConditionSyncError, "Failed last sync attempt")).
 		When().
-		// SyncError condition should be removed after successful sync
+		// Fix the bad value - self-heal allows the app to recover automatically
 		PatchFile("guestbook-ui-deployment.yaml", `[{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": 1}]`).
 		Refresh(RefreshTypeNormal).
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		When().
-		// Trigger refresh twice to make sure controller notices successful attempt and removes condition
 		Refresh(RefreshTypeNormal).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).


### PR DESCRIPTION
Currently even when selfHeal is set to true, whenever
attemptPhase.Successful() returns false, the application will be stuck
forever and sync will never be attempted again. This contradicts
https://argo-cd.readthedocs.io/en/stable/user-guide/auto_sync/#automated-sync-semantics
where we state that:
```
Automated sync will only attempt one synchronization per unique
combination of commit SHA1 and application parameters. If the most
recent successful sync in the history was already performed against the
same commit-SHA and parameters, a second sync will not be attempted,
unless selfHeal flag is set to true.
```

Let's fix that by only avoiding another sync when selfHeal is not set to
true.

Assuming alreadyAttempted is true here are the before and after
scenarios. Possible outcomes labels in (A,B,C):

*Before*

1. selfHeal is false and attemptPhase.Successful() is false ->
   (A) return SyncError "Skipping auto-sync: failed previous sync attempt to %s"
2. selfHeal is false and attemptPhase.Successful() is true ->
   (B) return nil, 0 "Skipping auto-sync: most recent sync already to %s"
3. selfHeal is true and attemptPhase.Successful() is false ->
   (A) return SyncError "Skipping auto-sync: failed previous sync attempt to %s"
4. selfHeal is true and attemptPhase.Successful() is true ->
   (C) return either nil, 0 if shouldSelfHeal is false or set
       op.Sync.Resources if shouldSelfHeal is true (C)

*After*

1. selfHeal is false and attemptPhase.Successful() is false ->
   (A) return SyncError "Skipping auto-sync: failed previous sync attempt to %s"
2. selfHeal is false and attemptPhase.Successful() is true ->
   (B) return nil, 0 "Skipping auto-sync: most recent sync already to %s"
3. selfHeal is true and attemptPhase.Successful() is false ->
   (C) return either nil, 0 if shouldSelfHeal is false or set
       op.Sync.Resources if shouldSelfHeal is true (C)
4. selfHeal is true and attemptPhase.Successful() is true ->
   (C) return either nil, 0 if shouldSelfHeal is false or set
       op.Sync.Resources if shouldSelfHeal is true (C)

Closes: #18442

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
