### PR TITLE
fix: Set operation state to nil if new operation has been initiated by a direct object update (#20875)

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -189,6 +189,11 @@ const (
 	// can be disregarded.
 	AnnotationIgnoreHealthCheck = "argocd.argoproj.io/ignore-healthcheck"
 
+	// AnnotationAllowPatchingOperationTestOnly when set the patch operations also can update the operation field.
+	// Intended for use in tests only. Keep in sync with tests using argocd.argoproj.io~1allow-patching-operation-test-only or
+	// argocd.argoproj.io/allow-patching-operation-test-only directly.
+	AnnotationAllowPatchingOperationTestOnly = "argocd.argoproj.io/allow-patching-operation-test-only"
+
 	// AnnotationKeyManagedBy is annotation name which indicates that k8s resource is managed by an application.
 	AnnotationKeyManagedBy = "managed-by"
 	// AnnotationValueManagedByArgoCD is a 'managed-by' annotation value for resources managed by Argo CD

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -937,12 +937,14 @@ func (s *Server) updateApp(app *appv1.Application, newApp *appv1.Application, ct
 			app.Labels = newApp.Labels
 			app.Annotations = newApp.Annotations
 		}
-
+		if app.Annotations[argocommon.AnnotationAllowPatchingOperationTestOnly] == "true" {
+			app.Operation = newApp.Operation
+		}
 		app.Finalizers = newApp.Finalizers
 
 		res, err := s.appclientset.ArgoprojV1alpha1().Applications(app.Namespace).Update(ctx, app, metav1.UpdateOptions{})
 		if err == nil {
-			s.logAppEvent(app, ctx, argo.EventReasonResourceUpdated, "updated application spec")
+			s.logAppEvent(app, ctx, argo.EventReasonResourceUpdated, "updated application")
 			s.waitSync(res)
 			return res, nil
 		}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -1972,6 +1972,39 @@ func TestAppJsonPatch(t *testing.T) {
 	app, err = appServer.Patch(ctx, &application.ApplicationPatchRequest{Name: &testApp.Name, Patch: ptr.To(`[{"op": "remove", "path": "/metadata/annotations/test.annotation"}]`)})
 	require.NoError(t, err)
 	assert.NotContains(t, app.Annotations, "test.annotation")
+
+	app, err = appServer.Patch(
+		ctx,
+		&application.ApplicationPatchRequest{
+			Name: &testApp.Name,
+			Patch: ptr.To(fmt.Sprintf(
+				`[
+					{
+						"op": "add",
+						"path": "/metadata/annotations",
+						"value": {
+							"%s": "true"
+						}
+					},
+					{
+						"op": "add",
+						"path": "/operation",
+						"value": {
+							"sync": {
+								"revisions": ["test"]
+							},
+							"initiatedBy": {
+								"username": "test"
+							}
+						}
+					}
+				]`,
+				common.AnnotationAllowPatchingOperationTestOnly,
+			)),
+		},
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, app.Operation)
 }
 
 func TestAppMergePatch(t *testing.T) {

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -50,6 +50,13 @@ func OperationMessageContains(text string) Expectation {
 	}
 }
 
+func OperationStateIsNil() Expectation {
+	return func(c *Consequences) (state, string) {
+		actual := c.app().Status.OperationState
+		return simple(actual == nil, fmt.Sprintf("operation state should be nil, is %s", actual))
+	}
+}
+
 func simple(success bool, message string) (state, string) {
 	if success {
 		return succeeded, message


### PR DESCRIPTION
Fixes #20875

Some systems like Kargo update the application operation directly to initiate a new sync, bypassing the server. However, they can't update the status operation state to become nil, resulting in discrepancy, see https://github.com/akuity/kargo/issues/2985 and the discussion. Handle this case on the app controller side.

Let's cherry-pick to v2.13.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
