### PR TITLE
fix(appset): migrateStatus updates appset pointer after updating

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -1268,8 +1268,15 @@ func (r *ApplicationSetReconciler) migrateStatus(ctx context.Context, appset *ar
 	}
 
 	if update {
+		namespacedName := types.NamespacedName{Namespace: appset.Namespace, Name: appset.Name}
 		if err := r.Client.Status().Update(ctx, appset); err != nil {
 			return fmt.Errorf("unable to set application set status: %w", err)
+		}
+		if err := r.Get(ctx, namespacedName, appset); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return nil
+			}
+			return fmt.Errorf("error fetching updated application set: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
  # Context:
  `migrateStatus` updates the status of the appset but after succeeding
  it does not update the in-memory object which means that the new
  updates may fail due to conflict since it's comparing it to the
  object previous to updating it in `migrateStatus`.

  # What does this PR?
  - After updating the appset object in `migrateStatus` it gets the object again to reference it in the appset pointer of the reconciler.

It can be related to this issue: #19535