### PR TITLE
chore: log panics in JSON (#20924)

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 	"time"
 
@@ -109,6 +110,13 @@ func NewCommand() *cobra.Command {
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
 			cli.SetGLogLevel(glogLevel)
+
+			// Recover from panic and log the error using the configured logger instead of the default.
+			defer func() {
+				if r := recover(); r != nil {
+					log.WithField("trace", string(debug.Stack())).Fatal("Recovered from panic: ", r)
+				}
+			}()
 
 			config, err := clientConfig.ClientConfig()
 			errors.CheckError(err)

--- a/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
+++ b/cmd/argocd-applicationset-controller/commands/applicationset_controller.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/argoproj/pkg/stats"
@@ -99,6 +100,13 @@ func NewCommand() *cobra.Command {
 			cli.SetLogLevel(cmdutil.LogLevel)
 
 			ctrl.SetLogger(logutils.NewLogrusLogger(logutils.NewWithCurrentConfig()))
+
+			// Recover from panic and log the error using the configured logger instead of the default.
+			defer func() {
+				if r := recover(); r != nil {
+					log.WithField("trace", string(debug.Stack())).Fatal("Recovered from panic: ", r)
+				}
+			}()
 
 			restConfig, err := clientConfig.ClientConfig()
 			errors.CheckError(err)

--- a/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
+++ b/cmd/argocd-cmp-server/commands/argocd_cmp_server.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"runtime/debug"
 	"time"
 
 	"github.com/argoproj/pkg/stats"
@@ -43,6 +44,13 @@ func NewCommand() *cobra.Command {
 
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
+
+			// Recover from panic and log the error using the configured logger instead of the default.
+			defer func() {
+				if r := recover(); r != nil {
+					log.WithField("trace", string(debug.Stack())).Fatal("Recovered from panic: ", r)
+				}
+			}()
 
 			config, err := plugin.ReadPluginConfig(configFilePath)
 			errors.CheckError(err)

--- a/cmd/argocd-dex/commands/argocd_dex.go
+++ b/cmd/argocd-dex/commands/argocd_dex.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -66,6 +67,14 @@ func NewRunDexCommand() *cobra.Command {
 
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
+
+			// Recover from panic and log the error using the configured logger instead of the default.
+			defer func() {
+				if r := recover(); r != nil {
+					log.WithField("trace", string(debug.Stack())).Fatal("Recovered from panic: ", r)
+				}
+			}()
+
 			_, err = exec.LookPath("dex")
 			errors.CheckError(err)
 			config, err := clientConfig.ClientConfig()

--- a/cmd/argocd-notification/commands/controller.go
+++ b/cmd/argocd-notification/commands/controller.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"syscall"
@@ -114,6 +115,13 @@ func NewCommand() *cobra.Command {
 			default:
 				return fmt.Errorf("unknown log format '%s'", logFormat)
 			}
+
+			// Recover from panic and log the error using the configured logger instead of the default.
+			defer func() {
+				if r := recover(); r != nil {
+					log.WithField("trace", string(debug.Stack())).Fatal("Recovered from panic: ", r)
+				}
+			}()
 
 			tlsConfig := apiclient.TLSConfiguration{
 				DisableTLS:       argocdRepoServerPlaintext,

--- a/cmd/argocd-repo-server/commands/argocd_repo_server.go
+++ b/cmd/argocd-repo-server/commands/argocd_repo_server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"time"
@@ -95,6 +96,13 @@ func NewCommand() *cobra.Command {
 
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
+
+			// Recover from panic and log the error using the configured logger instead of the default.
+			defer func() {
+				if r := recover(); r != nil {
+					log.WithField("trace", string(debug.Stack())).Fatal("Recovered from panic: ", r)
+				}
+			}()
 
 			if !disableTLS {
 				var err error

--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -118,6 +119,13 @@ func NewCommand() *cobra.Command {
 			cli.SetLogFormat(cmdutil.LogFormat)
 			cli.SetLogLevel(cmdutil.LogLevel)
 			cli.SetGLogLevel(glogLevel)
+
+			// Recover from panic and log the error using the configured logger instead of the default.
+			defer func() {
+				if r := recover(); r != nil {
+					log.WithField("trace", string(debug.Stack())).Fatal("Recovered from panic: ", r)
+				}
+			}()
 
 			config, err := clientConfig.ClientConfig()
 			errors.CheckError(err)


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/20924

Before:

```
{"built":"1970-01-01T00:00:00Z","commit":"","level":"info","msg":"ArgoCD API Server is starting","namespace":"argocd","port":8080,"time":"2024-11-24T14:54:08-05:00","version":"v99.99.99+unknown"}
panic: yikes

goroutine 1 [running]:
github.com/argoproj/argo-cd/v2/cmd/argocd-server/commands.NewCommand.func1(0x140008d0000?, {0x107c13006?, 0x4?, 0x107c1300a?})
        /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/cmd/argocd-server/commands/argocd_server.go:129 +0x200
github.com/spf13/cobra.(*Command).execute(0x14000d70c08, {0x140001aa0b0, 0x9, 0x9})
        /Users/mcrenshaw/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x14000d70c08)
        /Users/mcrenshaw/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/mcrenshaw/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.main()
        /Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/cmd/main.go:67 +0x364
```

After:

```
{"built":"1970-01-01T00:00:00Z","commit":"","level":"info","msg":"ArgoCD API Server is starting","namespace":"argocd","port":8080,"time":"2024-11-24T15:00:21-05:00","version":"v99.99.99+unknown"}
{"level":"fatal","msg":"Recovered from panic: yikes","time":"2024-11-24T15:00:21-05:00","trace":"goroutine 1 [running]:\nruntime/debug.Stack()\n\t/Users/mcrenshaw/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/runtime/debug/stack.go:24 +0x64\ngithub.com/argoproj/argo-cd/v2/cmd/argocd-server/commands.NewCommand.func1.1()\n\t/Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/cmd/argocd-server/commands/argocd_server.go:126 +0x34\npanic({0x109a49ea0?, 0x10a58f760?})\n\t/Users/mcrenshaw/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/runtime/panic.go:770 +0x124\ngithub.com/argoproj/argo-cd/v2/cmd/argocd-server/commands.NewCommand.func1(0x14000583400?, {0x105f4af66?, 0x4?, 0x105f4af6a?})\n\t/Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/cmd/argocd-server/commands/argocd_server.go:130 +0x21c\ngithub.com/spf13/cobra.(*Command).execute(0x14000770c08, {0x140001aa0b0, 0x9, 0x9})\n\t/Users/mcrenshaw/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x828\ngithub.com/spf13/cobra.(*Command).ExecuteC(0x14000770c08)\n\t/Users/mcrenshaw/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344\ngithub.com/spf13/cobra.(*Command).Execute(...)\n\t/Users/mcrenshaw/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041\nmain.main()\n\t/Users/mcrenshaw/go/src/github.com/argoproj/argo-cd/cmd/main.go:67 +0x364\n"}
```