### PR TITLE
chore: simplify sync status comparison

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2122,24 +2122,8 @@ func alreadyAttemptedSync(app *appv1.Application, commitSHA string, commitSHAsMS
 	}
 
 	if hasMultipleSources {
-		// Ignore differences in target revision, since we already just verified commitSHAs are equal,
-		// and we do not want to trigger auto-sync due to things like HEAD != master
-		specSources := app.Spec.Sources.DeepCopy()
-		syncSources := app.Status.OperationState.SyncResult.Sources.DeepCopy()
-		for _, source := range specSources {
-			source.TargetRevision = ""
-		}
-		for _, source := range syncSources {
-			source.TargetRevision = ""
-		}
 		return reflect.DeepEqual(app.Spec.Sources, app.Status.OperationState.SyncResult.Sources), app.Status.OperationState.Phase
 	} else {
-		// Ignore differences in target revision, since we already just verified commitSHAs are equal,
-		// and we do not want to trigger auto-sync due to things like HEAD != master
-		specSource := app.Spec.Source.DeepCopy()
-		specSource.TargetRevision = ""
-		syncResSource := app.Status.OperationState.SyncResult.Source.DeepCopy()
-		syncResSource.TargetRevision = ""
 		return reflect.DeepEqual(app.Spec.GetSource(), app.Status.OperationState.SyncResult.Source), app.Status.OperationState.Phase
 	}
 }

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -2097,7 +2097,7 @@ func (ctrl *ApplicationController) autoSync(app *appv1.Application, syncStatus *
 }
 
 // alreadyAttemptedSync returns whether the most recent sync was performed against the
-// commitSHA and with the same app source config which are currently set in the app
+// commitSHA and with the same app source config which are currently set in the app.
 func alreadyAttemptedSync(app *appv1.Application, commitSHA string, commitSHAsMS []string, hasMultipleSources bool, revisionUpdated bool) (bool, synccommon.OperationPhase) {
 	if app.Status.OperationState == nil || app.Status.OperationState.Operation.Sync == nil || app.Status.OperationState.SyncResult == nil {
 		return false, ""

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2430,42 +2430,70 @@ func TestAlreadyAttemptSync(t *testing.T) {
 		assert.False(t, attempted)
 	})
 
-	t.Run("same manifest with sync result", func(t *testing.T) {
-		attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, false)
-		assert.True(t, attempted)
+	t.Run("single source", func(t *testing.T) {
+		t.Run("same manifest with sync result", func(t *testing.T) {
+			attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, false)
+			assert.True(t, attempted)
+		})
+
+		t.Run("same manifest with sync result different targetRevision, same SHA", func(t *testing.T) {
+			// This test represents the case where the user changed a source's target revision to a new branch, but it
+			// points to the same revision as the old branch. We currently do not consider this as having been "already
+			// attempted." In the future we may want to short-circuit the auto-sync in these cases.
+			app := app.DeepCopy()
+			app.Status.OperationState.SyncResult.Source = v1alpha1.ApplicationSource{TargetRevision: "branch1"}
+			app.Spec.Source = &v1alpha1.ApplicationSource{TargetRevision: "branch2"}
+			app.Status.OperationState.SyncResult.Revision = "sha"
+			attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, false)
+			assert.False(t, attempted)
+		})
+
+		t.Run("different manifest with sync result, different SHA", func(t *testing.T) {
+			app := app.DeepCopy()
+			app.Status.OperationState.SyncResult.Revision = "sha1"
+			attempted, _ := alreadyAttemptedSync(app, "sha2", []string{}, false, true)
+			assert.False(t, attempted)
+		})
+
+		t.Run("different manifest with sync result, same SHA", func(t *testing.T) {
+			app := app.DeepCopy()
+			app.Status.OperationState.SyncResult.Revision = "sha"
+			attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, true)
+			assert.True(t, attempted)
+		})
 	})
 
