### PR TITLE
fix(ci): get correct previous release version for release notes (#19443)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Set GORELEASER_PREVIOUS_TAG # Workaround, GoReleaser uses 'git-describe' to determine a previous tag. Our tags are created in release branches.
         run: |
           set -xue
-          echo "GORELEASER_PREVIOUS_TAG=$(go run get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
+          echo "GORELEASER_PREVIOUS_TAG=$(go run hack/get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
           echo "$GORELEASER_PREVIOUS_TAG"
 
 #      - name: Set environment variables for ldflags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Set GORELEASER_PREVIOUS_TAG # Workaround, GoReleaser uses 'git-describe' to determine a previous tag. Our tags are created in release branches.
         run: |
           set -xue
-          echo "GORELEASER_PREVIOUS_TAG=$(go run hack/get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
+          echo "GORELEASER_PREVIOUS_TAG=$(go run hack/get-previous-release/get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
           echo "$GORELEASER_PREVIOUS_TAG"
 
 #      - name: Set environment variables for ldflags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,47 +14,47 @@ env:
   GOLANG_VERSION: '1.23.2' # Note: go-version must also be set in job argocd-image.with.go-version
 
 jobs:
-#  argocd-image:
-#    permissions:
-#      contents: read
-#      id-token: write # for creating OIDC tokens for signing.
-#      packages: write # used to push images to `ghcr.io` if used.
-#    #if: github.repository == 'argoproj/argo-cd'
-#    uses: ./.github/workflows/image-reuse.yaml
-#    with:
-#      quay_image_name: quay.io/argoproj/argocd:${{ github.ref_name }}
-#      # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
-#      # renovate: datasource=golang-version packageName=golang
-#      go-version: 1.23.2
-#      platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-#      push: true
-#    secrets:
-#      quay_username: ${{ secrets.RELEASE_QUAY_USERNAME }}
-#      quay_password: ${{ secrets.RELEASE_QUAY_TOKEN }}
-#
-#  argocd-image-provenance:
-#      needs: [argocd-image]
-#      permissions:
-#        actions: read # for detecting the Github Actions environment.
-#        id-token: write # for creating OIDC tokens for signing.
-#        packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
-#      # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-#      if: github.repository == 'argoproj/argo-cd'
-#      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
-#      with:
-#        image: quay.io/argoproj/argocd
-#        digest: ${{ needs.argocd-image.outputs.image-digest }}
-#      secrets:
-#        registry-username: ${{ secrets.RELEASE_QUAY_USERNAME }}
-#        registry-password: ${{ secrets.RELEASE_QUAY_TOKEN }}
+  argocd-image:
+    permissions:
+      contents: read
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # used to push images to `ghcr.io` if used.
+    if: github.repository == 'argoproj/argo-cd'
+    uses: ./.github/workflows/image-reuse.yaml
+    with:
+      quay_image_name: quay.io/argoproj/argocd:${{ github.ref_name }}
+      # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
+      # renovate: datasource=golang-version packageName=golang
+      go-version: 1.23.2
+      platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+      push: true
+    secrets:
+      quay_username: ${{ secrets.RELEASE_QUAY_USERNAME }}
+      quay_password: ${{ secrets.RELEASE_QUAY_TOKEN }}
+
+  argocd-image-provenance:
+      needs: [argocd-image]
+      permissions:
+        actions: read # for detecting the Github Actions environment.
+        id-token: write # for creating OIDC tokens for signing.
+        packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
+      # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+      if: github.repository == 'argoproj/argo-cd'
+      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+      with:
+        image: quay.io/argoproj/argocd
+        digest: ${{ needs.argocd-image.outputs.image-digest }}
+      secrets:
+        registry-username: ${{ secrets.RELEASE_QUAY_USERNAME }}
+        registry-password: ${{ secrets.RELEASE_QUAY_TOKEN }}
 
   goreleaser:
-#    needs:
-#      - argocd-image
-#      - argocd-image-provenance
+    needs:
+      - argocd-image
+      - argocd-image-provenance
     permissions:
       contents: write # used for uploading assets
-    #if: github.repository == 'argoproj/argo-cd'
+    if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-22.04
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -78,229 +78,228 @@ jobs:
         run: |
           set -xue
           echo "GORELEASER_PREVIOUS_TAG=$(go run hack/get-previous-release/get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
-          echo "$GORELEASER_PREVIOUS_TAG"
 
-#      - name: Set environment variables for ldflags
-#        id: set_ldflag
-#        run: |
-#          echo "KUBECTL_VERSION=$(go list -m k8s.io/client-go | head -n 1 | rev | cut -d' ' -f1 | rev)" >> $GITHUB_ENV
-#          echo "GIT_TREE_STATE=$(if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)" >> $GITHUB_ENV
-#
-#      - name: Free Disk Space (Ubuntu)
-#        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-#        with:
-#          large-packages: false
-#          docker-images: false
-#          swap-storage: false
-#          tool-cache: false
-#
-#      - name: Run GoReleaser
-#        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
-#        id: run-goreleaser
-#        with:
-#          version: latest
-#          args: release --clean --timeout 55m
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          KUBECTL_VERSION: ${{ env.KUBECTL_VERSION }}
-#          GIT_TREE_STATE: ${{ env.GIT_TREE_STATE }}
-#
-#      - name: Generate subject for provenance
-#        id: hash
-#        env:
-#          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
-#        run: |
-#          set -euo pipefail
-#
-#          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
-#          if test "$hashes" = ""; then # goreleaser < v1.13.0
-#            checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-#            hashes=$(cat $checksum_file | base64 -w0)
-#          fi
-#          echo "hashes=$hashes" >> $GITHUB_OUTPUT
+      - name: Set environment variables for ldflags
+        id: set_ldflag
+        run: |
+          echo "KUBECTL_VERSION=$(go list -m k8s.io/client-go | head -n 1 | rev | cut -d' ' -f1 | rev)" >> $GITHUB_ENV
+          echo "GIT_TREE_STATE=$(if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)" >> $GITHUB_ENV
 
-#  goreleaser-provenance:
-#    needs: [goreleaser]
-#    permissions:
-#      actions: read # for detecting the Github Actions environment
-#      id-token: write # Needed for provenance signing and ID
-#      contents: write #  Needed for release uploads
-#    #if: github.repository == 'argoproj/argo-cd'
-#    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-#    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-#    with:
-#      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
-#      provenance-name: "argocd-cli.intoto.jsonl"
-#      upload-assets: true
-#
-#  generate-sbom:
-#    name: Create SBOM and generate hash
-#    needs:
-#      - argocd-image
-#      - goreleaser
-#    permissions:
-#      contents: write # Needed for release uploads
-#    outputs:
-#      hashes: ${{ steps.sbom-hash.outputs.hashes}}
-#    #if: github.repository == 'argoproj/argo-cd'
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
-#        with:
-#          fetch-depth: 0
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Setup Golang
-#        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-#        with:
-#          go-version: ${{ env.GOLANG_VERSION }}
-#
-#      - name: Generate SBOM (spdx)
-#        id: spdx-builder
-#        env:
-#          # defines the spdx/spdx-sbom-generator version to use.
-#          SPDX_GEN_VERSION: v0.0.13
-#          # defines the sigs.k8s.io/bom version to use.
-#          SIGS_BOM_VERSION: v0.2.1
-#          # comma delimited list of project relative folders to inspect for package
-#          # managers (gomod, yarn, npm).
-#          PROJECT_FOLDERS: ".,./ui"
-#          # full qualified name of the docker image to be inspected
-#          DOCKER_IMAGE: quay.io/argoproj/argocd:${{ github.ref_name }}
-#        run: |
-#          yarn install --cwd ./ui
-#          go install github.com/spdx/spdx-sbom-generator/cmd/generator@$SPDX_GEN_VERSION
-#          go install sigs.k8s.io/bom/cmd/bom@$SIGS_BOM_VERSION
-#
-#          # Generate SPDX for project dependencies analyzing package managers
-#          for folder in $(echo $PROJECT_FOLDERS | sed "s/,/ /g")
-#          do
-#            generator -p $folder -o /tmp
-#          done
-#
-#          # Generate SPDX for binaries analyzing the docker image
-#          if [[ ! -z $DOCKER_IMAGE ]]; then
-#            bom generate -o /tmp/bom-docker-image.spdx -i $DOCKER_IMAGE
-#          fi
-#
-#          cd /tmp && tar -zcf sbom.tar.gz *.spdx
-#
-#      - name: Generate SBOM hash
-#        shell: bash
-#        id: sbom-hash
-#        run: |
-#          # sha256sum generates sha256 hash for sbom.
-#          # base64 -w0 encodes to base64 and outputs on a single line.
-#          # sha256sum /tmp/sbom.tar.gz ... | base64 -w0
-#          echo "hashes=$(sha256sum /tmp/sbom.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
-#
-#      - name: Upload SBOM
-#        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          files: |
-#            /tmp/sbom.tar.gz
-#
-#  sbom-provenance:
-#    needs: [generate-sbom]
-#    permissions:
-#      actions: read # for detecting the Github Actions environment
-#      id-token: write # Needed for provenance signing and ID
-#      contents: write #  Needed for release uploads
-#    #if: github.repository == 'argoproj/argo-cd'
-#    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-#    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-#    with:
-#      base64-subjects: "${{ needs.generate-sbom.outputs.hashes }}"
-#      provenance-name: "argocd-sbom.intoto.jsonl"
-#      upload-assets: true
-#
-#  post-release:
-#    needs:
-#      - argocd-image
-#      - goreleaser
-#      - generate-sbom
-#    permissions:
-#      contents: write # Needed to push commit to update stable tag
-#      pull-requests: write # Needed to create PR for VERSION update.
-#    #if: github.repository == 'argoproj/argo-cd'
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
-#        with:
-#          fetch-depth: 0
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Setup Git author information
-#        run: |
-#          set -ue
-#          git config --global user.email 'ci@argoproj.com'
-#          git config --global user.name 'CI'
-#
-#      - name: Check if tag is the latest version and not a pre-release
-#        run: |
-#          set -xue
-#          # Fetch all tag information
-#          git fetch --prune --tags --force
-#
-#          LATEST_TAG=$(git -c 'versionsort.suffix=-rc' tag --list --sort=version:refname | tail -n1)
-#
-#          PRE_RELEASE=false
-#          # Check if latest tag is a pre-release
-#          if echo $LATEST_TAG | grep -E -- '-rc[0-9]+$';then
-#            PRE_RELEASE=true
-#          fi
-#
-#          # Ensure latest tag matches github.ref_name & not a pre-release
-#          if [[ $LATEST_TAG == ${{ github.ref_name }} ]] && [[ $PRE_RELEASE != 'true' ]];then
-#            echo "TAG_STABLE=true" >> $GITHUB_ENV
-#          else
-#            echo "TAG_STABLE=false" >> $GITHUB_ENV
-#          fi
-#
-#      - name: Update stable tag to latest version
-#        run: |
-#          git tag -f stable ${{ github.ref_name }}
-#          git push -f origin stable
-#        if: ${{ env.TAG_STABLE == 'true' }}
-#
-#      - name: Check to see if VERSION should be updated on master branch
-#        run: |
-#          set -xue
-#          SOURCE_TAG=${{ github.ref_name }}
-#          VERSION_REF="${SOURCE_TAG#*v}"
-#          COMMIT_HASH=$(git rev-parse HEAD)
-#          if echo "$VERSION_REF" | grep -E -- '^[0-9]+\.[0-9]+\.0-rc1';then
-#            VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${VERSION_REF%-rc1}")
-#            echo "Updating VERSION to: $VERSION"
-#            echo "UPDATE_VERSION=true" >> $GITHUB_ENV
-#            echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV
-#            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
-#          else
-#            echo "Not updating VERSION"
-#            echo "UPDATE_VERSION=false" >> $GITHUB_ENV
-#          fi
-#
-#      - name: Update VERSION on master branch
-#        run: |
-#          echo ${{ env.NEW_VERSION }} > VERSION
-#          # Replace the 'project-release: vX.X.X-rcX' line in SECURITY-INSIGHTS.yml
-#          sed -i "s/project-release: v.*$/project-release: v${{ env.NEW_VERSION }}/" SECURITY-INSIGHTS.yml
-#          # Update the 'commit-hash: XXXXXXX' line in SECURITY-INSIGHTS.yml
-#          sed -i "s/commit-hash: .*/commit-hash: ${{ env.COMMIT_HASH }}/" SECURITY-INSIGHTS.yml
-#        if: ${{ env.UPDATE_VERSION == 'true' }}
-#
-#      - name: Create PR to update VERSION on master branch
-#        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
-#        with:
-#          commit-message: Bump version in master
-#          title: "chore: Bump version in master"
-#          body: All images built from master should indicate which version we are on track for.
-#          signoff: true
-#          branch: update-version
-#          branch-suffix: random
-#          base: master
-#        if: ${{ env.UPDATE_VERSION == 'true' }}
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+          tool-cache: false
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+        id: run-goreleaser
+        with:
+          version: latest
+          args: release --clean --timeout 55m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KUBECTL_VERSION: ${{ env.KUBECTL_VERSION }}
+          GIT_TREE_STATE: ${{ env.GIT_TREE_STATE }}
+
+      - name: Generate subject for provenance
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+
+          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
+          if test "$hashes" = ""; then # goreleaser < v1.13.0
+            checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+            hashes=$(cat $checksum_file | base64 -w0)
+          fi
+          echo "hashes=$hashes" >> $GITHUB_OUTPUT
+
+  goreleaser-provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read # for detecting the Github Actions environment
+      id-token: write # Needed for provenance signing and ID
+      contents: write #  Needed for release uploads
+    if: github.repository == 'argoproj/argo-cd'
+    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      provenance-name: "argocd-cli.intoto.jsonl"
+      upload-assets: true
+
+  generate-sbom:
+    name: Create SBOM and generate hash
+    needs:
+      - argocd-image
+      - goreleaser
+    permissions:
+      contents: write # Needed for release uploads
+    outputs:
+      hashes: ${{ steps.sbom-hash.outputs.hashes}}
+    if: github.repository == 'argoproj/argo-cd'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Golang
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
+      - name: Generate SBOM (spdx)
+        id: spdx-builder
+        env:
+          # defines the spdx/spdx-sbom-generator version to use.
+          SPDX_GEN_VERSION: v0.0.13
+          # defines the sigs.k8s.io/bom version to use.
+          SIGS_BOM_VERSION: v0.2.1
+          # comma delimited list of project relative folders to inspect for package
+          # managers (gomod, yarn, npm).
+          PROJECT_FOLDERS: ".,./ui"
+          # full qualified name of the docker image to be inspected
+          DOCKER_IMAGE: quay.io/argoproj/argocd:${{ github.ref_name }}
+        run: |
+          yarn install --cwd ./ui
+          go install github.com/spdx/spdx-sbom-generator/cmd/generator@$SPDX_GEN_VERSION
+          go install sigs.k8s.io/bom/cmd/bom@$SIGS_BOM_VERSION
+
+          # Generate SPDX for project dependencies analyzing package managers
+          for folder in $(echo $PROJECT_FOLDERS | sed "s/,/ /g")
+          do
+            generator -p $folder -o /tmp
+          done
+
+          # Generate SPDX for binaries analyzing the docker image
+          if [[ ! -z $DOCKER_IMAGE ]]; then
+            bom generate -o /tmp/bom-docker-image.spdx -i $DOCKER_IMAGE
+          fi
+
+          cd /tmp && tar -zcf sbom.tar.gz *.spdx
+
+      - name: Generate SBOM hash
+        shell: bash
+        id: sbom-hash
+        run: |
+          # sha256sum generates sha256 hash for sbom.
+          # base64 -w0 encodes to base64 and outputs on a single line.
+          # sha256sum /tmp/sbom.tar.gz ... | base64 -w0
+          echo "hashes=$(sha256sum /tmp/sbom.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload SBOM
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            /tmp/sbom.tar.gz
+
+  sbom-provenance:
+    needs: [generate-sbom]
+    permissions:
+      actions: read # for detecting the Github Actions environment
+      id-token: write # Needed for provenance signing and ID
+      contents: write #  Needed for release uploads
+    if: github.repository == 'argoproj/argo-cd'
+    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.generate-sbom.outputs.hashes }}"
+      provenance-name: "argocd-sbom.intoto.jsonl"
+      upload-assets: true
+
+  post-release:
+    needs:
+      - argocd-image
+      - goreleaser
+      - generate-sbom
+    permissions:
+      contents: write # Needed to push commit to update stable tag
+      pull-requests: write # Needed to create PR for VERSION update.
+    if: github.repository == 'argoproj/argo-cd'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Git author information
+        run: |
+          set -ue
+          git config --global user.email 'ci@argoproj.com'
+          git config --global user.name 'CI'
+
+      - name: Check if tag is the latest version and not a pre-release
+        run: |
+          set -xue
+          # Fetch all tag information
+          git fetch --prune --tags --force
+
+          LATEST_TAG=$(git -c 'versionsort.suffix=-rc' tag --list --sort=version:refname | tail -n1)
+
+          PRE_RELEASE=false
+          # Check if latest tag is a pre-release
+          if echo $LATEST_TAG | grep -E -- '-rc[0-9]+$';then
+            PRE_RELEASE=true
+          fi
+
+          # Ensure latest tag matches github.ref_name & not a pre-release
+          if [[ $LATEST_TAG == ${{ github.ref_name }} ]] && [[ $PRE_RELEASE != 'true' ]];then
+            echo "TAG_STABLE=true" >> $GITHUB_ENV
+          else
+            echo "TAG_STABLE=false" >> $GITHUB_ENV
+          fi
+
+      - name: Update stable tag to latest version
+        run: |
+          git tag -f stable ${{ github.ref_name }}
+          git push -f origin stable
+        if: ${{ env.TAG_STABLE == 'true' }}
+
+      - name: Check to see if VERSION should be updated on master branch
+        run: |
+          set -xue
+          SOURCE_TAG=${{ github.ref_name }}
+          VERSION_REF="${SOURCE_TAG#*v}"
+          COMMIT_HASH=$(git rev-parse HEAD)
+          if echo "$VERSION_REF" | grep -E -- '^[0-9]+\.[0-9]+\.0-rc1';then
+            VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${VERSION_REF%-rc1}")
+            echo "Updating VERSION to: $VERSION"
+            echo "UPDATE_VERSION=true" >> $GITHUB_ENV
+            echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV
+            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
+          else
+            echo "Not updating VERSION"
+            echo "UPDATE_VERSION=false" >> $GITHUB_ENV
+          fi
+
+      - name: Update VERSION on master branch
+        run: |
+          echo ${{ env.NEW_VERSION }} > VERSION
+          # Replace the 'project-release: vX.X.X-rcX' line in SECURITY-INSIGHTS.yml
+          sed -i "s/project-release: v.*$/project-release: v${{ env.NEW_VERSION }}/" SECURITY-INSIGHTS.yml
+          # Update the 'commit-hash: XXXXXXX' line in SECURITY-INSIGHTS.yml
+          sed -i "s/commit-hash: .*/commit-hash: ${{ env.COMMIT_HASH }}/" SECURITY-INSIGHTS.yml
+        if: ${{ env.UPDATE_VERSION == 'true' }}
+
+      - name: Create PR to update VERSION on master branch
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          commit-message: Bump version in master
+          title: "chore: Bump version in master"
+          body: All images built from master should indicate which version we are on track for.
+          signoff: true
+          branch: update-version
+          branch-suffix: random
+          base: master
+        if: ${{ env.UPDATE_VERSION == 'true' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,14 +69,10 @@ jobs:
       - name: Fetch all tags
         run: git fetch --force --tags
 
-      - name: Set GORELEASER_PREVIOUS_TAG # Workaround, GoReleaser uses 'git-describe' to determine a previous tag. Our tags are created in realease branches.
+      - name: Set GORELEASER_PREVIOUS_TAG # Workaround, GoReleaser uses 'git-describe' to determine a previous tag. Our tags are created in release branches.
         run: |
           set -xue
-          if echo ${{ github.ref_name }} | grep -E -- '-rc1+$';then
-            echo "GORELEASER_PREVIOUS_TAG=$(git -c 'versionsort.suffix=-rc' tag --list --sort=version:refname | tail -n 2 | head -n 1)" >> $GITHUB_ENV
-          else
-            echo "This is not the first release on the branch, Using GoReleaser defaults"
-          fi
+          echo "GORELEASER_PREVIOUS_TAG=$(go run get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
 
       - name: Setup Golang
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write # for creating OIDC tokens for signing.
       packages: write # used to push images to `ghcr.io` if used.
-    if: github.repository == 'argoproj/argo-cd'
+    #if: github.repository == 'argoproj/argo-cd'
     uses: ./.github/workflows/image-reuse.yaml
     with:
       quay_image_name: quay.io/argoproj/argocd:${{ github.ref_name }}
@@ -54,7 +54,7 @@ jobs:
       - argocd-image-provenance
     permissions:
       contents: write # used for uploading assets
-    if: github.repository == 'argoproj/argo-cd'
+    #if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-22.04
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -124,7 +124,7 @@ jobs:
       actions: read # for detecting the Github Actions environment
       id-token: write # Needed for provenance signing and ID
       contents: write #  Needed for release uploads
-    if: github.repository == 'argoproj/argo-cd'
+    #if: github.repository == 'argoproj/argo-cd'
     # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
@@ -141,7 +141,7 @@ jobs:
       contents: write # Needed for release uploads
     outputs:
       hashes: ${{ steps.sbom-hash.outputs.hashes}}
-    if: github.repository == 'argoproj/argo-cd'
+    #if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
@@ -208,7 +208,7 @@ jobs:
       actions: read # for detecting the Github Actions environment
       id-token: write # Needed for provenance signing and ID
       contents: write #  Needed for release uploads
-    if: github.repository == 'argoproj/argo-cd'
+    #if: github.repository == 'argoproj/argo-cd'
     # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
@@ -224,7 +224,7 @@ jobs:
     permissions:
       contents: write # Needed to push commit to update stable tag
       pull-requests: write # Needed to create PR for VERSION update.
-    if: github.repository == 'argoproj/argo-cd'
+    #if: github.repository == 'argoproj/argo-cd'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,44 +14,44 @@ env:
   GOLANG_VERSION: '1.23.2' # Note: go-version must also be set in job argocd-image.with.go-version
 
 jobs:
-  argocd-image:
-    permissions:
-      contents: read
-      id-token: write # for creating OIDC tokens for signing.
-      packages: write # used to push images to `ghcr.io` if used.
-    #if: github.repository == 'argoproj/argo-cd'
-    uses: ./.github/workflows/image-reuse.yaml
-    with:
-      quay_image_name: quay.io/argoproj/argocd:${{ github.ref_name }}
-      # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
-      # renovate: datasource=golang-version packageName=golang
-      go-version: 1.23.2
-      platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-      push: true
-    secrets:
-      quay_username: ${{ secrets.RELEASE_QUAY_USERNAME }}
-      quay_password: ${{ secrets.RELEASE_QUAY_TOKEN }}
-
-  argocd-image-provenance:
-      needs: [argocd-image]
-      permissions:
-        actions: read # for detecting the Github Actions environment.
-        id-token: write # for creating OIDC tokens for signing.
-        packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
-      # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-      if: github.repository == 'argoproj/argo-cd'
-      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
-      with:
-        image: quay.io/argoproj/argocd
-        digest: ${{ needs.argocd-image.outputs.image-digest }}
-      secrets:
-        registry-username: ${{ secrets.RELEASE_QUAY_USERNAME }}
-        registry-password: ${{ secrets.RELEASE_QUAY_TOKEN }}
+#  argocd-image:
+#    permissions:
+#      contents: read
+#      id-token: write # for creating OIDC tokens for signing.
+#      packages: write # used to push images to `ghcr.io` if used.
+#    #if: github.repository == 'argoproj/argo-cd'
+#    uses: ./.github/workflows/image-reuse.yaml
+#    with:
+#      quay_image_name: quay.io/argoproj/argocd:${{ github.ref_name }}
+#      # Note: cannot use env variables to set go-version (https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
+#      # renovate: datasource=golang-version packageName=golang
+#      go-version: 1.23.2
+#      platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+#      push: true
+#    secrets:
+#      quay_username: ${{ secrets.RELEASE_QUAY_USERNAME }}
+#      quay_password: ${{ secrets.RELEASE_QUAY_TOKEN }}
+#
+#  argocd-image-provenance:
+#      needs: [argocd-image]
+#      permissions:
+#        actions: read # for detecting the Github Actions environment.
+#        id-token: write # for creating OIDC tokens for signing.
+#        packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
+#      # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+#      if: github.repository == 'argoproj/argo-cd'
+#      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+#      with:
+#        image: quay.io/argoproj/argocd
+#        digest: ${{ needs.argocd-image.outputs.image-digest }}
+#      secrets:
+#        registry-username: ${{ secrets.RELEASE_QUAY_USERNAME }}
+#        registry-password: ${{ secrets.RELEASE_QUAY_TOKEN }}
 
   goreleaser:
-    needs:
-      - argocd-image
-      - argocd-image-provenance
+#    needs:
+#      - argocd-image
+#      - argocd-image-provenance
     permissions:
       contents: write # used for uploading assets
     #if: github.repository == 'argoproj/argo-cd'
@@ -69,237 +69,238 @@ jobs:
       - name: Fetch all tags
         run: git fetch --force --tags
 
+      - name: Setup Golang
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
       - name: Set GORELEASER_PREVIOUS_TAG # Workaround, GoReleaser uses 'git-describe' to determine a previous tag. Our tags are created in release branches.
         run: |
           set -xue
           echo "GORELEASER_PREVIOUS_TAG=$(go run get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
+          echo "$GORELEASER_PREVIOUS_TAG"
 
-      - name: Setup Golang
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
+#      - name: Set environment variables for ldflags
+#        id: set_ldflag
+#        run: |
+#          echo "KUBECTL_VERSION=$(go list -m k8s.io/client-go | head -n 1 | rev | cut -d' ' -f1 | rev)" >> $GITHUB_ENV
+#          echo "GIT_TREE_STATE=$(if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)" >> $GITHUB_ENV
+#
+#      - name: Free Disk Space (Ubuntu)
+#        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+#        with:
+#          large-packages: false
+#          docker-images: false
+#          swap-storage: false
+#          tool-cache: false
+#
+#      - name: Run GoReleaser
+#        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+#        id: run-goreleaser
+#        with:
+#          version: latest
+#          args: release --clean --timeout 55m
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          KUBECTL_VERSION: ${{ env.KUBECTL_VERSION }}
+#          GIT_TREE_STATE: ${{ env.GIT_TREE_STATE }}
+#
+#      - name: Generate subject for provenance
+#        id: hash
+#        env:
+#          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+#        run: |
+#          set -euo pipefail
+#
+#          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
+#          if test "$hashes" = ""; then # goreleaser < v1.13.0
+#            checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+#            hashes=$(cat $checksum_file | base64 -w0)
+#          fi
+#          echo "hashes=$hashes" >> $GITHUB_OUTPUT
 
-      - name: Set environment variables for ldflags
-        id: set_ldflag
-        run: |
-          echo "KUBECTL_VERSION=$(go list -m k8s.io/client-go | head -n 1 | rev | cut -d' ' -f1 | rev)" >> $GITHUB_ENV
-          echo "GIT_TREE_STATE=$(if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)" >> $GITHUB_ENV
-
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        with:
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-          tool-cache: false
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
-        id: run-goreleaser
-        with:
-          version: latest
-          args: release --clean --timeout 55m
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KUBECTL_VERSION: ${{ env.KUBECTL_VERSION }} 
-          GIT_TREE_STATE: ${{ env.GIT_TREE_STATE }}
-
-      - name: Generate subject for provenance
-        id: hash
-        env:
-          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
-        run: |
-          set -euo pipefail
-
-          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
-          if test "$hashes" = ""; then # goreleaser < v1.13.0
-            checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-            hashes=$(cat $checksum_file | base64 -w0)
-          fi
-          echo "hashes=$hashes" >> $GITHUB_OUTPUT
-
-  goreleaser-provenance:
-    needs: [goreleaser]
-    permissions:
-      actions: read # for detecting the Github Actions environment
-      id-token: write # Needed for provenance signing and ID
-      contents: write #  Needed for release uploads
-    #if: github.repository == 'argoproj/argo-cd'
-    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
-      provenance-name: "argocd-cli.intoto.jsonl"
-      upload-assets: true
-
-  generate-sbom:
-    name: Create SBOM and generate hash
-    needs:
-      - argocd-image
-      - goreleaser
-    permissions:
-      contents: write # Needed for release uploads
-    outputs:
-      hashes: ${{ steps.sbom-hash.outputs.hashes}}
-    #if: github.repository == 'argoproj/argo-cd'
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Golang
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
-
-      - name: Generate SBOM (spdx)
-        id: spdx-builder
-        env:
-          # defines the spdx/spdx-sbom-generator version to use.
-          SPDX_GEN_VERSION: v0.0.13
-          # defines the sigs.k8s.io/bom version to use.
-          SIGS_BOM_VERSION: v0.2.1
-          # comma delimited list of project relative folders to inspect for package
-          # managers (gomod, yarn, npm).
-          PROJECT_FOLDERS: ".,./ui"
-          # full qualified name of the docker image to be inspected
-          DOCKER_IMAGE: quay.io/argoproj/argocd:${{ github.ref_name }}
-        run: |
-          yarn install --cwd ./ui
-          go install github.com/spdx/spdx-sbom-generator/cmd/generator@$SPDX_GEN_VERSION
-          go install sigs.k8s.io/bom/cmd/bom@$SIGS_BOM_VERSION
-
-          # Generate SPDX for project dependencies analyzing package managers
-          for folder in $(echo $PROJECT_FOLDERS | sed "s/,/ /g")
-          do
-            generator -p $folder -o /tmp
-          done
-
-          # Generate SPDX for binaries analyzing the docker image
-          if [[ ! -z $DOCKER_IMAGE ]]; then
-            bom generate -o /tmp/bom-docker-image.spdx -i $DOCKER_IMAGE
-          fi
-
-          cd /tmp && tar -zcf sbom.tar.gz *.spdx
-          
-      - name: Generate SBOM hash
-        shell: bash
-        id: sbom-hash
-        run: |
-          # sha256sum generates sha256 hash for sbom.
-          # base64 -w0 encodes to base64 and outputs on a single line.
-          # sha256sum /tmp/sbom.tar.gz ... | base64 -w0
-          echo "hashes=$(sha256sum /tmp/sbom.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
-      
-      - name: Upload SBOM
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: |
-            /tmp/sbom.tar.gz
-  
-  sbom-provenance:
-    needs: [generate-sbom]
-    permissions:
-      actions: read # for detecting the Github Actions environment
-      id-token: write # Needed for provenance signing and ID
-      contents: write #  Needed for release uploads
-    #if: github.repository == 'argoproj/argo-cd'
-    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.generate-sbom.outputs.hashes }}"
-      provenance-name: "argocd-sbom.intoto.jsonl"
-      upload-assets: true
-      
-  post-release:
-    needs:
-      - argocd-image
-      - goreleaser
-      - generate-sbom
-    permissions:
-      contents: write # Needed to push commit to update stable tag
-      pull-requests: write # Needed to create PR for VERSION update.
-    #if: github.repository == 'argoproj/argo-cd'
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Git author information
-        run: |
-          set -ue
-          git config --global user.email 'ci@argoproj.com'
-          git config --global user.name 'CI'
-
-      - name: Check if tag is the latest version and not a pre-release
-        run: |
-          set -xue
-          # Fetch all tag information
-          git fetch --prune --tags --force
-
-          LATEST_TAG=$(git -c 'versionsort.suffix=-rc' tag --list --sort=version:refname | tail -n1)
-
-          PRE_RELEASE=false
-          # Check if latest tag is a pre-release
-          if echo $LATEST_TAG | grep -E -- '-rc[0-9]+$';then
-            PRE_RELEASE=true
-          fi
-
-          # Ensure latest tag matches github.ref_name & not a pre-release
-          if [[ $LATEST_TAG == ${{ github.ref_name }} ]] && [[ $PRE_RELEASE != 'true' ]];then
-            echo "TAG_STABLE=true" >> $GITHUB_ENV
-          else
-            echo "TAG_STABLE=false" >> $GITHUB_ENV
-          fi
-
-      - name: Update stable tag to latest version
-        run: |
-          git tag -f stable ${{ github.ref_name }}
-          git push -f origin stable
-        if: ${{ env.TAG_STABLE == 'true' }}
-
-      - name: Check to see if VERSION should be updated on master branch
-        run: |
-          set -xue
-          SOURCE_TAG=${{ github.ref_name }}
-          VERSION_REF="${SOURCE_TAG#*v}"
-          COMMIT_HASH=$(git rev-parse HEAD)
-          if echo "$VERSION_REF" | grep -E -- '^[0-9]+\.[0-9]+\.0-rc1';then
-            VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${VERSION_REF%-rc1}")
-            echo "Updating VERSION to: $VERSION"
-            echo "UPDATE_VERSION=true" >> $GITHUB_ENV
-            echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV
-            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
-          else
-            echo "Not updating VERSION"
-            echo "UPDATE_VERSION=false" >> $GITHUB_ENV
-          fi
-
-      - name: Update VERSION on master branch
-        run: |
-          echo ${{ env.NEW_VERSION }} > VERSION
-          # Replace the 'project-release: vX.X.X-rcX' line in SECURITY-INSIGHTS.yml
-          sed -i "s/project-release: v.*$/project-release: v${{ env.NEW_VERSION }}/" SECURITY-INSIGHTS.yml
-          # Update the 'commit-hash: XXXXXXX' line in SECURITY-INSIGHTS.yml
-          sed -i "s/commit-hash: .*/commit-hash: ${{ env.COMMIT_HASH }}/" SECURITY-INSIGHTS.yml
-        if: ${{ env.UPDATE_VERSION == 'true' }}
-
-      - name: Create PR to update VERSION on master branch
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
-        with:
-          commit-message: Bump version in master
-          title: "chore: Bump version in master"
-          body: All images built from master should indicate which version we are on track for.
-          signoff: true
-          branch: update-version
-          branch-suffix: random
-          base: master
-        if: ${{ env.UPDATE_VERSION == 'true' }}
+#  goreleaser-provenance:
+#    needs: [goreleaser]
+#    permissions:
+#      actions: read # for detecting the Github Actions environment
+#      id-token: write # Needed for provenance signing and ID
+#      contents: write #  Needed for release uploads
+#    #if: github.repository == 'argoproj/argo-cd'
+#    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+#    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+#    with:
+#      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+#      provenance-name: "argocd-cli.intoto.jsonl"
+#      upload-assets: true
+#
+#  generate-sbom:
+#    name: Create SBOM and generate hash
+#    needs:
+#      - argocd-image
+#      - goreleaser
+#    permissions:
+#      contents: write # Needed for release uploads
+#    outputs:
+#      hashes: ${{ steps.sbom-hash.outputs.hashes}}
+#    #if: github.repository == 'argoproj/argo-cd'
+#    runs-on: ubuntu-22.04
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
+#        with:
+#          fetch-depth: 0
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Setup Golang
+#        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+#        with:
+#          go-version: ${{ env.GOLANG_VERSION }}
+#
+#      - name: Generate SBOM (spdx)
+#        id: spdx-builder
+#        env:
+#          # defines the spdx/spdx-sbom-generator version to use.
+#          SPDX_GEN_VERSION: v0.0.13
+#          # defines the sigs.k8s.io/bom version to use.
+#          SIGS_BOM_VERSION: v0.2.1
+#          # comma delimited list of project relative folders to inspect for package
+#          # managers (gomod, yarn, npm).
+#          PROJECT_FOLDERS: ".,./ui"
+#          # full qualified name of the docker image to be inspected
+#          DOCKER_IMAGE: quay.io/argoproj/argocd:${{ github.ref_name }}
+#        run: |
+#          yarn install --cwd ./ui
+#          go install github.com/spdx/spdx-sbom-generator/cmd/generator@$SPDX_GEN_VERSION
+#          go install sigs.k8s.io/bom/cmd/bom@$SIGS_BOM_VERSION
+#
+#          # Generate SPDX for project dependencies analyzing package managers
+#          for folder in $(echo $PROJECT_FOLDERS | sed "s/,/ /g")
+#          do
+#            generator -p $folder -o /tmp
+#          done
+#
+#          # Generate SPDX for binaries analyzing the docker image
+#          if [[ ! -z $DOCKER_IMAGE ]]; then
+#            bom generate -o /tmp/bom-docker-image.spdx -i $DOCKER_IMAGE
+#          fi
+#
+#          cd /tmp && tar -zcf sbom.tar.gz *.spdx
+#
+#      - name: Generate SBOM hash
+#        shell: bash
+#        id: sbom-hash
+#        run: |
+#          # sha256sum generates sha256 hash for sbom.
+#          # base64 -w0 encodes to base64 and outputs on a single line.
+#          # sha256sum /tmp/sbom.tar.gz ... | base64 -w0
+#          echo "hashes=$(sha256sum /tmp/sbom.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
+#
+#      - name: Upload SBOM
+#        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          files: |
+#            /tmp/sbom.tar.gz
+#
+#  sbom-provenance:
+#    needs: [generate-sbom]
+#    permissions:
+#      actions: read # for detecting the Github Actions environment
+#      id-token: write # Needed for provenance signing and ID
+#      contents: write #  Needed for release uploads
+#    #if: github.repository == 'argoproj/argo-cd'
+#    # Must be refernced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+#    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+#    with:
+#      base64-subjects: "${{ needs.generate-sbom.outputs.hashes }}"
+#      provenance-name: "argocd-sbom.intoto.jsonl"
+#      upload-assets: true
+#
+#  post-release:
+#    needs:
+#      - argocd-image
+#      - goreleaser
+#      - generate-sbom
+#    permissions:
+#      contents: write # Needed to push commit to update stable tag
+#      pull-requests: write # Needed to create PR for VERSION update.
+#    #if: github.repository == 'argoproj/argo-cd'
+#    runs-on: ubuntu-22.04
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
+#        with:
+#          fetch-depth: 0
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Setup Git author information
+#        run: |
+#          set -ue
+#          git config --global user.email 'ci@argoproj.com'
+#          git config --global user.name 'CI'
+#
+#      - name: Check if tag is the latest version and not a pre-release
+#        run: |
+#          set -xue
+#          # Fetch all tag information
+#          git fetch --prune --tags --force
+#
+#          LATEST_TAG=$(git -c 'versionsort.suffix=-rc' tag --list --sort=version:refname | tail -n1)
+#
+#          PRE_RELEASE=false
+#          # Check if latest tag is a pre-release
+#          if echo $LATEST_TAG | grep -E -- '-rc[0-9]+$';then
+#            PRE_RELEASE=true
+#          fi
+#
+#          # Ensure latest tag matches github.ref_name & not a pre-release
+#          if [[ $LATEST_TAG == ${{ github.ref_name }} ]] && [[ $PRE_RELEASE != 'true' ]];then
+#            echo "TAG_STABLE=true" >> $GITHUB_ENV
+#          else
+#            echo "TAG_STABLE=false" >> $GITHUB_ENV
+#          fi
+#
+#      - name: Update stable tag to latest version
+#        run: |
+#          git tag -f stable ${{ github.ref_name }}
+#          git push -f origin stable
+#        if: ${{ env.TAG_STABLE == 'true' }}
+#
+#      - name: Check to see if VERSION should be updated on master branch
+#        run: |
+#          set -xue
+#          SOURCE_TAG=${{ github.ref_name }}
+#          VERSION_REF="${SOURCE_TAG#*v}"
+#          COMMIT_HASH=$(git rev-parse HEAD)
+#          if echo "$VERSION_REF" | grep -E -- '^[0-9]+\.[0-9]+\.0-rc1';then
+#            VERSION=$(awk 'BEGIN {FS=OFS="."} {$2++; print}' <<< "${VERSION_REF%-rc1}")
+#            echo "Updating VERSION to: $VERSION"
+#            echo "UPDATE_VERSION=true" >> $GITHUB_ENV
+#            echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV
+#            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
+#          else
+#            echo "Not updating VERSION"
+#            echo "UPDATE_VERSION=false" >> $GITHUB_ENV
+#          fi
+#
+#      - name: Update VERSION on master branch
+#        run: |
+#          echo ${{ env.NEW_VERSION }} > VERSION
+#          # Replace the 'project-release: vX.X.X-rcX' line in SECURITY-INSIGHTS.yml
+#          sed -i "s/project-release: v.*$/project-release: v${{ env.NEW_VERSION }}/" SECURITY-INSIGHTS.yml
+#          # Update the 'commit-hash: XXXXXXX' line in SECURITY-INSIGHTS.yml
+#          sed -i "s/commit-hash: .*/commit-hash: ${{ env.COMMIT_HASH }}/" SECURITY-INSIGHTS.yml
+#        if: ${{ env.UPDATE_VERSION == 'true' }}
+#
+#      - name: Create PR to update VERSION on master branch
+#        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+#        with:
+#          commit-message: Bump version in master
+#          title: "chore: Bump version in master"
+#          body: All images built from master should indicate which version we are on track for.
+#          signoff: true
+#          branch: update-version
+#          branch-suffix: random
+#          base: master
+#        if: ${{ env.UPDATE_VERSION == 'true' }}

