### PR TITLE
chore: use testify instead of testing.Fatal or testing.Error in util

### DIFF
--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -41,18 +43,11 @@ func TestHealthCheck(t *testing.T) {
 	server := "http://" + address
 
 	resp, err := http.Get(server + "/healthz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Was expecting status code 200 from health check, but got %d instead", resp.StatusCode)
-	}
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "Was expecting status code 200 from health check, but got %d instead", resp.StatusCode)
 
 	sentinel = true
 
 	resp, _ = http.Get(server + "/healthz")
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("Was expecting status code 503 from health check, but got %d instead", resp.StatusCode)
-	}
+	require.Equalf(t, http.StatusServiceUnavailable, resp.StatusCode, "Was expecting status code 503 from health check, but got %d instead", resp.StatusCode)
 }

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -185,10 +185,7 @@ func TestGetTagsFromUrl(t *testing.T) {
 				}
 			}
 			w.WriteHeader(http.StatusOK)
-			err := json.NewEncoder(w).Encode(responseTags)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, json.NewEncoder(w).Encode(responseTags))
 		}))
 
 		client := NewClient(server.URL, Creds{InsecureSkipVerify: true}, true, "", "")
@@ -243,10 +240,7 @@ func TestGetTagsFromURLPrivateRepoAuthentication(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		err := json.NewEncoder(w).Encode(responseTags)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, json.NewEncoder(w).Encode(responseTags))
 	}))
 	t.Cleanup(server.Close)
 
@@ -324,10 +318,7 @@ func TestGetTagsFromURLEnvironmentAuthentication(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		err := json.NewEncoder(w).Encode(responseTags)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, json.NewEncoder(w).Encode(responseTags))
 	}))
 	t.Cleanup(server.Close)
 

--- a/util/io/files/tar_test.go
+++ b/util/io/files/tar_test.go
@@ -108,9 +108,7 @@ func TestUntgz(t *testing.T) {
 	createTmpDir := func(t *testing.T) string {
 		t.Helper()
 		tmpDir, err := os.MkdirTemp(getTestDataDir(t), "")
-		if err != nil {
-			t.Fatalf("error creating tmpDir: %s", err)
-		}
+		require.NoErrorf(t, err, "error creating tmpDir: %s", err)
 		return tmpDir
 	}
 	deleteTmpDir := func(t *testing.T, dirname string) {
@@ -123,16 +121,11 @@ func TestUntgz(t *testing.T) {
 	createTgz := func(t *testing.T, fromDir, destDir string) *os.File {
 		t.Helper()
 		f, err := os.CreateTemp(destDir, "")
-		if err != nil {
-			t.Fatalf("error creating tmpFile in %q: %s", destDir, err)
-		}
+		require.NoErrorf(t, err, "error creating tmpFile in %q: %s", destDir, err)
 		_, err = files.Tgz(fromDir, nil, nil, f)
-		if err != nil {
-			t.Fatalf("error during Tgz: %s", err)
-		}
-		if _, err := f.Seek(0, io.SeekStart); err != nil {
-			t.Fatalf("seek error: %s", err)
-		}
+		require.NoErrorf(t, err, "error during Tgz: %s", err)
+		_, err = f.Seek(0, io.SeekStart)
+		require.NoErrorf(t, err, "seek error: %s", err)
 		return f
 	}
 	readFiles := func(t *testing.T, basedir string) map[string]string {
@@ -154,9 +147,7 @@ func TestUntgz(t *testing.T) {
 			names[relativePath] = link
 			return nil
 		})
-		if err != nil {
-			t.Fatalf("error reading files: %s", err)
-		}
+		require.NoErrorf(t, err, "error reading files: %s", err)
 		return names
 	}
 	t.Run("will untgz successfully", func(t *testing.T) {

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -251,9 +251,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/text")
 			_, err := w.Write([]byte("Ok"))
-			if err != nil {
-				t.Fatalf("error writing response: %s", err)
-			}
+			require.NoError(t, err, "error writing response: %s", err)
 		}
 	}
 	type testCase struct {
@@ -326,9 +324,7 @@ func TestSessionManager_WithAuthMiddleware(t *testing.T) {
 			ts := httptest.NewServer(WithAuthMiddleware(tc.authDisabled, tm, mux))
 			defer ts.Close()
 			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-			if err != nil {
-				t.Fatalf("error creating request: %s", err)
-			}
+			require.NoErrorf(t, err, "error creating request: %s", err)
 			if tc.cookieHeader {
 				req.Header.Add("Cookie", "argocd.token=123456")
 			}

--- a/util/swagger/swagger_test.go
+++ b/util/swagger/swagger_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/loads"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-cd/v2/util/assets"
 )
@@ -38,21 +39,12 @@ func TestSwaggerUI(t *testing.T) {
 	server := "http://" + address
 
 	specDoc, err := loads.Spec(server + "/swagger.json")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = json.MarshalIndent(specDoc.Spec(), "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	resp, err := http.Get(server + "/swagger-ui")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Was expecting status code 200 from swagger-ui, but got %d instead", resp.StatusCode)
-	}
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "Was expecting status code 200 from swagger-ui, but got %d instead", resp.StatusCode)
 }


### PR DESCRIPTION
### Description

* uses testify instead of testing.Fatal or testing.Error in util