### PR TITLE
feat: Add source namespaces output to printProject function #19344

### DIFF
--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -921,6 +921,16 @@ func printProject(p *v1alpha1.AppProject, scopedRepositories []*v1alpha1.Reposit
 		fmt.Printf(printProjFmtStr, "", p.Spec.SourceRepos[i])
 	}
 
+	// Print source namespaces
+	ns0 := "<none>"
+	if len(p.Spec.SourceNamespaces) > 0 {
+		ns0 = p.Spec.SourceNamespaces[0]
+	}
+	fmt.Printf(printProjFmtStr, "Source Namespaces:", ns0)
+	for i := 1; i < len(p.Spec.SourceNamespaces); i++ {
+		fmt.Printf(printProjFmtStr, "", p.Spec.SourceNamespaces[i])
+	}
+
 	// Print scoped repositories
 	scr0 := "<none>"
 	if len(scopedRepositories) > 0 {


### PR DESCRIPTION
This PR updates the printProject function to include the output of source namespaces.

Changes:
- Added logic to print the source namespaces from the AppProject specification.
- Ensured the source namespaces are formatted consistently with other project details.

This enhancement improves the visibility of source namespaces in the project output, making it easier to review and debug project configurations.

Closed [#19344](https://github.com/argoproj/argo-cd/issues/19344)
