### PR TITLE
feat: Support service account token for argocd server authentication

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# https://github.com/cse-labs/codespaces-images
+FROM ghcr.io/cse-labs/k3d:latest
+
+# some images require specific values
+ARG USERNAME=vscode
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,69 @@
+{
+	"name": "Kubernetes-in-Codespaces",
+	"dockerFile": "Dockerfile",
+
+	// do not change these if you want Docker in Docker support
+	"runArgs": ["--init", "--privileged"],
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
+	"overrideCommand": false,
+
+	// some base images require a specific user name
+	"remoteUser": "vscode",
+
+	// Set container specific settings
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "zsh",
+		"files.trimTrailingWhitespace": true,
+		"files.trimFinalNewlines": true,
+		"files.insertFinalNewline": true
+	},
+
+	"hostRequirements": {
+		"cpus": 4
+	},
+
+	// forward ports for the app
+	"forwardPorts": [
+		80,
+		3000,
+		8080,
+		30000,
+		30080,
+		31080,
+		32000
+	],
+
+	// add labels
+	"portsAttributes": {
+		"80": { "label": "ingress-http" },
+		"3000": { "label": "guestbook" },
+		"8080": { "label": "argocd" },
+		"30000": { "label": "Prometheus" },
+		"30080": { "label": "IMDb App" },
+		"31080": { "label": "Heartbeat" },
+		"32000": { "label": "Grafana" }
+	},
+
+	// Install extensions
+	"extensions": [
+		"ms-dotnettools.csharp",
+		"ms-azuretools.vscode-docker",
+		"ms-kubernetes-tools.vscode-kubernetes-tools",
+		"davidanson.vscode-markdownlint",
+		"gruntfuggly.todo-tree",
+		"mutantdino.resourcemonitor",
+		"humao.rest-client",
+		"timonwong.shellcheck",
+	],
+
+	"waitFor": "postCreateCommand",
+
+	// Use 'onCreateCommand' to run commands as part of container creation.
+	"onCreateCommand": "/bin/bash -c .devcontainer/on-create.sh",
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "/bin/bash -c .devcontainer/post-create.sh",
+
+	// Use 'postStartCommand' to run commands after the container starts.
+	"postStartCommand": "/bin/bash -c .devcontainer/post-start.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,22 +26,14 @@
 	"forwardPorts": [
 		80,
 		3000,
-		8080,
-		30000,
-		30080,
-		31080,
-		32000
+		8080
 	],
 
 	// add labels
 	"portsAttributes": {
 		"80": { "label": "ingress-http" },
 		"3000": { "label": "guestbook" },
-		"8080": { "label": "argocd" },
-		"30000": { "label": "Prometheus" },
-		"30080": { "label": "IMDb App" },
-		"31080": { "label": "Heartbeat" },
-		"32000": { "label": "Grafana" }
+		"8080": { "label": "argocd" }
 	},
 
 	// Install extensions

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,22 +1,11 @@
 #!/bin/bash
 
 # this runs as part of pre-build
-
-
 echo "on-create start"
 echo "$(date +'%Y-%m-%d %H:%M:%S')    on-create start" >> "$HOME/status"
 
-# clone repos
-git clone https://github.com/cse-labs/imdb-app /workspaces/imdb-app
-git clone https://github.com/microsoft/webvalidate /workspaces/webvalidate
-
-# restore the repos
-dotnet restore /workspaces/webvalidate/src/webvalidate.sln
-dotnet restore /workspaces/imdb-app/src/imdb.csproj
-
 export REPO_BASE=$PWD
 export PATH="$PATH:$REPO_BASE/cli"
-
 
 mkdir -p "$HOME/.ssh"
 
@@ -36,15 +25,7 @@ docker network connect kind kind-registry
 # update the base docker images
 docker pull mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 docker pull mcr.microsoft.com/dotnet/sdk:6.0
-docker pull ghcr.io/cse-labs/webv-red:latest
 
-# echo "downloading kic CLI"
-# cd cli || exit
-# tag="0.4.3"
-# wget -O kic.tar.gz "https://github.com/retaildevcrews/akdc/releases/download/$tag/kic-$tag-linux-amd64.tar.gz"
-# tar -xvzf kic.tar.gz
-# rm kic.tar.gz
-# cd "$OLDPWD" || exit
 
 echo "generating completions"
 kic completion zsh > "$HOME/.oh-my-zsh/completions/_kic"
