### PR TITLE
fix(ui): display correct init info in Pod UI

### DIFF
--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -379,12 +379,6 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 				readyContainers++
 			}
 			continue
-		case isRestartableInitContainer(initContainers[container.Name]) &&
-			container.Started != nil && *container.Started:
-			if container.Ready {
-				readyContainers++
-			}
-			continue
 		case container.State.Terminated != nil:
 			// initialization is failed
 			if len(container.State.Terminated.Reason) == 0 {

--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -379,6 +379,9 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 				readyContainers++
 			}
 			continue
+		case isRestartableInitContainer(initContainers[container.Name]) &&
+			container.Started != nil && *container.Started:
+			continue
 		case container.State.Terminated != nil:
 			// initialization is failed
 			if len(container.State.Terminated.Reason) == 0 {

--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -381,6 +381,9 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 			continue
 		case isRestartableInitContainer(initContainers[container.Name]) &&
 			container.Started != nil && *container.Started:
+			if container.Ready {
+				readyContainers++
+			}
 			continue
 		case container.State.Terminated != nil:
 			// initialization is failed

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -271,8 +271,15 @@ spec:
 `)
 )
 
+// These tests are equivalent to tests in ui/src/app/applications/components/utils.test.tsx. If you update tests here,
+// please make sure to update the equivalent tests in the UI.
 func TestGetPodInfo(t *testing.T) {
-	pod := strToUnstructured(`
+	t.Parallel()
+
+	t.Run("TestGetPodInfo", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -294,22 +301,22 @@ func TestGetPodInfo(t *testing.T) {
           memory: 128Mi
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-	}, info.Info)
-	assert.Equal(t, []string{"bar"}, info.Images)
-	assert.Equal(t, &PodInfo{
-		NodeName:         "minikube",
-		ResourceRequests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
-	}, info.PodInfo)
-	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{Labels: map[string]string{"app": "guestbook"}}, info.NetworkingInfo)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+		}, info.Info)
+		assert.Equal(t, []string{"bar"}, info.Images)
+		assert.Equal(t, &PodInfo{
+			NodeName:         "minikube",
+			ResourceRequests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+		}, info.PodInfo)
+		assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{Labels: map[string]string{"app": "guestbook"}}, info.NetworkingInfo)
+	})
 
-func TestGetPodWithInitialContainerInfo(t *testing.T) {
-	pod := strToUnstructured(`
+	t.Run("TestGetPodWithInitialContainerInfo", func(t *testing.T) {
+		pod := strToUnstructured(`
   apiVersion: "v1"
   kind: "Pod"
   metadata: 
@@ -354,17 +361,19 @@ func TestGetPodWithInitialContainerInfo(t *testing.T) {
     phase: "Running"
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Running"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "1/1"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Running"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "1/1"},
+		}, info.Info)
+	})
 
-func TestGetPodInfoWithSidecar(t *testing.T) {
-	pod := strToUnstructured(`
+	t.Run("TestGetPodInfoWithSidecar", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -409,17 +418,19 @@ func TestGetPodInfoWithSidecar(t *testing.T) {
     phase: Running
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Running"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "2/2"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Running"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "2/2"},
+		}, info.Info)
+	})
 
-func TestGetPodInfoWithInitialContainer(t *testing.T) {
-	pod := strToUnstructured(`
+	t.Run("TestGetPodInfoWithInitialContainer", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -465,18 +476,20 @@ func TestGetPodInfoWithInitialContainer(t *testing.T) {
     startTime: '2024-10-09T08:02:39Z'
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Init:0/1"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Init:0/1"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+		}, info.Info)
+	})
 
-// Test pod has 2 restartable init containers, the first one running but not started.
-func TestGetPodInfoWithRestartableInitContainer(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod has 2 restartable init containers, the first one running but not started.
+	t.Run("TestGetPodInfoWithRestartableInitContainer", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -519,19 +532,21 @@ func TestGetPodInfoWithRestartableInitContainer(t *testing.T) {
         status: "False"
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Init:0/2"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/3"},
-		{Name: "Restart Count", Value: "3"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Init:0/2"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/3"},
+			{Name: "Restart Count", Value: "3"},
+		}, info.Info)
+	})
 
