### PR TITLE
feat: Fixed manifest-generate-paths monorepo support for Bitbucket #18968

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -144,13 +144,7 @@ func ParseRevision(ref string) string {
 
 // affectedRevisionInfo examines a payload from a webhook event, and extracts the repo web URL,
 // the revision, and whether or not this affected origin/HEAD (the default branch of the repository)
-func affectedRevisionInfo(payloadIf interface{}, optionalHandler *ArgoCDWebhookHandler) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
-	// Check if a handler was passed
-	var webhookHandler *ArgoCDWebhookHandler
-	if optionalHandler != nil {
-		webhookHandler = optionalHandler
-	}
-
+func affectedRevisionInfo(payloadIf interface{}, webhookHandler *ArgoCDWebhookHandler) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
 	switch payload := payloadIf.(type) {
 	case azuredevops.GitPushEvent:
 		// See: https://learn.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops#git.push

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -144,13 +144,11 @@ func ParseRevision(ref string) string {
 
 // affectedRevisionInfo examines a payload from a webhook event, and extracts the repo web URL,
 // the revision, and whether or not this affected origin/HEAD (the default branch of the repository)
-func affectedRevisionInfo(payloadIf interface{}, optionalHandler ...interface{}) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
+func affectedRevisionInfo(payloadIf interface{}, optionalHandler *ArgoCDWebhookHandler) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
 	// Check if a handler was passed
 	var webhookHandler *ArgoCDWebhookHandler
-	if len(optionalHandler) > 0 {
-		if handler, ok := optionalHandler[0].(*ArgoCDWebhookHandler); ok {
-			webhookHandler = handler
-		}
+	if optionalHandler != nil {
+		webhookHandler = optionalHandler
 	}
 
 	switch payload := payloadIf.(type) {
@@ -285,8 +283,7 @@ func fetchDiffstatFromBitbucket(workspace, repoSlug, spec, accessToken string) (
 	// Getting the files changed from diff API:
 	// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-diffstat-spec-get
 
-	url := fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s/%s/diffstat/%s",
-		workspace, repoSlug, spec)
+	url := fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s/%s/diffstat/%s", workspace, repoSlug, spec)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -195,8 +195,6 @@ func affectedRevisionInfo(payloadIf interface{}, webhookHandler *ArgoCDWebhookHa
 		// See: https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push
 		// NOTE: this is untested
 		webURLs = append(webURLs, payload.Repository.Links.HTML.Href)
-		// TODO: bitbucket includes multiple changes as part of a single event.
-		// We only pick the first but need to consider how to handle multiple
 		fullName := strings.Split(payload.Repository.FullName, "/")
 		workspace := fullName[0]
 		repoSlug := payload.Repository.Name

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -600,7 +600,7 @@ func Test_affectedRevisionInfo_appRevisionHasChanged(t *testing.T) {
 		testCopy := testCase
 		t.Run(testCopy.name, func(t *testing.T) {
 			t.Parallel()
-			_, revisionFromHook, _, _, _ := affectedRevisionInfo(testCopy.hookPayload)
+			_, revisionFromHook, _, _, _ := affectedRevisionInfo(testCopy.hookPayload, nil)
 			if got := sourceRevisionHasChanged(sourceWithRevision(testCopy.targetRevision), revisionFromHook, false); got != testCopy.hasChanged {
 				t.Errorf("sourceRevisionHasChanged() = %v, want %v", got, testCopy.hasChanged)
 			}

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -53,6 +53,10 @@ func (f fakeSettingsSrc) GetInstallationID() (string, error) {
 	return "", nil
 }
 
+func (f fakeSettingsSrc) GetRepositorySecretAccessToken(string) (string, error) {
+	return "", nil
+}
+
 type reactorDef struct {
 	verb     string
 	resource string


### PR DESCRIPTION
Fixes #18968 

### PR Summary:

This PR addresses an issue with the `argocd.argoproj.io/manifest-generate-paths` [Manifest Paths Annotation](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#manifest-paths-annotation) in Argo CD when used with Bitbucket repositories.

### Key Changes:
- Prevents spurious refreshes in cases where multiple Applications are using the same Git monorepo stored in Bitbucket.
- Ensures that the `manifest-generate-paths` annotation is handled correctly, refreshing the app only when the files changed match with the paths in  `manifest-generate-paths` .

### Steps to Implement:

1. **Add Bitbucket Repository to ArgoCD:**
   Use the following command to add the Bitbucket repository to ArgoCD with authentication:
   ```sh
   argocd repo add <REPO_URL> --username <BITBUCKET_USERNAME> --password <BITBUCKET_APP_PASSWORD>
   ```
   - ```<REPO_URL>```: Replace with your Bitbucket repository URL.
   - ```<BITBUCKET_USERNAME>```: Your Bitbucket account username.
   - ```<BITBUCKET_APP_PASSWORD>```: An app password generated in Bitbucket (can be found in your [Bitbucket account setting](https://bitbucket.org/account/settings/)

2. **Generate an Access Token for the Repository in Bitbucket:**
    - Create an access token from your Bitbucket repository.
    - Use the access token in your repository's secret.
3. **Store the Access Token as a Secret:**
Convert the generated access token to Base64 format. You can use the following command:
    ```sh
    echo "ACCESS_TOKEN" | base64 -w0
    ```
    - Replace ```ACCESS_TOKEN``` with your actual Bitbucket access token.
    - Use the access token generated in the previous step to add a Kubernetes secret for the repository added in ```Step 1```.Store the access token in the secret under the key ```data.accessToken```
    
Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
