### PR TITLE
chore: ignore mocks in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,7 @@ ignore:
 - "pkg/client/.*"
 - "vendor/.*"
 - "test/.*"
+- "**/mocks/*"
 coverage:
   status:
     # we've found this not to be useful


### PR DESCRIPTION
Mocks are generally generated and shouldn't be counted in code coverage.