### PR TITLE
docs: Add error about empty`GitHub.repoURL` to troubleshooting docs

### DIFF
--- a/docs/operator-manual/notifications/troubleshooting-errors.md
+++ b/docs/operator-manual/notifications/troubleshooting-errors.md
@@ -40,6 +40,27 @@ You need to check your argocd-notifications controller version. For instance, th
 
 You have not defined `xxxx` in `argocd-notifications-cm` or to fail to parse settings.
 
+### GitHub.repoURL (\u003cno value\u003e) does not have a / using the configuration
+
+You probably have an Application with [multiple sources](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/):
+
+```yaml
+spec:
+  sources:  # <- multiple sources
+  - repoURL: https://github.com/exampleOrg/first.git
+    path: sources/example
+  - repoURL: https://github.com/exampleOrg/second.git
+    targetRevision: "{{branch}}"
+```
+
+So standard notification template won't work (`{{.app.spec.source.repoURL}}`). You should choose a single source instead:
+
+```yaml
+template.example: |
+  github:
+    repoURLPath: "{{ (index .app.spec.sources 0).repoURL }}"
+```
+
 ## config referenced xxx, but key does not exist in secret
 
 - If you are using a custom secret, check that the secret is in the same namespace


### PR DESCRIPTION
It was frustrating for me to see these kind of err in log. 
```json
{"level":"error","msg":"Failed to notify recipient {github } defined in resource argo/example: GitHub.repoURL (\u003cno value\u003e) does not have a / using the configuration in namespace argo","resource":"argo/example","time":"2024-09-12T16:32:09Z"}
```
After a while I reallized that my `Application` spec contains [multiple sources](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/) and default go template in github notification service `{{.app.spec.source.repoURL}}` doesn't match correctly ([sources](https://github.com/argoproj/notifications-engine/blob/261728a36e8357dfa7c258f7e1c4e3e763711ee1/pkg/services/github.go#L66-L66)). 

I added this case to the troubleshooting doc.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
