### PR TITLE
chore: enable lint for deprecated symbols

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,5 @@
 issues:
   exclude:
-    - SA1019
     - SA5011
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/applicationset/utils/clusterUtils.go
+++ b/applicationset/utils/clusterUtils.go
@@ -132,9 +132,12 @@ func getLocalCluster(clientset kubernetes.Interface) *appv1.Cluster {
 	initLocalCluster.Do(func() {
 		info, err := clientset.Discovery().ServerVersion()
 		if err == nil {
+			// nolint:staticcheck
 			localCluster.ServerVersion = fmt.Sprintf("%s.%s", info.Major, info.Minor)
+			// nolint:staticcheck
 			localCluster.ConnectionState = appv1.ConnectionState{Status: appv1.ConnectionStatusSuccessful}
 		} else {
+			// nolint:staticcheck
 			localCluster.ConnectionState = appv1.ConnectionState{
 				Status:  appv1.ConnectionStatusFailed,
 				Message: err.Error(),
@@ -143,6 +146,7 @@ func getLocalCluster(clientset kubernetes.Interface) *appv1.Cluster {
 	})
 	cluster := localCluster.DeepCopy()
 	now := metav1.Now()
+	// nolint:staticcheck
 	cluster.ConnectionState.ModifiedAt = &now
 	return cluster
 }

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2849,6 +2849,7 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 					errors.CheckError(err)
 
 					proj := getProject(c, clientOpts, ctx, app.Spec.Project)
+					// nolint:staticcheck
 					unstructureds = getLocalObjects(context.Background(), app, proj.Project, local, localRepoRoot, argoSettings.AppLabelKey, cluster.ServerVersion, cluster.Info.APIVersions, argoSettings.KustomizeOptions, argoSettings.TrackingMethod)
 				} else if len(revisions) > 0 && len(sourcePositions) > 0 {
 					q := application.ApplicationManifestQuery{

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -363,6 +363,7 @@ func printClusterDetails(clusters []argoappv1.Cluster) {
 		fmt.Printf("Cluster information\n\n")
 		fmt.Printf("  Server URL:            %s\n", cluster.Server)
 		fmt.Printf("  Server Name:           %s\n", strWithDefault(cluster.Name, "-"))
+		// nolint:staticcheck
 		fmt.Printf("  Server Version:        %s\n", cluster.ServerVersion)
 		fmt.Printf("  Namespaces:        	 %s\n", formatNamespaces(cluster))
 		fmt.Printf("\nTLS configuration\n\n")
@@ -455,6 +456,7 @@ func printClusterTable(clusters []argoappv1.Cluster) {
 		if len(c.Namespaces) > 0 {
 			server = fmt.Sprintf("%s (%d namespaces)", c.Server, len(c.Namespaces))
 		}
+		// nolint:staticcheck
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", server, c.Name, c.ServerVersion, c.ConnectionState.Status, c.ConnectionState.Message, c.Project)
 	}
 	_ = w.Flush()

--- a/reposerver/apiclient/clientset.go
+++ b/reposerver/apiclient/clientset.go
@@ -82,6 +82,7 @@ func NewConnection(address string, timeoutSeconds int, tlsConfig *TLSConfigurati
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
+	// nolint:staticcheck
 	conn, err := grpc.Dial(address, opts...)
 	if err != nil {
 		log.Errorf("Unable to connect to repository service with address %s", address)

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -3088,19 +3086,19 @@ func Test_RevisionMetadata(t *testing.T) {
 		{
 			name:                "single-source app without history, no source index, missing version ID",
 			multiSource:         false,
-			versionId:           pointer.Int32(999),
-			expectErrorContains: pointer.String("the app has no history"),
+			versionId:           ptr.To(int32(999)),
+			expectErrorContains: ptr.To("the app has no history"),
 		},
 		{
 			name:        "single source app without history, present source index, no version ID",
 			multiSource: false,
-			sourceIndex: pointer.Int32(0),
+			sourceIndex: ptr.To(int32(0)),
 		},
 		{
 			name:                "single source app without history, invalid source index, no version ID",
 			multiSource:         false,
-			sourceIndex:         pointer.Int32(999),
-			expectErrorContains: pointer.String("source index 999 not found"),
+			sourceIndex:         ptr.To(int32(999)),
+			expectErrorContains: ptr.To("source index 999 not found"),
 		},
 		{
 			name:        "single source app with matching history, no source index, no version ID",
@@ -3111,14 +3109,14 @@ func Test_RevisionMetadata(t *testing.T) {
 			name:                "single source app with matching history, no source index, missing version ID",
 			multiSource:         false,
 			history:             &struct{ matchesSourceType bool }{true},
-			versionId:           pointer.Int32(999),
-			expectErrorContains: pointer.String("history not found for version ID 999"),
+			versionId:           ptr.To(int32(999)),
+			expectErrorContains: ptr.To("history not found for version ID 999"),
 		},
 		{
 			name:        "single source app with matching history, no source index, present version ID",
 			multiSource: false,
 			history:     &struct{ matchesSourceType bool }{true},
-			versionId:   pointer.Int32(1),
+			versionId:   ptr.To(int32(1)),
 		},
 		{
 			name:        "single source app with multi-source history, no source index, no version ID",
@@ -3129,37 +3127,37 @@ func Test_RevisionMetadata(t *testing.T) {
 			name:                "single source app with multi-source history, no source index, missing version ID",
 			multiSource:         false,
 			history:             &struct{ matchesSourceType bool }{false},
-			versionId:           pointer.Int32(999),
-			expectErrorContains: pointer.String("history not found for version ID 999"),
+			versionId:           ptr.To(int32(999)),
+			expectErrorContains: ptr.To("history not found for version ID 999"),
 		},
 		{
 			name:        "single source app with multi-source history, no source index, present version ID",
 			multiSource: false,
 			history:     &struct{ matchesSourceType bool }{false},
-			versionId:   pointer.Int32(1),
+			versionId:   ptr.To(int32(1)),
 		},
 		{
 			name:        "single-source app with multi-source history, source index 1, no version ID",
 			multiSource: false,
-			sourceIndex: pointer.Int32(1),
+			sourceIndex: ptr.To(int32(1)),
 			history:     &struct{ matchesSourceType bool }{false},
 			// Since the user requested source index 1, but no version ID, we'll get an error when looking at the live
 			// source, because the live source is single-source.
-			expectErrorContains: pointer.String("there is only 1 source"),
+			expectErrorContains: ptr.To("there is only 1 source"),
 		},
 		{
 			name:                "single-source app with multi-source history, invalid source index, no version ID",
 			multiSource:         false,
-			sourceIndex:         pointer.Int32(999),
+			sourceIndex:         ptr.To(int32(999)),
 			history:             &struct{ matchesSourceType bool }{false},
-			expectErrorContains: pointer.String("source index 999 not found"),
+			expectErrorContains: ptr.To("source index 999 not found"),
 		},
 		{
 			name:        "single-source app with multi-source history, valid source index, present version ID",
 			multiSource: false,
-			sourceIndex: pointer.Int32(1),
+			sourceIndex: ptr.To(int32(1)),
 			history:     &struct{ matchesSourceType bool }{false},
-			versionId:   pointer.Int32(1),
+			versionId:   ptr.To(int32(1)),
 		},
 		{
 			name:        "multi-source app without history, no source index, no version ID",
@@ -3168,19 +3166,19 @@ func Test_RevisionMetadata(t *testing.T) {
 		{
 			name:                "multi-source app without history, no source index, missing version ID",
 			multiSource:         true,
-			versionId:           pointer.Int32(999),
-			expectErrorContains: pointer.String("the app has no history"),
+			versionId:           ptr.To(int32(999)),
+			expectErrorContains: ptr.To("the app has no history"),
 		},
 		{
 			name:        "multi-source app without history, present source index, no version ID",
 			multiSource: true,
-			sourceIndex: pointer.Int32(1),
+			sourceIndex: ptr.To(int32(1)),
 		},
 		{
 			name:                "multi-source app without history, invalid source index, no version ID",
 			multiSource:         true,
-			sourceIndex:         pointer.Int32(999),
-			expectErrorContains: pointer.String("source index 999 not found"),
+			sourceIndex:         ptr.To(int32(999)),
+			expectErrorContains: ptr.To("source index 999 not found"),
 		},
 		{
 			name:        "multi-source app with matching history, no source index, no version ID",
@@ -3191,14 +3189,14 @@ func Test_RevisionMetadata(t *testing.T) {
 			name:                "multi-source app with matching history, no source index, missing version ID",
 			multiSource:         true,
 			history:             &struct{ matchesSourceType bool }{true},
-			versionId:           pointer.Int32(999),
-			expectErrorContains: pointer.String("history not found for version ID 999"),
+			versionId:           ptr.To(int32(999)),
+			expectErrorContains: ptr.To("history not found for version ID 999"),
 		},
 		{
 			name:        "multi-source app with matching history, no source index, present version ID",
 			multiSource: true,
 			history:     &struct{ matchesSourceType bool }{true},
-			versionId:   pointer.Int32(1),
+			versionId:   ptr.To(int32(1)),
 		},
 		{
 			name:        "multi-source app with single-source history, no source index, no version ID",
@@ -3209,42 +3207,42 @@ func Test_RevisionMetadata(t *testing.T) {
 			name:                "multi-source app with single-source history, no source index, missing version ID",
 			multiSource:         true,
 			history:             &struct{ matchesSourceType bool }{false},
-			versionId:           pointer.Int32(999),
-			expectErrorContains: pointer.String("history not found for version ID 999"),
+			versionId:           ptr.To(int32(999)),
+			expectErrorContains: ptr.To("history not found for version ID 999"),
 		},
 		{
 			name:        "multi-source app with single-source history, no source index, present version ID",
 			multiSource: true,
 			history:     &struct{ matchesSourceType bool }{false},
-			versionId:   pointer.Int32(1),
+			versionId:   ptr.To(int32(1)),
 		},
 		{
 			name:        "multi-source app with single-source history, source index 1, no version ID",
 			multiSource: true,
-			sourceIndex: pointer.Int32(1),
+			sourceIndex: ptr.To(int32(1)),
 			history:     &struct{ matchesSourceType bool }{false},
 		},
 		{
 			name:                "multi-source app with single-source history, invalid source index, no version ID",
 			multiSource:         true,
-			sourceIndex:         pointer.Int32(999),
+			sourceIndex:         ptr.To(int32(999)),
 			history:             &struct{ matchesSourceType bool }{false},
-			expectErrorContains: pointer.String("source index 999 not found"),
+			expectErrorContains: ptr.To("source index 999 not found"),
 		},
 		{
 			name:        "multi-source app with single-source history, valid source index, present version ID",
 			multiSource: true,
-			sourceIndex: pointer.Int32(0),
+			sourceIndex: ptr.To(int32(0)),
 			history:     &struct{ matchesSourceType bool }{false},
-			versionId:   pointer.Int32(1),
+			versionId:   ptr.To(int32(1)),
 		},
 		{
 			name:                "multi-source app with single-source history, source index 1, present version ID",
 			multiSource:         true,
-			sourceIndex:         pointer.Int32(1),
+			sourceIndex:         ptr.To(int32(1)),
 			history:             &struct{ matchesSourceType bool }{false},
-			versionId:           pointer.Int32(1),
-			expectErrorContains: pointer.String("source index 1 not found"),
+			versionId:           ptr.To(int32(1)),
+			expectErrorContains: ptr.To("source index 1 not found"),
 		},
 	}
 
@@ -3274,8 +3272,8 @@ func Test_RevisionMetadata(t *testing.T) {
 			s := newTestAppServer(t, app)
 
 			request := &application.RevisionMetadataQuery{
-				Name:        pointer.String(app.Name),
-				Revision:    pointer.String("HEAD"),
+				Name:        ptr.To(app.Name),
+				Revision:    ptr.To("HEAD"),
 				SourceIndex: tcc.sourceIndex,
 				VersionId:   tcc.versionId,
 			}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -471,7 +471,9 @@ func (s *Server) toAPIResponse(clust *appv1.Cluster) *appv1.Cluster {
 		clust.Config.ExecProviderConfig.Args = nil
 	}
 	// populate deprecated fields for backward compatibility
+	// nolint:staticcheck
 	clust.ServerVersion = clust.Info.ServerVersion
+	// nolint:staticcheck
 	clust.ConnectionState = clust.Info.ConnectionState
 	return clust
 }

--- a/server/server.go
+++ b/server/server.go
@@ -489,6 +489,7 @@ func (a *ArgoCDServer) Listen() (*Listeners, error) {
 	} else {
 		dOpts = append(dOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
+	// nolint:staticcheck
 	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", a.ListenPort), dOpts...)
 	if err != nil {
 		io.Close(mainLn)

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -330,6 +330,7 @@ func ValidateRepo(
 		return conditions, nil
 	}
 	config := cluster.RESTConfig()
+	// nolint:staticcheck
 	cluster.ServerVersion, err = kubectl.GetServerVersion(config)
 	if err != nil {
 		return nil, fmt.Errorf("error getting k8s server version: %w", err)
@@ -427,6 +428,7 @@ func validateRepo(ctx context.Context,
 		proj,
 		sources,
 		repoClient,
+		// nolint:staticcheck
 		cluster.ServerVersion,
 		APIResourcesToStrings(apiGroups, true),
 		permittedHelmCredentials,

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -37,9 +37,12 @@ func (db *db) getLocalCluster() *appv1.Cluster {
 	initLocalCluster.Do(func() {
 		info, err := db.kubeclientset.Discovery().ServerVersion()
 		if err == nil {
+			// nolint:staticcheck
 			localCluster.ServerVersion = fmt.Sprintf("%s.%s", info.Major, info.Minor)
+			// nolint:staticcheck
 			localCluster.ConnectionState = appv1.ConnectionState{Status: appv1.ConnectionStatusSuccessful}
 		} else {
+			// nolint:staticcheck
 			localCluster.ConnectionState = appv1.ConnectionState{
 				Status:  appv1.ConnectionStatusFailed,
 				Message: err.Error(),
@@ -48,6 +51,7 @@ func (db *db) getLocalCluster() *appv1.Cluster {
 	})
 	cluster := localCluster.DeepCopy()
 	now := metav1.Now()
+	// nolint:staticcheck
 	cluster.ConnectionState.ModifiedAt = &now
 	return cluster
 }

--- a/util/grpc/grpc.go
+++ b/util/grpc/grpc.go
@@ -86,12 +86,15 @@ func BlockingDial(ctx context.Context, network, address string, creds credential
 	// channel to either get the channel or fail-fast.
 	go func() {
 		opts = append(opts,
+			// nolint:staticcheck
 			grpc.WithBlock(),
+			// nolint:staticcheck
 			grpc.FailOnNonTempDialError(true),
 			grpc.WithContextDialer(dialer),
 			grpc.WithTransportCredentials(insecure.NewCredentials()), // we are handling TLS, so tell grpc not to
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: common.GetGRPCKeepAliveTime()}),
 		)
+		// nolint:staticcheck
 		conn, err := grpc.DialContext(ctx, address, opts...)
 		var res interface{}
 		if err != nil {


### PR DESCRIPTION
While upgrading k8s libraries to 1.31 I realized there are a lot of things being deprecated but no easy way to find them.

This PR enabled a check for deprecated symbols. In cases where it was easy to upgrade, I did so. In other cases, I added a `nolint`.

I'll create an issue to track switching from `grpc.Dial` to `grpc.NewClient`. It's nontrivial.