### PR TITLE
fix: ApplicationSource.Equal return false negative (#18632)

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -2821,7 +2822,21 @@ func (source *ApplicationSource) Equals(other *ApplicationSource) bool {
 	otherCopy := other.DeepCopy()
 	sourceCopy.Plugin = nil
 	otherCopy.Plugin = nil
+	sourceCopy.htmlEscape()
+	otherCopy.htmlEscape()
 	return reflect.DeepEqual(sourceCopy, otherCopy)
+}
+
+func (source *ApplicationSource) htmlEscape() {
+	if source.Helm != nil {
+		if source.Helm.ValuesObject != nil {
+			if source.Helm.ValuesObject.Raw != nil {
+				var buf bytes.Buffer
+				json.HTMLEscape(&buf, source.Helm.ValuesObject.Raw)
+				source.Helm.ValuesObject.Raw = buf.Bytes()
+			}
+		}
+	}
 }
 
 // ExplicitType returns the type (e.g. Helm, Kustomize, etc) of the application. If either none or multiple types are defined, returns an error.

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1286,6 +1286,27 @@ func TestApplicationSource_IsZero(t *testing.T) {
 	}
 }
 
+func TestApplicationSource_Equals(t *testing.T) {
+	t.Run("Escaped Characters", func(t *testing.T) {
+		src1 := ApplicationSource{
+			Helm: &ApplicationSourceHelm{
+				ValuesObject: &runtime.RawExtension{
+					Raw: []byte(`{"Test":"test&<>  "}`),
+				},
+			},
+		}
+		src2 := ApplicationSource{
+			Helm: &ApplicationSourceHelm{
+				ValuesObject: &runtime.RawExtension{
+					Raw: []byte(`{"Test":"test\u0026\u003c\u003e\u2028\u2029"}`),
+				},
+			},
+		}
+
+		assert.True(t, src1.Equals(&src2))
+	})
+}
+
 func TestApplicationSourceHelm_AddParameter(t *testing.T) {
 	src := ApplicationSourceHelm{}
 	t.Run("Add", func(t *testing.T) {


### PR DESCRIPTION
Fixes: #18632

go's standard JSON library escape all HTML special character which cause Equal function to return false when comparing escaped and unescaped characters.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
