### PR TITLE
chore: use new fake k8s client constructor

### DIFF
--- a/cmd/argocd/commands/admin/app_test.go
+++ b/cmd/argocd/commands/admin/app_test.go
@@ -91,7 +91,7 @@ func TestGetReconcileResults_Refresh(t *testing.T) {
 
 	appClientset := appfake.NewSimpleClientset(app, proj)
 	deployment := test.NewDeployment()
-	kubeClientset := kubefake.NewSimpleClientset(deployment, &cm)
+	kubeClientset := kubefake.NewClientset(deployment, &cm)
 	clusterCache := clustermocks.ClusterCache{}
 	clusterCache.On("IsNamespaced", mock.Anything).Return(true, nil)
 	clusterCache.On("GetGVKParser", mock.Anything).Return(nil)

--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -617,7 +617,7 @@ func NewGenClusterConfigCommand(pathOpts *clientcmd.PathOptions) *cobra.Command 
 			clientConfig := clientcmd.NewDefaultClientConfig(*cfgAccess, &overrides)
 			conf, err := clientConfig.ClientConfig()
 			errors.CheckError(err)
-			kubeClientset := fake.NewSimpleClientset()
+			kubeClientset := fake.NewClientset()
 
 			var awsAuthConf *v1alpha1.AWSAuthConfig
 			var execProviderConf *v1alpha1.ExecProviderConfig

--- a/cmd/argocd/commands/admin/repo.go
+++ b/cmd/argocd/commands/admin/repo.go
@@ -150,7 +150,7 @@ func NewGenRepoSpecCommand() *cobra.Command {
 					},
 				},
 			}
-			kubeClientset := fake.NewSimpleClientset(argoCDCM)
+			kubeClientset := fake.NewClientset(argoCDCM)
 			settingsMgr := settings.NewSettingsManager(ctx, kubeClientset, ArgoCDNamespace)
 			argoDB := db.NewDB(ArgoCDNamespace, settingsMgr, kubeClientset)
 

--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -119,7 +119,7 @@ func (opts *settingsOpts) createSettingsManager(ctx context.Context) (*settings.
 		}
 	}
 	setSettingsMeta(argocdSecret)
-	clientset := fake.NewSimpleClientset(argocdSecret, argocdCM)
+	clientset := fake.NewClientset(argocdSecret, argocdCM)
 
 	manager := settings.NewSettingsManager(ctx, clientset, "default")
 	errors.CheckError(manager.ResyncInformers())

--- a/cmd/argocd/commands/admin/settings_rbac_test.go
+++ b/cmd/argocd/commands/admin/settings_rbac_test.go
@@ -147,7 +147,7 @@ func Test_PolicyFromK8s(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, err)
-	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-rbac-cm",
 			Namespace: "argocd",
