### PR TITLE
fix(app): Do not allow Argo-CD namespace access by default when app in any namespace restrictions exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,8 +484,8 @@ start-e2e-local: mod-vendor-local dep-ui-local cli-local
 	ARGOCD_ZJWT_FEATURE_FLAG=always \
 	ARGOCD_IN_CI=$(ARGOCD_IN_CI) \
 	BIN_MODE=$(ARGOCD_BIN_MODE) \
-	ARGOCD_APPLICATION_NAMESPACES=argocd-e2e-external,argocd-e2e-external-2 \
-	ARGOCD_APPLICATIONSET_CONTROLLER_NAMESPACES=argocd-e2e-external,argocd-e2e-external-2 \
+	ARGOCD_APPLICATION_NAMESPACES=argocd-e2e,argocd-e2e-external,argocd-e2e-external-2 \
+	ARGOCD_APPLICATIONSET_CONTROLLER_NAMESPACES=argocd-e2e,argocd-e2e-external,argocd-e2e-external-2 \
 	ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE=true \
 	ARGOCD_APPLICATIONSET_CONTROLLER_ALLOWED_SCM_PROVIDERS=http://127.0.0.1:8341,http://127.0.0.1:8342,http://127.0.0.1:8343,http://127.0.0.1:8344 \
 	ARGOCD_E2E_TEST=true \

--- a/docs/operator-manual/app-any-namespace.md
+++ b/docs/operator-manual/app-any-namespace.md
@@ -61,6 +61,8 @@ kubectl rollout restart -n argocd deployment argocd-server
 kubectl rollout restart -n argocd statefulset argocd-application-controller
 ```
 
+Please note that if you want to deploy `Applications` in the Argo CD namespace, you have to list this namespace in this list.
+
 #### Adapt Kubernetes RBAC
 
 We decided to not extend the Kubernetes RBAC for the `argocd-server` workload by default for the time being. If you want `Applications` in other namespaces to be managed by the Argo CD API (i.e. the CLI and UI), you need to extend the Kubernetes permissions for the `argocd-server` ServiceAccount.
@@ -110,7 +112,7 @@ spec:
   - namespace-two
 ```
 
-In order for an Application to set `.spec.project` to `project-one`, it would have to be created in either namespace `namespace-one` or `argocd`. Likewise, in order for an Application to set `.spec.project` to `project-two`, it would have to be created in either namespace `namespace-two` or `argocd`.
+In order for an Application to set `.spec.project` to `project-one`, it would have to be created in either namespace `namespace-one`. Likewise, in order for an Application to set `.spec.project` to `project-two`, it would have to be created in either namespace `namespace-two`.
 
 If an Application in `namespace-two` would set their `.spec.project` to `project-one` or an Application in `namespace-one` would set their `.spec.project` to `project-two`, Argo CD would consider this as a permission violation and refuse to reconcile the Application.
 
@@ -122,7 +124,7 @@ The `.spec.sourceNamespaces` field of the `AppProject` is a list that can contai
     Do not add user controlled namespaces in the `.spec.sourceNamespaces` field of any privileged AppProject like the `default` project. Always make sure that the AppProject follows the principle of granting least required privileges. Never grant access to the `argocd` namespace within the AppProject.
 
 !!! note
-    For backwards compatibility, Applications in the Argo CD control plane's namespace (`argocd`) are allowed to set their `.spec.project` field to reference any AppProject, regardless of the restrictions placed by the AppProject's `.spec.sourceNamespaces` field.
+    When starting to setup restrictions inside the AppProject's `.spec.sourceNamespaces` field, the `argocd` namespace is no longer allowed by default. To grant access to this namespace, you shoud add it in the list as well.
   
 ### Application names
 

--- a/pkg/apis/application/v1alpha1/app_project_types.go
+++ b/pkg/apis/application/v1alpha1/app_project_types.go
@@ -594,11 +594,10 @@ func jwtTokensCombine(tokens1 []JWTToken, tokens2 []JWTToken) []JWTToken {
 // this AppProject is allowed by comparing the Application's namespace with
 // the list of allowed namespaces in the AppProject.
 //
-// Applications in the installation namespace are always permitted. Also, at
-// application creation time, its namespace may yet be empty to indicate that
+// At application creation time, its namespace may yet be empty to indicate that
 // the application will be created in the controller's namespace.
 func (p AppProject) IsAppNamespacePermitted(app *Application, controllerNs string) bool {
-	if app.Namespace == "" || app.Namespace == controllerNs {
+	if app.Namespace == "" || (app.Namespace == controllerNs && len(p.Spec.SourceNamespaces) == 0) {
 		return true
 	}
 

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3673,7 +3673,7 @@ func TestAppProjectIsSourceNamespacePermitted(t *testing.T) {
 				Namespace: "argocd",
 			},
 			Spec: AppProjectSpec{
-				SourceNamespaces: []string{"other-ns"},
+				SourceNamespaces: []string{"argocd", "some-ns"},
 			},
 		}
 		// app1 is installed to argocd namespace, controller as well

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -641,7 +641,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 		SourceRepos:              []string{"*"},
 		Destinations:             []v1alpha1.ApplicationDestination{{Namespace: "*", Server: "*"}},
 		ClusterResourceWhitelist: []v1.GroupKind{{Group: "*", Kind: "*"}},
-		SourceNamespaces:         []string{AppNamespace()},
+		SourceNamespaces:         []string{"*"},
 	})
 
 	// Create separate project for testing gpg signature verification
@@ -652,7 +652,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 		Destinations:             []v1alpha1.ApplicationDestination{{Namespace: "*", Server: "*"}},
 		ClusterResourceWhitelist: []v1.GroupKind{{Group: "*", Kind: "*"}},
 		SignatureKeys:            []v1alpha1.SignatureKey{{KeyID: GpgGoodKeyID}},
-		SourceNamespaces:         []string{AppNamespace()},
+		SourceNamespaces:         []string{"*"},
 	})
 
 	// Recreate temp dir

--- a/util/security/application_namespaces.go
+++ b/util/security/application_namespaces.go
@@ -7,7 +7,7 @@ import (
 )
 
 func IsNamespaceEnabled(namespace string, serverNamespace string, enabledNamespaces []string) bool {
-	return namespace == serverNamespace || glob.MatchStringInList(enabledNamespaces, namespace, glob.REGEXP)
+	return (namespace == serverNamespace && len(enabledNamespaces) == 0) || glob.MatchStringInList(enabledNamespaces, namespace, glob.REGEXP)
 }
 
 func NamespaceNotPermittedError(namespace string) error {

--- a/util/security/application_namespaces_test.go
+++ b/util/security/application_namespaces_test.go
@@ -63,6 +63,13 @@ func Test_IsNamespaceEnabled(t *testing.T) {
 			[]string{"/^((?!disallowed).)*$/"},
 			true,
 		},
+		{
+			"argocd namespace is not in the enabled list",
+			"argocd",
+			"argocd",
+			[]string{"my-namespace"},
+			false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fix part of #20820.

With the current behavior it is not possible to restrict the usage of the Argo CD namespace when using the App in any namespace feature.
This PR contains changes that should allow the current behavior when no restrictions are in place, and allow to blacklist the controller namespace if desired. 

The new behavior should be quite sound but I can wrap it with a feature-flag if required.

I'd like this to be cherry-picked to 2.13 as well.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