--- a/hack/get-previous-release/get-previous-version-for-release-notes.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes.go
@@ -101,7 +101,7 @@ func findPreviousTag(currentTag string, tags []string) (string, error) {
 		}
 	}
 	if previousTag == "" {
-		return "", fmt.Errorf("no matching tag found")
+		return "", fmt.Errorf("no matching tag found for tags: " + strings.Join(tags, ", "))
 	}
 	return previousTag, nil
 }

--- a/hack/get-previous-release/get-previous-version-for-release-notes.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"golang.org/x/mod/semver"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+/**
+This script is used to determine the previous version of a release based on the current version. It is used to help
+generate release notes for a new release.
+*/
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run get-previous-version-for-release-notes.go <version being released>")
+		return
+	}
+
+	proposedTag := os.Args[1]
+
+	tags, err := getGitTags()
+	if err != nil {
+		fmt.Printf("Error getting git tags: %v\n", err)
+		return
+	}
+
+	previousTag, err := findPreviousTag(proposedTag, tags)
+	if err != nil {
+		fmt.Printf("Error finding previous tag: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("%s\n", previousTag)
+}
+
+func extractPatchAndRC(tag string) (string, string, error) {
+	re := regexp.MustCompile(`^v\d+\.\d+\.(\d+)(?:-rc(\d+))?$`)
+	matches := re.FindStringSubmatch(tag)
+	if len(matches) < 2 {
+		return "", "", fmt.Errorf("invalid tag format: %s", tag)
+	}
+	patch := matches[1]
+	rc := "0"
+	if len(matches) == 3 && matches[2] != "" {
+		rc = matches[2]
+	}
+	return patch, rc, nil
+}
+
+func findPreviousTag(currentTag string, tags []string) (string, error) {
+	var previousTag string
+	currentMajor := semver.Major(currentTag)
+	currentMinor := semver.MajorMinor(currentTag)
+
+	currentPatch, currentRC, err := extractPatchAndRC(currentTag)
+	if err != nil {
+		return "", err
+	}
+
+	// If the current tag is a .0 patch release or a 1 release candidate, adjust to the previous minor release series
+	if (currentPatch == "0" && currentRC == "0") || currentRC == "1" {
+		currentMinorInt, err := strconv.Atoi(strings.TrimPrefix(currentMinor, currentMajor+"."))
+		if err != nil {
+			return "", fmt.Errorf("invalid minor version: %v", err)
+		}
+		if currentMinorInt > 0 {
+			currentMinor = fmt.Sprintf("%s.%d", currentMajor, currentMinorInt-1)
+		}
+	}
+
+	for _, tag := range tags {
+		if tag == currentTag {
+			continue
+		}
+		tagMajor := semver.Major(tag)
+		tagMinor := semver.MajorMinor(tag)
+		tagPatch, tagRC, err := extractPatchAndRC(tag)
+		if err != nil {
+			continue
+		}
+
+		if tagMajor == currentMajor && tagMinor == currentMinor {
+			if currentRC != "0" && tagRC != "0" && tagPatch == currentPatch {
+				if semver.Compare(tag, previousTag) > 0 {
+					previousTag = tag
+				}
+			} else if currentRC == "0" && tagRC == "0" {
+				if semver.Compare(tag, previousTag) > 0 {
+					previousTag = tag
+				}
+			} else if currentRC != "0" && tagRC == "0" {
+				if semver.Compare(tag, previousTag) > 0 {
+					previousTag = tag
+				}
+			}
+		}
+	}
+	if previousTag == "" {
+		return "", fmt.Errorf("no matching tag found")
+	}
+	return previousTag, nil
+}
+
+func getGitTags() ([]string, error) {
+	cmd := exec.Command("git", "tag", "--sort=-v:refname")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("error executing git command: %v", err)
+	}
+
+	tags := strings.Split(string(output), "\n")
+	var semverTags []string
+	for _, tag := range tags {
+		if semver.IsValid(tag) {
+			semverTags = append(semverTags, tag)
+		}
+	}
+
+	return semverTags, nil
+}

