### PR TITLE
chore(ci): allow more go dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
     ignore:
     - dependency-name: k8s.io/*
 


### PR DESCRIPTION
go updates are usually relatively safe due to test coverage. We can afford to have more of them open.