### PR TITLE
fix(appset): Reconcile appset only once when appset is refreshed (#21171)

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -538,8 +538,14 @@ func ignoreNotAllowedNamespaces(namespaces []string) predicate.Predicate {
 func ignoreWhenAnnotationApplicationSetRefreshIsRemoved() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldAppset, _ := e.ObjectOld.(*argov1alpha1.ApplicationSet)
-			newAppset, _ := e.ObjectNew.(*argov1alpha1.ApplicationSet)
+			oldAppset, isAppSet := e.ObjectOld.(*argov1alpha1.ApplicationSet)
+			if !isAppSet {
+				return false
+			}
+			newAppset, isAppSet := e.ObjectNew.(*argov1alpha1.ApplicationSet)
+			if !isAppSet {
+				return false
+			}
 
 			_, oldHasRefreshAnnotation := oldAppset.Annotations[common.AnnotationApplicationSetRefresh]
 			_, newHasRefreshAnnotation := newAppset.Annotations[common.AnnotationApplicationSetRefresh]

--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -577,10 +577,9 @@ func (r *ApplicationSetReconciler) SetupWithManager(mgr ctrl.Manager, enableProg
 
 	return ctrl.NewControllerManagedBy(mgr).WithOptions(controller.Options{
 		MaxConcurrentReconciles: maxConcurrentReconciliations,
-	}).For(&argov1alpha1.ApplicationSet{}).
+	}).For(&argov1alpha1.ApplicationSet{}, builder.WithPredicates(ignoreWhenAnnotationApplicationSetRefreshIsRemoved())).
 		Owns(&argov1alpha1.Application{}, builder.WithPredicates(ownsHandler)).
 		WithEventFilter(ignoreNotAllowedNamespaces(r.ApplicationSetNamespaces)).
-		WithEventFilter(ignoreWhenAnnotationApplicationSetRefreshIsRemoved()).
 		Watches(
 			&corev1.Secret{},
 			&clusterSecretEventHandler{

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -6667,8 +6667,8 @@ func TestIgnoreWhenAnnotationApplicationSetRefreshIsRemoved(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		oldAppSet         *v1alpha1.ApplicationSet
-		newAppSet         *v1alpha1.ApplicationSet
+		oldAppSet         crtclient.Object
+		newAppSet         crtclient.Object
 		reconcileExpected bool
 	}{
 		{
@@ -6702,6 +6702,18 @@ func TestIgnoreWhenAnnotationApplicationSetRefreshIsRemoved(t *testing.T) {
 				argocommon.AnnotationApplicationSetRefresh: "true",
 			}),
 			reconcileExpected: true,
+		},
+		{
+			name:              "old object is not an appset",
+			oldAppSet:         &v1alpha1.Application{},
+			newAppSet:         buildAppSet(map[string]string{}),
+			reconcileExpected: false,
+		},
+		{
+			name:              "new object is not an appset",
+			oldAppSet:         buildAppSet(map[string]string{}),
+			newAppSet:         &v1alpha1.Application{},
+			reconcileExpected: false,
 		},
 	}
 

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -674,7 +674,7 @@ func TestCreateOrUpdateInCluster(t *testing.T) {
 					},
 					Spec: v1alpha1.ApplicationSpec{
 						Project: "project",
-						Source: &v1alpha1.ApplicationSource{
+						Source:  &v1alpha1.ApplicationSource{
 							// Directory and jsonnet block are removed
 						},
 					},


### PR DESCRIPTION
Fixes #21171 

Currently, when webhook wants to refresh an appset, it's done by setting this annotation :  **argocd.argoproj.io/application-set-refresh** via  [refreshApplicationSet](https://github.com/argoproj/argo-cd/blob/master/applicationset/webhook/webhook.go#L149) method. 

After that, appset controller enter the reconcile loop because he receives a change on Kubernetes object,
after processing the appset, the controller removes the annotation, which has the consequence to enter again in reconcile loop (because Kubernetes object is updated a second time).

In current PR, we implement an `EventFilter` to not requeue the second appset change, based on logic :
` if oldAppSet has refreshAnnotation and newAppSet do not have refreshAnnotation also do not requeue`.


Signed-off-by: Philippe Da Costa <pdacosta@gmail.com>

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
