### PR TITLE
feat: improve StatefulSet immutable field error messages

### DIFF
--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
@@ -54,12 +54,52 @@ const Filter = (props: {filters: string[]; setFilters: (f: string[]) => void; op
 
 export const ApplicationOperationState: React.StatelessComponent<Props> = ({application, operationState}, ctx: AppContext) => {
     const [messageFilters, setMessageFilters] = React.useState([]);
+    const getFormattedMessage = (message: string) => {
+        const prefix = 'one or more objects failed to apply, reason: ';
+        let cleanMessage = message;
+        
+        // Remove duplicate prefix if exists
+        if (message.startsWith(prefix) && message.substring(prefix.length).startsWith(prefix)) {
+            cleanMessage = prefix + message.substring(prefix.length * 2);
+        }
+        
+        // Format immutable fields error message
+        if (cleanMessage.includes('attempting to change immutable fields:')) {
+            const [header, ...details] = cleanMessage.split('\n');
+            const formattedDetails = details
+                .filter(line => line.trim())
+                .map(line => {
+                    if (line.startsWith('-')) {
+                        const [field, changes] = line.substring(2).split(':');
+                        if (changes) {
+                            const [from, to] = changes.split('to:').map(s => s.trim());
+                            return `   - ${field}:\n      from: ${from.replace('from:', '').trim()}\n      to:   ${to}`;
+                        }
+                    }
+                    return line;
+                })
+                .join('\n');
+                
+            return `${header}\n${formattedDetails}`;
+        }
+        
+        return cleanMessage;
+    };
 
     const operationAttributes = [
         {title: 'OPERATION', value: utils.getOperationType(application)},
         {title: 'PHASE', value: operationState.phase},
-        ...(operationState.message ? [{title: 'MESSAGE', value: operationState.message}] : []),
-        {title: 'STARTED AT', value: <Timestamp date={operationState.startedAt} />},
+        ...(operationState.message ? [{
+            title: 'MESSAGE', 
+            value: <pre style={{
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                margin: 0,
+                fontFamily: 'inherit'
+            }}>
+                {getFormattedMessage(operationState.message)}
+            </pre>
+        }] : []),        {title: 'STARTED AT', value: <Timestamp date={operationState.startedAt} />},
         {
             title: 'DURATION',
             value: (

--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
@@ -54,37 +54,6 @@ const Filter = (props: {filters: string[]; setFilters: (f: string[]) => void; op
 
 export const ApplicationOperationState: React.StatelessComponent<Props> = ({application, operationState}, ctx: AppContext) => {
     const [messageFilters, setMessageFilters] = React.useState([]);
-    const getFormattedMessage = (message: string) => {
-        const prefix = 'one or more objects failed to apply, reason: ';
-        let cleanMessage = message;
-
-        // Remove duplicate prefix if exists
-        if (message.startsWith(prefix) && message.substring(prefix.length).startsWith(prefix)) {
-            cleanMessage = prefix + message.substring(prefix.length * 2);
-        }
-
-        // Format immutable fields error message
-        if (cleanMessage.includes('attempting to change immutable fields:')) {
-            const [header, ...details] = cleanMessage.split('\n');
-            const formattedDetails = details
-                .filter(line => line.trim())
-                .map(line => {
-                    if (line.startsWith('-')) {
-                        const [field, changes] = line.substring(2).split(':');
-                        if (changes) {
-                            const [from, to] = changes.split('to:').map(s => s.trim());
-                            return `   - ${field}:\n      from: ${from.replace('from:', '').trim()}\n      to:   ${to}`;
-                        }
-                    }
-                    return line;
-                })
-                .join('\n');
-
-            return `${header}\n${formattedDetails}`;
-        }
-
-        return cleanMessage;
-    };
 
     const operationAttributes = [
         {title: 'OPERATION', value: utils.getOperationType(application)},
@@ -101,7 +70,7 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
                                   margin: 0,
                                   fontFamily: 'inherit'
                               }}>
-                              {getFormattedMessage(operationState.message)}
+                              {utils.formatOperationMessage(operationState.message)}
                           </pre>
                       )
                   }

--- a/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
+++ b/ui/src/app/applications/components/application-operation-state/application-operation-state.tsx
@@ -57,12 +57,12 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
     const getFormattedMessage = (message: string) => {
         const prefix = 'one or more objects failed to apply, reason: ';
         let cleanMessage = message;
-        
+
         // Remove duplicate prefix if exists
         if (message.startsWith(prefix) && message.substring(prefix.length).startsWith(prefix)) {
             cleanMessage = prefix + message.substring(prefix.length * 2);
         }
-        
+
         // Format immutable fields error message
         if (cleanMessage.includes('attempting to change immutable fields:')) {
             const [header, ...details] = cleanMessage.split('\n');
@@ -79,27 +79,35 @@ export const ApplicationOperationState: React.StatelessComponent<Props> = ({appl
                     return line;
                 })
                 .join('\n');
-                
+
             return `${header}\n${formattedDetails}`;
         }
-        
+
         return cleanMessage;
     };
 
     const operationAttributes = [
         {title: 'OPERATION', value: utils.getOperationType(application)},
         {title: 'PHASE', value: operationState.phase},
-        ...(operationState.message ? [{
-            title: 'MESSAGE', 
-            value: <pre style={{
-                whiteSpace: 'pre-wrap',
-                wordBreak: 'break-word',
-                margin: 0,
-                fontFamily: 'inherit'
-            }}>
-                {getFormattedMessage(operationState.message)}
-            </pre>
-        }] : []),        {title: 'STARTED AT', value: <Timestamp date={operationState.startedAt} />},
+        ...(operationState.message
+            ? [
+                  {
+                      title: 'MESSAGE',
+                      value: (
+                          <pre
+                              style={{
+                                  whiteSpace: 'pre-wrap',
+                                  wordBreak: 'break-word',
+                                  margin: 0,
+                                  fontFamily: 'inherit'
+                              }}>
+                              {getFormattedMessage(operationState.message)}
+                          </pre>
+                      )
+                  }
+              ]
+            : []),
+        {title: 'STARTED AT', value: <Timestamp date={operationState.startedAt} />},
         {
             title: 'DURATION',
             value: (

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1552,7 +1552,7 @@ export function formatOperationMessage(message: string): string {
         return message;
     }
 
-    let cleanMessage = message;
+    const cleanMessage = message;
 
     // Format immutable fields error message
     if (cleanMessage.includes('attempting to change immutable fields:')) {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1547,6 +1547,36 @@ export function formatCreationTimestamp(creationTimestamp: string) {
     );
 }
 
+export function formatOperationMessage(message: string): string {
+    if (!message) {
+        return message;
+    }
+
+    let cleanMessage = message;
+
+    // Format immutable fields error message
+    if (cleanMessage.includes('attempting to change immutable fields:')) {
+        const [header, ...details] = cleanMessage.split('\n');
+        const formattedDetails = details
+            .filter(line => line.trim())
+            .map(line => {
+                if (line.startsWith('-')) {
+                    const [field, changes] = line.substring(2).split(':');
+                    if (changes) {
+                        const [from, to] = changes.split('to:').map(s => s.trim());
+                        return `   - ${field}:\n      from: ${from.replace('from:', '').trim()}\n      to:   ${to}`;
+                    }
+                }
+                return line;
+            })
+            .join('\n');
+
+        return `${header}\n${formattedDetails}`;
+    }
+
+    return cleanMessage;
+}
+
 export const selectPostfix = (arr: string[], singular: string, plural: string) => (arr.length > 1 ? plural : singular);
 
 export function getUsrMsgKeyToDisplay(appName: string, msgKey: string, usrMessages: appModels.UserMessages[]) {

--- a/ui/src/app/applications/components/utils.tsx
+++ b/ui/src/app/applications/components/utils.tsx
@@ -1547,34 +1547,42 @@ export function formatCreationTimestamp(creationTimestamp: string) {
     );
 }
 
+/*
+ * formatStatefulSetChange reformats a single line describing changes to immutable fields in a StatefulSet.
+ * It extracts the field name and its "from" and "to" values for better readability.
+ */
+function formatStatefulSetChange(line: string): string {
+    if (line.startsWith('-')) {
+        // Remove leading "- " from the line and split into field and changes
+        const [field, changes] = line.substring(2).split(':');
+        if (changes) {
+            // Split "from: X to: Y" into separate lines with aligned values
+            const [from, to] = changes.split('to:').map(s => s.trim());
+            return `   - ${field}:\n      from: ${from.replace('from:', '').trim()}\n      to:   ${to}`;
+        }
+    }
+    return line;
+}
+
 export function formatOperationMessage(message: string): string {
     if (!message) {
         return message;
     }
 
-    const cleanMessage = message;
-
     // Format immutable fields error message
-    if (cleanMessage.includes('attempting to change immutable fields:')) {
-        const [header, ...details] = cleanMessage.split('\n');
+    if (message.includes('attempting to change immutable fields:')) {
+        const [header, ...details] = message.split('\n');
         const formattedDetails = details
+            // Remove empty lines
             .filter(line => line.trim())
-            .map(line => {
-                if (line.startsWith('-')) {
-                    const [field, changes] = line.substring(2).split(':');
-                    if (changes) {
-                        const [from, to] = changes.split('to:').map(s => s.trim());
-                        return `   - ${field}:\n      from: ${from.replace('from:', '').trim()}\n      to:   ${to}`;
-                    }
-                }
-                return line;
-            })
+            // Use helper function
+            .map(formatStatefulSetChange)
             .join('\n');
 
         return `${header}\n${formattedDetails}`;
     }
 
-    return cleanMessage;
+    return message;
 }
 
 export const selectPostfix = (arr: string[], singular: string, plural: string) => (arr.length > 1 ? plural : singular);


### PR DESCRIPTION
Checklist:

Fixes: #20899
Depends on: [654](https://github.com/argoproj/gitops-engine/pull/654)

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->


Before: 
![Screenshot 2024-12-13 at 8 30 35 PM](https://github.com/user-attachments/assets/66ad5058-82c9-4623-ac34-f1e406c30281)


After: 
![Screenshot 2025-02-13 at 4 33 35 PM](https://github.com/user-attachments/assets/73cb3d7c-b0d5-4aa1-8d28-9e7c4908f4f0)

