### PR TITLE
chore: rename Rollout 'Restart' action to 'Restart Pods'

### DIFF
--- a/resource_customizations/argoproj.io/Rollout/actions/action_test.yaml
+++ b/resource_customizations/argoproj.io/Rollout/actions/action_test.yaml
@@ -5,6 +5,7 @@ discoveryTests:
       disabled: false
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: abort
       disabled: false
     - name: retry
@@ -15,6 +16,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: true
     - name: abort
@@ -27,6 +29,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: true
     - name: abort
@@ -39,6 +42,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: false
     - name: abort
@@ -51,6 +55,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: true
     - name: abort
@@ -63,6 +68,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: true
     - name: abort
@@ -75,6 +81,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: true
     - name: abort
@@ -87,6 +94,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: true
     - name: abort
@@ -99,6 +107,7 @@ discoveryTests:
   result:
     - name: restart
       disabled: false
+      displayName: Restart Pods
     - name: resume
       disabled: true
     - name: abort

--- a/resource_customizations/argoproj.io/Rollout/actions/discovery.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/discovery.lua
@@ -1,5 +1,8 @@
 local actions = {}
-actions["restart"] = {["disabled"] = false}
+actions["restart"] = {
+    ["disabled"] = false,
+    ["displayName"] = "Restart Pods"
+}
 
 local paused = false
 if obj.status ~= nil and obj.status.pauseConditions ~= nil then

--- a/util/lua/custom_actions_test.go
+++ b/util/lua/custom_actions_test.go
@@ -110,8 +110,7 @@ func TestLuaResourceActionsScript(t *testing.T) {
 		}
 		require.NoError(t, err)
 		dir := filepath.Dir(path)
-		// TODO: Change to path
-		yamlBytes, err := os.ReadFile(dir + "/action_test.yaml")
+		yamlBytes, err := os.ReadFile(filepath.Join(dir, "action_test.yaml"))
 		require.NoError(t, err)
 		var resourceTest ActionTestStructure
 		err = yaml.Unmarshal(yamlBytes, &resourceTest)


### PR DESCRIPTION
Users have been confused about the difference between "retry" and "restart." This attempts to clarify a bit.

It's not a breaking API change. The action name is still "restart," but the display name is "restart pods."

![image](https://github.com/user-attachments/assets/c43d670b-1921-449e-b970-e88e1b43d6ce)