-	t.Run("different manifest with sync result, different SHA", func(t *testing.T) {
-		app := app.DeepCopy()
-		app.Status.OperationState.SyncResult.Revision = "sha1"
-		attempted, _ := alreadyAttemptedSync(app, "sha2", []string{}, false, true)
-		assert.False(t, attempted)
-	})
+	t.Run("multi-source", func(t *testing.T) {
+		t.Run("same manifest with sync result", func(t *testing.T) {
+			attempted, _ := alreadyAttemptedSync(app, "", []string{"sha"}, true, false)
+			assert.True(t, attempted)
+		})
 
-	t.Run("different manifest with sync result, same SHA", func(t *testing.T) {
-		app := app.DeepCopy()
-		app.Status.OperationState.SyncResult.Revision = "sha"
-		attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, true)
-		assert.True(t, attempted)
-	})
+		t.Run("same manifest with sync result, different targetRevision, same SHA", func(t *testing.T) {
+			// This test represents the case where the user changed a source's target revision to a new branch, but it
+			// points to the same revision as the old branch. We currently do not consider this as having been "already
+			// attempted." In the future we may want to short-circuit the auto-sync in these cases.
+			app := app.DeepCopy()
+			app.Status.OperationState.SyncResult.Sources = []v1alpha1.ApplicationSource{{TargetRevision: "branch1"}}
+			app.Spec.Sources = []v1alpha1.ApplicationSource{{TargetRevision: "branch2"}}
+			app.Status.OperationState.SyncResult.Revisions = []string{"sha"}
+			attempted, _ := alreadyAttemptedSync(app, "", []string{"sha"}, true, false)
+			assert.False(t, attempted)
+		})
 
-	t.Run("same manifest with sync result", func(t *testing.T) {
-		attempted, _ := alreadyAttemptedSync(app, "", []string{"sha"}, true, false)
-		assert.True(t, attempted)
-	})
+		t.Run("different manifest with sync result, different SHAs", func(t *testing.T) {
+			app := app.DeepCopy()
+			app.Status.OperationState.SyncResult.Revisions = []string{"sha_a_=", "sha_b_1"}
+			attempted, _ := alreadyAttemptedSync(app, "", []string{"sha_a_2", "sha_b_2"}, true, true)
+			assert.False(t, attempted)
+		})
 
-	t.Run("different manifest with sync result, different SHAs", func(t *testing.T) {
-		app := app.DeepCopy()
-		app.Status.OperationState.SyncResult.Revisions = []string{"sha_a_=", "sha_b_1"}
-		attempted, _ := alreadyAttemptedSync(app, "", []string{"sha_a_2", "sha_b_2"}, true, true)
-		assert.False(t, attempted)
-	})
-
-	t.Run("different manifest with sync result, same SHAs", func(t *testing.T) {
-		app := app.DeepCopy()
-		app.Status.OperationState.SyncResult.Revisions = []string{"sha_a", "sha_b"}
-		attempted, _ := alreadyAttemptedSync(app, "", []string{"sha_a", "sha_b"}, true, true)
-		assert.True(t, attempted)
+		t.Run("different manifest with sync result, same SHAs", func(t *testing.T) {
+			app := app.DeepCopy()
+			app.Status.OperationState.SyncResult.Revisions = []string{"sha_a", "sha_b"}
+			attempted, _ := alreadyAttemptedSync(app, "", []string{"sha_a", "sha_b"}, true, true)
+			assert.True(t, attempted)
+		})
 	})
 }
 

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -2408,14 +2408,64 @@ func TestAppStatusIsReplaced(t *testing.T) {
 
 func TestAlreadyAttemptSync(t *testing.T) {
 	app := newFakeApp()
+
+	t.Run("no operation state", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.OperationState = nil
+		attempted, _ := alreadyAttemptedSync(app, "", []string{}, false, false)
+		assert.False(t, attempted)
+	})
+
+	t.Run("no sync operation", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.OperationState.Operation.Sync = nil
+		attempted, _ := alreadyAttemptedSync(app, "", []string{}, false, false)
+		assert.False(t, attempted)
+	})
+
+	t.Run("no sync result", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.OperationState.SyncResult = nil
+		attempted, _ := alreadyAttemptedSync(app, "", []string{}, false, false)
+		assert.False(t, attempted)
+	})
+
 	t.Run("same manifest with sync result", func(t *testing.T) {
 		attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, false)
 		assert.True(t, attempted)
 	})
 
-	t.Run("different manifest with sync result", func(t *testing.T) {
-		attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, true)
+	t.Run("different manifest with sync result, different SHA", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.OperationState.SyncResult.Revision = "sha1"
+		attempted, _ := alreadyAttemptedSync(app, "sha2", []string{}, false, true)
 		assert.False(t, attempted)
+	})
+
+	t.Run("different manifest with sync result, same SHA", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.OperationState.SyncResult.Revision = "sha"
+		attempted, _ := alreadyAttemptedSync(app, "sha", []string{}, false, true)
+		assert.True(t, attempted)
+	})
+
+	t.Run("same manifest with sync result", func(t *testing.T) {
+		attempted, _ := alreadyAttemptedSync(app, "", []string{"sha"}, true, false)
+		assert.True(t, attempted)
+	})
+
+	t.Run("different manifest with sync result, different SHAs", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.OperationState.SyncResult.Revisions = []string{"sha_a_=", "sha_b_1"}
+		attempted, _ := alreadyAttemptedSync(app, "", []string{"sha_a_2", "sha_b_2"}, true, true)
+		assert.False(t, attempted)
+	})
+
+	t.Run("different manifest with sync result, same SHAs", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.OperationState.SyncResult.Revisions = []string{"sha_a", "sha_b"}
+		attempted, _ := alreadyAttemptedSync(app, "", []string{"sha_a", "sha_b"}, true, true)
+		assert.True(t, attempted)
 	})
 }
 

--- a/reposerver/apiclient/repository.pb.go
+++ b/reposerver/apiclient/repository.pb.go
@@ -2371,6 +2371,9 @@ func (m *UpdateRevisionForPathsRequest) GetInstallationID() string {
 }
 
 type UpdateRevisionForPathsResponse struct {
+	// Changes indicates whether any changes were detected in the provided paths. If false, it means that the manifest
+	// cache was updated to the new revision. If true, it means that there are relevant changes in the repo files and
+	// that new manifests should be generated.
 	Changes              bool     `protobuf:"varint,1,opt,name=changes,proto3" json:"changes,omitempty"`
 	Revision             string   `protobuf:"bytes,2,opt,name=revision,proto3" json:"revision,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/reposerver/repository/repository.proto
+++ b/reposerver/repository/repository.proto
@@ -289,6 +289,9 @@ message UpdateRevisionForPathsRequest {
 }
 
 message UpdateRevisionForPathsResponse {
+    // Changes indicates whether any changes were detected in the provided paths. If false, it means that the manifest
+    // cache was updated to the new revision. If true, it means that there are relevant changes in the repo files and
+    // that new manifests should be generated.
     bool changes = 1;
     string revision = 2;
 }


### PR DESCRIPTION
The variables we initialize from the deep copies and then mutate are never used again. I don't think this code does anything.

I also don't think it did anything [when it was first written](https://github.com/argoproj/argo-cd/commit/cc7b283f23d97f1a93521cfa212733ae45300f27#diff-f952d05ea83b61f771541425e28fa3931af2f2e7950261dd59cab93bdcfe2e9eR821).

As long as tests pass, and no one else spots something I'm missing, I think we can safely remove these lines. 