### PR TITLE
chore: Don't degrade PDB on InsufficientPods (#20171)

### DIFF
--- a/resource_customizations/policy/PodDisruptionBudget/health.lua
+++ b/resource_customizations/policy/PodDisruptionBudget/health.lua
@@ -7,12 +7,13 @@ hs.message = "Waiting for status"
 if obj.status ~= nil then
   if obj.status.conditions ~= nil then
     for i, condition in ipairs(obj.status.conditions) do
-      if condition.status == "False" then
+      -- InsufficientPods can have valid use cases
+      -- See a discussion in https://github.com/argoproj/argo-cd/issues/20171 for more details
+      if condition.status == "False" and condition.reason ~= "InsufficientPods" then
         hs.status = "Degraded"
         hs.message = "PodDisruptionBudget has " .. condition.reason
         return hs
-      end
-      if condition.status == "True" then
+      else
         hs.status = "Healthy"
         hs.message = "PodDisruptionBudget has " .. condition.reason
       end

--- a/resource_customizations/policy/PodDisruptionBudget/health_test.yaml
+++ b/resource_customizations/policy/PodDisruptionBudget/health_test.yaml
@@ -9,5 +9,5 @@ tests:
   inputPath: testdata/progressing.yaml
 - healthStatus:
     status: Degraded
-    message: 'PodDisruptionBudget has InsufficientPods'
+    message: 'PodDisruptionBudget has SyncFailed'
   inputPath: testdata/degraded.yaml

--- a/resource_customizations/policy/PodDisruptionBudget/testdata/degraded.yaml
+++ b/resource_customizations/policy/PodDisruptionBudget/testdata/degraded.yaml
@@ -16,6 +16,12 @@ status:
       reason: InsufficientPods
       status: "False"
       type: DisruptionAllowed
+    - lastTransitionTime: "2024-09-06T18:29:06Z"
+      message: ""
+      observedGeneration: 2
+      reason: SyncFailed
+      status: "False"
+      type: DisruptionAllowed
   currentHealthy: 2
   desiredHealthy: 3
   disruptionsAllowed: 0


### PR DESCRIPTION
Closes #20171

There are valid use cases for InsufficientPods, e.g. running some jobs or tests that don't want to be terminated. See the discussion on the issue for more details. So don't degrade the PDB on InsufficientPods condition.

This needs to be cherry picked to 2.13, as many people may not upgrade otherwise.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