-// Test pod has 2 restartable init containers, the first one started and the second one running but not started.
-func TestGetPodInfoWithPartiallyStartedInitContainers(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod has 2 restartable init containers, the first one started and the second one running but not started.
+	t.Run("TestGetPodInfoWithPartiallyStartedInitContainers", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -574,19 +589,21 @@ func TestGetPodInfoWithPartiallyStartedInitContainers(t *testing.T) {
         status: "False"
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Init:1/2"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/3"},
-		{Name: "Restart Count", Value: "3"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Init:1/2"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/3"},
+			{Name: "Restart Count", Value: "3"},
+		}, info.Info)
+	})
 
-// Test pod has 2 restartable init containers started and 1 container running
-func TestGetPodInfoWithStartedInitContainers(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod has 2 restartable init containers started and 1 container running
+	t.Run("TestGetPodInfoWithStartedInitContainers", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -632,19 +649,21 @@ func TestGetPodInfoWithStartedInitContainers(t *testing.T) {
         status: "True"
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Running"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "1/3"},
-		{Name: "Restart Count", Value: "7"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Running"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "1/3"},
+			{Name: "Restart Count", Value: "7"},
+		}, info.Info)
+	})
 
-// Test pod has 1 init container restarting and 1 container not running
-func TestGetPodInfoWithNormalInitContainer(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod has 1 init container restarting and 1 container not running
+	t.Run("TestGetPodInfoWithNormalInitContainer", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -672,19 +691,21 @@ func TestGetPodInfoWithNormalInitContainer(t *testing.T) {
           waiting: {}
 `)
 
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Init:0/1"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-		{Name: "Restart Count", Value: "3"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Init:0/1"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+			{Name: "Restart Count", Value: "3"},
+		}, info.Info)
+	})
 
-// Test pod condition succeed
-func TestPodConditionSucceeded(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod condition succeed
+	t.Run("TestPodConditionSucceeded", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -703,18 +724,20 @@ func TestPodConditionSucceeded(t *testing.T) {
             reason: Completed
             exitCode: 0
 `)
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Completed"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Completed"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+		}, info.Info)
+	})
 
-// Test pod condition failed
-func TestPodConditionFailed(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod condition failed
+	t.Run("TestPodConditionFailed", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -733,18 +756,20 @@ func TestPodConditionFailed(t *testing.T) {
             reason: Error
             exitCode: 1
 `)
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Error"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Error"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+		}, info.Info)
+	})
 
-// Test pod condition succeed with deletion
-func TestPodConditionSucceededWithDeletion(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod condition succeed with deletion
+	t.Run("TestPodConditionSucceededWithDeletion", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -764,18 +789,20 @@ func TestPodConditionSucceededWithDeletion(t *testing.T) {
             reason: Completed
             exitCode: 0
 `)
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Completed"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Completed"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+		}, info.Info)
+	})
 
-// Test pod condition running with deletion
-func TestPodConditionRunningWithDeletion(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod condition running with deletion
+	t.Run("TestPodConditionRunningWithDeletion", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -793,18 +820,20 @@ func TestPodConditionRunningWithDeletion(t *testing.T) {
         state:
           running: {}
 `)
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Terminating"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Terminating"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+		}, info.Info)
+	})
 
-// Test pod condition pending with deletion
-func TestPodConditionPendingWithDeletion(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test pod condition pending with deletion
+	t.Run("TestPodConditionPendingWithDeletion", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -817,18 +846,20 @@ func TestPodConditionPendingWithDeletion(t *testing.T) {
   status:
     phase: Pending
 `)
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "Terminating"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/1"},
-	}, info.Info)
-}
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "Terminating"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/1"},
+		}, info.Info)
+	})
 
