### PR TITLE
chore: avoid unnecessary alloc

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -380,7 +380,11 @@ func (projCache *appProjCache) GetAppProject(ctx context.Context) (*appv1.AppPro
 
 // getAppProj gets the AppProject for the given Application app.
 func (ctrl *ApplicationController) getAppProj(app *appv1.Application) (*appv1.AppProject, error) {
-	projCache, _ := ctrl.projByNameCache.LoadOrStore(app.Spec.GetProject(), ctrl.newAppProjCache(app.Spec.GetProject()))
+	projCache, _ := ctrl.projByNameCache.Load(app.Spec.GetProject())
+	if projCache == nil {
+		projCache = ctrl.newAppProjCache(app.Spec.GetProject())
+		ctrl.projByNameCache.Store(app.Spec.GetProject(), projCache)
+	}
 	proj, err := projCache.(*appProjCache).GetAppProject(context.TODO())
 	if err != nil {
 		if apierr.IsNotFound(err) {


### PR DESCRIPTION
`getAppProj` is on a fairly "hot" path (called from informer add/update/delete handlers), so avoiding the unnecessary 64B allocation here would be nice.