### PR TITLE
feat(appset): add 'project' to the Cluster Generator params

### DIFF
--- a/applicationset/generators/cluster.go
+++ b/applicationset/generators/cluster.go
@@ -107,6 +107,7 @@ func (g *ClusterGenerator) GenerateParams(appSetGenerator *argoappsetv1alpha1.Ap
 			params["name"] = cluster.Name
 			params["nameNormalized"] = cluster.Name
 			params["server"] = cluster.Server
+			params["project"] = ""
 
 			err = appendTemplatedValues(appSetGenerator.Clusters.Values, params, appSet.Spec.GoTemplate, appSet.Spec.GoTemplateOptions)
 			if err != nil {
@@ -130,6 +131,13 @@ func (g *ClusterGenerator) GenerateParams(appSetGenerator *argoappsetv1alpha1.Ap
 		params["name"] = string(cluster.Data["name"])
 		params["nameNormalized"] = utils.SanitizeName(string(cluster.Data["name"]))
 		params["server"] = string(cluster.Data["server"])
+
+		project, ok := cluster.Data["project"]
+		if ok {
+			params["project"] = string(project)
+		} else {
+			params["project"] = ""
+		}
 
 		if appSet.Spec.GoTemplate {
 			meta := map[string]interface{}{}

--- a/applicationset/generators/cluster_test.go
+++ b/applicationset/generators/cluster_test.go
@@ -76,9 +76,10 @@ func TestGenerateParams(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"config": []byte("{}"),
-				"name":   []byte("production_01/west"),
-				"server": []byte("https://production-01.example.com"),
+				"config":  []byte("{}"),
+				"name":    []byte("production_01/west"),
+				"server":  []byte("https://production-01.example.com"),
+				"project": []byte("prod-project"),
 			},
 			Type: corev1.SecretType("Opaque"),
 		},
@@ -106,15 +107,15 @@ func TestGenerateParams(t *testing.T) {
 				"aaa":   "{{ server }}",
 				"no-op": "{{ this-does-not-exist }}",
 			}, expected: []map[string]interface{}{
-				{"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "{{ metadata.annotations.foo.argoproj.io }}", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "{{ metadata.labels.environment }}", "values.aaa": "https://kubernetes.default.svc", "nameNormalized": "in-cluster", "name": "in-cluster", "server": "https://kubernetes.default.svc"},
+				{"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "{{ metadata.annotations.foo.argoproj.io }}", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "{{ metadata.labels.environment }}", "values.aaa": "https://kubernetes.default.svc", "nameNormalized": "in-cluster", "name": "in-cluster", "server": "https://kubernetes.default.svc", "project": ""},
 				{
 					"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "production", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "production", "values.aaa": "https://production-01.example.com", "name": "production_01/west", "nameNormalized": "production-01-west", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.org": "bar",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production", "project": "prod-project",
 				},
 
 				{
 					"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "staging", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "staging", "values.aaa": "https://staging-01.example.com", "name": "staging-01", "nameNormalized": "staging-01", "server": "https://staging-01.example.com", "metadata.labels.environment": "staging", "metadata.labels.org": "foo",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging", "project": "",
 				},
 			},
 			clientError:   false,
@@ -131,12 +132,12 @@ func TestGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"name": "production_01/west", "nameNormalized": "production-01-west", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.org": "bar",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production", "project": "prod-project",
 				},
 
 				{
 					"name": "staging-01", "nameNormalized": "staging-01", "server": "https://staging-01.example.com", "metadata.labels.environment": "staging", "metadata.labels.org": "foo",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging", "project": "",
 				},
 			},
 			clientError:   false,
@@ -155,7 +156,7 @@ func TestGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"values.foo": "bar", "name": "production_01/west", "nameNormalized": "production-01-west", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.org": "bar",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production", "project": "prod-project",
 				},
 			},
 			clientError:   false,
@@ -181,11 +182,11 @@ func TestGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"values.foo": "bar", "name": "staging-01", "nameNormalized": "staging-01", "server": "https://staging-01.example.com", "metadata.labels.environment": "staging", "metadata.labels.org": "foo",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging", "project": "",
 				},
 				{
 					"values.foo": "bar", "name": "production_01/west", "nameNormalized": "production-01-west", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.org": "bar",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production", "project": "prod-project",
 				},
 			},
 			clientError:   false,
@@ -214,7 +215,7 @@ func TestGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"values.name": "baz", "name": "staging-01", "nameNormalized": "staging-01", "server": "https://staging-01.example.com", "metadata.labels.environment": "staging", "metadata.labels.org": "foo",
-					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging",
+					"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging", "project": "",
 				},
 			},
 			clientError:   false,