@@ -57,7 +38,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   kubeadmConfigPatches:
-  
   - |
     kind: InitConfiguration
     nodeRegistration:
@@ -70,23 +50,12 @@ nodes:
   - containerPort: 443
     hostPort: 443
     protocol: TCP
-
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5500"]
     endpoint = ["http://kind-registry:5000"]
 EOF
 
-
-echo "building IMDb"
-kic build imdb
-
-echo "building WebValidate"
-sed -i "s/RUN dotnet test//g" /workspaces/webvalidate/Dockerfile
-kic build webv
-
-echo "deploying to Kind cluster"
-kic cluster deploy
 
 # only run apt upgrade on pre-build
 if [ "$CODESPACE_NAME" = "null" ]

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -2,6 +2,7 @@
 
 # this runs as part of pre-build
 
+
 echo "on-create start"
 echo "$(date +'%Y-%m-%d %H:%M:%S')    on-create start" >> "$HOME/status"
 

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# this runs as part of pre-build
+
+echo "on-create start"
+echo "$(date +'%Y-%m-%d %H:%M:%S')    on-create start" >> "$HOME/status"
+
+# clone repos
+git clone https://github.com/cse-labs/imdb-app /workspaces/imdb-app
+git clone https://github.com/microsoft/webvalidate /workspaces/webvalidate
+
+# restore the repos
+dotnet restore /workspaces/webvalidate/src/webvalidate.sln
+dotnet restore /workspaces/imdb-app/src/imdb.csproj
+
+export REPO_BASE=$PWD
+export PATH="$PATH:$REPO_BASE/cli"
+
+
+mkdir -p "$HOME/.ssh"
+
+{
+    # add cli to path
+    echo "export PATH=\$PATH:$REPO_BASE/cli"
+
+    echo "export REPO_BASE=$REPO_BASE"
+    echo "compinit"
+} >> "$HOME/.zshrc"
+
+# create local registry
+docker network create kind
+docker run -d -p 5500:5000 --name kind-registry --network kind registry:2
+docker network connect kind kind-registry
+
+# update the base docker images
+docker pull mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+docker pull mcr.microsoft.com/dotnet/sdk:6.0
+docker pull ghcr.io/cse-labs/webv-red:latest
+
+# echo "downloading kic CLI"
+# cd cli || exit
+# tag="0.4.3"
+# wget -O kic.tar.gz "https://github.com/retaildevcrews/akdc/releases/download/$tag/kic-$tag-linux-amd64.tar.gz"
+# tar -xvzf kic.tar.gz
+# rm kic.tar.gz
+# cd "$OLDPWD" || exit
+
+echo "generating completions"
+kic completion zsh > "$HOME/.oh-my-zsh/completions/_kic"
+kubectl completion zsh > "$HOME/.oh-my-zsh/completions/_kubectl"
+
+echo "creating Kind cluster"
+cat <<EOF | kind create cluster --name kind --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5500"]
+    endpoint = ["http://kind-registry:5000"]
+EOF
+
+
+echo "building IMDb"
+kic build imdb
+
+echo "building WebValidate"
+sed -i "s/RUN dotnet test//g" /workspaces/webvalidate/Dockerfile
+kic build webv
+
+echo "deploying to Kind cluster"
+kic cluster deploy
+
+# only run apt upgrade on pre-build
+if [ "$CODESPACE_NAME" = "null" ]
+then
+    sudo apt-get update
+    sudo apt-get upgrade -y
+    sudo apt-get autoremove -y
+    sudo apt-get clean -y
+fi
+
+echo "on-create complete"
+echo "$(date +'%Y-%m-%d %H:%M:%S')    on-create complete" >> "$HOME/status"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,11 +5,6 @@
 echo "post-create start"
 echo "$(date)    post-create start" >> "$HOME/status"
 
-# update the repos
-git -C /workspaces/imdb-app pull
-git -C /workspaces/webvalidate pull
-
-
 sudo apt-get install curl -y
 sudo apt-get install make -y
 
@@ -33,7 +28,6 @@ installgo() {
   # Delete the downloaded tar file
   rm go1.22.2.linux-amd64.tar.gz
 }