@@ -280,7 +280,7 @@ p, role:user, logs, get, .*/.*, allow
 p, role:user, exec, create, .*/.*, allow
 `
 
-	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-rbac-cm",
 			Namespace: "argocd",

--- a/cmd/argocd/commands/admin/settings_test.go
+++ b/cmd/argocd/commands/admin/settings_test.go
@@ -45,7 +45,7 @@ func captureStdout(callback func()) (string, error) {
 func newSettingsManager(data map[string]string) *settings.SettingsManager {
 	ctx := context.Background()
 
-	clientset := fake.NewSimpleClientset(&v1.ConfigMap{
+	clientset := fake.NewClientset(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      common.ArgoCDConfigMapName,

--- a/cmd/util/cluster_test.go
+++ b/cmd/util/cluster_test.go
@@ -162,7 +162,7 @@ func TestGetKubePublicEndpoint(t *testing.T) {
 			if tc.clusterInfo != nil {
 				objects = append(objects, tc.clusterInfo)
 			}
-			clientset := fake.NewSimpleClientset(objects...)
+			clientset := fake.NewClientset(objects...)
 			endpoint, err := GetKubePublicEndpoint(clientset)
 			if tc.expectError {
 				require.Error(t, err)

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -92,7 +92,7 @@ func TestSetOptionalRedisPasswordFromKubeConfig(t *testing.T) {
 			t.Parallel()
 			var (
 				ctx          = context.TODO()
-				kubeClient   = kubefake.NewSimpleClientset()
+				kubeClient   = kubefake.NewClientset()
 				redisOptions = &redis.Options{}
 			)
 			if tc.secret != nil {

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -148,7 +148,7 @@ func newFakeControllerWithResync(data *fakeData, appResyncPeriod time.Duration, 
 	}
 	runtimeObjs := []runtime.Object{&clust, &secret, &cm}
 	runtimeObjs = append(runtimeObjs, data.additionalObjs...)
-	kubeClient := fake.NewSimpleClientset(runtimeObjs...)
+	kubeClient := fake.NewClientset(runtimeObjs...)
 	settingsMgr := settings.NewSettingsManager(context.Background(), kubeClient, test.FakeArgoCDNamespace)
 	kubectl := &MockKubectl{Kubectl: &kubetest.MockKubectlCmd{}}
 	ctrl, err := NewApplicationController(

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -140,7 +140,7 @@ func TestHandleDeleteEvent_CacheDeadlock(t *testing.T) {
 	}
 	db := &dbmocks.ArgoDB{}
 	db.On("GetApplicationControllerReplicas").Return(1)
-	fakeClient := fake.NewSimpleClientset()
+	fakeClient := fake.NewClientset()
 	settingsMgr := argosettings.NewSettingsManager(context.TODO(), fakeClient, "argocd")
 	liveStateCacheLock := sync.RWMutex{}
 	gitopsEngineClusterCache := &mocks.ClusterCache{}

--- a/controller/clusterinfoupdater_test.go
+++ b/controller/clusterinfoupdater_test.go
@@ -67,7 +67,7 @@ func TestClusterSecretUpdater(t *testing.T) {
 			"server.secretkey": nil,
 		},
 	}
-	kubeclientset := fake.NewSimpleClientset(emptyArgoCDConfigMap, argoCDSecret)
+	kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecret)
 	appclientset := appsfake.NewSimpleClientset()
 	appInformer := appinformers.NewApplicationInformer(appclientset, "", time.Minute, cache.Indexers{})
 	settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)

--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -63,7 +63,7 @@ func newTestAccountServerExt(ctx context.Context, enforceFn rbac.ClaimsEnforcerF
 	for i := range opts {
 		opts[i](cm, secret)
 	}
-	kubeclientset := fake.NewSimpleClientset(cm, secret)
+	kubeclientset := fake.NewClientset(cm, secret)
 	settingsMgr := settings.NewSettingsManager(ctx, kubeclientset, testNamespace)
 	sessionMgr := sessionutil.NewSessionManager(settingsMgr, test.NewFakeProjLister(), "", nil, sessionutil.NewUserStateStorage(nil))
 	enforcer := rbac.NewEnforcer(kubeclientset, testNamespace, common.ArgoCDRBACConfigMapName, nil)

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -141,7 +141,7 @@ func newTestAppServer(t *testing.T, objects ...runtime.Object) *Server {
 
 func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer), additionalConfig map[string]string, objects ...runtime.Object) *Server {
 	t.Helper()
-	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
@@ -327,7 +327,7 @@ func newTestAppServerWithBenchmark(b *testing.B, objects ...runtime.Object) *Ser
 
 func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rbac.Enforcer), objects ...runtime.Object) *Server {
 	b.Helper()
-	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",

--- a/server/application/websocket_test.go
+++ b/server/application/websocket_test.go
@@ -34,7 +34,7 @@ func newTestTerminalSession(w http.ResponseWriter, r *http.Request) terminalSess
 
 func newEnforcer() *rbac.Enforcer {
 	additionalConfig := make(map[string]string, 0)
-	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",

--- a/server/applicationset/applicationset_test.go
+++ b/server/applicationset/applicationset_test.go
@@ -72,7 +72,7 @@ func newTestNamespacedAppSetServer(objects ...runtime.Object) *Server {
 }
 
 func newTestAppSetServerWithEnforcerConfigure(f func(*rbac.Enforcer), namespace string, objects ...runtime.Object) *Server {
-	kubeclientset := fake.NewSimpleClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -100,7 +100,7 @@ func testProject() *v1alpha1.AppProject {
 }
 
 func TestHandlerFeatureIsEnabled(t *testing.T) {
-	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(testApp()), settingsMgr, "default", []string{})
 	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app", nil)
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
 		argoCDCm.ObjectMeta.Namespace = tt.namespace
 		argoCDSecret.ObjectMeta.Namespace = tt.namespace
 
-		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm, argoCDSecret), tt.namespace)
+		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm, argoCDSecret), tt.namespace)
 		objects := []runtime.Object{testProject()}
 		for _, v := range tt.testApp {
 			objects = append(objects, v)
@@ -225,7 +225,7 @@ func TestHandlerFeatureProjectIsEnabled(t *testing.T) {
 
 func TestHandlerNamespacesIsEnabled(t *testing.T) {
 	t.Run("Application in allowed namespace", func(t *testing.T) {
-		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 		handler := NewHandler(appclientset.NewSimpleClientset(testApp2()), settingsMgr, "default", []string{"argocd-test"})
 		req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&namespace=argocd-test", nil)
 		require.NoError(t, err)
@@ -246,7 +246,7 @@ func TestHandlerNamespacesIsEnabled(t *testing.T) {
 	})
 
 	t.Run("Application in disallowed namespace", func(t *testing.T) {
-		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 		handler := NewHandler(appclientset.NewSimpleClientset(testApp2()), settingsMgr, "default", []string{"argocd-test"})
 		req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&namespace=kube-system", nil)
 		require.NoError(t, err)
@@ -263,7 +263,7 @@ func TestHandlerNamespacesIsEnabled(t *testing.T) {
 	})
 
 	t.Run("Request with illegal namespace", func(t *testing.T) {
-		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+		settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 		handler := NewHandler(appclientset.NewSimpleClientset(testApp2()), settingsMgr, "default", []string{"argocd-test"})
 		req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&namespace=kube()system", nil)
 		require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestHandlerNamespacesIsEnabled(t *testing.T) {
 }
 
 func TestHandlerFeatureIsEnabledKeepFullRevisionIsEnabled(t *testing.T) {
-	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(testApp3()), settingsMgr, "argocd-test", []string{""})
 	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&revision=true&keepFullRevision=true", nil)
 	require.NoError(t, err)
@@ -297,7 +297,7 @@ func TestHandlerFeatureIsEnabledKeepFullRevisionIsEnabled(t *testing.T) {
 }
 
 func TestHandlerFeatureIsEnabledKeepFullRevisionIsDisabled(t *testing.T) {
-	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(testApp3()), settingsMgr, "argocd-test", []string{})
 	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&revision=true&keepFullRevision=false", nil)
 	require.NoError(t, err)
@@ -318,7 +318,7 @@ func TestHandlerFeatureIsEnabledKeepFullRevisionIsDisabled(t *testing.T) {
 }
 
 func TestHandlerFeatureIsEnabledKeepFullRevisionAndWidthIsEnabled(t *testing.T) {
-	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(testApp3()), settingsMgr, "argocd-test", []string{""})
 	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&revision=true&keepFullRevision=true&width=500", nil)
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func createApplicationsWithName(appCombo, projectName []string, namespace string
 }
 
 func TestHandlerFeatureIsEnabledRevisionIsEnabled(t *testing.T) {
-	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(testApp()), settingsMgr, "default", []string{})
 	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&revision=true", nil)
 	require.NoError(t, err)
@@ -416,7 +416,7 @@ func TestHandlerRevisionIsEnabledNoOperationState(t *testing.T) {
 	app := testApp()
 	app.Status.OperationState = nil
 
-	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(app), settingsMgr, "default", []string{})
 	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&revision=true", nil)
 	require.NoError(t, err)
@@ -440,7 +440,7 @@ func TestHandlerRevisionIsEnabledShortCommitSHA(t *testing.T) {
 	app := testApp()
 	app.Status.OperationState.SyncResult.Revision = "abc"
 
-	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewSimpleClientset(argoCDCm(), argoCDSecret()), "default")
+	settingsMgr := settings.NewSettingsManager(context.Background(), fake.NewClientset(argoCDCm(), argoCDSecret()), "default")
 	handler := NewHandler(appclientset.NewSimpleClientset(app), settingsMgr, "default", []string{})
 	req, err := http.NewRequest(http.MethodGet, "/api/badge?name=test-app&revision=true", nil)
 	require.NoError(t, err)

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -120,13 +120,13 @@ func newServerInMemoryCache() *servercache.Cache {
 }
 
 func newNoopEnforcer() *rbac.Enforcer {
-	enf := rbac.NewEnforcer(fake.NewSimpleClientset(test.NewFakeConfigMap()), test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
+	enf := rbac.NewEnforcer(fake.NewClientset(test.NewFakeConfigMap()), test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableEnforce(false)
 	return enf
 }
 
 func newEnforcer() *rbac.Enforcer {
-	enforcer := rbac.NewEnforcer(fake.NewSimpleClientset(test.NewFakeConfigMap()), test.FakeArgoCDNamespace, common.ArgoCDRBACConfigMapName, nil)
+	enforcer := rbac.NewEnforcer(fake.NewClientset(test.NewFakeConfigMap()), test.FakeArgoCDNamespace, common.ArgoCDRBACConfigMapName, nil)
 	_ = enforcer.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
 	enforcer.SetDefaultRole("role:test")
 	enforcer.SetClaimsEnforcerFunc(func(claims jwt.Claims, rvals ...interface{}) bool {
@@ -229,7 +229,7 @@ func TestUpdateCluster_RejectInvalidParams(t *testing.T) {
 		},
 	)
 
-	enf := rbac.NewEnforcer(fake.NewSimpleClientset(test.NewFakeConfigMap()), test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
+	enf := rbac.NewEnforcer(fake.NewClientset(test.NewFakeConfigMap()), test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	_ = enf.SetBuiltinPolicy(`p, role:test, clusters, *, https://127.0.0.1, allow
 p, role:test, clusters, *, allowed-project/*, allow`)
 	enf.SetDefaultRole("role:test")
@@ -606,7 +606,7 @@ func getClientset(config map[string]string, ns string, objects ...runtime.Object
 		},
 		Data: config,
 	}
-	return fake.NewSimpleClientset(append(objects, &cm, &secret)...)
+	return fake.NewClientset(append(objects, &cm, &secret)...)
 }
 
 func TestListCluster(t *testing.T) {

--- a/server/logout/logout_test.go
+++ b/server/logout/logout_test.go
@@ -87,7 +87,7 @@ func TestConstructLogoutURL(t *testing.T) {
 }
 
 func TestHandlerConstructLogoutURL(t *testing.T) {
-	kubeClientWithOIDCConfig := fake.NewSimpleClientset(
+	kubeClientWithOIDCConfig := fake.NewClientset(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
@@ -119,7 +119,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 			},
 		},
 	)
-	kubeClientWithOIDCConfigButNoURL := fake.NewSimpleClientset(
+	kubeClientWithOIDCConfigButNoURL := fake.NewClientset(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
@@ -151,7 +151,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 			},
 		},
 	)
-	kubeClientWithOIDCConfigButNoLogoutURL := fake.NewSimpleClientset(
+	kubeClientWithOIDCConfigButNoLogoutURL := fake.NewClientset(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
@@ -182,7 +182,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 			},
 		},
 	)
-	kubeClientWithoutOIDCAndMultipleURLs := fake.NewSimpleClientset(
+	kubeClientWithoutOIDCAndMultipleURLs := fake.NewClientset(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
@@ -210,7 +210,7 @@ func TestHandlerConstructLogoutURL(t *testing.T) {
 			},
 		},
 	)
-	kubeClientWithoutOIDCConfig := fake.NewSimpleClientset(
+	kubeClientWithoutOIDCConfig := fake.NewClientset(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,

--- a/server/notification/notification_test.go
+++ b/server/notification/notification_test.go
@@ -35,7 +35,7 @@ func TestNotificationServer(t *testing.T) {
 	require.NoError(t, err)
 	cm.Namespace = testNamespace
 
-	kubeclientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-notifications-cm",

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -38,10 +38,10 @@ import (
 
 const testNamespace = "default"
 
-var testEnableEventList []string = argo.DefaultEnableEventList()
+var testEnableEventList = argo.DefaultEnableEventList()
 
 func TestProjectServer(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
@@ -94,7 +94,7 @@ func TestProjectServer(t *testing.T) {
 		role1 := v1alpha1.ProjectRole{Name: roleName, JWTTokens: []v1alpha1.JWTToken{{IssuedAt: 1}}}
 		projectWithRole.Spec.Roles = append(projectWithRole.Spec.Roles, role1)
 		argoDB := db.NewDB("default", settingsMgr, kubeclientset)
-		projectServer := NewServer("default", fake.NewSimpleClientset(), apps.NewSimpleClientset(projectWithRole), enforcer, sync.NewKeyLock(), sessionMgr, nil, projInformer, settingsMgr, argoDB, testEnableEventList)
+		projectServer := NewServer("default", fake.NewClientset(), apps.NewSimpleClientset(projectWithRole), enforcer, sync.NewKeyLock(), sessionMgr, nil, projInformer, settingsMgr, argoDB, testEnableEventList)
 		err := projectServer.NormalizeProjs()
 		require.NoError(t, err)
 

--- a/server/rbacpolicy/rbacpolicy_test.go
+++ b/server/rbacpolicy/rbacpolicy_test.go
@@ -49,7 +49,7 @@ func newFakeProj() *argoappv1.AppProject {
 }
 
 func TestEnforceAllPolicies(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(test.NewFakeConfigMap())
+	kubeclientset := fake.NewClientset(test.NewFakeConfigMap())
 	projLister := test.NewFakeProjLister(newFakeProj())
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableLog(true)
@@ -90,7 +90,7 @@ func TestEnforceAllPolicies(t *testing.T) {
 }
 
 func TestEnforceActionActions(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(test.NewFakeConfigMap())
+	kubeclientset := fake.NewClientset(test.NewFakeConfigMap())
 	projLister := test.NewFakeProjLister(newFakeProj())
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableLog(true)
@@ -123,7 +123,7 @@ p, cam, applications, %s/argoproj.io/Rollout/resume, my-proj/*, allow
 }
 
 func TestInvalidatedCache(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(test.NewFakeConfigMap())
+	kubeclientset := fake.NewClientset(test.NewFakeConfigMap())
 	projLister := test.NewFakeProjLister(newFakeProj())
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	enf.EnableLog(true)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -56,7 +56,7 @@ func fakeServer(t *testing.T) (*FakeArgoCDServer, func()) {
 	t.Helper()
 	cm := test.NewFakeConfigMap()
 	secret := test.NewFakeSecret()
-	kubeclientset := fake.NewSimpleClientset(cm, secret)
+	kubeclientset := fake.NewClientset(cm, secret)
 	appClientSet := apps.NewSimpleClientset()
 	redis, closer := test.NewInMemoryRedis()
 	mockRepoClient := &mocks.Clientset{RepoServerServiceClient: &mocks.RepoServerServiceClient{}}
@@ -125,7 +125,7 @@ func TestEnforceProjectToken(t *testing.T) {
 	}
 	cm := test.NewFakeConfigMap()
 	secret := test.NewFakeSecret()
-	kubeclientset := fake.NewSimpleClientset(cm, secret)
+	kubeclientset := fake.NewClientset(cm, secret)
 	mockRepoClient := &mocks.Clientset{RepoServerServiceClient: &mocks.RepoServerServiceClient{}}
 
 	t.Run("TestEnforceProjectTokenSuccessful", func(t *testing.T) {
@@ -204,7 +204,7 @@ func TestEnforceProjectToken(t *testing.T) {
 }
 
 func TestEnforceClaims(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(test.NewFakeConfigMap())
+	kubeclientset := fake.NewClientset(test.NewFakeConfigMap())
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
 	rbacEnf := rbacpolicy.NewRBACPolicyEnforcer(enf, test.NewFakeProjLister())
@@ -236,7 +236,7 @@ g, bob, role:admin
 }
 
 func TestDefaultRoleWithClaims(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
 	rbacEnf := rbacpolicy.NewRBACPolicyEnforcer(enf, test.NewFakeProjLister())
@@ -250,7 +250,7 @@ func TestDefaultRoleWithClaims(t *testing.T) {
 }
 
 func TestEnforceNilClaims(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(test.NewFakeConfigMap())
+	kubeclientset := fake.NewClientset(test.NewFakeConfigMap())
 	enf := rbac.NewEnforcer(kubeclientset, test.FakeArgoCDNamespace, common.ArgoCDConfigMapName, nil)
 	_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
 	rbacEnf := rbacpolicy.NewRBACPolicyEnforcer(enf, test.NewFakeProjLister())
@@ -263,7 +263,7 @@ func TestEnforceNilClaims(t *testing.T) {
 func TestInitializingExistingDefaultProject(t *testing.T) {
 	cm := test.NewFakeConfigMap()
 	secret := test.NewFakeSecret()
-	kubeclientset := fake.NewSimpleClientset(cm, secret)
+	kubeclientset := fake.NewClientset(cm, secret)
 	defaultProj := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DefaultAppProjectName, Namespace: test.FakeArgoCDNamespace},
 		Spec:       v1alpha1.AppProjectSpec{},
@@ -291,7 +291,7 @@ func TestInitializingExistingDefaultProject(t *testing.T) {
 func TestInitializingNotExistingDefaultProject(t *testing.T) {
 	cm := test.NewFakeConfigMap()
 	secret := test.NewFakeSecret()
-	kubeclientset := fake.NewSimpleClientset(cm, secret)
+	kubeclientset := fake.NewClientset(cm, secret)
 	appClientSet := apps.NewSimpleClientset()
 	mockRepoClient := &mocks.Clientset{RepoServerServiceClient: &mocks.RepoServerServiceClient{}}
 
@@ -343,7 +343,7 @@ func TestEnforceProjectGroups(t *testing.T) {
 		},
 	}
 	mockRepoClient := &mocks.Clientset{RepoServerServiceClient: &mocks.RepoServerServiceClient{}}
-	kubeclientset := fake.NewSimpleClientset(test.NewFakeConfigMap(), test.NewFakeSecret())
+	kubeclientset := fake.NewClientset(test.NewFakeConfigMap(), test.NewFakeSecret())
 	s := NewServer(context.Background(), ArgoCDServerOpts{Namespace: test.FakeArgoCDNamespace, KubeClientset: kubeclientset, AppClientset: apps.NewSimpleClientset(&existingProj), RepoClientset: mockRepoClient}, ApplicationSetOpts{})
 	cancel := test.StartInformer(s.projInformer)
 	defer cancel()
@@ -377,7 +377,7 @@ func TestRevokedToken(t *testing.T) {
 	defaultIssuedAt := int64(1)
 	defaultSub := fmt.Sprintf(subFormat, projectName, roleName)
 	defaultPolicy := fmt.Sprintf(policyTemplate, defaultSub, projectName, defaultObject, defaultEffect)
-	kubeclientset := fake.NewSimpleClientset(test.NewFakeConfigMap(), test.NewFakeSecret())
+	kubeclientset := fake.NewClientset(test.NewFakeConfigMap(), test.NewFakeSecret())
 	mockRepoClient := &mocks.Clientset{RepoServerServiceClient: &mocks.RepoServerServiceClient{}}
 
 	jwtTokenByRole := make(map[string]v1alpha1.JWTTokens)

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -78,7 +78,7 @@ func TestGetAppProjectWithNoProjDefined(t *testing.T) {
 	go informer.Run(ctx.Done())
 	cache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
 
-	kubeClient := fake.NewSimpleClientset(&cm)
+	kubeClient := fake.NewClientset(&cm)
 	settingsMgr := settings.NewSettingsManager(context.Background(), kubeClient, test.FakeArgoCDNamespace)
 	argoDB := db.NewDB("default", settingsMgr, kubeClient)
 	proj, err := GetAppProject(&testApp, applisters.NewAppProjectLister(informer.GetIndexer()), namespace, settingsMgr, argoDB, ctx)
@@ -446,7 +446,7 @@ func TestValidateRepo(t *testing.T) {
 		},
 	}
 
-	kubeClient := fake.NewSimpleClientset(&cm)
+	kubeClient := fake.NewClientset(&cm)
 	settingsMgr := settings.NewSettingsManager(context.Background(), kubeClient, test.FakeArgoCDNamespace)
 
 	conditions, err := ValidateRepo(context.Background(), app, repoClientSet, db, &kubetest.MockKubectlCmd{Version: kubeVersion, APIResources: apiResources}, proj, settingsMgr)

--- a/util/argo/audit_logger_test.go
+++ b/util/argo/audit_logger_test.go
@@ -36,12 +36,12 @@ func captureLogEntries(run func()) string {
 }
 
 func TestNewAuditLogger(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewSimpleClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 }
 
 func TestLogAppProjEvent(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewSimpleClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 
 	proj := argoappv1.AppProject{
@@ -82,7 +82,7 @@ func TestLogAppProjEvent(t *testing.T) {
 }
 
 func TestLogAppEvent(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewSimpleClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 
 	app := argoappv1.Application{
@@ -128,7 +128,7 @@ func TestLogAppEvent(t *testing.T) {
 }
 
 func TestLogResourceEvent(t *testing.T) {
-	logger := NewAuditLogger("default", fake.NewSimpleClientset(), _somecomponent, testEnableEventLog)
+	logger := NewAuditLogger("default", fake.NewClientset(), _somecomponent, testEnableEventLog)
 	assert.NotNil(t, logger)
 
 	res := argoappv1.ResourceNode{

--- a/util/db/certificate_test.go
+++ b/util/db/certificate_test.go
@@ -283,7 +283,7 @@ func getCertClientset() *fake.Clientset {
 		},
 	}
 
-	return fake.NewSimpleClientset([]runtime.Object{&cm, &sshCM, &tlsCM}...)
+	return fake.NewClientset([]runtime.Object{&cm, &sshCM, &tlsCM}...)
 }
 
 func Test_ListCertificate(t *testing.T) {

--- a/util/db/cluster_norace_test.go
+++ b/util/db/cluster_norace_test.go
@@ -46,7 +46,7 @@ func TestWatchClusters_CreateRemoveCluster(t *testing.T) {
 			"server.secretkey": nil,
 		},
 	}
-	kubeclientset := fake.NewSimpleClientset(emptyArgoCDConfigMap, argoCDSecret)
+	kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecret)
 	settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 	runWatchTest(t, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){
@@ -101,7 +101,7 @@ func TestWatchClusters_LocalClusterModifications(t *testing.T) {
 			"server.secretkey": nil,
 		},
 	}
-	kubeclientset := fake.NewSimpleClientset(emptyArgoCDConfigMap, argoCDSecret)
+	kubeclientset := fake.NewClientset(emptyArgoCDConfigMap, argoCDSecret)
 	settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 	runWatchTest(t, db, []func(old *v1alpha1.Cluster, new *v1alpha1.Cluster){

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -172,7 +172,7 @@ func Test_secretToCluster_InvalidConfig(t *testing.T) {
 }
 
 func TestUpdateCluster(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(&v1.Secret{
+	kubeclientset := fake.NewClientset(&v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
 			Namespace: fakeNamespace,
@@ -202,7 +202,7 @@ func TestUpdateCluster(t *testing.T) {
 }
 
 func TestDeleteUnknownCluster(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(&v1.Secret{
+	kubeclientset := fake.NewClientset(&v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
 			Namespace: fakeNamespace,
@@ -244,7 +244,7 @@ func TestRejectCreationForInClusterWhenDisabled(t *testing.T) {
 			"server.secretkey": nil,
 		},
 	}
-	kubeclientset := fake.NewSimpleClientset(argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
+	kubeclientset := fake.NewClientset(argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
 	settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 	_, err := db.CreateCluster(context.Background(), &appv1.Cluster{
@@ -371,7 +371,7 @@ func TestListClusters(t *testing.T) {
 	}
 
 	t.Run("Valid clusters", func(t *testing.T) {
-		kubeclientset := fake.NewSimpleClientset(secretForServerWithInClusterAddr, secretForServerWithExternalClusterAddr, emptyArgoCDConfigMap, argoCDSecret)
+		kubeclientset := fake.NewClientset(secretForServerWithInClusterAddr, secretForServerWithExternalClusterAddr, emptyArgoCDConfigMap, argoCDSecret)
 		settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
@@ -381,7 +381,7 @@ func TestListClusters(t *testing.T) {
 	})
 
 	t.Run("Cluster list with invalid cluster", func(t *testing.T) {
-		kubeclientset := fake.NewSimpleClientset(secretForServerWithInClusterAddr, secretForServerWithExternalClusterAddr, invalidSecret, emptyArgoCDConfigMap, argoCDSecret)
+		kubeclientset := fake.NewClientset(secretForServerWithInClusterAddr, secretForServerWithExternalClusterAddr, invalidSecret, emptyArgoCDConfigMap, argoCDSecret)
 		settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
@@ -391,7 +391,7 @@ func TestListClusters(t *testing.T) {
 	})
 
 	t.Run("Implicit in-cluster secret", func(t *testing.T) {
-		kubeclientset := fake.NewSimpleClientset(secretForServerWithExternalClusterAddr, emptyArgoCDConfigMap, argoCDSecret)
+		kubeclientset := fake.NewClientset(secretForServerWithExternalClusterAddr, emptyArgoCDConfigMap, argoCDSecret)
 		settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
@@ -402,7 +402,7 @@ func TestListClusters(t *testing.T) {
 	})
 
 	t.Run("ListClusters() should not add the cluster with in-cluster server address since in-cluster is disabled", func(t *testing.T) {
-		kubeclientset := fake.NewSimpleClientset(secretForServerWithInClusterAddr, argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
+		kubeclientset := fake.NewClientset(secretForServerWithInClusterAddr, argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
 		settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
@@ -412,7 +412,7 @@ func TestListClusters(t *testing.T) {
 	})
 
 	t.Run("ListClusters() should add this cluster since it does not contain in-cluster server address even though in-cluster is disabled", func(t *testing.T) {
-		kubeclientset := fake.NewSimpleClientset(secretForServerWithExternalClusterAddr, argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
+		kubeclientset := fake.NewClientset(secretForServerWithExternalClusterAddr, argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
 		settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 		db := NewDB(fakeNamespace, settingsManager, kubeclientset)
 
@@ -439,7 +439,7 @@ func TestClusterRaceConditionClusterSecrets(t *testing.T) {
 			"config": []byte("{}"),
 		},
 	}
-	kubeClient := fake.NewSimpleClientset(
+	kubeClient := fake.NewClientset(
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,

--- a/util/db/db_test.go
+++ b/util/db/db_test.go
@@ -47,7 +47,7 @@ func getClientset(config map[string]string, objects ...runtime.Object) *fake.Cli
 		},
 		Data: config,
 	}
-	return fake.NewSimpleClientset(append(objects, &cm, &secret)...)
+	return fake.NewClientset(append(objects, &cm, &secret)...)
 }
 
 func TestCreateRepository(t *testing.T) {

--- a/util/db/gpgkeys_test.go
+++ b/util/db/gpgkeys_test.go
@@ -112,7 +112,7 @@ func getGPGKeysClientset(gpgCM v1.ConfigMap) *fake.Clientset {
 		Data: nil,
 	}
 
-	return fake.NewSimpleClientset([]runtime.Object{&cm, &gpgCM}...)
+	return fake.NewClientset([]runtime.Object{&cm, &gpgCM}...)
 }
 
 func Test_ValidatePGPKey(t *testing.T) {

--- a/util/kube/util_test.go
+++ b/util/kube/util_test.go
@@ -47,7 +47,7 @@ func Test_CreateOrUpdateSecretField(t *testing.T) {
 		"annotation3": "foo",
 	}
 
-	client := fake.NewSimpleClientset(secret)
+	client := fake.NewClientset(secret)
 
 	t.Run("Change field in existing secret", func(t *testing.T) {
 		ku := NewKubeUtil(client, context.TODO())
@@ -133,7 +133,7 @@ func Test_CreateOrUpdateSecretData(t *testing.T) {
 		"password": []byte("foobarbaz"),
 	}
 
-	client := fake.NewSimpleClientset(secret)
+	client := fake.NewClientset(secret)
 
 	t.Run("Change data in existing secret with merge", func(t *testing.T) {
 		ku := NewKubeUtil(client, context.TODO())

--- a/util/notification/settings/settings_test.go
+++ b/util/notification/settings/settings_test.go
@@ -44,7 +44,7 @@ func TestInitGetVars(t *testing.T) {
 			"notification-secret": []byte("secret-value"),
 		},
 	}
-	kubeclientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-notifications-cm",

--- a/util/rbac/rbac_norace_test.go
+++ b/util/rbac/rbac_norace_test.go
@@ -26,7 +26,7 @@ func TestPolicyInformer(t *testing.T) {
 
 	cm := fakeConfigMap()
 	cm.Data[ConfigMapPolicyCSVKey] = "p, admin, applications, delete, */*, allow"
