### PR TITLE
fix: GOLANGCI_LINT_VERSION

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -393,7 +393,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        uses: SonarSource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.2
+        uses: SonarSource/sonarqube-scan-action@0c0f3958d90fc466625f1d1af1f47bddd4cc6bd1 # v2.2
         if: env.sonar_secret != ''
   test-e2e:
     name: Run end-to-end tests

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -2,6 +2,6 @@
 set -eux -o pipefail
 
 # renovate: datasource=go packageName=github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION=1.61.0
+GOLANGCI_LINT_VERSION=v1.61.0
 
 GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"

--- a/hack/installers/install-lint-tools.sh
+++ b/hack/installers/install-lint-tools.sh
@@ -2,6 +2,6 @@
 set -eux -o pipefail
 
 # renovate: datasource=go packageName=github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION=v1.61.0
+GOLANGCI_LINT_VERSION=1.61.0
 
-GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+GO111MODULE=on go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}"


### PR DESCRIPTION
Without this, I get an error while building the master branch of argo-cd:

go: downloading gopkg.in/ini.v1 v1.67.0
go: downloading github.com/magiconair/properties v1.8.7
go: downloading github.com/pelletier/go-toml/v2 v2.0.6
go: downloading golang.org/x/text v0.7.0
+ export DOWNLOADS=/tmp/dl
+ DOWNLOADS=/tmp/dl
+ export BIN=/usr/local/bin
+ BIN=/usr/local/bin
+ mkdir -p /tmp/dl
+ ARCHITECTURE=
+ case $(uname -m) in
++ uname -m
+ ARCHITECTURE=amd64
+ INSTALL_OS=
++ uname -s
+ unameOut=Linux
+ case "${unameOut}" in
+ INSTALL_OS=linux
+ for product in $*
++ dirname ./install.sh
+ ARCHITECTURE=amd64
+ INSTALL_OS=linux
+ ./installers/install-lint-tools.sh
+ GOLANGCI_LINT_VERSION=1.61.0
+ GO111MODULE=on
+ go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.61.0
go: github.com/golangci/golangci-lint/cmd/golangci-lint@1.61.0: github.com/golangci/golangci-lint/cmd/golangci-lint@1.61.0: invalid version: unknown revision 1.61.0
building at STEP "RUN ./install.sh helm &&     ./install.sh kustomize &&     ./install.sh codegen-tools &&     ./install.sh codegen-go-tools &&     ./install.sh lint-tools &&     go install github.com/mattn/goreman@latest &&     go install github.com/kisielk/godepgraph@latest &&     go install github.com/jstemmer/go-junit-report@latest &&     rm -rf /tmp/dl &&     rm -rf /tmp/helm &&     rm -rf /tmp/ks_*": while running runtime: exit status 1

make: *** [Makefile:276: test-tools-image] Error 1

