### PR TITLE
fix(ui): incorrect notifications annotation regex

### DIFF
--- a/ui/src/app/applications/components/application-summary/edit-notification-subscriptions.tsx
+++ b/ui/src/app/applications/components/application-summary/edit-notification-subscriptions.tsx
@@ -10,8 +10,7 @@ import './edit-notification-subscriptions.scss';
 
 export const NOTIFICATION_SUBSCRIPTION_ANNOTATION_PREFIX = 'notifications.argoproj.io/subscribe';
 
-// eslint-disable-next-line no-useless-escape
-export const NOTIFICATION_SUBSCRIPTION_ANNOTATION_REGEX = new RegExp(`^notifications\.argoproj\.io\/subscribe\.[a-zA-Z-]{1,100}\.[a-zA-Z-]{1,100}$`);
+export const NOTIFICATION_SUBSCRIPTION_ANNOTATION_REGEX = new RegExp(`^notifications\\.argoproj\\.io/subscribe\\.[a-zA-Z-]{1,100}\\.[a-zA-Z-]{1,100}$`);
 
 export type TNotificationSubscription = {
     trigger: string;

--- a/ui/src/app/applications/components/application-summary/edit-notification-subscriptsions.test.ts
+++ b/ui/src/app/applications/components/application-summary/edit-notification-subscriptsions.test.ts
@@ -1,0 +1,6 @@
+import {NOTIFICATION_SUBSCRIPTION_ANNOTATION_REGEX} from "./edit-notification-subscriptions";
+
+test('rejects incorrect annotations', () => {
+    expect(NOTIFICATION_SUBSCRIPTION_ANNOTATION_REGEX.test('notifications_argoproj_io/subscribe_a_b')).toEqual(false)
+    expect(NOTIFICATION_SUBSCRIPTION_ANNOTATION_REGEX.test('notifications.argoproj.io/subscribe.a.b')).toEqual(true)
+})


### PR DESCRIPTION
The existing regex has some useless escapes (`\.` evaluated to just `.` before the regex was validated), and the `\` in `\/` was simply unnecessary.