### PR TITLE
fix(diff): avoid cache miss in server-side diff

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -965,6 +965,10 @@ func specEqualsCompareTo(spec v1alpha1.ApplicationSpec, comparedTo v1alpha1.Comp
 		currentSpec.Destination.Name = ""
 	}
 
+	// Set IsServerInferred to false on both, because that field is not important for comparison.
+	comparedTo.Destination.SetIsServerInferred(false)
+	currentSpec.Destination.SetIsServerInferred(false)
+
 	return reflect.DeepEqual(comparedTo, currentSpec)
 }
 

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -1528,6 +1528,10 @@ func TestUseDiffCache(t *testing.T) {
 				t.Fatalf("error merging app: %s", err)
 			}
 		}
+		if app.Spec.Destination.Name != "" && app.Spec.Destination.Server != "" {
+			// Simulate the controller's process for populating both of these fields.
+			app.Spec.Destination.SetInferredServer(app.Spec.Destination.Server)
+		}
 		return app
 	}
 

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -1003,6 +1003,12 @@ type ApplicationDestination struct {
 	isServerInferred bool `json:"-"`
 }
 
+// SetIsServerInferred sets the isServerInferred flag. This is used to allow comparison between two destinations where
+// one server is inferred and the other is not.
+func (d *ApplicationDestination) SetIsServerInferred(inferred bool) {
+	d.isServerInferred = inferred
+}
+
 type ResourceHealthLocation string
 
 var (


### PR DESCRIPTION
Follows up on https://github.com/argoproj/argo-cd/pull/20424 because that PR didn't handle the inferred field.