### PR TITLE
fix: diffing should not fail if resource fail schema validation

### DIFF
--- a/util/argo/managedfields/managed_fields.go
+++ b/util/argo/managedfields/managed_fields.go
@@ -28,12 +28,14 @@ func Normalize(live, config *unstructured.Unstructured, trustedManagers []string
 
 	liveCopy := live.DeepCopy()
 	configCopy := config.DeepCopy()
+	normalized := false
+
 	results, err := newTypedResults(liveCopy, configCopy, pt)
+	// error might happen if the resources are not parsable and so cannot be normalized
 	if err != nil {
-		return nil, nil, fmt.Errorf("error building typed results: %w", err)
+		return liveCopy, configCopy, nil
 	}
 
-	normalized := false
 	for _, mf := range live.GetManagedFields() {
 		if trustedManager(mf.Manager, trustedManagers) {
 			err := normalize(mf, results)

--- a/util/argo/managedfields/managed_fields.go
+++ b/util/argo/managedfields/managed_fields.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
@@ -33,6 +34,7 @@ func Normalize(live, config *unstructured.Unstructured, trustedManagers []string
 	results, err := newTypedResults(liveCopy, configCopy, pt)
 	// error might happen if the resources are not parsable and so cannot be normalized
 	if err != nil {
+		log.Debugf("error building typed results: %v", err)
 		return liveCopy, configCopy, nil
 	}
 

--- a/util/argo/managedfields/managed_fields_test.go
+++ b/util/argo/managedfields/managed_fields_test.go
@@ -143,6 +143,16 @@ func TestNormalize(t *testing.T) {
 		assert.Len(t, vwcConfig.Webhooks, 1)
 		assert.Equal(t, "", string(vwcConfig.Webhooks[0].ClientConfig.CABundle))
 	})
+	t.Run("does not fail if object fails validation schema", func(t *testing.T) {
+		desiredState := StrToUnstructured(testdata.DesiredDeploymentYaml)
+		require.NoError(t, unstructured.SetNestedField(desiredState.Object, "spec", "hello", "world"))
+		liveState := StrToUnstructured(testdata.LiveDeploymentWithManagedReplicaYaml)
+
+		pt := parser.Type("io.k8s.api.apps.v1.Deployment")
+
+		_, _, err := managedfields.Normalize(liveState, desiredState, []string{}, &pt)
+		require.NoError(t, err)
+	})
 }
 
 func validateNestedFloat64(t *testing.T, expected float64, obj *unstructured.Unstructured, fields ...string) {


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/18402

When Argo CD is configured to ignore differences using `managedFieldsManagers`, the controller unnecessarily applies schema validation to known k8s types and fails if the object is invalid.  Instead controller should just skip diff normalization so that user can see the diff