### PR TITLE
chore: fix lint

### DIFF
--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -2231,7 +2231,7 @@ func TestGenerateManifestWithAnnotatedTagsAndMultiSourceApp(t *testing.T) {
 
 func TestGenerateMultiSourceHelmWithFileParameter(t *testing.T) {
 	expectedFileContent, err := os.ReadFile("../../util/helm/testdata/external/external-secret.txt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	service := newService(t, "../../util/helm/testdata")
 
@@ -2281,7 +2281,7 @@ func TestGenerateMultiSourceHelmWithFileParameter(t *testing.T) {
 			res, err := service.GenerateManifest(context.Background(), manifestRequest)
 
 			if !tc.expectedErr {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// Check that any of the manifests contains the secret
 				idx := slices.IndexFunc(res.Manifests, func(content string) bool {


### PR DESCRIPTION
Something must have sneaked in past the new lint checks, this is failing in master.