### PR TITLE
chore: simplify 'get repo' API implementation

### DIFF
--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/common"
 	"reflect"
 	"sort"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/argoproj/argo-cd/v2/common"
 	repositorypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/repository"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -369,6 +369,68 @@ func TestRepositoryServer(t *testing.T) {
 		assert.Equal(t, "rpc error: code = NotFound desc = repo 'https://test' not found", err.Error())
 	})
 
+	t.Run("Test_GetRepoIsSanitized", func(t *testing.T) {
+		repoServerClient := mocks.RepoServerServiceClient{}
+		repoServerClient.On("TestRepository", mock.Anything, mock.Anything).Return(&apiclient.TestRepositoryResponse{}, nil)
+		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
+
+		url := "https://test"
+		db := &dbmocks.ArgoDB{}
+		db.On("ListRepositories", context.TODO()).Return([]*appsv1.Repository{{Repo: url, Username: "test", Password: "it's a secret"}}, nil)
+		db.On("GetRepository", context.TODO(), url, "").Return(&appsv1.Repository{Repo: url, Username: "test", Password: "it's a secret"}, nil)
+		db.On("RepositoryExists", context.TODO(), url, "").Return(true, nil)
+
+		s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, appLister, projInformer, testNamespace, settingsMgr)
+		repo, err := s.Get(context.TODO(), &repository.RepoQuery{
+			Repo: url,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "https://test", repo.Repo)
+		assert.Empty(t, repo.Password)
+	})
+
+	t.Run("Test_GetRepoIsNormalized", func(t *testing.T) {
+		repoServerClient := mocks.RepoServerServiceClient{}
+		repoServerClient.On("TestRepository", mock.Anything, mock.Anything).Return(&apiclient.TestRepositoryResponse{}, nil)
+		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
+
+		url := "https://test"
+		db := &dbmocks.ArgoDB{}
+		db.On("ListRepositories", context.TODO()).Return([]*appsv1.Repository{{Repo: url}}, nil)
+		db.On("GetRepository", context.TODO(), url, "").Return(&appsv1.Repository{Repo: url, Username: "test"}, nil)
+		db.On("RepositoryExists", context.TODO(), url, "").Return(true, nil)
+
+		s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, appLister, projInformer, testNamespace, settingsMgr)
+		repo, err := s.Get(context.TODO(), &repository.RepoQuery{
+			Repo: url,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "https://test", repo.Repo)
+		assert.Equal(t, common.DefaultRepoType, repo.Type)
+	})
+
+	t.Run("Test_GetRepoHasConnectionState", func(t *testing.T) {
+		repoServerClient := mocks.RepoServerServiceClient{}
+		repoServerClient.On("TestRepository", mock.Anything, mock.Anything).Return(&apiclient.TestRepositoryResponse{
+			VerifiedRepository: true,
+		}, nil)
+		repoServerClientset := mocks.Clientset{RepoServerServiceClient: &repoServerClient}
+
+		url := "https://test"
+		db := &dbmocks.ArgoDB{}
+		db.On("ListRepositories", context.TODO()).Return([]*appsv1.Repository{{Repo: url}}, nil)
+		db.On("GetRepository", context.TODO(), url, "").Return(&appsv1.Repository{Repo: url}, nil)
+		db.On("RepositoryExists", context.TODO(), url, "").Return(true, nil)
+
+		s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, appLister, projInformer, testNamespace, settingsMgr)
+		repo, err := s.Get(context.TODO(), &repository.RepoQuery{
+			Repo: url,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, repo.ConnectionState)
+		assert.Equal(t, appsv1.ConnectionStatusSuccessful, repo.ConnectionState.Status)
+	})
+
 	t.Run("Test_CreateRepositoryWithoutUpsert", func(t *testing.T) {
 		repoServerClient := mocks.RepoServerServiceClient{}
 		repoServerClient.On("TestRepository", mock.Anything, mock.Anything).Return(&apiclient.TestRepositoryResponse{}, nil)


### PR DESCRIPTION
The repository `Get` endpoint currently normalizes, sanitizes, and augments the repo object with the connection status.

But that work is already done by the call to `s.ListRepositories`.

For normalization and sanitization, the duplication is a drift risk, but isn't otherwise a problem.

The extra connection status check shouldn't be a huge problem, because it's cached. But it'll duplicate the check when anyone clicks "refresh" in the repo list UI.

I've added unit tests to confirm that `Get` still gets the normalized, sanitized, and augmented repo object. I've confirmed that, if I remove those behaviors from the ListRepositories function, the tests fail (so we would catch a regression).