--- a/hack/get-previous-release/get-previous-version-for-release-notes_test.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindPreviousTagRules(t *testing.T) {
+	t.Parallel()
+	tags := []string{"v1.2.3", "v1.2.2", "v1.2.1", "v1.2.0", "v1.1.9", "v1.1.8", "v1.1.7-rc1", "v1.1.6"}
+
+	tests := []struct {
+		name, proposedTag, expected string
+		expectError                 bool
+	}{
+		// Rule 1: If we're releasing a .0 patch release, get the most recent tag on the previous minor release series.
+		{"Rule 1: .0 patch release", "v1.2.0", "v1.1.9", false},
+		// Rule 2: If we're releasing a non-0 patch release, get the most recent tag within the same minor release series.
+		{"Rule 2: non-0 patch release", "v1.2.3", "v1.2.2", false},
+		// Rule 3: If we're releasing a 1 release candidate, get the most recent tag on the previous minor release series.
+		{"Rule 3: 1 release candidate", "v1.2.0-rc1", "v1.1.9", false},
+		// Rule 4: If we're releasing a non-1 release candidate, get the most recent rc tag on the current minor release series.
+		{"Rule 4: non-1 release candidate", "v1.2.0-rc2", "v1.2.0-rc1", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := findPreviousTag(test.proposedTag, tags)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equalf(t, test.expected, test.expected, "for proposed tag %s expected %s but got %s", test.proposedTag, test.expected, result)
+			}
+		})
+	}
+}

