### PR TITLE
chore: use testify instead of testing.Fatal or testing.Error in cmd

### DIFF
--- a/cmd/argocd/commands/app_resource_test.go
+++ b/cmd/argocd/commands/app_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
@@ -37,9 +38,7 @@ func TestPrintTreeViewAppResources(t *testing.T) {
 	w := tabwriter.NewWriter(buf, 0, 0, 2, ' ', 0)
 
 	printTreeViewAppResourcesNotOrphaned(nodeMapping, mapParentToChild, parentNode, w)
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Flush())
 	output := buf.String()
 
 	assert.Contains(t, output, "Rollout")
@@ -78,9 +77,7 @@ func TestPrintTreeViewDetailedAppResources(t *testing.T) {
 	w := tabwriter.NewWriter(buf, 0, 0, 2, ' ', 0)
 
 	printDetailedTreeViewAppResourcesNotOrphaned(nodeMapping, mapParentToChild, parentNode, w)
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Flush())
 	output := buf.String()
 
 	assert.Contains(t, output, "Rollout")

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -136,13 +136,8 @@ func TestFindRevisionHistoryWithoutPassedId(t *testing.T) {
 	}
 
 	history, err := findRevisionHistory(&application, -1)
-	if err != nil {
-		t.Fatal("Find revision history should fail without errors")
-	}
-
-	if history == nil {
-		t.Fatal("History should be found")
-	}
+	require.NoError(t, err, "Find revision history should fail without errors")
+	require.NotNil(t, history, "History should be found")
 }
 
 func TestPrintTreeViewAppGet(t *testing.T) {
@@ -249,13 +244,8 @@ func TestFindRevisionHistoryWithoutPassedIdWithMultipleSources(t *testing.T) {
 	}
 
 	history, err := findRevisionHistory(&application, -1)
-	if err != nil {
-		t.Fatal("Find revision history should fail without errors")
-	}
-
-	if history == nil {
-		t.Fatal("History should be found")
-	}
+	require.NoError(t, err, "Find revision history should fail without errors")
+	require.NotNil(t, history, "History should be found")
 }
 
 func TestDefaultWaitOptions(t *testing.T) {
@@ -308,17 +298,9 @@ func TestFindRevisionHistoryWithoutPassedIdAndEmptyHistoryList(t *testing.T) {
 
 	history, err := findRevisionHistory(&application, -1)
 
-	if err == nil {
-		t.Fatal("Find revision history should fail with errors")
-	}
-
-	if history != nil {
-		t.Fatal("History should be empty")
-	}
-
-	if err.Error() != "Application '' should have at least two successful deployments" {
-		t.Fatal("Find revision history should fail with correct error message")
-	}
+	require.Error(t, err, "Find revision history should fail with errors")
+	require.Nil(t, history, "History should be empty")
+	require.EqualError(t, err, "Application '' should have at least two successful deployments", "Find revision history should fail with correct error message")
 }
 
 func TestFindRevisionHistoryWithPassedId(t *testing.T) {
@@ -346,17 +328,9 @@ func TestFindRevisionHistoryWithPassedId(t *testing.T) {
 	}
 
 	history, err := findRevisionHistory(&application, 3)
-	if err != nil {
-		t.Fatal("Find revision history should fail without errors")
-	}
-
-	if history == nil {
-		t.Fatal("History should be found")
-	}
-
-	if history.Revision != "123" {
-		t.Fatal("Failed to find correct history with correct revision")
-	}
+	require.NoError(t, err, "Find revision history should fail without errors")
+	require.NotNil(t, history, "History should be found")
+	require.Equal(t, "123", history.Revision, "Failed to find correct history with correct revision")
 }
 
 func TestFindRevisionHistoryWithPassedIdThatNotExist(t *testing.T) {
@@ -385,17 +359,9 @@ func TestFindRevisionHistoryWithPassedIdThatNotExist(t *testing.T) {
 
 	history, err := findRevisionHistory(&application, 4)
 
-	if err == nil {
-		t.Fatal("Find revision history should fail with errors")
-	}
-
-	if history != nil {
-		t.Fatal("History should be not found")
-	}
-
-	if err.Error() != "Application '' does not have deployment id '4' in history\n" {
-		t.Fatal("Find revision history should fail with correct error message")
-	}
+	require.Error(t, err, "Find revision history should fail with errors")
+	require.Nil(t, history, "History should be not found")
+	require.EqualError(t, err, "Application '' does not have deployment id '4' in history\n", "Find revision history should fail with correct error message")
 }
 
 func Test_groupObjsByKey(t *testing.T) {
@@ -457,9 +423,7 @@ func TestFormatSyncPolicy(t *testing.T) {
 
 		policy := formatSyncPolicy(app)
 
-		if policy != "Manual" {
-			t.Fatalf("Incorrect policy %q, should be Manual", policy)
-		}
+		require.Equalf(t, "Manual", policy, "Incorrect policy %q, should be Manual", policy)
 	})
 
 	t.Run("Auto policy", func(t *testing.T) {
@@ -473,9 +437,7 @@ func TestFormatSyncPolicy(t *testing.T) {
 
 		policy := formatSyncPolicy(app)
 
-		if policy != "Auto" {
-			t.Fatalf("Incorrect policy %q, should be Auto", policy)
-		}
+		require.Equalf(t, "Auto", policy, "Incorrect policy %q, should be Auto", policy)
 	})
 
 	t.Run("Auto policy with prune", func(t *testing.T) {
@@ -491,9 +453,7 @@ func TestFormatSyncPolicy(t *testing.T) {
 
 		policy := formatSyncPolicy(app)
 
-		if policy != "Auto-Prune" {
-			t.Fatalf("Incorrect policy %q, should be Auto-Prune", policy)
-		}
+		require.Equalf(t, "Auto-Prune", policy, "Incorrect policy %q, should be Auto-Prune", policy)
 	})
 }
 
@@ -510,9 +470,7 @@ func TestFormatConditionSummary(t *testing.T) {
 		}
 
 		summary := formatConditionsSummary(app)
-		if summary != "<none>" {
-			t.Fatalf("Incorrect summary %q, should be <none>", summary)
-		}
+		require.Equalf(t, "<none>", summary, "Incorrect summary %q, should be <none>", summary)
 	})
 
 	t.Run("Few conditions are defined", func(t *testing.T) {
@@ -533,9 +491,7 @@ func TestFormatConditionSummary(t *testing.T) {
 		}
 
 		summary := formatConditionsSummary(app)
-		if summary != "type1(2),type2" && summary != "type2,type1(2)" {
-			t.Fatalf("Incorrect summary %q, should be type1(2),type2", summary)
-		}
+		require.Equalf(t, "type1(2),type2", summary, "Incorrect summary %q, should be type1(2),type2", summary)
 	})
 }
 
