### PR TITLE
feat: add `--source-position` flag to `argocd get app` command to show parameter changes for multi-source application

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -294,7 +294,7 @@ func parentChildDetails(appIf application.ApplicationServiceClient, ctx context.
 	return mapUidToNode, mapParentToChild, parentNode
 }
 
-func printHeader(acdClient argocdclient.Client, app *argoappv1.Application, ctx context.Context, windows *argoappv1.SyncWindows, showOperation bool, showParams bool) {
+func printHeader(acdClient argocdclient.Client, app *argoappv1.Application, ctx context.Context, windows *argoappv1.SyncWindows, showOperation bool, showParams bool, sourcePosition int) {
 	aURL := appURL(ctx, acdClient, app.Name)
 	printAppSummaryTable(app, aURL, windows)
 
@@ -309,20 +309,21 @@ func printHeader(acdClient argocdclient.Client, app *argoappv1.Application, ctx 
 		fmt.Println()
 		printOperationResult(app.Status.OperationState)
 	}
-	if !app.Spec.HasMultipleSources() && showParams {
-		printParams(app)
+	if showParams {
+		printParams(app, sourcePosition)
 	}
 }
 
 // NewApplicationGetCommand returns a new instance of an `argocd app get` command
 func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		refresh       bool
-		hardRefresh   bool
-		output        string
-		showParams    bool
-		showOperation bool
-		appNamespace  string
+		refresh        bool
+		hardRefresh    bool
+		output         string
+		showParams     bool
+		showOperation  bool
+		appNamespace   string
+		sourcePosition int
 	)
 	command := &cobra.Command{
 		Use:   "get APPNAME",
@@ -342,6 +343,9 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 
   # Show application parameters and overrides
   argocd app get my-app --show-params
+
+  # Show application parameters and overrides for a source at position 1 under spec.sources of app my-app
+  argocd app get my-app --show-params --source-position 1
 
   # Refresh application data when retrieving
   argocd app get my-app --refresh
@@ -373,8 +377,16 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 				Refresh:      getRefreshType(refresh, hardRefresh),
 				AppNamespace: &appNs,
 			})
-
 			errors.CheckError(err)
+
+			if app.Spec.HasMultipleSources() {
+				if sourcePosition <= 0 {
+					errors.CheckError(fmt.Errorf("Source position should be specified and must be greater than 0 for applications with multiple sources"))
+				}
+				if len(app.Spec.GetSources()) < sourcePosition {
+					errors.CheckError(fmt.Errorf("Source position should be less than the number of sources in the application"))
+				}
+			}
 
 			pConn, projIf := headless.NewClientOrDie(clientOpts, c).NewProjectClientOrDie()
 			defer argoio.Close(pConn)
@@ -388,7 +400,7 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 				err := PrintResource(app, output)
 				errors.CheckError(err)
 			case "wide", "":
-				printHeader(acdClient, app, ctx, windows, showOperation, showParams)
+				printHeader(acdClient, app, ctx, windows, showOperation, showParams, sourcePosition)
 				if len(app.Status.Resources) > 0 {
 					fmt.Println()
 					w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -396,14 +408,14 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 					_ = w.Flush()
 				}
 			case "tree":
-				printHeader(acdClient, app, ctx, windows, showOperation, showParams)
+				printHeader(acdClient, app, ctx, windows, showOperation, showParams, sourcePosition)
 				mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appName, appNs)
 				if len(mapUidToNode) > 0 {
 					fmt.Println()
 					printTreeView(mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
 				}
 			case "tree=detailed":
-				printHeader(acdClient, app, ctx, windows, showOperation, showParams)
+				printHeader(acdClient, app, ctx, windows, showOperation, showParams, sourcePosition)
 				mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appName, appNs)
 				if len(mapUidToNode) > 0 {
 					fmt.Println()
@@ -420,6 +432,7 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Only get application from namespace")
+	command.Flags().IntVar(&sourcePosition, "source-position", -1, "Position of the source from the list of sources of the app. Counting starts at 1.")
 	return command
 }
 
