### PR TITLE
chore(deps): upgrade haproxy to 2.6.17-alpine

### DIFF
--- a/manifests/ha/base/redis-ha/chart/upstream.yaml
+++ b/manifests/ha/base/redis-ha/chart/upstream.yaml
@@ -1091,7 +1091,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
       - name: config-init
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: public.ecr.aws/docker/library/haproxy:2.6.17-alpine
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -1115,7 +1115,7 @@ spec:
           mountPath: /data
       containers:
       - name: haproxy
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: public.ecr.aws/docker/library/haproxy:2.6.17-alpine
         imagePullPolicy: IfNotPresent
         securityContext: 
           allowPrivilegeEscalation: false

--- a/manifests/ha/base/redis-ha/chart/values.yaml
+++ b/manifests/ha/base/redis-ha/chart/values.yaml
@@ -14,7 +14,7 @@ redis-ha:
     IPv6:
       enabled: false
     image:
-      tag: 2.6.14-alpine
+      tag: 2.6.17-alpine
     containerSecurityContext: null
     timeout:
       server: 6m

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -22894,7 +22894,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: public.ecr.aws/docker/library/haproxy:2.6.17-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -22949,7 +22949,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: public.ecr.aws/docker/library/haproxy:2.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1971,7 +1971,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: public.ecr.aws/docker/library/haproxy:2.6.17-alpine
         imagePullPolicy: IfNotPresent
         lifecycle: {}
         livenessProbe:
@@ -2026,7 +2026,7 @@ spec:
         - /readonly/haproxy_init.sh
         command:
         - sh
-        image: public.ecr.aws/docker/library/haproxy:2.6.14-alpine
+        image: public.ecr.aws/docker/library/haproxy:2.6.17-alpine
         imagePullPolicy: IfNotPresent
         name: config-init
         securityContext:


### PR DESCRIPTION
2.6.14 has two high-severity CVE's
```
haproxy:2.6.14-alpine (alpine 3.18.3)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ fixed  │ 3.1.2-r0          │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │        │                   │               │                                                        │
│ libssl3    │               │          │        │                   │               │                                                        │
│            │               │          │        │                   │               │                                                        │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘
```