### PR TITLE
feat(cli): Add app diff option to specify exit code when diff

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1140,6 +1140,7 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		refresh              bool
 		hardRefresh          bool
 		exitCode             bool
+		diffExitCode         int
 		local                string
 		revision             string
 		localRepoRoot        string
@@ -1242,13 +1243,14 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			proj := getProject(c, clientOpts, ctx, app.Spec.Project)
 			foundDiffs := findandPrintDiff(ctx, app, proj.Project, resources, argoSettings, diffOption, ignoreNormalizerOpts)
 			if foundDiffs && exitCode {
-				os.Exit(1)
+				os.Exit(diffExitCode)
 			}
 		},
 	}
 	command.Flags().BoolVar(&refresh, "refresh", false, "Refresh application data when retrieving")
 	command.Flags().BoolVar(&hardRefresh, "hard-refresh", false, "Refresh application data as well as target manifests cache")
-	command.Flags().BoolVar(&exitCode, "exit-code", true, "Return non-zero exit code when there is a diff")
+	command.Flags().BoolVar(&exitCode, "exit-code", true, "Return non-zero exit code when there is a diff. May also return non-zero exit code if there is an error.")
+	command.Flags().IntVar(&diffExitCode, "diff-exit-code", 1, "Return specified exit code when there is a diff. Typical error code is 20.")
 	command.Flags().StringVar(&local, "local", "", "Compare live app to a local manifests")
 	command.Flags().StringVar(&revision, "revision", "", "Compare live app to a particular revision")
 	command.Flags().StringVar(&localRepoRoot, "local-repo-root", "/", "Path to the repository root. Used together with --local allows setting the repository root")

--- a/docs/user-guide/commands/argocd_app_diff.md
+++ b/docs/user-guide/commands/argocd_app_diff.md
@@ -19,7 +19,8 @@ argocd app diff APPNAME [flags]
 
 ```
   -N, --app-namespace string                              Only render the difference in namespace
-      --exit-code                                         Return non-zero exit code when there is a diff (default true)
+      --diff-exit-code int                                Return specified exit code when there is a diff. Typical error code is 20. (default 1)
+      --exit-code                                         Return non-zero exit code when there is a diff. May also return non-zero exit code if there is an error. (default true)
       --hard-refresh                                      Refresh application data as well as target manifests cache
   -h, --help                                              help for diff
       --ignore-normalizer-jq-execution-timeout duration   Set ignore normalizer JQ execution timeout (default 1s)


### PR DESCRIPTION
The argocd app diff command returns 1 if a difference is found. In related issues, they want to return an error code that is distinguishable from common errors. However, changing the existing behavior is likely to break user's automation code. So we want to provide an explicit option(--diff-exit-code) to specify an error code.

Issue: #3588