@@ -701,10 +714,21 @@ func truncateString(str string, num int) string {
 }
 
 // printParams prints parameters and overrides
-func printParams(app *argoappv1.Application) {
-	if app.Spec.GetSource().Helm != nil {
-		printHelmParams(app.Spec.GetSource().Helm)
+func printParams(app *argoappv1.Application, sourcePosition int) {
+	var source *argoappv1.ApplicationSource
+
+	if app.Spec.HasMultipleSources() {
+		// Get the source by the sourcePosition whose params you'd like to print
+		source = app.Spec.GetSourcePtrByPosition(sourcePosition)
+		if source == nil {
+			source = &argoappv1.ApplicationSource{}
+		}
+	} else {
+		src := app.Spec.GetSource()
+		source = &src
 	}
+
+	printHelmParams(source.Helm)
 }
 
 func printHelmParams(helm *argoappv1.ApplicationSourceHelm) {
@@ -793,9 +817,9 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().IntVar(&sourcePosition, "source-position", -1, "Position of the source from the list of sources of the app. Counting starts at 1.")
 	cmdutil.AddAppFlags(command, &appOpts)
 	command.Flags().StringVarP(&appNamespace, "app-namespace", "N", "", "Set application parameters in namespace")
+	command.Flags().IntVar(&sourcePosition, "source-position", -1, "Position of the source from the list of sources of the app. Counting starts at 1.")
 	return command
 }
 

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -728,7 +728,9 @@ func printParams(app *argoappv1.Application, sourcePosition int) {
 		source = &src
 	}
 
-	printHelmParams(source.Helm)
+	if source.Helm != nil {
+		printHelmParams(source.Helm)
+	}
 }
 
 func printHelmParams(helm *argoappv1.ApplicationSourceHelm) {

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -918,35 +918,83 @@ func TestPrintAppConditions(t *testing.T) {
 }
 
 func TestPrintParams(t *testing.T) {
-	output, _ := captureOutput(func() error {
-		app := &v1alpha1.Application{
-			Spec: v1alpha1.ApplicationSpec{
-				Source: &v1alpha1.ApplicationSource{
-					Helm: &v1alpha1.ApplicationSourceHelm{
-						Parameters: []v1alpha1.HelmParameter{
-							{
-								Name:  "name1",
-								Value: "value1",
-							},
-							{
-								Name:  "name2",
-								Value: "value2",
-							},
-							{
-								Name:  "name3",
-								Value: "value3",
+	testCases := []struct {
+		name           string
+		app            *v1alpha1.Application
+		sourcePosition int
+		expectedOutput string
+	}{
+		{
+			name: "Single Source application with valid helm parameters",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							Parameters: []v1alpha1.HelmParameter{
+								{
+									Name:  "name1",
+									Value: "value1",
+								},
+								{
+									Name:  "name2",
+									Value: "value2",
+								},
+								{
+									Name:  "name3",
+									Value: "value3",
+								},
 							},
 						},
 					},
 				},
 			},
-		}
-		printParams(app)
-		return nil
-	})
-	expectation := "\n\nNAME   VALUE\nname1  value1\nname2  value2\nname3  value3\n"
-	if output != expectation {
-		t.Fatalf("Incorrect print params output %q, should be %q", output, expectation)
+			sourcePosition: -1,
+			expectedOutput: "\n\nNAME   VALUE\nname1  value1\nname2  value2\nname3  value3\n",
+		},
+		{
+			name: "Multi-source application with a valid Source Position",
+			app: &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Sources: []v1alpha1.ApplicationSource{
+						{
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								Parameters: []v1alpha1.HelmParameter{
+									{
+										Name:  "nameA",
+										Value: "valueA",
+									},
+								},
+							},
+						},
+						{
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								Parameters: []v1alpha1.HelmParameter{
+									{
+										Name:  "nameB",
+										Value: "valueB",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			sourcePosition: 1,
+			expectedOutput: "\n\nNAME   VALUE\nnameA  valueA\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, _ := captureOutput(func() error {
+				printParams(tc.app, tc.sourcePosition)
+				return nil
+			})
+
+			if output != tc.expectedOutput {
+				t.Fatalf("Incorrect print params output %q, should be %q\n", output, tc.expectedOutput)
+			}
+		})
 	}
 }
 

--- a/docs/user-guide/commands/argocd_app_get.md
+++ b/docs/user-guide/commands/argocd_app_get.md
@@ -26,6 +26,9 @@ argocd app get APPNAME [flags]
   # Show application parameters and overrides
   argocd app get my-app --show-params
   
+  # Show application parameters and overrides for a source at position 1 under spec.sources of app my-app
+  argocd app get my-app --show-params --source-position 1
+  
   # Refresh application data when retrieving
   argocd app get my-app --refresh
   
@@ -49,6 +52,7 @@ argocd app get APPNAME [flags]
       --refresh                Refresh application data when retrieving
       --show-operation         Show application operation
       --show-params            Show application parameters and overrides
+      --source-position int    Position of the source from the list of sources of the app. Counting starts at 1. (default -1)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Closes #19824

This PR adds the `--source-position` flag to the `argocd get app` command that will be useful when trying to show the parameters in a multi-source application.

```
> dist/argocd app get multi-source-helm-app --show-params                    
2024/09/11 15:03:40 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined
FATA[0000] Source position should be specified and must be greater than 0 for applications with multiple sources 
               
 > dist/argocd app get multi-source-helm-app --show-params --source-position 1
2024/09/11 15:03:50 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined
Name:               argocd/multi-source-helm-app
Project:            default
Server:             https://kubernetes.default.svc
Namespace:          helm
URL:                https://localhost:8080/applications/multi-source-helm-app
Sources:
- Repo:             https://github.com/nitishfy/repo1
  Target:           HEAD
  Path:             .
  Helm Values:      values.yaml
- Repo:             https://github.com/nitishfy/repo2
  Target:           HEAD
  Path:             .
  Helm Values:      values.yaml
SyncWindow:         Sync Allowed
Sync Policy:        Automated (Prune)
Sync Status:        Synced to HEAD
Health Status:      Healthy


NAME  VALUE
name  nitish

GROUP  KIND        NAMESPACE  NAME                STATUS     HEALTH   HOOK  MESSAGE
apps   Deployment  helm       nginx-deploy        Succeeded  Pruned         pruned
apps   Deployment  helm       nginx-deploy-repo1  Synced     Healthy        deployment.apps/nginx-deploy-repo1 created
apps   Deployment  helm       nginx-deploy-repo2  Synced     Healthy        deployment.apps/nginx-deploy-repo2 unchanged
               
> dist/argocd app get multi-source-helm-app --show-params --source-position 2
2024/09/11 15:03:55 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined
Name:               argocd/multi-source-helm-app
Project:            default
Server:             https://kubernetes.default.svc
Namespace:          helm
URL:                https://localhost:8080/applications/multi-source-helm-app
Sources:
- Repo:             https://github.com/nitishfy/repo1
  Target:           HEAD
  Path:             .
  Helm Values:      values.yaml
- Repo:             https://github.com/nitishfy/repo2
  Target:           HEAD
  Path:             .
  Helm Values:      values.yaml
SyncWindow:         Sync Allowed
Sync Policy:        Automated (Prune)
Sync Status:        Synced to HEAD
Health Status:      Healthy


NAME  VALUE
name  argoproj
game  sports

GROUP  KIND        NAMESPACE  NAME                STATUS     HEALTH   HOOK  MESSAGE
apps   Deployment  helm       nginx-deploy        Succeeded  Pruned         pruned
apps   Deployment  helm       nginx-deploy-repo1  Synced     Healthy        deployment.apps/nginx-deploy-repo1 created
apps   Deployment  helm       nginx-deploy-repo2  Synced     Healthy        deployment.apps/nginx-deploy-repo2 unchanged
```

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
