### PR TITLE
chore: remove unnecessary 'replace' in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -293,9 +293,6 @@ require (
 )
 
 replace (
-	// https://github.com/golang/go/issues/33546#issuecomment-519656923
-	github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
-
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 => github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf
 
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
This `replace` has been around for quite some time, and I don't think it's necessary any more: https://github.com/argoproj/argo-cd/pull/7744/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6

`go mod tidy` doesn't show a diff.

@pasha-codefresh any concerns about removing this?