### PR TITLE
feat(dex): set logger based on argo config (#13191)

### DIFF
--- a/cmd/argocd-dex/commands/argocd_dex.go
+++ b/cmd/argocd-dex/commands/argocd_dex.go
@@ -136,8 +136,8 @@ func NewRunDexCommand() *cobra.Command {
 	}
 
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
-	command.Flags().StringVar(&cmdutil.LogFormat, "logformat", "text", "Set the logging format. One of: text|json")
-	command.Flags().StringVar(&cmdutil.LogLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
+	command.Flags().StringVar(&cmdutil.LogFormat, "logformat", env.StringFromEnv("ARGOCD_DEX_SERVER_LOGFORMAT", "text"), "Set the logging format. One of: text|json")
+	command.Flags().StringVar(&cmdutil.LogLevel, "loglevel", env.StringFromEnv("ARGOCD_DEX_SERVER_LOGLEVEL", "info"), "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().BoolVar(&disableTLS, "disable-tls", env.ParseBoolFromEnv("ARGOCD_DEX_SERVER_DISABLE_TLS", false), "Disable TLS on the HTTP endpoint")
 	return &command
 }
@@ -204,8 +204,8 @@ func NewGenDexConfigCommand() *cobra.Command {
 	}
 
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
-	command.Flags().StringVar(&cmdutil.LogFormat, "logformat", "text", "Set the logging format. One of: text|json")
-	command.Flags().StringVar(&cmdutil.LogLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
+	command.Flags().StringVar(&cmdutil.LogFormat, "logformat", env.StringFromEnv("ARGOCD_DEX_SERVER_LOGFORMAT", "text"), "Set the logging format. One of: text|json")
+	command.Flags().StringVar(&cmdutil.LogLevel, "loglevel", env.StringFromEnv("ARGOCD_DEX_SERVER_LOGLEVEL", "info"), "Set the logging level. One of: debug|info|warn|error")
 	command.Flags().StringVarP(&out, "out", "o", "", "Output to the specified file instead of stdout")
 	command.Flags().BoolVar(&disableTLS, "disable-tls", env.ParseBoolFromEnv("ARGOCD_DEX_SERVER_DISABLE_TLS", false), "Disable TLS on the HTTP endpoint")
 	return &command

--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -188,6 +188,11 @@ data:
   # Include hidden directories from Git
   reposerver.include.hidden.directories: "false"
 
+
+  # Set the logging format. One of: text|json (default "text")
+  dexserver.log.format: "text"
+  # Set the logging level. One of: debug|info|warn|error (default "info")
+  dexserver.log.level: "info"
   # Disable TLS on the HTTP endpoint
   dexserver.disable.tls: "false"
 

--- a/manifests/base/dex/argocd-dex-server-deployment.yaml
+++ b/manifests/base/dex/argocd-dex-server-deployment.yaml
@@ -41,6 +41,18 @@ spec:
         imagePullPolicy: Always
         command: [/shared/argocd-dex, rundex]
         env:
+          - name: ARGOCD_DEX_SERVER_LOGFORMAT
+            valueFrom:
+              configMapKeyRef:
+                key: dexserver.log.format
+                name: argocd-cmd-params-cm
+                optional: true
+          - name: ARGOCD_DEX_SERVER_LOGLEVEL
+            valueFrom:
+              configMapKeyRef:
+                key: dexserver.log.level
+                name: argocd-cmd-params-cm
+                optional: true
           - name: ARGOCD_DEX_SERVER_DISABLE_TLS
             valueFrom:
               configMapKeyRef:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -23948,6 +23948,18 @@ spec:
         - /shared/argocd-dex
         - rundex
         env:
+        - name: ARGOCD_DEX_SERVER_LOGFORMAT
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.format
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_DEX_SERVER_LOGLEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.level
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEX_SERVER_DISABLE_TLS
           valueFrom:
             configMapKeyRef:

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -1782,6 +1782,18 @@ spec:
         - /shared/argocd-dex
         - rundex
         env:
+        - name: ARGOCD_DEX_SERVER_LOGFORMAT
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.format
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_DEX_SERVER_LOGLEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.level
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEX_SERVER_DISABLE_TLS
           valueFrom:
             configMapKeyRef:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -23065,6 +23065,18 @@ spec:
         - /shared/argocd-dex
         - rundex
         env:
+        - name: ARGOCD_DEX_SERVER_LOGFORMAT
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.format
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_DEX_SERVER_LOGLEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.level
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEX_SERVER_DISABLE_TLS
           valueFrom:
             configMapKeyRef:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -899,6 +899,18 @@ spec:
         - /shared/argocd-dex
         - rundex
         env:
+        - name: ARGOCD_DEX_SERVER_LOGFORMAT
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.format
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: ARGOCD_DEX_SERVER_LOGLEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: dexserver.log.level
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEX_SERVER_DISABLE_TLS
           valueFrom:
             configMapKeyRef:

--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -2,11 +2,14 @@ package dex
 
 import (
 	"fmt"
+	"os"
 
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/util/settings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTls bool) ([]byte, error) {
@@ -35,6 +38,20 @@ func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTls b
 			"https":   "0.0.0.0:5556",
 			"tlsCert": "/tmp/tls.crt",
 			"tlsKey":  "/tmp/tls.key",
+		}
+	}
+
+	if loggerCfg, found := dexCfg["logger"].(map[string]interface{}); found {
+		if _, found := loggerCfg["level"]; !found {
+			loggerCfg["level"] = slogLevelFromLogrus(os.Getenv(common.EnvLogLevel))
+		}
+		if _, found := loggerCfg["format"]; !found {
+			loggerCfg["format"] = os.Getenv(common.EnvLogFormat)
+		}
+	} else {
+		dexCfg["logger"] = map[string]interface{}{
+			"level":  slogLevelFromLogrus(os.Getenv(common.EnvLogLevel)),
+			"format": os.Getenv(common.EnvLogFormat),
 		}
 	}
 
@@ -129,4 +146,24 @@ func needsRedirectURI(connectorType string) bool {
 		return true
 	}
 	return false
+}
+
+func slogLevelFromLogrus(level string) string {
+	logrusLevel, err := log.ParseLevel(level)
+	if err != nil {
+		return level
+	}
+
+	switch logrusLevel {
+	case log.DebugLevel, log.TraceLevel:
+		return "DEBUG"
+	case log.InfoLevel:
+		return "INFO"
+	case log.WarnLevel:
+		return "WARN"
+	case log.ErrorLevel, log.FatalLevel, log.PanicLevel:
+		return "ERROR"
+	}
+	// return the logrus level and let slog parse it
+	return level
 }

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -9,15 +9,14 @@ import (
 	"strings"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-cd/v2/common"
-	"github.com/argoproj/argo-cd/v2/util/settings"
-
 	utillog "github.com/argoproj/argo-cd/v2/util/log"
-	log "github.com/sirupsen/logrus"
+	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
 const invalidURL = ":://localhost/foo/bar"

--- a/util/dex/dex_test.go
+++ b/util/dex/dex_test.go
@@ -13,8 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
-	// "github.com/argoproj/argo-cd/common"
+	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/util/settings"
+
+	utillog "github.com/argoproj/argo-cd/v2/util/log"
+	log "github.com/sirupsen/logrus"
 )
 
 const invalidURL = ":://localhost/foo/bar"
@@ -140,6 +143,33 @@ connectors:
       baseDN: ou=Groups,dc=example,dc=org
       filter: "(objectClass=groupOfNames)"
       nameAttr: cn
+`
+
+var goodDexConfigWithLogger = `
+logger:
+  level: debug
+  other: value
+connectors:
+# GitHub example
+- type: github
+  id: github
+  name: GitHub
+  config:
+    clientID: aabbccddeeff00112233
+    clientSecret: $dex.github.clientSecret
+    orgs:
+    - name: your-github-org
+
+# GitHub enterprise example
+- type: github
+  id: acme-github
+  name: Acme GitHub
+  config:
+    hostName: github.acme.example.com
+    clientID: abcdefghijklmnopqrst
+    clientSecret: $dex.acme.clientSecret
+    orgs:
+    - name: your-github-org
 `
 
 var goodSecrets = map[string]string{
@@ -270,6 +300,65 @@ func Test_GenerateDexConfig(t *testing.T) {
 				assert.Equal(t, "barfoo", config["clientSecret"])
 			}
 		}
+	})
+
+	t.Run("Logging level", func(t *testing.T) {
+		s := settings.ArgoCDSettings{
+			URL:       "http://localhost",
+			DexConfig: goodDexConfig,
+		}
+		t.Setenv(common.EnvLogLevel, log.WarnLevel.String())
+		t.Setenv(common.EnvLogFormat, utillog.JsonFormat)
+
+		config, err := GenerateDexConfigYAML(&s, false)
+		require.NoError(t, err)
+		assert.NotNil(t, config)
+		var dexCfg map[string]interface{}
+		err = yaml.Unmarshal(config, &dexCfg)
+		if err != nil {
+			panic(err.Error())
+		}
+		loggerCfg, ok := dexCfg["logger"].(map[string]interface{})
+		assert.True(t, ok)
+
+		level, ok := loggerCfg["level"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "WARN", level)
+
+		format, ok := loggerCfg["format"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "json", format)
+	})
+
+	t.Run("Logging level with config", func(t *testing.T) {
+		s := settings.ArgoCDSettings{
+			URL:       "http://localhost",
+			DexConfig: goodDexConfigWithLogger,
+		}
+		t.Setenv(common.EnvLogLevel, log.WarnLevel.String())
+		t.Setenv(common.EnvLogFormat, utillog.JsonFormat)
+
+		config, err := GenerateDexConfigYAML(&s, false)
+		require.NoError(t, err)
+		assert.NotNil(t, config)
+		var dexCfg map[string]interface{}
+		err = yaml.Unmarshal(config, &dexCfg)
+		if err != nil {
+			panic(err.Error())
+		}
+		loggerCfg, ok := dexCfg["logger"].(map[string]interface{})
+		assert.True(t, ok)
+
+		level, ok := loggerCfg["level"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "debug", level)
+
+		format, ok := loggerCfg["format"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "json", format)
+
+		_, ok = loggerCfg["other"].(string)
+		assert.True(t, ok)
 	})
 
 	t.Run("Redirect config", func(t *testing.T) {


### PR DESCRIPTION
Closes #13191

- If dex config `logger.level` or `logger.format` are not defined, use the argo-cd configs
  - This preserves the backward compatibility, and allows users to configure different levels for dex itself and the argo-cd wrapper.
- Add `ARGOCD_DEX_SERVER_LOGFORMAT` and `ARGOCD_DEX_SERVER_LOGLEVEL` 
- Because dex uses slog and the text level are different, create a wrapper to convert to the corresponding slog from logrus levels, without importing slog package

