### PR TITLE
chore(tests): speed up unit tests

### DIFF
--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2654,7 +2654,10 @@ func TestIsApplicationPermitted(t *testing.T) {
 }
 
 func TestAppNamespaceRestrictions(t *testing.T) {
+	t.Parallel()
+
 	t.Run("List applications in controller namespace", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		appServer := newTestAppServer(t, testApp)
 		apps, err := appServer.List(context.TODO(), &application.ApplicationQuery{})
@@ -2663,6 +2666,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 	})
 
 	t.Run("List applications with non-allowed apps existing", func(t *testing.T) {
+		t.Parallel()
 		testApp1 := newTestApp()
 		testApp1.Namespace = "argocd-1"
 		appServer := newTestAppServer(t, testApp1)
@@ -2672,6 +2676,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 	})
 
 	t.Run("List applications with non-allowed apps existing and explicit ns request", func(t *testing.T) {
+		t.Parallel()
 		testApp1 := newTestApp()
 		testApp2 := newTestApp()
 		testApp2.Namespace = "argocd-1"
@@ -2682,6 +2687,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 	})
 
 	t.Run("List applications with allowed apps in other namespaces", func(t *testing.T) {
+		t.Parallel()
 		testApp1 := newTestApp()
 		testApp1.Namespace = "argocd-1"
 		appServer := newTestAppServer(t, testApp1)
@@ -2692,6 +2698,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 	})
 
 	t.Run("Get application in control plane namespace", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		appServer := newTestAppServer(t, testApp)
 		app, err := appServer.Get(context.TODO(), &application.ApplicationQuery{
@@ -2701,6 +2708,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		assert.Equal(t, "test-app", app.GetName())
 	})
 	t.Run("Get application in other namespace when forbidden", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		appServer := newTestAppServer(t, testApp)
@@ -2713,6 +2721,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		require.Nil(t, app)
 	})
 	t.Run("Get application in other namespace when allowed", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2736,6 +2745,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		require.Equal(t, "test-app", app.Name)
 	})
 	t.Run("Get application in other namespace when project is not allowed", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2758,6 +2768,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		require.ErrorContains(t, err, "app is not allowed in project")
 	})
 	t.Run("Create application in other namespace when allowed", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2781,6 +2792,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 	})
 
 	t.Run("Create application in other namespace when not allowed by project", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2803,6 +2815,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 	})
 
 	t.Run("Create application in other namespace when not allowed by configuration", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2824,6 +2837,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		require.ErrorContains(t, err, "namespace 'argocd-1' is not permitted")
 	})
 	t.Run("Get application sync window in other namespace when project is allowed", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2842,6 +2856,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		assert.Empty(t, active.ActiveWindows)
 	})
 	t.Run("Get application sync window in other namespace when project is not allowed", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2861,6 +2876,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		require.ErrorContains(t, err, "app is not allowed in project")
 	})
 	t.Run("Get list of links in other namespace when project is not allowed", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -2883,6 +2899,7 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		require.ErrorContains(t, err, "app is not allowed in project")
 	})
 	t.Run("Get list of links in other namespace when project is allowed", func(t *testing.T) {
+		t.Parallel()
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
@@ -3029,6 +3046,8 @@ func TestServer_ResolveSourceRevisions_SingleSource(t *testing.T) {
 }
 
 func Test_RevisionMetadata(t *testing.T) {
+	t.Parallel()
+
 	singleSourceApp := newTestApp()
 	singleSourceApp.Name = "single-source-app"
 	singleSourceApp.Spec = appv1.ApplicationSpec{
@@ -3251,9 +3270,11 @@ func Test_RevisionMetadata(t *testing.T) {
 	for _, tc := range testCases {
 		tcc := tc
 		t.Run(tcc.name, func(t *testing.T) {
-			app := singleSourceApp
+			t.Parallel()
+
+			app := singleSourceApp.DeepCopy()
 			if tcc.multiSource {
-				app = multiSourceApp
+				app = multiSourceApp.DeepCopy()
 			}
 			if tcc.history != nil {
 				if tcc.history.matchesSourceType {


### PR DESCRIPTION
These tests have been running ~10sec. Parallelizing them brings it down to ~2sec on my machine.

Micro-optimization maybe, but if we do this occasionally, it'll add up. 

You can track tests timing here: https://app.codecov.io/gh/argoproj/argo-cd/tests/master