### PR TITLE
chore: use redis secret when running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,6 +494,7 @@ start-local: mod-vendor-local dep-ui-local cli-local
 	mkdir -p /tmp/argocd-local
 	mkdir -p /tmp/argocd-local/gpg/keys && chmod 0700 /tmp/argocd-local/gpg/keys
 	mkdir -p /tmp/argocd-local/gpg/source
+	REDIS_PASSWORD=$(shell kubectl get secret argocd-redis -o jsonpath='{.data.auth}' | base64 -d) \
 	ARGOCD_ZJWT_FEATURE_FLAG=always \
 	ARGOCD_IN_CI=false \
 	ARGOCD_GPG_ENABLED=$(ARGOCD_GPG_ENABLED) \


### PR DESCRIPTION
The make target currently fails when using in-cluster Redis with local components, because the default in-cluster Redis requires a password.

If the secret doesn't exist, the password var is set to empty. If they need it, it'll be up to the user to debug why the secret doesn't exist.