### PR TITLE
fix: Fix semver resolution

### DIFF
--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -27,6 +27,21 @@ func TestGitSemverResolutionNotUsingConstraint(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced))
 }
 
+func TestGitSemverResolutionNotUsingConstraintWithLeadingZero(t *testing.T) {
+	Given(t).
+		Path("deployment").
+		CustomSSHKnownHostsAdded().
+		SSHRepoURLAdded(true).
+		RepoURLType(fixture.RepoURLTypeSSH).
+		Revision("0.1.0").
+		When().
+		AddTag("0.1.0").
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced))
+}
+
 func TestGitSemverResolutionUsingConstraint(t *testing.T) {
 	Given(t).
 		Path("deployment").
@@ -46,6 +61,31 @@ func TestGitSemverResolutionUsingConstraint(t *testing.T) {
 	{"op": "replace", "path": "/spec/replicas", "value": 1}
 ]`).
 		AddTag("v0.1.2").
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(Pod(func(p v1.Pod) bool { return strings.HasPrefix(p.Name, "new-app") }))
+}
+
+func TestGitSemverResolutionUsingConstraintWithLeadingZero(t *testing.T) {
+	Given(t).
+		Path("deployment").
+		CustomSSHKnownHostsAdded().
+		SSHRepoURLAdded(true).
+		RepoURLType(fixture.RepoURLTypeSSH).
+		Revision("0.1.*").
+		When().
+		AddTag("0.1.0").
+		CreateApp().
+		Sync().
+		Then().
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		When().
+		PatchFile("deployment.yaml", `[
+	{"op": "replace", "path": "/metadata/name", "value": "new-app"},
+	{"op": "replace", "path": "/spec/replicas", "value": 1}
+]`).
+		AddTag("0.1.2").
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).


### PR DESCRIPTION
# Description:

This PR addresses an issue where a repository with invalid semver references can't be resolved. This is caused by [this change](https://github.com/argoproj/argo-cd/pull/17566/files#diff-b431853d628a3d3169b6298c356c8b57fed26c1174269fa3ab356a128ed9ecc4) which assumes that all references on the repository are valid semver revisions.

# Solution:

The code has been modified to ensure that the revision is a valid semver constraint before attempting to resolve it.

# Related Issue:

Fixes #19495

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).