@@ -546,9 +502,7 @@ func TestPrintOperationResult(t *testing.T) {
 			return nil
 		})
 
-		if output != "" {
-			t.Fatalf("Incorrect print operation output %q, should be ''", output)
-		}
+		require.Emptyf(t, output, "Incorrect print operation output %q, should be ''", output)
 	})
 
 	t.Run("Operation state sync result is not empty", func(t *testing.T) {
@@ -562,9 +516,7 @@ func TestPrintOperationResult(t *testing.T) {
 		})
 
 		expectation := "Operation:          Sync\nSync Revision:      revision\nPhase:              \nStart:              0001-01-01 00:00:00 +0000 UTC\nFinished:           2020-11-10 23:00:00 +0000 UTC\nDuration:           2333448h16m18.871345152s\n"
-		if output != expectation {
-			t.Fatalf("Incorrect print operation output %q, should be %q", output, expectation)
-		}
+		require.Equalf(t, output, expectation, "Incorrect print operation output %q, should be %q", output, expectation)
 	})
 
 	t.Run("Operation state sync result with message is not empty", func(t *testing.T) {
@@ -579,9 +531,7 @@ func TestPrintOperationResult(t *testing.T) {
 		})
 
 		expectation := "Operation:          Sync\nSync Revision:      revision\nPhase:              \nStart:              0001-01-01 00:00:00 +0000 UTC\nFinished:           2020-11-10 23:00:00 +0000 UTC\nDuration:           2333448h16m18.871345152s\nMessage:            test\n"
-		if output != expectation {
-			t.Fatalf("Incorrect print operation output %q, should be %q", output, expectation)
-		}
+		require.Equalf(t, output, expectation, "Incorrect print operation output %q, should be %q", output, expectation)
 	})
 }
 
