### PR TITLE
fix(pkce): 20111 PKCE auth flow does not return user to previous path like dex auth flow

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -4,6 +4,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import {Helmet} from 'react-helmet';
 import {Redirect, Route, RouteComponentProps, Router, Switch} from 'react-router';
+import {Subscription} from 'rxjs';
 import applications from './applications';
 import help from './help';
 import login from './login';
@@ -21,7 +22,6 @@ import {AuthSettings} from './shared/models';
 import {PKCEVerification} from './login/components/pkce-verify';
 import {getPKCERedirectURI, pkceLogin} from './login/components/utils';
 import {SystemLevelExtension} from './shared/services/extensions-service';
-import {Subscription} from 'rxjs';
 
 services.viewPreferences.init();
 const bases = document.getElementsByTagName('base');

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -110,7 +110,7 @@ requests.onError.subscribe(async err => {
                     ctx.notifications.show({
                         type: NotificationType.Error,
                         content: err?.message || JSON.stringify(err)
-                    })
+                    });
                 });
             } else {
                 window.location.href = `${basehref}/auth/login?return_url=${encodeURIComponent(location.href)}`;

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -103,11 +103,10 @@ requests.onError.subscribe(async err => {
         const basehref = document.querySelector('head > base').getAttribute('href').replace(/\/$/, '');
         if (isSSO) {
             const authSettings = await services.authService.settings();
-            const ctx = React.useContext(Context);
 
             if (authSettings?.oidcConfig?.enablePKCEAuthentication) {
                 pkceLogin(authSettings.oidcConfig, getPKCERedirectURI().toString()).catch(err => {
-                    ctx.notifications.show({
+                    Context.notifications.show({
                         type: NotificationType.Error,
                         content: err?.message || JSON.stringify(err)
                     });

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -124,7 +124,7 @@ export class App extends React.Component<
 
     public async componentDidMount() {
         this.popupPropsSubscription = this.popupManager.popupProps.subscribe(popupProps => this.setState({popupProps}));
-        this.subscribeUnauthorized().then((subscription) => {
+        this.subscribeUnauthorized().then(subscription => {
             this.unauthorizedSubscription = subscription;
         });
         const authSettings = await services.authService.settings();
@@ -244,7 +244,7 @@ export class App extends React.Component<
                 if (history.location.pathname.startsWith('/login')) {
                     return;
                 }
-        
+
                 const isSSO = await isExpiredSSO();
                 // location might change after async method call, so we need to check again.
                 if (history.location.pathname.startsWith('/login')) {
@@ -255,7 +255,7 @@ export class App extends React.Component<
                 const basehref = document.querySelector('head > base').getAttribute('href').replace(/\/$/, '');
                 if (isSSO) {
                     const authSettings = await services.authService.settings();
-        
+
                     if (authSettings?.oidcConfig?.enablePKCEAuthentication) {
                         pkceLogin(authSettings.oidcConfig, getPKCERedirectURI().toString()).catch(err => {
                             this.getChildContext().apis.notifications.show({

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -21,6 +21,7 @@ import {AuthSettings} from './shared/models';
 import {PKCEVerification} from './login/components/pkce-verify';
 import {getPKCERedirectURI, pkceLogin} from './login/components/utils';
 import {SystemLevelExtension} from './shared/services/extensions-service';
+import {Subscription} from 'rxjs';
 
 services.viewPreferences.init();
 const bases = document.getElementsByTagName('base');
@@ -105,6 +106,8 @@ export class App extends React.Component<
     private navigationManager: NavigationManager;
     private navItems: NavItem[];
     private routes: Routes;
+    private popupPropsSubscription: Subscription;
+    private unauthorizedSubscription: Subscription;
 
     constructor(props: {}) {
         super(props);
@@ -148,8 +151,8 @@ export class App extends React.Component<
     }
 
     public componentWillUnmount() {
-        this.popupManager.popupProps.unsubscribe();
-        this.unsubscribeUnauthorized();
+        this.popupPropsSubscription.unsubscribe();
+        this.unauthorizedSubscription.unsubscribe();
     }
 
     public render() {
@@ -260,10 +263,6 @@ export class App extends React.Component<
                 }
             }
         });
-    }
-
-    private unsubscribeUnauthorized() {
-        requests.onError.unsubscribe();
     }
 
     private onAddSystemLevelExtension(extension: SystemLevelExtension) {

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -123,9 +123,7 @@ export class App extends React.Component<
     }
 
     public async componentDidMount() {
-        this.popupManager.popupProps.subscribe(popupProps => this.setState({popupProps})).then((subscription) => {
-            this.popupPropsSubscription = subscription;
-        });
+        this.popupPropsSubscription = this.popupManager.popupProps.subscribe(popupProps => this.setState({popupProps}));
         this.subscribeUnauthorized().then((subscription) => {
             this.unauthorizedSubscription = subscription;
         });

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -121,8 +121,8 @@ export class App extends React.Component<
     }
 
     public async componentDidMount() {
-        this.popupManager.popupProps.subscribe(popupProps => this.setState({popupProps}));
-        this.subscribeUnauthorized();
+        this.popupPropsSubscription = this.popupManager.popupProps.subscribe(popupProps => this.setState({popupProps}));
+        this.unauthorizedSubscription = this.subscribeUnauthorized();
         const authSettings = await services.authService.settings();
         const {trackingID, anonymizeUsers} = authSettings.googleAnalytics || {trackingID: '', anonymizeUsers: true};
         const {loggedIn, username} = await services.users.get();

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -231,7 +231,7 @@ export class App extends React.Component<
     }
 
     private async subscribeUnauthorized() {
-        requests.onError.subscribe(async err => {
+        return requests.onError.subscribe(async err => {
             if (err.status === 401) {
                 if (history.location.pathname.startsWith('/login')) {
                     return;

--- a/ui/src/app/login/components/pkce-verify.tsx
+++ b/ui/src/app/login/components/pkce-verify.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 import {services} from '../../shared/services';
 import {PKCECodeVerifier, PKCEState, PKCELoginError, getPKCERedirectURI, pkceCallback} from './utils';
+import requests from '../../shared/services/requests';
 
 import './pkce-verify.scss';
 
@@ -32,7 +33,7 @@ export const PKCEVerification = (props: RouteComponentProps<any>) => {
                 <div>
                     <h3>Error occurred: </h3>
                     <p>{error?.message || JSON.stringify(error)}</p>
-                    <a href='/login'>Try to Login again</a>
+                    <a href={requests.toAbsURL('/login')}>Try to Login again</a>
                 </div>
             </div>
         );


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Fixes https://github.com/argoproj/argo-cd/issues/20111
Fixes https://github.com/argoproj/argo-cd/issues/18045

This stores the users path during a PKCE auth flow and returns the user to the saved path on the PKCE callback in order to mirror the behavior that dex auth has. With the exception of the login path, the users path is stored in session storage during pkcelogin and retrieved during pkcecallback, defaulting to '/applications' when not present. This mirrors Dex's behavior with the return_url query parameter.

This fix should be cherry-picked to 2.12

Below is a screenshot of a pkce token expiry triggering a reauth that now redirects the user to their previous path. Certain sections have been redacted to not leak confidential or sensitive information.
![pkce_return_path](https://github.com/user-attachments/assets/c79c1583-bd89-41c9-ab44-18b47514f8e7)


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [n/a] Does this PR require documentation updates?
* [n/a] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [n/a] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
