### PR TITLE
chore(ci): update renovate config

### DIFF
--- a/renovate-presets/README.md
+++ b/renovate-presets/README.md
@@ -1,0 +1,60 @@
+# Renovate shared presets
+
+Presets makes rules easier to maintain and reusable across multiple repositories.
+
+# How to use a preset
+
+Reference the preset in the `extends` field of the `renovate.json` file in the repository.  
+Presets can reference other presets. (read more about [shared presets](https://docs.renovatebot.com/config-presets/))  
+
+```json
+{
+  "extends": [
+    "github>argoproj/argo-cd//renovate-presets/custom-managers/bash.json5"
+]
+}
+```
+
+### Note :
+
+It would make sense to move this folder to a new repository in the future.  
+
+Benefits:  
+- Avoids consuming the repository's CI/CD resources.  
+- Faster feedback loop for configuration changes.
+- Avoid polluting the master git history.  
+- The `renovate.json` in each repository can be simplified to only include a single presets :
+	```json
+	{
+	  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	  "extends": [
+	    "github>argoproj/renovate-presets//argoproj/argo-cd/renovate.json5"
+	  ],
+	  // rules are empty and this file won't need to be modified again.
+	  "packageRules": []
+	}
+	```
+Inconvenient:  
+- Owners of a repository can impact the configuration of all repositories. Use codeowners to reduce the risk.  
+
+Example of repo structure :  
+```shell
+.
+├── README.md
+├── .github/CODEOWNERS
+├── common.json5       # common presets for all repositories
+├── fix/
+│   └── openssf-merge-confidence-columns.json5
+├── custom-managers/
+│   ├── bash.json5
+│   └── yaml.json5
+└── argoproj/ # organization
+    ├── argo-cd/ # repository
+    │   ├── devtools.json5 # rules specific to the devtool (CI and dev environment...)
+    │   ├── docs.json5 # rules specific to the docs folder.
+    │   ├── # etc...
+    │   └── renovate.json5 # this is the single preset referenced from the repository argopro/argo-cd.
+    └── argo-rollouts/ # repository
+        └── renovate.json5
+
+```

--- a/renovate-presets/commons.json5
+++ b/renovate-presets/commons.json5
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Contains rules that makes sense to enforce by default.",
+  "dependencyDashboard": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "all",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "description": "Settings specific to PRs of type security",
+    "addLabels": ["security"]
+  },
+  "extends": [
+    "config:best-practices",
+    ":gitSignOff",
+    ":labels(dependencies)",
+    "customManagers:dockerfileVersions",
+    "security:openssf-scorecard",
+    "mergeConfidence:all-badges",
+    "github>argoproj/argo-cd//renovate-presets/fix/openssf-merge-confidence-columns.json5",
+  ],
+  "packageRules": [
+    {
+      "description": "Define the label to make Renovate stop updating a PR.",
+      "stopUpdatingLabel": "renovate:stop-updating"
+    },
+    {
+      "description": "Define the label to make Renovate rebase a PR.",
+      "rebaseLabel": "renovate:do-rebase"
+    },
+    {
+      "description": "Define labels of the dependency dashboard issues.",
+      "dependencyDashboardLabels": [
+        "dependencies",
+      ]
+    },
+    {
+      "description": "Add label major to PRs with major updates",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "addLabels": [
+        "major"
+      ]
+    },
+    {
+      "description": "Add labels for PRs related to javascript",
+      "matchDatasources": [
+        "node-version",
+        "npm"
+      ],
+      "addLabels": [
+        "javascript"
+      ]
+    },
+    {
+      "description": "Add labels for PRs related to go",
+      "matchDatasources": [
+        "golang-version",
+        "go"
+      ],
+      "addLabels": [
+        "go"
+      ]
+    },
+    {
+      "description": "Add labels for PRs related to python",
+      "matchCategories": [
+        "python"
+      ],
+      "addLabels": [
+        "python"
+      ]
+    }
+  ]
+}

--- a/renovate-presets/custom-managers/yaml.json5
+++ b/renovate-presets/custom-managers/yaml.json5
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
-      "description": "A generic custom manager for updating any yaml fields ending by *version: case incensitive",
+      "description": "A generic custom manager for updating any yaml fields ending by 'version:' (case insensitive)",
       "customType": "regex",
       "fileMatch": [
         ".github\\/workflows.+\\.(?:yml|yaml)$"

--- a/renovate-presets/devtool.json5
+++ b/renovate-presets/devtool.json5
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Rules specific to the devtool (CI, dev environment...)",
+  "packageRules": [
+    {
+      "description": "Enable updates from specified datasources",
+      "matchDatasources": [
+        "node-version",
+        "golang-version"
+      ],
+      "enabled": true
+    },
+    {
+      "description": "Enable updates from specified go modules",
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackageNames": [
+        "github.com/golangci/golangci-lint"
+      ],
+      "enabled": true
+    },
+    {
+      "description": "Enable updates from specified docker images",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "docker.io/library/node",
+        "docker.io/library/golang"
+      ],
+      "enabled": true
+    },
+    {
+      "description": "Group golang-version packages",
+      "groupName": "group golang",
+      "matchDatasources": [
+        "docker",
+        "golang-version"
+      ],
+      "matchPackageNames": [
+        "/(?:^|/)golang$/"
+      ]
+    },
+    {
+      "description": "Group node-version packages",
+      "groupName": "group node",
+      "matchDatasources": [
+        "docker",
+        "node-version"
+      ],
+      "matchPackageNames": [
+        "/(?:^|/)node$/",
+        "!calico/node",
+        "!docker.io/calico/node",
+        "!kindest/node"
+      ]
+    },
+    {
+      "description": "Example to reduce noise with the automerge features.",
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": false
+    }
+  ]
+}

