### PR TITLE
fix(#19263): 'argocd admin settings rbac can' command should honor server.rbac.log.enforce.enable param in argocd-cm

### DIFF
--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -159,7 +159,7 @@ func NewSettingsCommand() *cobra.Command {
 
 	command.AddCommand(NewValidateSettingsCommand(&opts))
 	command.AddCommand(NewResourceOverridesCommand(&opts))
-	command.AddCommand(NewRBACCommand())
+	command.AddCommand(NewRBACCommand(&opts))
 
 	opts.clientConfig = cli.AddKubectlFlagsToCmd(command)
 	command.PersistentFlags().StringVar(&opts.argocdCMPath, "argocd-cm-path", "", "Path to local argocd-cm.yaml file")

--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -18,6 +18,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
 	"github.com/argoproj/argo-cd/v2/util/assets"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/rbac"
 )
 
@@ -109,7 +110,7 @@ var extensionActions = actionTraitMap{
 }
 
 // NewRBACCommand is the command for 'rbac'
-func NewRBACCommand() *cobra.Command {
+func NewRBACCommand(cmdCtx commandContext) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "rbac",
 		Short: "Validate and test RBAC configuration",
@@ -117,13 +118,13 @@ func NewRBACCommand() *cobra.Command {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(NewRBACCanCommand())
+	command.AddCommand(NewRBACCanCommand(cmdCtx))
 	command.AddCommand(NewRBACValidateCommand())
 	return command
 }
 
-// NewRBACCanCommand is the command for 'rbac can-role'
-func NewRBACCanCommand() *cobra.Command {
+// NewRBACCanCommand is the command for 'rbac can'
+func NewRBACCanCommand(cmdCtx commandContext) *cobra.Command {
 	var (
 		policyFile   string
 		defaultRole  string
@@ -175,11 +176,6 @@ argocd admin settings rbac can someuser create application 'default/app' --defau
 				subResource = args[3]
 			}
 
-			userPolicy := ""
-			builtinPolicy := ""
-
-			var newDefaultRole string
-
 			namespace, nsOverride, err := clientConfig.Namespace()
 			if err != nil {
 				log.Fatalf("could not create k8s client: %v", err)
@@ -203,6 +199,7 @@ argocd admin settings rbac can someuser create application 'default/app' --defau
 			userPolicy, newDefaultRole, matchMode := getPolicy(ctx, policyFile, realClientset, namespace)
 
 			// Use built-in policy as augmentation if requested
+			builtinPolicy := ""
 			if useBuiltin {
 				builtinPolicy = assets.BuiltinPolicyCSV
 			}
@@ -213,7 +210,30 @@ argocd admin settings rbac can someuser create application 'default/app' --defau
 				defaultRole = newDefaultRole
 			}
 
-			res := checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole, matchMode, strict)
+			// Logs RBAC will be enforced only if an internal var serverRBACLogEnforceEnable
+			// (representing server.rbac.log.enforce.enable env var in argocd-cm)
+			// is defined and has a "true" value
+			// Otherwise, no RBAC enforcement for logs will take place (meaning, 'can' request on a logs resource will result in "yes",
+			// even if there is no explicit RBAC allow, or if there is an explicit RBAC deny)
+			var isLogRbacEnforced func() bool
+			if nsOverride && policyFile == "" {
+				if resolveRBACResourceName(resource) == rbacpolicy.ResourceLogs {
+					isLogRbacEnforced = func() bool {
+						if opts, ok := cmdCtx.(*settingsOpts); ok {
+							opts.loadClusterSettings = true
+							opts.clientConfig = clientConfig
+							settingsMgr, err := opts.createSettingsManager(ctx)
+							errors.CheckError(err)
+							logEnforceEnable, err := settingsMgr.GetServerRBACLogEnforceEnable()
+							errors.CheckError(err)
+							return logEnforceEnable
+						}
+						return false
+					}
+				}
+			}
+			res := checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole, matchMode, strict, isLogRbacEnforced)
+
 			if res {
 				if !quiet {
 					fmt.Println("Yes")
@@ -382,7 +402,7 @@ func getPolicyConfigMap(ctx context.Context, client kubernetes.Interface, namesp
 
 // checkPolicy checks whether given subject is allowed to execute specified
 // action against specified resource
-func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole, matchMode string, strict bool) bool {
+func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPolicy, defaultRole, matchMode string, strict bool, isLogRbacEnforced func() bool) bool {
 	enf := rbac.NewEnforcer(nil, "argocd", "argocd-rbac-cm", nil)
 	enf.SetDefaultRole(defaultRole)
 	enf.SetMatchMode(matchMode)
@@ -423,8 +443,11 @@ func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPoli
 		if subResource == "*" || subResource == "" {
 			subResource = "*/*"
 		}
+	} else if realResource == rbacpolicy.ResourceLogs {
+		if isLogRbacEnforced != nil && !isLogRbacEnforced() {
+			return true
+		}
 	}
-
 	return enf.Enforce(subject, realResource, action, subResource)
 }
 

--- a/cmd/argocd/commands/admin/settings_rbac_test.go
+++ b/cmd/argocd/commands/admin/settings_rbac_test.go
@@ -131,7 +131,15 @@ func Test_PolicyFromYAML(t *testing.T) {
 	require.Equal(t, "role:unknown", dRole)
 	require.Empty(t, matchMode)
 	require.True(t, checkPolicy("my-org:team-qa", "update", "project", "foo",
-		"", uPol, dRole, matchMode, true))
+		"", uPol, dRole, matchMode, true, nil))
+}
+
+func trueLogRbacEnforce() bool {
+	return true
+}
+
+func falseLogRbacEnforce() bool {
+	return false
 }
 
 func Test_PolicyFromK8s(t *testing.T) {
@@ -155,43 +163,97 @@ func Test_PolicyFromK8s(t *testing.T) {
 	require.Equal(t, "", matchMode)
 
 	t.Run("get applications", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "applications", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
+		ok := checkPolicy("role:user", "get", "applications", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("get clusters", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "clusters", "*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
+		ok := checkPolicy("role:user", "get", "clusters", "*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("get certificates", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", "*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
+		ok := checkPolicy("role:user", "get", "certificates", "*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
 		require.False(t, ok)
 	})
 	t.Run("get certificates by default role", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", "*", assets.BuiltinPolicyCSV, uPol, "role:readonly", "glob", true)
+		ok := checkPolicy("role:user", "get", "certificates", "*", assets.BuiltinPolicyCSV, uPol, "role:readonly", "glob", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("get certificates by default role without builtin policy", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", "*", "", uPol, "role:readonly", "glob", true)
+		ok := checkPolicy("role:user", "get", "certificates", "*", "", uPol, "role:readonly", "glob", true, nil)
 		require.False(t, ok)
 	})
 	t.Run("use regex match mode instead of glob", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", ".*", assets.BuiltinPolicyCSV, uPol, "role:readonly", "regex", true)
+		ok := checkPolicy("role:user", "get", "certificates", ".*", assets.BuiltinPolicyCSV, uPol, "role:readonly", "regex", true, nil)
 		require.False(t, ok)
 	})
 	t.Run("get logs", func(t *testing.T) {
-		ok := checkPolicy("role:test", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
+		ok := checkPolicy("role:test", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
+		require.True(t, ok)
+	})
+	// no function is provided to check if logs rbac is enforced or not, so the policy permissions are queried to determine if no-such-user can get logs
+	t.Run("no-such-user get logs", func(t *testing.T) {
+		ok := checkPolicy("no-such-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
+		require.False(t, ok)
+	})
+	// logs rbac policy is enforced, and no-such-user is not granted logs permission in user policy, so the result should be false (cannot get logs)
+	t.Run("no-such-user get logs rbac enforced", func(t *testing.T) {
+		ok := checkPolicy("no-such-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, trueLogRbacEnforce)
+		require.False(t, ok)
+	})
+	// no-such-user is not granted logs permission in user policy, but logs rbac policy is not enforced, so logs permission is open to all
+	t.Run("no-such-user get logs rbac not enforced", func(t *testing.T) {
+		ok := checkPolicy("no-such-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, falseLogRbacEnforce)
+		require.True(t, ok)
+	})
+	// no function is provided to check if logs rbac is enforced or not, so the policy permissions are queried to determine if log-deny-user can get logs
+	t.Run("log-deny-user get logs", func(t *testing.T) {
+		ok := checkPolicy("log-deny-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
+		require.False(t, ok)
+	})
+	// logs rbac policy is enforced, and log-deny-user is denied logs permission in user policy, so the result should be false (cannot get logs)
+	t.Run("log-deny-user get logs rbac enforced", func(t *testing.T) {
+		ok := checkPolicy("log-deny-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, trueLogRbacEnforce)
+		require.False(t, ok)
+	})
+	// log-deny-user is denied logs permission in user policy, but logs rbac policy is not enforced, so logs permission is open to all
+	t.Run("log-deny-user get logs rbac not enforced", func(t *testing.T) {
+		ok := checkPolicy("log-deny-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, falseLogRbacEnforce)
+		require.True(t, ok)
+	})
+	// no function is provided to check if logs rbac is enforced or not, so the policy permissions are queried to determine if log-allow-user can get logs
+	t.Run("log-allow-user get logs", func(t *testing.T) {
+		ok := checkPolicy("log-allow-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
+		require.True(t, ok)
+	})
+	// logs rbac policy is enforced, and log-allow-user is granted logs permission in user policy, so the result should be true (can get logs)
+	t.Run("log-allow-user get logs rbac enforced", func(t *testing.T) {
+		ok := checkPolicy("log-allow-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, trueLogRbacEnforce)
+		require.True(t, ok)
+	})
+	// log-allow-user is granted logs permission in user policy, and logs rbac policy is not enforced, so logs permission is open to all
+	t.Run("log-allow-user get logs rbac not enforced", func(t *testing.T) {
+		ok := checkPolicy("log-allow-user", "get", "logs", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, falseLogRbacEnforce)
 		require.True(t, ok)
 	})
 	t.Run("create exec", func(t *testing.T) {
-		ok := checkPolicy("role:test", "create", "exec", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
+		ok := checkPolicy("role:test", "create", "exec", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("create applicationsets", func(t *testing.T) {
-		ok := checkPolicy("role:user", "create", "applicationsets", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
+		ok := checkPolicy("role:user", "create", "applicationsets", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
+		require.True(t, ok)
+	})
+	// trueLogRbacEnforce or falseLogRbacEnforce should not affect non-logs resources
+	t.Run("create applicationsets with trueLogRbacEnforce", func(t *testing.T) {
+		ok := checkPolicy("role:user", "create", "applicationsets", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, trueLogRbacEnforce)
+		require.True(t, ok)
+	})
+	t.Run("create applicationsets with falseLogRbacEnforce", func(t *testing.T) {
+		ok := checkPolicy("role:user", "create", "applicationsets", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, trueLogRbacEnforce)
 		require.True(t, ok)
 	})
 	t.Run("delete applicationsets", func(t *testing.T) {
-		ok := checkPolicy("role:user", "delete", "applicationsets", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true)
+		ok := checkPolicy("role:user", "delete", "applicationsets", "*/*", assets.BuiltinPolicyCSV, uPol, dRole, "", true, nil)
 		require.True(t, ok)
 	})
 }
@@ -231,49 +293,49 @@ p, role:readonly, certificates, get, .*, allow
 p, role:, certificates, get, .*, allow`
 
 	t.Run("get applications", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "applications", ".*/.*", builtInPolicy, uPol, dRole, "regex", true)
+		ok := checkPolicy("role:user", "get", "applications", ".*/.*", builtInPolicy, uPol, dRole, "regex", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("get clusters", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "clusters", ".*", builtInPolicy, uPol, dRole, "regex", true)
+		ok := checkPolicy("role:user", "get", "clusters", ".*", builtInPolicy, uPol, dRole, "regex", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("get certificates", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", ".*", builtInPolicy, uPol, dRole, "regex", true)
+		ok := checkPolicy("role:user", "get", "certificates", ".*", builtInPolicy, uPol, dRole, "regex", true, nil)
 		require.False(t, ok)
 	})
 	t.Run("get certificates by default role", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", ".*", builtInPolicy, uPol, "role:readonly", "regex", true)
+		ok := checkPolicy("role:user", "get", "certificates", ".*", builtInPolicy, uPol, "role:readonly", "regex", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("get certificates by default role without builtin policy", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", ".*", "", uPol, "role:readonly", "regex", true)
+		ok := checkPolicy("role:user", "get", "certificates", ".*", "", uPol, "role:readonly", "regex", true, nil)
 		require.False(t, ok)
 	})
 	t.Run("use glob match mode instead of regex", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "certificates", ".+", builtInPolicy, uPol, dRole, "glob", true)
+		ok := checkPolicy("role:user", "get", "certificates", ".+", builtInPolicy, uPol, dRole, "glob", true, nil)
 		require.False(t, ok)
 	})
 	t.Run("get logs via glob match mode", func(t *testing.T) {
-		ok := checkPolicy("role:user", "get", "logs", ".*/.*", builtInPolicy, uPol, dRole, "glob", true)
+		ok := checkPolicy("role:user", "get", "logs", ".*/.*", builtInPolicy, uPol, dRole, "glob", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("create exec", func(t *testing.T) {
-		ok := checkPolicy("role:user", "create", "exec", ".*/.*", builtInPolicy, uPol, dRole, "regex", true)
+		ok := checkPolicy("role:user", "create", "exec", ".*/.*", builtInPolicy, uPol, dRole, "regex", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("create applicationsets", func(t *testing.T) {
-		ok := checkPolicy("role:user", "create", "applicationsets", ".*/.*", builtInPolicy, uPol, dRole, "regex", true)
+		ok := checkPolicy("role:user", "create", "applicationsets", ".*/.*", builtInPolicy, uPol, dRole, "regex", true, nil)
 		require.True(t, ok)
 	})
 	t.Run("delete applicationsets", func(t *testing.T) {
-		ok := checkPolicy("role:user", "delete", "applicationsets", ".*/.*", builtInPolicy, uPol, dRole, "regex", true)
+		ok := checkPolicy("role:user", "delete", "applicationsets", ".*/.*", builtInPolicy, uPol, dRole, "regex", true, nil)
 		require.True(t, ok)
 	})
 }
 
 func TestNewRBACCanCommand(t *testing.T) {
-	command := NewRBACCanCommand()
+	command := NewRBACCanCommand(&settingsOpts{})
 
 	require.NotNil(t, command)
 	assert.Equal(t, "can", command.Name())

--- a/cmd/argocd/commands/admin/testdata/rbac/policy.csv
+++ b/cmd/argocd/commands/admin/testdata/rbac/policy.csv
@@ -10,4 +10,6 @@ p, role:user, applicationsets, delete, */*, allow
 p, role:test, certificates, get, *, allow
 p, role:test, logs, get, */*, allow
 p, role:test, exec, create, */*, allow
+p, log-allow-user, logs, get, */*, allow
+p, log-deny-user, logs, get, */*, deny
 g, test, role:user


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/19263

With the fix in this PR, both `argocd admin settings rbac can` and `argocd account can-i` commands will produce the same result for the same logs RBAC and subject in a live cluster.

When running `argocd admin settings rbac can user1 get logs` with a local policy (`--policy-file` option), the behavior is unchanged: it only checks local policy.

Sample runs with the fix:
```bash
~/go/src/argo-cd$ dist/argocd admin settings rbac can alice get logs '*/*' --namespace argocd
INFO[0000] Starting configmap/secret informers
INFO[0000] Configmap/secret informer synced
Yes
~/go/src/argo-cd$ dist/argocd admin settings rbac can bob get logs '*/*' --namespace argocd
INFO[0000] Starting configmap/secret informers
INFO[0000] Configmap/secret informer synced
Yes

~/go/src/argo-cd$ dist/argocd admin settings rbac can alice get logs '*/*' --policy-file ~/tmp/g.csv
Yes
~/go/src/argo-cd$ dist/argocd admin settings rbac can bob get logs '*/*' --policy-file ~/tmp/g.csv
No
```
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
