### PR TITLE
fix: prevent crash during timer expiration after stream is closed (#19917)

### DIFF
--- a/server/application/logs.go
+++ b/server/application/logs.go
@@ -144,8 +144,8 @@ func mergeLogStreams(streams []chan logEntry, bufferingDuration time.Duration) c
 
 		_ = send(true)
 
-		close(merged)
 		ticker.Stop()
+		close(merged)
 	}()
 	return merged
 }


### PR DESCRIPTION
Cherry pick https://github.com/argoproj/argo-cd/pull/19917 because the gcp bot does not seem to be working