-
 
 # Run the installgo function
 installgo

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# this runs at Codespace creation - not part of pre-build
+
+echo "post-create start"
+echo "$(date)    post-create start" >> "$HOME/status"
+
+# update the repos
+git -C /workspaces/imdb-app pull
+git -C /workspaces/webvalidate pull
+
+
+sudo apt-get install curl -y
+sudo apt-get install make -y
+
+installgo() {
+  sudo rm -rf /usr/local/go
+  curl -OL https://golang.org/dl/go1.22.2.linux-amd64.tar.gz
+  sudo tar -C /usr/local -xvf go1.22.2.linux-amd64.tar.gz
+
+  # Add Go to PATH for the current user
+  echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
+
+  # Add Go to PATH for all users (including root)
+  sudo sh -c 'echo "export PATH=\$PATH:/usr/local/go/bin" >> /etc/profile'
+
+  # Source the updated profile for the current user
+  source ~/.profile
+
+  # Source the updated profile for the root user
+  sudo sh -c 'source /etc/profile'
+
+  # Delete the downloaded tar file
+  rm go1.22.2.linux-amd64.tar.gz
+}
+
+
+# Run the installgo function
+installgo
+
+# install nginx ingress by default enabled for kind cluster
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+echo "post-create complete"
+echo "$(date +'%Y-%m-%d %H:%M:%S')    post-create complete" >> "$HOME/status"

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
 # this runs each time the container starts
-
 echo "post-start start"
 echo "$(date +'%Y-%m-%d %H:%M:%S')    post-start start" >> "$HOME/status"
 
 # update the base docker images
 docker pull mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 docker pull mcr.microsoft.com/dotnet/sdk:6.0
-docker pull ghcr.io/cse-labs/webv-red:latest
 
 echo "post-start complete"
 echo "$(date +'%Y-%m-%d %H:%M:%S')    post-start complete" >> "$HOME/status"

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# this runs each time the container starts
+
+echo "post-start start"
+echo "$(date +'%Y-%m-%d %H:%M:%S')    post-start start" >> "$HOME/status"
+
+# update the base docker images
+docker pull mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+docker pull mcr.microsoft.com/dotnet/sdk:6.0
+docker pull ghcr.io/cse-labs/webv-red:latest
+
+
+echo "post-start complete"
+echo "$(date +'%Y-%m-%d %H:%M:%S')    post-start complete" >> "$HOME/status"

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -10,6 +10,5 @@ docker pull mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 docker pull mcr.microsoft.com/dotnet/sdk:6.0
 docker pull ghcr.io/cse-labs/webv-red:latest
 
-
 echo "post-start complete"
 echo "$(date +'%Y-%m-%d %H:%M:%S')    post-start complete" >> "$HOME/status"

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,18 +1,36 @@
 #!/bin/bash
 set -eux -o pipefail
 
+# Ensure go-junit-report is installed
 which go-junit-report || go install github.com/jstemmer/go-junit-report@latest
 
+# Ensure DIST_DIR is defined and set to the directory where gotestsum should be installed
+DIST_DIR=${DIST_DIR:-/go/src/github.com/argoproj/argo-cd/dist}
+
+# Ensure gotestsum is installed in DIST_DIR
+if [ ! -x "${DIST_DIR}/gotestsum" ]; then
+    echo "gotestsum not found in DIST_DIR, installing..."
+    go install gotest.tools/gotestsum@latest
+    mkdir -p "${DIST_DIR}"
+    cp "$(which gotestsum)" "${DIST_DIR}/gotestsum"
+else
+    echo "gotestsum is already installed in DIST_DIR."
+fi
+
+# Set default values for TEST_RESULTS and TEST_FLAGS
 TEST_RESULTS=${TEST_RESULTS:-test-results}
 TEST_FLAGS=${TEST_FLAGS:-}
 
-if test "${ARGOCD_TEST_PARALLELISM:-}" != ""; then
-	TEST_FLAGS="$TEST_FLAGS -p $ARGOCD_TEST_PARALLELISM"
+# Append parallelism and verbosity flags if set
+if [ "${ARGOCD_TEST_PARALLELISM:-}" != "" ]; then
+    TEST_FLAGS="$TEST_FLAGS -p $ARGOCD_TEST_PARALLELISM"
 fi
-if test "${ARGOCD_TEST_VERBOSE:-}" != ""; then
-	TEST_FLAGS="$TEST_FLAGS -v"
+if [ "${ARGOCD_TEST_VERBOSE:-}" != "" ]; then
+    TEST_FLAGS="$TEST_FLAGS -v"
 fi
 
