### PR TITLE
docs: fix typo on 2.13 upgrade manual

### DIFF
--- a/docs/operator-manual/upgrading/2.12-2.13.md
+++ b/docs/operator-manual/upgrading/2.12-2.13.md
@@ -10,7 +10,7 @@ The following actions are now available:
 | HelmRelease           | `Suspend`, `Resume`, `Reconcile` |
 | ImageRepository       | `Suspend`, `Resume`, `Reconcile` |
 | ImageUpdateAutomation | `Suspend`, `Resume`, `Reconcile` |
-| Kustomziation         | `Suspend`, `Resume`, `Reconcile` |
+| Kustomization         | `Suspend`, `Resume`, `Reconcile` |
 | Alert                 | `Suspend`, `Resume`              |
 | Provider              | `Suspend`, `Resume`              |
 | Receiver              | `Suspend`, `Resume`, `Reconcile` |


### PR DESCRIPTION
fix typo on 2.13 upgrade manual

Checklist:

* [c] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)