### PR TITLE
fix(server): accept HTTP/1.1 for backward compatibility

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -562,7 +562,8 @@ func (a *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 		// If not matched, we assume that its TLS.
 		tlsl := tcpm.Match(cmux.Any())
 		tlsConfig := tls.Config{
-			NextProtos: []string{"h2", "http/1.1"},
+			// Prefer http/1.1 for HTTPS and HTTP2 for grpc
+			NextProtos: []string{"http/1.1", "h2"},
 		}
 		tlsConfig.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return a.settings.Certificate, nil

--- a/server/server.go
+++ b/server/server.go
@@ -562,7 +562,7 @@ func (a *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 		// If not matched, we assume that its TLS.
 		tlsl := tcpm.Match(cmux.Any())
 		tlsConfig := tls.Config{
-			NextProtos: []string{"h2"},
+			NextProtos: []string{"h2", "http/1.1"},
 		}
 		tlsConfig.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return a.settings.Certificate, nil

--- a/server/server.go
+++ b/server/server.go
@@ -562,7 +562,10 @@ func (a *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 		// If not matched, we assume that its TLS.
 		tlsl := tcpm.Match(cmux.Any())
 		tlsConfig := tls.Config{
-			// Prefer http/1.1 for HTTPS and HTTP2 for grpc
+			// Advertise that we support both http/1.1 and http2 for application level communication.
+			// By putting http/1.1 first, we ensure that HTTPS clients will use http/1.1, which is the only
+			// protocol our server supports for HTTPS clients. By including h2 in the list, we ensure that
+			// gRPC clients know we support http2 for their communication.
 			NextProtos: []string{"http/1.1", "h2"},
 		}
 		tlsConfig.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {


### PR DESCRIPTION
Some client such as curl will use http/1.1 by default and only supporting the http2 protocol is a breaking change for these clients. Also, the http2 is not supported in Argo currently for HTTPS as far as I can see, only for grpc.

We must support HTTP1.1 . Here is a quick recap of the NextProtos config
http1.1 + h2 => works
h2 + http1.1 => curl needs --http1.1 param && readiness are different depending if server is insecure or not => very annoying
h2 => curl/readiness wont work
http1.1 => grpc/UI wont work
nothing => we need to add an env var to disable this, which ends up doing the same as "http1.1 + h2"


Caused by #20579 