@@ -617,9 +567,7 @@ func TestPrintApplicationHistoryTable(t *testing.T) {
 
 	expectation := "SOURCE  test\nID      DATE                           REVISION\n1       0001-01-01 00:00:00 +0000 UTC  1\n2       0001-01-01 00:00:00 +0000 UTC  2\n3       0001-01-01 00:00:00 +0000 UTC  3\n"
 
-	if output != expectation {
-		t.Fatalf("Incorrect print operation output %q, should be %q", output, expectation)
-	}
+	require.Equalf(t, output, expectation, "Incorrect print operation output %q, should be %q", output, expectation)
 }
 
 func TestPrintApplicationHistoryTableWithMultipleSources(t *testing.T) {
@@ -696,9 +644,7 @@ func TestPrintApplicationHistoryTableWithMultipleSources(t *testing.T) {
 
 	expectation := "SOURCE  test\nID      DATE                           REVISION\n0       0001-01-01 00:00:00 +0000 UTC  0\n\nSOURCE  test-1\nID      DATE                           REVISION\n1       0001-01-01 00:00:00 +0000 UTC  1a\n2       0001-01-01 00:00:00 +0000 UTC  2a\n3       0001-01-01 00:00:00 +0000 UTC  3a\n\nSOURCE  test-2\nID      DATE                           REVISION\n1       0001-01-01 00:00:00 +0000 UTC  1b\n2       0001-01-01 00:00:00 +0000 UTC  2b\n3       0001-01-01 00:00:00 +0000 UTC  3b\n"
 
-	if output != expectation {
-		t.Fatalf("Incorrect print operation output %q, should be %q", output, expectation)
-	}
+	require.Equalf(t, output, expectation, "Incorrect print operation output %q, should be %q", output, expectation)
 }
 
 func TestPrintAppSummaryTable(t *testing.T) {
@@ -912,9 +858,7 @@ func TestPrintAppConditions(t *testing.T) {
 		return nil
 	})
 	expectation := "CONDITION\tMESSAGE\tLAST TRANSITION\nDeletionError\ttest\t<nil>\nExcludedResourceWarning\ttest2\t<nil>\nRepeatedResourceWarning\ttest3\t<nil>\n"
-	if output != expectation {
-		t.Fatalf("Incorrect print app conditions output %q, should be %q", output, expectation)
-	}
+	require.Equalf(t, output, expectation, "Incorrect print app conditions output %q, should be %q", output, expectation)
 }
 
 func TestPrintParams(t *testing.T) {
@@ -991,9 +935,7 @@ func TestPrintParams(t *testing.T) {
 				return nil
 			})
 
-			if output != tc.expectedOutput {
-				t.Fatalf("Incorrect print params output %q, should be %q\n", output, tc.expectedOutput)
-			}
+			require.Equalf(t, tc.expectedOutput, output, "Incorrect print params output %q, should be %q\n", output, tc.expectedOutput)
 		})
 	}
 }
@@ -1005,9 +947,7 @@ func TestAppUrlDefault(t *testing.T) {
 			PlainText:  true,
 		}), "test")
 		expectation := "http://localhost:80/applications/test"
