### PR TITLE
fix: handle logging empty args in strings

### DIFF
--- a/util/exec/exec.go
+++ b/util/exec/exec.go
@@ -66,6 +66,11 @@ func RunWithExecRunOpts(cmd *exec.Cmd, opts ExecRunOpts) (string, error) {
 func GetCommandArgsToLog(cmd *exec.Cmd) string {
 	var argsToLog []string
 	for _, arg := range cmd.Args {
+		if arg == "" {
+			argsToLog = append(argsToLog, `""`)
+			continue
+		}
+
 		containsSpace := false
 		for _, r := range arg {
 			if unicode.IsSpace(r) {

--- a/util/exec/exec_test.go
+++ b/util/exec/exec_test.go
@@ -71,6 +71,11 @@ func Test_getCommandArgsToLog(t *testing.T) {
 			args:     []string{"sh", "-c", `echo "hello world"`},
 			expected: `sh -c "echo \"hello world\""`,
 		},
+		{
+			name:     "empty string arg",
+			args:     []string{"sh", "-c", ""},
+			expected: `sh -c ""`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
To help when debugging, we log CMP commands.

Sometimes the args set in CMPs are empty strings.

To represent those args in logs, we should convert the empty string to empty quotation marks.

This has no impact on any user-facing feature. It'll only impact the debug logs that are generated to help CMP authors debug their CMP config.