### PR TITLE
feat: always execute sync as before if at least one revision was not possible to update

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -185,6 +185,8 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 
 	revisionUpdated := false
 
+	atLeastOneRevisionIsNotPossibleToBeUpdated := false
+
 	keyManifestGenerateAnnotationVal, keyManifestGenerateAnnotationExists := app.Annotations[v1alpha1.AnnotationKeyManifestGeneratePaths]
 
 	for i, source := range sources {
@@ -240,6 +242,9 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 			if updateRevisionResult.Revision != "" {
 				revision = updateRevisionResult.Revision
 			}
+		} else {
+			// revisionUpdated is set to true if at least one revision is not possible to be updated,
+			atLeastOneRevisionIsNotPossibleToBeUpdated = true
 		}
 
 		log.Debugf("Generating Manifest for source %s revision %s", source, revision)
@@ -287,7 +292,7 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 	logCtx.Info("GetRepoObjs stats")
 
 	// in case if annotation not exists, we should always execute selfheal if manifests changed
-	if !keyManifestGenerateAnnotationExists || keyManifestGenerateAnnotationVal == "" {
+	if atLeastOneRevisionIsNotPossibleToBeUpdated {
 		revisionUpdated = true
 	}
 

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -1733,3 +1733,26 @@ func TestCompareAppStateDefaultRevisionUpdated(t *testing.T) {
 	assert.NotNil(t, compRes.syncStatus)
 	assert.True(t, compRes.revisionUpdated)
 }
+
+func TestCompareAppStateRevisionUpdatedWithHelmSource(t *testing.T) {
+	app := newFakeMultiSourceApp()
+	data := fakeData{
+		manifestResponse: &apiclient.ManifestResponse{
+			Manifests: []string{},
+			Namespace: test.FakeDestNamespace,
+			Server:    test.FakeClusterURL,
+			Revision:  "abc123",
+		},
+		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
+	}
+	ctrl := newFakeController(&data, nil)
+	sources := make([]argoappv1.ApplicationSource, 0)
+	sources = append(sources, app.Spec.GetSource())
+	revisions := make([]string, 0)
+	revisions = append(revisions, "")
+	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false, false)
+	require.NoError(t, err)
+	assert.NotNil(t, compRes)
+	assert.NotNil(t, compRes.syncStatus)
+	assert.True(t, compRes.revisionUpdated)
+}


### PR DESCRIPTION
Behavior should be same in case if at least one revision is not possible to identify if something was changed for app or no

Related to https://github.com/argoproj/argo-cd/pull/19799