### PR TITLE
test: add Unit Tests for SecureMkdirAll Function

### DIFF
--- a/commitserver/commit/secure_mkdir_default_test.go
+++ b/commitserver/commit/secure_mkdir_default_test.go
@@ -5,6 +5,7 @@ package commit
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,17 @@ func TestSecureMkdirAllWithExistingDir(t *testing.T) {
 	newPath, err := SecureMkdirAll(root, unsafePath, os.ModePerm)
 	require.NoError(t, err)
 	assert.Equal(t, fullPath, newPath)
+}
+
+func TestSecureMkdirAllWithFile(t *testing.T) {
+	root := t.TempDir()
+	unsafePath := "file.txt"
+
+	filePath := filepath.Join(root, unsafePath)
+	err := os.WriteFile(filePath, []byte("test"), os.ModePerm)
+	require.NoError(t, err)
+
+	_, err = SecureMkdirAll(root, unsafePath, os.ModePerm)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create directory")
 }

--- a/commitserver/commit/secure_mkdir_default_test.go
+++ b/commitserver/commit/secure_mkdir_default_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +47,23 @@ func TestSecureMkdirAllWithFile(t *testing.T) {
 	_, err = SecureMkdirAll(root, unsafePath, os.ModePerm)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create directory")
+}
+
+func TestSecureMkdirAllDotDotPath(t *testing.T) {
+	root := t.TempDir()
+	unsafePath := "../outside"
+
+	fullPath, err := SecureMkdirAll(root, unsafePath, os.ModePerm)
+	require.NoError(t, err)
+
+	expectedPath := filepath.Join(root, "outside")
+	assert.Equal(t, expectedPath, fullPath)
+
+	info, err := os.Stat(fullPath)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	relPath, err := filepath.Rel(root, fullPath)
+	require.NoError(t, err)
+	assert.False(t, strings.HasPrefix(relPath, ".."))
 }

--- a/commitserver/commit/secure_mkdir_default_test.go
+++ b/commitserver/commit/secure_mkdir_default_test.go
@@ -21,3 +21,15 @@ func TestSecureMkdirAllDefault(t *testing.T) {
 	expectedPath := path.Join(root, unsafePath)
 	assert.Equal(t, expectedPath, fullPath)
 }
+
+func TestSecureMkdirAllWithExistingDir(t *testing.T) {
+	root := t.TempDir()
+	unsafePath := "existing/dir"
+
+	fullPath, err := SecureMkdirAll(root, unsafePath, os.ModePerm)
+	require.NoError(t, err)
+
+	newPath, err := SecureMkdirAll(root, unsafePath, os.ModePerm)
+	require.NoError(t, err)
+	assert.Equal(t, fullPath, newPath)
+}


### PR DESCRIPTION
#19303 
This PR adds unit tests for the SecureMkdirAll function to enhance its robustness and reliability. The following test cases have been included:

- TestSecureMkdirAllWithExistingDir: Verifies that SecureMkdirAll returns the same path when creating a directory that already exists.
- TestSecureMkdirAllWithFile: Ensures that SecureMkdirAll returns an error when attempting to create a directory where a file exists.
- TestSecureMkdirAllDotDotPath: Tests that SecureMkdirAll handles ../ path correctly and does not allow directory traversal outside the intended root.