### PR TITLE
chore: mark generated files as generated to suppress diffs in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+**/*.pb.go linguist-generated=true
+**/mocks/*.go linguist-generated=true
+assets/swagger.json linguist-generated=true
+docs/operator-manual/resource_actions_builtin.md linguist-generated=true
+docs/operator-manual/server-commands/argocd-*.md linguist-generated=true
+docs/user-guide/commands/argocd_*.md linguist-generated=true
+manifests/core-install.yaml linguist-generated=true
+manifests/crds/*-crd.yaml linguist-generated=true
+manifests/ha/install.yaml linguist-generated=true
+manifests/ha/namespace-install.yaml linguist-generated=true
+manifests/install.yaml linguist-generated=true
+manifests/namespace-install.yaml linguist-generated=true
+pkg/apis/api-rules/violation_exceptions.list linguist-generated=true


### PR DESCRIPTION
The listed files are generated and should be minimized in diffs by default. I've followed the GitHub docs: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

A side-effect will be that these files will be excluded from the language statistics for the repo. I think that's fine.

Here's the current state in case we want to compare later: 
![image](https://github.com/user-attachments/assets/5130321f-7c11-4511-b4df-f86df123ad73)
