### PR TITLE
test: fix flaky test (#20847)

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1738,6 +1738,9 @@ func formatConditionsSummary(app argoappv1.Application) string {
 	}
 	summary := "<none>"
 	if len(items) > 0 {
+		sort.Slice(items, func(i, j int) bool {
+			return items[i] < items[j]
+		})
 		summary = strings.Join(items, ",")
 	}
 	return summary


### PR DESCRIPTION
Fixes TestFormatConditionSummary, which assumed a particular output order.

Performance shouldn't be an issue. The only consumer of this function is a user-invoked CLI command. 

Fixes #20847