-	kubeclientset := fake.NewSimpleClientset(cm)
+	kubeclientset := fake.NewClientset(cm)
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 
 	ctx := context.Background()
@@ -58,7 +58,7 @@ func TestResourceActionWildcards(t *testing.T) {
 	// !race:
 	// Same as TestPolicyInformer
 
-	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
+	kubeclientset := fake.NewClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	policy := `
 p, alice, *, get, foo/obj, allow

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -106,7 +106,7 @@ func TestPolicyCSV(t *testing.T) {
 
 // TestBuiltinPolicyEnforcer tests the builtin policy rules
 func TestBuiltinPolicyEnforcer(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
 
@@ -142,7 +142,7 @@ func TestBuiltinPolicyEnforcer(t *testing.T) {
 
 // TestProjectIsolationEnforcement verifies the ability to create Project specific policies
 func TestProjectIsolationEnforcement(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
+	kubeclientset := fake.NewClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	policy := `
 p, role:foo-admin, *, *, foo/*, allow
@@ -162,7 +162,7 @@ g, bob, role:bar-admin
 
 // TestProjectReadOnly verifies the ability to have a read only role in a Project
 func TestProjectReadOnly(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
+	kubeclientset := fake.NewClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	policy := `
 p, role:foo-readonly, *, get, foo/*, allow
@@ -178,7 +178,7 @@ g, alice, role:foo-readonly
 
 // TestDefaultRole tests the ability to set a default role
 func TestDefaultRole(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
 	_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
@@ -191,7 +191,7 @@ func TestDefaultRole(t *testing.T) {
 
 // TestURLAsObjectName tests the ability to have a URL as an object name
 func TestURLAsObjectName(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
 	policy := `
@@ -209,7 +209,7 @@ p, cathy, repositories, *, foo/*, allow
 }
 
 func TestEnableDisableEnforce(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
+	kubeclientset := fake.NewClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	policy := `
 p, alice, *, get, foo/obj, allow
@@ -237,7 +237,7 @@ p, mike, *, get, foo/obj, deny
 }
 
 func TestUpdatePolicy(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset(fakeConfigMap())
+	kubeclientset := fake.NewClientset(fakeConfigMap())
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 
 	_ = enf.SetUserPolicy("p, alice, *, get, foo/obj, allow")
@@ -267,14 +267,14 @@ func TestUpdatePolicy(t *testing.T) {
 
 func TestNoPolicy(t *testing.T) {
 	cm := fakeConfigMap()
-	kubeclientset := fake.NewSimpleClientset(cm)
+	kubeclientset := fake.NewClientset(cm)
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	assert.False(t, enf.Enforce("admin", "applications", "delete", "foo/bar"))
 }
 
 // TestClaimsEnforcerFunc tests
 func TestClaimsEnforcerFunc(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	claims := jwt.RegisteredClaims{
 		Subject: "foo",
@@ -289,7 +289,7 @@ func TestClaimsEnforcerFunc(t *testing.T) {
 // TestDefaultRoleWithRuntimePolicy tests the ability for a default role to still take affect when
 // enforcing a runtime policy
 func TestDefaultRoleWithRuntimePolicy(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
 	runtimePolicy := assets.BuiltinPolicyCSV
@@ -301,7 +301,7 @@ func TestDefaultRoleWithRuntimePolicy(t *testing.T) {
 // TestClaimsEnforcerFuncWithRuntimePolicy tests the ability for claims enforcer function to still
 // take effect when enforcing a runtime policy
 func TestClaimsEnforcerFuncWithRuntimePolicy(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
 	runtimePolicy := assets.BuiltinPolicyCSV
@@ -318,7 +318,7 @@ func TestClaimsEnforcerFuncWithRuntimePolicy(t *testing.T) {
 // TestInvalidRuntimePolicy tests when an invalid policy is supplied, it falls back to normal enforcement
 func TestInvalidRuntimePolicy(t *testing.T) {
 	cm := fakeConfigMap()
-	kubeclientset := fake.NewSimpleClientset(cm)
+	kubeclientset := fake.NewClientset(cm)
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
 	_ = enf.SetBuiltinPolicy(assets.BuiltinPolicyCSV)
@@ -351,7 +351,7 @@ func TestValidatePolicy(t *testing.T) {
 
 // TestEnforceErrorMessage ensures we give descriptive error message
 func TestEnforceErrorMessage(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	err := enf.syncUpdate(fakeConfigMap(), noOpUpdate)
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestEnforceErrorMessage(t *testing.T) {
 }
 
 func TestDefaultGlobMatchMode(t *testing.T) {
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(fakeConfigMap(), noOpUpdate))
 	policy := `
@@ -407,7 +407,7 @@ p, alice, clusters, get, "https://github.com/*/*.git", allow
 func TestGlobMatchMode(t *testing.T) {
 	cm := fakeConfigMap()
 	cm.Data[ConfigMapMatchModeKey] = GlobMatchMode
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
 	policy := `
@@ -422,7 +422,7 @@ p, alice, clusters, get, "https://github.com/*/*.git", allow
 func TestRegexMatchMode(t *testing.T) {
 	cm := fakeConfigMap()
 	cm.Data[ConfigMapMatchModeKey] = RegexMatchMode
-	kubeclientset := fake.NewSimpleClientset()
+	kubeclientset := fake.NewClientset()
 	enf := NewEnforcer(kubeclientset, fakeNamespace, fakeConfigMapName, nil)
 	require.NoError(t, enf.syncUpdate(cm, noOpUpdate))
 	policy := `

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -52,7 +52,7 @@ func getKubeClient(pass string, enabled bool, capabilities ...settings.AccountCa
 		capabilitiesStr = append(capabilitiesStr, string(capabilities[i]))
 	}
 
-	return fake.NewSimpleClientset(&corev1.ConfigMap{
+	return fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
 			Namespace: "argocd",
@@ -577,7 +577,7 @@ func getKubeClientWithConfig(config map[string]string, secretConfig map[string][
 		mergedSecretConfig[key] = value
 	}
 
-	return fake.NewSimpleClientset(&corev1.ConfigMap{
+	return fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
 			Namespace: "argocd",

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -50,7 +50,7 @@ func fixtures(data map[string]string, opts ...func(secret *v1.Secret)) (*fake.Cl
 	for i := range opts {
 		opts[i](secret)
 	}
-	kubeClient := fake.NewSimpleClientset(cm, secret)
+	kubeClient := fake.NewClientset(cm, secret)
 	settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
 
 	return kubeClient, settingsManager
@@ -135,7 +135,7 @@ func TestSaveRepositories(t *testing.T) {
 }
 
 func TestSaveRepositoriesNoConfigMap(t *testing.T) {
-	kubeClient := fake.NewSimpleClientset()
+	kubeClient := fake.NewClientset()
 	settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
 
 	err := settingsManager.SaveRepositories([]Repository{{URL: "http://foo"}})
@@ -198,7 +198,7 @@ func TestInClusterServerAddressEnabled(t *testing.T) {
 }
 
 func TestInClusterServerAddressEnabledByDefault(t *testing.T) {
-	kubeClient := fake.NewSimpleClientset(
+	kubeClient := fake.NewClientset(
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
@@ -920,7 +920,7 @@ func TestSettingsManager_GetHelp(t *testing.T) {
 
 func TestSettingsManager_GetSettings(t *testing.T) {
 	t.Run("UserSessionDurationNotProvided", func(t *testing.T) {
-		kubeClient := fake.NewSimpleClientset(
+		kubeClient := fake.NewClientset(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
@@ -950,7 +950,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 		assert.Equal(t, time.Hour*24, s.UserSessionDuration)
 	})
 	t.Run("UserSessionDurationInvalidFormat", func(t *testing.T) {
-		kubeClient := fake.NewSimpleClientset(
+		kubeClient := fake.NewClientset(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
@@ -982,7 +982,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 		assert.Equal(t, time.Hour*24, s.UserSessionDuration)
 	})
 	t.Run("UserSessionDurationProvided", func(t *testing.T) {
-		kubeClient := fake.NewSimpleClientset(
+		kubeClient := fake.NewClientset(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
@@ -1016,7 +1016,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 }
 
 func TestGetOIDCConfig(t *testing.T) {
-	kubeClient := fake.NewSimpleClientset(
+	kubeClient := fake.NewClientset(
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
@@ -1096,7 +1096,7 @@ func Test_validateExternalURL(t *testing.T) {
 }
 
 func TestGetOIDCSecretTrim(t *testing.T) {
-	kubeClient := fake.NewSimpleClientset(
+	kubeClient := fake.NewClientset(
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
@@ -1142,7 +1142,7 @@ func getCNFromCertificate(cert *tls.Certificate) string {
 
 func Test_GetTLSConfiguration(t *testing.T) {
 	t.Run("Valid external TLS secret with success", func(t *testing.T) {
-		kubeClient := fake.NewSimpleClientset(
+		kubeClient := fake.NewClientset(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
@@ -1188,7 +1188,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 	})
 
 	t.Run("Valid external TLS secret overrides argocd-secret", func(t *testing.T) {
-		kubeClient := fake.NewSimpleClientset(
+		kubeClient := fake.NewClientset(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
@@ -1235,7 +1235,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 		assert.Contains(t, getCNFromCertificate(settings.Certificate), "localhost")
 	})
 	t.Run("Invalid external TLS secret", func(t *testing.T) {
-		kubeClient := fake.NewSimpleClientset(
+		kubeClient := fake.NewClientset(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
@@ -1278,7 +1278,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 		assert.NotNil(t, settings)
 	})
 	t.Run("No external TLS secret", func(t *testing.T) {
-		kubeClient := fake.NewSimpleClientset(
+		kubeClient := fake.NewClientset(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
@@ -1385,7 +1385,7 @@ requestedIDTokenClaims: {"groups": {"essential": true}}`,
 			"webhook.github.secret": []byte("mywebhooksecret"),
 		},
 	}
-	kubeClient := fake.NewSimpleClientset(cm, secret, argocdSecret)
+	kubeClient := fake.NewClientset(cm, secret, argocdSecret)
 	settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
 
 	settings, err := settingsManager.GetSettings()
@@ -1443,7 +1443,7 @@ func TestGetEnableManifestGeneration(t *testing.T) {
 				},
 			}
 
-			kubeClient := fake.NewSimpleClientset(cm, argocdSecret)
+			kubeClient := fake.NewClientset(cm, argocdSecret)
 			settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
 
 			enableManifestGeneration, err := settingsManager.GetEnabledSourceTypes()
@@ -1512,7 +1512,7 @@ func TestGetHelmSettings(t *testing.T) {
 					"clientSecret": []byte("deadbeef"),
 				},
 			}
-			kubeClient := fake.NewSimpleClientset(cm, secret, argocdSecret)
+			kubeClient := fake.NewClientset(cm, secret, argocdSecret)
 			settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
 
 			helmSettings, err := settingsManager.GetHelmSettings()
@@ -1781,7 +1781,7 @@ func TestRedirectAdditionalURLs(t *testing.T) {
 func TestIsImpersonationEnabled(t *testing.T) {
 	// When there is no argocd-cm itself,
 	// Then IsImpersonationEnabled() must return false (default value) and an error with appropriate error message.
-	kubeClient := fake.NewSimpleClientset()
+	kubeClient := fake.NewClientset()
 	settingsManager := NewSettingsManager(context.Background(), kubeClient, "default")
 	featureFlag, err := settingsManager.IsImpersonationEnabled()
 	require.False(t, featureFlag,


### PR DESCRIPTION
fake.NewSimpleClientset is deprecated in favor of fake.NewClientset.