### PR TITLE
chore: enable usestdlibvars linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,7 @@ linters:
     - testifylint
     - unparam
     - unused
+    - usestdlibvars
     - whitespace 
 linters-settings:
   gocritic:

--- a/applicationset/metrics/metrics_test.go
+++ b/applicationset/metrics/metrics_test.go
@@ -178,7 +178,7 @@ func TestApplicationsetCollector(t *testing.T) {
 	appsetCollector := newAppsetCollector(utils.NewAppsetLister(client), collectedLabels, filter)
 
 	metrics.Registry.MustRegister(appsetCollector)
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	require.NoError(t, err)
 	rr := httptest.NewRecorder()
 	handler := promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{})
@@ -220,7 +220,7 @@ func TestObserveReconcile(t *testing.T) {
 
 	appsetMetrics := NewApplicationsetMetrics(utils.NewAppsetLister(client), collectedLabels, filter)
 
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	require.NoError(t, err)
 	rr := httptest.NewRecorder()
 	handler := promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{})

--- a/applicationset/services/internal/http/client.go
+++ b/applicationset/services/internal/http/client.go
@@ -134,7 +134,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 
 // CheckResponse checks the API response for errors, and returns them if present.
 func CheckResponse(resp *http.Response) error {
-	if c := resp.StatusCode; 200 <= c && c <= 299 {
+	if c := resp.StatusCode; http.StatusOK <= c && c < http.StatusMultipleChoices {
 		return nil
 	}
 

--- a/applicationset/services/internal/http/client_test.go
+++ b/applicationset/services/internal/http/client_test.go
@@ -77,7 +77,7 @@ func TestClientDo(t *testing.T) {
 					"key3": float64(123),
 				},
 			},
-			expectedCode:  200,
+			expectedCode:  http.StatusOK,
 			expectedError: nil,
 		},
 		{
@@ -109,7 +109,7 @@ func TestClientDo(t *testing.T) {
 			})),
 			clientOptionFns: nil,
 			expected:        []map[string]interface{}(nil),
