### PR TITLE
fix(cli): add missing resources and actions to cani CLI

### DIFF
--- a/docs/user-guide/commands/argocd_account_can-i.md
+++ b/docs/user-guide/commands/argocd_account_can-i.md
@@ -21,8 +21,8 @@ argocd account can-i update projects 'default'
 # Can I create a cluster?
 argocd account can-i create clusters '*'
 
-Actions: [get create update delete sync override]
-Resources: [clusters projects applications applicationsets repositories certificates logs exec]
+Actions: [get create update delete sync override action invoke]
+Resources: [clusters projects applications applicationsets repositories certificates accounts gpgkeys logs exec extensions]
 
 ```
 

--- a/server/rbacpolicy/rbacpolicy.go
+++ b/server/rbacpolicy/rbacpolicy.go
@@ -46,8 +46,11 @@ var (
 		ResourceApplicationSets,
 		ResourceRepositories,
 		ResourceCertificates,
+		ResourceAccounts,
+		ResourceGPGKeys,
 		ResourceLogs,
 		ResourceExec,
+		ResourceExtensions,
 	}
 	Actions = []string{
 		ActionGet,
@@ -56,6 +59,8 @@ var (
 		ActionDelete,
 		ActionSync,
 		ActionOverride,
+		ActionAction,
+		ActionInvoke,
 	}
 )
 


### PR DESCRIPTION
These lists are only used by the CLI and CanI API. They just got out of date as resources and actions were added.