### PR TITLE
chore: Optimize e2e tests by removing redundant ensure clean state + some refactoring

### DIFF
--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -1251,7 +1251,7 @@ func TestNamespacedPermissionWithScopedRepo(t *testing.T) {
 		When().
 		Create()
 
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(RepoURL(RepoURLTypeFile)).
 		Project(projName).
@@ -1291,7 +1291,7 @@ func TestNamespacedPermissionDeniedWithScopedRepo(t *testing.T) {
 		When().
 		Create()
 
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(RepoURL(RepoURLTypeFile)).
 		Create()

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -195,7 +195,7 @@ func TestGetLogsAllowSwitchOff(t *testing.T) {
 			},
 		}, "app-creator")
 
-	Given(t).
+	GivenWithSameState(t).
 		Path("guestbook-logs").
 		When().
 		CreateApp().
@@ -1519,7 +1519,7 @@ func TestPermissions(t *testing.T) {
 	appCtx := Given(t)
 	projName := "argo-project"
 	projActions := projectFixture.
-		Given(t).
+		GivenWithSameState(t).
 		Name(projName).
 		When().
 		Create()
@@ -1603,7 +1603,7 @@ func TestPermissionWithScopedRepo(t *testing.T) {
 		Create().
 		AddSource("*")
 
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(RepoURL(RepoURLTypeFile)).
 		Project(projName).
@@ -1640,7 +1640,7 @@ func TestPermissionDeniedWithScopedRepo(t *testing.T) {
 		When().
 		Create()
 
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(RepoURL(RepoURLTypeFile)).
 		Create()
@@ -1666,7 +1666,7 @@ func TestPermissionDeniedWithNegatedNamespace(t *testing.T) {
 		When().
 		Create()
 
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(RepoURL(RepoURLTypeFile)).
 		Project(projName).
@@ -1693,7 +1693,7 @@ func TestPermissionDeniedWithNegatedServer(t *testing.T) {
 		When().
 		Create()
 
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(RepoURL(RepoURLTypeFile)).
 		Project(projName).

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -1405,7 +1405,6 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 	}
 	project := "gpg"
 
-	fixture.EnsureCleanState(t)
 	Given(t).
 		Project(project).
 		When().
@@ -1724,7 +1723,6 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 		generateExpectedApp("engineering-prod-guestbook"),
 	}
 
-	fixture.EnsureCleanState(t)
 	Given(t).
 		Project(project).
 		When().
@@ -1826,7 +1824,6 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 		generateExpectedApp("engineering-prod-guestbook"),
 	}
 
-	fixture.EnsureCleanState(t)
 	Given(t).
 		Project(project).
 		Path(guestbookPath).

--- a/test/e2e/fixture/repos/context.go
+++ b/test/e2e/fixture/repos/context.go
@@ -19,11 +19,16 @@ type Context struct {
 	project string
 }
 
-func Given(t *testing.T, sameState bool) *Context {
+func Given(t *testing.T) *Context {
 	t.Helper()
-	if !sameState {
-		fixture.EnsureCleanState(t)
-	}
+	fixture.EnsureCleanState(t)
+	return GivenWithSameState(t)
+}
+
+// GivenWithSameState skips cleaning state. Use this when you've already ensured you have a clean
+// state in your test setup don't want to waste time by doing so again.
+func GivenWithSameState(t *testing.T) *Context {
+	t.Helper()
 	// ARGOCE_E2E_DEFAULT_TIMEOUT can be used to override the default timeout
 	// for any context.
 	timeout := env.ParseNumFromEnv("ARGOCD_E2E_DEFAULT_TIMEOUT", 10, 0, 180)

--- a/test/e2e/scoped_repository_test.go
+++ b/test/e2e/scoped_repository_test.go
@@ -23,7 +23,7 @@ func TestCreateRepositoryWithProject(t *testing.T) {
 		Then()
 
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(path).
 		Project("argo-project").
@@ -48,7 +48,7 @@ func TestCreateRepositoryNonAdminUserPermissionDenied(t *testing.T) {
 		Login()
 
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(path).
 		Project("argo-project").
@@ -75,7 +75,7 @@ func TestCreateRepositoryNonAdminUserWithWrongProject(t *testing.T) {
 		}, "org-admin")
 
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(path).
 		Project("argo-project").
@@ -112,7 +112,7 @@ func TestDeleteRepositoryRbacAllowed(t *testing.T) {
 		}, "org-admin")
 
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(path).
 		Project("argo-project").
@@ -155,7 +155,7 @@ func TestDeleteRepositoryRbacDenied(t *testing.T) {
 		}, "org-admin")
 
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, true).
+	repoFixture.GivenWithSameState(t).
 		When().
 		Path(path).
 		Project("argo-project").
@@ -176,7 +176,7 @@ func TestDeleteRepositoryRbacDenied(t *testing.T) {
 
 func TestDeleteRepository(t *testing.T) {
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, false).
+	repoFixture.Given(t).
 		When().
 		Path(path).
 		Project("argo-project").
@@ -195,7 +195,7 @@ func TestDeleteRepository(t *testing.T) {
 
 func TestListRepoCLIOutput(t *testing.T) {
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, false).
+	repoFixture.Given(t).
 		When().
 		Path(path).
 		Project("argo-project").
@@ -215,7 +215,7 @@ git         https://github.com/argoproj/argo-cd.git  false     false  false  fal
 
 func TestGetRepoCLIOutput(t *testing.T) {
 	path := "https://github.com/argoproj/argo-cd.git"
-	repoFixture.Given(t, false).
+	repoFixture.Given(t).
 		When().
 		Path(path).
 		Project("argo-project").


### PR DESCRIPTION
Closes #20938

There's no need to do multiple ensure clean state in tests, which `Given` does, so using `GivenWithSameState` in places not using it already. There were only a few, so I don't expect a big win, but it may help with test consistency as well. Also, refactor to use `Given` and `GivenWithSameState` for repo fixture instead of `Given(t, <bool>)`.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
