### PR TITLE
chore(ci): better handling of Go and Node dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # We use consistent go and node versions across a lot of different files, and updating via dependabot would cause
+      # drift among those files.
+      # Use `make update-go` and `make update-node` to update these versions.
+      - dependency-name: "library/golang"
+      - dependency-name: "library/node"
 
   - package-ecosystem: "docker"
     directory: "/test/container/"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.22'
+  GOLANG_VERSION: '1.23.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -305,7 +305,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
         with:
-          node-version: '21.6.1'
+          node-version: '22.8.0'
       - name: Restore node dependency cache
         id: cache-dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.58.2
+          version: v1.61.0
           args: --verbose
 
   test-go:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/image-reuse.yaml
     with:
       # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
-      go-version: 1.22
+      go-version: 1.23.1
       platforms: ${{ needs.set-vars.outputs.platforms }}
       push: false
 
@@ -68,7 +68,7 @@ jobs:
       quay_image_name: quay.io/argoproj/argocd:latest
       ghcr_image_name: ghcr.io/argoproj/argo-cd/argocd:${{ needs.set-vars.outputs.image-tag }}
       # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
-      go-version: 1.22
+      go-version: 1.23.1
       platforms: ${{ needs.set-vars.outputs.platforms }}
       push: true
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 
 env:
-  GOLANG_VERSION: '1.22' # Note: go-version must also be set in job argocd-image.with.go-version
+  GOLANG_VERSION: '1.23.1' # Note: go-version must also be set in job argocd-image.with.go-version
 
 jobs:
   argocd-image:
@@ -23,7 +23,7 @@ jobs:
     with:
       quay_image_name: quay.io/argoproj/argocd:${{ github.ref_name }}
       # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
-      go-version: 1.22
+      go-version: 1.23.1
       platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
       push: true
     secrets:

--- a/.github/workflows/update-go.yaml
+++ b/.github/workflows/update-go.yaml
@@ -1,0 +1,42 @@
+# Update golang version on a daily basis and open a PR.
+name: Update Go
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  update-go:
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.repository == 'argoproj/argo-cd'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+    - name: Update Go
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        make update-go
+        
+        # If there are no changes, quit early.
+        if [[ -z $(git status -s) ]]; then
+          echo "No changes detected"
+          exit 0
+        fi
+        
+        pr_branch="update-go-$(echo $RANDOM | md5sum | head -c 20)"
+        git checkout -b "$pr_branch"
+        git config --global user.email 'ci@argoproj.com'
+        git config --global user.name 'CI'
+        git add .
+        git commit -m "[Bot] chore(dep): Update Go" --signoff
+        git push --set-upstream origin "$pr_branch"
+        gh pr create -B master -H "$pr_branch" --title '[Bot] chore(dep): Update Go' --body ''

--- a/.github/workflows/update-node.yaml
+++ b/.github/workflows/update-node.yaml
@@ -1,0 +1,42 @@
+# Update Node version on a daily basis and open a PR.
+name: Update Node
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  update-node:
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.repository == 'argoproj/argo-cd'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+      - name: Update Node
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make update-node
+          
+          # If there are no changes, quit early.
+          if [[ -z $(git status -s) ]]; then
+            echo "No changes detected"
+            exit 0
+          fi
+          
+          pr_branch="update-node-$(echo $RANDOM | md5sum | head -c 20)"
+          git checkout -b "$pr_branch"
+          git config --global user.email 'ci@argoproj.com'
+          git config --global user.name 'CI'
+          git add .
+          git commit -m "[Bot] chore(dep): Update Node" --signoff
+          git push --set-upstream origin "$pr_branch"
+          gh pr create -B master -H "$pr_branch" --title '[Bot] chore(dep): Update Node' --body ''

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=docker.io/library/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8
 # Initial stage which pulls prepares build dependencies and CLI tooling we need for our final image
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
-FROM docker.io/library/golang:1.23.1@sha256:2fe82a3f3e006b4f2a316c6a21f62b66e1330ae211d039bb8d1128e12ed57bf1 AS builder
+FROM docker.io/library/golang:1.23.1@sha256:4f063a24d429510e512cc730c3330292ff49f3ade3ae79bda8f84a24fa25ecb0 AS builder
 
 RUN echo 'deb http://archive.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 
