### PR TITLE
fix: zip slip issue 

### DIFF
--- a/util/io/files/tar.go
+++ b/util/io/files/tar.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-
+	"strings"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/util/io/files/tar.go
+++ b/util/io/files/tar.go
@@ -79,12 +79,16 @@ func Untgz(dstPath string, r io.Reader, maxSize int64, preserveFileMode bool) er
 			}
 			return fmt.Errorf("error while iterating on tar reader: %w", err)
 		}
-		if header == nil || header.Name == "." {
+		if header == nil {
 			continue
 		}
-
-		target := filepath.Join(dstPath, header.Name)
-		// Sanity check to protect against zip-slip
+	 
+		normalizedHeaderName := filepath.Clean(header.Name)
+		if normalizedHeaderName == "." || strings.Contains(normalizedHeaderName, "..") {
+			continue
+		}
+	 
+		target := filepath.Join(dstPath, normalizedHeaderName)
 		if !Inbound(target, dstPath) {
 			return fmt.Errorf("illegal filepath in archive: %s", target)
 		}


### PR DESCRIPTION
fixes: #19710 

[a496278_fidelity](https://github.com/a496278_fidelity) commented [on Jul 23](https://github.com/Fidelity-External-Staging/argoproj-argo-cd/issues/216#issue-2424912830)
codeql issue:
rule - go/zipslip
severity - error
level - high

Summary: Arbitrary file access during archive extraction ("Zip Slip")

Unsanitized archive entry, which may contain '..', is used in a file system operation.
Unsanitized archive entry, which may contain '..', is used in a file system operation.
Unsanitized archive entry, which may contain '..', is used in a file system operation.

Fix added to lines 74-94 in util/io/files/tar.go
