### PR TITLE
feat: gracefully shut down repo-server on SIGTERM

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -364,11 +364,12 @@ jobs:
           name: test-results
           path: test-results
       - name: combine-go-coverage
-        # We generate coverage reports for all Argo CD components, but only the applicationset-controller report
-        # contains coverage data. The other components currently don't shut down gracefully, so no coverage data is
-        # produced. Once those components are fixed, we can add references to their coverage output directories.
+        # We generate coverage reports for all Argo CD components, but only the applicationset-controller and
+        # repo-server report contain coverage data. The other components currently don't shut down gracefully, so no
+        # coverage data is produced. Once those components are fixed, we can add references to their coverage output
+        # directories.
         run: |
-          go tool covdata percent -i=test-results,e2e-code-coverage/applicationset-controller -o test-results/full-coverage.out
+          go tool covdata percent -i=test-results,e2e-code-coverage/applicationset-controller,e2e-code-coverage/repo-server -o test-results/full-coverage.out
       - name: Upload code coverage information to codecov.io
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:


### PR DESCRIPTION
Increases code coverage by ensuring the repo-server shuts down gracefully and writes coverage data.

![image](https://github.com/user-attachments/assets/45995693-1ccf-4a46-9b43-4ef4f65c1f3d)
