### PR TITLE
fix: Temporary move TestMaxPodLogsRender to run with no race

### DIFF
--- a/server/application/application_norace_test.go
+++ b/server/application/application_norace_test.go
@@ -1,0 +1,67 @@
+//go:build !race
+// +build !race
+
+package application
+
+import (
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/utils/ptr"
+	"testing"
+)
+
+func TestMaxPodLogsRender(t *testing.T) {
+	// !race:
+	// Intermittent failure when running TestMaxPodLogsRender with -race, likely due to race condition
+	// https://github.com/argoproj/argo-cd/issues/4755
+	defaultMaxPodLogsToRender, _ := newTestAppServer(t).settingsMgr.GetMaxPodLogsToRender()
+
+	// Case: number of pods to view logs is less than defaultMaxPodLogsToRender
+	podNumber := int(defaultMaxPodLogsToRender - 1)
+	appServer, adminCtx := createAppServerWithMaxLodLogs(t, podNumber)
+
+	t.Run("PodLogs", func(t *testing.T) {
+		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
+		statusCode, _ := status.FromError(err)
+		assert.Equal(t, codes.OK, statusCode.Code())
+	})
+
+	// Case: number of pods higher than defaultMaxPodLogsToRender
+	podNumber = int(defaultMaxPodLogsToRender + 1)
+	appServer, adminCtx = createAppServerWithMaxLodLogs(t, podNumber)
+
+	t.Run("PodLogs", func(t *testing.T) {
+		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
+		require.Error(t, err)
+		statusCode, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, statusCode.Code())
+		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = max pods to view logs are reached. Please provide more granular query")
+	})
+
+	// Case: number of pods to view logs is less than customMaxPodLogsToRender
+	customMaxPodLogsToRender := int64(15)
+	podNumber = int(customMaxPodLogsToRender - 1)
+	appServer, adminCtx = createAppServerWithMaxLodLogs(t, podNumber, customMaxPodLogsToRender)
+
+	t.Run("PodLogs", func(t *testing.T) {
+		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
+		statusCode, _ := status.FromError(err)
+		assert.Equal(t, codes.OK, statusCode.Code())
+	})
+
+	// Case: number of pods higher than customMaxPodLogsToRender
+	customMaxPodLogsToRender = int64(15)
+	podNumber = int(customMaxPodLogsToRender + 1)
+	appServer, adminCtx = createAppServerWithMaxLodLogs(t, podNumber, customMaxPodLogsToRender)
+
+	t.Run("PodLogs", func(t *testing.T) {
+		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
+		require.Error(t, err)
+		statusCode, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, statusCode.Code())
+		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = max pods to view logs are reached. Please provide more granular query")
+	})
+}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2183,56 +2183,6 @@ func TestLogsGetSelectedPod(t *testing.T) {
 	})
 }
 
-func TestMaxPodLogsRender(t *testing.T) {
-	defaultMaxPodLogsToRender, _ := newTestAppServer(t).settingsMgr.GetMaxPodLogsToRender()
-
-	// Case: number of pods to view logs is less than defaultMaxPodLogsToRender
-	podNumber := int(defaultMaxPodLogsToRender - 1)
-	appServer, adminCtx := createAppServerWithMaxLodLogs(t, podNumber)
-
-	t.Run("PodLogs", func(t *testing.T) {
-		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
-		statusCode, _ := status.FromError(err)
-		assert.Equal(t, codes.OK, statusCode.Code())
-	})
-
-	// Case: number of pods higher than defaultMaxPodLogsToRender
-	podNumber = int(defaultMaxPodLogsToRender + 1)
-	appServer, adminCtx = createAppServerWithMaxLodLogs(t, podNumber)
-
-	t.Run("PodLogs", func(t *testing.T) {
-		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
-		require.Error(t, err)
-		statusCode, _ := status.FromError(err)
-		assert.Equal(t, codes.InvalidArgument, statusCode.Code())
-		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = max pods to view logs are reached. Please provide more granular query")
-	})
-
-	// Case: number of pods to view logs is less than customMaxPodLogsToRender
-	customMaxPodLogsToRender := int64(15)
-	podNumber = int(customMaxPodLogsToRender - 1)
-	appServer, adminCtx = createAppServerWithMaxLodLogs(t, podNumber, customMaxPodLogsToRender)
-
-	t.Run("PodLogs", func(t *testing.T) {
-		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
-		statusCode, _ := status.FromError(err)
-		assert.Equal(t, codes.OK, statusCode.Code())
-	})
-
-	// Case: number of pods higher than customMaxPodLogsToRender
-	customMaxPodLogsToRender = int64(15)
-	podNumber = int(customMaxPodLogsToRender + 1)
-	appServer, adminCtx = createAppServerWithMaxLodLogs(t, podNumber, customMaxPodLogsToRender)
-
-	t.Run("PodLogs", func(t *testing.T) {
-		err := appServer.PodLogs(&application.ApplicationPodLogsQuery{Name: ptr.To("test")}, &TestPodLogsServer{ctx: adminCtx})
-		require.Error(t, err)
-		statusCode, _ := status.FromError(err)
-		assert.Equal(t, codes.InvalidArgument, statusCode.Code())
-		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = max pods to view logs are reached. Please provide more granular query")
-	})
-}
-
 // createAppServerWithMaxLodLogs creates a new app server with given number of pods and resources
 func createAppServerWithMaxLodLogs(t *testing.T, podNumber int, maxPodLogsToRender ...int64) (*Server, context.Context) {
 	t.Helper()


### PR DESCRIPTION
Temporary disable `TestMaxPodLogsRender` to run when go test `-race` flag is enabled
Alternative to https://github.com/argoproj/argo-cd/pull/21201.

It should be reverted once https://github.com/argoproj/argo-cd/pull/21189 or similar is implemented.


Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
