### PR TITLE
feat: allow for specifying pre-release in regex

### DIFF
--- a/util/git/git_test.go
+++ b/util/git/git_test.go
@@ -253,6 +253,11 @@ func TestLsRemote(t *testing.T) {
 			expectedCommit: "0fd6344537eb948cff602824a1d060421ceff40e",
 		},
 		{
+			name:           "should resolve to a pre-release tag with semantic versioning",
+			revision:       "v2.13.*-rc3", // it should resolve to v2.13.0-rc3
+			expectedCommit: "ec60abd4d810a2070930be09a4754ca73dd8be18",
+		},
+		{
 			name:     "should resolve a star range tag with semantic versioning",
 			revision: "*",
 		},


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This PR allows for checking for pre-release specific tags

previously in the case of having a pre-release (i.e `v1.0.*-rc`) the git check would ignore the pre-release versions and just do the latest tag (i.e v1.0.1) which could be a different release entirely.

**NOTE:** My assumption is that this is only valid with wildcards as I dont think something like `< v1.2.*-rc` would be a valid constraint, but if this is incorrect please let me know

I am not entirely sure if this is considered a bug fix or a feature

Related Issue: https://github.com/argoproj/argo-cd/issues/18899

Related Discussion: https://github.com/argoproj/argo-cd/discussions/20595


would be great to have this patched in `v2.12`

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
