### PR TITLE
fix: order conditions summary

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1738,6 +1739,7 @@ func formatConditionsSummary(app argoappv1.Application) string {
 	}
 	summary := "<none>"
 	if len(items) > 0 {
+		slices.Sort(items)
 		summary = strings.Join(items, ",")
 	}
 	return summary

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -493,6 +493,27 @@ func TestFormatConditionSummary(t *testing.T) {
 		summary := formatConditionsSummary(app)
 		require.Equalf(t, "type1(2),type2", summary, "Incorrect summary %q, should be type1(2),type2", summary)
 	})
+
+	t.Run("Conditions are sorted for idempotent summary", func(t *testing.T) {
+		app := v1alpha1.Application{
+			Status: v1alpha1.ApplicationStatus{
+				Conditions: []v1alpha1.ApplicationCondition{
+					{
+						Type: "type2",
+					},
+					{
+						Type: "type1",
+					},
+					{
+						Type: "type1",
+					},
+				},
+			},
+		}
+
+		summary := formatConditionsSummary(app)
+		require.Equalf(t, "type1(2),type2", summary, "Incorrect summary %q, should be type1(2),type2", summary)
+	})
 }
 
 func TestPrintOperationResult(t *testing.T) {


### PR DESCRIPTION
The formatConditionsSummary doesn't have a predictable outcome.
This fixes this situation caused by https://github.com/argoproj/argo-cd/pull/20750/files#diff-09dc2060ef1815120b6ffc55153594e558691f94bd2fcd47e0e0acb8ba68066aL536-R494