### PR TITLE
feat: add prompting to confirm deletion of gpg public key

### DIFF
--- a/cmd/argocd/commands/gpg.go
+++ b/cmd/argocd/commands/gpg.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/utils"
-
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/utils"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	gpgkeypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/gpgkey"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/cmd/argocd/commands/utils/prompt.go
+++ b/cmd/argocd/commands/utils/prompt.go
@@ -8,10 +8,10 @@ type Prompt struct {
 	enabled bool
 }
 
-func NewPrompt(promptsEnabled bool) (*Prompt, error) {
+func NewPrompt(promptsEnabled bool) *Prompt {
 	return &Prompt{
 		enabled: promptsEnabled,
-	}, nil
+	}
 }
 
 func (p *Prompt) Confirm(message string) bool {

--- a/cmd/argocd/commands/utils/prompt_test.go
+++ b/cmd/argocd/commands/utils/prompt_test.go
@@ -4,32 +4,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewPrompt_PromptsEnabled_True(t *testing.T) {
-	promptsEnabled := true
-
-	prompt, err := NewPrompt(promptsEnabled)
-	require.NoError(t, err)
-
+	prompt := NewPrompt(true)
 	assert.True(t, prompt.enabled)
 }
 
 func TestNewPrompt_PromptsEnabled_False(t *testing.T) {
-	promptsEnabled := false
-
-	prompt, err := NewPrompt(promptsEnabled)
-	require.NoError(t, err)
-
+	prompt := NewPrompt(false)
 	assert.False(t, prompt.enabled)
 }
 
 func TestConfirm_PromptsEnabled_False(t *testing.T) {
-	promptsEnabled := false
-
-	prompt, err := NewPrompt(promptsEnabled)
-	require.NoError(t, err)
-
+	prompt := NewPrompt(false)
 	assert.True(t, prompt.Confirm("Are you sure you want to run this command? (y/n) "))
 }


### PR DESCRIPTION
It uses ability to configure prompts behavior inside configuration or flags. Default behavior is no promts, so we actually not affecting any existing behavior, but users can define promts to be enabled for their CLI 
Details here: 

https://github.com/argoproj/argo-cd/issues/19528

1. Default behavior 

![Снимок экрана 2024-10-26 в 00 38 14](https://github.com/user-attachments/assets/b236def8-6fb8-441c-adea-86d341d2df8b)

2. Prompts enabled

![Снимок экрана 2024-10-26 в 00 38 33](https://github.com/user-attachments/assets/448ea44f-37a6-4f93-b6de-ed8896286f02)
![Снимок экрана 2024-10-26 в 00 38 40](https://github.com/user-attachments/assets/cf660e35-14d6-4ac8-977c-b68fac37a68c)
