### PR TITLE
chore: use testify instead of testing.Fatal or testing.Error in test

### DIFF
--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -2300,9 +2300,7 @@ func testServerWithPort(t *testing.T, port int, handler http.Handler) *httptest.
 	t.Helper()
 	// Use mocked API response to avoid rate-limiting.
 	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	if err != nil {
-		t.Error(fmt.Errorf("Unable to start server %w", err))
-	}
+	require.NoError(t, err, "Unable to start server")
 
 	ts := httptest.NewUnstartedServer(handler)
 

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -308,19 +308,13 @@ func TestClusterDelete(t *testing.T) {
 
 	// Check that RBAC is created
 	_, err := fixture.Run("", "kubectl", "get", "serviceaccount", "argocd-manager", "-n", "kube-system")
-	if err != nil {
-		t.Errorf("Expected no error from not finding serviceaccount argocd-manager but got:\n%s", err.Error())
-	}
+	require.NoError(t, err, "Expected no error from not finding serviceaccount argocd-manager")
 
 	_, err = fixture.Run("", "kubectl", "get", "clusterrole", "argocd-manager-role")
-	if err != nil {
-		t.Errorf("Expected no error from not finding clusterrole argocd-manager-role but got:\n%s", err.Error())
-	}
+	require.NoError(t, err, "Expected no error from not finding clusterrole argocd-manager-role")
 
 	_, err = fixture.Run("", "kubectl", "get", "clusterrolebinding", "argocd-manager-role-binding")
-	if err != nil {
-		t.Errorf("Expected no error from not finding clusterrolebinding argocd-manager-role-binding but got:\n%s", err.Error())
-	}
+	require.NoError(t, err, "Expected no error from not finding clusterrolebinding argocd-manager-role-binding")
 
 	clstAction.DeleteByName().
 		Then().
@@ -330,17 +324,11 @@ func TestClusterDelete(t *testing.T) {
 
 	// Check that RBAC is removed after delete
 	output, err := fixture.Run("", "kubectl", "get", "serviceaccount", "argocd-manager", "-n", "kube-system")
-	if err == nil {
-		t.Errorf("Expected error from not finding serviceaccount argocd-manager but got:\n%s", output)
-	}
+	require.Error(t, err, "Expected error from not finding serviceaccount argocd-manager but got:\n%s", output)
 
 	output, err = fixture.Run("", "kubectl", "get", "clusterrole", "argocd-manager-role")
-	if err == nil {
-		t.Errorf("Expected error from not finding clusterrole argocd-manager-role but got:\n%s", output)
-	}
+	require.Error(t, err, "Expected error from not finding clusterrole argocd-manager-role but got:\n%s", output)
 
 	output, err = fixture.Run("", "kubectl", "get", "clusterrolebinding", "argocd-manager-role-binding")
-	if err == nil {
-		t.Errorf("Expected error from not finding clusterrolebinding argocd-manager-role-binding but got:\n%s", output)
-	}
+	assert.Error(t, err, "Expected error from not finding clusterrolebinding argocd-manager-role-binding but got:\n%s", output)
 }

--- a/test/e2e/project_management_test.go
+++ b/test/e2e/project_management_test.go
@@ -148,17 +148,13 @@ func TestAddProjectDestination(t *testing.T) {
 	projectName := "proj-" + strconv.FormatInt(time.Now().Unix(), 10)
 	_, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Create(
 		context.Background(), &v1alpha1.AppProject{ObjectMeta: metav1.ObjectMeta{Name: projectName}}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unable to create project %v", err)
-	}
+	require.NoError(t, err, "Unable to create project")
 
 	_, err = fixture.RunCli("proj", "add-destination", projectName,
 		"https://192.168.99.100:8443",
 		"test1",
 	)
-	if err != nil {
-		t.Fatalf("Unable to add project destination %v", err)
-	}
+	require.NoError(t, err, "Unable to add project destination")
 
 	_, err = fixture.RunCli("proj", "add-destination", projectName,
 		"https://192.168.99.100:8443",
@@ -194,18 +190,14 @@ func TestAddProjectDestinationWithName(t *testing.T) {
 	projectName := "proj-" + strconv.FormatInt(time.Now().Unix(), 10)
 	_, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Create(
 		context.Background(), &v1alpha1.AppProject{ObjectMeta: metav1.ObjectMeta{Name: projectName}}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unable to create project %v", err)
-	}
+	require.NoError(t, err, "Unable to create project")
 
 	_, err = fixture.RunCli("proj", "add-destination", projectName,
 		"in-cluster",
 		"test1",
 		"--name",
 	)
-	if err != nil {
-		t.Fatalf("Unable to add project destination %v", err)
-	}
+	require.NoError(t, err, "Unable to add project destination")
 
 	proj, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Get(context.Background(), projectName, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -231,17 +223,13 @@ func TestRemoveProjectDestination(t *testing.T) {
 			}},
 		},
 	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unable to create project %v", err)
-	}
+	require.NoError(t, err, "Unable to create project")
 
 	_, err = fixture.RunCli("proj", "remove-destination", projectName,
 		"https://192.168.99.100:8443",
 		"test",
 	)
-	if err != nil {
-		t.Fatalf("Unable to remove project destination %v", err)
-	}
+	require.NoError(t, err, "Unable to remove project destination")
 
 	_, err = fixture.RunCli("proj", "remove-destination", projectName,
 		"https://192.168.99.100:8443",
@@ -250,9 +238,7 @@ func TestRemoveProjectDestination(t *testing.T) {
 	require.ErrorContains(t, err, "does not exist")
 
 	proj, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Get(context.Background(), projectName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Unable to get project %v", err)
-	}
+	require.NoError(t, err, "Unable to get project")
 	assert.Equal(t, projectName, proj.Name)
 	assert.Empty(t, proj.Spec.Destinations)
 	assertProjHasEvent(t, proj, "update", argo.EventReasonResourceUpdated)
@@ -264,14 +250,10 @@ func TestAddProjectSource(t *testing.T) {
 	projectName := "proj-" + strconv.FormatInt(time.Now().Unix(), 10)
 	_, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Create(
 		context.Background(), &v1alpha1.AppProject{ObjectMeta: metav1.ObjectMeta{Name: projectName}}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unable to create project %v", err)
-	}
+	require.NoError(t, err, "Unable to create project")
 
 	_, err = fixture.RunCli("proj", "add-source", projectName, "https://github.com/argoproj/argo-cd.git")
-	if err != nil {
-		t.Fatalf("Unable to add project source %v", err)
-	}
+	require.NoError(t, err, "Unable to add project source")
 
 	_, err = fixture.RunCli("proj", "add-source", projectName, "https://github.com/argoproj/argo-cd.git")
 	require.NoError(t, err)
@@ -396,9 +378,7 @@ func TestAddOrphanedIgnore(t *testing.T) {
 	projectName := "proj-" + strconv.FormatInt(time.Now().Unix(), 10)
 	_, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Create(
 		context.Background(), &v1alpha1.AppProject{ObjectMeta: metav1.ObjectMeta{Name: projectName}}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unable to create project %v", err)
-	}
+	require.NoError(t, err, "Unable to create project")
 
 	_, err = fixture.RunCli("proj", "add-orphaned-ignore", projectName,
 		"group",
@@ -406,9 +386,7 @@ func TestAddOrphanedIgnore(t *testing.T) {
 		"--name",
 		"name",
 	)
-	if err != nil {
-		t.Fatalf("Unable to add resource to orphaned ignore %v", err)
-	}
+	require.NoError(t, err, "Unable to add resource to orphaned ignore")
 
 	_, err = fixture.RunCli("proj", "add-orphaned-ignore", projectName,
 		"group",
@@ -442,9 +420,7 @@ func TestRemoveOrphanedIgnore(t *testing.T) {
 			},
 		},
 	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unable to create project %v", err)
-	}
+	require.NoError(t, err, "Unable to create project")
 
 	_, err = fixture.RunCli("proj", "remove-orphaned-ignore", projectName,
 		"group",
@@ -452,9 +428,7 @@ func TestRemoveOrphanedIgnore(t *testing.T) {
 		"--name",
 		"name",
 	)
-	if err != nil {
-		t.Fatalf("Unable to remove resource from orphaned ignore list %v", err)
-	}
+	require.NoError(t, err, "Unable to remove resource from orphaned ignore list")
 
 	_, err = fixture.RunCli("proj", "remove-orphaned-ignore", projectName,
 		"group",
@@ -465,9 +439,7 @@ func TestRemoveOrphanedIgnore(t *testing.T) {
 	require.ErrorContains(t, err, "does not exist")
 
 	proj, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Get(context.Background(), projectName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Unable to get project %v", err)
-	}
+	require.NoError(t, err, "Unable to get project")
 	assert.Equal(t, projectName, proj.Name)
 	assert.Empty(t, proj.Spec.OrphanedResources.Ignore)
 	assertProjHasEvent(t, proj, "update", argo.EventReasonResourceUpdated)
@@ -620,9 +592,7 @@ func TestAddProjectDestinationServiceAccount(t *testing.T) {
 	projectName := "proj-" + strconv.FormatInt(time.Now().Unix(), 10)
 	_, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Create(
 		context.Background(), &v1alpha1.AppProject{ObjectMeta: metav1.ObjectMeta{Name: projectName}}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unable to create project %v", err)
-	}
+	require.NoError(t, err, "Unable to create project")
 
 	// Given, an existing project
 	// When, a default destination service account with all valid fields is added to it,
@@ -632,9 +602,7 @@ func TestAddProjectDestinationServiceAccount(t *testing.T) {
 		"test-ns",
 		"test-sa",
 	)
-	if err != nil {
-		t.Fatalf("Unable to add project destination service account %v", err)
-	}
+	require.NoError(t, err, "Unable to add project destination service account")
 
 	// Given, an existing project
 	// When, a default destination service account with empty namespace is added to it,
@@ -644,9 +612,7 @@ func TestAddProjectDestinationServiceAccount(t *testing.T) {
 		"",
 		"test-sa",
 	)
-	if err != nil {
-		t.Fatalf("Unable to add project destination service account %v", err)
-	}
+	require.NoError(t, err, "Unable to add project destination service account")
 
 	// Given, an existing project,
 	// When, a default destination service account is added with a custom service account namespace,
@@ -658,9 +624,7 @@ func TestAddProjectDestinationServiceAccount(t *testing.T) {
 		"--service-account-namespace",
 		"default",
 	)
-	if err != nil {
-		t.Fatalf("Unable to add project destination service account %v", err)
-	}
+	require.NoError(t, err, "Unable to add project destination service account")
 
 	// Given, an existing project,
 	// When, a duplicate default destination service account is added,


### PR DESCRIPTION
### Description

* uses testify instead of testing.Fatal or testing.Error in test