### PR TITLE
chore: enable require-error rule from testifylint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,14 @@ issues:
     - path: "(cmpserver|reposerver|server)/"
       linters:
         - errorlint
+    - path: "(applicationset|cmd|cmpserver|controller|pkg|reposerver|server|test)/"
+      text: "require-error:"
+      linters:
+        - testifylint
+    - path: "util/(argo|cache|cert|clusterauth|config|db|dex|git|gpg|grpc|helm|http|io|kube|kustomize|lua|notification|oidc|rbac|security|session|settings|tls|webhook)/"
+      text: "require-error:"
+      linters:
+        - testifylint
   max-issues-per-linter: 0
   max-same-issues: 0
 linters:
@@ -30,6 +38,5 @@ linters-settings:
       - error-is-as
       - float-compare
       - go-require
-      - require-error
 run:
   timeout: 50m

--- a/util/app/discovery/discovery_test.go
+++ b/util/app/discovery/discovery_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiscover(t *testing.T) {
 	apps, err := Discover(context.Background(), "./testdata", "./testdata", map[string]bool{}, []string{}, []string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"foo": "Kustomize",
 		"baz": "Helm",
@@ -20,15 +21,15 @@ func TestDiscover(t *testing.T) {
 
 func TestAppType(t *testing.T) {
 	appType, err := AppType(context.Background(), "./testdata/foo", "./testdata", map[string]bool{}, []string{}, []string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Kustomize", appType)
 
 	appType, err = AppType(context.Background(), "./testdata/baz", "./testdata", map[string]bool{}, []string{}, []string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Helm", appType)
 
 	appType, err = AppType(context.Background(), "./testdata", "./testdata", map[string]bool{}, []string{}, []string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 }
 
@@ -38,14 +39,14 @@ func TestAppType_Disabled(t *testing.T) {
 		string(v1alpha1.ApplicationSourceTypeHelm):      false,
 	}
 	appType, err := AppType(context.Background(), "./testdata/foo", "./testdata", enableManifestGeneration, []string{}, []string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 
 	appType, err = AppType(context.Background(), "./testdata/baz", "./testdata", enableManifestGeneration, []string{}, []string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 
 	appType, err = AppType(context.Background(), "./testdata", "./testdata", enableManifestGeneration, []string{}, []string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Directory", appType)
 }

--- a/util/app/path/path_test.go
+++ b/util/app/path/path_test.go
@@ -16,70 +16,70 @@ import (
 
 func TestPathRoot(t *testing.T) {
 	_, err := Path("./testdata", "/")
-	assert.EqualError(t, err, "/: app path is absolute")
+	require.EqualError(t, err, "/: app path is absolute")
 }
 
 func TestPathAbsolute(t *testing.T) {
 	_, err := Path("./testdata", "/etc/passwd")
-	assert.EqualError(t, err, "/etc/passwd: app path is absolute")
+	require.EqualError(t, err, "/etc/passwd: app path is absolute")
 }
 
 func TestPathDotDot(t *testing.T) {
 	_, err := Path("./testdata", "..")
-	assert.EqualError(t, err, "..: app path outside root")
+	require.EqualError(t, err, "..: app path outside root")
 }
 
 func TestPathDotDotSlash(t *testing.T) {
 	_, err := Path("./testdata", "../")
-	assert.EqualError(t, err, "../: app path outside root")
+	require.EqualError(t, err, "../: app path outside root")
 }
 
 func TestPathDot(t *testing.T) {
 	_, err := Path("./testdata", ".")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestPathDotSlash(t *testing.T) {
 	_, err := Path("./testdata", "./")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestNonExistentPath(t *testing.T) {
 	_, err := Path("./testdata", "does-not-exist")
-	assert.EqualError(t, err, "does-not-exist: app path does not exist")
+	require.EqualError(t, err, "does-not-exist: app path does not exist")
 }
 
 func TestPathNotDir(t *testing.T) {
 	_, err := Path("./testdata", "file.txt")
-	assert.EqualError(t, err, "file.txt: app path is not a directory")
+	require.EqualError(t, err, "file.txt: app path is not a directory")
 }
 
 func TestGoodSymlinks(t *testing.T) {
 	err := CheckOutOfBoundsSymlinks("./testdata/goodlink")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Simple check of leaving the repo
 func TestBadSymlinks(t *testing.T) {
 	err := CheckOutOfBoundsSymlinks("./testdata/badlink")
-	oobError := &OutOfBoundsSymlinkError{}
-	assert.ErrorAs(t, err, &oobError)
+	var oobError *OutOfBoundsSymlinkError
+	require.ErrorAs(t, err, &oobError)
 	assert.Equal(t, "badlink", oobError.File)
 }
 
 // Crazy formatting check
 func TestBadSymlinks2(t *testing.T) {
 	err := CheckOutOfBoundsSymlinks("./testdata/badlink2")
-	oobError := &OutOfBoundsSymlinkError{}
-	assert.ErrorAs(t, err, &oobError)
+	var oobError *OutOfBoundsSymlinkError
+	require.ErrorAs(t, err, &oobError)
 	assert.Equal(t, "badlink", oobError.File)
 }
 
 // Make sure no part of the symlink can leave the repo, even if it ultimately targets inside the repo
 func TestBadSymlinks3(t *testing.T) {
 	err := CheckOutOfBoundsSymlinks("./testdata/badlink3")
-	oobError := &OutOfBoundsSymlinkError{}
-	assert.ErrorAs(t, err, &oobError)
+	var oobError *OutOfBoundsSymlinkError
+	require.ErrorAs(t, err, &oobError)
 	assert.Equal(t, "badlink", oobError.File)
 }
 
@@ -89,8 +89,8 @@ func TestAbsSymlink(t *testing.T) {
 	require.NoError(t, fileutil.CreateSymlink(t, testDir, "/somethingbad", "abslink"))
 	defer os.Remove(path.Join(testDir, "abslink"))
 	err := CheckOutOfBoundsSymlinks(testDir)
-	oobError := &OutOfBoundsSymlinkError{}
-	assert.ErrorAs(t, err, &oobError)
+	var oobError *OutOfBoundsSymlinkError
+	require.ErrorAs(t, err, &oobError)
 	assert.Equal(t, "abslink", oobError.File)
 }
 

--- a/util/exec/exec_test.go
+++ b/util/exec/exec_test.go
@@ -9,6 +9,7 @@ import (
 
 	argoexec "github.com/argoproj/pkg/exec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_timeout(t *testing.T) {
@@ -25,7 +26,7 @@ func Test_timeout(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	out, err := Run(exec.Command("ls"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, out)
 }
 

--- a/util/github_app/repos_test.go
+++ b/util/github_app/repos_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/v2/applicationset/services/github_app_auth"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -51,7 +52,7 @@ func Test_repoAsCredentials_GetAuth(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, auth)
 		})
 	}

--- a/util/jwt/jwt_test.go
+++ b/util/jwt/jwt_test.go
@@ -7,6 +7,7 @@ import (
 
 	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetSingleStringScope(t *testing.T) {
@@ -43,7 +44,7 @@ func TestIssuedAtTime_Int64(t *testing.T) {
 	// Tuesday, 1 December 2020 14:00:00
 	claims := jwt.MapClaims{"iat": int64(1606831200)}
 	issuedAt, err := IssuedAtTime(claims)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	str := fmt.Sprint(issuedAt.UTC().Format("Mon Jan _2 15:04:05 2006"))
 	assert.Equal(t, "Tue Dec  1 14:00:00 2020", str)
 }
@@ -57,7 +58,7 @@ func TestIssuedAtTime_Error_NoInt(t *testing.T) {
 func TestIssuedAtTime_Error_Missing(t *testing.T) {
 	claims := jwt.MapClaims{}
 	iat, err := IssuedAtTime(claims)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, time.Unix(0, 0), iat)
 }
 

--- a/util/proxy/proxy_test.go
+++ b/util/proxy/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddProxyEnvIfAbsent(t *testing.T) {
@@ -30,14 +31,14 @@ func TestGetCallBack(t *testing.T) {
 	t.Run("custom proxy present", func(t *testing.T) {
 		proxy := "http://proxy:8888"
 		url, err := GetCallback(proxy)(nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, proxy, url.String())
 	})
 	t.Run("custom proxy absent", func(t *testing.T) {
 		proxyEnv := "http://proxy:8888"
 		t.Setenv("http_proxy", "http://proxy:8888")
 		url, err := GetCallback("")(httptest.NewRequest(http.MethodGet, proxyEnv, nil))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, proxyEnv, url.String())
 	})
 }

--- a/util/text/label/label_test.go
+++ b/util/text/label/label_test.go
@@ -4,21 +4,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseLabels(t *testing.T) {
 	validLabels := []string{"key=value", "foo=bar", "intuit=inc"}
 
 	result, err := Parse(validLabels)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, result, 3)
 
 	invalidLabels := []string{"key=value", "too=many=equals"}
 	_, err = Parse(invalidLabels)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	emptyLabels := []string{}
 	result, err = Parse(emptyLabels)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, result)
 }


### PR DESCRIPTION
enable and fixes require-error rule from testifylint linter first part.
