### PR TITLE
feat:19259 - disableCompression flag --added

### DIFF
--- a/cmd/argocd/commands/admin/dashboard.go
+++ b/cmd/argocd/commands/admin/dashboard.go
@@ -19,10 +19,11 @@ import (
 
 func NewDashboardCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var (
-		port           int
-		address        string
-		compressionStr string
-		clientConfig   clientcmd.ClientConfig
+		port               int
+		address            string
+		compressionStr     string
+		clientConfig       clientcmd.ClientConfig
+		disableCompression bool
 	)
 	cmd := &cobra.Command{
 		Use:   "dashboard",
@@ -51,5 +52,6 @@ $ argocd admin dashboard --redis-compress gzip
 	cmd.Flags().IntVar(&port, "port", common.DefaultPortAPIServer, "Listen on given port")
 	cmd.Flags().StringVar(&address, "address", common.DefaultAddressAdminDashboard, "Listen on given address")
 	cmd.Flags().StringVar(&compressionStr, "redis-compress", env.StringFromEnv("REDIS_COMPRESSION", string(cache.RedisCompressionGZip)), "Enable this if the application controller is configured with redis compression enabled. (possible values: gzip, none)")
+	cmd.Flags().BoolVar(&disableCompression, "disable-compression", false, "opt-out of response compression for all requests to the server")
 	return cmd
 }

--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -191,6 +191,7 @@ func NewClusterAddCommand(clientOpts *argocdclient.ClientOptions, pathOpts *clie
 	command.Flags().BoolVarP(&skipConfirmation, "yes", "y", false, "Skip explicit confirmation")
 	command.Flags().StringArrayVar(&labels, "label", nil, "Set metadata labels (e.g. --label key=value)")
 	command.Flags().StringArrayVar(&annotations, "annotation", nil, "Set metadata annotations (e.g. --annotation key=value)")
+	command.Flags().BoolVar(&clusterOpts.DisableCompression, "compression", false, "opt-out of response compression for all requests to the server")
 	cmdutil.AddClusterFlags(command, &clusterOpts)
 	return command
 }

--- a/cmd/util/cluster.go
+++ b/cmd/util/cluster.go
@@ -158,6 +158,7 @@ type ClusterOptions struct {
 	ExecProviderAPIVersion  string
 	ExecProviderInstallHint string
 	ClusterEndpoint         string
+	DisableCompression      bool
 }
 
 // InClusterEndpoint returns true if ArgoCD should reference the in-cluster


### PR DESCRIPTION
Description:
This PR supports the kubectl option to have one optional flag, disableCompression, to support the response compression.

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Fixes [#19259]" in the description to automatically close the associated issue.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