-		if result != expectation {
-			t.Fatalf("Incorrect url %q, should be %q", result, expectation)
-		}
+		require.Equalf(t, result, expectation, "Incorrect url %q, should be %q", result, expectation)
 	})
 	t.Run("https", func(t *testing.T) {
 		result := appURLDefault(argocdclient.NewClientOrDie(&argocdclient.ClientOptions{
@@ -1015,18 +955,14 @@ func TestAppUrlDefault(t *testing.T) {
 			PlainText:  false,
 		}), "test")
 		expectation := "https://localhost/applications/test"
-		if result != expectation {
-			t.Fatalf("Incorrect url %q, should be %q", result, expectation)
-		}
+		require.Equalf(t, result, expectation, "Incorrect url %q, should be %q", result, expectation)
 	})
 }
 
 func TestTruncateString(t *testing.T) {
 	result := truncateString("argocdtool", 2)
 	expectation := "ar..."
-	if result != expectation {
-		t.Fatalf("Incorrect truncate string %q, should be %q", result, expectation)
-	}
+	require.Equalf(t, result, expectation, "Incorrect truncate string %q, should be %q", result, expectation)
 }
 
 func TestGetService(t *testing.T) {
@@ -1040,9 +976,7 @@ func TestGetService(t *testing.T) {
 		}
 		result := getServer(app)
 		expectation := "test-server"
-		if result != expectation {
-			t.Fatalf("Incorrect server %q, should be %q", result, expectation)
-		}
+		require.Equal(t, result, expectation, "Incorrect server %q, should be %q", result, expectation)
 	})
 	t.Run("Name", func(t *testing.T) {
 		app := &v1alpha1.Application{
@@ -1054,9 +988,7 @@ func TestGetService(t *testing.T) {
 		}
 		result := getServer(app)
 		expectation := "test-name"
-		if result != expectation {
-			t.Fatalf("Incorrect server name %q, should be %q", result, expectation)
-		}
+		require.Equal(t, result, expectation, "Incorrect server name %q, should be %q", result, expectation)
 	})
 }
 
@@ -1070,17 +1002,9 @@ func TestTargetObjects(t *testing.T) {
 		},
 	}
 	objects, err := targetObjects(resources)
-	if err != nil {
-		t.Fatal("operation should finish without error")
-	}
-
-	if len(objects) != 2 {
-		t.Fatalf("incorrect number of objects %v, should be 2", len(objects))
-	}
-
-	if objects[0].GetName() != "test-helm-guestbook" {
-		t.Fatalf("incorrect name %q, should be %q", objects[0].GetName(), "test-helm-guestbook")
-	}
+	require.NoError(t, err, "operation should finish without error")
+	require.Lenf(t, objects, 2, "incorrect number of objects %v, should be 2", len(objects))
+	require.Equalf(t, "test-helm-guestbook", objects[0].GetName(), "incorrect name %q, should be %q", objects[0].GetName(), "test-helm-guestbook")
 }
 
 func TestTargetObjects_invalid(t *testing.T) {
@@ -1107,9 +1031,7 @@ func TestPrintApplicationNames(t *testing.T) {
 		return nil
 	})
 	expectation := "test\ntest\n"
-	if output != expectation {
-		t.Fatalf("Incorrect print params output %q, should be %q", output, expectation)
-	}
+	require.Equalf(t, output, expectation, "Incorrect print params output %q, should be %q", output, expectation)
 }
 
 func Test_unset(t *testing.T) {
@@ -1899,9 +1821,8 @@ func Test_hasAppChanged(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := hasAppChanged(tt.args.appReq, tt.args.appRes, tt.args.upsert); got != tt.want {
-				t.Errorf("hasAppChanged() = %v, want %v", got, tt.want)
-			}
+			got := hasAppChanged(tt.args.appReq, tt.args.appRes, tt.args.upsert)
+			assert.Equalf(t, tt.want, got, "hasAppChanged() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -29,9 +29,7 @@ func TestPrintApplicationSetNames(t *testing.T) {
 		return nil
 	})
 	expectation := "test\nteam-one/test\n"
-	if output != expectation {
-		t.Fatalf("Incorrect print params output %q, should be %q", output, expectation)
-	}
+	require.Equalf(t, output, expectation, "Incorrect print params output %q, should be %q", output, expectation)
 }
 
 func TestPrintApplicationSetTable(t *testing.T) {

--- a/cmd/argocd/commands/cluster_test.go
+++ b/cmd/argocd/commands/cluster_test.go
@@ -102,7 +102,7 @@ func Test_getRestConfig(t *testing.T) {
 			if tt.wantErr {
 				require.EqualError(t, err, tt.expectedErr)
 			} else {
-				require.Errorf(t, err, "An unexpected error occurred during test %s:\n%s", tt.name, err.Error())
+				require.NoErrorf(t, err, "An unexpected error occurred during test %s", tt.name)
 				require.Equal(t, tt.expected, got)
 			}
 		})

