### PR TITLE
fix: selfHeal should always be respected with Multi-Source Apps #19452

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1957,11 +1957,18 @@ func (ctrl *ApplicationController) autoSync(app *appv1.Application, syncStatus *
 		}
 	}
 
+	selfHeal := app.Spec.SyncPolicy.Automated.SelfHeal
+	// Multi-Source Apps with selfHeal disabled should not trigger an autosync if
+	// the last sync revision and the new sync revision is the same.
+	if app.Spec.HasMultipleSources() && !selfHeal && reflect.DeepEqual(app.Status.Sync.Revisions, syncStatus.Revisions) {
+		logCtx.Infof("Skipping auto-sync: selfHeal disabled and sync caused by object update")
+		return nil, 0
+	}
+
 	desiredCommitSHA := syncStatus.Revision
 	desiredCommitSHAsMS := syncStatus.Revisions
 	alreadyAttempted, attemptPhase := alreadyAttemptedSync(app, desiredCommitSHA, desiredCommitSHAsMS, app.Spec.HasMultipleSources())
 	ts.AddCheckpoint("already_attempted_sync_ms")
-	selfHeal := app.Spec.SyncPolicy.Automated.SelfHeal
 	op := appv1.Operation{
 		Sync: &appv1.SyncOperation{
 			Revision:    desiredCommitSHA,


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/19452

~~Currently set to Draft as this PR should come with testing as well to ensure that this resolves the issue~~

**This PR should be able to be released immediately to the next patch/minor version.**

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

When using Multi-Source Apps with `selfHeal: false`, Argo will autosync the App if the last successful sync revision hash does not match the latest `HEAD` commit hash in the repo even though the cause of the OutOfSync is from an object update/change from in the cluster. If the last successful sync revision hash and HEAD commit hash in the repo match, then any OutOfSync caused by change in the cluster will respect the `selfHeal: false`.

The issue occurs when comparing https://github.com/argoproj/argo-cd/blob/master/controller/appcontroller.go#L2063 `OperationState.SyncResult.Revisions` with current `syncStatus.Revisions` (which caused the current OutOfSync status) https://github.com/argoproj/argo-cd/blob/master/controller/appcontroller.go#L1961. If my understanding of this is correct, `alreadyAttemptedSync` will return `false` if a change is triggered in cluster and the last sync hash on the App doesn't match the current `HEAD`.

This PR seeks to resolve this by checking before `autoSyncAttempted` whether we should continue or return early. We check the App's last sync revision hashes with the new syncStatus revisions. If they are the same, then that means this OutOfSync was triggered by a cluster object change and not from a new Git commit, so we can return early if `selfHeal: false` is set.