+# Create the test results directory if it does not exist
 mkdir -p $TEST_RESULTS
 
+# Run gotestsum with the specified parameters
 GODEBUG="tarinsecurepath=0,zipinsecurepath=0" ${DIST_DIR}/gotestsum --rerun-fails-report=rerunreport.txt --junitfile=$TEST_RESULTS/junit.xml --format=testname --rerun-fails="$RERUN_FAILS" --packages="$PACKAGES" -- -cover $TEST_FLAGS $*

--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -69,8 +69,9 @@ func newTestAccountServerExt(ctx context.Context, enforceFn rbac.ClaimsEnforcerF
 	enforcer := rbac.NewEnforcer(kubeclientset, testNamespace, common.ArgoCDRBACConfigMapName, nil)
 	enforcer.SetClaimsEnforcerFunc(enforceFn)
 
-	return NewServer(sessionMgr, settingsMgr, enforcer), session.NewServer(sessionMgr, settingsMgr, nil, nil, nil)
+	return NewServer(sessionMgr, settingsMgr, enforcer, kubeclientset), session.NewServer(sessionMgr, settingsMgr, nil, nil, nil, kubeclientset)
 }
+
 
 func getAdminAccount(mgr *settings.SettingsManager) (*settings.Account, error) {
 	accounts, err := mgr.GetAccounts()
@@ -104,6 +105,8 @@ func projTokenContext(ctx context.Context) context.Context {
 }
 
 func TestUpdatePassword(t *testing.T) {
+	// Create a fake Kubernetes clientset for testing
+	kubeClientset := fake.NewSimpleClientset()
 	accountServer, sessionServer := newTestAccountServer(context.Background())
 	ctx := adminContext(context.Background())
 	var err error
@@ -111,8 +114,8 @@ func TestUpdatePassword(t *testing.T) {
 	// ensure password is not allowed to be updated if given bad password
 	_, err = accountServer.UpdatePassword(ctx, &account.UpdatePasswordRequest{CurrentPassword: "badpassword", NewPassword: "newpassword"})
 	require.Error(t, err)
-	require.NoError(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "oldpassword"))
-	require.Error(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "newpassword"))
+	require.NoError(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "oldpassword",kubeClientset))
+	require.Error(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "newpassword",kubeClientset))
 	// verify old password works
 	_, err = sessionServer.Create(ctx, &sessionpkg.SessionCreateRequest{Username: "admin", Password: "oldpassword"})
 	require.NoError(t, err)
@@ -129,8 +132,8 @@ func TestUpdatePassword(t *testing.T) {
 	adminAccount, err = getAdminAccount(accountServer.settingsMgr)
 	require.NoError(t, err)
 	assert.NotEqual(t, prevHash, adminAccount.PasswordHash)
-	require.NoError(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "newpassword"))
-	require.Error(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "oldpassword"))
+	require.NoError(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "newpassword",kubeClientset))
+	require.Error(t, accountServer.sessionMgr.VerifyUsernamePassword("admin", "oldpassword",kubeClientset))
 	// verify old password is invalid
 	_, err = sessionServer.Create(ctx, &sessionpkg.SessionCreateRequest{Username: "admin", Password: "oldpassword"})
 	require.Error(t, err)

