### PR TITLE
feat(askpass): make askpass socket path configurable

### DIFF
--- a/cmd/argocd-git-ask-pass/commands/argocd_git_ask_pass.go
+++ b/cmd/argocd-git-ask-pass/commands/argocd_git_ask_pass.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/argoproj/argo-cd/v2/util/git"
-
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -33,9 +31,9 @@ func NewCommand() *cobra.Command {
 			if len(os.Args) != 2 {
 				errors.CheckError(fmt.Errorf("expected 1 argument, got %d", len(os.Args)-1))
 			}
-			nonce := os.Getenv(git.ASKPASS_NONCE_ENV)
+			nonce := os.Getenv(askpass.ASKPASS_NONCE_ENV)
 			if nonce == "" {
-				errors.CheckError(fmt.Errorf("%s is not set", git.ASKPASS_NONCE_ENV))
+				errors.CheckError(fmt.Errorf("%s is not set", askpass.ASKPASS_NONCE_ENV))
 			}
 			conn, err := grpc_util.BlockingDial(ctx, "unix", askpass.SocketPath, nil, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			errors.CheckError(err)

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -119,7 +119,7 @@ func NewCommand() *cobra.Command {
 			helmRegistryMaxIndexSizeQuantity, err := resource.ParseQuantity(helmRegistryMaxIndexSize)
 			errors.CheckError(err)
 
-			askPassServer := askpass.NewServer()
+			askPassServer := askpass.NewServer(askpass.SocketPath)
 			metricsServer := metrics.NewMetricsServer()
 			cacheutil.CollectMetrics(redisClient, metricsServer)
 			server, err := reposerver.NewServer(metricsServer, cache, tlsConfigCustomizer, repository.RepoServerInitConstants{
@@ -177,7 +177,7 @@ func NewCommand() *cobra.Command {
 			})
 			http.Handle("/metrics", metricsServer.GetHandler())
 			go func() { errors.CheckError(http.ListenAndServe(fmt.Sprintf("%s:%d", metricsHost, metricsPort), nil)) }()
-			go func() { errors.CheckError(askPassServer.Run(askpass.SocketPath)) }()
+			go func() { errors.CheckError(askPassServer.Run()) }()
 
 			if gpg.IsGPGEnabled() {
 				log.Infof("Initializing GnuPG keyring at %s", common.GetGnuPGHomePath())

--- a/reposerver/askpass/common.go
+++ b/reposerver/askpass/common.go
@@ -6,8 +6,16 @@ import (
 
 var SocketPath = "/tmp/reposerver-ask-pass.sock"
 
+const (
+	// ASKPASS_NONCE_ENV is the environment variable that is used to pass the nonce to the askpass script
+	ASKPASS_NONCE_ENV = "ARGOCD_GIT_ASKPASS_NONCE"
+	// AKSPASS_SOCKET_PATH_ENV is the environment variable that is used to pass the socket path to the askpass script
+	AKSPASS_SOCKET_PATH_ENV = "ARGOCD_ASK_PASS_SOCK"
+	CommitServerSocketPath  = "/tmp/commit-server-ask-pass.sock"
+)
+
 func init() {
-	SocketPath = env.StringFromEnv("ARGOCD_ASK_PASS_SOCK", SocketPath)
+	SocketPath = env.StringFromEnv(AKSPASS_SOCKET_PATH_ENV, SocketPath)
 }
 
 type Creds struct {

--- a/reposerver/askpass/common.go
+++ b/reposerver/askpass/common.go
@@ -11,7 +11,6 @@ const (
 	ASKPASS_NONCE_ENV = "ARGOCD_GIT_ASKPASS_NONCE"
 	// AKSPASS_SOCKET_PATH_ENV is the environment variable that is used to pass the socket path to the askpass script
 	AKSPASS_SOCKET_PATH_ENV = "ARGOCD_ASK_PASS_SOCK"
-	CommitServerSocketPath  = "/tmp/commit-server-ask-pass.sock"
 )
 
 func init() {

--- a/reposerver/askpass/server.go
+++ b/reposerver/askpass/server.go
@@ -95,7 +95,7 @@ func (s *server) getCreds(id string) (*Creds, bool) {
 // Environ returns the environment variables that should be set when invoking git.
 func (s *server) Environ(id string) []string {
 	return []string{
-		fmt.Sprintf("GIT_ASKPASS=%s", "argocd"),
+		"GIT_ASKPASS=argocd",
 		fmt.Sprintf("%s=%s", ASKPASS_NONCE_ENV, id),
 		"GIT_TERMINAL_PROMPT=0",
 		"ARGOCD_BINARY_NAME=argocd-git-ask-pass",

--- a/reposerver/askpass/server.go
+++ b/reposerver/askpass/server.go
@@ -2,6 +2,7 @@ package askpass
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"sync"
@@ -22,14 +23,16 @@ type Server interface {
 }
 
 type server struct {
-	lock  sync.Mutex
-	creds map[string]Creds
+	lock       sync.Mutex
+	creds      map[string]Creds
+	socketPath string
 }
 
 // NewServer returns a new server
-func NewServer() *server {
+func NewServer(socketPath string) *server {
 	return &server{
-		creds: make(map[string]Creds),
+		creds:      make(map[string]Creds),
+		socketPath: socketPath,
 	}
 }
 
@@ -58,8 +61,8 @@ func (s *server) Start(path string) (io.Closer, error) {
 	return io.NewCloser(listener.Close), nil
 }
 
-func (s *server) Run(path string) error {
-	_, err := s.Start(path)
+func (s *server) Run() error {
+	_, err := s.Start(s.socketPath)
 	return err
 }
 
@@ -87,4 +90,15 @@ func (s *server) getCreds(id string) (*Creds, bool) {
 	defer s.lock.Unlock()
 	creds, ok := s.creds[id]
 	return &creds, ok
+}
+
+// Environ returns the environment variables that should be set when invoking git.
+func (s *server) Environ(id string) []string {
+	return []string{
+		fmt.Sprintf("GIT_ASKPASS=%s", "argocd"),
+		fmt.Sprintf("%s=%s", ASKPASS_NONCE_ENV, id),
+		"GIT_TERMINAL_PROMPT=0",
+		"ARGOCD_BINARY_NAME=argocd-git-ask-pass",
+		fmt.Sprintf("%s=%s", AKSPASS_SOCKET_PATH_ENV, s.socketPath),
+	}
 }

--- a/reposerver/askpass/server_test.go
+++ b/reposerver/askpass/server_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	s := NewServer()
+	s := NewServer(SocketPath)
 	nonce := s.Add("foo", "bar")
 
 	assert.Equal(t, "foo", s.creds[nonce].Username)
@@ -15,7 +15,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	s := NewServer()
+	s := NewServer(SocketPath)
 	s.creds["some-id"] = Creds{Username: "foo"}
 
 	s.Remove("some-id")

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -43,21 +43,18 @@ func (s *memoryCredsStore) Remove(id string) {
 	delete(s.creds, id)
 }
 
+func (s *memoryCredsStore) Environ(id string) []string {
+	return nil
+}
+
 func TestHTTPSCreds_Environ_no_cert_cleanup(t *testing.T) {
 	store := &memoryCredsStore{creds: make(map[string]cred)}
 	creds := NewHTTPSCreds("", "", "", "", true, "", store, false)
-	closer, env, err := creds.Environ()
+	closer, _, err := creds.Environ()
 	require.NoError(t, err)
-	var nonce string
-	for _, envVar := range env {
-		if strings.HasPrefix(envVar, ASKPASS_NONCE_ENV) {
-			nonce = envVar[len(ASKPASS_NONCE_ENV)+1:]
-			break
-		}
-	}
-	assert.Contains(t, store.creds, nonce)
+	credsLenBefore := len(store.creds)
 	io.Close(closer)
-	assert.NotContains(t, store.creds, nonce)
+	assert.Len(t, store.creds, credsLenBefore-1)
 }
 
 func TestHTTPSCreds_Environ_insecure_true(t *testing.T) {
@@ -385,16 +382,9 @@ func TestGoogleCloudCreds_Environ_cleanup(t *testing.T) {
 		JSON:        []byte(gcpServiceAccountKeyJSON),
 	}, store}
 
-	closer, env, err := googleCloudCreds.Environ()
+	closer, _, err := googleCloudCreds.Environ()
 	require.NoError(t, err)
-	var nonce string
-	for _, envVar := range env {
-		if strings.HasPrefix(envVar, ASKPASS_NONCE_ENV) {
-			nonce = envVar[len(ASKPASS_NONCE_ENV)+1:]
-			break
-		}
-	}
-	assert.Contains(t, store.creds, nonce)
+	credsLenBefore := len(store.creds)
 	io.Close(closer)
-	assert.NotContains(t, store.creds, nonce)
+	assert.Len(t, store.creds, credsLenBefore-1)
 }


### PR DESCRIPTION
`getGitAskPassEnv` doesn't allow specifying the askpass server's socket path. This means that if two different Argo CD components are running an askpass server, the client has no way to differentiate calling one versus the other.

This change allows the askpass server to report to the user what socket path it's configured to serve on. So the client always has the correct socket path, even if multiple servers are running.

The change isn't strictly necessary today, as only repo-server uses the askpass server. The change will be necessary for the manifest hydrator.

I propose to go ahead and make the change in a separate PR to simplify the hydrator PR. I think this implementation is more intuitive anyway.