### PR TITLE
chore: reduce default max payload size in webhooks to 50MB

### DIFF
--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -117,6 +117,7 @@ func (h *WebhookHandler) startWorkerPool(webhookParallelism int) {
 		}()
 	}
 }
+
 func (h *WebhookHandler) HandleEvent(payload interface{}) {
 	gitGenInfo := getGitGeneratorInfo(payload)
 	prGenInfo := getPRGeneratorInfo(payload)

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -117,7 +117,6 @@ func (h *WebhookHandler) startWorkerPool(webhookParallelism int) {
 		}()
 	}
 }
-
 func (h *WebhookHandler) HandleEvent(payload interface{}) {
 	gitGenInfo := getGitGeneratorInfo(payload)
 	prGenInfo := getPRGeneratorInfo(payload)

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -432,7 +432,7 @@ data:
                 name: some-cluster
                 server: https://some-cluster
   # The maximum size of the payload that can be sent to the webhook server.
-  webhook.maxPayloadSizeMB: "1024"
+  webhook.maxPayloadSizeMB: "50"
 
   # application.sync.impersonation.enabled enables application sync to use a custom service account, via impersonation. This allows decoupling sync from control-plane service account.
   application.sync.impersonation.enabled: "false"

--- a/docs/operator-manual/webhook.md
+++ b/docs/operator-manual/webhook.md
@@ -19,7 +19,7 @@ URL configured in the Git provider should use the `/api/webhook` endpoint of you
 (e.g. `https://argocd.example.com/api/webhook`). If you wish to use a shared secret, input an
 arbitrary value in the secret. This value will be used when configuring the webhook in the next step.
 
-To prevent DDoS attacks with unauthenticated webhook events (the `/api/webhook` endpoint currently lacks rate limiting protection), it is recommended to limit the payload size. You can achieve this by configuring the `argocd-cm` ConfigMap with the `webhook.maxPayloadSizeMB` attribute. The default value is 1GB.
+To prevent DDoS attacks with unauthenticated webhook events (the `/api/webhook` endpoint currently lacks rate limiting protection), it is recommended to limit the payload size. You can achieve this by configuring the `argocd-cm` ConfigMap with the `webhook.maxPayloadSizeMB` attribute. The default value is 50MB.
 
 ## Github
 

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -537,8 +537,8 @@ const (
 )
 
 const (
-	// default max webhook payload size is 1GB
-	defaultMaxWebhookPayloadSize = int64(1) * 1024 * 1024 * 1024
+	// default max webhook payload size is 50MB
+	defaultMaxWebhookPayloadSize = int64(50) * 1024 * 1024
 
 	// application sync with impersonation feature is disabled by default.
 	defaultImpersonationEnabledFlag = false

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -60,7 +60,7 @@ type reactorDef struct {
 }
 
 func NewMockHandler(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
-	defaultMaxPayloadSize := int64(1) * 1024 * 1024 * 1024
+	defaultMaxPayloadSize := int64(50) * 1024 * 1024
 	return NewMockHandlerWithPayloadLimit(reactor, applicationNamespaces, defaultMaxPayloadSize, objects...)
 }
 

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -428,7 +428,7 @@ func TestInvalidEvent(t *testing.T) {
 	close(h.queue)
 	h.Wait()
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	expectedLogResult := "Webhook processing failed: The payload is either too large or corrupted. Please check the payload size (must be under 1024 MB) and ensure it is valid JSON"
+	expectedLogResult := "Webhook processing failed: The payload is either too large or corrupted. Please check the payload size (must be under 50 MB) and ensure it is valid JSON"
 	assert.Equal(t, expectedLogResult, hook.LastEntry().Message)
 	assert.Equal(t, expectedLogResult+"\n", w.Body.String())
 	hook.Reset()


### PR DESCRIPTION
During the implementation of [GHSA-jmvp-698c-4x3w](https://github.com/argoproj/argo-cd/security/advisories/GHSA-jmvp-698c-4x3w), we initially set the payload size limit to 1GB by default. However, after further discussion with the SIG-Security group, we decided to reduce this limit to 50MB, as 1GB was still considered too large for a payload size.