### PR TITLE
chore: enable errorlint linter on `cmd` folder

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,7 @@ issues:
   exclude:
     - SA5011
   exclude-rules:
-    - path: "(applicationset|cmd|cmpserver|controller|reposerver|server|util)/"
+    - path: "(applicationset|cmpserver|controller|reposerver|server|util)/"
       linters:
         - errorlint
   max-issues-per-linter: 0

--- a/cmd/argocd-k8s-auth/commands/aws.go
+++ b/cmd/argocd-k8s-auth/commands/aws.go
@@ -70,7 +70,7 @@ func getSignedRequestWithRetry(ctx context.Context, timeout, interval time.Durat
 		}
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("timeout while trying to get signed aws request: last error: %s", err)
+			return "", fmt.Errorf("timeout while trying to get signed aws request: last error: %w", err)
 		case <-time.After(interval):
 		}
 	}
@@ -81,7 +81,7 @@ func getSignedRequest(clusterName, roleARN string, profile string) (string, erro
 		Profile: profile,
 	})
 	if err != nil {
-		return "", fmt.Errorf("error creating new AWS session: %s", err)
+		return "", fmt.Errorf("error creating new AWS session: %w", err)
 	}
 	stsAPI := sts.New(sess)
 	if roleARN != "" {
@@ -92,7 +92,7 @@ func getSignedRequest(clusterName, roleARN string, profile string) (string, erro
 	request.HTTPRequest.Header.Add(clusterIDHeader, clusterName)
 	signed, err := request.Presign(requestPresignParam)
 	if err != nil {
-		return "", fmt.Errorf("error presigning AWS request: %s", err)
+		return "", fmt.Errorf("error presigning AWS request: %w", err)
 	}
 	return signed, nil
 }

--- a/cmd/argocd/commands/admin/project_allowlist.go
+++ b/cmd/argocd/commands/admin/project_allowlist.go
@@ -88,15 +88,15 @@ argocd admin proj generate-allow-list /path/to/clusterrole.yaml my-project`,
 func getResourceList(clientConfig clientcmd.ClientConfig) ([]*metav1.APIResourceList, error) {
 	config, err := clientConfig.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error while creating client config: %s", err)
+		return nil, fmt.Errorf("error while creating client config: %w", err)
 	}
 	disco, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("error while creating discovery client: %s", err)
+		return nil, fmt.Errorf("error while creating discovery client: %w", err)
 	}
 	serverResources, err := disco.ServerPreferredResources()
 	if err != nil {
-		return nil, fmt.Errorf("error while getting server resources: %s", err)
+		return nil, fmt.Errorf("error while getting server resources: %w", err)
 	}
 	return serverResources, nil
 }
@@ -104,18 +104,18 @@ func getResourceList(clientConfig clientcmd.ClientConfig) ([]*metav1.APIResource
 func generateProjectAllowList(serverResources []*metav1.APIResourceList, clusterRoleFileName string, projName string) (*v1alpha1.AppProject, error) {
 	yamlBytes, err := os.ReadFile(clusterRoleFileName)
 	if err != nil {
-		return nil, fmt.Errorf("error reading cluster role file: %s", err)
+		return nil, fmt.Errorf("error reading cluster role file: %w", err)
 	}
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling cluster role file yaml: %s", err)
+		return nil, fmt.Errorf("error unmarshalling cluster role file yaml: %w", err)
 	}
 
 	clusterRole := &rbacv1.ClusterRole{}
 	err = scheme.Scheme.Convert(&obj, clusterRole, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error converting cluster role yaml into ClusterRole struct: %s", err)
+		return nil, fmt.Errorf("error converting cluster role yaml into ClusterRole struct: %w", err)
 	}
 
 	resourceList := make([]metav1.GroupKind, 0)

--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -202,12 +202,12 @@ var validatorsByGroup = map[string]settingValidator{
 		ssoProvider := ""
 		if general.DexConfig != "" {
 			if _, err := settings.UnmarshalDexConfig(general.DexConfig); err != nil {
-				return "", fmt.Errorf("invalid dex.config: %v", err)
+				return "", fmt.Errorf("invalid dex.config: %w", err)
 			}
 			ssoProvider = "Dex"
 		} else if general.OIDCConfigRAW != "" {
 			if err := settings.ValidateOIDCConfig(general.OIDCConfigRAW); err != nil {
-				return "", fmt.Errorf("invalid oidc.config: %v", err)
+				return "", fmt.Errorf("invalid oidc.config: %w", err)
 			}
 			ssoProvider = "OIDC"
 		}

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	std_errors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -514,10 +515,10 @@ func NewApplicationLogsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				}
 				for {
 					msg, err := stream.Recv()
-					if err == io.EOF {
-						return
-					}
 					if err != nil {
+						if std_errors.Is(err, io.EOF) {
+							return
+						}
 						st, ok := status.FromError(err)
 						if !ok {
 							log.Fatalf("stream read failed: %v", err)

--- a/cmd/argocd/commands/project_role.go
+++ b/cmd/argocd/commands/project_role.go
@@ -314,7 +314,7 @@ Create token succeeded for proj:test-project:test-role.
 
 			token, err := jwtgo.Parse(tokenResponse.Token, nil)
 			if token == nil {
-				err = fmt.Errorf("received malformed token %v", err)
+				err = fmt.Errorf("received malformed token %w", err)
 				errors.CheckError(err)
 				return
 			}


### PR DESCRIPTION
Activates and fixes errorlint on `cmd` folder.