### PR TITLE
docs: clarify usage of `ref` parameter and `$values` variable with Helm multiple sources

### DIFF
--- a/docs/user-guide/multiple_sources.md
+++ b/docs/user-guide/multiple_sources.md
@@ -70,9 +70,11 @@ spec:
     ref: values
 ```
 
-In the above example, the `prometheus` chart will use the value file from `git.example.gom/org/value-files.git`. 
-`$values` resolves to the root of the `value-files` repository. The `$values` variable may only be specified at the 
-beginning of the value file path.
+In the above example, the `prometheus` chart will use the value file from `git.example.com/org/value-files.git`. 
+For Argo to reference the external Git repository containing the value files, you must set the `ref` parameter on
+the repository. In the above example, the parameter `ref: values` maps to the variable `$values`, which resolves
+to the root of the `value-files` repository. 
+Note that the `$values` variable can only be used at the beginning of the value file path.
 
 If the `path` field is set in the `$values` source, Argo CD will attempt to generate resources from the git repository
 at that URL. If the `path` field is not set, Argo CD will use the repository solely as a source of value files.


### PR DESCRIPTION
minor update to wording around the use of `ref` when using multiple repos for helm values. Given the ambiguity of the term `ref` in the context of git repos generally, the additional clarity should help new users.