### PR TITLE
feat: adopt delete app confirmation to new prompt util

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1450,7 +1450,9 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 
 			numOfApps := len(appNames)
 
-			promptUtil := utils.NewPrompt(isTerminal && !noPrompt)
+			// This is for backward compatibility, 
+			// before we showed the prompts only when condition cascade && isTerminal && !noPrompt is true
+			promptUtil := utils.NewPrompt(cascade && isTerminal && !noPrompt)
 			var (
 				confirmAll      = false
 				confirm    bool = false

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1454,8 +1454,8 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 			// before we showed the prompts only when condition cascade && isTerminal && !noPrompt is true
 			promptUtil := utils.NewPrompt(cascade && isTerminal && !noPrompt)
 			var (
-				confirmAll      = false
-				confirm    bool = false
+				confirmAll = false
+				confirm    = false
 			)
 
 			for _, appFullName := range appNames {

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
+	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/utils"
+
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
 	cmdutil "github.com/argoproj/argo-cd/v2/cmd/util"
 	"github.com/argoproj/argo-cd/v2/controller"
@@ -1435,8 +1437,6 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 			conn, appIf := acdClient.NewApplicationClientOrDie()
 			defer argoio.Close(conn)
 			var isTerminal bool = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
-			var isConfirmAll bool = false
-			numOfApps := len(args)
 			promptFlag := c.Flag("yes")
 			if promptFlag.Changed && promptFlag.Value.String() == "true" {
 				noPrompt = true
@@ -1448,6 +1448,14 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 			if len(appNames) == 0 {
 				appNames = args
 			}
+
+			numOfApps := len(appNames)
+
+			promptUtil := utils.NewPrompt(isTerminal && !noPrompt)
+			var (
+				confirmAll      = false
+				confirm    bool = false
+			)
 
 			for _, appFullName := range appNames {
 				appName, appNs := argo.ParseFromQualifiedName(appFullName, appNamespace)
@@ -1461,38 +1469,21 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 				if c.Flag("propagation-policy").Changed {
 					appDeleteReq.PropagationPolicy = &propagationPolicy
 				}
-				if cascade && isTerminal && !noPrompt {
-					var lowercaseAnswer string
-					if numOfApps == 1 {
-						lowercaseAnswer = cli.AskToProceedS("Are you sure you want to delete '" + appFullName + "' and all its resources? [y/n] ")
-					} else {
-						if !isConfirmAll {
-							lowercaseAnswer = cli.AskToProceedS("Are you sure you want to delete '" + appFullName + "' and all its resources? [y/n/A] where 'A' is to delete all specified apps and their resources without prompting ")
-							if lowercaseAnswer == "a" {
-								lowercaseAnswer = "y"
-								isConfirmAll = true
-							}
-						} else {
-							lowercaseAnswer = "y"
-						}
-					}
-					if lowercaseAnswer == "y" {
-						_, err := appIf.Delete(ctx, &appDeleteReq)
-						errors.CheckError(err)
-						if wait {
-							checkForDeleteEvent(ctx, acdClient, appFullName)
-						}
-						fmt.Printf("application '%s' deleted\n", appFullName)
-					} else {
-						fmt.Println("The command to delete '" + appFullName + "' was cancelled.")
-					}
-				} else {
+				messageForSingle := "Are you sure you want to delete '" + appFullName + "' and all its resources? [y/n] "
+				messageForAll := "Are you sure you want to delete '" + appFullName + "' and all its resources? [y/n/a] where 'a' is to delete all specified apps and their resources without prompting "
+
+				if !confirmAll {
+					confirm, confirmAll = promptUtil.ConfirmBaseOnCount(messageForSingle, messageForAll, numOfApps)
+				}
+				if confirm || confirmAll {
 					_, err := appIf.Delete(ctx, &appDeleteReq)
 					errors.CheckError(err)
-
 					if wait {
 						checkForDeleteEvent(ctx, acdClient, appFullName)
 					}
+					fmt.Printf("application '%s' deleted\n", appFullName)
+				} else {
+					fmt.Println("The command to delete '" + appFullName + "' was cancelled.")
 				}
 			}
 		},

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -34,9 +34,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
-	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/utils"
-
 	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/headless"
+	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/utils"
 	cmdutil "github.com/argoproj/argo-cd/v2/cmd/util"
 	"github.com/argoproj/argo-cd/v2/controller"
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1450,7 +1450,7 @@ func NewApplicationDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 
 			numOfApps := len(appNames)
 
-			// This is for backward compatibility, 
+			// This is for backward compatibility,
 			// before we showed the prompts only when condition cascade && isTerminal && !noPrompt is true
 			promptUtil := utils.NewPrompt(cascade && isTerminal && !noPrompt)
 			var (

--- a/cmd/argocd/commands/utils/prompt.go
+++ b/cmd/argocd/commands/utils/prompt.go
@@ -21,3 +21,40 @@ func (p *Prompt) Confirm(message string) bool {
 
 	return cli.AskToProceed(message)
 }
+
+// ConfirmAll asks the user to confirm an action. If prompts are disabled, it will return true.
+// support y/n and A, which means all
+// return if confirm and if all
+func (p *Prompt) ConfirmAll(message string) (bool, bool) {
+	if !p.enabled {
+		return true, true
+	}
+
+	result := cli.AskToProceedS(message)
+
+	if result == "a" {
+		return true, true
+	}
+
+	if result == "y" {
+		return true, false
+	}
+
+	return false, false
+}
+
+func (p *Prompt) ConfirmBaseOnCount(messageForSingle string, messageForArray string, count int) (bool, bool) {
+	if !p.enabled {
+		return true, true
+	}
+
+	if count == 0 {
+		return true, true
+	}
+
+	if count == 1 {
+		return p.Confirm(messageForSingle), true
+	}
+
+	return p.ConfirmAll(messageForArray)
+}

--- a/cmd/argocd/commands/utils/prompt_test.go
+++ b/cmd/argocd/commands/utils/prompt_test.go
@@ -20,3 +20,30 @@ func TestConfirm_PromptsEnabled_False(t *testing.T) {
 	prompt := NewPrompt(false)
 	assert.True(t, prompt.Confirm("Are you sure you want to run this command? (y/n) "))
 }
+
+// Returns true, true when prompt is disabled
+func TestConfirmAllPromptDisabled(t *testing.T) {
+	p := &Prompt{enabled: false}
+	result1, result2 := p.ConfirmAll("Proceed?")
+	if result1 != true || result2 != true {
+		t.Errorf("Expected (true, true), got (%v, %v)", result1, result2)
+	}
+}
+
+func TestConfirmBaseOnCountPromptDisabled(t *testing.T) {
+	p := &Prompt{enabled: false}
+	result1, result2 := p.ConfirmBaseOnCount("Proceed?", "Process all?", 2)
+
+	if result1 != true || result2 != true {
+		t.Errorf("Expected (true, true), got (%v, %v)", result1, result2)
+	}
+}
+
+func TestConfirmBaseOnCountZeroApps(t *testing.T) {
+	p := &Prompt{enabled: true}
+	result1, result2 := p.ConfirmBaseOnCount("Proceed?", "Process all?", 0)
+
+	if result1 != true || result2 != true {
+		t.Errorf("Expected (true, true), got (%v, %v)", result1, result2)
+	}
+}


### PR DESCRIPTION
Related to: https://github.com/argoproj/argo-cd/issues/19528

Here also was a bug related to deletion of multiple resources, it didnt because numOfApps was initialized incorrectly

1. Cascade delete is false and no --yes flag ( which enables prompts )

![Снимок экрана 2024-11-05 в 14 15 17](https://github.com/user-attachments/assets/7c79543e-c56c-49e6-951b-65b0ed27e836)


2. Cascade delete is true and noPrompt is false
![Снимок экрана 2024-11-05 в 14 45 19](https://github.com/user-attachments/assets/c0a19683-b058-4853-a07f-dab2eead314c)




 