### PR TITLE
fix: handle incorrect cluster RESTconfig without panic

### DIFF
--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -565,7 +565,9 @@ argocd admin cluster kubeconfig https://cluster-api-url:6443 /path/to/output/kub
 
 			cluster, err := db.NewDB(namespace, settings.NewSettingsManager(ctx, kubeclientset, namespace), kubeclientset).GetCluster(ctx, serverUrl)
 			errors.CheckError(err)
-			err = kube.WriteKubeConfig(cluster.RawRestConfig(), namespace, output)
+			rawConfig, err := cluster.RawRestConfig()
+			errors.CheckError(err)
+			err = kube.WriteKubeConfig(rawConfig, namespace, output)
 			errors.CheckError(err)
 		},
 	}

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1163,7 +1163,11 @@ func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Applic
 		logCtx.Infof("Resource entries removed from undefined cluster")
 		return nil
 	}
-	config := metrics.AddMetricsTransportWrapper(ctrl.metricsServer, app, cluster.RESTConfig())
+	clusterRESTConfig, err := cluster.RESTConfig()
+	if err != nil {
+		return err
+	}
+	config := metrics.AddMetricsTransportWrapper(ctrl.metricsServer, app, clusterRESTConfig)
 
 	if app.CascadedDeletion() {
 		logCtx.Infof("Deleting resources")

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -490,7 +490,10 @@ func (c *liveStateCache) getCluster(server string) (clustercache.ClusterCache, e
 		return nil, fmt.Errorf("error getting value for %v: %w", settings.RespectRBAC, err)
 	}
 
-	clusterCacheConfig := cluster.RESTConfig()
+	clusterCacheConfig, err := cluster.RESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error getting cluster RESTConfig: %w", err)
+	}
 	// Controller dynamically fetches all resource types available on the cluster
 	// using a discovery API that may contain deprecated APIs.
 	// This causes log flooding when managing a large number of clusters.
@@ -821,7 +824,12 @@ func (c *liveStateCache) handleModEvent(oldCluster *appv1.Cluster, newCluster *a
 
 		var updateSettings []clustercache.UpdateSettingsFunc
 		if !reflect.DeepEqual(oldCluster.Config, newCluster.Config) {
-			updateSettings = append(updateSettings, clustercache.SetConfig(newCluster.RESTConfig()))
+			newClusterRESTConfig, err := newCluster.RESTConfig()
+			if err == nil {
+				updateSettings = append(updateSettings, clustercache.SetConfig(newClusterRESTConfig))
+			} else {
+				log.Errorf("error getting cluster REST config: %v", err)
+			}
 		}
 		if !reflect.DeepEqual(oldCluster.Namespaces, newCluster.Namespaces) {
 			updateSettings = append(updateSettings, clustercache.SetNamespaces(newCluster.Namespaces))

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -76,7 +76,12 @@ func (m *appStateManager) getResourceOperations(server string) (kube.ResourceOpe
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting cluster: %w", err)
 	}
-	ops, cleanup, err := m.kubectl.ManageResources(cluster.RawRestConfig(), clusterCache.GetOpenAPISchema())
+
+	rawConfig, err := cluster.RawRestConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting cluster REST config: %w", err)
+	}
+	ops, cleanup, err := m.kubectl.ManageResources(rawConfig, clusterCache.GetOpenAPISchema())
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating kubectl ResourceOperations: %w", err)
 	}
@@ -213,8 +218,20 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		return
 	}
 
