### PR TITLE
fix(deeplinks): do not evaluate template when condition is false (#19625)

### DIFF
--- a/server/deeplinks/deeplinks_test.go
+++ b/server/deeplinks/deeplinks_test.go
@@ -172,6 +172,28 @@ func TestDeepLinks(t *testing.T) {
 			}},
 			error: []string{},
 		},
+		{
+			name:        "evaluate template for valid condition",
+			appObj:      appObj,
+			resourceObj: resourceObj,
+			projectObj:  projectObj,
+			inputLinks: []settings.DeepLink{
+				{
+					Title:     "link",
+					URL:       "http://not-evaluated.com/{{ index \"invalid\" .application.metadata.labels }}",
+					Condition: ptr.To(`false`),
+				},
+				{
+					Title:     "link",
+					URL:       "http://evaluated.com/{{ index \"invalid\" .application.metadata.labels }}",
+					Condition: ptr.To(`true`),
+				},
+			},
+			outputLinks: []*application.LinkInfo{},
+			error: []string{
+				"failed to evaluate link template 'http://evaluated.com/{{ index \"invalid\" .application.metadata.labels }}' with resource test, error=template: deep-link:1:24: executing \"deep-link\" at <index \"invalid\" .application.metadata.labels>: error calling index: cannot index slice/array with nil",
+			},
+		},
 	}
 
 	for _, tc := range testTable {


### PR DESCRIPTION
 ### Description

Only evaluate the url template if the condition is true. this allows us to use more complex templating in the url template and validate for nil fields in the condition.

Closes #19625 
Credits to @Aakash788 for initial contribution