--- a/cmd/argocd/commands/cluster_test.go
+++ b/cmd/argocd/commands/cluster_test.go
@@ -98,12 +98,12 @@ func Test_getRestConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, err := getRestConfig(tt.args.pathOpts, tt.args.ctxName); err == nil {
-				require.Equal(t, tt.expected, got)
-			} else if tt.wantErr {
-				require.Equal(t, tt.expectedErr, err.Error())
+			got, err := getRestConfig(tt.args.pathOpts, tt.args.ctxName)
+			if tt.wantErr {
+				require.EqualError(t, err, tt.expectedErr)
 			} else {
-				t.Errorf("An unexpected error occurred during test %s:\n%s", tt.name, err.Error())
+				require.Errorf(t, err, "An unexpected error occurred during test %s:\n%s", tt.name, err.Error())
+				require.Equal(t, tt.expected, got)
 			}
 		})
 	}

--- a/cmd/argocd/commands/tree_test.go
+++ b/cmd/argocd/commands/tree_test.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
@@ -38,9 +39,7 @@ func TestTreeViewAppGet(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := tabwriter.NewWriter(buf, 0, 0, 2, ' ', 0)
 	treeViewAppGet("", objs, childMapping, parent, stateMap, w)
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Flush())
 	output := buf.String()
 	assert.Contains(t, output, "ReplicaSet")
 	assert.Contains(t, output, "Rollout")
@@ -77,9 +76,7 @@ func TestTreeViewDetailedAppGet(t *testing.T) {
 	buf := &bytes.Buffer{}
 	w := tabwriter.NewWriter(buf, 0, 0, 2, ' ', 0)
 	detailedTreeViewAppGet("", objs, childMapping, parent, stateMap, w)
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Flush())
 
 	output := buf.String()
 
@@ -119,9 +116,7 @@ func TestTreeViewAppResources(t *testing.T) {
 	orphanParent := orphan
 
 	treeViewAppResourcesOrphaned("", objsOrphan, orphanchildMapping, orphanParent, w)
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Flush())
 	output := buf.String()
 
 	assert.Contains(t, output, "ReplicaSet")
@@ -159,9 +154,7 @@ func TestTreeViewDetailedAppResources(t *testing.T) {
 	orphanchildMapping := make(map[string][]string)
 	orphanParent := orphan
 	detailedTreeViewAppResourcesOrphaned("", objsOrphan, orphanchildMapping, orphanParent, w)
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, w.Flush())
 	output := buf.String()
 
 	assert.Contains(t, output, "ReplicaSet")

