### PR TITLE
docs(reconcile): adding optional condition when ignoring json

### DIFF
--- a/docs/operator-manual/reconcile.md
+++ b/docs/operator-manual/reconcile.md
@@ -110,7 +110,7 @@ data:
     jqPathExpressions:
     # Ignore lastTransitionTime for conditions; helpful when SharedResourceWarnings are being regularly updated but not
     # actually changing in content.
-    - .status.conditions[].lastTransitionTime
+    - .status?.conditions[]?.lastTransitionTime
 ```
 
 ## Ignoring updates for untracked resources


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

If an application has no conditions, eg failures or shared warning messages the conditions array won't be populated. The json patch will cause (debug) logs to be produced.
`time="2024-09-19T14:43:44Z" level=debug msg="Failed to apply normalization: JQ patch returned error: cannot iterate over: null"`

```
❯ k get applications.argoproj.io kust-app2 -o json | jq '.status?.conditions[]?.lastTransitionTime'
"2024-09-18T12:21:11Z"
~                                                                                                                                                                                                                                                                        
❯ k get applications.argoproj.io kust-app -o json | jq '.status?.conditions[]?.lastTransitionTime'
~                                                                                                                                                                                                                                                                        
❯ k get applications.argoproj.io kust-app -o json | jq '.status.conditions[].lastTransitionTime'
jq: error (at <stdin>:161): Cannot iterate over null (null)
```

While the logline only happens in debug mode, it floods the logs when you have many applications that are "healthy" without conditions. It spams the logs and makes it hard to see what actual debug logs you are after. :)

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
