### PR TITLE
fix(ci):  fix flaky e2e tests - ignore temporary files when checking for out of bound symlinks

### DIFF
--- a/util/app/path/path.go
+++ b/util/app/path/path.go
@@ -1,6 +1,7 @@
 package path
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,6 +52,11 @@ func CheckOutOfBoundsSymlinks(basePath string) error {
 	}
 	return filepath.Walk(absBasePath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			// Ignore "no such file or directory" errors than can happen with
+			// temporary files such as .git/*.lock
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
 			return fmt.Errorf("failed to walk for symlinks in %s: %w", absBasePath, err)
 		}
 		if files.IsSymlink(info) {


### PR DESCRIPTION
Addresses part of https://github.com/argoproj/argo-cd/issues/11667

# Description

This PR fixes errors that happen frequently in the CI [1](https://github.com/argoproj/argo-cd/actions/runs/11494345566/job/31991806822#step:16:4377), [2](https://github.com/argoproj/argo-cd/actions/runs/11453505375/job/31866171929#step:16:10272). 

These issues arise when walking through a directory, where temporary files—like Git lock files—are scanned but may be deleted by the time their handlers execute.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
