### PR TITLE
fix: check for app.Name if is empty, and pick the args[0] if so #20474

### DIFF
--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -607,7 +607,12 @@ func constructAppsFromFileUrl(fileURL, appName string, labels, annotations, args
 	for _, app := range apps {
 		// if app.Name is empty, it should be picked from the command line
 		if len(args) == 1 && app.Name == "" {
-			app.Name = args[0]
+			// split the appname from the command line <ns>/<appname>
+			_, appNameFromCommand, err := GetNamespaceAndAppName(args[0])
+			if err != nil {
+				return nil, err
+			}
+			app.Name = appNameFromCommand
 		}
 		if len(args) == 1 && args[0] != app.Name {
 			return nil, fmt.Errorf("app name '%s' does not match app spec metadata.name '%s'", args[0], app.Name)

--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -605,6 +605,10 @@ func constructAppsFromFileUrl(fileURL, appName string, labels, annotations, args
 		return nil, err
 	}
 	for _, app := range apps {
+		// if app.Name is empty, it should be picked from the command line
+		if len(args) == 1 && app.Name == "" {
+			app.Name = args[0]
+		}
 		if len(args) == 1 && args[0] != app.Name {
 			return nil, fmt.Errorf("app name '%s' does not match app spec metadata.name '%s'", args[0], app.Name)
 		}

--- a/cmd/util/common.go
+++ b/cmd/util/common.go
@@ -1,6 +1,26 @@
 package util
 
+import (
+	"fmt"
+	"strings"
+)
+
 var (
 	LogFormat string
 	LogLevel  string
 )
+
+func GetNamespaceAndAppName(key string) (string, string, error) {
+	var ns, appName string
+	parts := strings.Split(key, "/")
+
+	if len(parts) == 2 {
+		ns = parts[0]
+		appName = parts[1]
+	} else if len(parts) == 1 {
+		appName = parts[0]
+	} else {
+		return "", "", fmt.Errorf("APPNAME must be <namespace>/<appname> or <appname>, got: '%s' ", key)
+	}
+	return ns, appName, nil
+}


### PR DESCRIPTION
The appname is specified in the command create, so when the `metadata.name` is empty, the name could be used from the command line.

Fixes #20474
