### PR TITLE
chore: enable goimports linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
   enable:
     - errcheck
     - gofmt
+    - goimports
     - gosimple
     - govet
     - ineffassign
@@ -15,6 +16,8 @@ linters:
     - testifylint
     - unused
 linters-settings:
+  goimports:
+    local-prefixes: github.com/argoproj/argo-cd/v2
   testifylint:
     enable-all: true
     disable:

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/applicationset/services/mocks"
-	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/argoproj/argo-cd/v2/applicationset/services/mocks"
+	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func Test_generateParamsFromGitFile(t *testing.T) {

--- a/applicationset/services/pull_request/bitbucket_server.go
+++ b/applicationset/services/pull_request/bitbucket_server.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 )
 
 type BitbucketService struct {

--- a/applicationset/services/pull_request/bitbucket_server_test.go
+++ b/applicationset/services/pull_request/bitbucket_server_test.go
@@ -7,8 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func defaultHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {

--- a/applicationset/services/pull_request/gitlab.go
+++ b/applicationset/services/pull_request/gitlab.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 	"github.com/hashicorp/go-retryablehttp"
 	gitlab "github.com/xanzy/go-gitlab"
+
+	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 )
 
 type GitLabService struct {

--- a/applicationset/services/pull_request/utils_test.go
+++ b/applicationset/services/pull_request/utils_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func strp(s string) *string {

--- a/applicationset/services/repo_service_test.go
+++ b/applicationset/services/repo_service_test.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	repo_mocks "github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
 	"github.com/argoproj/argo-cd/v2/util/git"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )

--- a/applicationset/services/scm_provider/aws_codecommit.go
+++ b/applicationset/services/scm_provider/aws_codecommit.go
@@ -3,12 +3,12 @@ package scm_provider
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/request"
 	pathpkg "path"
 	"path/filepath"
 	"strings"
 
-	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws/request"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -19,6 +19,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	"k8s.io/utils/strings/slices"
+
+	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 const (

--- a/applicationset/services/scm_provider/aws_codecommit_test.go
+++ b/applicationset/services/scm_provider/aws_codecommit_test.go
@@ -6,14 +6,15 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/applicationset/services/scm_provider/aws_codecommit/mocks"
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codecommit"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/argoproj/argo-cd/v2/applicationset/services/scm_provider/aws_codecommit/mocks"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 type awsCodeCommitTestRepository struct {

--- a/applicationset/services/scm_provider/azure_devops_test.go
+++ b/applicationset/services/scm_provider/azure_devops_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"k8s.io/utils/ptr"
 
-	azureMock "github.com/argoproj/argo-cd/v2/applicationset/services/scm_provider/azure_devops/git/mocks"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	azureGit "github.com/microsoft/azure-devops-go-api/azuredevops/git"
+
+	azureMock "github.com/argoproj/argo-cd/v2/applicationset/services/scm_provider/azure_devops/git/mocks"
 )
 
 //go:generate go run github.com/vektra/mockery/v2@v2.40.2 --srcpkg=github.com/microsoft/azure-devops-go-api/azuredevops/git --name=Client --output=azure_devops/git/mocks --outpkg=mocks

--- a/applicationset/services/scm_provider/bitbucket_server.go
+++ b/applicationset/services/scm_provider/bitbucket_server.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 )
 
 type BitbucketServerProvider struct {

--- a/applicationset/services/scm_provider/gitlab.go
+++ b/applicationset/services/scm_provider/gitlab.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	pathpkg "path"
 
-	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/xanzy/go-gitlab"
+
+	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 )
 
 type GitlabProvider struct {

--- a/applicationset/utils/selector.go
+++ b/applicationset/utils/selector.go
@@ -2,15 +2,16 @@ package utils
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 var (

--- a/cmd/argocd/commands/admin/dashboard.go
+++ b/cmd/argocd/commands/admin/dashboard.go
@@ -3,9 +3,10 @@ package admin
 import (
 	"fmt"
 
-	"github.com/argoproj/argo-cd/v2/util/cli"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/argoproj/argo-cd/v2/util/cli"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/initialize"

--- a/cmd/argocd/commands/admin/notifications.go
+++ b/cmd/argocd/commands/admin/notifications.go
@@ -15,9 +15,10 @@ import (
 	settings "github.com/argoproj/argo-cd/v2/util/notification/settings"
 	"github.com/argoproj/argo-cd/v2/util/tls"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"github.com/argoproj/notifications-engine/pkg/cmd"
 	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 )
 
 var (

--- a/cmd/argocd/commands/admin/redis_initial_password.go
+++ b/cmd/argocd/commands/admin/redis_initial_password.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v2/util/cli"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/argoproj/argo-cd/v2/util/errors"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/cli"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/argoproj/argo-cd/v2/util/errors"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"

--- a/cmd/argocd/commands/admin/settings_rbac_test.go
+++ b/cmd/argocd/commands/admin/settings_rbac_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
-	"github.com/argoproj/argo-cd/v2/util/assets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -15,6 +13,9 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
+	"github.com/argoproj/argo-cd/v2/util/assets"
 )
 
 type FakeClientConfig struct {

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func TestPrintApplicationSetNames(t *testing.T) {

--- a/cmd/argocd/commands/cluster_test.go
+++ b/cmd/argocd/commands/cluster_test.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func Test_getQueryBySelector(t *testing.T) {

--- a/cmd/argocd/commands/context_test.go
+++ b/cmd/argocd/commands/context_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/util/localconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-cd/v2/util/localconfig"
 )
 
 const testConfig = `contexts:

--- a/cmd/argocd/commands/tree.go
+++ b/cmd/argocd/commands/tree.go
@@ -6,9 +6,10 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/health"
 	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 const (

--- a/cmd/argocd/commands/tree_test.go
+++ b/cmd/argocd/commands/tree_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"text/tabwriter"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func TestTreeViewAppGet(t *testing.T) {

--- a/cmd/argocd/commands/version_test.go
+++ b/cmd/argocd/commands/version_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestShortVersionClient(t *testing.T) {

--- a/cmd/util/applicationset.go
+++ b/cmd/util/applicationset.go
@@ -5,9 +5,10 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/config"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 )
 
 func ConstructApplicationSet(fileURL string) ([]*argoprojiov1alpha1.ApplicationSet, error) {

--- a/cmd/util/applicationset_test.go
+++ b/cmd/util/applicationset_test.go
@@ -3,8 +3,9 @@ package util
 import (
 	"testing"
 
-	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 var appSet = `apiVersion: argoproj.io/v1alpha1

--- a/cmpserver/apiclient/clientset.go
+++ b/cmpserver/apiclient/clientset.go
@@ -2,10 +2,11 @@ package apiclient
 
 import (
 	"context"
-	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/util/env"
 	"math"
 	"time"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/argoproj/argo-cd/v2/util/env"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"

--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -24,7 +24,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/io/files"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	"github.com/cyphar/filepath-securejoin"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/mattn/go-zglob"
 	log "github.com/sirupsen/logrus"
 )

--- a/cmpserver/server.go
+++ b/cmpserver/server.go
@@ -18,6 +18,8 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
+	"google.golang.org/grpc/keepalive"
+
 	"github.com/argoproj/argo-cd/v2/cmpserver/apiclient"
 	"github.com/argoproj/argo-cd/v2/cmpserver/plugin"
 	"github.com/argoproj/argo-cd/v2/common"
@@ -25,7 +27,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/server/version"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	grpc_util "github.com/argoproj/argo-cd/v2/util/grpc"
-	"google.golang.org/grpc/keepalive"
 )
 
 // ArgoCDCMPServer is the config management plugin server implementation

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -19,7 +19,6 @@ import (
 	statecache "github.com/argoproj/argo-cd/v2/controller/cache"
 	"github.com/argoproj/argo-cd/v2/controller/sharding"
 
-	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
 	"github.com/argoproj/gitops-engine/pkg/cache/mocks"
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
@@ -35,6 +34,8 @@ import (
 	kubetesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/yaml"
+
+	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
 
 	mockstatecache "github.com/argoproj/argo-cd/v2/controller/cache/mocks"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/controller/clusterinfoupdater.go
+++ b/controller/clusterinfoupdater.go
@@ -3,15 +3,17 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/common"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/util/env"
+	"github.com/argoproj/argo-cd/v2/common"
+
 	"github.com/argoproj/gitops-engine/pkg/cache"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/argoproj/argo-cd/v2/util/env"
 
 	"github.com/argoproj/argo-cd/v2/controller/metrics"
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/controller/sharding/cache.go
+++ b/controller/sharding/cache.go
@@ -3,9 +3,10 @@ package sharding
 import (
 	"sync"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/db"
-	log "github.com/sirupsen/logrus"
 )
 
 type ClusterShardingCache interface {

--- a/controller/sharding/cache_test.go
+++ b/controller/sharding/cache_test.go
@@ -3,9 +3,10 @@ package sharding
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
-	"github.com/stretchr/testify/assert"
 )
 
 func setupTestSharding(shard int, replicas int) *ClusterSharding {

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -13,20 +13,22 @@ import (
 
 	"encoding/json"
 
-	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/controller/sharding/consistent"
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	slices "golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/argoproj/argo-cd/v2/controller/sharding/consistent"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+
+	log "github.com/sirupsen/logrus"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/settings"
-	log "github.com/sirupsen/logrus"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // Make it overridable for testing

--- a/controller/sharding/sharding_test.go
+++ b/controller/sharding/sharding_test.go
@@ -10,10 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
-	"github.com/argoproj/argo-cd/v2/util/settings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,6 +18,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
+	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
 func TestGetShardByID_NotEmptyID(t *testing.T) {

--- a/controller/sharding/shuffle_test.go
+++ b/controller/sharding/shuffle_test.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestLargeShuffle(t *testing.T) {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -9,8 +9,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	cdcommon "github.com/argoproj/argo-cd/v2/common"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+
+	cdcommon "github.com/argoproj/argo-cd/v2/common"
 
 	"github.com/argoproj/gitops-engine/pkg/sync"
 	"github.com/argoproj/gitops-engine/pkg/sync/common"

--- a/controller/sync_namespace.go
+++ b/controller/sync_namespace.go
@@ -1,10 +1,11 @@
 package controller
 
 import (
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v2/util/argo"
 	gitopscommon "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/argo"
 )
 
 // syncNamespace determine if Argo CD should create and/or manage the namespace

--- a/controller/sync_namespace_test.go
+++ b/controller/sync_namespace_test.go
@@ -1,13 +1,15 @@
 package controller
 
 import (
-	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/argo-cd/v2/util/argo"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/argo"
 )
 
 func createFakeNamespace(uid string, resourceVersion string, labels map[string]string, annotations map[string]string) *unstructured.Unstructured {

--- a/hack/gen-resources/generators/project_generator.go
+++ b/hack/gen-resources/generators/project_generator.go
@@ -3,8 +3,9 @@ package generator
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/hack/gen-resources/util"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/hack/gen-resources/util/gen_options_parser.go
+++ b/hack/gen-resources/util/gen_options_parser.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"gopkg.in/yaml.v2"
 	"os"
+
+	"gopkg.in/yaml.v2"
 )
 
 type SourceOpts struct {

--- a/notification_controller/controller/controller.go
+++ b/notification_controller/controller/controller.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/util/notification/settings"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"github.com/argoproj/notifications-engine/pkg/api"
 	"github.com/argoproj/notifications-engine/pkg/controller"
 	"github.com/argoproj/notifications-engine/pkg/services"
@@ -32,6 +31,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 )
 
 const (

--- a/notification_controller/controller/controller_test.go
+++ b/notification_controller/controller/controller_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -13,6 +12,8 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func TestIsAppSyncStatusRefreshed(t *testing.T) {

--- a/reposerver/apiclient/clientset.go
+++ b/reposerver/apiclient/clientset.go
@@ -4,10 +4,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/util/env"
 	"math"
 	"time"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	"github.com/argoproj/argo-cd/v2/util/env"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"

--- a/reposerver/apiclient/clientset_test.go
+++ b/reposerver/apiclient/clientset_test.go
@@ -3,9 +3,10 @@ package apiclient_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewRepoServerClient_CorrectClientReturned(t *testing.T) {

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -8,15 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/cache/mocks"
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 type MockedCache struct {

--- a/reposerver/cache/mocks/reposervercache.go
+++ b/reposerver/cache/mocks/reposervercache.go
@@ -5,10 +5,11 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
-	cacheutilmocks "github.com/argoproj/argo-cd/v2/util/cache/mocks"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/mock"
+
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
+	cacheutilmocks "github.com/argoproj/argo-cd/v2/util/cache/mocks"
 )
 
 type MockCacheType int

--- a/reposerver/repository/chart.go
+++ b/reposerver/repository/chart.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func getChartDetails(chartYAML string) (*v1alpha1.ChartDetails, error) {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 	"time"
 
-	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	util_session "github.com/argoproj/argo-cd/v2/util/session"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -16,6 +15,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+
+	util_session "github.com/argoproj/argo-cd/v2/util/session"
 
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	applisters "github.com/argoproj/argo-cd/v2/pkg/client/listers/application/v1alpha1"

--- a/server/application/websocket.go
+++ b/server/application/websocket.go
@@ -3,12 +3,13 @@ package application
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/common"
-	httputil "github.com/argoproj/argo-cd/v2/util/http"
-	util_session "github.com/argoproj/argo-cd/v2/util/session"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	httputil "github.com/argoproj/argo-cd/v2/util/http"
+	util_session "github.com/argoproj/argo-cd/v2/util/session"
 
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"

--- a/server/application/websocket_test.go
+++ b/server/application/websocket_test.go
@@ -2,12 +2,13 @@ package application
 
 import (
 	"encoding/json"
-	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 )
 
 func reconnect(w http.ResponseWriter, r *http.Request) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -4,12 +4,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
-	"github.com/argoproj/argo-cd/v2/util/assets"
-	"github.com/golang-jwt/jwt/v4"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
+	"github.com/argoproj/argo-cd/v2/util/assets"
+
+	"github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/cluster"
@@ -24,16 +37,6 @@ import (
 	dbmocks "github.com/argoproj/argo-cd/v2/util/db/mocks"
 	"github.com/argoproj/argo-cd/v2/util/rbac"
 	"github.com/argoproj/argo-cd/v2/util/settings"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube/kubetest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 )
 
 func newServerInMemoryCache() *servercache.Cache {

--- a/server/extension/extension_test.go
+++ b/server/extension/extension_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/server/extension"

--- a/server/notification/notification.go
+++ b/server/notification/notification.go
@@ -3,10 +3,11 @@ package notification
 import (
 	"context"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apiclient/notification"
 	"github.com/argoproj/notifications-engine/pkg/api"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/notification"
 )
 
 // Server provides an Application service

--- a/server/notification/notification_test.go
+++ b/server/notification/notification_test.go
@@ -5,16 +5,17 @@ import (
 	"os"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apiclient/notification"
-	"github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
-	service "github.com/argoproj/argo-cd/v2/util/notification/argocd"
-	"github.com/argoproj/argo-cd/v2/util/notification/k8s"
-	"github.com/argoproj/argo-cd/v2/util/notification/settings"
 	"github.com/argoproj/notifications-engine/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/notification"
+	"github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
+	service "github.com/argoproj/argo-cd/v2/util/notification/argocd"
+	"github.com/argoproj/argo-cd/v2/util/notification/k8s"
+	"github.com/argoproj/argo-cd/v2/util/notification/settings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/server/repocreds/repocreds.go
+++ b/server/repocreds/repocreds.go
@@ -6,6 +6,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/argo"
 
 	"context"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -3,8 +3,9 @@ package repository
 import (
 	"context"
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/util/git"
 	"reflect"
+
+	"github.com/argoproj/argo-cd/v2/util/git"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/gitops-engine/pkg/utils/text"

--- a/test/e2e/fixture/cluster/actions.go
+++ b/test/e2e/fixture/cluster/actions.go
@@ -7,11 +7,12 @@ import (
 	"log"
 	"strings"
 
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/clusterauth"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	clusterpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/cluster"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"

--- a/test/e2e/notification_test.go
+++ b/test/e2e/notification_test.go
@@ -3,10 +3,11 @@ package e2e
 import (
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apiclient/notification"
-	notifFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/notification"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/notification"
+	notifFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/notification"
 )
 
 func TestNotificationsListServices(t *testing.T) {

--- a/test/testutil.go
+++ b/test/testutil.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 // StartInformer is a helper to start an informer, wait for its cache to sync and return a cancel func

--- a/util/app/path/path_test.go
+++ b/util/app/path/path_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	fileutil "github.com/argoproj/argo-cd/v2/test/fixture/path"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPathRoot(t *testing.T) {

--- a/util/argo/managedfields/managed_fields_test.go
+++ b/util/argo/managedfields/managed_fields_test.go
@@ -10,9 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	"github.com/argoproj/gitops-engine/pkg/utils/kube/scheme"
+
 	"github.com/argoproj/argo-cd/v2/util/argo/managedfields"
 	"github.com/argoproj/argo-cd/v2/util/argo/testdata"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube/scheme"
 )
 
 func TestNormalize(t *testing.T) {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -11,12 +11,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 
-	"github.com/argoproj/argo-cd/v2/common"
-	certutil "github.com/argoproj/argo-cd/v2/util/cert"
-	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/argoproj/argo-cd/v2/common"
+	certutil "github.com/argoproj/argo-cd/v2/util/cert"
+	"github.com/argoproj/argo-cd/v2/util/env"
 )
 
 const (

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-cd/v2/common"
 )
 
 func TestAddCacheFlagsToCmd(t *testing.T) {

--- a/util/clusterauth/clusterauth.go
+++ b/util/clusterauth/clusterauth.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/common"
 	jwt "github.com/golang-jwt/jwt/v4"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/argoproj/argo-cd/v2/common"
 )
 
 // ArgoCDManagerServiceAccount is the name of the service account for managing a cluster

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +16,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v2/util/errors"
 )
 
 const (

--- a/util/db/certificate.go
+++ b/util/db/certificate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"context"
+
 	"golang.org/x/crypto/ssh"
 
 	log "github.com/sirupsen/logrus"

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -10,11 +10,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/argoproj/argo-cd/v2/common"
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/settings"
-	log "github.com/sirupsen/logrus"
 )
 
 // SecretMaperValidation determine whether the secret should be transformed(i.e. trailing CRLF characters trimmed)

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"context"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -15,9 +15,10 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
+	argoio "github.com/argoproj/gitops-engine/pkg/utils/io"
+
 	"github.com/argoproj/argo-cd/v2/util/cert"
 	"github.com/argoproj/argo-cd/v2/util/io"
-	argoio "github.com/argoproj/gitops-engine/pkg/utils/io"
 )
 
 type cred struct {

--- a/util/grpc/grpc.go
+++ b/util/grpc/grpc.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/proxy"
 	"google.golang.org/grpc"
@@ -18,6 +17,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
+
+	"github.com/argoproj/argo-cd/v2/common"
 )
 
 // PanicLoggerUnaryServerInterceptor returns a new unary server interceptor for recovering from panics and returning error

--- a/util/grpc/useragent.go
+++ b/util/grpc/useragent.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"context"
+
 	"github.com/Masterminds/semver/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/util/io/bytereadseeker_test.go
+++ b/util/io/bytereadseeker_test.go
@@ -1,10 +1,11 @@
 package io
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestByteReadSeeker_Read(t *testing.T) {

--- a/util/localconfig/localconfig_test.go
+++ b/util/localconfig/localconfig_test.go
@@ -4,11 +4,12 @@ package localconfig
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/util/log/logrus_test.go
+++ b/util/log/logrus_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-cd/v2/common"
 )
 
 func TestCreateFormatter(t *testing.T) {

--- a/util/manifeststream/stream_test.go
+++ b/util/manifeststream/stream_test.go
@@ -10,13 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/test"
 	"github.com/argoproj/argo-cd/v2/util/io/files"
 	"github.com/argoproj/argo-cd/v2/util/manifeststream"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type applicationStreamMock struct {

--- a/util/notification/expression/shared/appdetail.go
+++ b/util/notification/expression/shared/appdetail.go
@@ -1,8 +1,9 @@
 package shared
 
 import (
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"time"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 )

--- a/util/notification/expression/shared/appdetail_test.go
+++ b/util/notification/expression/shared/appdetail_test.go
@@ -1,10 +1,12 @@
 package shared
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetParameterValueByName(t *testing.T) {

--- a/util/notification/settings/settings_test.go
+++ b/util/notification/settings/settings_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
-	service "github.com/argoproj/argo-cd/v2/util/notification/argocd"
 	"github.com/argoproj/notifications-engine/pkg/api"
 	"github.com/argoproj/notifications-engine/pkg/services"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +11,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
+	service "github.com/argoproj/argo-cd/v2/util/notification/argocd"
 )
 
 const testNamespace = "default"

--- a/util/tgzstream/stream.go
+++ b/util/tgzstream/stream.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/argoproj/argo-cd/v2/util/io/files"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-cd/v2/util/io/files"
 )
 
 func CloseAndDelete(f *os.File) {


### PR DESCRIPTION
goimports is used for generated sources but not for the other files.
This pr enables it with the help of golangci