### PR TITLE
docs(ingress): use GRPC instead of HTTP2 for AWS

### DIFF
--- a/docs/operator-manual/ingress.md
+++ b/docs/operator-manual/ingress.md
@@ -415,7 +415,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    alb.ingress.kubernetes.io/backend-protocol-version: HTTP2 #This tells AWS to send traffic from the ALB using HTTP2. Can use GRPC as well if you want to leverage GRPC specific features
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC # This tells AWS to send traffic from the ALB using GRPC. Plain HTTP2 can be used, but the health checks wont be available because argo currently downgrade non-grpc calls to HTTP1
   labels:
     app: argogrpc
   name: argogrpc
@@ -454,7 +454,7 @@ Once we create this service, we can configure the Ingress to conditionally route
         - path: /
           backend:
             service:
-              name: argogrpc
+              name: argogrpc # The grpc service must be placed before the argocd-server for the listening rules to be created in the correct order
               port:
                 number: 443
           pathType: Prefix


### PR DESCRIPTION
Clarify documentation on GRPC ingress with ALB. When HTTP2 is used, the target group will be in a unhealthy state because the HTTP2 health check is downgraded to HTTP1 by argo (Argo-server does not actually support http2, it downgrades everything non-grpc to HTTP1).

When using HTTP2 with [Pod Readiness Gates](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/deploy/pod_readiness_gate/), the pods will never show as "Ready" because the associated target group with the grpc service will never be healthy (due to the invalid health check).

This also matches the default working value in the Helm chart: https://github.com/argoproj/argo-helm/blob/168bc63bd6b65586720ebbcea197dbce123c03f5/charts/argo-cd/values.yaml#L2284-L2288