### PR TITLE
fix: API server should not attempt to read secrets in all namespaces

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -163,6 +163,7 @@ func NewCommand() *cobra.Command {
 			controllerClient, err := client.New(config, client.Options{Scheme: scheme})
 			errors.CheckError(err)
 			controllerClient = client.NewDryRunClient(controllerClient)
+			controllerClient = client.NewNamespacedClient(controllerClient, namespace)
 
 			// Load CA information to use for validating connections to the
 			// repository server, if strict TLS validation was requested.

--- a/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
+++ b/manifests/cluster-rbac/server/argocd-server-clusterrole.yaml
@@ -15,7 +15,6 @@ rules:
   - delete  # supports deletion a live object in UI
   - get     # supports viewing live object manifest in UI
   - patch   # supports `argocd app patch`
-  - list    # supports `argocd appset generate` with cluster generator
 - apiGroups:
   - ""
   resources:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -22776,7 +22776,6 @@ rules:
   - delete
   - get
   - patch
-  - list
 - apiGroups:
   - ""
   resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -22743,7 +22743,6 @@ rules:
   - delete
   - get
   - patch
-  - list
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Followup for https://github.com/argoproj/argo-cd/issues/20161 

The https://github.com/argoproj/argo-cd/pull/20162 fixes the issue by giving cluster-level secret permissions, but only if Argo CD is installed in a cluster-level mode.  

PR fixes the root cause of  https://github.com/argoproj/argo-cd/issues/20161: API server incorrectly attempting to read secrets from all namespaces. Also reverts  https://github.com/argoproj/argo-cd/pull/20162 since API server should not really have permissions to list everything in a whole cluster.

