### PR TITLE
fix: check err before use schedule and duration

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -585,8 +585,8 @@ func printAppSummaryTable(app *argoappv1.Application, appURL string, windows *ar
 	var status string
 	var allow, deny, inactiveAllows bool
 	if windows.HasWindows() {
-		active := windows.Active()
-		if active.HasWindows() {
+		active, err := windows.Active()
+		if err == nil && active.HasWindows() {
 			for _, w := range *active {
 				if w.Kind == "deny" {
 					deny = true
@@ -595,13 +595,14 @@ func printAppSummaryTable(app *argoappv1.Application, appURL string, windows *ar
 				}
 			}
 		}
-		if windows.InactiveAllows().HasWindows() {
+		inactiveAllowWindows, err := windows.InactiveAllows()
+		if err == nil && inactiveAllowWindows.HasWindows() {
 			inactiveAllows = true
 		}
 
-		s := windows.CanSync(true)
 		if deny || !deny && !allow && inactiveAllows {
-			if s {
+			s, err := windows.CanSync(true)
+			if err == nil && s {
 				status = "Manual Allowed"
 			} else {
 				status = "Sync Denied"

--- a/cmd/argocd/commands/projectwindows.go
+++ b/cmd/argocd/commands/projectwindows.go
@@ -352,9 +352,10 @@ func printSyncWindows(proj *v1alpha1.AppProject) {
 	fmt.Fprintf(w, fmtStr, headers...)
 	if proj.Spec.SyncWindows.HasWindows() {
 		for i, window := range proj.Spec.SyncWindows {
+			isActive, _ := window.Active()
 			vals := []interface{}{
 				strconv.Itoa(i),
-				formatBoolOutput(window.Active()),
+				formatBoolOutput(isActive),
 				window.Kind,
 				window.Schedule,
 				window.Duration,

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1696,7 +1696,8 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 		app.Status.Summary = tree.GetSummary(app)
 	}
 
-	if project.Spec.SyncWindows.Matches(app).CanSync(false) {
+	canSync, _ := project.Spec.SyncWindows.Matches(app).CanSync(false)
+	if canSync {
 		syncErrCond, opMS := ctrl.autoSync(app, compareResult.syncStatus, compareResult.resources, compareResult.revisionUpdated)
 		setOpMs = opMS
 		if syncErrCond != nil {

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -179,12 +179,18 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		state.Phase = common.OperationError
 		state.Message = fmt.Sprintf("Failed to load application project: %v", err)
 		return
-	} else if syncWindowPreventsSync(app, proj) {
-		// If the operation is currently running, simply let the user know the sync is blocked by a current sync window
-		if state.Phase == common.OperationRunning {
-			state.Message = "Sync operation blocked by sync window"
+	} else {
+		isBlocked, err := syncWindowPreventsSync(app, proj)
+		if isBlocked {
+			// If the operation is currently running, simply let the user know the sync is blocked by a current sync window
+			if state.Phase == common.OperationRunning {
+				state.Message = "Sync operation blocked by sync window"
+				if err != nil {
+					state.Message = fmt.Sprintf("%s: %v", state.Message, err)
+				}
+			}
+			return
 		}
-		return
 	}
 
 	if !isMultiSourceRevision {
@@ -579,13 +585,18 @@ func delayBetweenSyncWaves(phase common.SyncPhase, wave int, finalWave bool) err
 	return nil
 }
 
-func syncWindowPreventsSync(app *v1alpha1.Application, proj *v1alpha1.AppProject) bool {
+func syncWindowPreventsSync(app *v1alpha1.Application, proj *v1alpha1.AppProject) (bool, error) {
 	window := proj.Spec.SyncWindows.Matches(app)
 	isManual := false
 	if app.Status.OperationState != nil {
 		isManual = !app.Status.OperationState.Operation.InitiatedBy.Automated
 	}
-	return !window.CanSync(isManual)
+	canSync, err := window.CanSync(isManual)
+	if err != nil {
+		// prevents sync because sync window has an error
+		return true, err
+	}
+	return !canSync, nil
 }
 
 // deriveServiceAccountToImpersonate determines the service account to be used for impersonation for the sync operation.

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2386,11 +2386,11 @@ func (s *SyncWindows) HasWindows() bool {
 }
 
 // Active returns a list of sync windows that are currently active
-func (s *SyncWindows) Active() *SyncWindows {
+func (s *SyncWindows) Active() (*SyncWindows, error) {
 	return s.active(time.Now())
 }
 
-func (s *SyncWindows) active(currentTime time.Time) *SyncWindows {
+func (s *SyncWindows) active(currentTime time.Time) (*SyncWindows, error) {
 	// If SyncWindows.Active() is called outside of a UTC locale, it should be
 	// first converted to UTC before we scan through the SyncWindows.
 	currentTime = currentTime.In(time.UTC)
@@ -2401,13 +2401,11 @@ func (s *SyncWindows) active(currentTime time.Time) *SyncWindows {
 		for _, w := range *s {
 			schedule, sErr := specParser.Parse(w.Schedule)
 			if sErr != nil {
-				log.Warnf("invalid sync window schedule '%v': %s", w.Schedule, sErr)
-				continue
+				return nil, fmt.Errorf("cannot parse schedule '%s': %w", w.Schedule, sErr)
 			}
 			duration, dErr := time.ParseDuration(w.Duration)
 			if dErr != nil {
-				log.Warnf("invalid sync window duration '%v': %s", w.Duration, dErr)
-				continue
+				return nil, fmt.Errorf("cannot parse duration '%s': %w", w.Duration, dErr)
 			}
 
 			// Offset the nextWindow time to consider the timeZone of the sync window
@@ -2418,20 +2416,20 @@ func (s *SyncWindows) active(currentTime time.Time) *SyncWindows {
 			}
 		}
 		if len(active) > 0 {
-			return &active
+			return &active, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // InactiveAllows will iterate over the SyncWindows and return all inactive allow windows
 // for the current time. If the current time is in an inactive allow window, syncs will
 // be denied.
-func (s *SyncWindows) InactiveAllows() *SyncWindows {
+func (s *SyncWindows) InactiveAllows() (*SyncWindows, error) {
 	return s.inactiveAllows(time.Now())
 }
 
-func (s *SyncWindows) inactiveAllows(currentTime time.Time) *SyncWindows {
+func (s *SyncWindows) inactiveAllows(currentTime time.Time) (*SyncWindows, error) {
 	// If SyncWindows.InactiveAllows() is called outside of a UTC locale, it should be
 	// first converted to UTC before we scan through the SyncWindows.
 	currentTime = currentTime.In(time.UTC)
@@ -2443,13 +2441,11 @@ func (s *SyncWindows) inactiveAllows(currentTime time.Time) *SyncWindows {
 			if w.Kind == "allow" {
 				schedule, sErr := specParser.Parse(w.Schedule)
 				if sErr != nil {
-					log.Warnf("invalid sync window schedule '%v': %s", w.Schedule, sErr)
-					continue
+					return nil, fmt.Errorf("cannot parse schedule '%s': %w", w.Schedule, sErr)
 				}
 				duration, dErr := time.ParseDuration(w.Duration)
 				if dErr != nil {
-					log.Warnf("invalid sync window duration '%v': %s", w.Duration, dErr)
-					continue
+					return nil, fmt.Errorf("cannot parse duration '%s': %w", w.Duration, dErr)
 				}
 				// Offset the nextWindow time to consider the timeZone of the sync window
 				timeZoneOffsetDuration := w.scheduleOffsetByTimeZone()
@@ -2461,10 +2457,10 @@ func (s *SyncWindows) inactiveAllows(currentTime time.Time) *SyncWindows {
 			}
 		}
 		if len(inactive) > 0 {
-			return &inactive
+			return &inactive, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (w *SyncWindow) scheduleOffsetByTimeZone() time.Duration {
@@ -2568,36 +2564,42 @@ func (w *SyncWindows) Matches(app *Application) *SyncWindows {
 }
 
 // CanSync returns true if a sync window currently allows a sync. isManual indicates whether the sync has been triggered manually.
-func (w *SyncWindows) CanSync(isManual bool) bool {
+func (w *SyncWindows) CanSync(isManual bool) (bool, error) {
 	if !w.HasWindows() {
-		return true
+		return true, nil
 	}
 
-	active := w.Active()
+	active, err := w.Active()
+	if err != nil {
+		return false, fmt.Errorf("invalid sync windows: %w", err)
+	}
 	hasActiveDeny, manualEnabled := active.hasDeny()
 
 	if hasActiveDeny {
 		if isManual && manualEnabled {
-			return true
+			return true, nil
 		} else {
-			return false
+			return false, nil
 		}
 	}
 
 	if active.hasAllow() {
-		return true
+		return true, nil
 	}
 
-	inactiveAllows := w.InactiveAllows()
+	inactiveAllows, err := w.InactiveAllows()
+	if err != nil {
+		return false, fmt.Errorf("invalid sync windows: %w", err)
+	}
 	if inactiveAllows.HasWindows() {
 		if isManual && inactiveAllows.manualEnabled() {
-			return true
+			return true, nil
 		} else {
-			return false
+			return false, nil
 		}
 	}
 
-	return true
+	return true, nil
 }
 
 // hasDeny will iterate over the SyncWindows and return if a deny window is found and if
@@ -2652,11 +2654,11 @@ func (w *SyncWindows) manualEnabled() bool {
 }
 
 // Active returns true if the sync window is currently active
-func (w SyncWindow) Active() bool {
+func (w SyncWindow) Active() (bool, error) {
 	return w.active(time.Now())
 }
 
-func (w SyncWindow) active(currentTime time.Time) bool {
+func (w SyncWindow) active(currentTime time.Time) (bool, error) {
 	// If SyncWindow.Active() is called outside of a UTC locale, it should be
 	// first converted to UTC before search
 	currentTime = currentTime.UTC()
@@ -2664,20 +2666,18 @@ func (w SyncWindow) active(currentTime time.Time) bool {
 	specParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 	schedule, sErr := specParser.Parse(w.Schedule)
 	if sErr != nil {
-		log.Warnf("invalid sync window schedule '%v': %s", w.Schedule, sErr)
-		return false
+		return false, fmt.Errorf("cannot parse schedule '%s': %w", w.Schedule, sErr)
 	}
 	duration, dErr := time.ParseDuration(w.Duration)
 	if dErr != nil {
-		log.Warnf("invalid sync window duration '%v': %s", w.Duration, dErr)
-		return false
+		return false, fmt.Errorf("cannot parse duration '%s': %w", w.Duration, dErr)
 	}
 
 	// Offset the nextWindow time to consider the timeZone of the sync window
 	timeZoneOffsetDuration := w.scheduleOffsetByTimeZone()
 	nextWindow := schedule.Next(currentTime.Add(timeZoneOffsetDuration - duration))
 
-	return nextWindow.Before(currentTime.Add(timeZoneOffsetDuration))
+	return nextWindow.Before(currentTime.Add(timeZoneOffsetDuration)), nil
 }
 
 // Update updates a sync window's settings with the given parameter

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1926,6 +1926,24 @@ func TestSyncWindows_Active(t *testing.T) {
 			matchingIndex:  0,
 			expectedLength: 1,
 		},
+		{
+			name: "MatchNone-InvalidSchedule",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * 7", "3h", ""),
+				syncWindow("allow", "* 11 * * 7", "3h", ""),
+			},
+			currentTime:    timeWithHour(12, time.UTC),
+			expectedLength: 0,
+		},
+		{
+			name: "MatchNone-InvalidDuration",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "3a", ""),
+				syncWindow("allow", "* 11 * * *", "3a", ""),
+			},
+			currentTime:    timeWithHour(12, time.UTC),
+			expectedLength: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2098,6 +2116,22 @@ func TestSyncWindows_InactiveAllows(t *testing.T) {
 			currentTime:    timeWithHour(7, time.UTC),
 			matchingIndex:  0,
 			expectedLength: 1,
+		},
+		{
+			name: "MatchNone-InvalidSchedule",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * 7", "2h", ""),
+			},
+			currentTime:    timeWithHour(17, time.UTC),
+			expectedLength: 0,
+		},
+		{
+			name: "MatchNone-InvalidDuration",
+			syncWindow: SyncWindows{
+				syncWindow("allow", "* 10 * * *", "2a", ""),
+			},
+			currentTime:    timeWithHour(17, time.UTC),
+			expectedLength: 0,
 		},
 	}
 
@@ -2651,6 +2685,30 @@ func TestSyncWindow_Active(t *testing.T) {
 			name:           "Deny-inactive-NonUTC",
 			syncWindow:     syncWindow("deny", "* 10 * * *", "2h"),
 			currentTime:    timeWithHour(13-4, utcM4Zone),
+			expectedResult: false,
+		},
+		{
+			name:           "Allow-inactive-InvalidSchedule",
+			syncWindow:     syncWindow("allow", "* 10 * * 7", "2h"),
+			currentTime:    timeWithHour(11, time.UTC),
+			expectedResult: false,
+		},
+		{
+			name:           "Deny-inactive-InvalidSchedule",
+			syncWindow:     syncWindow("deny", "* 10 * * 7", "2h"),
+			currentTime:    timeWithHour(11, time.UTC),
+			expectedResult: false,
+		},
+		{
+			name:           "Allow-inactive-InvalidDuration",
+			syncWindow:     syncWindow("allow", "* 10 * * *", "2a"),
+			currentTime:    timeWithHour(11, time.UTC),
+			expectedResult: false,
+		},
+		{
+			name:           "Deny-inactive-InvalidDuration",
+			syncWindow:     syncWindow("deny", "* 10 * * *", "2a"),
+			currentTime:    timeWithHour(11, time.UTC),
 			expectedResult: false,
 		},
 	}

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1793,7 +1793,7 @@ func TestSyncWindows_Active(t *testing.T) {
 	t.Run("WithTestProject", func(t *testing.T) {
 		proj := newTestProjectWithSyncWindows()
 		activeWindows, err := proj.Spec.SyncWindows.Active()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Len(t, *activeWindows, 1)
 	})
 
@@ -1955,9 +1955,9 @@ func TestSyncWindows_Active(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.syncWindow.active(tt.currentTime)
 			if tt.isErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			if result == nil {
 				result = &SyncWindows{}
@@ -1976,7 +1976,7 @@ func TestSyncWindows_InactiveAllows(t *testing.T) {
 		proj := newTestProjectWithSyncWindows()
 		proj.Spec.SyncWindows[0].Schedule = "0 0 1 1 1"
 		inactiveAllowWindows, err := proj.Spec.SyncWindows.InactiveAllows()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Len(t, *inactiveAllowWindows, 1)
 	})
 
@@ -2154,9 +2154,9 @@ func TestSyncWindows_InactiveAllows(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.syncWindow.inactiveAllows(tt.currentTime)
 			if tt.isErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			if result == nil {
 				result = &SyncWindows{}
@@ -2271,7 +2271,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow manual sync if inactive-deny-window set with manual false", func(t *testing.T) {
@@ -2283,7 +2283,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny manual sync if one inactive-allow-windows set with manual false", func(t *testing.T) {
@@ -2298,7 +2298,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync if on active-allow-window set with manual true", func(t *testing.T) {
@@ -2312,7 +2312,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow manual sync if on active-allow-window set with manual false", func(t *testing.T) {
@@ -2326,7 +2326,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow auto sync if on active-allow-window", func(t *testing.T) {
@@ -2340,7 +2340,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow manual sync active-allow and inactive-deny", func(t *testing.T) {
@@ -2355,7 +2355,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow auto sync active-allow and inactive-deny", func(t *testing.T) {
@@ -2370,7 +2370,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny manual sync inactive-allow", func(t *testing.T) {
@@ -2384,7 +2384,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync inactive-allow", func(t *testing.T) {
@@ -2398,7 +2398,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync inactive-allow with ManualSync enabled", func(t *testing.T) {
@@ -2412,7 +2412,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny auto sync inactive-allow with ManualSync enabled", func(t *testing.T) {
@@ -2426,7 +2426,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny manual sync with inactive-allow and inactive-deny", func(t *testing.T) {
@@ -2441,7 +2441,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync with inactive-allow and inactive-deny", func(t *testing.T) {
@@ -2456,7 +2456,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow auto sync with active-allow and inactive-allow", func(t *testing.T) {
@@ -2471,7 +2471,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny manual sync with active-deny", func(t *testing.T) {
@@ -2485,7 +2485,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync with active-deny", func(t *testing.T) {
@@ -2499,7 +2499,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync with active-deny with ManualSync enabled", func(t *testing.T) {
@@ -2513,7 +2513,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny auto sync with active-deny with ManualSync enabled", func(t *testing.T) {
@@ -2527,7 +2527,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny manual sync with many active-deny having one with ManualSync disabled", func(t *testing.T) {
@@ -2544,7 +2544,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync with many active-deny having one with ManualSync disabled", func(t *testing.T) {
@@ -2561,7 +2561,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny manual sync with active-deny and active-allow windows with ManualSync disabled", func(t *testing.T) {
@@ -2576,7 +2576,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync with active-deny and active-allow windows with ManualSync enabled", func(t *testing.T) {
@@ -2591,7 +2591,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny auto sync with active-deny and active-allow windows with ManualSync enabled", func(t *testing.T) {
@@ -2606,7 +2606,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny and return error with invalid windows", func(t *testing.T) {
@@ -2620,7 +2620,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.False(t, canSync)
 	})
 }
@@ -2671,7 +2671,7 @@ func TestSyncWindow_Active(t *testing.T) {
 	window := &SyncWindow{Schedule: "* * * * *", Duration: "1h"}
 	t.Run("ActiveWindow", func(t *testing.T) {
 		isActive, err := window.Active()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, isActive)
 	})
 
@@ -2781,9 +2781,9 @@ func TestSyncWindow_Active(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.syncWindow.active(tt.currentTime)
 			if tt.isErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expectedResult, result)
 		})

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1793,7 +1793,7 @@ func TestSyncWindows_Active(t *testing.T) {
 	t.Run("WithTestProject", func(t *testing.T) {
 		proj := newTestProjectWithSyncWindows()
 		activeWindows, err := proj.Spec.SyncWindows.Active()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, *activeWindows, 1)
 	})
 
@@ -1955,9 +1955,9 @@ func TestSyncWindows_Active(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.syncWindow.active(tt.currentTime)
 			if tt.isErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			if result == nil {
 				result = &SyncWindows{}
@@ -1976,7 +1976,7 @@ func TestSyncWindows_InactiveAllows(t *testing.T) {
 		proj := newTestProjectWithSyncWindows()
 		proj.Spec.SyncWindows[0].Schedule = "0 0 1 1 1"
 		inactiveAllowWindows, err := proj.Spec.SyncWindows.InactiveAllows()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, *inactiveAllowWindows, 1)
 	})
 
@@ -2154,9 +2154,9 @@ func TestSyncWindows_InactiveAllows(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.syncWindow.inactiveAllows(tt.currentTime)
 			if tt.isErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			if result == nil {
 				result = &SyncWindows{}
@@ -2271,7 +2271,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow manual sync if inactive-deny-window set with manual false", func(t *testing.T) {
@@ -2283,7 +2283,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny manual sync if one inactive-allow-windows set with manual false", func(t *testing.T) {
@@ -2298,7 +2298,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync if on active-allow-window set with manual true", func(t *testing.T) {
@@ -2312,7 +2312,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow manual sync if on active-allow-window set with manual false", func(t *testing.T) {
@@ -2326,7 +2326,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow auto sync if on active-allow-window", func(t *testing.T) {
@@ -2340,7 +2340,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow manual sync active-allow and inactive-deny", func(t *testing.T) {
@@ -2355,7 +2355,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will allow auto sync active-allow and inactive-deny", func(t *testing.T) {
@@ -2370,7 +2370,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny manual sync inactive-allow", func(t *testing.T) {
@@ -2384,7 +2384,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync inactive-allow", func(t *testing.T) {
@@ -2398,7 +2398,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync inactive-allow with ManualSync enabled", func(t *testing.T) {
@@ -2412,7 +2412,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny auto sync inactive-allow with ManualSync enabled", func(t *testing.T) {
@@ -2426,7 +2426,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny manual sync with inactive-allow and inactive-deny", func(t *testing.T) {
@@ -2441,7 +2441,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync with inactive-allow and inactive-deny", func(t *testing.T) {
@@ -2456,7 +2456,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow auto sync with active-allow and inactive-allow", func(t *testing.T) {
@@ -2471,7 +2471,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny manual sync with active-deny", func(t *testing.T) {
@@ -2485,7 +2485,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync with active-deny", func(t *testing.T) {
@@ -2499,7 +2499,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync with active-deny with ManualSync enabled", func(t *testing.T) {
@@ -2513,7 +2513,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny auto sync with active-deny with ManualSync enabled", func(t *testing.T) {
@@ -2527,7 +2527,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny manual sync with many active-deny having one with ManualSync disabled", func(t *testing.T) {
@@ -2544,7 +2544,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny auto sync with many active-deny having one with ManualSync disabled", func(t *testing.T) {
@@ -2561,7 +2561,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny manual sync with active-deny and active-allow windows with ManualSync disabled", func(t *testing.T) {
@@ -2576,7 +2576,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will allow manual sync with active-deny and active-allow windows with ManualSync enabled", func(t *testing.T) {
@@ -2591,7 +2591,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(true)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, canSync)
 	})
 	t.Run("will deny auto sync with active-deny and active-allow windows with ManualSync enabled", func(t *testing.T) {
@@ -2606,7 +2606,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, canSync)
 	})
 	t.Run("will deny and return error with invalid windows", func(t *testing.T) {
@@ -2620,7 +2620,7 @@ func TestSyncWindows_CanSync(t *testing.T) {
 		canSync, err := proj.Spec.SyncWindows.CanSync(false)
 
 		// then
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.False(t, canSync)
 	})
 }
@@ -2671,7 +2671,7 @@ func TestSyncWindow_Active(t *testing.T) {
 	window := &SyncWindow{Schedule: "* * * * *", Duration: "1h"}
 	t.Run("ActiveWindow", func(t *testing.T) {
 		isActive, err := window.Active()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, isActive)
 	})
 
@@ -2781,9 +2781,9 @@ func TestSyncWindow_Active(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.syncWindow.active(tt.currentTime)
 			if tt.isErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.expectedResult, result)
 		})

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -525,7 +525,10 @@ func (s *Server) GetSyncWindowsState(ctx context.Context, q *project.SyncWindows
 
 	res := &project.SyncWindowsResponse{}
 
-	windows := proj.Spec.SyncWindows.Active()
+	windows, err := proj.Spec.SyncWindows.Active()
+	if err != nil {
+		return nil, err
+	}
 	if windows.HasWindows() {
 		res.Windows = *windows
 	} else {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fix #19605 

~~I have made some modifications to the related code, though it doesn't fully resolve the issue.~~
I have made some modifications to resolve the issue.
Previously, `schedule` and `duration` were used before checking `sErr` and `dErr`, which could result in a nil pointer exception if an error occurred. (use values in line 2433, check error in line 2435)
I have updated the code to check for errors first and use `continue` if an error is found.

If I've misunderstood something, please let me know in the comments. Thank you! :)

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