--- a/server/server.go
+++ b/server/server.go
@@ -866,7 +866,7 @@ func newArgoCDServiceSet(a *ArgoCDServer) *ArgoCDServiceSet {
 	if maxConcurrentLoginRequestsCount > 0 {
 		loginRateLimiter = session.NewLoginRateLimiter(maxConcurrentLoginRequestsCount)
 	}
-	sessionService := session.NewServer(a.sessionMgr, a.settingsMgr, a, a.policyEnforcer, loginRateLimiter)
+	sessionService := session.NewServer(a.sessionMgr, a.settingsMgr, a, a.policyEnforcer, loginRateLimiter,a.KubeClientset)
 	projectLock := sync.NewKeyLock()
 	applicationService, appResourceTreeFn := application.NewServer(
 		a.Namespace,
@@ -910,7 +910,7 @@ func newArgoCDServiceSet(a *ArgoCDServer) *ArgoCDServiceSet {
 	projectService := project.NewServer(a.Namespace, a.KubeClientset, a.AppClientset, a.enf, projectLock, a.sessionMgr, a.policyEnforcer, a.projInformer, a.settingsMgr, a.db)
 	appsInAnyNamespaceEnabled := len(a.ArgoCDServerOpts.ApplicationNamespaces) > 0
 	settingsService := settings.NewServer(a.settingsMgr, a.RepoClientset, a, a.DisableAuth, appsInAnyNamespaceEnabled)
-	accountService := account.NewServer(a.sessionMgr, a.settingsMgr, a.enf)
+	accountService := account.NewServer(a.sessionMgr, a.settingsMgr, a.enf,a.KubeClientset)
 
 	notificationService := notification.NewServer(a.apiFactory)
 	certificateService := certificate.NewServer(a.RepoClientset, a.db, a.enf)

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -460,7 +460,7 @@ func TestVerifyUsernamePassword(t *testing.T) {
                 if tc.password == validK8sToken {
                     // Mock TokenReview response
                     kubeClientset.(*fake.Clientset).Fake.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
-                        tr := action.(testing.CreateAction).GetObject().(*authenticationv1.TokenReview)
+                        tr := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
                         if tr.Spec.Token == validK8sToken { // Use valid JWT
                             return true, &authenticationv1.TokenReview{
                                 Status: authenticationv1.TokenReviewStatus{

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes"
+	k8stesting "k8s.io/client-go/testing"
 	
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -458,7 +459,7 @@ func TestVerifyUsernamePassword(t *testing.T) {
 
                 if tc.password == validK8sToken {
                     // Mock TokenReview response
-                    kubeClientset.(*fake.Clientset).Fake.PrependReactor("create", "tokenreviews", func(action testing.Action) (bool, runtime.Object, error) {
+                    kubeClientset.(*fake.Clientset).Fake.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
                         tr := action.(testing.CreateAction).GetObject().(*authenticationv1.TokenReview)
                         if tr.Spec.Token == validK8sToken { // Use valid JWT
                             return true, &authenticationv1.TokenReview{


### PR DESCRIPTION
**Support service account token for argocd server authentication**

- Argocd application and applicationset are already considered highlevel abstractions, however end-users might want to put together argocd offered capabilities into a more simplified interface either as part of an IDP implementation or even for personal convenience

- This requires setting up and authenticating with argocd server incluster, however the current implementation works well with out of cluster programmatic authentication. 

- For incluster setup a typical flow should be that all authentication and authorization be done incluster

- The typical way to achieve this as of now , requires using `admin user` with `initial argocd password`. 

**Proposed implementation;** Use kubernetes `service account token` together with `admin user`. 

> **Expiration tokens can be generated off service account incluster and use for argocd server authentication.**

> **Since the current kubernetes service account token generation is secure and can easily be rotated.**

> **The user can  periodically rotate this token , use it for argocd authentication, ensuring simplicity, and security, in addition leveraging kubernetes native implementation of authentication**

**Update `VerifyUsernamePassword` function to authenticate with service account token**

```go
// Allow service account token authentication only for the 'admin' user
	if username == "admin" && mgr.isKubernetesToken(password) {
		// Simply verify that the token is valid
		valid, err := mgr.verifyKubernetesToken(password,kubeClientset)
		if err != nil || !valid {
			mgr.updateFailureCount(username, true)
			return InvalidLoginErr
		}
	} else {
		// If it's not a token or the username isn't 'admin', proceed with standard password verification
		valid, _ := passwordutil.VerifyPassword(password, account.PasswordHash)
		if !valid {
			mgr.updateFailureCount(username, true)
			return InvalidLoginErr
		}
	}
```

**Usage**

```go
sa := &corev1.ServiceAccount{
        ObjectMeta: metav1.ObjectMeta{
            Name:      "test-sa",
            Namespace: "default",
        },
    }
    createdSA, err := kubeClientset.CoreV1().ServiceAccounts("default").Create(context.TODO(), sa, metav1.CreateOptions{})
 
###########################################################

tokenRequest := &authv1.TokenRequest{
        Spec: authv1.TokenRequestSpec{
            Audiences:         []string{"https://kubernetes.default.svc.cluster.local"},
            ExpirationSeconds: int64Ptr(3600), // Token valid for 1 hour
        },
    }
    tokenResponse, err := kubeClientset.CoreV1().ServiceAccounts("default").CreateToken(context.TODO(), createdSA.Name, tokenRequest, metav1.CreateOptions{})

    password = tokenResponse.Status.Token

```


> *A scheduleTokenRefresh() function can be setup by the user in another go routine to periodically refresh token and client*

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->




