### PR TITLE
feat: Add metric to expose Applications conditions

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -62,6 +62,7 @@ func NewCommand() *cobra.Command {
 		metricsPort                      int
 		metricsCacheExpiration           time.Duration
 		metricsAplicationLabels          []string
+		metricsAplicationConditions      []string
 		kubectlParallelismLimit          int64
 		cacheSource                      func() (*appstatecache.Cache, error)
 		redisClient                      *redis.Client
@@ -167,6 +168,7 @@ func NewCommand() *cobra.Command {
 				metricsPort,
 				metricsCacheExpiration,
 				metricsAplicationLabels,
+				metricsAplicationConditions,
 				kubectlParallelismLimit,
 				persistResourceHealth,
 				clusterSharding,
@@ -229,6 +231,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().BoolVar(&repoServerPlaintext, "repo-server-plaintext", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_PLAINTEXT", false), "Disable TLS on connections to repo server")
 	command.Flags().BoolVar(&repoServerStrictTLS, "repo-server-strict-tls", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_STRICT_TLS", false), "Whether to use strict validation of the TLS cert presented by the repo server")
 	command.Flags().StringSliceVar(&metricsAplicationLabels, "metrics-application-labels", []string{}, "List of Application labels that will be added to the argocd_application_labels metric")
+	command.Flags().StringSliceVar(&metricsAplicationConditions, "metrics-application-conditions", []string{}, "List of Application conditions that will be added to the argocd_application_conditions metric")
 	command.Flags().StringVar(&otlpAddress, "otlp-address", env.StringFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_ADDRESS", ""), "OpenTelemetry collector address to send traces to")
 	command.Flags().BoolVar(&otlpInsecure, "otlp-insecure", env.ParseBoolFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_INSECURE", true), "OpenTelemetry collector insecure mode")
 	command.Flags().StringToStringVar(&otlpHeaders, "otlp-headers", env.ParseStringToStringFromEnv("ARGOCD_APPLICATION_CONTROLLER_OTLP_HEADERS", map[string]string{}, ","), "List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2)")

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -387,7 +387,7 @@ func reconcileApplications(
 		return true
 	}, func(r *http.Request) error {
 		return nil
-	}, []string{})
+	}, []string{}, []string{})
 	if err != nil {
 		return nil, err
 	}

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -164,6 +164,7 @@ func NewApplicationController(
 	metricsPort int,
 	metricsCacheExpiration time.Duration,
 	metricsApplicationLabels []string,
+	metricsApplicationConditions []string,
 	kubectlParallelismLimit int64,
 	persistResourceHealth bool,
 	clusterSharding sharding.ClusterShardingCache,
@@ -279,7 +280,7 @@ func NewApplicationController(
 
 	metricsAddr := fmt.Sprintf("0.0.0.0:%d", metricsPort)
 
-	ctrl.metricsServer, err = metrics.NewMetricsServer(metricsAddr, appLister, ctrl.canProcessApp, readinessHealthCheck, metricsApplicationLabels)
+	ctrl.metricsServer, err = metrics.NewMetricsServer(metricsAddr, appLister, ctrl.canProcessApp, readinessHealthCheck, metricsApplicationLabels, metricsApplicationConditions)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -155,6 +155,7 @@ func newFakeController(data *fakeData, repoErr error) *ApplicationController {
 		common.DefaultPortArgoCDMetrics,
 		data.metricsCacheExpiration,
 		[]string{},
+		[]string{},
 		0,
 		true,
 		nil,

--- a/docs/operator-manual/metrics.md
+++ b/docs/operator-manual/metrics.md
@@ -8,6 +8,7 @@ Metrics about applications. Scraped at the `argocd-metrics:8082/metrics` endpoin
 | Metric | Type | Description |
 |--------|:----:|-------------|
 | `argocd_app_info` | gauge | Information about Applications. It contains labels such as `sync_status` and `health_status` that reflect the application state in Argo CD. |
+| `argocd_app_condition` | gauge | Report Applications conditions. It contains the conditions currently present in the application status. |
 | `argocd_app_k8s_request_total` | counter | Number of Kubernetes requests executed during application reconciliation |
 | `argocd_app_labels` | gauge | Argo Application labels converted to Prometheus labels. Disabled by default. See section below about how to enable it. |
 | `argocd_app_reconcile` | histogram | Application reconciliation performance in seconds. |
@@ -58,6 +59,28 @@ In this case, the metric would look like:
 argocd_app_labels{label_business_unit="bu-id-1",label_team_name="my-team",name="my-app-1",namespace="argocd",project="important-project"} 1
 argocd_app_labels{label_business_unit="bu-id-1",label_team_name="my-team",name="my-app-2",namespace="argocd",project="important-project"} 1
 argocd_app_labels{label_business_unit="bu-id-2",label_team_name="another-team",name="my-app-3",namespace="argocd",project="important-project"} 1
+```
+
+### Exposing Application conditions as Prometheus metrics
+
+There are use-cases where Argo CD Applications contain conditions that are desired to be exposed as Prometheus metrics.
+Some examples are:
+
+* Hunting orphaned resources across all deployed applications
+* Knowing which resources are excluded from ArgoCD
+
+As the Application conditions are specific to each company, this feature is disabled by default. To enable it, add the
+`--metrics-application-conditions` flag to the Argo CD application controller.
+
+The example below will expose the Argo CD Application condition `OrphanedResourceWarning` and `ExcludedResourceWarning` to Prometheus:
+
+    containers:
+    - command:
+      - argocd-application-controller
+      - --metrics-application-conditions
+      - OrphanedResourceWarning
+      - --metrics-application-conditions
+      - ExcludedResourceWarning
 ```
 
 ## API Server Metrics

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -39,6 +39,7 @@ argocd-application-controller [flags]
       --kubectl-parallelism-limit int                             Number of allowed concurrent kubectl fork/execs. Any value less than 1 means no limit. (default 20)
       --logformat string                                          Set the logging format. One of: text|json (default "text")
       --loglevel string                                           Set the logging level. One of: debug|info|warn|error (default "info")
+      --metrics-application-conditions strings                    List of Application conditions that will be added to the argocd_application_conditions metric
       --metrics-application-labels strings                        List of Application labels that will be added to the argocd_application_labels metric
       --metrics-cache-expiration duration                         Prometheus metrics cache expiration (disabled  by default. e.g. 24h0m0s)
       --metrics-port int                                          Start metrics server on given port (default 8082)


### PR DESCRIPTION
Hello,

Closes #13096

Implement a new metric exposing Applications conditions. This is particularly useful for SRE teams to be able to setup alerts on issues that aren't displayed via "health_status" and "sync_status" in the metric "argocd_app_info".

Our use case is similar to  #13096. We want to ensure flawless reinstallation of our Kubernetes clusters. To do this we need to take care to not have some resources that for some reason aren't managed by ArgoCD but that end up being necessary for our workloads to run properly.

Best Regards.