--- a/hack/get-previous-release/get-previous-version-for-release-notes_test.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes_test.go
@@ -8,20 +8,74 @@ import (
 
 func TestFindPreviousTagRules(t *testing.T) {
 	t.Parallel()
-	tags := []string{"v1.2.3", "v1.2.2", "v1.2.1", "v1.2.0", "v1.1.9", "v1.1.8", "v1.1.7-rc1", "v1.1.6"}
+	// Sample pulled from git tag --sort=-v:refname output.
+	tags := []string{
+		"v2.13.0-rc3",
+		"v2.13.0-rc2",
+		"v2.13.0-rc1",
+		"v2.12.5",
+		"v2.12.4",
+		"v2.12.3",
+		"v2.12.2",
+		"v2.12.1",
+		"v2.12.0-rc5",
+		"v2.12.0-rc4",
+		"v2.12.0-rc3",
+		"v2.12.0-rc2",
+		"v2.12.0-rc1",
+		"v2.12.0",
+		"v2.11.11",
+		"v2.11.10",
+		"v2.11.9",
+		"v2.11.8",
+		"v2.11.7",
+		"v2.11.6",
+		"v2.11.5",
+		"v2.11.4",
+		"v2.11.3",
+		"v2.11.2",
+		"v2.11.1",
+		"v2.11.0-rc3",
+		"v2.11.0-rc2",
+		"v2.11.0-rc1",
+		"v2.11.0",
+		"v2.10.17",
+		"v2.10.16",
+		"v2.10.15",
+		"v2.10.14",
+		"v2.10.13",
+		"v2.10.12",
+		"v2.10.11",
+		"v2.10.10",
+		"v2.10.9",
+		"v2.10.8",
+		"v2.10.7",
+		"v2.10.6",
+		"v2.10.5",
+		"v2.10.4",
+		"v2.10.3",
+		"v2.10.2",
+		"v2.10.1",
+		"v2.10.0-rc5",
+		"v2.10.0-rc4",
+		"v2.10.0-rc3",
+		"v2.10.0-rc2",
+		"v2.10.0-rc1",
+		"v2.10.0",
+	}
 
 	tests := []struct {
 		name, proposedTag, expected string
 		expectError                 bool
 	}{
 		// Rule 1: If we're releasing a .0 patch release, get the most recent tag on the previous minor release series.
-		{"Rule 1: .0 patch release", "v1.2.0", "v1.1.9", false},
+		{"Rule 1: .0 patch release", "v2.13.0", "v2.12.5", false},
 		// Rule 2: If we're releasing a non-0 patch release, get the most recent tag within the same minor release series.
-		{"Rule 2: non-0 patch release", "v1.2.3", "v1.2.2", false},
+		{"Rule 2: non-0 patch release", "v2.12.6", "v2.12.5", false},
 		// Rule 3: If we're releasing a 1 release candidate, get the most recent tag on the previous minor release series.
-		{"Rule 3: 1 release candidate", "v1.2.0-rc1", "v1.1.9", false},
+		{"Rule 3: 1 release candidate", "v2.14.0-rc1", "v2.13.0-rc3", false},
 		// Rule 4: If we're releasing a non-1 release candidate, get the most recent rc tag on the current minor release series.
-		{"Rule 4: non-1 release candidate", "v1.2.0-rc2", "v1.2.0-rc1", false},
+		{"Rule 4: non-1 release candidate", "v2.13.0-rc4", "v2.13.0-rc3", false},
 	}
 
 	for _, test := range tests {

--- a/hack/get-previous-release/go.mod
+++ b/hack/get-previous-release/go.mod
@@ -1,0 +1,14 @@
+module github.com/argoproj/argo-cd/get-previous-release
+
+go 1.22.5
+
+require (
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/mod v0.21.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/hack/get-previous-release/go.sum
+++ b/hack/get-previous-release/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Fixes #19443

The script is overcomplicated, but the tests are simple. 

I tested on my fork, and the code ran and got the correct tag for the test tag. I've probably missed edge cases, but at least this gives us something to iterate.