-	rawConfig := clst.RawRestConfig()
-	restConfig := metrics.AddMetricsTransportWrapper(m.metricsServer, app, clst.RESTConfig())
+	rawConfig, err := clst.RawRestConfig()
+	if err != nil {
+		state.Phase = common.OperationError
+		state.Message = err.Error()
+		return
+	}
+
+	clusterRESTConfig, err := clst.RESTConfig()
+	if err != nil {
+		state.Phase = common.OperationError
+		state.Message = err.Error()
+		return
+	}
+	restConfig := metrics.AddMetricsTransportWrapper(m.metricsServer, app, clusterRESTConfig)
 
 	resourceOverrides, err := m.settingsMgr.GetResourceOverrides()
 	if err != nil {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1284,7 +1284,11 @@ func (s *Server) getApplicationClusterConfig(ctx context.Context, a *appv1.Appli
 	if err != nil {
 		return nil, fmt.Errorf("error getting cluster: %w", err)
 	}
-	config := clst.RESTConfig()
+	config, err := clst.RESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error getting cluster REST config: %w", err)
+	}
+
 	return config, err
 }
 

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -70,7 +70,11 @@ func (s *terminalHandler) getApplicationClusterRawConfig(ctx context.Context, a 
 	if err != nil {
 		return nil, err
 	}
-	return clst.RawRestConfig(), nil
+	rawConfig, err := clst.RawRestConfig()
+	if err != nil {
+		return nil, err
+	}
+	return rawConfig, nil
 }
 
 type GetSettingsFunc func() (*settings.ArgoCDSettings, error)

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -39,6 +39,74 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
+const (
+	rootCACert = `-----BEGIN CERTIFICATE-----
+MIIC4DCCAcqgAwIBAgIBATALBgkqhkiG9w0BAQswIzEhMB8GA1UEAwwYMTAuMTMu
+MTI5LjEwNkAxNDIxMzU5MDU4MB4XDTE1MDExNTIxNTczN1oXDTE2MDExNTIxNTcz
+OFowIzEhMB8GA1UEAwwYMTAuMTMuMTI5LjEwNkAxNDIxMzU5MDU4MIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAunDRXGwsiYWGFDlWH6kjGun+PshDGeZX
+xtx9lUnL8pIRWH3wX6f13PO9sktaOWW0T0mlo6k2bMlSLlSZgG9H6og0W6gLS3vq
+s4VavZ6DbXIwemZG2vbRwsvR+t4G6Nbwelm6F8RFnA1Fwt428pavmNQ/wgYzo+T1
+1eS+HiN4ACnSoDSx3QRWcgBkB1g6VReofVjx63i0J+w8Q/41L9GUuLqquFxu6ZnH
+60vTB55lHgFiDLjA1FkEz2dGvGh/wtnFlRvjaPC54JH2K1mPYAUXTreoeJtLJKX0
+ycoiyB24+zGCniUmgIsmQWRPaOPircexCp1BOeze82BT1LCZNTVaxQIDAQABoyMw
+ITAOBgNVHQ8BAf8EBAMCAKQwDwYDVR0TAQH/BAUwAwEB/zALBgkqhkiG9w0BAQsD
+ggEBADMxsUuAFlsYDpF4fRCzXXwrhbtj4oQwcHpbu+rnOPHCZupiafzZpDu+rw4x
+YGPnCb594bRTQn4pAu3Ac18NbLD5pV3uioAkv8oPkgr8aUhXqiv7KdDiaWm6sbAL
+EHiXVBBAFvQws10HMqMoKtO8f1XDNAUkWduakR/U6yMgvOPwS7xl0eUTqyRB6zGb
+K55q2dejiFWaFqB/y78txzvz6UlOZKE44g2JAVoJVM6kGaxh33q8/FmrL4kuN3ut
+W+MmJCVDvd4eEqPwbp7146ZWTqpIJ8lvA6wuChtqV8lhAPka2hD/LMqY8iXNmfXD
+uml0obOEy+ON91k+SWTJ3ggmF/U=
+-----END CERTIFICATE-----`
+
+	certData = `-----BEGIN CERTIFICATE-----
+MIIC6jCCAdSgAwIBAgIBCzALBgkqhkiG9w0BAQswIzEhMB8GA1UEAwwYMTAuMTMu
+MTI5LjEwNkAxNDIxMzU5MDU4MB4XDTE1MDExNTIyMDEzMVoXDTE2MDExNTIyMDEz
+MlowGzEZMBcGA1UEAxMQb3BlbnNoaWZ0LWNsaWVudDCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAKtdhz0+uCLXw5cSYns9rU/XifFSpb/x24WDdrm72S/v
+b9BPYsAStiP148buylr1SOuNi8sTAZmlVDDIpIVwMLff+o2rKYDicn9fjbrTxTOj
+lI4pHJBH+JU3AJ0tbajupioh70jwFS0oYpwtneg2zcnE2Z4l6mhrj2okrc5Q1/X2
+I2HChtIU4JYTisObtin10QKJX01CLfYXJLa8upWzKZ4/GOcHG+eAV3jXWoXidtjb
+1Usw70amoTZ6mIVCkiu1QwCoa8+ycojGfZhvqMsAp1536ZcCul+Na+AbCv4zKS7F
+kQQaImVrXdUiFansIoofGlw/JNuoKK6ssVpS5Ic3pgcCAwEAAaM1MDMwDgYDVR0P
+AQH/BAQDAgCgMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwCwYJ
+KoZIhvcNAQELA4IBAQCKLREH7bXtXtZ+8vI6cjD7W3QikiArGqbl36bAhhWsJLp/
+p/ndKz39iFNaiZ3GlwIURWOOKx3y3GA0x9m8FR+Llthf0EQ8sUjnwaknWs0Y6DQ3
+jjPFZOpV3KPCFrdMJ3++E3MgwFC/Ih/N2ebFX9EcV9Vcc6oVWMdwT0fsrhu683rq
+6GSR/3iVX1G/pmOiuaR0fNUaCyCfYrnI4zHBDgSfnlm3vIvN2lrsR/DQBakNL8DJ
+HBgKxMGeUPoneBv+c8DMXIL0EhaFXRlBv9QW45/GiAIOuyFJ0i6hCtGZpJjq4OpQ
+BRjCI+izPzFTjsxD4aORE+WOkyWFCGPWKfNejfw0
+-----END CERTIFICATE-----`
+
+	keyData = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAq12HPT64ItfDlxJiez2tT9eJ8VKlv/HbhYN2ubvZL+9v0E9i
+wBK2I/Xjxu7KWvVI642LyxMBmaVUMMikhXAwt9/6jaspgOJyf1+NutPFM6OUjikc
+kEf4lTcAnS1tqO6mKiHvSPAVLShinC2d6DbNycTZniXqaGuPaiStzlDX9fYjYcKG
+0hTglhOKw5u2KfXRAolfTUIt9hcktry6lbMpnj8Y5wcb54BXeNdaheJ22NvVSzDv
+RqahNnqYhUKSK7VDAKhrz7JyiMZ9mG+oywCnXnfplwK6X41r4BsK/jMpLsWRBBoi
+ZWtd1SIVqewiih8aXD8k26gorqyxWlLkhzemBwIDAQABAoIBAD2XYRs3JrGHQUpU
+FkdbVKZkvrSY0vAZOqBTLuH0zUv4UATb8487anGkWBjRDLQCgxH+jucPTrztekQK
+aW94clo0S3aNtV4YhbSYIHWs1a0It0UdK6ID7CmdWkAj6s0T8W8lQT7C46mWYVLm
+5mFnCTHi6aB42jZrqmEpC7sivWwuU0xqj3Ml8kkxQCGmyc9JjmCB4OrFFC8NNt6M
+ObvQkUI6Z3nO4phTbpxkE1/9dT0MmPIF7GhHVzJMS+EyyRYUDllZ0wvVSOM3qZT0
+JMUaBerkNwm9foKJ1+dv2nMKZZbJajv7suUDCfU44mVeaEO+4kmTKSGCGjjTBGkr
+7L1ySDECgYEA5ElIMhpdBzIivCuBIH8LlUeuzd93pqssO1G2Xg0jHtfM4tz7fyeI
+cr90dc8gpli24dkSxzLeg3Tn3wIj/Bu64m2TpZPZEIlukYvgdgArmRIPQVxerYey
+OkrfTNkxU1HXsYjLCdGcGXs5lmb+K/kuTcFxaMOs7jZi7La+jEONwf8CgYEAwCs/
+rUOOA0klDsWWisbivOiNPII79c9McZCNBqncCBfMUoiGe8uWDEO4TFHN60vFuVk9
+8PkwpCfvaBUX+ajvbafIfHxsnfk1M04WLGCeqQ/ym5Q4sQoQOcC1b1y9qc/xEWfg
+nIUuia0ukYRpl7qQa3tNg+BNFyjypW8zukUAC/kCgYB1/Kojuxx5q5/oQVPrx73k
+2bevD+B3c+DYh9MJqSCNwFtUpYIWpggPxoQan4LwdsmO0PKzocb/ilyNFj4i/vII
+NToqSc/WjDFpaDIKyuu9oWfhECye45NqLWhb/6VOuu4QA/Nsj7luMhIBehnEAHW+
+GkzTKM8oD1PxpEG3nPKXYQKBgQC6AuMPRt3XBl1NkCrpSBy/uObFlFaP2Enpf39S
+3OZ0Gv0XQrnSaL1kP8TMcz68rMrGX8DaWYsgytstR4W+jyy7WvZwsUu+GjTJ5aMG
+77uEcEBpIi9CBzivfn7hPccE8ZgqPf+n4i6q66yxBJflW5xhvafJqDtW2LcPNbW/
+bvzdmQKBgExALRUXpq+5dbmkdXBHtvXdRDZ6rVmrnjy4nI5bPw+1GqQqk6uAR6B/
+F6NmLCQOO4PDG/cuatNHIr2FrwTmGdEL6ObLUGWn9Oer9gJhHVqqsY5I4sEPo4XX
+stR0Yiw0buV6DL/moUO0HIM9Bjh96HJp+LxiIS6UCdIhMPp5HoQa
+-----END RSA PRIVATE KEY-----`
+)
+
 func newServerInMemoryCache() *servercache.Cache {
 	return servercache.NewCache(
 		appstatecache.NewCache(
@@ -236,6 +304,42 @@ func TestGetCluster_NameWithUrlEncodingButShouldNotBeUnescaped(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "test%2fing", cluster.Name)
+}
+
+func TestGetCluster_CannotSetCADataAndInsecureTrue(t *testing.T) {
+	testNamespace := "default"
+	cluster := &v1alpha1.Cluster{
+		Name:       "my-cluster-name",
+		Server:     "https://my-cluster-server",
+		Namespaces: []string{testNamespace},
+		Config: v1alpha1.ClusterConfig{
+			TLSClientConfig: v1alpha1.TLSClientConfig{
+				Insecure: true,
+				CAData:   []byte(rootCACert),
+				CertData: []byte(certData),
+				KeyData:  []byte(keyData),
+			},
+		},
+	}
+	clientset := getClientset(nil, testNamespace)
+	db := db.NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
+	server := NewServer(db, newNoopEnforcer(), newServerInMemoryCache(), &kubetest.MockKubectlCmd{})
+
+	t.Run("Create Fails When CAData is Set and Insecure is True", func(t *testing.T) {
+		_, err := server.Create(context.Background(), &clusterapi.ClusterCreateRequest{
+			Cluster: cluster,
+		})
+
+		assert.EqualError(t, err, `Unable to apply K8s REST config defaults: specifying a root certificates file with the insecure flag is not allowed`)
+	})
+
+	cluster.Config.TLSClientConfig.CAData = nil
+	t.Run("Create Succeeds When CAData is nil and Insecure is True", func(t *testing.T) {
+		_, err := server.Create(context.Background(), &clusterapi.ClusterCreateRequest{
+			Cluster: cluster,
+		})
+		require.NoError(t, err)
+	})
 }
 
 func TestUpdateCluster_NoFieldsPaths(t *testing.T) {

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -329,7 +329,10 @@ func ValidateRepo(
 		})
 		return conditions, nil
 	}
-	config := cluster.RESTConfig()
+	config, err := cluster.RESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error getting cluster REST config: %w", err)
+	}
 	// nolint:staticcheck
 	cluster.ServerVersion, err = kubectl.GetServerVersion(config)
 	if err != nil {


### PR DESCRIPTION
# Description
fixes https://github.com/argoproj/argo-cd/issues/19496

The issue arises when a cluster has its secret configuration set with `insecure` as `true` but includes a non-empty `caData`. This PR resolves the issue by handling the error gracefully rather than causing a panic.

# Testing Instruction

1. Deploy a kind cluster. `kind create cluster`.
2. Add the cluster to ArgoCD by creating the following secret ( `yq` is needed to run the command):

```
cat << EOF > /tmp/kind-cluster-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: mycluster-kind
  labels:
    argocd.argoproj.io/secret-type: cluster
type: Opaque
stringData:
  name: kind
  server: $(kind get kubeconfig | yq eval '.clusters[0].cluster["server"]' -)
  config: |
    $(kind get kubeconfig | yq eval -j '
     {
          "tlsClientConfig": {
            "keyData": .users[0].user["client-key-data"],
            "certData": .users[0].user["client-certificate-data"],
            "insecure":  false,
            "caData": .clusters[0].cluster["certificate-authority-data"]
          }
      }' -)

EOF
```
In my case, the following is generated `/tmp/kind-cluster-secret.yaml`:
```
apiVersion: v1
kind: Secret
metadata:
  name: mycluster-kind
  labels:
    argocd.argoproj.io/secret-type: cluster
type: Opaque
stringData:
  name: kind
  server: https://127.0.0.1:37173
  config: |
    {
      "tlsClientConfig": {
        "keyData": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBMTZmMnlTY1lqKzVmMERNRlJNalp6VW0xOW5rRmIyRHF0ZTdETXlhVE43TG5pbTJrCkVGTjF6NFd6NkhKcytPelhtNld6RGlxcng4NVo5LzJHWDJQZjJvQVVvclBJQU41TWtadEVWTWNoSEZodmNOWWwKZjd5L3Y2czJrZWVPQnpPOTgzVUNFWmM1bEFnYmltWDBnWVJLNjhndXhDVHNvU0JyalY2OGZhVHc2ai9UTG1kdgp4ZENmMHBrSXBRSm8rRkkwdEN1dkt2REh1eWU5c3doSm5oZitqdmlqcVJYZmR4bXIwdDd6c1FYZHZjZlJHSGNpCmw5dWNoUDZzRk5DOHJxODJhRWtPNmdtbkRvb1RSNld1Y3lNTGt6eVpEdTJpOGpucEJ6QUh1a1A5cDBld0YxODYKbG8zY21GbWZHMnJpVm5iSnI0TmJCdy9VbXE2UmQyc1FNQjdoWXdJREFRQUJBb0lCQVFDRnJ4ZHFwcE94VllHTApuTFVkYUt5cmQ1QVhFL3BzaXRXMHBpZlhJNGlMTkpvWDA5T3FVekpxekdVMEtRcW9YSmxqWVJwWUk5ZU02cndXCjROQlZmYUljM3R6cjV5cUtiME5qMTY1S0o0Njg5WTFQazFCM21OZjh4dlB6Q21tZXlWSnRBeEdmT2ZGMWRIa3UKRi9teitBQkJuVHh3VnJ0aFBxbXRYeGJWaEZQYndVV21kVzY1Q0w3Tk9qQXNiUjZ0SlkyL2hRaEtWanVla3ZCMApiT1htRWhlS1FrWVVnV3crSkNKRDE0a2J3ZDJiQXEvd1B0Zk95K3JMQXlHelFSNTA2QUxiTHRVeGg4Y2MxY2xhClNQNXAyZVk1SXNZdXdldHl2b3A0TFB4YkxsaTlRNnBOK0dWQ1NLaFAzUjZQTllsN290c3ZWZE1URnY3OGJxWkwKSXJzaUpkS0JBb0dCQU9vbEVFeDVKQW93aXQ2aUxvSWt0R0Era0x2RGVORndsbUZ6Z242YUJLWFdpK0JJU1d5OApFQnNIL1JWK1d4akg5WUlGdjlnaGMwR3gxcFZ3czNGL3B1MGxhd2M4NjJ1YXJHVU1ZTjJiRlRkNTNtMWh2M0pCCkdndHJ4OE1BbDhpdzNwZXJXbHplYkxiNXhqVUovQ1E2T1NLMUtORTgyTDc5ejltRkUvWkJPcGlEQW9HQkFPdkoKSEIvUmRkT1dvWWd6UTc2SXJkUnRhOUZSVW42TUhIMElMT1FkVWFnM2FWaUFjb0tXYjhKRmFGdlRwZzlaVGxCcQpiU0xIV0NaMFdMRmM0T0M2WFppR2E0dEkzcHdDMmV4OUhiZTFicWUwbytmd2gycWZaSGVyM3JTMllRRzFwSEhOCmxkQzc3NkIrUFovbnNRM1QrWFFaY0RaaENET2ZvZDRvMm5WUGIzMmhBb0dCQUllbUVWczhrM1NUeXVCUWRVRlEKb205Zno5bjMxUGNCa3gzQ0hjZmEwdmFBNVdoNmVJOVdKTDZFVWtzeGVQVlNZeG1BMnpRTHJRcFNUVThtaTg4bApkVC9PZmNNanVBQVBDL0UreXArWVNTSnFxRUlXYnlOeU0vU0o3S0U4cHJMT1JTYjVUdENleTd6MTE2N0NxaUVTCjJpY1JiU1JMYkFhNlpNQlFLTkJ4MmRDaEFuOGJvWFdxUk9HSjZoMEQyUDRYVmUwSTk4bXF2ZHpzOTM1ZktKWWEKSlZWc1lSSDNUUlllTjRMaFFVRDVnZFB6K0lNMDZVUGd6M3VGQmgxZXE0T3UwaWdsdDVyaXQ2ZGVvUGJvdjhDNwp4b2N4SC9vVk5CcXFaQU5pQXNJV2Ewank2bFphLzd5T3VYZGJWMi9oVFVWeVdXVGlOaGp3Um02dm5nVmFBMitXClQ3akJBb0dCQU5xSi94UldnbkZsTkZxUmpuZFZ5eTRiVk0wV3U2ZXVNRjBZRGJUcDdpZkRYRUY2REhBa1RKS0oKU1E5TFQ1NUZXZVJHWTRaSGVZTjZpV0lMbUgwZ01ITUxsVFFnSVRydDVIMDZ6cHFtelNSUGtYT2JXbytyb2EySQovQmlOeUZvRys3T0xzMGEvQXFncE1XR2RqdGNwTnFndmkzSHRXelZlSWY3VzJYNTBsVms1Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==",
        "certData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLVENDQWhHZ0F3SUJBZ0lJVDdPSk4rTDdVZ3N3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TkRBNU1qRXlNVEEyTkRGYUZ3MHlOVEE1TWpFeU1URXhOREZhTUR3eApIekFkQmdOVkJBb1RGbXQxWW1WaFpHMDZZMngxYzNSbGNpMWhaRzFwYm5NeEdUQVhCZ05WQkFNVEVHdDFZbVZ5CmJtVjBaWE10WVdSdGFXNHdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEWHAvYkoKSnhpUDdsL1FNd1ZFeU5uTlNiWDJlUVZ2WU9xMTdzTXpKcE0zc3VlS2JhUVFVM1hQaGJQb2NtejQ3TmVicGJNTwpLcXZIemxuMy9ZWmZZOS9hZ0JTaXM4Z0Eza3lSbTBSVXh5RWNXRzl3MWlWL3ZMKy9xemFSNTQ0SE03M3pkUUlSCmx6bVVDQnVLWmZTQmhFcnJ5QzdFSk95aElHdU5Ycng5cFBEcVA5TXVaMi9GMEovU21RaWxBbWo0VWpTMEs2OHEKOE1lN0o3MnpDRW1lRi82TytLT3BGZDkzR2F2UzN2T3hCZDI5eDlFWWR5S1gyNXlFL3F3VTBMeXVyelpvU1E3cQpDYWNPaWhOSHBhNXpJd3VUUEprTzdhTHlPZWtITUFlNlEvMm5SN0FYWHpxV2pkeVlXWjhiYXVKV2RzbXZnMXNICkQ5U2FycEYzYXhBd0h1RmpBZ01CQUFHalZqQlVNQTRHQTFVZER3RUIvd1FFQXdJRm9EQVRCZ05WSFNVRUREQUsKQmdnckJnRUZCUWNEQWpBTUJnTlZIUk1CQWY4RUFqQUFNQjhHQTFVZEl3UVlNQmFBRk53YVFpNmtEdnFPaTJjTAo1ZENKRnphdEtwZHBNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJ5eWpLU1BGakUwTmJqY0Y3Vm9KSnNuTE42CmxOcjNlSU80NEU3eDJCNkh6VXFOMTFGN2JJRU5PWjJNVEFRSCtkMHg2eVdUZFBSazJ2dE05TjlrOVR0U2Qxa2oKdlh6bGVmbjBzR2pKU2JjczlpeG9GRjJZdUVVTk1TK1dqWTZHOVJtV2xDalJ1OFNHQ1NtK3RBejdtWWJnZEQ4bgpsbDlLZUF5dEtiWnJTWlJVYzQ2ZGJTYktldlFoVHdFd2RXTU5BeFcwUDRCUU83bis3K2ljSE9nRGs4VUEzaUkzCkdmazNBRzBOc21BTUV3Tndkek81UXNzYm9ZanRVLzZvSm92K1c0VGlVWU1qazM0OTFaZlRSKzJzQkxxNDMzOFEKSyt0eFBZQmlSdk5od05vQjhISnFHZmxSTFhCUTBoVGxvMURQcC9EWkJEUDR3bktGOTZrTTV3UDlLaW13Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
        "insecure": false,
        "caData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lJYjJTcmhBMzJjNzh3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TkRBNU1qRXlNVEEyTkRGYUZ3MHpOREE1TVRreU1URXhOREZhTUJVeApFekFSQmdOVkJBTVRDbXQxWW1WeWJtVjBaWE13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURCeWpCeEl5NHlkVnRVUFhIbGNiYkYzSGwwRkNUTnE3UFBPb1hHODd3Zzh0RlExd1RicWg0Uit2MlUKUThJLyt1UmNRMllibGJiQzZnekY1NlhqUWJMRG9UOWwxbHJlVEl3emdCUG9UaTZmQmwvQjQ5dmFqdFQxbDNYbQpFSDNJTmhaME5FbTlZQXZZVmoyc2libWhIaDVrWnNDQUdOeW5JZFlUYkNIYlZRaEFtdUV2YzdDNG1qNlNCbFZPCkJJQkt2NGhyZ3c2dUhQMFJtOVhoR0dnbk5wQU1IYUtxaitoZ1lQcis5WFVWRW1pZjkyRjRnZTdvSlhWUC9nY3YKNllBd1d4K0NpN1RwczhZbGxFd3pCUVNiSHhURE45L3U5U2Vja0FlRHl0bmplK2Q3RjhqeFg5eFNabjZEc2tQRgpxNEova1V6MlN6ZW41SFRHNmRxYmQwTUdVVnVGQWdNQkFBR2pXVEJYTUE0R0ExVWREd0VCL3dRRUF3SUNwREFQCkJnTlZIUk1CQWY4RUJUQURBUUgvTUIwR0ExVWREZ1FXQkJUY0drSXVwQTc2am90bkMrWFFpUmMyclNxWGFUQVYKQmdOVkhSRUVEakFNZ2dwcmRXSmxjbTVsZEdWek1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ2pUYjFJOUQyWApONFNJQjljc1FjK3dSRUV0NlhWYVhIOVUycW9NVFR3VFRrUW9mNzIrYk9jMG1UaHZnR21KTmZiaEVzWFJES1VkCk1PTVAwWEtZZ0lOMlNENE02dHE0c1J2WnJocTY2ck5vRlJFNUpmKzFxKzBxakhpdDA4OWFlMldWRHhzN1BGMGIKb1k3WW9MTXpvTGdSNjQ4NkdQdlRMYm8wcHVveDJIVHlMYjhWSUFwVStJU0tIcDBrT2pBTFJuSUhEbTM4RG1WVgpTZ0d3aGd1N284UkFPbzhTZit2QVJLTXhvZ2d6NWc4QkQzQzRteE9mcUNndVFUeitXc0JKTldQUkFYaHFWRFNQCm81Vk5iN0FsR2d5Y2VKS3k5LzVNczM0WVlPdkRDK1NDT2k2MWFPbXBTd1BHanIrSm5LTmI2anpSdjhDYlNSQXYKcXRnMnhRVERDWjRJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
      }
    }

```
Create the secret by running  `kubectl apply -f /tmp/kind-cluster-secret.yaml`.

3. Create an ArgoCD Application and assign it to the created cluster.  Everything should be working normally.
4. Set `insecure` to `true` then update the secret:
```
sed -i  's/false/true/' /tmp/kind-cluster-secret.yaml&& kubectl apply -f /tmp/kind-cluster-secret.yaml
```
5. The controller fails with the following:
<details>
<summary>Trace</summary>

```
19:35:00                controller | panic: Unable to apply K8s REST config defaults: specifying a root certificates file with the insecure flag is not allowed [recovered]
19:35:00                controller | 	panic: Unable to apply K8s REST config defaults: specifying a root certificates file with the insecure flag is not allowed
19:35:00                controller | goroutine 93 [running]:
19:35:00                controller | k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x7375150, 0xa0cffc0}, {0x5c85840, 0xc0047161b0}, {0xa0cffc0, 0x0, 0x224b125?})
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/runtime/runtime.go:89 +0xee
19:35:00                controller | k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc001a941c0?})
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/runtime/runtime.go:59 +0x108
19:35:00                controller | panic({0x5c85840?, 0xc0047161b0?})
19:35:00                controller | 	/usr/local/go/src/runtime/panic.go:785 +0x132
19:35:00                controller | github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1.(*Cluster).RESTConfig(0x645e2c0?)
19:35:00                controller | 	/home/cef/work/misc/K8S/argocd/argo-cd/pkg/apis/application/v1alpha1/types.go:3198 +0x79
19:35:00                controller | github.com/argoproj/argo-cd/v2/controller/cache.(*liveStateCache).handleModEvent(0xc000842b60, 0xc00083e1e0, 0xc00083e3c0)
19:35:00                controller | 	/home/cef/work/misc/K8S/argocd/argo-cd/controller/cache/cache.go:824 +0x165
19:35:00                controller | github.com/argoproj/argo-cd/v2/util/db.(*db).WatchClusters.func2(0xc0010b4c80, 0xc004b28000)
19:35:00                controller | 	/home/cef/work/misc/K8S/argocd/argo-cd/util/db/cluster.go:184 +0xda
19:35:00                controller | github.com/argoproj/argo-cd/v2/util/db.(*db).watchSecrets.func4({0x670afc0?, 0xc0010b4c80?}, {0x670afc0?, 0xc004b28000?})
19:35:00                controller | 	/home/cef/work/misc/K8S/argocd/argo-cd/util/db/secrets.go:134 +0x49
19:35:00                controller | k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/controller.go:253
19:35:00                controller | k8s.io/client-go/tools/cache.(*processorListener).run.func1()
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/shared_informer.go:976 +0xea
19:35:00                controller | k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:226 +0x33
19:35:00                controller | k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0047c9f70, {0x7335440, 0xc001404f90}, 0x1, 0xc00140a690)
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:227 +0xaf
19:35:00                controller | k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc001308770, 0x3b9aca00, 0x0, 0x1, 0xc00140a690)
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:204 +0x7f
19:35:00                controller | k8s.io/apimachinery/pkg/util/wait.Until(...)
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:161
19:35:00                controller | k8s.io/client-go/tools/cache.(*processorListener).run(0xc00144a3f0)
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/shared_informer.go:972 +0x5a
19:35:00                controller | k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/wait.go:72 +0x4c
19:35:00                controller | created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 292
19:35:00                controller | 	/home/cef/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/wait.go:70 +0x73
19:35:00                controller | exit status 2
19:35:00                controller | Terminating controller
```
</details>


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
