### PR TITLE
fix: fix plugin select icon issue

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.scss
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.scss
@@ -64,6 +64,10 @@
 
     .select {
         padding-bottom: 0;
+
+        .select__value{
+            min-height: 28px;
+        }
     }
 
     .row.application-retry-options {


### PR DESCRIPTION
Fix #https://github.com/argoproj/argo-cd/issues/19134
Fix plugin name select arrow icon was hidden if nothing is selected

After change:
![image](https://github.com/user-attachments/assets/3603a31a-db55-4bce-a649-fc981beae7bd)
