### PR TITLE
fix(ci): use commit hash instead of release number in security insights

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -291,7 +291,7 @@ jobs:
           # Replace the 'project-release: vX.X.X-rcX' line in SECURITY-INSIGHTS.yml
           sed -i "s/project-release: v.*$/project-release: v${{ env.NEW_VERSION }}/" SECURITY-INSIGHTS.yml
           # Update the 'commit-hash: XXXXXXX' line in SECURITY-INSIGHTS.yml
-          sed -i "s/commit-hash: .*/commit-hash: ${{ env.NEW_VERSION }}/" SECURITY-INSIGHTS.yml
+          sed -i "s/commit-hash: .*/commit-hash: ${{ env.COMMIT_HASH }}/" SECURITY-INSIGHTS.yml
         if: ${{ env.UPDATE_VERSION == 'true' }}
 
       - name: Create PR to update VERSION on master branch


### PR DESCRIPTION
Currently produces an incorrect yaml file: https://github.com/argoproj/argo-cd/pull/18717/files