### PR TITLE
chore(ci): make sure CI fails when e2e test fails

### DIFF
--- a/test/e2e/accounts_test.go
+++ b/test/e2e/accounts_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/io"
 )
 
+func TestFails(t *testing.T) {
+	// This should fail CI e2e tests.
+	require.True(t, false)
+}
+
 func TestCreateAndUseAccount(t *testing.T) {
 	ctx := accountFixture.Given(t)
 	ctx.


### PR DESCRIPTION
I think maybe failing tests aren't failing in CI.