### PR TITLE
chore: Fix to intermittent E2E test failures in deployment_test.go

### DIFF
--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -309,10 +310,19 @@ func createNamespaceScopedUser(t *testing.T, username string, clusterScopedSecre
 	_, err = KubeClientset.RbacV1().RoleBindings(roleBinding.Namespace).Create(context.Background(), &roleBinding, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// Retrieve the bearer token from the ServiceAccount
-	token, err := clusterauth.GetServiceAccountBearerToken(KubeClientset, ns.Name, serviceAccountName, time.Second*60)
-	require.NoError(t, err)
-	assert.NotEmpty(t, token)
+	var token string
+
+	// Attempting to patch the ServiceAccount can intermittently fail with 'failed to patch serviceaccount "(...)" with bearer token secret: Operation cannot be fulfilled on serviceaccounts "(...)": the object has been modified; please apply your changes to the latest version and try again'
+	// We thus keep trying for up to 20 seconds.
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 20*time.Second, true, func(context.Context) (done bool, err error) {
+		// Retrieve the bearer token from the ServiceAccount
+		token, err = clusterauth.GetServiceAccountBearerToken(KubeClientset, ns.Name, serviceAccountName, time.Second*60)
+
+		// Success is no error and a real token, otherwise keep trying
+		return (err == nil && token != ""), nil
+	})
+	require.NoError(t, waitErr)
+	require.NotEmpty(t, token)
 
 	// In order to test a cluster-scoped Argo CD Cluster Secret, we may optionally grant the ServiceAccount read-all permissions at cluster scope.
 	if clusterScopedSecrets {


### PR DESCRIPTION
This PR is a simple test update to fix flaky E2E tests.

A couple of E2E tests (that I originally wrote some time ago) are intermittently failing due to a race condition in acquisition of the `ServiceAccount` secret.

Both `TestArgoCDSupportsMultipleServiceAccountsWithDifferingRBACOnSameCluster` and `TestDeployToKubernetesAPIURLWithQueryParameter`, in `deployment_test.go`, attempt to acquire a `ServiceAccount` using `GetServiceAccountBearerToken` from `clusterauth.go`. However, within that package, `createServiceAccountToken` can fail with the following error:

`failed to patch serviceaccount "e2e-test-user1-serviceaccount" with bearer token secret: Operation cannot be fulfilled on serviceaccounts "e2e-test-user1-serviceaccount": the object has been modified; please apply your changes to the latest version and try again
`

As you can probably guess, this is because another process is modifying the resource before our code can complete the patch. 

The proposed fix is to retry on failure, up to a maximum of 20 seconds.

I have run these tests over and over for several hours, and did not hit the issue, so as best as I can tell the issue is resolved with this PR.


Example of failing run:	
```
=== RUN   TestDeployToKubernetesAPIURLWithQueryParameter
time="2024-08-29T18:33:20Z" level=info msg="kubectl delete ns -l e2e.argoproj.io=true --field-selector status.phase=Active --wait=false" dir= execID=4bf1a
time="2024-08-29T18:33:20Z" level=debug msg="namespace \"argocd-e2e--test-deployment-without-tracking-mode-jlxqv\" deleted\n" duration=280.930217ms execID=4bf1a
time="2024-08-29T18:33:20Z" level=info msg="kubectl delete crd -l e2e.argoproj.io=true --wait=false" dir= execID=26fa6
time="2024-08-29T18:33:21Z" level=debug msg="No resources found\n" duration=736.63983ms execID=26fa6
time="2024-08-29T18:33:21Z" level=info msg="kubectl delete clusterroles -l e2e.argoproj.io=true --wait=false" dir= execID=a6188
time="2024-08-29T18:33:21Z" level=debug msg="No resources found\n" duration=220.337006ms execID=a6188
time="2024-08-29T18:33:22Z" level=warning msg="Failed to invoke grpc call. Use flag --grpc-web in grpc calls. To avoid this warning message, use flag --grpc-web."
time="2024-08-29T18:33:22Z" level=info msg="../../dist/argocd proj create gpg --server argocd-test-server-argocd-e2e.apps.rosa-qe-415.i1qm.p1.openshiftapps.com --auth-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhcmdvY2QiLCJzdWIiOiJhZG1pbjpsb2dpbiIsImV4cCI6MTcyNTA0MjgwMiwibmJmIjoxNzI0OTU2NDAyLCJpYXQiOjE3MjQ5NTY0MDIsImp0aSI6IjUxNzU4OWFjLTQxMjktNDNkMS1hOTAwLWUxZmQzNWZkNjdlNyJ9.69GMMnp64BvgJZ7ZJaCRP2mqODctv44QyOMa2oGKgpI --insecure" dir= execID=3f5aa
time="2024-08-29T18:33:22Z" level=debug duration=132.070553ms execID=3f5aa
time="2024-08-29T18:33:22Z" level=info msg="mkdir -p /tmp/argo-e2e" dir= execID=effe0
time="2024-08-29T18:33:22Z" level=debug duration=1.970259ms execID=effe0
time="2024-08-29T18:33:22Z" level=info msg="mkdir -p /tmp/argo-e2e/gpg" dir= execID=f1823
time="2024-08-29T18:33:22Z" level=debug duration=1.607923ms execID=f1823
time="2024-08-29T18:33:22Z" level=info msg="chmod 0700 /tmp/argo-e2e/gpg" dir= execID=431be
time="2024-08-29T18:33:22Z" level=debug duration=1.778624ms execID=431be
time="2024-08-29T18:33:22Z" level=info msg="pkill -9 gpg-agent" dir= execID=0e848
time="2024-08-29T18:33:22Z" level=info msg="gpg --import ../fixture/gpg/signingkey.asc" dir= execID=91772
time="2024-08-29T18:33:22Z" level=debug duration=10.727778ms execID=91772
time="2024-08-29T18:33:22Z" level=info msg="cp -Rf testdata /tmp/argo-e2e/testdata.git" dir= execID=bad2d
time="2024-08-29T18:33:23Z" level=debug duration=265.091727ms execID=bad2d
time="2024-08-29T18:33:23Z" level=info msg="chmod 777 ." dir=/tmp/argo-e2e/testdata.git execID=528cb
time="2024-08-29T18:33:23Z" level=debug duration=1.88798ms execID=528cb
time="2024-08-29T18:33:23Z" level=info msg="git init -b master" dir=/tmp/argo-e2e/testdata.git execID=d7dd0
time="2024-08-29T18:33:23Z" level=debug msg="Initialized empty Git repository in /tmp/argo-e2e/testdata.git/.git/\n" duration=3.832245ms execID=d7dd0
time="2024-08-29T18:33:23Z" level=info msg="git add ." dir=/tmp/argo-e2e/testdata.git execID=90e4d
time="2024-08-29T18:33:23Z" level=debug duration=30.579905ms execID=90e4d
time="2024-08-29T18:33:23Z" level=info msg="git commit -q -m initial commit" dir=/tmp/argo-e2e/testdata.git execID=c1d5c
time="2024-08-29T18:33:23Z" level=debug duration=23.928072ms execID=c1d5c
time="2024-08-29T18:33:23Z" level=info msg="git remote add origin http://127.0.0.1:9081/argo-e2e/testdata.git" dir=/tmp/argo-e2e/testdata.git execID=ff654
time="2024-08-29T18:33:23Z" level=debug duration=2.302404ms execID=ff654
time="2024-08-29T18:33:23Z" level=info msg="git push origin master -f" dir=/tmp/argo-e2e/testdata.git execID=86119
time="2024-08-29T18:33:23Z" level=debug duration=137.342519ms execID=86119
time="2024-08-29T18:33:23Z" level=info msg="kubectl create ns argocd-e2e--test-deploy-to-kubernetes-apiurl-with-query-p-xcrix" dir= execID=d2123
time="2024-08-29T18:33:23Z" level=debug msg="namespace/argocd-e2e--test-deploy-to-kubernetes-apiurl-with-query-p-xcrix created\n" duration=140.73248ms execID=d2123
time="2024-08-29T18:33:23Z" level=info msg="kubectl label ns argocd-e2e--test-deploy-to-kubernetes-apiurl-with-query-p-xcrix e2e.argoproj.io=true" dir= execID=4897e
time="2024-08-29T18:33:23Z" level=debug msg="namespace/argocd-e2e--test-deploy-to-kubernetes-apiurl-with-query-p-xcrix labeled\n" duration=311.18895ms execID=4897e
time="2024-08-29T18:33:23Z" level=info msg="clean state" duration=3.781812414s id=TestDeployToKubernetesAPIURLWithQueryParameter-xcrix name=TestDeployToKubernetesAPIURLWithQueryParameter password=password username=admin
time="2024-08-29T18:33:23Z" level=info msg="ServiceAccount \"e2e-test-user1-serviceaccount\" created in namespace \"e2e-test-user1\""
time="2024-08-29T18:33:24Z" level=info msg="Created bearer token secret for ServiceAccount \"e2e-test-user1-serviceaccount\""
    deployment_test.go:313: 
            Error Trace:    /argocd-e2e/argo-cd/test/e2e/deployment_test.go:313
                                        /argocd-e2e/argo-cd/test/e2e/deployment_test.go:137
            Error:          Received unexpected error:
                            failed to patch serviceaccount "e2e-test-user1-serviceaccount" with bearer token secret: Operation cannot be fulfilled on serviceaccounts "e2e-test-user1-serviceaccount": the object has been modified; please apply your changes to the latest version and try again
            Test:           TestDeployToKubernetesAPIURLWithQueryParameter
--- FAIL: TestDeployToKubernetesAPIURLWithQueryParameter (3.99s){noformat}
```




Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
