### PR TITLE
fix(server): missing selected ALPN property

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -561,7 +561,9 @@ func (a *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 
 		// If not matched, we assume that its TLS.
 		tlsl := tcpm.Match(cmux.Any())
-		tlsConfig := tls.Config{}
+		tlsConfig := tls.Config{
+			NextProtos: []string{"h2"},
+		}
 		tlsConfig.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return a.settings.Certificate, nil
 		}


### PR DESCRIPTION
With the dependency update (https://github.com/argoproj/argo-cd/pull/19229), we included https://github.com/grpc/grpc-go/issues/7769 and are now getting the following when using TLS:
```
Unable to load data: connection error: desc = "transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property"
```

A possible workaround is to kustomize patch the argocd-server Deployment to add
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: argocd-server
spec:
  template:
    spec:
      containers:
        - name: argocd-server
          env:
            - name: GRPC_ENFORCE_ALPN_ENABLED
              value: 'false'
```  