### PR TITLE
fix: notification controller crash loop in 2.13 RC1

### DIFF
--- a/cmd/argocd-notification/commands/controller.go
+++ b/cmd/argocd-notification/commands/controller.go
@@ -163,6 +163,7 @@ func NewCommand() *cobra.Command {
 			}()
 
 			go ctrl.Run(ctx, processorsCount)
+			<-ctx.Done()
 			return nil
 		},
 	}


### PR DESCRIPTION
Closes: https://github.com/argoproj/argo-cd/issues/19968