### PR TITLE
feat: cmp/stream - allow to exclude all('*')

### DIFF
--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -109,12 +109,9 @@ func SendRepoStream(ctx context.Context, appPath, repoPath string, sender Stream
 
 func GetCompressedRepoAndMetadata(repoPath string, appPath string, env []string, excludedGlobs []string, opt *senderOption) (*os.File, *pluginclient.AppStreamRequest, error) {
 	// compress all files in repoPath in tgz
-	tgz, filesWritten, checksum, err := tgzstream.CompressFiles(repoPath, nil, excludedGlobs)
+	tgz, _, checksum, err := tgzstream.CompressFiles(repoPath, nil, excludedGlobs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error compressing repo files: %w", err)
-	}
-	if filesWritten == 0 {
-		return nil, nil, fmt.Errorf("no files to send")
 	}
 	if opt != nil && opt.tarDoneChan != nil {
 		opt.tarDoneChan <- true


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

This one is regarding:
https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#plugin-tar-stream-exclusions

This one is a tricky one. It's not a "new feature", yet it's not really a "bug fix", it's just merely allowing to set
**ARGOCD_REPO_SERVER_PLUGIN_TAR_EXCLUSIONS='*'**

No need to edit the current document since the document doesn't suggest anything about not excluding all the files
In practice, if you actually try to exclude all the files you will get the 'no files to send' error

Why should we allow exclude everything?
- well, it's the "admin" choice to do so, if he knows what he's doing then it shouldn't bother the argo development team and he should have the freedom to do so, if it's not introducing breaking changes.
- maybe i got an empty repo and i already exclude '.git/*', in that case i'll have the same error result. but who to decide that an empty repository can't get processed by a plugin that generates manifests on the fly from build envs/other sources?

So is it backward compatible?
- yes, because it just gives you the possibility to configure to send an empty TAR to the CMP server (this is probably not configured anywhere because it was not allowed...) , it doesn't disable the possibility to send a non-empty TAR.. 

Why was it not allowed so far?
- I guess there was an assumption that if it's a GitOps tool you should have at least some sources that you want to process in order to generate manifests.
- to safeguard users from misconfiguration of the exclusion globs. (which it doesn't really keep them safe..). we might consider adding a notice such as "Use exclusion wisly and make sure you do not exclude files that are needed for your plugin operation".

---

My use case:
we have a monorepo, we do not change files in the file system during generation yet we can not use the same source  to generate manifests. the default tar-gz/stream/untar-gz per generation operation takes a heavy toll on the Disk I/O.
our quick workaround this problem could be:
- copy nothing (exlude '*')
- have a shared volume between the `argocd-repo-server` and the plugin sidecar.  (shared /tmp/_argocd-repo)
- change the plugin manifest like so:
```
apiVersion: argoproj.io/v1alpha1
kind: ConfigManagementPlugin
metadata:
  name: my-plugin
spec:
  generate:
    command:
      - bash
      - -c
      - |
        ### added changes to support such change, pseudo code
        cd /_tmp/_argocd-repo && match the "correct-repo-uuid" using "$ARGOCD_APP_SOURCE_REPO_URL"
        cd "correct-repo-uuid/$ARGOCD_APP_SOURCE_PATH"
        
        ### rest of the plugin commands
        kustimoze build . | helm template . | envsubst | you-name-it | argocd-vault-plugin | etc etc...
```

I'm not claiming this is a way to go. or such methods should be the preferred way of doing stuff, there are probably more pitfalls one might think about, such as multiple plugins needs extra attention, discovery rules needed to be carefully crafted, generate operations that do change the filesystem in order to manipulate the manifests, etc etc etc
but all those concerns are offloaded to the admin and are not part of the argocd scope

**for us it's a quick win by enabling something which is only logical - allowing the admin to exclude what ever he want.**

this can allow other quick wins for admins, without being too hacky or have a customized forked binary that they don't want to maintain, i've collected issues that could benefit or in someway related:

https://github.com/argoproj/argo-cd/pull/16146
https://github.com/argoproj/argo-cd/issues/15763
https://github.com/argoproj/argo-cd/issues/17775 
https://github.com/argoproj/argo-cd/pull/18054
https://github.com/argoproj/argo-cd/issues/17951
https://github.com/argoproj/argo-cd/issues/16837
https://github.com/argoproj/argo-cd/issues/18795

@crenshaw-dev @jsolana @czchen @momilo @clement-heetch @woehrl01

and this is the PR the introduced the big change CMP way of operation https://github.com/argoproj/argo-cd/pull/8600 
my PR doesn't revert anything. just allows one to have a logical escape hatch 

