### PR TITLE
fix(ui): Prevent versionId 0 Error on New Applications with No History

### DIFF
--- a/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.tsx
+++ b/ui/src/app/applications/components/application-deployment-history/revision-metadata-rows.tsx
@@ -4,7 +4,7 @@ import {Timestamp} from '../../../shared/components/timestamp';
 import {ApplicationSource, RevisionMetadata, ChartDetails} from '../../../shared/models';
 import {services} from '../../../shared/services';
 
-export const RevisionMetadataRows = (props: {applicationName: string; applicationNamespace: string; source: ApplicationSource; index: number; versionId: number}) => {
+export const RevisionMetadataRows = (props: {applicationName: string; applicationNamespace: string; source: ApplicationSource; index: number; versionId: number | null}) => {
     if (props?.source?.chart) {
         return (
             <DataLoader

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -296,7 +296,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
         const getContentForNonChart = (
             aRevision: string,
             aSourceIndex: number,
-            aVersionId: number,
+            aVersionId: number | null,
             indx: number,
             aSource: models.ApplicationSource,
             sourceHeader?: JSX.Element

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -64,7 +64,7 @@ export class ApplicationsService {
         return r.then(res => res.body as models.RevisionMetadata);
     }
 
-    public revisionChartDetails(name: string, appNamespace: string, revision: string, sourceIndex: number | null, versionId: number | null): Promise<models.ChartDetails> {
+    public revisionChartDetails(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number | null): Promise<models.ChartDetails> {
         let r = requests.get(`/applications/${name}/revisions/${revision || 'HEAD'}/chartdetails`).query({appNamespace});
         if (sourceIndex !== null) {
             r = r.query({sourceIndex});

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -53,7 +53,7 @@ export class ApplicationsService {
             .then(res => res.body as models.ApplicationSyncWindowState);
     }
 
-    public revisionMetadata(name: string, appNamespace: string, revision: string, sourceIndex: number | null, versionId: number | null): Promise<models.RevisionMetadata> {
+    public revisionMetadata(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number | null): Promise<models.RevisionMetadata> {
         let r = requests.get(`/applications/${name}/revisions/${revision || 'HEAD'}/metadata`).query({appNamespace});
         if (sourceIndex !== null) {
             r = r.query({sourceIndex});
@@ -64,7 +64,7 @@ export class ApplicationsService {
         return r.then(res => res.body as models.RevisionMetadata);
     }
 
-    public revisionChartDetails(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number): Promise<models.ChartDetails> {
+    public revisionChartDetails(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number | null): Promise<models.ChartDetails> {
         let r = requests.get(`/applications/${name}/revisions/${revision || 'HEAD'}/chartdetails`).query({appNamespace});
         if (sourceIndex !== null) {
             r = r.query({sourceIndex});

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -53,7 +53,7 @@ export class ApplicationsService {
             .then(res => res.body as models.ApplicationSyncWindowState);
     }
 
-    public revisionMetadata(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number | null): Promise<models.RevisionMetadata> {
+    public revisionMetadata(name: string, appNamespace: string, revision: string, sourceIndex: number | null, versionId: number | null): Promise<models.RevisionMetadata> {
         let r = requests.get(`/applications/${name}/revisions/${revision || 'HEAD'}/metadata`).query({appNamespace});
         if (sourceIndex !== null) {
             r = r.query({sourceIndex});
@@ -64,7 +64,7 @@ export class ApplicationsService {
         return r.then(res => res.body as models.RevisionMetadata);
     }
 
-    public revisionChartDetails(name: string, appNamespace: string, revision: string, sourceIndex: number, versionId: number | null): Promise<models.ChartDetails> {
+    public revisionChartDetails(name: string, appNamespace: string, revision: string, sourceIndex: number | null, versionId: number | null): Promise<models.ChartDetails> {
         let r = requests.get(`/applications/${name}/revisions/${revision || 'HEAD'}/chartdetails`).query({appNamespace});
         if (sourceIndex !== null) {
             r = r.query({sourceIndex});

--- a/ui/src/app/shared/services/repo-service.ts
+++ b/ui/src/app/shared/services/repo-service.ts
@@ -224,7 +224,7 @@ export class RepositoriesService {
         return requests.get(`/repositories/${encodeURIComponent(repo)}/helmcharts`).then(res => (res.body.items as models.HelmChart[]) || []);
     }
 
-    public appDetails(source: models.ApplicationSource, appName: string, appProject: string, sourceIndex: number, versionId: number): Promise<models.RepoAppDetails> {
+    public appDetails(source: models.ApplicationSource, appName: string, appProject: string, sourceIndex: number, versionId: number | null): Promise<models.RepoAppDetails> {
         return requests
             .post(`/repositories/${encodeURIComponent(source.repoURL)}/appdetails`)
             .send({source, appName, appProject, sourceIndex, versionId})


### PR DESCRIPTION
**Description:**

For newly created applications without any history, an error occurs because versionId 0 is not found. This happens because the front-end currently sends a versionId even when there is no historical data available.

**Expected Behavior:** 

The front-end should check for the presence of history before sending a versionId. If no history exists, it should avoid sending a versionId, ensuring no error appears on the UI.

**Steps to Reproduce:**

1. Create a new application with no historical data.
2. Attempt to load the application in the UI.
3. Observe the error caused by versionId 0.

![Снимок экрана 2024-10-29 в 15 04 39](https://github.com/user-attachments/assets/91b2e8c5-87e6-49f0-9e44-9900724549b4)
