### PR TITLE
fix(appset): missing permissions (#18829)

### DIFF
--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-role.yaml
@@ -27,6 +27,8 @@ rules:
       - appprojects
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - argoproj.io
     resources:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -20822,6 +20822,8 @@ rules:
   - appprojects
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -20860,6 +20860,8 @@ rules:
   - appprojects
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -149,6 +149,8 @@ rules:
   - appprojects
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -20849,6 +20849,8 @@ rules:
   - appprojects
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - argoproj.io
   resources:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -138,6 +138,8 @@ rules:
   - appprojects
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - argoproj.io
   resources:


### PR DESCRIPTION
Closes #18829

Not too sure when the above issue started, it might be related to Kubernetes libraries updates, but it is fairly common to have get/list/watch permissions given together.

We should cherry pick in 2.12