### PR TITLE
chore(appset): reduce dupe code w/ DB

### DIFF
--- a/applicationset/utils/clusterUtils.go
+++ b/applicationset/utils/clusterUtils.go
@@ -3,13 +3,13 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/argoproj/argo-cd/v2/util/db"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sync"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/util/db"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/applicationset/utils/clusterUtils.go
+++ b/applicationset/utils/clusterUtils.go
@@ -2,22 +2,15 @@ package utils
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
-
-	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/argoproj/argo-cd/v2/util/db"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sync"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/ptr"
 )
 
 // The contents of this file are from
@@ -126,10 +119,14 @@ func ListClusters(ctx context.Context, clientset kubernetes.Interface, namespace
 	hasInClusterCredentials := false
 	for i, clusterSecret := range clusterSecrets {
 		// This line has changed from the original Argo CD code: now receives an error, and handles it
-		cluster, err := secretToCluster(&clusterSecret)
+		cluster, err := db.SecretToCluster(&clusterSecret)
 		if err != nil || cluster == nil {
 			return nil, fmt.Errorf("unable to convert cluster secret to cluster object '%s': %w", clusterSecret.Name, err)
 		}
+
+		// db.SecretToCluster populates these, but they're not meant to be available to the caller.
+		cluster.Labels = nil
+		cluster.Annotations = nil
 
 		clusterList.Items[i] = *cluster
 		if cluster.Server == appv1.KubernetesInternalAPIServerAddr {
@@ -166,49 +163,4 @@ func getLocalCluster(clientset kubernetes.Interface) *appv1.Cluster {
 	// nolint:staticcheck
 	cluster.ConnectionState.ModifiedAt = &now
 	return cluster
-}
-
-// secretToCluster converts a secret into a Cluster object
-func secretToCluster(s *corev1.Secret) (*appv1.Cluster, error) {
-	var config appv1.ClusterConfig
-	if len(s.Data["config"]) > 0 {
-		if err := json.Unmarshal(s.Data["config"], &config); err != nil {
-			// This line has changed from the original Argo CD: now returns an error rather than panicing.
-			return nil, err
-		}
-	}
-
-	var namespaces []string
-	for _, ns := range strings.Split(string(s.Data["namespaces"]), ",") {
-		if ns = strings.TrimSpace(ns); ns != "" {
-			namespaces = append(namespaces, ns)
-		}
-	}
-	var refreshRequestedAt *metav1.Time
-	if v, found := s.Annotations[appv1.AnnotationKeyRefresh]; found {
-		requestedAt, err := time.Parse(time.RFC3339, v)
-		if err != nil {
-			log.Warnf("Error while parsing date in cluster secret '%s': %v", s.Name, err)
-		} else {
-			refreshRequestedAt = &metav1.Time{Time: requestedAt}
-		}
-	}
-	var shard *int64
-	if shardStr := s.Data["shard"]; shardStr != nil {
-		if val, err := strconv.Atoi(string(shardStr)); err != nil {
-			log.Warnf("Error while parsing shard in cluster secret '%s': %v", s.Name, err)
-		} else {
-			shard = ptr.To(int64(val))
-		}
-	}
-	cluster := appv1.Cluster{
-		ID:                 string(s.UID),
-		Server:             strings.TrimRight(string(s.Data["server"]), "/"),
-		Name:               string(s.Data["name"]),
-		Namespaces:         namespaces,
-		Config:             config,
-		RefreshRequestedAt: refreshRequestedAt,
-		Shard:              shard,
-	}
-	return &cluster, nil
 }

--- a/applicationset/utils/clusterUtils_test.go
+++ b/applicationset/utils/clusterUtils_test.go
@@ -20,51 +20,6 @@ const (
 	fakeNamespace = "fake-ns"
 )
 
-// From Argo CD util/db/cluster_test.go
-func Test_secretToCluster(t *testing.T) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mycluster",
-			Namespace: fakeNamespace,
-		},
-		Data: map[string][]byte{
-			"name":   []byte("test"),
-			"server": []byte("http://mycluster"),
-			"config": []byte("{\"username\":\"foo\", \"disableCompression\":true}"),
-		},
-	}
-	cluster, err := secretToCluster(secret)
-	require.NoError(t, err)
-	assert.Equal(t, argoappv1.Cluster{
-		Name:   "test",
-		Server: "http://mycluster",
-		Config: argoappv1.ClusterConfig{
-			Username:           "foo",
-			DisableCompression: true,
-		},
-	}, *cluster)
-}
-
-// From Argo CD util/db/cluster_test.go
-func Test_secretToCluster_NoConfig(t *testing.T) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mycluster",
-			Namespace: fakeNamespace,
-		},
-		Data: map[string][]byte{
-			"name":   []byte("test"),
-			"server": []byte("http://mycluster"),
-		},
-	}
-	cluster, err := secretToCluster(secret)
-	require.NoError(t, err)
-	assert.Equal(t, argoappv1.Cluster{
-		Name:   "test",
-		Server: "http://mycluster",
-	}, *cluster)
-}
-
 func createClusterSecret(secretName string, clusterName string, clusterServer string) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The clusterUtils function is almost identical to the DB function. Green in the diff below is the DB function. 

Since the DB function populates Labels and Annotations, I'm dropping those just to be safe. I'm leaving the logic that populates the Project and ClusterResources fields, because I can't think of a reason why populating those could be problematic.

```diff
1,2c1,2
< // secretToCluster converts a secret into a Cluster object
< func secretToCluster(s *corev1.Secret) (*appv1.Cluster, error) {
---
> // SecretToCluster converts a secret into a Cluster object
> func SecretToCluster(s *apiv1.Secret) (*appv1.Cluster, error) {
5,7c5,7
< 		if err := json.Unmarshal(s.Data["config"], &config); err != nil {
< 			// This line has changed from the original Argo CD: now returns an error rather than panicing.
< 			return nil, err
---
> 		err := json.Unmarshal(s.Data["config"], &config)
> 		if err != nil {
> 			return nil, fmt.Errorf("failed to unmarshal cluster config: %w", err)
33a34,48
> 
> 	// copy labels and annotations excluding system ones
> 	labels := map[string]string{}
> 	if s.Labels != nil {
> 		labels = maps.Clone(s.Labels)
> 		delete(labels, common.LabelKeySecretType)
> 	}
> 	annotations := map[string]string{}
> 	if s.Annotations != nil {
> 		annotations = maps.Clone(s.Annotations)
> 		// delete system annotations
> 		delete(annotations, apiv1.LastAppliedConfigAnnotation)
> 		delete(annotations, common.AnnotationKeyManagedBy)
> 	}
> 
38a54
> 		ClusterResources:   string(s.Data["clusterResources"]) == "true",
41a58,60
> 		Project:            string(s.Data["project"]),
> 		Labels:             labels,
> 		Annotations:        annotations,

```