### PR TITLE
fix: 'argocd admin settings rbac can' - yaml loading problem (#19403)

### DIFF
--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -359,20 +359,16 @@ func getPolicyFromFile(policyFile string) (string, string, string, error) {
 // Retrieve policy information from a ConfigMap
 func getPolicyFromConfigMap(cm *corev1.ConfigMap) (string, string, string) {
 	var (
-		userPolicy  string
 		defaultRole string
 		ok          bool
 	)
-	userPolicy, ok = cm.Data[rbac.ConfigMapPolicyCSVKey]
-	if !ok {
-		userPolicy = ""
-	}
+
 	defaultRole, ok = cm.Data[rbac.ConfigMapPolicyDefaultKey]
 	if !ok {
 		defaultRole = ""
 	}
 
-	return userPolicy, defaultRole, cm.Data[rbac.ConfigMapMatchModeKey]
+	return rbac.PolicyCSV(cm.Data), defaultRole, cm.Data[rbac.ConfigMapMatchModeKey]
 }
 
 // getPolicyConfigMap fetches the RBAC config map from K8s cluster

--- a/cmd/argocd/commands/admin/settings_rbac_test.go
+++ b/cmd/argocd/commands/admin/settings_rbac_test.go
@@ -130,6 +130,8 @@ func Test_PolicyFromYAML(t *testing.T) {
 	require.NotEmpty(t, uPol)
 	require.Equal(t, "role:unknown", dRole)
 	require.Empty(t, matchMode)
+	require.True(t, checkPolicy("my-org:team-qa", "update", "project", "foo",
+		"", uPol, dRole, matchMode, true))
 }
 
 func Test_PolicyFromK8s(t *testing.T) {

--- a/cmd/argocd/commands/admin/testdata/rbac/argocd-rbac-cm.yaml
+++ b/cmd/argocd/commands/admin/testdata/rbac/argocd-rbac-cm.yaml
@@ -12,6 +12,10 @@ data:
     p, role:user, applicationsets, delete, */*, allow
     p, role:user, logs, get, */*, allow
     g, test, role:user
+  policy.overlay.csv: |
+    p, role:tester, applications, *, */*, allow
+    p, role:tester, projects, *, *, allow
+    g, my-org:team-qa, role:tester
   policy.default: role:unknown
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
fixes: #19403

The CLI command: `argocd admin settings rbac can ...` provides to test policy yaml file with `--policy-file` option.

The yaml file can contains one or more policy data like this:
```
...
data:
  policy.csv: |
    p, my-org:team-alpha, applications, sync, my-project/*, allow
    g, my-org:team-beta, role:admin
  policy.overlay.csv: |
    p, role:tester, applications, *, */*, allow
    p, role:tester, projects, *, *, allow
    g, my-org:team-qa, role:tester
...
```
The problem is that the policy loader doesn't load the second policy.

I fixed the code and added test data and test code.

