### PR TITLE
chore(server): better error message for missing action (#20408)

### DIFF
--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -24,12 +24,21 @@ import (
 
 const (
 	incorrectReturnType       = "expect %s output from Lua script, not %s"
-	incorrectInnerType        = "expect %s inner type from Lua script, not %s"
 	invalidHealthStatus       = "Lua returned an invalid health status"
 	healthScriptFile          = "health.lua"
 	actionScriptFile          = "action.lua"
 	actionDiscoveryScriptFile = "discovery.lua"
 )
+
+// ScriptDoesNotExistError is an error type for when a built-in script does not exist.
+type ScriptDoesNotExistError struct {
+	// ScriptName is the name of the script that does not exist.
+	ScriptName string
+}
+
+func (e ScriptDoesNotExistError) Error() string {
+	return fmt.Sprintf("built-in script %q does not exist", e.ScriptName)
+}
 
 type ResourceHealthOverrides map[string]appv1.ResourceOverride
 
@@ -132,8 +141,9 @@ func (vm VM) ExecuteHealthLua(obj *unstructured.Unstructured, script string) (*h
 	return nil, fmt.Errorf(incorrectReturnType, "table", returnValue.Type().String())
 }
 
-// GetHealthScript attempts to read lua script from config and then filesystem for that resource
-func (vm VM) GetHealthScript(obj *unstructured.Unstructured) (string, bool, error) {
+// GetHealthScript attempts to read lua script from config and then filesystem for that resource. If none exists, return
+// an empty string.
+func (vm VM) GetHealthScript(obj *unstructured.Unstructured) (script string, useOpenLibs bool, err error) {
 	// first, search the gvk as is in the ResourceOverrides
 	key := GetConfigMapKey(obj.GroupVersionKind())
 
@@ -151,6 +161,14 @@ func (vm VM) GetHealthScript(obj *unstructured.Unstructured) (string, bool, erro
 	// if not found in the ResourceOverrides at all, search it as is in the built-in scripts
 	// (as built-in scripts are files in folders, named after the GVK, currently there is no wildcard support for them)
 	builtInScript, err := vm.getPredefinedLuaScripts(key, healthScriptFile)
+	if err != nil {
+		var doesNotExist *ScriptDoesNotExistError
+		if errors.As(err, &doesNotExist) {
+			// It's okay if no built-in health script exists. Just return an empty string and let the caller handle it.
+			return "", false, nil
+		}
+		return "", false, err
+	}
 	// standard libraries will be enabled for all built-in scripts
 	return builtInScript, true, err
 }
@@ -380,7 +398,10 @@ func (vm VM) GetResourceActionDiscovery(obj *unstructured.Unstructured) ([]strin
 	// Fetch predefined Lua scripts
 	discoveryKey := fmt.Sprintf("%s/actions/", key)
 	discoveryScript, err := vm.getPredefinedLuaScripts(discoveryKey, actionDiscoveryScriptFile)
-	if err != nil {
+
+	// Ignore the error if the script does not exist.
+	var doesNotExistErr *ScriptDoesNotExistError
+	if err != nil && !errors.As(err, &doesNotExistErr) {
 		return nil, fmt.Errorf("error while fetching predefined lua scripts: %w", err)
 	}
 
@@ -442,7 +463,7 @@ func (vm VM) getPredefinedLuaScripts(objKey string, scriptFile string) (string, 
 	data, err := resource_customizations.Embedded.ReadFile(filepath.Join(objKey, scriptFile))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", nil
+			return "", &ScriptDoesNotExistError{ScriptName: objKey}
 		}
 		return "", err
 	}

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -284,7 +284,7 @@ func TestGetResourceActionNoPredefined(t *testing.T) {
 	vm := VM{}
 	action, err := vm.GetResourceAction(testObj, "test")
 	var expectedErr *ScriptDoesNotExistError
-	assert.ErrorAs(t, err, &expectedErr)
+	require.ErrorAs(t, err, &expectedErr)
 	assert.Empty(t, action.ActionLua)
 }
 

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -266,7 +266,7 @@ func TestGetHealthScriptNoPredefined(t *testing.T) {
 	vm := VM{}
 	script, useOpenLibs, err := vm.GetHealthScript(testObj)
 	require.NoError(t, err)
-	assert.True(t, useOpenLibs)
+	assert.False(t, useOpenLibs)
 	assert.Equal(t, "", script)
 }
 
@@ -283,7 +283,8 @@ func TestGetResourceActionNoPredefined(t *testing.T) {
 	testObj := StrToUnstructured(objWithNoScriptJSON)
 	vm := VM{}
 	action, err := vm.GetResourceAction(testObj, "test")
-	require.NoError(t, err)
+	var expectedErr *ScriptDoesNotExistError
+	assert.ErrorAs(t, err, &expectedErr)
 	assert.Empty(t, action.ActionLua)
 }
 


### PR DESCRIPTION
Fixes #20408

The output is much nicer:

```
> argocd app actions run blue-green oops --kind Rollout --group argoproj.io  --all --grpc-web
FATA[0000] rpc error: code = Unknown desc = error getting Lua resource action: built-in script "argoproj.io/Rollout/actions/oops" does not exist
```