### PR TITLE
chore: use testify instead of testing.Fatal or testing.Error in pkg

### DIFF
--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"reflect"
 	"testing"
 	"time"
 
@@ -1130,9 +1129,7 @@ func TestAppProjectSpec_DestinationClusters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := AppProjectSpec{Destinations: tt.destinations}
-			if got := d.DestinationClusters(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("AppProjectSpec.DestinationClusters() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, d.DestinationClusters(), "AppProjectSpec.DestinationClusters()")
 		})
 	}
 }
@@ -1176,9 +1173,7 @@ func TestRepository_HasCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.repo.HasCredentials(); got != tt.want {
-				t.Errorf("Repository.HasCredentials() = %v, want %v", got, tt.want)
-			}
+			assert.Equalf(t, tt.want, tt.repo.HasCredentials(), "Repository.HasCredentials()")
 		})
 	}
 }
@@ -1217,9 +1212,7 @@ func TestRepository_IsInsecure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.repo.IsInsecure(); got != tt.want {
-				t.Errorf("Repository.IsInsecure() = %v, want %v", got, tt.want)
-			}
+			assert.Equalf(t, tt.want, tt.repo.IsInsecure(), "Repository.IsInsecure()")
 		})
 	}
 }
@@ -1258,9 +1251,7 @@ func TestRepository_IsLFSEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.repo.IsLFSEnabled(); got != tt.want {
-				t.Errorf("Repository.IsLFSEnabled() = %v, want %v", got, tt.want)
-			}
+			assert.Equalf(t, tt.want, tt.repo.IsLFSEnabled(), "Repository.IsLFSEnabled()")
 		})
 	}
 }
@@ -1376,9 +1367,7 @@ func TestSyncStrategy_Force(t *testing.T) {
 				Apply: tt.fields.Apply,
 				Hook:  tt.fields.Hook,
 			}
-			if got := m.Force(); got != tt.want {
-				t.Errorf("SyncStrategy.Force() = %v, want %v", got, tt.want)
-			}
+			assert.Equalf(t, tt.want, m.Force(), "SyncStrategy.Force()")
 		})
 	}
 }
@@ -1401,9 +1390,7 @@ func TestSyncOperation_IsApplyStrategy(t *testing.T) {
 			o := &SyncOperation{
 				SyncStrategy: tt.fields.SyncStrategy,
 			}
-			if got := o.IsApplyStrategy(); got != tt.want {
-				t.Errorf("SyncOperation.IsApplyStrategy() = %v, want %v", got, tt.want)
-			}
+			assert.Equalf(t, tt.want, o.IsApplyStrategy(), "SyncOperation.IsApplyStrategy()")
 		})
 	}
 }
@@ -1435,12 +1422,8 @@ func TestResourceResults_Find(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := tt.r.Find(tt.args.group, tt.args.kind, tt.args.namespace, tt.args.name, tt.args.phase)
-			if got != tt.want {
-				t.Errorf("ResourceResults.Find() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("ResourceResults.Find() got1 = %v, want %v", got1, tt.want1)
-			}
+			assert.Equal(t, tt.want, got, "ResourceResults.Find()")
+			assert.Equal(t, tt.want1, got1, "ResourceResults.Find()")
 		})
 	}
 }
@@ -1458,9 +1441,7 @@ func TestResourceResults_PruningRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotNum := tt.r.PruningRequired(); gotNum != tt.wantNum {
-				t.Errorf("ResourceResults.PruningRequired() = %v, want %v", gotNum, tt.wantNum)
-			}
+			assert.Equalf(t, tt.wantNum, tt.r.PruningRequired(), "ResourceResults.PruningRequired()")
 		})
 	}
 }


### PR DESCRIPTION
### Description

* uses testify instead of testing.Fatal or testing.Error in pkg