### PR TITLE
chore: add codecov config to CI approvers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 /mkdocs.yml  @argoproj/argocd-approvers @argoproj/argocd-approvers-docs
 
 # CI
+/.codecov.yml             @argoproj/argocd-approvers @argoproj/argocd-approvers-ci
 /.github/**               @argoproj/argocd-approvers @argoproj/argocd-approvers-ci
 /.goreleaser.yaml         @argoproj/argocd-approvers @argoproj/argocd-approvers-ci
 /sonar-project.properties @argoproj/argocd-approvers @argoproj/argocd-approvers-ci


### PR DESCRIPTION
Codecov config changes should be approvable by CI maintainers.