### PR TITLE
fix(appset): Fix perpetual appset reconciliation

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -1295,6 +1296,9 @@ func (r *ApplicationSetReconciler) updateResourcesStatus(ctx context.Context, lo
 	for _, status := range statusMap {
 		statuses = append(statuses, status)
 	}
+	sort.Slice(statuses, func(i, j int) bool {
+		return statuses[i].Name < statuses[j].Name
+	})
 	appset.Status.Resources = statuses
 	// DefaultRetry will retry 5 times with a backoff factor of 1, jitter of 0.1 and a duration of 10ms
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {


### PR DESCRIPTION
ScmProvider does not guarantee order of the application resources from the applicationset which causes rapid sync activity for the applicationset as the objects and hence their resourceVersions are updated after each reconcile loop.

This then triggers reconciliation of all objects watching the ApplicationSet.

In order to prevent this behaviour, ensure that the ApplicationSet reconciler provides an idempotent list of resources, ensuring objects are not updated.

Fixes: #19757

This PR is an alternate approach to #19676.

In #19676, the approach is to only reconcile based on generation changes, i.e. `spec` changes as defined by the [generation implementation in CRDs](https://github.com/kubernetes/kubernetes/pull/55168).
This means that, with this PR, any change of metadata (labels, annotations, ...) or status will be taken into consideration on the next run (triggered by [requeueAfter](https://github.com/argoproj/argo-cd/blob/3d66b05899f4af3ad30df3edd75ed68e36e0e705/applicationset/controllers/applicationset_controller.go#L338), 3mn by default in my trials), which is the way new SCM repos or folders are discovered from my understanding.

This PR takes a different approach, ensuring that status updates are idempotent across reconcile loops and hence prevents from triggering any reconciliation in other reconcilers unless there is an actual change on the ApplicationSet.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).


