### PR TITLE
fix: spec comparison for app creation

### DIFF
--- a/server/application/application.go
+++ b/server/application/application.go
@@ -369,7 +369,16 @@ func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateReq
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to check existing application details (%s): %v", appNs, err)
 	}
-	equalSpecs := reflect.DeepEqual(existing.Spec, a.Spec) &&
+
+	equalSpecs := reflect.DeepEqual(existing.Spec.Source, a.Spec.Source) &&
+		reflect.DeepEqual(existing.Spec.Project, a.Spec.Project) &&
+		reflect.DeepEqual(existing.Spec.Destination.Namespace, a.Spec.Destination.Namespace) &&
+		reflect.DeepEqual(existing.Spec.Destination.Name, a.Spec.Destination.Name) &&
+		reflect.DeepEqual(existing.Spec.SyncPolicy, a.Spec.SyncPolicy) &&
+		reflect.DeepEqual(existing.Spec.IgnoreDifferences, a.Spec.IgnoreDifferences) &&
+		reflect.DeepEqual(existing.Spec.Info, a.Spec.Info) &&
+		reflect.DeepEqual(existing.Spec.RevisionHistoryLimit, a.Spec.RevisionHistoryLimit) &&
+		reflect.DeepEqual(existing.Spec.Sources, a.Spec.Sources) &&
 		reflect.DeepEqual(existing.Labels, a.Labels) &&
 		reflect.DeepEqual(existing.Annotations, a.Annotations) &&
 		reflect.DeepEqual(existing.Finalizers, a.Finalizers)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Issue
Executing this command twice:
```
argocd app create guestbook-2 --repo=https://github.com/argoproj/argocd-example-apps.git --path=guestbook --dest-name in-cluster --dest-namespace=argocd-test-2 --sync-option=CreateNamespace=true --sync-policy=automated
```

will return error `InvalidArgument` with error message `existing application spec is different, use upsert flag to force update`.

Expected is to return `application '<app-name>' unchanged` since `--dest-name` argument should be idempotent.

## Root cause
Comparison of application spec structs using `reflect.DeepEqual` means that private fields will also be compared. Additionally, the `Destination.Server` field in the 'local' app spec is not present and therefore needs to be excluded when comparing the app specs



Fixes #18794

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
