### PR TITLE
chore(tests): fix erroneous cherry-pick

### DIFF
--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -6423,7 +6423,6 @@ func TestResourceStatusAreOrdered(t *testing.T) {
 			argoObjs := []runtime.Object{}
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&cc.appSet).WithObjects(&cc.appSet).Build()
-			metrics := appsetmetrics.NewFakeAppsetMetrics(client)
 
 			r := ApplicationSetReconciler{
 				Client:           client,
@@ -6433,7 +6432,6 @@ func TestResourceStatusAreOrdered(t *testing.T) {
 				ArgoDB:           &argoDBMock,
 				ArgoAppClientset: appclientset.NewSimpleClientset(argoObjs...),
 				KubeClientset:    kubeclientset,
-				Metrics:          metrics,
 			}
 
 			err := r.updateResourcesStatus(context.TODO(), log.NewEntry(log.StandardLogger()), &cc.appSet, cc.apps)


### PR DESCRIPTION
[This fix](https://github.com/argoproj/argo-cd/commit/15681651664e29a2546f6b87f6f976ef6cc1ce9d#diff-88fec9c8d881ff513bb04ee8842efcc4f0db0ec0ce631fec3f730633a91ebea6R6375) was cherry-picked, but the referenced field was not [added](https://github.com/argoproj/argo-cd/commit/3cbb1522ddabf0e2750eedd3487d991cbbacd336) until later.