### PR TITLE
fix: ArgoCD 2.11 - Loop of PATCH calls to Application objects (#19340)

### DIFF
--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -989,7 +989,7 @@ func TestNormalizeApplication(t *testing.T) {
 		normalized := false
 		fakeAppCs.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 			if patchAction, ok := action.(kubetesting.PatchAction); ok {
-				if string(patchAction.GetPatch()) == `{"spec":{"project":"default"},"status":{"sync":{"comparedTo":{"destination":{},"source":{"repoURL":""}}}}}` {
+				if string(patchAction.GetPatch()) == `{"spec":{"project":"default"}}` {
 					normalized = true
 				}
 			}
@@ -1913,4 +1913,66 @@ func TestAddControllerNamespace(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, test.FakeArgoCDNamespace, updatedApp.Status.ControllerNamespace)
 	})
+}
+
+func TestHelmValuesObjectHasReplaceStrategy(t *testing.T) {
+	app := v1alpha1.Application{
+		Status: v1alpha1.ApplicationStatus{Sync: v1alpha1.SyncStatus{ComparedTo: v1alpha1.ComparedTo{
+			Source: v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValuesObject: &runtime.RawExtension{
+						Object: &unstructured.Unstructured{Object: map[string]interface{}{"key": []string{"value"}}},
+					},
+				},
+			},
+		}}},
+	}
+
+	appModified := v1alpha1.Application{
+		Status: v1alpha1.ApplicationStatus{Sync: v1alpha1.SyncStatus{ComparedTo: v1alpha1.ComparedTo{
+			Source: v1alpha1.ApplicationSource{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					ValuesObject: &runtime.RawExtension{
+						Object: &unstructured.Unstructured{Object: map[string]interface{}{"key": []string{"value-modified1"}}},
+					},
+				},
+			},
+		}}},
+	}
+
+	patch, _, err := createMergePatch(
+		app,
+		appModified)
+	require.NoError(t, err)
+	assert.Equal(t, `{"status":{"sync":{"comparedTo":{"source":{"helm":{"valuesObject":{"key":["value-modified1"]}}}}}}}`, string(patch))
+}
+
+func TestAppStatusIsReplaced(t *testing.T) {
+	original := &v1alpha1.ApplicationStatus{Sync: v1alpha1.SyncStatus{
+		ComparedTo: v1alpha1.ComparedTo{
+			Destination: v1alpha1.ApplicationDestination{
+				Server: "https://mycluster",
+			},
+		},
+	}}
+
+	updated := &v1alpha1.ApplicationStatus{Sync: v1alpha1.SyncStatus{
+		ComparedTo: v1alpha1.ComparedTo{
+			Destination: v1alpha1.ApplicationDestination{
+				Name: "mycluster",
+			},
+		},
+	}}
+
+	patchData, ok, err := createMergePatch(original, updated)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	patchObj := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(patchData, &patchObj))
+
+	val, has, err := unstructured.NestedFieldNoCopy(patchObj, "sync", "comparedTo", "destination", "server")
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Nil(t, val)
 }

--- a/pkg/apis/application/v1alpha1/generated.proto
+++ b/pkg/apis/application/v1alpha1/generated.proto
@@ -2227,7 +2227,6 @@ message SyncStatus {
   optional string status = 1;
 
   // ComparedTo contains information about what has been compared
-  // +patchStrategy=replace
   optional ComparedTo comparedTo = 2;
 
   // Revision contains information about the revision the comparison has been performed to

--- a/pkg/apis/application/v1alpha1/openapi_generated.go
+++ b/pkg/apis/application/v1alpha1/openapi_generated.go
@@ -7705,11 +7705,6 @@ func schema_pkg_apis_application_v1alpha1_SyncStatus(ref common.ReferenceCallbac
 						},
 					},
 					"comparedTo": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-patch-strategy": "replace",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "ComparedTo contains information about what has been compared",
 							Default:     map[string]interface{}{},

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1509,8 +1509,7 @@ type SyncStatus struct {
 	// Status is the sync state of the comparison
 	Status SyncStatusCode `json:"status" protobuf:"bytes,1,opt,name=status,casttype=SyncStatusCode"`
 	// ComparedTo contains information about what has been compared
-	// +patchStrategy=replace
-	ComparedTo ComparedTo `json:"comparedTo,omitempty" protobuf:"bytes,2,opt,name=comparedTo" patchStrategy:"replace"`
+	ComparedTo ComparedTo `json:"comparedTo,omitempty" protobuf:"bytes,2,opt,name=comparedTo"`
 	// Revision contains information about the revision the comparison has been performed to
 	Revision string `json:"revision,omitempty" protobuf:"bytes,3,opt,name=revision"`
 	// Revisions contains information about the revisions of multiple sources the comparison has been performed to

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -11,13 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/gitops-engine/pkg/diff"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
-
 	argocdcommon "github.com/argoproj/argo-cd/v2/common"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
 
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
@@ -3669,36 +3665,4 @@ func TestApplicationSpec_GetSourcePtrByIndex(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
-}
-
-func TestHelmValuesObjectHasReplaceStrategy(t *testing.T) {
-	app := Application{
-		Status: ApplicationStatus{Sync: SyncStatus{ComparedTo: ComparedTo{
-			Source: ApplicationSource{
-				Helm: &ApplicationSourceHelm{
-					ValuesObject: &runtime.RawExtension{
-						Object: &unstructured.Unstructured{Object: map[string]interface{}{"key": []string{"value"}}},
-					},
-				},
-			},
-		}}},
-	}
-
-	appModified := Application{
-		Status: ApplicationStatus{Sync: SyncStatus{ComparedTo: ComparedTo{
-			Source: ApplicationSource{
-				Helm: &ApplicationSourceHelm{
-					ValuesObject: &runtime.RawExtension{
-						Object: &unstructured.Unstructured{Object: map[string]interface{}{"key": []string{"value-modified1"}}},
-					},
-				},
-			},
-		}}},
-	}
-
-	patch, _, err := diff.CreateTwoWayMergePatch(
-		app,
-		appModified, Application{})
-	require.NoError(t, err)
-	assert.Equal(t, `{"status":{"sync":{"comparedTo":{"destination":{},"source":{"helm":{"valuesObject":{"key":["value-modified1"]}},"repoURL":""}}}}}`, string(patch))
 }


### PR DESCRIPTION
PR cherry-picks https://github.com/argoproj/argo-cd/pull/19340 into release-2.11