### PR TITLE
docs(cli): remove docs for non-existing `argocd app set` flags (#18671)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -746,12 +746,6 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
   # Set and validate application parameters for "my-app"
   argocd app set my-app --parameter key1=value1 --parameter key2=value2 --validate
 
-  # Set and override application parameters with JSON or YAML file
-  argocd app set my-app --from-file path/to/parameters.json
-
-  # Set and override application parameters with a parameter file
-  argocd app set my-app --parameter-file path/to/parameter-file.yaml
-
   # Set and override application parameters for a source at position 1 under spec.sources of app my-app. source-position starts at 1.
   argocd app set my-app --source-position 1 --repo https://github.com/argoproj/argocd-example-apps.git
 

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -17,12 +17,6 @@ argocd app set APPNAME [flags]
   # Set and validate application parameters for "my-app"
   argocd app set my-app --parameter key1=value1 --parameter key2=value2 --validate
   
-  # Set and override application parameters with JSON or YAML file
-  argocd app set my-app --from-file path/to/parameters.json
-  
-  # Set and override application parameters with a parameter file
-  argocd app set my-app --parameter-file path/to/parameter-file.yaml
-  
   # Set and override application parameters for a source at position 1 under spec.sources of app my-app. source-position starts at 1.
   argocd app set my-app --source-position 1 --repo https://github.com/argoproj/argocd-example-apps.git
   


### PR DESCRIPTION
These flags don't actually exist.

Fixes #18671