### PR TITLE
chore: Remove sleep from when/then in e2e tests

### DIFF
--- a/test/e2e/fixture/account/context.go
+++ b/test/e2e/fixture/account/context.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"testing"
-	"time"
 
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -46,7 +45,5 @@ func (c *Context) And(block func()) *Context {
 }
 
 func (c *Context) When() *Actions {
-	// in case any settings have changed, pause for 1s, not great, but fine
-	time.Sleep(1 * time.Second)
 	return &Actions{context: c}
 }

--- a/test/e2e/fixture/app/context.go
+++ b/test/e2e/fixture/app/context.go
@@ -311,8 +311,6 @@ func (c *Context) And(block func()) *Context {
 }
 
 func (c *Context) When() *Actions {
-	// in case any settings have changed, pause for 1s, not great, but fine
-	time.Sleep(1 * time.Second)
 	return &Actions{context: c}
 }
 

--- a/test/e2e/fixture/applicationsets/context.go
+++ b/test/e2e/fixture/applicationsets/context.go
@@ -27,8 +27,6 @@ func Given(t *testing.T) *Context {
 }
 
 func (c *Context) When() *Actions {
-	// in case any settings have changed, pause for 1s, not great, but fine
-	time.Sleep(1 * time.Second)
 	return &Actions{context: c}
 }
 

--- a/test/e2e/fixture/cluster/context.go
+++ b/test/e2e/fixture/cluster/context.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"testing"
-	"time"
 
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -60,8 +59,6 @@ func (c *Context) And(block func()) *Context {
 }
 
 func (c *Context) When() *Actions {
-	// in case any settings have changed, pause for 1s, not great, but fine
-	time.Sleep(1 * time.Second)
 	return &Actions{context: c}
 }
 

--- a/test/e2e/fixture/notification/actions.go
+++ b/test/e2e/fixture/notification/actions.go
@@ -1,8 +1,6 @@
 package notification
 
 import (
-	"time"
-
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 )
 
@@ -23,8 +21,6 @@ func (a *Actions) SetParamInNotificationConfigMap(key, value string) *Actions {
 
 func (a *Actions) Then() *Consequences {
 	a.context.t.Helper()
-	// in case any settings have changed, pause for 1s, not great, but fine
-	time.Sleep(1 * time.Second)
 	return &Consequences{a.context, a}
 }
 

--- a/test/e2e/fixture/project/context.go
+++ b/test/e2e/fixture/project/context.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"testing"
-	"time"
 
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -63,7 +62,5 @@ func (c *Context) And(block func()) *Context {
 }
 
 func (c *Context) When() *Actions {
-	// in case any settings have changed, pause for 1s, not great, but fine
-	time.Sleep(1 * time.Second)
 	return &Actions{context: c}
 }

--- a/test/e2e/fixture/repos/context.go
+++ b/test/e2e/fixture/repos/context.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"testing"
-	"time"
 
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -55,8 +54,6 @@ func (c *Context) And(block func()) *Context {
 }
 
 func (c *Context) When() *Actions {
-	// in case any settings have changed, pause for 1s, not great, but fine
-	time.Sleep(1 * time.Second)
 	return &Actions{context: c}
 }
 


### PR DESCRIPTION
These sleeps might be unnecessary, remove them and check the e2e tests.

Closes #21007

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