@@ -83,7 +83,7 @@ WORKDIR /home/argocd
 ####################################################################################################
 # Argo CD UI stage
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:22.9.0@sha256:cbe2d5f94110cea9817dd8c5809d05df49b4bd1aac5203f3594d88665ad37988 AS argocd-ui
+FROM --platform=$BUILDPLATFORM docker.io/library/node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52 AS argocd-ui
 
 WORKDIR /src
 COPY ["ui/package.json", "ui/yarn.lock", "./"]
@@ -101,7 +101,7 @@ RUN HOST_ARCH=$TARGETARCH NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OP
 ####################################################################################################
 # Argo CD Build stage which performs the actual build of Argo CD binaries
 ####################################################################################################
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.1@sha256:2fe82a3f3e006b4f2a316c6a21f62b66e1330ae211d039bb8d1128e12ed57bf1 AS argocd-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.1@sha256:4f063a24d429510e512cc730c3330292ff49f3ade3ae79bda8f84a24fa25ecb0 AS argocd-build
 
 WORKDIR /go/src/github.com/argoproj/argo-cd
 

--- a/Makefile
+++ b/Makefile
@@ -631,6 +631,14 @@ snyk-non-container-tests:
 snyk-report:
 	./hack/snyk-report.sh $(target_branch)
 
+.PHONY: update-go
+update-go:
+	./hack/update-go.sh
+
+.PHONY: update-node
+update-node:
+	./hack/update-node.sh
+
 .PHONY: help
 help:
 	@echo 'Note: Generally an item w/ (-local) will run inside docker unless you use the -local variant'

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2
+GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0

