### PR TITLE
fix: show multisource details for an appset when using `argocd appset get` command

### DIFF
--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -443,9 +443,45 @@ func printAppSetSummaryTable(appSet *arogappsetv1.ApplicationSet) {
 	} else {
 		fmt.Println("Sources:")
 	}
-	for _, source := range appSet.Spec.Template.Spec.GetSources() {
-		printAppSourceDetails(&source)
+
+	// if no source has been defined, print the default value for a source
+	if len(appSet.Spec.Template.Spec.GetSources()) == 0 {
+		src := appSet.Spec.Template.Spec.GetSource()
+		printAppSourceDetails(&src)
+	} else {
+		// otherwise range over the sources and print each source details
+		for _, source := range appSet.Spec.Template.Spec.GetSources() {
+			printAppSourceDetails(&source)
+		}
 	}
+
+	var (
+		syncPolicyStr string
+		syncPolicy    = appSet.Spec.Template.Spec.SyncPolicy
+	)
+	if syncPolicy != nil && syncPolicy.Automated != nil {
+		syncPolicyStr = "Automated"
+		if syncPolicy.Automated.Prune {
+			syncPolicyStr += " (Prune)"
+		}
+	} else {
+		syncPolicyStr = "<none>"
+	}
+	fmt.Printf(printOpFmtStr, "SyncPolicy:", syncPolicyStr)
+}
+
+func printAppSetSummaryTables(appSet *arogappsetv1.ApplicationSet) {
+	source := appSet.Spec.Template.Spec.GetSource()
+	fmt.Printf(printOpFmtStr, "Name:", appSet.QualifiedName())
+	fmt.Printf(printOpFmtStr, "Project:", appSet.Spec.Template.Spec.GetProject())
+	fmt.Printf(printOpFmtStr, "Server:", getServerForAppSet(appSet))
+	fmt.Printf(printOpFmtStr, "Namespace:", appSet.Spec.Template.Spec.Destination.Namespace)
+	if !appSet.Spec.Template.Spec.HasMultipleSources() {
+		fmt.Println("Source:")
+	} else {
+		fmt.Println("Sources:")
+	}
+	printAppSourceDetails(&source)
 
 	var (
 		syncPolicyStr string

--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -324,24 +324,6 @@ func NewApplicationSetListCommand(clientOpts *argocdclient.ClientOptions) *cobra
 	return command
 }
 
-// NewApplicationSetSetCommand returns a new instance of an `argocd appset set` command
-//func NewApplicationSetSetCommand(clientOpts *argocdclient.Client) *cobra.Command {
-//	command := &cobra.Command{
-//		Use:     "set",
-//		Short:   "Set ApplicationSets Parameters",
-//		Example: templates.Examples(""),
-//		Run: func(c *cobra.Command, args []string) {
-//			ctx := c.Context()
-//
-//			if len(args) != 1 {
-//				c.HelpFunc()(c, args)
-//				os.Exit(1)
-//			}
-//
-//		},
-//	}
-//}
-
 // NewApplicationSetDeleteCommand returns a new instance of an `argocd appset delete` command
 func NewApplicationSetDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var noPrompt bool

--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -93,7 +93,6 @@ func NewApplicationSetGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 				errors.CheckError(err)
 			case "wide", "":
 				printAppSetSummaryTable(appSet)
-
 				if len(appSet.Status.Conditions) > 0 {
 					fmt.Println()
 					w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -325,6 +324,24 @@ func NewApplicationSetListCommand(clientOpts *argocdclient.ClientOptions) *cobra
 	return command
 }
 
+// NewApplicationSetSetCommand returns a new instance of an `argocd appset set` command
+//func NewApplicationSetSetCommand(clientOpts *argocdclient.Client) *cobra.Command {
+//	command := &cobra.Command{
+//		Use:     "set",
+//		Short:   "Set ApplicationSets Parameters",
+//		Example: templates.Examples(""),
+//		Run: func(c *cobra.Command, args []string) {
+//			ctx := c.Context()
+//
+//			if len(args) != 1 {
+//				c.HelpFunc()(c, args)
+//				os.Exit(1)
+//			}
+//
+//		},
+//	}
+//}
+
 // NewApplicationSetDeleteCommand returns a new instance of an `argocd appset delete` command
 func NewApplicationSetDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 	var noPrompt bool
@@ -435,7 +452,6 @@ func getServerForAppSet(appSet *arogappsetv1.ApplicationSet) string {
 }
 
 func printAppSetSummaryTable(appSet *arogappsetv1.ApplicationSet) {
-	source := appSet.Spec.Template.Spec.GetSource()
 	fmt.Printf(printOpFmtStr, "Name:", appSet.QualifiedName())
 	fmt.Printf(printOpFmtStr, "Project:", appSet.Spec.Template.Spec.GetProject())
 	fmt.Printf(printOpFmtStr, "Server:", getServerForAppSet(appSet))
@@ -445,7 +461,9 @@ func printAppSetSummaryTable(appSet *arogappsetv1.ApplicationSet) {
 	} else {
 		fmt.Println("Sources:")
 	}
-	printAppSourceDetails(&source)
+	for _, source := range appSet.Spec.Template.Spec.GetSources() {
+		printAppSourceDetails(&source)
+	}
 
 	var (
 		syncPolicyStr string

--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -470,34 +470,6 @@ func printAppSetSummaryTable(appSet *arogappsetv1.ApplicationSet) {
 	fmt.Printf(printOpFmtStr, "SyncPolicy:", syncPolicyStr)
 }
 
-func printAppSetSummaryTables(appSet *arogappsetv1.ApplicationSet) {
-	source := appSet.Spec.Template.Spec.GetSource()
-	fmt.Printf(printOpFmtStr, "Name:", appSet.QualifiedName())
-	fmt.Printf(printOpFmtStr, "Project:", appSet.Spec.Template.Spec.GetProject())
-	fmt.Printf(printOpFmtStr, "Server:", getServerForAppSet(appSet))
-	fmt.Printf(printOpFmtStr, "Namespace:", appSet.Spec.Template.Spec.Destination.Namespace)
-	if !appSet.Spec.Template.Spec.HasMultipleSources() {
-		fmt.Println("Source:")
-	} else {
-		fmt.Println("Sources:")
-	}
-	printAppSourceDetails(&source)
-
-	var (
-		syncPolicyStr string
-		syncPolicy    = appSet.Spec.Template.Spec.SyncPolicy
-	)
-	if syncPolicy != nil && syncPolicy.Automated != nil {
-		syncPolicyStr = "Automated"
-		if syncPolicy.Automated.Prune {
-			syncPolicyStr += " (Prune)"
-		}
-	} else {
-		syncPolicyStr = "<none>"
-	}
-	fmt.Printf(printOpFmtStr, "SyncPolicy:", syncPolicyStr)
-}
-
 func printAppSetConditions(w io.Writer, appSet *arogappsetv1.ApplicationSet) {
 	_, _ = fmt.Fprintf(w, "CONDITION\tSTATUS\tMESSAGE\tLAST TRANSITION\n")
 	for _, item := range appSet.Status.Conditions {

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -145,6 +145,26 @@ func TestPrintAppSetSummaryTable(t *testing.T) {
 			},
 		},
 	}
+	appsetSpecSource := baseAppSet.DeepCopy()
+	appsetSpecSource.Spec.Template.Spec.Source = &v1alpha1.ApplicationSource{
+		RepoURL:        "test1",
+		TargetRevision: "master1",
+		Path:           "/test1",
+	}
+
+	appsetSpecSources := baseAppSet.DeepCopy()
+	appsetSpecSources.Spec.Template.Spec.Sources = v1alpha1.ApplicationSources{
+		{
+			RepoURL:        "test1",
+			TargetRevision: "master1",
+			Path:           "/test1",
+		},
+		{
+			RepoURL:        "test2",
+			TargetRevision: "master2",
+			Path:           "/test2",
+		},
+	}
 
 	appsetSpecSyncPolicy := baseAppSet.DeepCopy()
 	appsetSpecSyncPolicy.Spec.SyncPolicy = &v1alpha1.ApplicationSetSyncPolicy{
@@ -173,6 +193,37 @@ func TestPrintAppSetSummaryTable(t *testing.T) {
 		appSet         *v1alpha1.ApplicationSet
 		expectedOutput string
 	}{
+		{
+			name:   "appset with a single source",
+			appSet: appsetSpecSource,
+			expectedOutput: `Name:               app-name
+Project:            default
+Server:             
+Namespace:          
+Source:
+- Repo:             test1
+  Target:           master1
+  Path:             /test1
+SyncPolicy:         <none>
+`,
+		},
+		{
+			name:   "appset with a multiple sources",
+			appSet: appsetSpecSources,
+			expectedOutput: `Name:               app-name
+Project:            default
+Server:             
+Namespace:          
+Sources:
+- Repo:             test1
+  Target:           master1
+  Path:             /test1
+- Repo:             test2
+  Target:           master2
+  Path:             /test2
+SyncPolicy:         <none>
+`,
+		},
 		{
 			name:   "appset with only spec.syncPolicy set",
 			appSet: appsetSpecSyncPolicy,

--- a/cmd/argocd/commands/applicationset_test.go
+++ b/cmd/argocd/commands/applicationset_test.go
@@ -194,37 +194,6 @@ func TestPrintAppSetSummaryTable(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			name:   "appset with a single source",
-			appSet: appsetSpecSource,
-			expectedOutput: `Name:               app-name
-Project:            default
-Server:             
-Namespace:          
-Source:
-- Repo:             test1
-  Target:           master1
-  Path:             /test1
-SyncPolicy:         <none>
-`,
-		},
-		{
-			name:   "appset with a multiple sources",
-			appSet: appsetSpecSources,
-			expectedOutput: `Name:               app-name
-Project:            default
-Server:             
-Namespace:          
-Sources:
-- Repo:             test1
-  Target:           master1
-  Path:             /test1
-- Repo:             test2
-  Target:           master2
-  Path:             /test2
-SyncPolicy:         <none>
-`,
-		},
-		{
 			name:   "appset with only spec.syncPolicy set",
 			appSet: appsetSpecSyncPolicy,
 			expectedOutput: `Name:               app-name
@@ -261,6 +230,37 @@ Source:
 - Repo:             
   Target:           
 SyncPolicy:         Automated
+`,
+		},
+		{
+			name:   "appset with a single source",
+			appSet: appsetSpecSource,
+			expectedOutput: `Name:               app-name
+Project:            default
+Server:             
+Namespace:          
+Source:
+- Repo:             test1
+  Target:           master1
+  Path:             /test1
+SyncPolicy:         <none>
+`,
+		},
+		{
+			name:   "appset with a multiple sources",
+			appSet: appsetSpecSources,
+			expectedOutput: `Name:               app-name
+Project:            default
+Server:             
+Namespace:          
+Sources:
+- Repo:             test1
+  Target:           master1
+  Path:             /test1
+- Repo:             test2
+  Target:           master2
+  Path:             /test2
+SyncPolicy:         <none>
 `,
 		},
 	} {


### PR DESCRIPTION
Closes #20902
Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

**Before:**

```
> argocd appset get color-applicationset-multi-source
Name:               argocd/color-applicationset-multi-source
Project:            default
Server:             https://kubernetes.default.svc
Namespace:          {{namespace}}
Sources:
- Repo:             https://github.com/argoproj/argocd-example-apps.git
  Target:           HEAD
  Path:             apps
SyncPolicy:         <none>

CONDITION            STATUS  MESSAGE                                                 LAST TRANSITION
ErrorOccurred        False   Successfully generated parameters for all Applications  2024-11-21 18:54:36 +0530 IST
ParametersGenerated  True    Successfully generated parameters for all Applications  2024-11-21 18:47:40 +0530 IST
ResourcesUpToDate    True    ApplicationSet up to date                               2024-11-21 18:54:36 +0530 IST
```

**After:**
```
> argocd appset get color-applicationset-multi-source
Name:               argocd/color-applicationset-multi-source
Project:            default
Server:             https://kubernetes.default.svc
Namespace:          {{namespace}}
Sources:
- Repo:             https://github.com/argoproj/argocd-example-apps.git
  Target:           HEAD
  Path:             apps
- Repo:             https://github.com/argoproj/argocd-example-apps.git
  Target:           HEAD
  Path:             guestbook
SyncPolicy:         <none>

CONDITION            STATUS  MESSAGE                                                 LAST TRANSITION
ErrorOccurred        False   Successfully generated parameters for all Applications  2024-11-21 18:54:36 +0530 IST
ParametersGenerated  True    Successfully generated parameters for all Applications  2024-11-21 18:47:40 +0530 IST
ResourcesUpToDate    True    ApplicationSet up to date                               2024-11-21 18:54:36 +0530 IST

```