### PR TITLE
chore: remove unused param and associated test

### DIFF
--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -270,7 +270,7 @@ func createNamespaceScopedUser(t *testing.T, username string, clusterScopedSecre
 
 	// Create a ServiceAccount in that Namespace, which will be used for the Argo CD Cluster SEcret
 	serviceAccountName := username + "-serviceaccount"
-	err = clusterauth.CreateServiceAccount(KubeClientset, serviceAccountName, ns.Name)
+	err = clusterauth.CreateServiceAccount(KubeClientset, ns.Name)
 	require.NoError(t, err)
 
 	// Create a Role that allows the ServiceAccount to read/write all within the Namespace

--- a/util/clusterauth/clusterauth.go
+++ b/util/clusterauth/clusterauth.go
@@ -50,30 +50,26 @@ var ArgoCDManagerNamespacePolicyRules = []rbacv1.PolicyRule{
 }
 
 // CreateServiceAccount creates a service account in a given namespace
-func CreateServiceAccount(
-	clientset kubernetes.Interface,
-	serviceAccountName string,
-	namespace string,
-) error {
+func CreateServiceAccount(clientset kubernetes.Interface, namespace string) error {
 	serviceAccount := corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "ServiceAccount",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceAccountName,
+			Name:      ArgoCDManagerServiceAccount,
 			Namespace: namespace,
 		},
 	}
 	_, err := clientset.CoreV1().ServiceAccounts(namespace).Create(context.Background(), &serviceAccount, metav1.CreateOptions{})
 	if err != nil {
 		if !apierr.IsAlreadyExists(err) {
-			return fmt.Errorf("Failed to create service account %q in namespace %q: %w", serviceAccountName, namespace, err)
+			return fmt.Errorf("Failed to create service account %q in namespace %q: %w", ArgoCDManagerServiceAccount, namespace, err)
 		}
-		log.Infof("ServiceAccount %q already exists in namespace %q", serviceAccountName, namespace)
+		log.Infof("ServiceAccount %q already exists in namespace %q", ArgoCDManagerServiceAccount, namespace)
 		return nil
 	}
-	log.Infof("ServiceAccount %q created in namespace %q", serviceAccountName, namespace)
+	log.Infof("ServiceAccount %q created in namespace %q", ArgoCDManagerServiceAccount, namespace)
 	return nil
 }
 
@@ -178,7 +174,7 @@ func upsertRoleBinding(clientset kubernetes.Interface, name string, roleName str
 
 // InstallClusterManagerRBAC installs RBAC resources for a cluster manager to operate a cluster. Returns a token
 func InstallClusterManagerRBAC(clientset kubernetes.Interface, ns string, namespaces []string, bearerTokenTimeout time.Duration) (string, error) {
-	err := CreateServiceAccount(clientset, ArgoCDManagerServiceAccount, ns)
+	err := CreateServiceAccount(clientset, ns)
 	if err != nil {
 		return "", err
 	}

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -78,7 +78,7 @@ func TestCreateServiceAccount(t *testing.T) {
 
 	t.Run("New SA", func(t *testing.T) {
 		cs := fake.NewSimpleClientset(ns)
-		err := CreateServiceAccount(cs, "argocd-manager", "kube-system")
+		err := CreateServiceAccount(cs, "kube-system")
 		require.NoError(t, err)
 		rsa, err := cs.CoreV1().ServiceAccounts("kube-system").Get(context.Background(), "argocd-manager", metav1.GetOptions{})
 		require.NoError(t, err)
@@ -87,25 +87,16 @@ func TestCreateServiceAccount(t *testing.T) {
 
 	t.Run("SA exists already", func(t *testing.T) {
 		cs := fake.NewSimpleClientset(ns, sa)
-		err := CreateServiceAccount(cs, "argocd-manager", "kube-system")
+		err := CreateServiceAccount(cs, "kube-system")
 		require.NoError(t, err)
 		rsa, err := cs.CoreV1().ServiceAccounts("kube-system").Get(context.Background(), "argocd-manager", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, rsa)
 	})
 
-	t.Run("Invalid name", func(t *testing.T) {
-		cs := fake.NewSimpleClientset(ns)
-		err := CreateServiceAccount(cs, "", "kube-system")
-		require.NoError(t, err)
-		rsa, err := cs.CoreV1().ServiceAccounts("kube-system").Get(context.Background(), "argocd-manager", metav1.GetOptions{})
-		require.Error(t, err)
-		assert.Nil(t, rsa)
-	})
-
 	t.Run("Invalid namespace", func(t *testing.T) {
 		cs := fake.NewSimpleClientset()
-		err := CreateServiceAccount(cs, "argocd-manager", "invalid")
+		err := CreateServiceAccount(cs, "invalid")
 		require.NoError(t, err)
 		rsa, err := cs.CoreV1().ServiceAccounts("invalid").Get(context.Background(), "argocd-manager", metav1.GetOptions{})
 		require.NoError(t, err)


### PR DESCRIPTION
The 1.31 k8s test client no longer throws an error on creating a resource with an empty name. So the 1.31 upgrade will break the test that this PR removes.

Since there's only one non-test user of `CreateServiceAccount`, and that user hard-codes a resource name of `ArgoCDManagerServiceAccount`, we should just drop the parameter.

Insert standard bit about "technically it's a breaking library change, but technically we don't promise not to change library functions". I think it's a justified breaking change.