### PR TITLE
feat(sharding): Additional legacy shard algorithm that provides consistent shard on duplicate server URLs (#18118)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -113,6 +113,8 @@ const (
 
 	// LegacyShardingAlgorithm is the default value for Sharding Algorithm it uses an `uid` based distribution (non-uniform)
 	LegacyShardingAlgorithm = "legacy"
+	// LegacyURLShardingAlgorithm is a modification of LegacyShardingAlgorithm that ensures consistency with the same server URL
+	LegacyURLShardingAlgorithm = "legacy-url"
 	// RoundRobinShardingAlgorithm is a flag value that can be opted for Sharding Algorithm it uses an equal distribution across all shards
 	RoundRobinShardingAlgorithm = "round-robin"
 	// AppControllerHeartbeatUpdateRetryCount is the retry count for updating the Shard Mapping to the Shard Mapping ConfigMap used by Application Controller

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -89,6 +89,8 @@ func GetDistributionFunction(clusters clusterAccessor, apps appAccessor, shardin
 		distributionFunction = RoundRobinDistributionFunction(clusters, replicasCount)
 	case common.LegacyShardingAlgorithm:
 		distributionFunction = LegacyDistributionFunction(replicasCount)
+	case common.LegacyURLShardingAlgorithm:
+		distributionFunction = LegacyDistributionByURLFunction(replicasCount)
 	case common.ConsistentHashingWithBoundedLoadsAlgorithm:
 		distributionFunction = ConsistentHashingWithBoundedLoadsDistributionFunction(clusters, apps, replicasCount)
 	default:
@@ -126,6 +128,35 @@ func LegacyDistributionFunction(replicas int) DistributionFunction {
 			_, _ = h.Write([]byte(id))
 			shard := int32(h.Sum32() % uint32(replicas))
 			log.Debugf("Cluster with id=%s will be processed by shard %d", id, shard)
+			return int(shard)
+		}
+	}
+}
+
+// LegacyDistributionByURLFunction is the same as LegacyDistributionFunction except
+// it will ensure that clusters with the same server URL will return the same shard
+func LegacyDistributionByURLFunction(replicas int) DistributionFunction {
+	return func(c *v1alpha1.Cluster) int {
+		if replicas == 0 {
+			log.Debugf("Replicas count is : %d, returning -1", replicas)
+			return -1
+		}
+		if c == nil {
+			log.Debug("In-cluster: returning 0")
+			return 0
+		}
+		if c.Shard != nil && int(*c.Shard) < replicas {
+			return int(*c.Shard)
+		}
+		server := c.Server
+		log.Debugf("Calculating cluster shard for cluster id=%s and server=%s", c.ID, c.Server)
+		if server == "" {
+			return 0
+		} else {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(server))
+			shard := int32(h.Sum32() % uint32(replicas))
+			log.Debugf("Cluster with id=%s and server=%s will be processed by shard %d", c.ID, server, shard)
 			return int(shard)
 		}
 	}

--- a/controller/sharding/sharding_test.go
+++ b/controller/sharding/sharding_test.go
@@ -101,6 +101,20 @@ func TestGetClusterFilterLegacy(t *testing.T) {
 	assert.Equal(t, 1, distributionFunction(&cluster4))
 }
 
+func TestGetDuplicateClusterFilterLegacy(t *testing.T) {
+	// Clusters with same URL should return same shard
+	_, db, cluster1, cluster2, cluster3, cluster4, _ := createDuplicateTestClusters()
+	replicasCount := 2
+	db.On("GetApplicationControllerReplicas").Return(replicasCount)
+	t.Setenv(common.EnvControllerShardingAlgorithm, common.LegacyURLShardingAlgorithm)
+	distributionFunction := LegacyDistributionByURLFunction(replicasCount)
+	assert.Equal(t, 0, distributionFunction(nil))
+	assert.Equal(t, 1, distributionFunction(&cluster1))
+	assert.Equal(t, 1, distributionFunction(&cluster2))
+	assert.Equal(t, 1, distributionFunction(&cluster3))
+	assert.Equal(t, 1, distributionFunction(&cluster4))
+}
+
 func TestGetClusterFilterUnknown(t *testing.T) {
 	clusterAccessor, db, cluster1, cluster2, cluster3, cluster4, _ := createTestClusters()
 	appAccessor, _, _, _, _, _ := createTestApps()
@@ -438,6 +452,22 @@ func createTestClusters() (clusterAccessor, *dbmocks.ArgoDB, v1alpha1.Cluster, v
 	return getClusterAccessor(clusters), &db, cluster1, cluster2, cluster3, cluster4, cluster5
 }
 
+func createDuplicateTestClusters() (clusterAccessor, *dbmocks.ArgoDB, v1alpha1.Cluster, v1alpha1.Cluster, v1alpha1.Cluster, v1alpha1.Cluster, v1alpha1.Cluster) {
+	db := dbmocks.ArgoDB{}
+	cluster1 := createDuplicateCluster("cluster1", "1")
+	cluster2 := createDuplicateCluster("cluster2", "2")
+	cluster3 := createDuplicateCluster("cluster3", "3")
+	cluster4 := createDuplicateCluster("cluster4", "4")
+	cluster5 := createDuplicateCluster("cluster5", "5")
+
+	clusters := []v1alpha1.Cluster{cluster1, cluster2, cluster3, cluster4, cluster5}
+
+	db.On("ListClusters", mock.Anything).Return(&v1alpha1.ClusterList{Items: []v1alpha1.Cluster{
+		cluster1, cluster2, cluster3, cluster4, cluster5,
+	}}, nil)
+	return getClusterAccessor(clusters), &db, cluster1, cluster2, cluster3, cluster4, cluster5
+}
+
 func getClusterAccessor(clusters []v1alpha1.Cluster) clusterAccessor {
 	// Convert the array to a slice of pointers
 	clusterPointers := getClusterPointers(clusters)
@@ -458,6 +488,15 @@ func createCluster(name string, id string) v1alpha1.Cluster {
 		Name:   name,
 		ID:     id,
 		Server: "https://kubernetes.default.svc?" + id,
+	}
+	return cluster
+}
+
+func createDuplicateCluster(name string, id string) v1alpha1.Cluster {
+	cluster := v1alpha1.Cluster{
+		Name:   name,
+		ID:     id,
+		Server: "https://kubernetes.default.svc",
 	}
 	return cluster
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

Closes #18118

There is an edge case where cluster secrets may be duplicated (by server URL, or in other words multiple cluster secrets that point to the same physical cluster) to be able to easily target an ApplicationSet to tenants within the same physical cluster.

Unfortunately, this causes an issue when there are more than 1 controller replicas, because the sharding algorithms assume that the cluster ID uniquely identifies each physical cluster. This results in potentially the same physical cluster being sharded to more than one controller and causing sync/race condition issues (e.g. helm hooks breaking as two controllers race against each other).

This PR adds an additional sharding algorithm that is a modification of the existing legacy distribution algorithm. It shards by the cluster's server URL instead so that any cluster with the same server URL will return the same consistent shard to avoid the above described issue.

Please let me know if there is a better method or preferred solution to this issue; this seemed like the least harmful to cause issue to existing users as it is opt-in.