@@ -244,15 +245,15 @@ func TestGenerateParams(t *testing.T) {
 			expected: []map[string]interface{}{
 				{
 					"clusters": []map[string]interface{}{
-						{"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "{{ metadata.annotations.foo.argoproj.io }}", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "{{ metadata.labels.environment }}", "values.aaa": "https://kubernetes.default.svc", "nameNormalized": "in-cluster", "name": "in-cluster", "server": "https://kubernetes.default.svc"},
+						{"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "{{ metadata.annotations.foo.argoproj.io }}", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "{{ metadata.labels.environment }}", "values.aaa": "https://kubernetes.default.svc", "nameNormalized": "in-cluster", "name": "in-cluster", "server": "https://kubernetes.default.svc", "project": ""},
 						{
 							"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "production", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "production", "values.aaa": "https://production-01.example.com", "name": "production_01/west", "nameNormalized": "production-01-west", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.org": "bar",
-							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production",
+							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production", "project": "prod-project",
 						},
 
 						{
 							"values.lol1": "lol", "values.lol2": "{{values.lol1}}{{values.lol1}}", "values.lol3": "{{values.lol2}}{{values.lol2}}{{values.lol2}}", "values.foo": "bar", "values.bar": "staging", "values.no-op": "{{ this-does-not-exist }}", "values.bat": "staging", "values.aaa": "https://staging-01.example.com", "name": "staging-01", "nameNormalized": "staging-01", "server": "https://staging-01.example.com", "metadata.labels.environment": "staging", "metadata.labels.org": "foo",
-							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging",
+							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging", "project": "",
 						},
 					},
 				},
@@ -284,11 +285,11 @@ func TestGenerateParams(t *testing.T) {
 					"clusters": []map[string]interface{}{
 						{
 							"values.foo": "bar", "name": "production_01/west", "nameNormalized": "production-01-west", "server": "https://production-01.example.com", "metadata.labels.environment": "production", "metadata.labels.org": "bar",
-							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production",
+							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "production", "project": "prod-project",
 						},
 						{
 							"values.foo": "bar", "name": "staging-01", "nameNormalized": "staging-01", "server": "https://staging-01.example.com", "metadata.labels.environment": "staging", "metadata.labels.org": "foo",
-							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging",
+							"metadata.labels.argocd.argoproj.io/secret-type": "cluster", "metadata.annotations.foo.argoproj.io": "staging", "project": "",
 						},
 					},
 				},
@@ -419,6 +420,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "production_01/west",
 					"nameNormalized": "production-01-west",
 					"server":         "https://production-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -444,6 +446,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "staging-01",
 					"nameNormalized": "staging-01",
 					"server":         "https://staging-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -469,6 +472,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"nameNormalized": "in-cluster",
 					"name":           "in-cluster",
 					"server":         "https://kubernetes.default.svc",
+					"project":        "",
 					"values": map[string]string{
 						"lol1":  "lol",
 						"lol2":  "<no value><no value>",
@@ -497,6 +501,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "production_01/west",
 					"nameNormalized": "production-01-west",
 					"server":         "https://production-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -512,6 +517,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "staging-01",
 					"nameNormalized": "staging-01",
 					"server":         "https://staging-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -542,6 +548,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "production_01/west",
 					"nameNormalized": "production-01-west",
 					"server":         "https://production-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -582,6 +589,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "production_01/west",
 					"nameNormalized": "production-01-west",
 					"server":         "https://production-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -600,6 +608,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "staging-01",
 					"nameNormalized": "staging-01",
 					"server":         "https://staging-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -643,6 +652,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					"name":           "staging-01",
 					"nameNormalized": "staging-01",
 					"server":         "https://staging-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"argocd.argoproj.io/secret-type": "cluster",
@@ -690,6 +700,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 							"nameNormalized": "in-cluster",
 							"name":           "in-cluster",
 							"server":         "https://kubernetes.default.svc",
+							"project":        "",
 							"values": map[string]string{
 								"lol1":  "lol",
 								"lol2":  "<no value><no value>",
@@ -705,6 +716,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 							"name":           "production_01/west",
 							"nameNormalized": "production-01-west",
 							"server":         "https://production-01.example.com",
+							"project":        "",
 							"metadata": map[string]interface{}{
 								"labels": map[string]string{
 									"argocd.argoproj.io/secret-type": "cluster",
@@ -730,6 +742,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 							"name":           "staging-01",
 							"nameNormalized": "staging-01",
 							"server":         "https://staging-01.example.com",
+							"project":        "",
 							"metadata": map[string]interface{}{
 								"labels": map[string]string{
 									"argocd.argoproj.io/secret-type": "cluster",
@@ -782,6 +795,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 							"name":           "production_01/west",
 							"nameNormalized": "production-01-west",
 							"server":         "https://production-01.example.com",
+							"project":        "",
 							"metadata": map[string]interface{}{
 								"labels": map[string]string{
 									"argocd.argoproj.io/secret-type": "cluster",
@@ -800,6 +814,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 							"name":           "staging-01",
 							"nameNormalized": "staging-01",
 							"server":         "https://staging-01.example.com",
+							"project":        "",
 							"metadata": map[string]interface{}{
 								"labels": map[string]string{
 									"argocd.argoproj.io/secret-type": "cluster",

--- a/applicationset/generators/generator_spec_processor_test.go
+++ b/applicationset/generators/generator_spec_processor_test.go
@@ -199,6 +199,7 @@ func TestTransForm(t *testing.T) {
 				"name":                                           "production_01/west",
 				"nameNormalized":                                 "production-01-west",
 				"server":                                         "https://production-01.example.com",
+				"project":                                        "",
 			}},
 		},
 		{
@@ -214,6 +215,7 @@ func TestTransForm(t *testing.T) {
 				"name":                                           "some-really-long-server-url",
 				"nameNormalized":                                 "some-really-long-server-url",
 				"server":                                         "https://some-really-long-url-that-will-exceed-63-characters.com",
+				"project":                                        "",
 			}},
 		},
 	}

--- a/applicationset/generators/matrix_test.go
+++ b/applicationset/generators/matrix_test.go
@@ -578,8 +578,8 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 				},
 			},
 			expected: []map[string]interface{}{
-				{"path": "examples/git-generator-files-discovery/cluster-config/dev/config.json", "path.basename": "dev", "path.basenameNormalized": "dev", "name": "dev-01", "nameNormalized": "dev-01", "server": "https://dev-01.example.com", "metadata.labels.environment": "dev", "metadata.labels.argocd.argoproj.io/secret-type": "cluster"},
-				{"path": "examples/git-generator-files-discovery/cluster-config/prod/config.json", "path.basename": "prod", "path.basenameNormalized": "prod", "name": "prod-01", "nameNormalized": "prod-01", "server": "https://prod-01.example.com", "metadata.labels.environment": "prod", "metadata.labels.argocd.argoproj.io/secret-type": "cluster"},
+				{"path": "examples/git-generator-files-discovery/cluster-config/dev/config.json", "path.basename": "dev", "path.basenameNormalized": "dev", "name": "dev-01", "nameNormalized": "dev-01", "server": "https://dev-01.example.com", "metadata.labels.environment": "dev", "metadata.labels.argocd.argoproj.io/secret-type": "cluster", "project": ""},
+				{"path": "examples/git-generator-files-discovery/cluster-config/prod/config.json", "path.basename": "prod", "path.basenameNormalized": "prod", "name": "prod-01", "nameNormalized": "prod-01", "server": "https://prod-01.example.com", "metadata.labels.environment": "prod", "metadata.labels.argocd.argoproj.io/secret-type": "cluster", "project": ""},
 			},
 			clientError: false,
 		},
@@ -734,6 +734,7 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 					"name":           "dev-01",
 					"nameNormalized": "dev-01",
 					"server":         "https://dev-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"environment":                    "dev",
@@ -750,6 +751,7 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 					"name":           "prod-01",
 					"nameNormalized": "prod-01",
 					"server":         "https://prod-01.example.com",
+					"project":        "",
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"environment":                    "prod",

--- a/docs/operator-manual/applicationset/Generators-Cluster.md
+++ b/docs/operator-manual/applicationset/Generators-Cluster.md
@@ -9,6 +9,7 @@ It automatically provides the following parameter values to the Application temp
 - `name`
 - `nameNormalized` *('name' but normalized to contain only lowercase alphanumeric characters, '-' or '.')*
 - `server`
+- `project` *(the Secret's 'project' field, if present; otherwise, it defaults to '')*
 - `metadata.labels.<key>` *(for each label in the Secret)*
 - `metadata.annotations.<key>` *(for each annotation in the Secret)*
 


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/18814

# Description
This PR adds the `project` parameter to the Cluster generator. If the cluster doesn't have a `project` field within its Secret, the param's value defaults to `default`.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [X] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [X] Does this PR require documentation updates?
* [X] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

