### PR TITLE
fix: Memory leak in repo-server

### DIFF
--- a/util/app/discovery/discovery.go
+++ b/util/app/discovery/discovery.go
@@ -170,6 +170,7 @@ func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fil
 	cfg, err := cmpClient.CheckPluginConfiguration(ctx, &empty.Empty{})
 	if err != nil {
 		log.Errorf("error checking plugin configuration %s, %v", fileName, err)
+		io.Close(conn)
 		return nil, nil, false
 	}
 
@@ -178,6 +179,7 @@ func cmpSupports(ctx context.Context, pluginSockFilePath, appPath, repoPath, fil
 		if namedPlugin {
 			return conn, cmpClient, true
 		}
+		io.Close(conn)
 		return nil, nil, false
 	}
 


### PR DESCRIPTION
This resolves a memory leak in the repo-server during plugin discovery caused by the connection not being closed.

Repo-Server Goroutines Leak
![Screenshot 2024-11-20 at 3 21 32 PM](https://github.com/user-attachments/assets/11a1682c-9ab9-47e4-aaec-18acd0375014)

```
goroutine profile: total 1500
1458 @ 0x474eae 0x450a25 0x23d30ec 0x47d741
#	0x23d30eb	google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run+0x10b	/go/pkg/mod/google.golang.org/grpc@v1.66.2/internal/grpcsync/callback_serializer.go:88
```

Repo-Server Goroutines Leak - Hard Refresh Applications x2
![Screenshot 2024-11-20 at 3 28 43 PM](https://github.com/user-attachments/assets/35b38de8-f087-4633-a602-285123319fe2)
```
goroutine profile: total 4842
3138 @ 0x474eae 0x450a25 0x23d30ec 0x47d741
#	0x23d30eb	google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run+0x10b	/go/pkg/mod/google.golang.org/grpc@v1.66.2/internal/grpcsync/callback_serializer.go:88
```

Fix Applied - Repo-Server Goroutines Leak - Hard Refresh Applications x2
![Screenshot 2024-11-20 at 4 02 11 PM](https://github.com/user-attachments/assets/93575053-3240-4ab7-88aa-c6c7a3d36771)


Introduced by: #20196 

Related improvement that would make this class of error harder to occur: #20217

This should be cherry-picked into the v2.13 release.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
