### PR TITLE
feat!: disable profile endpoint by default

### DIFF
--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -72,6 +72,8 @@ data:
   # Diff calculation will be done by running a server side apply dryrun (when
   # diff cache is unavailable).
   controller.diff.server.side: "false"
+  # Enables profile endpoint on the internal metrics port
+  controller.profile.enabled: "false"
 
   ## Server properties
   # Listen on given address for incoming connections (default "0.0.0.0")
@@ -136,6 +138,8 @@ data:
   server.default.cache.expiration: "24h0m0s"
   # Enable the experimental proxy extension feature
   server.enable.proxy.extension: "false"
+  # Enables profile endpoint on the internal metrics port
+  server.profile.enabled: "false"
 
   ## Repo-server properties
   # Listen on given address for incoming connections (default "0.0.0.0")

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -371,3 +371,16 @@ Not all HTTP responses are eligible for retries. The following conditions will n
 
 * Responses with a status code indicating client errors (4xx) except for 429 Too Many Requests.
 * Responses with the status code 501 Not Implemented.
+
+
+## CPU/Memory Profiling
+
+Argo CD optionally exposes a profiling endpoint that can be used to profile the CPU and memory usage of the Argo CD component.
+The profiling endpoint is available on metrics port of each component. See [metrics](./metrics.md) for more information about the port.
+For security reasons the profiling endpoint is disabled by default and can be enabled creating a file named `/home/argocd/.enable-profiler`.
+Once the file is created you can use go profile tool to collect the CPU and memory profiles. Example:
+
+```bash
+$ kubectl port-forward svc/argocd-metrics 8082:8082
+$ go tool pprof http://localhost:8082/debug/pprof/heap
+```

--- a/docs/operator-manual/high_availability.md
+++ b/docs/operator-manual/high_availability.md
@@ -377,8 +377,9 @@ Not all HTTP responses are eligible for retries. The following conditions will n
 
 Argo CD optionally exposes a profiling endpoint that can be used to profile the CPU and memory usage of the Argo CD component.
 The profiling endpoint is available on metrics port of each component. See [metrics](./metrics.md) for more information about the port.