--- a/renovate-presets/docs.json5
+++ b/renovate-presets/docs.json5
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Rules specific to the docs directory",
+  "packageRules": [
+    {
+      "description": "Group all dependencies from the docs directory",
+      "matchFileNames": ["docs/**"],
+      "matchCategories": [
+        "python"
+      ],
+      "excludePackageNames": [
+        "mkdocs-material"
+      ],
+      "groupName": "Docs dependencies",
+      "enabled": true
+    }
+  ]
+}
+
+
+

--- a/renovate-presets/fix/disable-all-updates.json5
+++ b/renovate-presets/fix/disable-all-updates.json5
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Disable all updates to avoid conflicts with dependabot, then enable what you need.",
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "*"
+      ],
+      "enabled": false
+    }
+  ]
+}
+

--- a/renovate.json
+++ b/renovate.json
@@ -1,113 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "dependencyDashboardOSVVulnerabilitySummary": "all",
-  "osvVulnerabilityAlerts": true,
-  "reviewersFromCodeOwners": true,
   "extends": [
-    "config:best-practices",
-    "customManagers:dockerfileVersions",
-    "security:openssf-scorecard",
-    "mergeConfidence:all-badges",
-    "github>argoproj/argo-cd//renovate-presets/fix/openssf-merge-confidence-columns.json5",
+    "github>argoproj/argo-cd//renovate-presets/commons.json5",
     "github>argoproj/argo-cd//renovate-presets/custom-managers/shell.json5",
-    "github>argoproj/argo-cd//renovate-presets/custom-managers/yaml.json5"
-  ],
-  "packageRules": [
-    {
-      "description": "Disable all updates to avoid conflicts with dependabot, then enable what we want",
-      "matchPackageNames": [
-        "*"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Add label dependencies to all PRs",
-      "matchPackageNames": [
-        "*"
-      ],
-      "labels": [
-        "dependencies"
-      ]
-    },
-    {
-      "description": "Enable node-version",
-      "matchDatasources": [
-        "node-version"
-      ],
-      "addLabels": [
-        "javascript"
-      ],
-      "enabled": true
-    },
-    {
-      "description": "Enable golang-version",
-      "matchDatasources": [
-        "golang-version"
-      ],
-      "addLabels": [
-        "go"
-      ],
-      "enabled": true
-    },
-    {
-      "description": "Enable some go modules",
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackageNames": [
-        "go",
-        "github.com/golangci/golangci-lint"
-      ],
-      "addLabels": [
-        "go"
-      ],
-      "enabled": true
-    },
-    {
-      "description": "Enable bump of golang version in go.mod",
-      "matchDatasources": [
-        "golang-version"
-      ],
-      "rangeStrategy": "bump"
-    },
-    {
-      "description": "Enable some docker images",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "docker.io/library/node",
-        "docker.io/library/golang"
-      ],
-      "enabled": true
-    },
-    {
-      "description": "Group golang-version packages",
-      "groupName": "golang version",
-      "matchDepNames": [
-        "go",
-        "golang",
-        "docker.io/golang",
-        "docker.io/library/golang"
-      ]
-    },
-    {
-      "description": "Group node-version packages",
-      "groupName": "node version",
-      "matchDepNames": [
-        "node",
-        "docker.io/library/node"
-      ]
-    },
-    {
-      "description": "an example to reduce noise by automerging pkgs that are safe to merge, multiple match fields can be used to reduce the scope of this rule...)",
-      "matchUpdateTypes": [
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "automerge": false
-    }
+    "github>argoproj/argo-cd//renovate-presets/custom-managers/yaml.json5",
+    "github>argoproj/argo-cd//renovate-presets/fix/disable-all-updates.json5",
+    "github>argoproj/argo-cd//renovate-presets/devtool.json5",
+    "github>argoproj/argo-cd//renovate-presets/docs.json5"
   ]
 }


### PR DESCRIPTION
cc: @crenshaw-dev 

- [x] Added renovate signoff
- [x] Removed gomod golang version bump  
  https://github.com/ggjulio/argo-cd/pull/41
- [x] splitted config across different presets. 
- [ ] Didn't properly fixed node grouping when a major is available.   
     Spent quite some time, but haven't found an okay solution... I let it as it is then.
     As long as there is no major, it works fine
     https://github.com/ggjulio/argo-cd/pull/42
- [x] Added a group for updating mkdocs.
  The group won't include any major update, separate PR.s will be created instead.
  You can modify or disable it in this PR
   - https://github.com/ggjulio/argo-cd/pull/43