### PR TITLE
fix(helm): escape consecutive commas in cleanSetParameters (#19269)

### DIFF
--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -366,6 +366,8 @@ func cleanSetParameters(val string) string {
 	return result.String()
 }
 
+var apiVersionsRemover = regexp.MustCompile(`(--api-versions [^ ]+ )+`)
+
 func (c *Cmd) template(chartPath string, opts *TemplateOpts) (string, string, error) {
 	if callback, err := cleanupChartLockFile(filepath.Clean(path.Join(c.WorkDir, chartPath))); err == nil {
 		defer callback()
@@ -402,8 +404,6 @@ func (c *Cmd) template(chartPath string, opts *TemplateOpts) (string, string, er
 	if !opts.SkipCrds {
 		args = append(args, "--include-crds")
 	}
-
-	apiVersionsRemover := regexp.MustCompile(`(--api-versions [^ ]+ )+`)
 
 	out, command, err := c.run(args...)
 	if err != nil {

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -352,6 +352,7 @@ func cleanSetParameters(val string) string {
 	if strings.HasPrefix(val, `{`) && strings.HasSuffix(val, `}`) {
 		return val
 	}
+	re := regexp.MustCompile(`,`)
 	return re.ReplaceAllString(val, `$1\,`)
 }
 

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -360,7 +360,7 @@ func replaceAllWithLookbehind(val string, old rune, new string, lookbehind rune)
 			if prevR != lookbehind {
 				result.WriteString(new)
 			} else {
-				result.WriteRune(old) // 원래 문자를 그대로 추가
+				result.WriteRune(old)
 			}
 		} else {
 			result.WriteRune(r)

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -353,9 +353,10 @@ func cleanSetParameters(val string) string {
 	}
 
 	var result strings.Builder
-	for _, r := range val {
+	var prevR rune
+	for i, r := range val {
 		if r == ',' {
-			if result.Len() == 0 || result.String()[result.Len()-1] != '\\' {
+			if i == 0 || prevR != '\\' {
 				result.WriteString(`\,`)
 			} else {
 				result.WriteRune(',')
@@ -363,6 +364,7 @@ func cleanSetParameters(val string) string {
 		} else {
 			result.WriteRune(r)
 		}
+		prevR = r
 	}
 
 	return result.String()

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -343,7 +343,6 @@ type TemplateOpts struct {
 }
 
 var (
-	re                 = regexp.MustCompile(`([^\\]),`)
 	apiVersionsRemover = regexp.MustCompile(`(--api-versions [^ ]+ )+`)
 )
 
@@ -352,8 +351,21 @@ func cleanSetParameters(val string) string {
 	if strings.HasPrefix(val, `{`) && strings.HasSuffix(val, `}`) {
 		return val
 	}
-	re := regexp.MustCompile(`,`)
-	return re.ReplaceAllString(val, `$1\,`)
+
+	var result strings.Builder
+	for i := 0; i < len(val); i++ {
+		if val[i] == ',' {
+			if i == 0 || val[i-1] != '\\' {
+				result.WriteString(`\,`)
+			} else {
+				result.WriteByte(',')
+			}
+		} else {
+			result.WriteByte(val[i])
+		}
+	}
+
+	return result.String()
 }
 
 func (c *Cmd) template(chartPath string, opts *TemplateOpts) (string, string, error) {

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -342,10 +342,6 @@ type TemplateOpts struct {
 	SkipCrds    bool
 }
 
-var (
-	apiVersionsRemover = regexp.MustCompile(`(--api-versions [^ ]+ )+`)
-)
-
 func cleanSetParameters(val string) string {
 	// `{}` equal helm list parameters format, so don't escape `,`.
 	if strings.HasPrefix(val, `{`) && strings.HasSuffix(val, `}`) {
@@ -407,6 +403,8 @@ func (c *Cmd) template(chartPath string, opts *TemplateOpts) (string, string, er
 		args = append(args, "--include-crds")
 	}
 
+	var apiVersionsRemover = regexp.MustCompile(`(--api-versions [^ ]+ )+`)
+	
 	out, command, err := c.run(args...)
 	if err != nil {
 		msg := err.Error()

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -350,9 +350,9 @@ func cleanSetParameters(val string) string {
 
 	var result strings.Builder
 	var prevR rune
-	for i, r := range val {
+	for _, r := range val {
 		if r == ',' {
-			if i == 0 || prevR != '\\' {
+			if prevR != '\\' {
 				result.WriteString(`\,`)
 			} else {
 				result.WriteRune(',')

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -342,8 +342,6 @@ type TemplateOpts struct {
 	SkipCrds    bool
 }
 
-var re = regexp.MustCompile(`([^\\]),`)
-
 func cleanSetParameters(val string) string {
 	// `{}` equal helm list parameters format, so don't escape `,`.
 	if strings.HasPrefix(val, `{`) && strings.HasSuffix(val, `}`) {

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -342,27 +342,33 @@ type TemplateOpts struct {
 	SkipCrds    bool
 }
 
+var re = regexp.MustCompile(`([^\\]),`)
+
 func cleanSetParameters(val string) string {
 	// `{}` equal helm list parameters format, so don't escape `,`.
 	if strings.HasPrefix(val, `{`) && strings.HasSuffix(val, `}`) {
 		return val
 	}
 
+	val = replaceAllWithLookbehind(val, ',', `\,`, '\\')
+	return val
+}
+
+func replaceAllWithLookbehind(val string, old rune, new string, lookbehind rune) string {
 	var result strings.Builder
 	var prevR rune
 	for _, r := range val {
-		if r == ',' {
-			if prevR != '\\' {
-				result.WriteString(`\,`)
+		if r == old {
+			if prevR != lookbehind {
+				result.WriteString(new)
 			} else {
-				result.WriteRune(',')
+				result.WriteRune(old) // 원래 문자를 그대로 추가
 			}
 		} else {
 			result.WriteRune(r)
 		}
 		prevR = r
 	}
-
 	return result.String()
 }
 

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -403,8 +403,8 @@ func (c *Cmd) template(chartPath string, opts *TemplateOpts) (string, string, er
 		args = append(args, "--include-crds")
 	}
 
-	var apiVersionsRemover = regexp.MustCompile(`(--api-versions [^ ]+ )+`)
-	
+	apiVersionsRemover := regexp.MustCompile(`(--api-versions [^ ]+ )+`)
+
 	out, command, err := c.run(args...)
 	if err != nil {
 		msg := err.Error()

--- a/util/helm/cmd.go
+++ b/util/helm/cmd.go
@@ -353,15 +353,15 @@ func cleanSetParameters(val string) string {
 	}
 
 	var result strings.Builder
-	for i := 0; i < len(val); i++ {
-		if val[i] == ',' {
-			if i == 0 || val[i-1] != '\\' {
+	for _, r := range val {
+		if r == ',' {
+			if result.Len() == 0 || result.String()[result.Len()-1] != '\\' {
 				result.WriteString(`\,`)
 			} else {
-				result.WriteByte(',')
+				result.WriteRune(',')
 			}
 		} else {
-			result.WriteByte(val[i])
+			result.WriteRune(r)
 		}
 	}
 

--- a/util/helm/cmd_test.go
+++ b/util/helm/cmd_test.go
@@ -48,22 +48,3 @@ func TestNewCmd_withProxy(t *testing.T) {
 	assert.Equal(t, "https://proxy:8888", cmd.proxy)
 	assert.Equal(t, ".argoproj.io", cmd.noProxy)
 }
-
-func TestCleanSetParameters(t *testing.T) {
-	val := "{key=value, key2=value2}"
-	result := cleanSetParameters(val)
-	require.NotEmpty(t, result)
-	assert.Equal(t, "{key=value, key2=value2}", result)
-
-	val = "key=value,key2=value2"
-	result = cleanSetParameters(val)
-	assert.Equal(t, "key=value\\,key2=value2", result)
-
-	val = ""
-	result = cleanSetParameters(val)
-	assert.Equal(t, "", result)
-
-	val = ",,,,,,,,value"
-	result = cleanSetParameters(val)
-	assert.Equal(t, "\\,\\,\\,\\,\\,\\,\\,\\,value", result)
-}

--- a/util/helm/cmd_test.go
+++ b/util/helm/cmd_test.go
@@ -48,3 +48,22 @@ func TestNewCmd_withProxy(t *testing.T) {
 	assert.Equal(t, "https://proxy:8888", cmd.proxy)
 	assert.Equal(t, ".argoproj.io", cmd.noProxy)
 }
+
+func TestCleanSetParameters(t *testing.T) {
+	val := "{key=value, key2=value2}"
+	result := cleanSetParameters(val)
+	require.NotEmpty(t, result)
+	assert.Equal(t, "{key=value, key2=value2}", result)
+
+	val = "key=value,key2=value2"
+	result = cleanSetParameters(val)
+	assert.Equal(t, "key=value\\,key2=value2", result)
+
+	val = ""
+	result = cleanSetParameters(val)
+	assert.Equal(t, "", result)
+
+	val = ",,,,,,,,value"
+	result = cleanSetParameters(val)
+	assert.Equal(t, "\\,\\,\\,\\,\\,\\,\\,\\,value", result)
+}

--- a/util/helm/helm_test.go
+++ b/util/helm/helm_test.go
@@ -166,6 +166,7 @@ func TestHelmArgCleaner(t *testing.T) {
 		`not, clean`: `not\, clean`,
 		`a\,b,c`:     `a\,b\,c`,
 		`{a,b,c}`:    `{a,b,c}`,
+		`,,,,,\,`:    `\,\,\,\,\,\,`,
 	} {
 		cleaned := cleanSetParameters(input)
 		assert.Equal(t, expected, cleaned)

--- a/util/helm/helm_test.go
+++ b/util/helm/helm_test.go
@@ -167,6 +167,7 @@ func TestHelmArgCleaner(t *testing.T) {
 		`a\,b,c`:     `a\,b\,c`,
 		`{a,b,c}`:    `{a,b,c}`,
 		`,,,,,\,`:    `\,\,\,\,\,\,`,
+		`\,,\\,,`:    `\,\,\\,\,`,
 	} {
 		cleaned := cleanSetParameters(input)
 		assert.Equal(t, expected, cleaned)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

related issue #19269 (1 problem / 2 problems)

AS-IS: Consecutive commas are not properly escaped in helm template parameters.

TO-BE: To ensure that consecutive commas are properly handled in Helm template parameters, locate and escape commas instead of regular expressions.

REASON: Properly escaping consecutive commas is essential to avoid issues with parameter parsing. This change improves the handling of parameters and aligns with the expected behavior when using helm, ensuring that parameters with multiple commas are treated correctly.

Changes: Added test code and fixed errors.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
