### PR TITLE
chore: Reduce e2e tests runtime by using better sleep intervals in Expect

### DIFF
--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -25,8 +25,19 @@ func (c *Consequences) Expect(e Expectation) *Consequences {
 	c.context.t.Helper()
 	var message string
 	var state state
+	sleepIntervals := []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		300 * time.Millisecond,
+		500 * time.Millisecond,
+		1 * time.Second,
+	}
+	sleepIntervalsIdx := -1
 	timeout := time.Duration(c.timeout) * time.Second
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(3 * time.Second) {
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(sleepIntervals[sleepIntervalsIdx]) {
 		state, message = e(c)
 		switch state {
 		case succeeded:
@@ -37,6 +48,9 @@ func (c *Consequences) Expect(e Expectation) *Consequences {
 			return c
 		}
 		log.Infof("pending: %s", message)
+		if sleepIntervalsIdx < len(sleepIntervals)-1 {
+			sleepIntervalsIdx++
+		}
 	}
 	c.context.t.Fatal("timeout waiting for: " + message)
 	return c

--- a/test/e2e/fixture/applicationsets/consequences.go
+++ b/test/e2e/fixture/applicationsets/consequences.go
@@ -31,7 +31,18 @@ func (c *Consequences) ExpectWithDuration(e Expectation, timeout time.Duration) 
 	c.context.t.Helper()
 	var message string
 	var state state
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(3 * time.Second) {
+	sleepIntervals := []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		300 * time.Millisecond,
+		500 * time.Millisecond,
+		1 * time.Second,
+	}
+	sleepIntervalsIdx := -1
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(sleepIntervals[sleepIntervalsIdx]) {
 		state, message = e(c)
 		switch state {
 		case succeeded:
@@ -42,6 +53,9 @@ func (c *Consequences) ExpectWithDuration(e Expectation, timeout time.Duration) 
 			return c
 		}
 		log.Infof("expectation pending: %s", message)
+		if sleepIntervalsIdx < len(sleepIntervals)-1 {
+			sleepIntervalsIdx++
+		}
 	}
 	c.context.t.Fatal("timeout waiting for: " + message)
 	return c


### PR DESCRIPTION
Closes #20923

Right now the condition is checked immediately and then only after 3 seconds and so on. But sometimes the need for a wait may be much smaller than 3 seconds. So, try using smaller intervals with exponential increase up to 3 seconds instead.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
