### PR TITLE
fix(api): send to closed channel in mergeLogStreams (#7006)

### DIFF
--- a/server/application/logs_test.go
+++ b/server/application/logs_test.go
@@ -96,9 +96,12 @@ func TestMergeLogStreams_RaceCondition(t *testing.T) {
 
 		merged := mergeLogStreams([]chan logEntry{first, second}, 1*time.Millisecond)
 
-		var lines []string
-		for entry := range merged {
-			lines = append(lines, entry.line)
+		// Drain the channel
+		for range merged {
 		}
+
+		// This test intentionally doesn't test the order of the output. Under these intense conditions, the test would
+		// fail often due to out of order entries. This test is only meant to reproduce a race between a channel writer
+		// and channel closer.
 	}
 }

--- a/server/application/logs_test.go
+++ b/server/application/logs_test.go
@@ -78,23 +78,23 @@ func TestMergeLogStreams(t *testing.T) {
 
 func TestMergeLogStreams_RaceCondition(t *testing.T) {
 	// Test for regression of this issue: https://github.com/argoproj/argo-cd/issues/7006
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		first := make(chan logEntry)
 		second := make(chan logEntry)
 
 		go func() {
 			parseLogsStream("first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1`)), first)
-			time.Sleep(time.Duration(i%5) * time.Millisecond)
+			time.Sleep(time.Duration(i%10) * time.Millisecond)
 			close(first)
 		}()
 
 		go func() {
 			parseLogsStream("second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2`)), second)
-			time.Sleep(time.Duration((i+2)%5) * time.Millisecond)
+			time.Sleep(time.Duration((i+5)%10) * time.Millisecond)
 			close(second)
 		}()
 
-		merged := mergeLogStreams([]chan logEntry{first, second}, 1*time.Millisecond)
+		merged := mergeLogStreams([]chan logEntry{first, second}, 5*time.Millisecond)
 
 		var lines []string
 		for entry := range merged {

--- a/server/application/logs_test.go
+++ b/server/application/logs_test.go
@@ -78,30 +78,27 @@ func TestMergeLogStreams(t *testing.T) {
 
 func TestMergeLogStreams_RaceCondition(t *testing.T) {
 	// Test for regression of this issue: https://github.com/argoproj/argo-cd/issues/7006
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 5000; i++ {
 		first := make(chan logEntry)
 		second := make(chan logEntry)
 
 		go func() {
 			parseLogsStream("first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1`)), first)
-			time.Sleep(time.Duration(i%10) * time.Millisecond)
+			time.Sleep(time.Duration(i%3) * time.Millisecond) // Reduce the variability in timing
 			close(first)
 		}()
 
 		go func() {
 			parseLogsStream("second", io.NopCloser(strings.NewReader(`2021-02-09T00:00:02Z 2`)), second)
-			time.Sleep(time.Duration((i+5)%10) * time.Millisecond)
+			time.Sleep(time.Duration((i+1)%3) * time.Millisecond)
 			close(second)
 		}()
 
-		merged := mergeLogStreams([]chan logEntry{first, second}, 5*time.Millisecond)
+		merged := mergeLogStreams([]chan logEntry{first, second}, 1*time.Millisecond)
 
 		var lines []string
 		for entry := range merged {
 			lines = append(lines, entry.line)
 		}
-
-		expected := []string{"1", "2"}
-		assert.Equal(t, expected, lines)
 	}
 }

--- a/server/application/logs_test.go
+++ b/server/application/logs_test.go
@@ -84,7 +84,7 @@ func TestMergeLogStreams_RaceCondition(t *testing.T) {
 
 		go func() {
 			parseLogsStream("first", io.NopCloser(strings.NewReader(`2021-02-09T00:00:01Z 1`)), first)
-			time.Sleep(time.Duration(i%3) * time.Millisecond) // Reduce the variability in timing
+			time.Sleep(time.Duration(i%3) * time.Millisecond)
 			close(first)
 		}()
 


### PR DESCRIPTION
Fixes #7006

The test reproduces the issue in GitHub.