### PR TITLE
fix: ensure the extension loads even if extensions.js is loaded after the component is mounted

### DIFF
--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -86,6 +86,41 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
 
     constructor(props: RouteComponentProps<{appnamespace: string; name: string}>) {
         super(props);
+        this.state = {
+            page: 0,
+            groupedResources: [],
+            slidingPanelPage: 0,
+            filteredGraph: [],
+            truncateNameOnRight: false,
+            collapsedNodes: [],
+            ...this.getExtensionsState()
+        };
+        if (typeof this.props.match.params.appnamespace === 'undefined') {
+            this.appNamespace = '';
+        } else {
+            this.appNamespace = this.props.match.params.appnamespace;
+        }
+    }
+
+    public componentDidMount() {
+        services.extensions.addEventListener('resource', this.onExtensionsUpdate);
+        services.extensions.addEventListener('appView', this.onExtensionsUpdate);
+        services.extensions.addEventListener('statusPanel', this.onExtensionsUpdate);
+        services.extensions.addEventListener('topBar', this.onExtensionsUpdate);
+    }
+
+    public componentWillUnmount() {
+        services.extensions.removeEventListener('resource', this.onExtensionsUpdate);
+        services.extensions.removeEventListener('appView', this.onExtensionsUpdate);
+        services.extensions.removeEventListener('statusPanel', this.onExtensionsUpdate);
+        services.extensions.removeEventListener('topBar', this.onExtensionsUpdate);
+    }
+
+    private onExtensionsUpdate = () => {
+        this.setState({...this.state, ...this.getExtensionsState()});
+    };
+
+    private getExtensionsState = () => {
         const extensions = services.extensions.getAppViewExtensions();
         const extensionsMap: {[key: string]: AppViewExtension} = {};
         extensions.forEach(ext => {
@@ -101,26 +136,8 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
         topBarActionMenuExts.forEach(ext => {
             topBarActionMenuExtsMap[ext.id] = ext;
         });
-        this.state = {
-            page: 0,
-            groupedResources: [],
-            slidingPanelPage: 0,
-            filteredGraph: [],
-            truncateNameOnRight: false,
-            collapsedNodes: [],
-            extensions,
-            extensionsMap,
-            statusExtensions,
-            statusExtensionsMap,
-            topBarActionMenuExts,
-            topBarActionMenuExtsMap
-        };
-        if (typeof this.props.match.params.appnamespace === 'undefined') {
-            this.appNamespace = '';
-        } else {
-            this.appNamespace = this.props.match.params.appnamespace;
-        }
-    }
+        return {extensions, extensionsMap, statusExtensions, statusExtensionsMap, topBarActionMenuExts, topBarActionMenuExtsMap};
+    };
 
     private get showOperationState() {
         return new URLSearchParams(this.props.history.location.search).get('operation') === 'true';

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -3,7 +3,7 @@ import * as minimatch from 'minimatch';
 
 import {Application, ApplicationTree, State} from '../models';
 
-type ExtensionsEventType = 'resource' | 'systemLevel' | 'appView' | 'statusPanel' | 'top-bar';
+type ExtensionsEventType = 'resource' | 'systemLevel' | 'appView' | 'statusPanel' | 'topBar';
 type ExtensionsType = ResourceTabExtension | SystemLevelExtension | AppViewExtension | StatusPanelExtension | TopBarActionMenuExt;
 
 class ExtensionsEventTarget {
@@ -73,7 +73,7 @@ function registerTopBarActionMenuExt(
 ) {
     const ext = {component, flyout, shouldDisplay, title, id, iconClassName, isMiddle};
     extensions.topBarActionMenuExts.push(ext);
-    extensions.eventTarget.emit('top-bar', ext);
+    extensions.eventTarget.emit('topBar', ext);
 }
 
 let legacyInitialized = false;


### PR DESCRIPTION
In this PR, we address a minor issue with the extension, which also relates to #16842 and #19612. Previously, this issue occurred with system-level extensions, and we have now identified the same problem with resource-level extensions.

## The Issue

ArgoCD loads extensions when mounting components, but if `extensions.js` is loaded after the component has already mounted, the extension fails to appear. The short video provided demonstrates this issue. Only by manually triggering a component re-render does the extension become visible again.

https://github.com/user-attachments/assets/41d3ebc8-87cf-4aee-bcc8-1856ff3327d6

We use the `console` to simulate a slow load of extensions.js. Since the webpage is fully rendered, executing code in the console does not update the UI. As a result, the resource extension and status panel extension only appear after we manually trigger a component re-render.

## Fix

We added an event listener to the application details component. Whenever a new extension is added, it triggers a re-render of the component, ensuring the extension appears as expected. Most importantly, the extension’s URL works correctly, regardless of whether `extensions.js` loads before or after the UI code.

https://github.com/user-attachments/assets/98b888bb-2eae-48e8-8208-de8923ee33c3

Checklist:

* [b] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