-For security reasons the profiling endpoint is disabled by default and can be enabled creating a file named `/home/argocd/.enable-profiler`.
-Once the file is created you can use go profile tool to collect the CPU and memory profiles. Example:
+For security reasons the profiling endpoint is disabled by default. The endpoint can be enabled by setting the `server.profile.enabled`
+or `controller.profile.enabled` key of [argocd-cmd-params-cm](argocd-cmd-params-cm.yaml) ConfigMap to `true`.
+Once the endpoint is enabled you can use go profile tool to collect the CPU and memory profiles. Example:
 
 ```bash
 $ kubectl port-forward svc/argocd-metrics 8082:8082

--- a/manifests/base/application-controller-deployment/argocd-application-controller-deployment.yaml
+++ b/manifests/base/application-controller-deployment/argocd-application-controller-deployment.yaml
@@ -225,6 +225,8 @@ spec:
           mountPath: /app/config/controller/tls
         - name: argocd-home
           mountPath: /home/argocd
+        - name: argocd-cmd-params-cm
+          mountPath: /home/argocd/params
       serviceAccountName: argocd-application-controller
       affinity:
         podAntiAffinity:
@@ -255,3 +257,10 @@ spec:
             path: tls.key
           - key: ca.crt
             path: ca.crt
+      - name: argocd-cmd-params-cm
+        configMap:
+          optional: true
+          name: argocd-cmd-params-cm
+          items:
+          - key: controller.profile.enabled
+            path: profiler.enabled

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -234,6 +234,8 @@ spec:
           mountPath: /app/config/controller/tls
         - name: argocd-home
           mountPath: /home/argocd
+        - name: argocd-cmd-params-cm
+          mountPath: /home/argocd/params
       serviceAccountName: argocd-application-controller
       affinity:
         podAntiAffinity:
@@ -264,3 +266,10 @@ spec:
             path: tls.key
           - key: ca.crt
             path: ca.crt
+      - name: argocd-cmd-params-cm
+        configMap:
+          optional: true
+          name: argocd-cmd-params-cm
+          items:
+            - key: controller.profile.enabled
+              path: profiler.enabled

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -305,6 +305,8 @@ spec:
               name: plugins-home
             - mountPath: /tmp
               name: tmp
+            - name: argocd-cmd-params-cm
+              mountPath: /home/argocd/params
           ports:
             - containerPort: 8080
             - containerPort: 8083
@@ -361,6 +363,13 @@ spec:
                 path: tls.crt
               - key: ca.crt
                 path: ca.crt
+        - name: argocd-cmd-params-cm
+          configMap:
+            optional: true
+            name: argocd-cmd-params-cm
+            items:
+            - key: server.profile.enabled
+              path: profiler.enabled
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -22218,6 +22218,8 @@ spec:
           name: argocd-repo-server-tls
         - mountPath: /home/argocd
           name: argocd-home
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
         workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
@@ -22234,6 +22236,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-repo-server-tls
+      - configMap:
+          items:
+          - key: controller.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -23891,6 +23891,8 @@ spec:
           name: plugins-home
         - mountPath: /tmp
           name: tmp
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
       serviceAccountName: argocd-server
       volumes:
       - emptyDir: {}
@@ -23923,6 +23925,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-dex-server-tls
+      - configMap:
+          items:
+          - key: server.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -24174,6 +24183,8 @@ spec:
           name: argocd-repo-server-tls
         - mountPath: /home/argocd
           name: argocd-home
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
         workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
@@ -24190,6 +24201,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-repo-server-tls
+      - configMap:
+          items:
+          - key: controller.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2746,6 +2746,8 @@ spec:
           name: plugins-home
         - mountPath: /tmp
           name: tmp
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
       serviceAccountName: argocd-server
       volumes:
       - emptyDir: {}
@@ -2778,6 +2780,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-dex-server-tls
+      - configMap:
+          items:
+          - key: server.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -3029,6 +3038,8 @@ spec:
           name: argocd-repo-server-tls
         - mountPath: /home/argocd
           name: argocd-home
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
         workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
@@ -3045,6 +3056,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-repo-server-tls
+      - configMap:
+          items:
+          - key: controller.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -22959,6 +22959,8 @@ spec:
           name: plugins-home
         - mountPath: /tmp
           name: tmp
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
       serviceAccountName: argocd-server
       volumes:
       - emptyDir: {}
@@ -22991,6 +22993,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-dex-server-tls
+      - configMap:
+          items:
+          - key: server.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -23242,6 +23251,8 @@ spec:
           name: argocd-repo-server-tls
         - mountPath: /home/argocd
           name: argocd-home
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
         workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
@@ -23258,6 +23269,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-repo-server-tls
+      - configMap:
+          items:
+          - key: controller.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1814,6 +1814,8 @@ spec:
           name: plugins-home
         - mountPath: /tmp
           name: tmp
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
       serviceAccountName: argocd-server
       volumes:
       - emptyDir: {}
@@ -1846,6 +1848,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-dex-server-tls
+      - configMap:
+          items:
+          - key: server.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -2097,6 +2106,8 @@ spec:
           name: argocd-repo-server-tls
         - mountPath: /home/argocd
           name: argocd-home
+        - mountPath: /home/argocd/params
+          name: argocd-cmd-params-cm
         workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
@@ -2113,6 +2124,13 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-repo-server-tls
+      - configMap:
+          items:
+          - key: controller.profile.enabled
+            path: profiler.enabled
+          name: argocd-cmd-params-cm
+          optional: true
+        name: argocd-cmd-params-cm
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/util/profile/profile.go
+++ b/util/profile/profile.go
@@ -8,11 +8,11 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/env"
 )
 
-var enableProfilerFilePath = env.StringFromEnv("ARGOCD_ENABLE_PROFILER_FILE_PATH", "/home/argocd/.enable-profiler")
+var enableProfilerFilePath = env.StringFromEnv("ARGOCD_ENABLE_PROFILER_FILE_PATH", "/home/argocd/params/profiler.enabled")
 
 func wrapHandler(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if _, err := os.Stat(enableProfilerFilePath); err == nil {
+		if data, err := os.ReadFile(enableProfilerFilePath); err == nil && string(data) == "true" {
 			handler.ServeHTTP(w, r)
 		} else {
 			http.NotFound(w, r)

--- a/util/profile/profile.go
+++ b/util/profile/profile.go
@@ -3,13 +3,28 @@ package profile
 import (
 	"net/http"
 	"net/http/pprof"
+	"os"
+
+	"github.com/argoproj/argo-cd/v2/util/env"
 )
+
+var enableProfilerFilePath = env.StringFromEnv("ARGOCD_ENABLE_PROFILER_FILE_PATH", "/home/argocd/.enable-profiler")
+
+func wrapHandler(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, err := os.Stat(enableProfilerFilePath); err == nil {
+			handler.ServeHTTP(w, r)
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+}
 
 // RegisterProfiler adds pprof endpoints to mux.
 func RegisterProfiler(mux *http.ServeMux) {
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.HandleFunc("/debug/pprof/", wrapHandler(pprof.Index))
+	mux.HandleFunc("/debug/pprof/cmdline", wrapHandler(pprof.Cmdline))
+	mux.HandleFunc("/debug/pprof/profile", wrapHandler(pprof.Profile))
+	mux.HandleFunc("/debug/pprof/symbol", wrapHandler(pprof.Symbol))
+	mux.HandleFunc("/debug/pprof/trace", wrapHandler(pprof.Trace))
 }

--- a/util/profile/profile.go
+++ b/util/profile/profile.go
@@ -15,7 +15,7 @@ func wrapHandler(handler http.HandlerFunc) http.HandlerFunc {
 		if data, err := os.ReadFile(enableProfilerFilePath); err == nil && string(data) == "true" {
 			handler.ServeHTTP(w, r)
 		} else {
-			http.NotFound(w, r)
+			http.Error(w, "Profiler endpoint is not enabled in 'argocd-cmd-params-cm' ConfigMap", http.StatusUnauthorized)
 		}
 	}
 }

--- a/util/profile/profile_test.go
+++ b/util/profile/profile_test.go
@@ -30,6 +30,8 @@ func TestRegisterProfile_FileExist(t *testing.T) {
 
 	f, err := os.CreateTemp("", "test")
 	require.NoError(t, err)
+	_, err = f.WriteString("true")
+	require.NoError(t, err)
 
 	oldVal := enableProfilerFilePath
 	enableProfilerFilePath = f.Name()

--- a/util/profile/profile_test.go
+++ b/util/profile/profile_test.go
@@ -1,0 +1,46 @@
+package profile
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterProfile_FileIsMissing(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterProfiler(mux)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/debug/pprof/")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestRegisterProfile_FileExist(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterProfiler(mux)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	f, err := os.CreateTemp("", "test")
+	require.NoError(t, err)
+
+	oldVal := enableProfilerFilePath
+	enableProfilerFilePath = f.Name()
+
+	resp, err := http.Get(srv.URL + "/debug/pprof/")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	defer func() {
+		enableProfilerFilePath = oldVal
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+}

--- a/util/profile/profile_test.go
+++ b/util/profile/profile_test.go
@@ -18,7 +18,7 @@ func TestRegisterProfile_FileIsMissing(t *testing.T) {
 
 	resp, err := http.Get(srv.URL + "/debug/pprof/")
 	require.NoError(t, err)
-	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
 func TestRegisterProfile_FileExist(t *testing.T) {


### PR DESCRIPTION
PR disables the metrics endpoint by default and allows dynamically enable it by creating a file in the argocd pods.