### PR TITLE
fix: notifications triggered from CLI fails for repo functions

### DIFF
--- a/cmd/argocd/commands/admin/notifications.go
+++ b/cmd/argocd/commands/admin/notifications.go
@@ -35,7 +35,8 @@ func NewNotificationsCommand() *cobra.Command {
 		"notifications",
 		"argocd admin notifications",
 		applications,
-		settings.GetFactorySettings(argocdService, "argocd-notifications-secret", "argocd-notifications-cm", false), func(clientConfig clientcmd.ClientConfig) {
+		settings.GetFactorySettingsForCLI(&argocdService, "argocd-notifications-secret", "argocd-notifications-cm", false),
+		func(clientConfig clientcmd.ClientConfig) {
 			k8sCfg, err := clientConfig.ClientConfig()
 			if err != nil {
 				log.Fatalf("Failed to parse k8s config: %v", err)


### PR DESCRIPTION
## Description
This PR is to provide fix for https://github.com/argoproj/argo-cd/issues/10912, where user is not able to send a notification via argocd CLI if template is using any [repo functions](https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/functions/#repo).

Fixes https://github.com/argoproj/argo-cd/issues/10912

#### Note:- 
If template is using `.repo` functions for example `.repo.getAppDetails`, it needs to connect with ArgoCD Repo Server, as CLI call is executed from local it can not connect with Repo Server from cluster and shows connection error. To avoid it users need to do port forwarding and configure Repo Server URL in argocd CLI command something like this.

`kubectl port-forward svc/argocd-repo-server -n argocd 8081:8081`

`argocd admin notifications template notify app-sync-succeeded my-app --argocd-repo-server 127.0.0.1:8081`

