### PR TITLE
chore: remove unused defaults from image workflow

### DIFF
--- a/.github/workflows/image-reuse.yaml
+++ b/.github/workflows/image-reuse.yaml
@@ -17,11 +17,9 @@ on:
       platforms:
         required: true
         type: string
-        default: linux/amd64
       push:
         required: true
         type: boolean
-        default: false
       target:
         required: false
         type: string


### PR DESCRIPTION
Ran an action linter on a whim and realized these two inputs specify defaults even though they're required inputs. So the defaults never actually get used.