--- a/cmd/argocd/commands/utils/prompt_test.go
+++ b/cmd/argocd/commands/utils/prompt_test.go
@@ -26,27 +26,22 @@ func TestConfirm_PromptsEnabled_False(t *testing.T) {
 func TestConfirmAllPromptDisabled(t *testing.T) {
 	p := &Prompt{enabled: false}
 	result1, result2 := p.ConfirmAll("Proceed?")
-	if result1 != true || result2 != true {
-		t.Errorf("Expected (true, true), got (%v, %v)", result1, result2)
-	}
+	assert.True(t, result1)
+	assert.True(t, result2)
 }
 
 func TestConfirmBaseOnCountPromptDisabled(t *testing.T) {
 	p := &Prompt{enabled: false}
 	result1, result2 := p.ConfirmBaseOnCount("Proceed?", "Process all?", 2)
-
-	if result1 != true || result2 != true {
-		t.Errorf("Expected (true, true), got (%v, %v)", result1, result2)
-	}
+	assert.True(t, result1)
+	assert.True(t, result2)
 }
 
 func TestConfirmBaseOnCountZeroApps(t *testing.T) {
 	p := &Prompt{enabled: true}
 	result1, result2 := p.ConfirmBaseOnCount("Proceed?", "Process all?", 0)
-
-	if result1 != true || result2 != true {
-		t.Errorf("Expected (true, true), got (%v, %v)", result1, result2)
-	}
+	assert.True(t, result1)
+	assert.True(t, result2)
 }
 
 func TestConfirmPrompt(t *testing.T) {

--- a/cmd/argocd/commands/utils/prompt_test.go
+++ b/cmd/argocd/commands/utils/prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPrompt_PromptsEnabled_True(t *testing.T) {
@@ -57,9 +58,7 @@ func TestConfirmPrompt(t *testing.T) {
 
 	for _, c := range cases {
 		tmpFile, err := writeToStdin(c.input)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		p := &Prompt{enabled: true}
 		result := p.Confirm("Are you sure you want to run this command? (y/n) \n")
 		assert.Equal(t, c.output, result)
@@ -85,9 +84,7 @@ func TestConfirmAllPrompt(t *testing.T) {
 
 	for _, c := range cases {
 		tmpFile, err := writeToStdin(c.input)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		p := &Prompt{enabled: true}
 		confirm, confirmAll := p.ConfirmAll("Are you sure you want to run this command? (y/n) \n")
 		assert.Equal(t, c.confirm, confirm)

--- a/cmd/argocd/commands/version_test.go
+++ b/cmd/argocd/commands/version_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
@@ -15,10 +16,7 @@ func TestShortVersionClient(t *testing.T) {
 	cmd := NewVersionCmd(&argocdclient.ClientOptions{}, nil)
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"version", "--short", "--client"})
-	err := cmd.Execute()
-	if err != nil {
-		t.Fatal("Failed to execute short version command")
-	}
+	require.NoError(t, cmd.Execute(), "Failed to execute short version command")
 	output := buf.String()
 	assert.Equal(t, "argocd: v99.99.99+unknown\n", output)
 }
@@ -29,10 +27,6 @@ func TestShortVersion(t *testing.T) {
 	cmd := NewVersionCmd(&argocdclient.ClientOptions{}, serverVersion)
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"argocd", "version", "--short"})
-	err := cmd.Execute()
-	if err != nil {
-		t.Fatal("Failed to execute short version command")
-	}
-	output := buf.String()
-	assert.Equal(t, "argocd: v99.99.99+unknown\nargocd-server: v99.99.99+unknown\n", output)
+	require.NoError(t, cmd.Execute(), "Failed to execute short version command")
+	assert.Equal(t, "argocd: v99.99.99+unknown\nargocd-server: v99.99.99+unknown\n", buf.String())
 }

--- a/cmd/argocd/commands/version_test.go
+++ b/cmd/argocd/commands/version_test.go
@@ -17,8 +17,7 @@ func TestShortVersionClient(t *testing.T) {
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"version", "--short", "--client"})
 	require.NoError(t, cmd.Execute(), "Failed to execute short version command")
-	output := buf.String()
-	assert.Equal(t, "argocd: v99.99.99+unknown\n", output)
+	assert.Equal(t, "argocd: v99.99.99+unknown\n", buf.String())
 }
 
 func TestShortVersion(t *testing.T) {

--- a/cmd/util/cluster_test.go
+++ b/cmd/util/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -163,15 +164,12 @@ func TestGetKubePublicEndpoint(t *testing.T) {
 			}
 			clientset := fake.NewSimpleClientset(objects...)
 			endpoint, err := GetKubePublicEndpoint(clientset)
-			if err != nil && !tc.expectError {
-				t.Fatalf("unexpected error: %v", err)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
-			if err == nil && tc.expectError {
-				t.Error("expected error to be returned, received none")
-			}
-			if endpoint != tc.expectedEndpoint {
-				t.Errorf("expected endpoint %s, got %s", tc.expectedEndpoint, endpoint)
-			}
+			require.Equalf(t, tc.expectedEndpoint, endpoint, "expected endpoint %s, got %s", tc.expectedEndpoint, endpoint)
 		})
 	}
 }


### PR DESCRIPTION
### Description

* uses testify instead of testing.Fatal or testing.Error in cmd