### PR TITLE
feat(ui): split arrays in yaml to fix ambiguous collapse when array items have nested objects

### DIFF
--- a/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
+++ b/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
@@ -9,6 +9,20 @@ import {MonacoEditor} from '../monaco-editor';
 const jsonMergePatch = require('json-merge-patch');
 require('./yaml-editor.scss');
 
+const formatYamlWithArrays = (input: any): string => {
+    // First, get the basic YAML
+    let yaml = jsYaml.dump(input, {
+        indent: 2,
+        lineWidth: -1,
+        noArrayIndent: false
+    });
+
+    // Add newline after dash for nested objects
+    yaml = yaml.replace(/^(\s*)-\s+(\w+):/gm, '$1-\n$1  $2:');
+
+    return yaml;
+};
+
 export class YamlEditor<T> extends React.Component<
     {
         input: T;
@@ -33,7 +47,7 @@ export class YamlEditor<T> extends React.Component<
 
     public render() {
         const props = this.props;
-        const yaml = props.input ? jsYaml.dump(props.input) : '';
+        const yaml = props.input ? formatYamlWithArrays(props.input) : '';
 
         return (
             <div className='yaml-editor'>

--- a/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
+++ b/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
@@ -18,8 +18,9 @@ const formatYamlWithArrays = (input: any): string => {
     });
 
     // Format nested arrays to improve readability when collapsed
-    //- puts first item on new line, keeps subsequent items inline
-    yaml = yaml.replace(/:(\s*)\n(\s*)-(\s+)(\w+):(\s*)\n(\s*)-/, ':$1\n$2-\n$2  $4:$5\n$6-');
+    yaml = yaml.replace(/(\s+)(-\s*)(\w+):/g, (match, indent, dash, key) => {
+        return `${indent}-${indent}  ${key}:`;
+    });
 
     return yaml;
 };

--- a/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
+++ b/ui/src/app/shared/components/yaml-editor/yaml-editor.tsx
@@ -17,8 +17,9 @@ const formatYamlWithArrays = (input: any): string => {
         noArrayIndent: false
     });
 
-    // Add newline after dash for nested objects
-    yaml = yaml.replace(/^(\s*)-\s+(\w+):/gm, '$1-\n$1  $2:');
+    // Format nested arrays to improve readability when collapsed
+    //- puts first item on new line, keeps subsequent items inline
+    yaml = yaml.replace(/:(\s*)\n(\s*)-(\s+)(\w+):(\s*)\n(\s*)-/, ':$1\n$2-\n$2  $4:$5\n$6-');
 
     return yaml;
 };


### PR DESCRIPTION
Fixes: #20905 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
### Motivation
[see link](https://github.com/argoproj/argo-cd/issues/20905#:~:text=Motivation-,Typically,-the%20first%20item)

### Description of the change
Improve YAML array formatting in the UI to avoid ambiguous collapse behavior. When an array item contains nested objects, the dash (`-`) is now placed on its own line, making it clear which elements can be collapsed independently.
