### PR TITLE
docs: don't populate tested versions on latest

### DIFF
--- a/docs/operator-manual/tested-kubernetes-versions.md
+++ b/docs/operator-manual/tested-kubernetes-versions.md
@@ -1,6 +1,2 @@
-| Argo CD version | Kubernetes versions |
-|-----------------|---------------------|
-| 2.7 | v1.26, v1.25, v1.24, v1.23 |
-| 2.6 | v1.24, v1.23, v1.22 |
-| 2.5 | v1.24, v1.23, v1.22 |
-
+This page is populated for released Argo CD versions. Use the version selector to view this table for a specific 
+version. 


### PR DESCRIPTION
Automation currently only updates this table on release branches.