### PR TITLE
feat: add prompting to confirm prune during backup import

### DIFF
--- a/cmd/argocd/commands/admin/backup.go
+++ b/cmd/argocd/commands/admin/backup.go
@@ -17,12 +17,11 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/utils"
-	"github.com/argoproj/argo-cd/v2/util/localconfig"
-
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"github.com/argoproj/argo-cd/v2/util/cli"
 	"github.com/argoproj/argo-cd/v2/util/errors"
+	"github.com/argoproj/argo-cd/v2/util/localconfig"
 	secutil "github.com/argoproj/argo-cd/v2/util/security"
 )
 

--- a/cmd/argocd/commands/admin/backup.go
+++ b/cmd/argocd/commands/admin/backup.go
@@ -16,6 +16,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 
+	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/utils"
+	"github.com/argoproj/argo-cd/v2/util/localconfig"
+
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"github.com/argoproj/argo-cd/v2/util/cli"
@@ -137,6 +140,7 @@ func NewImportCommand() *cobra.Command {
 		verbose                  bool
 		stopOperation            bool
 		ignoreTracking           bool
+		promptsEnabled           bool
 		applicationNamespaces    []string
 		applicationsetNamespaces []string
 	)
@@ -308,6 +312,8 @@ func NewImportCommand() *cobra.Command {
 				}
 			}
 
+			promptUtil := utils.NewPrompt(promptsEnabled)
+
 			// Delete objects not in backup
 			for key, liveObj := range pruneObjects {
 				if prune {
@@ -335,13 +341,19 @@ func NewImportCommand() *cobra.Command {
 						log.Fatalf("Unexpected kind '%s' in prune list", key.Kind)
 					}
 					isForbidden := false
+
 					if !dryRun {
-						err = dynClient.Delete(ctx, key.Name, v1.DeleteOptions{})
-						if apierr.IsForbidden(err) || apierr.IsNotFound(err) {
-							isForbidden = true
-							log.Warnf("%s/%s %s: %v\n", key.Group, key.Kind, key.Name, err)
+						canPrune := promptUtil.Confirm(fmt.Sprintf("Are you sure you want to prune %s/%s %s ? [y/n]", key.Group, key.Kind, key.Name))
+						if canPrune {
+							err = dynClient.Delete(ctx, key.Name, v1.DeleteOptions{})
+							if apierr.IsForbidden(err) || apierr.IsNotFound(err) {
+								isForbidden = true
+								log.Warnf("%s/%s %s: %v\n", key.Group, key.Kind, key.Name, err)
+							} else {
+								errors.CheckError(err)
+							}
 						} else {
-							errors.CheckError(err)
+							fmt.Printf("The command to prune %s/%s %s was cancelled.\n", key.Group, key.Kind, key.Name)
 						}
 					}
 					if !isForbidden {
@@ -362,6 +374,7 @@ func NewImportCommand() *cobra.Command {
 	command.Flags().BoolVar(&stopOperation, "stop-operation", false, "Stop any existing operations")
 	command.Flags().StringSliceVarP(&applicationNamespaces, "application-namespaces", "", []string{}, fmt.Sprintf("Comma separated list of namespace globs to which import of applications is allowed. If not provided value from '%s' in %s will be used,if it's not defined only applications without an explicit namespace will be imported to the Argo CD namespace", applicationNamespacesCmdParamsKey, common.ArgoCDCmdParamsConfigMapName))
 	command.Flags().StringSliceVarP(&applicationsetNamespaces, "applicationset-namespaces", "", []string{}, fmt.Sprintf("Comma separated list of namespace globs which import of applicationsets is allowed. If not provided value from '%s' in %s will be used,if it's not defined only applicationsets without an explicit namespace will be imported to the Argo CD namespace", applicationsetNamespacesCmdParamsKey, common.ArgoCDCmdParamsConfigMapName))
+	command.PersistentFlags().BoolVar(&promptsEnabled, "force-prompts-enabled", localconfig.GetPromptsEnabled(true), "Force optional interactive prompts to be enabled or disabled, overriding local configuration. If not specified, the local configuration value will be used, which is false by default.")
 
 	return &command
 }

--- a/docs/user-guide/commands/argocd_admin_import.md
+++ b/docs/user-guide/commands/argocd_admin_import.md
@@ -23,6 +23,7 @@ argocd admin import SOURCE [flags]
       --context string                      The name of the kubeconfig context to use
       --disable-compression                 If true, opt-out of response compression for all requests to the server
       --dry-run                             Print what will be performed
+      --force-prompts-enabled               Force optional interactive prompts to be enabled or disabled, overriding local configuration. If not specified, the local configuration value will be used, which is false by default.
   -h, --help                                help for import
       --ignore-tracking                     Do not update the tracking annotation if the resource is already tracked
       --insecure-skip-tls-verify            If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -51,7 +52,6 @@ argocd admin import SOURCE [flags]
       --config string                   Path to Argo CD config (default "/home/user/.config/argocd/config")
       --controller-name string          Name of the Argo CD Application controller; set this or the ARGOCD_APPLICATION_CONTROLLER_NAME environment variable when the controller's name label differs from the default, for example when installing via the Helm chart (default "argocd-application-controller")
       --core                            If set to true then CLI talks directly to Kubernetes instead of talking to Argo CD API server
-      --force-prompts-enabled           Force optional interactive prompts to be enabled or disabled, overriding local configuration. If not specified, the local configuration value will be used, which is false by default.
       --grpc-web                        Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2.
       --grpc-web-root-path string       Enables gRPC-web protocol. Useful if Argo CD server is behind proxy which does not support HTTP2. Set web root.
   -H, --header strings                  Sets additional header to all requests made by Argo CD CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers)


### PR DESCRIPTION
It allows for prompt behavior configuration through settings or flags. By default, prompts are disabled, ensuring no change to existing functionality. However, users can enable prompts for their CLI if desired.

Details here:

https://github.com/argoproj/argo-cd/issues/19528