### PR TITLE
feat(reposerver): Skip calling git fetch if commit to checkout exists locally

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2428,10 +2428,19 @@ func checkoutRevision(gitClient git.Client, revision string, submoduleEnabled bo
 		return status.Errorf(codes.Internal, "Failed to initialize git repo: %v", err)
 	}
 
-	// Fetching with no revision first. Fetching with an explicit version can cause repo bloat. https://github.com/argoproj/argo-cd/issues/8845
-	err = gitClient.Fetch("")
-	if err != nil {
-		return status.Errorf(codes.Internal, "Failed to fetch default: %v", err)
+	revisionPresent := gitClient.IsRevisionPresent(revision)
+
+	log.WithFields(map[string]interface{}{
+		"skipFetch": revisionPresent,
+	}).Infof("Checking out revision %v", revision)
+
+	// Fetching can be skipped if the revision is already present locally.
+	if !revisionPresent {
+		// Fetching with no revision first. Fetching with an explicit version can cause repo bloat. https://github.com/argoproj/argo-cd/issues/8845
+		err = gitClient.Fetch("")
+		if err != nil {
+			return status.Errorf(codes.Internal, "Failed to fetch default: %v", err)
+		}
 	}
 
 	err = gitClient.Checkout(revision, submoduleEnabled)

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -2432,7 +2432,7 @@ func checkoutRevision(gitClient git.Client, revision string, submoduleEnabled bo
 
 	log.WithFields(map[string]interface{}{
 		"skipFetch": revisionPresent,
-	}).Infof("Checking out revision %v", revision)
+	}).Debugf("Checking out revision %v", revision)
 
 	// Fetching can be skipped if the revision is already present locally.
 	if !revisionPresent {

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -81,6 +81,7 @@ type Client interface {
 	VerifyCommitSignature(string) (string, error)
 	IsAnnotatedTag(string) bool
 	ChangedFiles(revision string, targetRevision string) ([]string, error)
+	IsRevisionPresent(revision string) bool
 }
 
 type EventHandlers struct {
@@ -355,6 +356,21 @@ func (m *nativeGitClient) fetch(revision string) error {
 		err = m.runCredentialedCmd("fetch", "origin", "--tags", "--force", "--prune")
 	}
 	return err
+}
+
+// IsRevisionPresent checks to see if the given revision already exists locally.
+func (m *nativeGitClient) IsRevisionPresent(revision string) bool {
+	if revision == "" {
+		return false
+	}
+
+	cmd := exec.Command("git", "cat-file", "-t", revision)
+	out, err := m.runCmdOutput(cmd, runOpts{SkipErrorLogging: true})
+	if out == "commit" && err == nil {
+		return true
+	} else {
+		return false
+	}
 }
 
 // Fetch fetches latest updates from origin

--- a/util/git/mocks/Client.go
+++ b/util/git/mocks/Client.go
@@ -142,6 +142,24 @@ func (_m *Client) IsAnnotatedTag(_a0 string) bool {
 	return r0
 }
 
+// IsRevisionPresent provides a mock function with given fields: revision
+func (_m *Client) IsRevisionPresent(revision string) bool {
+	ret := _m.Called(revision)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsRevisionPresent")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(revision)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // LsFiles provides a mock function with given fields: path, enableNewGitFileGlobbing
 func (_m *Client) LsFiles(path string, enableNewGitFileGlobbing bool) ([]string, error) {
 	ret := _m.Called(path, enableNewGitFileGlobbing)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Problem

Our monorepo is frequently updated with hundreds of application changes in a very short period of time (within 15 to 30 minutes). This leads to a large amount of calls to [checkoutRevision](https://github.com/argoproj/argo-cd/blob/9f1e2e84530e94a110a66c3cd95793584c8f313e/reposerver/repository/repository.go#L2425) in the reposerver, where `git fetch` is called each time. Since `checkoutRevision` is wrapped in a lock, it becomes a bottleneck that causes the application controller's work-queue depth to blow up:

<img width="381" alt="image" src="https://github.com/argoproj/argo-cd/assets/94873900/b123a68e-c254-4fdd-a549-7698fbba2768">

## Solution

When we have a lot of commits landing around the same time, chances are a previous `git fetch` would have already pulled in the commit SHA we want to checkout. Therefore, this PR introduces a check to see if the revision being checked out already exists locally. If so, `git fetch` is skipped and we move on directly to `git checkout`.

## Outcome

### Decreased `git fetch` calls
We've had this change deployed in production for a month now, and so far we've seen an 80% decrease in `git fetch` calls. Over a two week period, we ended up skipping 134,000 calls we would have otherwise made:

<img width="985" alt="image" src="https://github.com/argoproj/argo-cd/assets/94873900/2e3a64e9-4aa8-40a8-8fc7-45b7cb353da9">

### Decreased work-queue depth
Our application-controller has been a lot healthier since we made this change. During most peak periods, we only see a work-queue depth in the single digits now. Previously we were dealing with a depth exceeding 400.

<img width="381" alt="image" src="https://github.com/argoproj/argo-cd/assets/94873900/699f7979-7aec-4315-89c6-29fff03c88c0">


### Decreased sync times
Our application sync durations are now steady and predictable, usually in the range of 20 to 30 seconds, no matter the load. Prior to the change, we were dealing with sync durations in the 5 to 10 minute range.

<img width="1170" alt="image" src="https://github.com/argoproj/argo-cd/assets/94873900/1427096c-5695-4645-96b5-3c9877b1dacb">

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
