### PR TITLE
feat(ui): Support filter for `configured` and `unchanged` on SYNC STATUS view

### DIFF
--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
@@ -182,8 +182,8 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
                 pass = false;
             }
 
-            if (pass && messageFilters.length !== 0 && !messageFilters.includes(r.message)) {
-                pass = false;
+            if (pass && messageFilters.length !== 0) {
+                pass = messageFilters.some(filter => r.message?.toLowerCase().includes(filter.toLowerCase()));
             }
 
             return pass;
@@ -211,7 +211,6 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
                             <Filter options={Statuses} filters={filters} setFilters={setFilters} title='STATUS' style={{marginRight: '5px'}} />
                             <Filter options={OperationPhases} filters={filters} setFilters={setFilters} title='HOOK' />
                             <Filter options={MessageStatuses} filters={messageFilters} setFilters={setMessageFilters} title='MESSAGE' />
-
                         </div>
                     </div>
                     <div className='argo-table-list'>

--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
@@ -16,6 +16,7 @@ interface Props {
     operationState: models.OperationState;
 }
 const buildResourceUniqueId = (res: Omit<models.ResourceRef, 'uid'>) => `${res.group}-${res.kind}-${res.version}-${res.namespace}-${res.name}`;
+const MessageStatuses = ['configured', 'unchanged'];
 
 const Filter = (props: {filters: string[]; setFilters: (f: string[]) => void; options: string[]; title: string; style?: React.CSSProperties}) => {
     const {filters, setFilters, options, title, style} = props;
@@ -52,6 +53,8 @@ const Filter = (props: {filters: string[]; setFilters: (f: string[]) => void; op
 };
 
 export const ApplicationOperationState: React.StatelessComponent<Props> = ({application, operationState}, ctx: AppContext) => {
+    const [messageFilters, setMessageFilters] = React.useState([]);
+
     const operationAttributes = [
         {title: 'OPERATION', value: utils.getOperationType(application)},
         {title: 'PHASE', value: operationState.phase},
@@ -166,7 +169,7 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
 
     if (combinedHealthSyncResult && combinedHealthSyncResult.length > 0) {
         filtered = combinedHealthSyncResult.filter(r => {
-            if (filters.length === 0 && healthFilters.length === 0) {
+            if (filters.length === 0 && healthFilters.length === 0 && messageFilters.length === 0) {
                 return true;
             }
 
@@ -176,6 +179,10 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
             }
 
             if (pass && healthFilters.length !== 0 && !healthFilters.includes(r.health?.status)) {
+                pass = false;
+            }
+
+            if (pass && messageFilters.length !== 0 && !messageFilters.includes(r.message)) {
                 pass = false;
             }
 
@@ -203,6 +210,8 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
                             <Filter options={Healths} filters={healthFilters} setFilters={setHealthFilters} title='HEALTH' style={{marginRight: '5px'}} />
                             <Filter options={Statuses} filters={filters} setFilters={setFilters} title='STATUS' style={{marginRight: '5px'}} />
                             <Filter options={OperationPhases} filters={filters} setFilters={setFilters} title='HOOK' />
+                            <Filter options={MessageStatuses} filters={messageFilters} setFilters={setMessageFilters} title='MESSAGE' />
+
                         </div>
                     </div>
                     <div className='argo-table-list'>

--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
@@ -16,7 +16,7 @@ interface Props {
     operationState: models.OperationState;
 }
 const buildResourceUniqueId = (res: Omit<models.ResourceRef, 'uid'>) => `${res.group}-${res.kind}-${res.version}-${res.namespace}-${res.name}`;
-const MessageStatuses = ['configured', 'unchanged'];
+const FilterableMessageStatuses = ['configured', 'unchanged'];
 
 const Filter = (props: {filters: string[]; setFilters: (f: string[]) => void; options: string[]; title: string; style?: React.CSSProperties}) => {
     const {filters, setFilters, options, title, style} = props;
@@ -210,7 +210,7 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
                             <Filter options={Healths} filters={healthFilters} setFilters={setHealthFilters} title='HEALTH' style={{marginRight: '5px'}} />
                             <Filter options={Statuses} filters={filters} setFilters={setFilters} title='STATUS' style={{marginRight: '5px'}} />
                             <Filter options={OperationPhases} filters={filters} setFilters={setFilters} title='HOOK' />
-                            <Filter options={MessageStatuses} filters={messageFilters} setFilters={setMessageFilters} title='MESSAGE' />
+                            <Filter options={FilterableMessageStatuses} filters={messageFilters} setFilters={setMessageFilters} title='MESSAGE' />
                         </div>
                     </div>
                     <div className='argo-table-list'>


### PR DESCRIPTION
Fixes: #13457 

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

No filter:

<img width="1502" alt="Screenshot 2024-11-19 at 6 07 10 PM" src="https://github.com/user-attachments/assets/ab284224-1e7b-43c6-9f4a-ed6deac0a244">

Filter configured

<img width="1217" alt="Screenshot 2024-11-19 at 6 07 33 PM" src="https://github.com/user-attachments/assets/bbf7a877-9851-44e6-b624-2881e863d6a9">


Filter unchanged
<img width="1268" alt="Screenshot 2024-11-20 at 11 47 34 AM" src="https://github.com/user-attachments/assets/8a4e1251-009f-406a-8888-e8f010b44467">


