### PR TITLE
test: Add unit tests for HydratorHelper methods

### DIFF
--- a/commitserver/commit/hydratorhelper_test.go
+++ b/commitserver/commit/hydratorhelper_test.go
@@ -1,0 +1,65 @@
+package commit
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v2/commitserver/apiclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteMetadata(t *testing.T) {
+	dir := t.TempDir()
+
+	metadata := hydratorMetadataFile{
+		RepoURL: "https://github.com/example/repo",
+		DrySHA:  "abc123",
+	}
+
+	err := writeMetadata(dir, metadata)
+	assert.NoError(t, err)
+
+	metadataPath := path.Join(dir, "hydrator.metadata")
+	metadataBytes, err := os.ReadFile(metadataPath)
+	assert.NoError(t, err)
+
+	var readMetadata hydratorMetadataFile
+	err = json.Unmarshal(metadataBytes, &readMetadata)
+	assert.NoError(t, err)
+	assert.Equal(t, metadata, readMetadata)
+}
+
+func TestWriteReadme(t *testing.T) {
+	dir := t.TempDir()
+
+	metadata := hydratorMetadataFile{
+		RepoURL: "https://github.com/example/repo",
+		DrySHA:  "abc123",
+	}
+
+	err := writeReadme(dir, metadata)
+	assert.NoError(t, err)
+
+	readmePath := path.Join(dir, "README.md")
+	readmeBytes, err := os.ReadFile(readmePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(readmeBytes), metadata.RepoURL)
+}
+
+func TestWriteManifests(t *testing.T) {
+	dir := t.TempDir()
+
+	manifests := []*apiclient.ManifestDetails{
+		{Manifest: `{"kind":"Pod","apiVersion":"v1"}`},
+	}
+
+	err := writeManifests(dir, manifests)
+	assert.NoError(t, err)
+
+	manifestPath := path.Join(dir, "manifest.yaml")
+	manifestBytes, err := os.ReadFile(manifestPath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(manifestBytes), "kind: Pod")
+}

--- a/commitserver/commit/hydratorhelper_test.go
+++ b/commitserver/commit/hydratorhelper_test.go
@@ -6,8 +6,10 @@ import (
 	"path"
 	"testing"
 
-	"github.com/argoproj/argo-cd/v2/commitserver/apiclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-cd/v2/commitserver/apiclient"
 )
 
 func TestWriteMetadata(t *testing.T) {
@@ -19,15 +21,15 @@ func TestWriteMetadata(t *testing.T) {
 	}
 
 	err := writeMetadata(dir, metadata)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	metadataPath := path.Join(dir, "hydrator.metadata")
 	metadataBytes, err := os.ReadFile(metadataPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var readMetadata hydratorMetadataFile
 	err = json.Unmarshal(metadataBytes, &readMetadata)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, metadata, readMetadata)
 }
 
@@ -40,11 +42,11 @@ func TestWriteReadme(t *testing.T) {
 	}
 
 	err := writeReadme(dir, metadata)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	readmePath := path.Join(dir, "README.md")
 	readmeBytes, err := os.ReadFile(readmePath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(readmeBytes), metadata.RepoURL)
 }
 
@@ -56,10 +58,10 @@ func TestWriteManifests(t *testing.T) {
 	}
 
 	err := writeManifests(dir, manifests)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	manifestPath := path.Join(dir, "manifest.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(manifestBytes), "kind: Pod")
 }


### PR DESCRIPTION
In response to issue #19303 , this PR introduces unit tests for the `HydratorHelper` methods. These tests aim to ensure the correct behavior of the following methods:

## Summary

This PR adds unit tests for the `HydratorHelper` methods. The tests ensure the correct behavior of the following methods:
- `WriteMetadata`
- `WriteReadme`
- `WriteManifests`

Thank you for your time and consideration in reviewing this PR.