-// Test PodScheduled condition with reason SchedulingGated
-func TestPodScheduledWithSchedulingGated(t *testing.T) {
-	pod := strToUnstructured(`
+	// Test PodScheduled condition with reason SchedulingGated
+	t.Run("TestPodScheduledWithSchedulingGated", func(t *testing.T) {
+		t.Parallel()
+
+		pod := strToUnstructured(`
   apiVersion: v1
   kind: Pod
   metadata:
@@ -845,13 +876,14 @@ func TestPodScheduledWithSchedulingGated(t *testing.T) {
         status: "False"
         reason: SchedulingGated
 `)
-	info := &ResourceInfo{}
-	populateNodeInfo(pod, info, []string{})
-	assert.Equal(t, []v1alpha1.InfoItem{
-		{Name: "Status Reason", Value: "SchedulingGated"},
-		{Name: "Node", Value: "minikube"},
-		{Name: "Containers", Value: "0/2"},
-	}, info.Info)
+		info := &ResourceInfo{}
+		populateNodeInfo(pod, info, []string{})
+		assert.Equal(t, []v1alpha1.InfoItem{
+			{Name: "Status Reason", Value: "SchedulingGated"},
+			{Name: "Node", Value: "minikube"},
+			{Name: "Containers", Value: "0/2"},
+		}, info.Info)
+	})
 }
 
 func TestGetNodeInfo(t *testing.T) {

--- a/ui/src/app/applications/components/utils.test.tsx
+++ b/ui/src/app/applications/components/utils.test.tsx
@@ -1,7 +1,25 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import {Application, HealthStatus, HealthStatuses, OperationPhases, ResourceResult, ResultCodes, SyncStatuses} from '../../shared/models';
-import {ComparisonStatusIcon, getAppOperationState, getOperationType, HealthStatusIcon, OperationState, ResourceResultIcon} from './utils';
+import {
+    Application,
+    HealthStatus,
+    HealthStatuses,
+    OperationPhases,
+    ResourceResult,
+    ResultCodes,
+    State,
+    SyncStatuses
+} from '../../shared/models';
+import * as jsYaml from 'js-yaml';
+import {
+    ComparisonStatusIcon,
+    getAppOperationState,
+    getOperationType,
+    getPodStateReason,
+    HealthStatusIcon,
+    OperationState,
+    ResourceResultIcon
+} from './utils';
 
 const zero = new Date(0).toISOString();
 
@@ -220,4 +238,524 @@ test('ResourceResultIcon.Hook.Terminating', () => {
     const tree = renderer.create(<ResourceResultIcon resource={{hookType: 'Sync', hookPhase: OperationPhases.Terminating} as ResourceResult} />).toJSON();
 
     expect(tree).toMatchSnapshot();
+});
+
+// These tests are equivalent to those in controller/cache/info_test.go. If you change a test here, update the corresponding test there.
+describe('getPodStateReason', () => {
+    it('TestGetPodInfo', () => {
+      const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: helm-guestbook-pod
+    namespace: default
+    ownerReferences:
+    - apiVersion: extensions/v1beta1
+      kind: ReplicaSet
+      name: helm-guestbook-rs
+    resourceVersion: "123"
+    labels:
+      app: guestbook
+  spec:
+    nodeName: minikube
+    containers:
+    - image: bar
+      resources:
+        requests:
+          memory: 128Mi
+      `
+
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+
+        expect(reason).toBe('Unknown');
+    });
+
+    it('TestGetPodWithInitialContainerInfo', () => {
+        const podYaml = `
+  apiVersion: "v1"
+  kind: "Pod"
+  metadata: 
+    labels: 
+      app: "app-with-initial-container"
+    name: "app-with-initial-container-5f46976fdb-vd6rv"
+    namespace: "default"
+    ownerReferences: 
+    - apiVersion: "apps/v1"
+      kind: "ReplicaSet"
+      name: "app-with-initial-container-5f46976fdb"
+  spec: 
+    containers: 
+    - image: "alpine:latest"
+      imagePullPolicy: "Always"
+      name: "app-with-initial-container"
+    initContainers: 
+    - image: "alpine:latest"
+      imagePullPolicy: "Always"
+      name: "app-with-initial-container-logshipper"
+    nodeName: "minikube"
+  status: 
+    containerStatuses: 
+    - image: "alpine:latest"
+      name: "app-with-initial-container"
+      ready: true
+      restartCount: 0
+      started: true
+      state: 
+        running: 
+          startedAt: "2024-10-08T08:44:25Z"
+    initContainerStatuses: 
+    - image: "alpine:latest"
+      name: "app-with-initial-container-logshipper"
+      ready: true
+      restartCount: 0
+      started: false
+      state: 
+        terminated: 
+          exitCode: 0
+          reason: "Completed"
+    phase: "Running"
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+            expect(reason).toBe('Running');
+    });
+
+    it('TestGetPodInfoWithSidecar', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    labels:
+      app: app-with-sidecar
+    name: app-with-sidecar-6664cc788c-lqlrp
+    namespace: default
+    ownerReferences:
+      - apiVersion: apps/v1
+        kind: ReplicaSet
+        name: app-with-sidecar-6664cc788c
+  spec:
+    containers:
+    - image: 'docker.m.daocloud.io/library/alpine:latest'
+      imagePullPolicy: Always
+      name: app-with-sidecar
+    initContainers:
+    - image: 'docker.m.daocloud.io/library/alpine:latest'
+      imagePullPolicy: Always
+      name: logshipper
+      restartPolicy: Always
+    nodeName: minikube
+  status:
+    containerStatuses:
+    - image: 'docker.m.daocloud.io/library/alpine:latest'
+      name: app-with-sidecar
+      ready: true
+      restartCount: 0
+      started: true
+      state:
+        running:
+          startedAt: '2024-10-08T08:39:43Z'
+    initContainerStatuses:
+    - image: 'docker.m.daocloud.io/library/alpine:latest'
+      name: logshipper
+      ready: true
+      restartCount: 0
+      started: true
+      state:
+        running:
+          startedAt: '2024-10-08T08:39:40Z'
+    phase: Running
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+            expect(reason).toBe('Running');
+    });
+
+    it('TestGetPodInfoWithInitialContainer', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    generateName: myapp-long-exist-56b7d8794d-
+    labels:
+      app: myapp-long-exist
+    name: myapp-long-exist-56b7d8794d-pbgrd
+    namespace: linghao
+    ownerReferences:
+      - apiVersion: apps/v1
+        kind: ReplicaSet
+        name: myapp-long-exist-56b7d8794d
+  spec:
+    containers:
+      - image: alpine:latest
+        imagePullPolicy: Always
+        name: myapp-long-exist
+    initContainers:
+      - image: alpine:latest
+        imagePullPolicy: Always
+        name: myapp-long-exist-logshipper
+    nodeName: minikube
+  status:
+    containerStatuses:
+      - image: alpine:latest
+        name: myapp-long-exist
+        ready: false
+        restartCount: 0
+        started: false
+        state:
+          waiting:
+            reason: PodInitializing
+    initContainerStatuses:
+      - image: alpine:latest
+        name: myapp-long-exist-logshipper
+        ready: false
+        restartCount: 0
+        started: true
+        state:
+          running:
+            startedAt: '2024-10-09T08:03:45Z'
+    phase: Pending
+    startTime: '2024-10-09T08:02:39Z'
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+            expect(reason).toBe('Init:0/1');
+    });
+
+    it('TestGetPodInfoWithRestartableInitContainer', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test1
+  spec:
+    initContainers:
+      - name: restartable-init-1
+        restartPolicy: Always
+      - name: restartable-init-2
+        restartPolicy: Always
+    containers:
+      - name: container
+    nodeName: minikube
+  status:
+    phase: Pending
+    initContainerStatuses:
+      - name: restartable-init-1
+        ready: false
+        restartCount: 3
+        state:
+          running: {}
+        started: false
+        lastTerminationState:
+          terminated:
+            finishedAt: "2023-10-01T00:00:00Z" # Replace with actual time
+      - name: restartable-init-2
+        ready: false
+        state:
+          waiting: {}
+        started: false
+    containerStatuses:
+      - ready: false
+        restartCount: 0
+        state:
+          waiting: {}
+    conditions:
+      - type: PodInitialized
+        status: "False"
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+            expect(reason).toBe('Init:0/2');
+    });
+
+    it('TestGetPodInfoWithPartiallyStartedInitContainers', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test1
+  spec:
+    initContainers:
+      - name: restartable-init-1
+        restartPolicy: Always
+      - name: restartable-init-2
+        restartPolicy: Always
+    containers:
+      - name: container
+    nodeName: minikube
+  status:
+    phase: Pending
+    initContainerStatuses:
+      - name: restartable-init-1
+        ready: false
+        restartCount: 3
+        state:
+          running: {}
+        started: true
+        lastTerminationState:
+          terminated:
+            finishedAt: "2023-10-01T00:00:00Z" # Replace with actual time
+      - name: restartable-init-2
+        ready: false
+        state:
+          running: {}
+        started: false
+    containerStatuses:
+      - ready: false
+        restartCount: 0
+        state:
+          waiting: {}
+    conditions:
+      - type: PodInitialized
+        status: "False"
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+        expect(reason).toBe('Init:1/2');
+    });
+
+    it('TestGetPodInfoWithStartedInitContainers', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test2
+  spec:
+    initContainers:
+      - name: restartable-init-1
+        restartPolicy: Always
+      - name: restartable-init-2
+        restartPolicy: Always
+    containers:
+      - name: container
+    nodeName: minikube
+  status:
+    phase: Running
+    initContainerStatuses:
+      - name: restartable-init-1
+        ready: false
+        restartCount: 3
+        state:
+          running: {}
+        started: true
+        lastTerminationState:
+          terminated:
+            finishedAt: "2023-10-01T00:00:00Z" # Replace with actual time
+      - name: restartable-init-2
+        ready: false
+        state:
+          running: {}
+        started: true
+    containerStatuses:
+      - ready: true
+        restartCount: 4
+        state:
+          running: {}
+        lastTerminationState:
+          terminated:
+            finishedAt: "2023-10-01T00:00:00Z" # Replace with actual time
+    conditions:
+      - type: PodInitialized
+        status: "True"
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+            expect(reason).toBe('Running');
+    });
+
+    it('TestGetPodInfoWithNormalInitContainer', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test7
+  spec:
+    initContainers:
+      - name: init-container
+    containers:
+      - name: main-container
+    nodeName: minikube
+  status:
+    phase: podPhase
+    initContainerStatuses:
+      - ready: false
+        restartCount: 3
+        state:
+          running: {}
+        lastTerminationState:
+          terminated:
+            finishedAt: "2023-10-01T00:00:00Z" # Replace with the actual time
+    containerStatuses:
+      - ready: false
+        restartCount: 0
+        state:
+          waiting: {}
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+            expect(reason).toBe('Init:0/1');
+    });
+
+    it('TestPodConditionSucceeded', () => {
+        const podYaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test8
+spec:
+  nodeName: minikube
+  containers:
+    - name: container
+status:
+  phase: Succeeded
+  containerStatuses:
+    - ready: false
+      restartCount: 0
+      state:
+        terminated:
+          reason: Completed
+          exitCode: 0
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+
+            expect(reason).toBe('Completed');
+    });
+
+    it('TestPodConditionFailed', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test9
+  spec:
+    nodeName: minikube
+    containers:
+      - name: container
+  status:
+    phase: Failed
+    containerStatuses:
+      - ready: false
+        restartCount: 0
+        state:
+          terminated:
+            reason: Error
+            exitCode: 1
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+
+            expect(reason).toBe('Error');
+    });
+
+    it('TestPodConditionSucceededWithDeletion', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test10
+    deletionTimestamp: "2023-10-01T00:00:00Z"
+  spec:
+    nodeName: minikube
+    containers:
+      - name: container
+  status:
+    phase: Succeeded
+    containerStatuses:
+      - ready: false
+        restartCount: 0
+        state:
+          terminated:
+            reason: Completed
+            exitCode: 0
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+
+            expect(reason).toBe('Completed');
+    });
+
+    it('TestPodConditionRunningWithDeletion', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test11
+    deletionTimestamp: "2023-10-01T00:00:00Z"
+  spec:
+    nodeName: minikube
+    containers:
+      - name: container
+  status:
+    phase: Running
+    containerStatuses:
+      - ready: false
+        restartCount: 0
+        state:
+          running: {}
+`;
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+
+            expect(reason).toBe('Terminating');
+    });
+
+    it('TestPodConditionPendingWithDeletion', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test12
+    deletionTimestamp: "2023-10-01T00:00:00Z"
+  spec:
+    nodeName: minikube
+    containers:
+      - name: container
+  status:
+    phase: Pending
+        `
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+
+            expect(reason).toBe('Terminating');
+    });
+
+    it('TestPodScheduledWithSchedulingGated', () => {
+        const podYaml = `
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test13
+  spec:
+    nodeName: minikube
+    containers:
+      - name: container1
+      - name: container2
+  status:
+    phase: podPhase
+    conditions:
+      - type: PodScheduled
+        status: "False"
+        reason: SchedulingGated
+          `
+
+        const pod = jsYaml.load(podYaml);
+
+        const {reason} = getPodStateReason(pod as State);
+
+        expect(reason).toBe('SchedulingGated');
+    });
 });

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1035,9 +1035,9 @@ export function getPodStateReason(pod: appModels.State): {message: string; reaso
     }
 
     let initializing = false;
-    let i = -1;
-    for (const container of (pod.status.initContainerStatuses || []).slice()) {
-        i++;
+    const initContainerStatuses = pod.status.initContainerStatuses || [];
+    for (let i = 0; i < initContainerStatuses.length; i++) {
+        const container = initContainerStatuses[i];
         if (container.state.terminated && container.state.terminated.exitCode === 0) {
             continue;
         }

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1008,6 +1008,10 @@ function isPodPhaseTerminal(phase: appModels.PodPhase): boolean {
 }
 
 export function getPodStateReason(pod: appModels.State): {message: string; reason: string; netContainerStatuses: any[]} {
+    if (!pod.status) {
+        return {reason: 'Unknown', message: '', netContainerStatuses: []};
+    }
+
     const podPhase = pod.status.phase;
     let reason = podPhase;
     let message = '';
@@ -1031,7 +1035,9 @@ export function getPodStateReason(pod: appModels.State): {message: string; reaso
     }
 
     let initializing = false;
-    for (const container of (pod.status.initContainerStatuses || []).slice().reverse()) {
+    let i = -1;
+    for (const container of (pod.status.initContainerStatuses || []).slice()) {
+        i++;
         if (container.state.terminated && container.state.terminated.exitCode === 0) {
             continue;
         }
@@ -1051,7 +1057,7 @@ export function getPodStateReason(pod: appModels.State): {message: string; reaso
             reason = `Init:${container.state.waiting.reason}`;
             message = `Init:${container.state.waiting.message}`;
         } else {
-            reason = `Init: ${(pod.spec.initContainers || []).length})`;
+            reason = `Init:${i}/${(pod.spec.initContainers || []).length}`;
         }
         initializing = true;
         break;


### PR DESCRIPTION
The UI currently displays incorrect/incomplete information about a Pod's initialization process. This PR takes existing tests from similar backend code and adds them to the frontend code. I also tidied and parallelized the backend tests. I fixed three broken UI behaviors:

1) Removed trailing `)` in init messages
2) Added count of initialized vs. un-initialized containers
3) Removed `.reverse()` from container status traversal, which was producing inaccurate container counts

Ignore whitespace for an easier review: https://github.com/argoproj/argo-cd/pull/20387/files?w=1

The UI in question: 
![image](https://github.com/user-attachments/assets/43d7db31-eda4-489f-88e9-9d3edc0ca3e3)

`Init: 1)` should be `Init: 0/1`.