-			expectedCode:    401,
+			expectedCode:    http.StatusUnauthorized,
 			expectedError:   fmt.Errorf("API error with status code 401: "),
 		},
 	} {

--- a/applicationset/services/pull_request/bitbucket_cloud_test.go
+++ b/applicationset/services/pull_request/bitbucket_cloud_test.go
@@ -233,7 +233,7 @@ func TestListPullRequestPaginationCloud(t *testing.T) {
 
 func TestListResponseErrorCloud(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
 	svc, _ := NewBitbucketCloudServiceNoAuth(ts.URL, "OWNER", "REPO")

--- a/applicationset/services/scm_provider/bitbucket_server.go
+++ b/applicationset/services/scm_provider/bitbucket_server.go
@@ -129,7 +129,7 @@ func (b *BitbucketServerProvider) RepoHasPath(_ context.Context, repo *Repositor
 	}
 	// No need to query for all pages here
 	response, err := b.client.DefaultApi.GetContent_0(repo.Organization, repo.Repository, path, opts)
-	if response != nil && response.StatusCode == 404 {
+	if response != nil && response.StatusCode == http.StatusNotFound {
 		// File/directory not found
 		return false, nil
 	}
@@ -203,7 +203,7 @@ func (b *BitbucketServerProvider) getDefaultBranch(org string, repo string) (*bi
 	response, err := b.client.DefaultApi.GetDefaultBranch(org, repo)
 	// The API will return 404 if a default branch is set but doesn't exist. In case the repo is empty and default branch is unset,
 	// we will get an EOF and a nil response.
-	if (response != nil && response.StatusCode == 404) || (response == nil && err != nil && errors.Is(err, io.EOF)) {
+	if (response != nil && response.StatusCode == http.StatusNotFound) || (response == nil && err != nil && errors.Is(err, io.EOF)) {
 		return nil, nil
 	}
 	if err != nil {

--- a/applicationset/services/scm_provider/gitea.go
+++ b/applicationset/services/scm_provider/gitea.go
@@ -128,7 +128,7 @@ func (g *GiteaProvider) ListRepos(ctx context.Context, cloneProtocol string) ([]
 
 func (g *GiteaProvider) RepoHasPath(ctx context.Context, repo *Repository, path string) (bool, error) {
 	_, resp, err := g.client.GetContents(repo.Organization, repo.Repository, repo.Branch, path)
-	if resp != nil && resp.StatusCode == 404 {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return false, nil
 	}
 	if fmt.Sprint(err) == "expect file, got directory" {

--- a/applicationset/services/scm_provider/github.go
+++ b/applicationset/services/scm_provider/github.go
@@ -107,7 +107,7 @@ func (g *GithubProvider) RepoHasPath(ctx context.Context, repo *Repository, path
 		Ref: repo.Branch,
 	})
 	// 404s are not an error here, just a normal false.
-	if resp != nil && resp.StatusCode == 404 {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return false, nil
 	}
 	if err != nil {

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -209,7 +209,7 @@ func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
 		require.NoError(t, err)
 		handler.ServeHTTP(rr, req)
 		require.Equal(t, tt.response, rr.Result().StatusCode)
-		if rr.Result().StatusCode != 400 {
+		if rr.Result().StatusCode != http.StatusBadRequest {
 			assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
 			assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
 			response := rr.Body.String()

--- a/server/extension/extension_test.go
+++ b/server/extension/extension_test.go
@@ -27,7 +27,7 @@ import (
 func TestValidateHeaders(t *testing.T) {
 	t.Run("will build RequestResources successfully", func(t *testing.T) {
 		// given
-		r, err := http.NewRequest("Get", "http://null", nil)
+		r, err := http.NewRequest(http.MethodGet, "http://null", nil)
 		if err != nil {
 			t.Fatalf("error initializing request: %s", err)
 		}
@@ -46,7 +46,7 @@ func TestValidateHeaders(t *testing.T) {
 	})
 	t.Run("will return error if application is malformatted", func(t *testing.T) {
 		// given
-		r, err := http.NewRequest("Get", "http://null", nil)
+		r, err := http.NewRequest(http.MethodGet, "http://null", nil)
 		if err != nil {
 			t.Fatalf("error initializing request: %s", err)
 		}
@@ -61,7 +61,7 @@ func TestValidateHeaders(t *testing.T) {
 	})
 	t.Run("will return error if application header is missing", func(t *testing.T) {
 		// given
-		r, err := http.NewRequest("Get", "http://null", nil)
+		r, err := http.NewRequest(http.MethodGet, "http://null", nil)
 		if err != nil {
 			t.Fatalf("error initializing request: %s", err)
 		}
@@ -76,7 +76,7 @@ func TestValidateHeaders(t *testing.T) {
 	})
 	t.Run("will return error if project header is missing", func(t *testing.T) {
 		// given
-		r, err := http.NewRequest("Get", "http://null", nil)
+		r, err := http.NewRequest(http.MethodGet, "http://null", nil)
 		if err != nil {
 			t.Fatalf("error initializing request: %s", err)
 		}
@@ -91,7 +91,7 @@ func TestValidateHeaders(t *testing.T) {
 	})
 	t.Run("will return error if invalid namespace", func(t *testing.T) {
 		// given
-		r, err := http.NewRequest("Get", "http://null", nil)
+		r, err := http.NewRequest(http.MethodGet, "http://null", nil)
 		if err != nil {
 			t.Fatalf("error initializing request: %s", err)
 		}
@@ -107,7 +107,7 @@ func TestValidateHeaders(t *testing.T) {
 	})
 	t.Run("will return error if invalid app name", func(t *testing.T) {
 		// given
-		r, err := http.NewRequest("Get", "http://null", nil)
+		r, err := http.NewRequest(http.MethodGet, "http://null", nil)
 		if err != nil {
 			t.Fatalf("error initializing request: %s", err)
 		}
@@ -123,7 +123,7 @@ func TestValidateHeaders(t *testing.T) {
 	})
 	t.Run("will return error if invalid project name", func(t *testing.T) {
 		// given
-		r, err := http.NewRequest("Get", "http://null", nil)
+		r, err := http.NewRequest(http.MethodGet, "http://null", nil)
 		if err != nil {
 			t.Fatalf("error initializing request: %s", err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -1287,7 +1287,7 @@ func (server *ArgoCDServer) newStaticAssetsHandler() func(http.ResponseWriter, *
 		w.Header().Set("X-XSS-Protection", "1")
 
 		// serve index.html for non file requests to support HTML5 History API
-		if acceptHTML && !fileRequest && (r.Method == "GET" || r.Method == "HEAD") {
+		if acceptHTML && !fileRequest && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
 			for k, v := range noCacheHeaders {
 				w.Header().Set(k, v)
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1355,7 +1355,7 @@ func TestCacheControlHeaders(t *testing.T) {
 			name:                        "file exists",
 			filename:                    "exists.html",
 			createFile:                  true,
-			expectedStatus:              200,
+			expectedStatus:              http.StatusOK,
 			expectedCacheControlHeaders: nil,
 		},
 		{
@@ -1369,7 +1369,7 @@ func TestCacheControlHeaders(t *testing.T) {
 			name:                        "main js bundle exists",
 			filename:                    "main.e4188e5adc97bbfc00c3.js",
 			createFile:                  true,
-			expectedStatus:              200,
+			expectedStatus:              http.StatusOK,
 			expectedCacheControlHeaders: []string{"public, max-age=31536000, immutable"},
 		},
 		{
@@ -1534,7 +1534,7 @@ func Test_enforceContentTypes(t *testing.T) {
 	getBaseHandler := func(t *testing.T, allow bool) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			assert.True(t, allow, "http handler was hit when it should have been blocked by content type enforcement")
-			writer.WriteHeader(200)
+			writer.WriteHeader(http.StatusOK)
 		})
 	}
 
@@ -1542,33 +1542,33 @@ func Test_enforceContentTypes(t *testing.T) {
 
 	t.Run("GET - not providing a content type, should still succeed", func(t *testing.T) {
 		handler := enforceContentTypes(getBaseHandler(t, true), []string{"application/json"}).(http.HandlerFunc)
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 		handler(w, req)
 		resp := w.Result()
-		assert.Equal(t, 200, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("POST", func(t *testing.T) {
 		handler := enforceContentTypes(getBaseHandler(t, true), []string{"application/json"}).(http.HandlerFunc)
-		req := httptest.NewRequest("POST", "/", nil)
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
 		w := httptest.NewRecorder()
 		handler(w, req)
 		resp := w.Result()
-		assert.Equal(t, 415, resp.StatusCode, "didn't provide a content type, should have gotten an error")
+		assert.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode, "didn't provide a content type, should have gotten an error")
 
-		req = httptest.NewRequest("POST", "/", nil)
+		req = httptest.NewRequest(http.MethodPost, "/", nil)
 		req.Header = map[string][]string{"Content-Type": {"application/json"}}
 		w = httptest.NewRecorder()
 		handler(w, req)
 		resp = w.Result()
-		assert.Equal(t, 200, resp.StatusCode, "should have passed, since an allowed content type was provided")
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "should have passed, since an allowed content type was provided")
 
-		req = httptest.NewRequest("POST", "/", nil)
+		req = httptest.NewRequest(http.MethodPost, "/", nil)
 		req.Header = map[string][]string{"Content-Type": {"not-allowed"}}
 		w = httptest.NewRecorder()
 		handler(w, req)
 		resp = w.Result()
-		assert.Equal(t, 415, resp.StatusCode, "should not have passed, since a disallowed content type was provided")
+		assert.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode, "should not have passed, since a disallowed content type was provided")
 	})
 }

--- a/util/kube/failureretrywrapper.go
+++ b/util/kube/failureretrywrapper.go
@@ -27,7 +27,7 @@ func shouldRetry(counter int, r *http.Request, response *http.Response, err erro
 			return true
 		}
 	}
-	if response != nil && (response.StatusCode == 504 || response.StatusCode == 503) {
+	if response != nil && (response.StatusCode == http.StatusGatewayTimeout || response.StatusCode == http.StatusServiceUnavailable) {
 		return true
 	}
 

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -590,7 +590,7 @@ func (a *ClientApp) GetUserInfo(actualClaims jwt.MapClaims, issuerURL, userInfoP
 	}
 
 	url := issuerURL + userInfoPath
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		err = fmt.Errorf("failed creating new http request: %w", err)
 		return claims, false, err

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -273,7 +273,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			cookieHeader:         true,
 			verifiedClaims:       &claimsMock{},
 			verifyTokenErr:       nil,
-			expectedStatusCode:   200,
+			expectedStatusCode:   http.StatusOK,
 			expectedResponseBody: strPointer("Ok"),
 		},
 		{
@@ -282,7 +282,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			cookieHeader:         false,
 			verifiedClaims:       nil,
 			verifyTokenErr:       nil,
-			expectedStatusCode:   200,
+			expectedStatusCode:   http.StatusOK,
 			expectedResponseBody: strPointer("Ok"),
 		},
 		{
@@ -291,7 +291,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			cookieHeader:         false,
 			verifiedClaims:       &claimsMock{},
 			verifyTokenErr:       nil,
-			expectedStatusCode:   400,
+			expectedStatusCode:   http.StatusBadRequest,
 			expectedResponseBody: nil,
 		},
 		{
@@ -300,7 +300,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			cookieHeader:         true,
 			verifiedClaims:       &claimsMock{},
 			verifyTokenErr:       stderrors.New("token error"),
-			expectedStatusCode:   401,
+			expectedStatusCode:   http.StatusUnauthorized,
 			expectedResponseBody: nil,
 		},
 		{
@@ -309,7 +309,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			cookieHeader:         true,
 			verifiedClaims:       nil,
 			verifyTokenErr:       nil,
-			expectedStatusCode:   200,
+			expectedStatusCode:   http.StatusOK,
 			expectedResponseBody: strPointer("Ok"),
 		},
 	}

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -245,7 +245,7 @@ func TestGitHubCommitEvent_AppsInOtherNamespaces(t *testing.T) {
 			},
 		},
 	)
-	req := httptest.NewRequest("POST", "/api/webhook", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
 	req.Header.Set("X-GitHub-Event", "push")
 	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
 	require.NoError(t, err)


### PR DESCRIPTION
enables and fixes [usestdlibvars](https://golangci-lint.run/usage/linters/#usestdlibvars) linter issues.