--- a/hack/update-go.sh
+++ b/hack/update-go.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This script is used to update the Go version in the project.
+# We use this because Dependabot doesn't support updating the Go version in all the places we use Go.
+
+set -e
+
+echo "Getting latest Go version..."
+
+# Get the current stable Go version. This assumes the JSON is sorted newest-to-oldest.
+GO_VERSION=$(curl -s https://go.dev/dl/?mode=json | jq 'map(select(.stable == true))[0].version' -r)
+
+# Make sure the version number is semver.
+if [[ ! "$GO_VERSION" =~ ^go[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Failed to get the latest Go version."
+  exit 1
+fi
+
+# Remove the 'go' prefix from the version number.
+GO_VERSION=${GO_VERSION#go}
+
+# Get the digest of the Go image.
+DIGEST=$(crane digest "docker.io/library/golang:$GO_VERSION")
+
+echo "Updating to Go version $GO_VERSION with digest $DIGEST..."
+
+# Replace the Go image in the Dockerfile.
+sed -r -i.bak "s/docker\.io\/library\/golang:[0-9.]+@sha256:[0-9a-f]+/docker.io\/library\/golang:$GO_VERSION@$DIGEST/" Dockerfile test/container/Dockerfile test/remote/Dockerfile
+rm Dockerfile.bak test/container/Dockerfile.bak test/remote/Dockerfile.bak
+
+# Update the go version in ci-build.yaml, image.yaml, and release.yaml.
+sed -r -i.bak "s/go-version: [0-9.]+/go-version: $GO_VERSION/" .github/workflows/ci-build.yaml .github/workflows/image.yaml .github/workflows/release.yaml
+rm .github/workflows/ci-build.yaml.bak .github/workflows/image.yaml.bak .github/workflows/release.yaml.bak
+
+# Repeat for env var instead of go-version.
+sed -r -i.bak "s/GOLANG_VERSION: '[0-9.]+'/GOLANG_VERSION: '$GO_VERSION'/" .github/workflows/ci-build.yaml .github/workflows/image.yaml .github/workflows/release.yaml
+rm .github/workflows/ci-build.yaml.bak .github/workflows/image.yaml.bak .github/workflows/release.yaml.bak
+

--- a/hack/update-node.sh
+++ b/hack/update-node.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This script is used to update the node version in the project.
+# We use this because Dependabot doesn't support updating the Node version in all the places we use Node.
+
+set -e
+
+echo "Getting latest Node version..."
+
+# Get the current LTS node version. This assumes the JSON is sorted newest-to-oldest.
+NODE_VERSION=$(curl -s https://nodejs.org/download/release/index.json | jq '.[0].version' -r)
+
+# Make sure the version number is semver with a preceding 'v'.
+if [[ ! "$NODE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Failed to get the latest Node version."
+  exit 1
+fi
+
+# Strip the preceding 'v' from the version number.
+NODE_VERSION=${NODE_VERSION#v}
+
+# Get the manifest SHA of the library/node image.
+DIGEST=$(crane digest "docker.io/library/node:$NODE_VERSION")
+
+echo "Updating to Node version $NODE_VERSION with digest $DIGEST..."
+
+# Replace the node image in the Dockerfiles.
+sed -r -i.bak "s/docker\.io\/library\/node:[0-9.]+@sha256:[0-9a-f]+/docker.io\/library\/node:$NODE_VERSION@$DIGEST/" Dockerfile ui-test/Dockerfile test/container/Dockerfile
+rm Dockerfile.bak ui-test/Dockerfile.bak test/container/Dockerfile.bak
+
+# Replace node version in ci-build.yaml.
+sed -r -i.bak "s/node-version: '[0-9.]+'/node-version: '$NODE_VERSION'/" .github/workflows/ci-build.yaml
+rm .github/workflows/ci-build.yaml.bak

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -6,9 +6,9 @@ FROM docker.io/library/redis:7.4.0@sha256:eadf354977d428e347d93046bb1a5569d701e8
 RUN ln -s /usr/lib/$(uname -m)-linux-gnu /usr/lib/linux-gnu
 
 # Please make sure to also check the contained yarn version and update the references below when upgrading this image's version
-FROM docker.io/library/node:22.9.0@sha256:cbe2d5f94110cea9817dd8c5809d05df49b4bd1aac5203f3594d88665ad37988 as node
+FROM docker.io/library/node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52 as node
 
-FROM docker.io/library/golang:1.23@sha256:2fe82a3f3e006b4f2a316c6a21f62b66e1330ae211d039bb8d1128e12ed57bf1 as golang
+FROM docker.io/library/golang:1.23.1@sha256:4f063a24d429510e512cc730c3330292ff49f3ade3ae79bda8f84a24fa25ecb0 as golang
 
 FROM docker.io/library/registry:2.8@sha256:ac0192b549007e22998eb74e8d8488dcfe70f1489520c3b144a6047ac5efbe90 as registry
 

--- a/test/remote/Dockerfile
+++ b/test/remote/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=docker.io/library/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
 
-FROM docker.io/library/golang:1.23.1@sha256:2fe82a3f3e006b4f2a316c6a21f62b66e1330ae211d039bb8d1128e12ed57bf1 AS go
+FROM docker.io/library/golang:1.23.1@sha256:4f063a24d429510e512cc730c3330292ff49f3ade3ae79bda8f84a24fa25ecb0 AS go
 
 RUN go install github.com/mattn/goreman@latest && \
     go install github.com/kisielk/godepgraph@latest

--- a/ui-test/Dockerfile
+++ b/ui-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:22.9.0@sha256:cbe2d5f94110cea9817dd8c5809d05df49b4bd1aac5203f3594d88665ad37988 as node
+FROM docker.io/library/node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52 as node
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     software-properties-common 


### PR DESCRIPTION
Dependabot does a pretty bad job of keeping our golang and Node versions up to date and in sync.

We'll have to maintain these scripts, but I think it's still better than the current experience.

I've tested both scripts on my fork.