### PR TITLE
chore: improve comment inside manifest-generate-paths with autosync causes an undesirable refresh sync logic

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -299,7 +299,8 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 	logCtx = logCtx.WithField("time_ms", time.Since(ts.StartTime).Milliseconds())
 	logCtx.Info("GetRepoObjs stats")
 
-	// in case if annotation not exists, we should always execute selfheal if manifests changed
+	// If a revision in any of the sources cannot be updated,
+	// we should trigger self-healing whenever there are changes to the manifests.
 	if atLeastOneRevisionIsNotPossibleToBeUpdated {
 		revisionUpdated = true
 	}


### PR DESCRIPTION
Related to https://github.com/argoproj/argo-cd/pull/19828

Logic was changed, so this comment is not relevant anymore