### PR TITLE
chore: enable errorlint linter on `pkg` folder

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,11 +1,16 @@
 issues:
   exclude:
     - SA5011
+  exclude-rules:
+    - path: "(applicationset|cmd|cmpserver|controller|reposerver|server|util)/"
+      linters:
+        - errorlint
   max-issues-per-linter: 0
   max-same-issues: 0
 linters:
   enable:
     - errcheck
+    - errorlint
     - gofmt
     - gosimple
     - govet

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -342,11 +342,11 @@ func (c *client) OIDCConfig(ctx context.Context, set *settingspkg.Settings) (*oa
 	}
 	provider, err := oidc.NewProvider(ctx, issuerURL)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to query provider %q: %v", issuerURL, err)
+		return nil, nil, fmt.Errorf("Failed to query provider %q: %w", issuerURL, err)
 	}
 	oidcConf, err := oidcutil.ParseConfig(provider)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to parse provider config: %v", err)
+		return nil, nil, fmt.Errorf("Failed to parse provider config: %w", err)
 	}
 	scopes = oidcutil.GetScopesOrDefault(scopes)
 	if oidcutil.OfflineAccess(oidcConf.ScopesSupported) {
@@ -853,7 +853,7 @@ func (c *client) WatchApplicationWithRetry(ctx context.Context, appName string, 
 }
 
 func isCanceledContextErr(err error) bool {
-	if err == context.Canceled {
+	if err != nil && errors.Is(err, context.Canceled) {
 		return true
 	}
 	if stat, ok := status.FromError(err); ok {

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -3,6 +3,7 @@ package apiclient
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -154,7 +155,7 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 			for {
 				header := make([]byte, frameHeaderLength)
 				if _, err := io.ReadAtLeast(resp.Body, header, frameHeaderLength); err != nil {
-					if err == io.EOF {
+					if errors.Is(err, io.EOF) {
 						err = io.ErrUnexpectedEOF
 					}
 					return err
@@ -167,7 +168,7 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 				data := make([]byte, length)
 
 				if read, err := io.ReadAtLeast(resp.Body, data, length); err != nil {
-					if err != io.EOF {
+					if !errors.Is(err, io.EOF) {
 						return err
 					} else if read < length {
 						return io.ErrUnexpectedEOF

--- a/pkg/apis/application/v1alpha1/app_project_types.go
+++ b/pkg/apis/application/v1alpha1/app_project_types.go
@@ -428,7 +428,7 @@ func (proj AppProject) IsDestinationPermitted(dst ApplicationDestination, projec
 	if destinationMatched && proj.Spec.PermitOnlyProjectScopedClusters {
 		clusters, err := projectClusters(proj.Name)
 		if err != nil {
-			return false, fmt.Errorf("could not retrieve project clusters: %s", err)
+			return false, fmt.Errorf("could not retrieve project clusters: %w", err)
 		}
 
 		for _, cluster := range clusters {

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2577,11 +2577,11 @@ func (w *SyncWindow) Validate() error {
 	specParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 	_, err := specParser.Parse(w.Schedule)
 	if err != nil {
-		return fmt.Errorf("cannot parse schedule '%s': %s", w.Schedule, err)
+		return fmt.Errorf("cannot parse schedule '%s': %w", w.Schedule, err)
 	}
 	_, err = time.ParseDuration(w.Duration)
 	if err != nil {
-		return fmt.Errorf("cannot parse duration '%s': %s", w.Duration, err)
+		return fmt.Errorf("cannot parse duration '%s': %w", w.Duration, err)
 	}
 	return nil
 }

--- a/pkg/apis/application/v1alpha1/values.go
+++ b/pkg/apis/application/v1alpha1/values.go
@@ -19,11 +19,11 @@ func (h *ApplicationSourceHelm) SetValuesString(value string) error {
 	} else {
 		data, err := yaml.YAMLToJSON([]byte(value))
 		if err != nil {
-			return fmt.Errorf("failed converting yaml to json: %v", err)
+			return fmt.Errorf("failed converting yaml to json: %w", err)
 		}
 		var v interface{}
 		if err := json.Unmarshal(data, &v); err != nil {
-			return fmt.Errorf("failed to unmarshal json: %v", err)
+			return fmt.Errorf("failed to unmarshal json: %w", err)
 		}
 		switch v.(type) {
 		case string:


### PR DESCRIPTION
Errorlint is a linter that helps following best practices with errors in go .

This PR activate errorlint on `pkg` folder. 
It is not applied on the whole project to have small pr for reviewers