### PR TITLE
fix(appset): `setApplicationSetStatusCondition` updates appset in memory

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -442,6 +442,12 @@ func (r *ApplicationSetReconciler) setApplicationSetStatusCondition(ctx context.
 		if err != nil && !apierr.IsNotFound(err) {
 			return fmt.Errorf("unable to set application set condition: %w", err)
 		}
+		if err := r.Get(ctx, namespacedName, applicationSet); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return nil
+			}
+			return fmt.Errorf("error fetching updated application set: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
  # Context:
  `setApplicationSetStatusCondition` function does not update the appset
  in memory after updating it in the cluster, this means that new
  updates using the appset object in memory may fail due to conflict.
  Before it was not an issue since `setApplicationSetStatusCondition`
  was almost always used before finishing the reconcile so no new
  updates were done.

  Now this function is also used when performing progressive syncs as
  introduced in this PR: https://github.com/argoproj/argo-cd/pull/19473
  So it's very likely that a new update after this function so new
  updates may fail due to conflict.

  # What does this PR?
  - After updating the appset object in `setApplicationSetStatusCondition` it gets the object again to reference it in the appset pointer of the reconciler.

Probably fixes: https://github.com/argoproj/argo-cd/issues/19535