### PR TITLE
chore: enable importas for k8s.io/apimachinery/pkg/api/errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,6 +62,8 @@ linters-settings:
         pkg: github.com/golang-jwt/jwt/v5
       - alias: corev1
         pkg: k8s.io/api/core/v1
+      - alias: apierrors 
+        pkg: k8s.io/apimachinery/pkg/api/errors
       - alias: metav1 
         pkg: k8s.io/apimachinery/pkg/apis/meta/v1
       - alias: stderrors

--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -465,7 +465,7 @@ func (r *ApplicationSetReconciler) setApplicationSetStatusCondition(ctx context.
 			updatedAppset.DeepCopyInto(applicationSet)
 			return nil
 		})
-		if err != nil && !apierr.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("unable to set application set condition: %w", err)
 		}
 	}
@@ -489,7 +489,7 @@ func (r *ApplicationSetReconciler) validateGeneratedApplications(ctx context.Con
 		appProject := &argov1alpha1.AppProject{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: app.Spec.Project, Namespace: r.ArgoCDNamespace}, appProject)
 		if err != nil {
-			if apierr.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				errorsByIndex[i] = fmt.Errorf("application references project %s which does not exist", app.Spec.Project)
 				continue
 			}
@@ -1302,7 +1302,7 @@ func (r *ApplicationSetReconciler) migrateStatus(ctx context.Context, appset *ar
 			updatedAppset.DeepCopyInto(appset)
 			return nil
 		})
-		if err != nil && !apierr.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("unable to set application set condition: %w", err)
 		}
 	}

--- a/cmd/argocd/commands/admin/redis_initial_password.go
+++ b/cmd/argocd/commands/admin/redis_initial_password.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -74,7 +74,7 @@ func NewRedisInitialPasswordCommand() *cobra.Command {
 				Type: corev1.SecretTypeOpaque,
 			}
 			_, err = kubeClientset.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
-			if err != nil && !apierr.IsAlreadyExists(err) {
+			if err != nil && !apierrors.IsAlreadyExists(err) {
 				errors.CheckError(err)
 			}
 

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -26,7 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -59,8 +59,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/argo/normalizers"
 	"github.com/argoproj/argo-cd/v2/util/env"
 	"github.com/argoproj/argo-cd/v2/util/stats"
-
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/argoproj/argo-cd/v2/pkg/ratelimiter"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
@@ -277,7 +275,7 @@ func NewApplicationController(
 			applicationControllerName := env.StringFromEnv(common.EnvAppControllerName, common.DefaultApplicationControllerName)
 			appControllerDeployment, err := deploymentInformer.Lister().Deployments(settingsMgr.GetNamespace()).Get(applicationControllerName)
 			if err != nil {
-				if kubeerrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					appControllerDeployment = nil
 				} else {
 					return fmt.Errorf("error retrieving Application Controller Deployment: %w", err)
@@ -400,7 +398,7 @@ func (ctrl *ApplicationController) getAppProj(app *appv1.Application) (*appv1.Ap
 	}
 	proj, err := projCache.(*appProjCache).GetAppProject(context.TODO())
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, err
 		} else {
 			return nil, fmt.Errorf("could not retrieve AppProject '%s' from cache: %w", app.Spec.Project, err)
@@ -1180,7 +1178,7 @@ func (ctrl *ApplicationController) finalizeApplicationDeletion(app *appv1.Applic
 	// Get refreshed application info, since informer app copy might be stale
 	app, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
 	if err != nil {
-		if !apierr.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			logCtx.Errorf("Unable to get refreshed application info prior deleting resources: %v", err)
 		}
 		return nil
@@ -1535,7 +1533,7 @@ func (ctrl *ApplicationController) setOperationState(app *appv1.Application, sta
 		_, err := ctrl.PatchAppWithWriteBack(context.Background(), app.Name, app.Namespace, types.MergePatchType, patchJSON, metav1.PatchOptions{})
 		if err != nil {
 			// Stop retrying updating deleted application
-			if apierr.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil
 			}
 			// kube.RetryUntilSucceed logs failed attempts at "debug" level, but we want to know if this fails. Log a
@@ -2449,7 +2447,7 @@ func (ctrl *ApplicationController) newApplicationInformerAndLister() (cache.Shar
 
 func (ctrl *ApplicationController) projectErrorToCondition(err error, app *appv1.Application) appv1.ApplicationCondition {
 	var condition appv1.ApplicationCondition
-	if apierr.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		condition = appv1.ApplicationCondition{
 			Type:    appv1.ApplicationConditionInvalidSpecError,
 			Message: fmt.Sprintf("Application referencing project %s which does not exist", app.Spec.Project),

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1309,7 +1309,7 @@ func TestSetOperationStateOnDeletedApp(t *testing.T) {
 	patched := false
 	fakeAppCs.AddReactor("patch", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		patched = true
-		return true, &v1alpha1.Application{}, apierr.NewNotFound(schema.GroupResource{}, "my-app")
+		return true, &v1alpha1.Application{}, apierrors.NewNotFound(schema.GroupResource{}, "my-app")
 	})
 	ctrl.setOperationState(newFakeApp(), &v1alpha1.OperationState{Phase: synccommon.OperationSucceeded})
 	assert.True(t, patched)

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -409,14 +409,14 @@ func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return kerrors.IsInternalError(err) ||
-		kerrors.IsInvalid(err) ||
-		kerrors.IsTooManyRequests(err) ||
-		kerrors.IsServerTimeout(err) ||
-		kerrors.IsServiceUnavailable(err) ||
-		kerrors.IsTimeout(err) ||
-		kerrors.IsUnexpectedObjectError(err) ||
-		kerrors.IsUnexpectedServerError(err) ||
+	return apierrors.IsInternalError(err) ||
+		apierrors.IsInvalid(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsUnexpectedObjectError(err) ||
+		apierrors.IsUnexpectedServerError(err) ||
 		isResourceQuotaConflictErr(err) ||
 		isTransientNetworkErr(err) ||
 		isExceededQuotaErr(err) ||
@@ -429,11 +429,11 @@ func isHTTP2GoawayErr(err error) bool {
 }
 
 func isExceededQuotaErr(err error) bool {
-	return kerrors.IsForbidden(err) && strings.Contains(err.Error(), "exceeded quota")
+	return apierrors.IsForbidden(err) && strings.Contains(err.Error(), "exceeded quota")
 }
 
 func isResourceQuotaConflictErr(err error) bool {
-	return kerrors.IsConflict(err) && strings.Contains(err.Error(), "Operation cannot be fulfilled on resourcequota")
+	return apierrors.IsConflict(err) && strings.Contains(err.Error(), "Operation cannot be fulfilled on resourcequota")
 }
 
 func isTransientNetworkErr(err error) bool {

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -239,15 +239,15 @@ func TestIsRetryableError(t *testing.T) {
 		assert.False(t, isRetryableError(nil))
 	})
 	t.Run("ResourceQuotaConflictErr", func(t *testing.T) {
-		assert.False(t, isRetryableError(apierr.NewConflict(schema.GroupResource{}, "", nil)))
-		assert.True(t, isRetryableError(apierr.NewConflict(schema.GroupResource{Group: "v1", Resource: "resourcequotas"}, "", nil)))
+		assert.False(t, isRetryableError(apierrors.NewConflict(schema.GroupResource{}, "", nil)))
+		assert.True(t, isRetryableError(apierrors.NewConflict(schema.GroupResource{Group: "v1", Resource: "resourcequotas"}, "", nil)))
 	})
 	t.Run("ExceededQuotaErr", func(t *testing.T) {
-		assert.False(t, isRetryableError(apierr.NewForbidden(schema.GroupResource{}, "", nil)))
-		assert.True(t, isRetryableError(apierr.NewForbidden(schema.GroupResource{Group: "v1", Resource: "pods"}, "", errors.New("exceeded quota"))))
+		assert.False(t, isRetryableError(apierrors.NewForbidden(schema.GroupResource{}, "", nil)))
+		assert.True(t, isRetryableError(apierrors.NewForbidden(schema.GroupResource{Group: "v1", Resource: "pods"}, "", errors.New("exceeded quota"))))
 	})
 	t.Run("TooManyRequestsDNS", func(t *testing.T) {
-		assert.True(t, isRetryableError(apierr.NewTooManyRequests("", 0)))
+		assert.True(t, isRetryableError(apierrors.NewTooManyRequests("", 0)))
 	})
 	t.Run("DNSError", func(t *testing.T) {
 		assert.True(t, isRetryableError(&net.DNSError{}))

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -23,7 +23,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 
 	log "github.com/sirupsen/logrus"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -313,7 +313,7 @@ func GetOrUpdateShardFromConfigMap(kubeClient kubernetes.Interface, settingsMgr 
 	shardMappingCM, err := kubeClient.CoreV1().ConfigMaps(settingsMgr.GetNamespace()).Get(context.Background(), common.ArgoCDAppControllerShardConfigMapName, metav1.GetOptions{})
 
 	if err != nil {
-		if !kubeerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return -1, fmt.Errorf("error getting sharding config map: %w", err)
 		}
 		log.Infof("shard mapping configmap %s not found. Creating default shard mapping configmap.", common.ArgoCDAppControllerShardConfigMapName)
@@ -487,7 +487,7 @@ func GetClusterSharding(kubeClient kubernetes.Interface, settingsMgr *settings.S
 			// If we still see conflicts after the retries, wait for next iteration of heartbeat process.
 			for i := 0; i <= common.AppControllerHeartbeatUpdateRetryCount; i++ {
 				shardNumber, err = GetOrUpdateShardFromConfigMap(kubeClient, settingsMgr, replicasCount, shardNumber)
-				if err != nil && !kubeerrors.IsConflict(err) {
+				if err != nil && !apierrors.IsConflict(err) {
 					err = fmt.Errorf("unable to get shard due to error updating the sharding config map: %w", err)
 					break
 				}

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -9,7 +9,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -170,7 +170,7 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	a, err := s.appLister.Applications(ns).Get(app)
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			http.Error(w, "App not found", http.StatusNotFound)
 			return
 		}

--- a/server/applicationset/applicationset.go
+++ b/server/applicationset/applicationset.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
@@ -230,7 +230,7 @@ func (s *Server) Create(ctx context.Context, q *applicationset.ApplicationSetCre
 		return created, nil
 	}
 
-	if !apierr.IsAlreadyExists(err) {
+	if !apierrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("error creating ApplicationSet: %w", err)
 	}
 	// act idempotent if existing spec matches new spec
@@ -314,7 +314,7 @@ func (s *Server) updateAppSet(appset *v1alpha1.ApplicationSet, newAppset *v1alph
 			s.waitSync(res)
 			return res, nil
 		}
-		if !apierr.IsConflict(err) {
+		if !apierrors.IsConflict(err) {
 			return nil, err
 		}
 
@@ -453,7 +453,7 @@ func (s *Server) checkCreatePermissions(ctx context.Context, appset *v1alpha1.Ap
 
 	_, err := s.appclientset.ArgoprojV1alpha1().AppProjects(s.ns).Get(ctx, projectName, metav1.GetOptions{})
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return status.Errorf(codes.InvalidArgument, "ApplicationSet references project %s which does not exist", projectName)
 		}
 		return fmt.Errorf("error getting ApplicationSet's project %q: %w", projectName, err)

--- a/server/notification/notification.go
+++ b/server/notification/notification.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/argoproj/notifications-engine/pkg/api"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/notification"
@@ -25,7 +25,7 @@ func NewServer(apiFactory api.Factory) notification.NotificationServiceServer {
 func (s *Server) ListTriggers(ctx context.Context, q *notification.TriggersListRequest) (*notification.TriggerList, error) {
 	api, err := s.apiFactory.GetAPI()
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return &notification.TriggerList{}, nil
 		}
 	}
@@ -40,7 +40,7 @@ func (s *Server) ListTriggers(ctx context.Context, q *notification.TriggersListR
 func (s *Server) ListServices(ctx context.Context, q *notification.ServicesListRequest) (*notification.ServiceList, error) {
 	api, err := s.apiFactory.GetAPI()
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return &notification.ServiceList{}, nil
 		}
 		return nil, err
@@ -56,7 +56,7 @@ func (s *Server) ListServices(ctx context.Context, q *notification.ServicesListR
 func (s *Server) ListTemplates(ctx context.Context, q *notification.TemplatesListRequest) (*notification.TemplateList, error) {
 	api, err := s.apiFactory.GetAPI()
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return &notification.TemplateList{}, nil
 		}
 		return nil, err

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
@@ -260,7 +260,7 @@ func (s *Server) Create(ctx context.Context, q *project.ProjectCreateRequest) (*
 		return nil, fmt.Errorf("error validating project: %w", err)
 	}
 	res, err := s.appclientset.ArgoprojV1alpha1().AppProjects(s.ns).Create(ctx, q.Project, metav1.CreateOptions{})
-	if apierr.IsAlreadyExists(err) {
+	if apierrors.IsAlreadyExists(err) {
 		existing, getErr := s.appclientset.ArgoprojV1alpha1().AppProjects(s.ns).Get(ctx, q.Project.Name, metav1.GetOptions{})
 		if getErr != nil {
 			return nil, status.Errorf(codes.Internal, "unable to check existing project details: %v", getErr)
@@ -539,7 +539,7 @@ func (s *Server) NormalizeProjs() error {
 					log.Infof("Successfully normalized project %s.", proj.Name)
 					break
 				}
-				if !apierr.IsConflict(err) {
+				if !apierrors.IsConflict(err) {
 					log.Warnf("Failed normalize project %s", proj.Name)
 					break
 				}

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -330,7 +330,7 @@ func (s *Server) GetAppDetails(ctx context.Context, q *repositorypkg.RepoAppDeta
 	if err := s.enf.EnforceErr(claims, rbacpolicy.ResourceApplications, rbacpolicy.ActionGet, appRBACObj); err != nil {
 		return nil, err
 	}
-	if apierr.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		// app doesn't exist since it still is being formulated. verify they can create the app
 		// before we reveal repo details
 		if err := s.enf.EnforceErr(claims, rbacpolicy.ResourceApplications, rbacpolicy.ActionCreate, appRBACObj); err != nil {

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -10,7 +10,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 
@@ -223,7 +223,7 @@ func DoesNotExist() Expectation {
 	return func(c *Consequences) (state, string) {
 		_, err := c.get()
 		if err != nil {
-			if apierr.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return succeeded, "app does not exist"
 			}
 			return failed, err.Error()
@@ -236,7 +236,7 @@ func DoesNotExistNow() Expectation {
 	return func(c *Consequences) (state, string) {
 		_, err := c.get()
 		if err != nil {
-			if apierr.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return succeeded, "app does not exist"
 			}
 			return failed, err.Error()

--- a/test/e2e/fixture/applicationsets/utils/fixture.go
+++ b/test/e2e/fixture/applicationsets/utils/fixture.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -118,7 +118,7 @@ func EnsureCleanState(t *testing.T) {
 		func() error {
 			// Delete the applicationset-e2e namespace, if it exists
 			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), ApplicationsResourcesNamespace, metav1.DeleteOptions{PropagationPolicy: &policy})
-			if err != nil && !apierr.IsNotFound(err) { // 'not found' error is expected
+			if err != nil && !apierrors.IsNotFound(err) { // 'not found' error is expected
 				return err
 			}
 			return nil
@@ -126,7 +126,7 @@ func EnsureCleanState(t *testing.T) {
 		func() error {
 			// Delete the argocd-e2e-external namespace, if it exists
 			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), string(ArgoCDExternalNamespace), metav1.DeleteOptions{PropagationPolicy: &policy})
-			if err != nil && !apierr.IsNotFound(err) { // 'not found' error is expected
+			if err != nil && !apierrors.IsNotFound(err) { // 'not found' error is expected
 				return err
 			}
 			return nil
@@ -134,7 +134,7 @@ func EnsureCleanState(t *testing.T) {
 		func() error {
 			// Delete the argocd-e2e-external namespace, if it exists
 			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), string(ArgoCDExternalNamespace2), metav1.DeleteOptions{PropagationPolicy: &policy})
-			if err != nil && !apierr.IsNotFound(err) { // 'not found' error is expected
+			if err != nil && !apierrors.IsNotFound(err) { // 'not found' error is expected
 				return err
 			}
 			return nil
@@ -276,7 +276,7 @@ func cleanUpNamespace(fixtureClient *E2EFixtureK8sClient, namespace string) erro
 		msg = fmt.Sprintf("namespace '%s' still exists, after delete", namespace)
 	}
 
-	if msg == "" && err != nil && apierr.IsNotFound(err) {
+	if msg == "" && err != nil && apierrors.IsNotFound(err) {
 		// Success is an error containing 'applicationset-e2e' not found.
 		return nil
 	}

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -244,7 +244,7 @@ func RefreshApp(appIf v1alpha1.ApplicationInterface, name string, refreshType ar
 	for attempt := 0; attempt < 5; attempt++ {
 		app, err := appIf.Patch(context.Background(), name, types.MergePatchType, patch, metav1.PatchOptions{})
 		if err != nil {
-			if !apierr.IsConflict(err) {
+			if !apierrors.IsConflict(err) {
 				return nil, fmt.Errorf("error patching annotations in application %q: %w", name, err)
 			}
 		} else {
@@ -881,7 +881,7 @@ func SetAppOperation(appIf v1alpha1.ApplicationInterface, appName string, op *ar
 		if err == nil {
 			return a, nil
 		}
-		if !apierr.IsConflict(err) {
+		if !apierrors.IsConflict(err) {
 			return nil, fmt.Errorf("error updating application %q: %w", appName, err)
 		}
 		log.Warnf("Failed to set operation for app '%s' due to update conflict. Retrying again...", appName)

--- a/util/clusterauth/clusterauth.go
+++ b/util/clusterauth/clusterauth.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -67,7 +67,7 @@ func CreateServiceAccount(
 	}
 	_, err := clientset.CoreV1().ServiceAccounts(namespace).Create(context.Background(), &serviceAccount, metav1.CreateOptions{})
 	if err != nil {
-		if !apierr.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("Failed to create service account %q in namespace %q: %w", serviceAccountName, namespace, err)
 		}
 		log.Infof("ServiceAccount %q already exists in namespace %q", serviceAccountName, namespace)
@@ -80,7 +80,7 @@ func CreateServiceAccount(
 func upsert(kind string, name string, create func() (any, error), update func() (any, error)) error {
 	_, err := create()
 	if err != nil {
-		if !apierr.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("Failed to create %s %q: %w", kind, name, err)
 		}
 		_, err = update()
@@ -339,7 +339,7 @@ func UninstallClusterManagerRBAC(clientset kubernetes.Interface) error {
 // UninstallRBAC uninstalls RBAC related resources  for a binding, role, and service account
 func UninstallRBAC(clientset kubernetes.Interface, namespace, bindingName, roleName, serviceAccount string) error {
 	if err := clientset.RbacV1().ClusterRoleBindings().Delete(context.Background(), bindingName, metav1.DeleteOptions{}); err != nil {
-		if !apierr.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("Failed to delete ClusterRoleBinding: %w", err)
 		}
 		log.Infof("ClusterRoleBinding %q not found", bindingName)
@@ -348,7 +348,7 @@ func UninstallRBAC(clientset kubernetes.Interface, namespace, bindingName, roleN
 	}
 
 	if err := clientset.RbacV1().ClusterRoles().Delete(context.Background(), roleName, metav1.DeleteOptions{}); err != nil {
-		if !apierr.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("Failed to delete ClusterRole: %w", err)
 		}
 		log.Infof("ClusterRole %q not found", roleName)
@@ -357,7 +357,7 @@ func UninstallRBAC(clientset kubernetes.Interface, namespace, bindingName, roleN
 	}
 
 	if err := clientset.CoreV1().ServiceAccounts(namespace).Delete(context.Background(), serviceAccount, metav1.DeleteOptions{}); err != nil {
-		if !apierr.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("Failed to delete ServiceAccount: %w", err)
 		}
 		log.Infof("ServiceAccount %q in namespace %q not found", serviceAccount, namespace)
@@ -456,7 +456,7 @@ func RotateServiceAccountSecrets(clientset kubernetes.Interface, claims *Service
 	// 2. delete existing secret object
 	secretsClient := clientset.CoreV1().Secrets(claims.Namespace)
 	err = secretsClient.Delete(context.Background(), claims.SecretName, metav1.DeleteOptions{})
-	if !apierr.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -224,7 +224,7 @@ func TestRotateServiceAccountSecrets(t *testing.T) {
 	}, sa.Secrets)
 	secretsClient := kubeclientset.CoreV1().Secrets(testClaims.Namespace)
 	_, err = secretsClient.Get(context.Background(), testClaims.SecretName, metav1.GetOptions{})
-	assert.True(t, apierr.IsNotFound(err))
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestGetServiceAccountBearerToken(t *testing.T) {

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/ptr"
@@ -118,7 +118,7 @@ func (db *db) CreateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Clust
 
 	clusterSecret, err = db.createSecret(ctx, clusterSecret)
 	if err != nil {
-		if apierr.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return nil, status.Errorf(codes.AlreadyExists, "cluster %q already exists", c.Server)
 		}
 		return nil, err

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -176,7 +176,7 @@ func (db *db) GetApplicationControllerReplicas() int {
 	appControllerDeployment, err := db.kubeclientset.AppsV1().Deployments(db.settingsMgr.GetNamespace()).Get(context.Background(), applicationControllerName, metav1.GetOptions{})
 	if err != nil {
 		appControllerDeployment = nil
-		if !kubeerrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			log.Warnf("error retrieveing Argo CD controller deployment: %s", err)
 		}
 	}

--- a/util/db/repository_legacy.go
+++ b/util/db/repository_legacy.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -307,7 +307,7 @@ func (l *legacyRepositoryBackend) updateCredentialsSecret(credsInfo *settings.Re
 func (l *legacyRepositoryBackend) upsertSecret(name string, data map[string][]byte) error {
 	secret, err := l.db.kubeclientset.CoreV1().Secrets(l.db.ns).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			if len(data) == 0 {
 				return nil
 			}

--- a/util/db/repository_secrets.go
+++ b/util/db/repository_secrets.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -38,7 +38,7 @@ func (s *secretsRepositoryBackend) CreateRepository(ctx context.Context, reposit
 
 	_, err := s.db.createSecret(ctx, repositorySecret)
 	if err != nil {
-		if apierr.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			hasLabel, err := s.hasRepoTypeLabel(secName)
 			if err != nil {
 				return nil, status.Error(codes.Internal, err.Error())
@@ -63,7 +63,7 @@ func (s *secretsRepositoryBackend) hasRepoTypeLabel(secretName string) (bool, er
 	noCache := make(map[string]*corev1.Secret)
 	sec, err := s.db.getSecret(secretName, noCache)
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err
@@ -192,7 +192,7 @@ func (s *secretsRepositoryBackend) CreateRepoCreds(ctx context.Context, repoCred
 
 	_, err := s.db.createSecret(ctx, repoCredsSecret)
 	if err != nil {
-		if apierr.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return nil, status.Errorf(codes.AlreadyExists, "repository credentials %q already exists", repoCreds.URL)
 		}
 		return nil, err

--- a/util/db/repository_secrets_test.go
+++ b/util/db/repository_secrets_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -93,7 +93,7 @@ func TestSecretsRepositoryBackend_CreateRepository(t *testing.T) {
 				Group:    "v1",
 				Resource: "secrets",
 			}
-			return true, nil, k8serrors.NewAlreadyExists(gr, "already exists")
+			return true, nil, apierrors.NewAlreadyExists(gr, "already exists")
 		})
 
 		// when
@@ -130,7 +130,7 @@ func TestSecretsRepositoryBackend_CreateRepository(t *testing.T) {
 				Group:    "v1",
 				Resource: "secrets",
 			}
-			return true, nil, k8serrors.NewAlreadyExists(gr, "already exists")
+			return true, nil, apierrors.NewAlreadyExists(gr, "already exists")
 		})
 		watcher := watch.NewFakeWithChanSize(1, true)
 		watcher.Add(secret)

--- a/util/grpc/errors.go
+++ b/util/grpc/errors.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func rewrapError(err error, code codes.Code) error {
@@ -66,31 +66,31 @@ func kubeErrToGRPC(err error) error {
 	*/
 
 	switch {
-	case apierr.IsNotFound(err):
+	case apierrors.IsNotFound(err):
 		err = rewrapError(err, codes.NotFound)
-	case apierr.IsAlreadyExists(err):
+	case apierrors.IsAlreadyExists(err):
 		err = rewrapError(err, codes.AlreadyExists)
-	case apierr.IsInvalid(err):
+	case apierrors.IsInvalid(err):
 		err = rewrapError(err, codes.InvalidArgument)
-	case apierr.IsMethodNotSupported(err):
+	case apierrors.IsMethodNotSupported(err):
 		err = rewrapError(err, codes.Unimplemented)
-	case apierr.IsServiceUnavailable(err):
+	case apierrors.IsServiceUnavailable(err):
 		err = rewrapError(err, codes.Unavailable)
-	case apierr.IsBadRequest(err):
+	case apierrors.IsBadRequest(err):
 		err = rewrapError(err, codes.FailedPrecondition)
-	case apierr.IsUnauthorized(err):
+	case apierrors.IsUnauthorized(err):
 		err = rewrapError(err, codes.Unauthenticated)
-	case apierr.IsForbidden(err):
+	case apierrors.IsForbidden(err):
 		err = rewrapError(err, codes.PermissionDenied)
-	case apierr.IsTimeout(err):
+	case apierrors.IsTimeout(err):
 		err = rewrapError(err, codes.DeadlineExceeded)
-	case apierr.IsServerTimeout(err):
+	case apierrors.IsServerTimeout(err):
 		err = rewrapError(err, codes.Unavailable)
-	case apierr.IsConflict(err):
+	case apierrors.IsConflict(err):
 		err = rewrapError(err, codes.Aborted)
-	case apierr.IsTooManyRequests(err):
+	case apierrors.IsTooManyRequests(err):
 		err = rewrapError(err, codes.ResourceExhausted)
-	case apierr.IsInternalError(err):
+	case apierrors.IsInternalError(err):
 		err = rewrapError(err, codes.Internal)
 	default:
 		// This is necessary as GRPC Status don't support wrapped errors:

--- a/util/grpc/errors_test.go
+++ b/util/grpc/errors_test.go
@@ -7,7 +7,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/stretchr/testify/assert"
@@ -51,10 +51,10 @@ func Test_kubeErrToGRPC(t *testing.T) {
 			Group:    "apps",
 			Resource: "Deployment",
 		}
-		return apierr.NewForbidden(gr, "some-app", errors.New("authentication error"))
+		return apierrors.NewForbidden(gr, "some-app", errors.New("authentication error"))
 	}
 	newUnauthorizedError := func() error {
-		return apierr.NewUnauthorized("unauthenticated")
+		return apierrors.NewUnauthorized("unauthenticated")
 	}
 	cases := []*testCase{
 		{
@@ -80,7 +80,7 @@ func Test_kubeErrToGRPC(t *testing.T) {
 			expectedGRPCStatus: status.New(codes.NotFound, "Not found"),
 		},
 		{
-			name: "will return permission denied if apierr.IsForbidden",
+			name: "will return permission denied if apierrors.IsForbidden",
 			givenErrFn: func() error {
 				return newForbiddenError()
 			},
@@ -92,7 +92,7 @@ func Test_kubeErrToGRPC(t *testing.T) {
 			expectedGRPCStatus: status.New(codes.PermissionDenied, newForbiddenError().Error()),
 		},
 		{
-			name: "will return unauthenticated if apierr.IsUnauthorized",
+			name: "will return unauthenticated if apierrors.IsUnauthorized",
 			givenErrFn: func() error {
 				return newUnauthorizedError()
 			},
@@ -104,40 +104,40 @@ func Test_kubeErrToGRPC(t *testing.T) {
 			expectedGRPCStatus: status.New(codes.Unauthenticated, newUnauthorizedError().Error()),
 		},
 		{
-			name: "will return Unavailable if apierr.IsServerTimeout",
+			name: "will return Unavailable if apierrors.IsServerTimeout",
 			givenErrFn: func() error {
-				return apierr.NewServerTimeout(schema.GroupResource{}, "update", 1)
+				return apierrors.NewServerTimeout(schema.GroupResource{}, "update", 1)
 			},
 			expectedErrFn: func() error {
-				err := apierr.NewServerTimeout(schema.GroupResource{}, "update", 1)
+				err := apierrors.NewServerTimeout(schema.GroupResource{}, "update", 1)
 				grpcStatus := status.New(codes.Unavailable, err.Error())
 				return grpcStatus.Err()
 			},
-			expectedGRPCStatus: status.New(codes.Unavailable, apierr.NewServerTimeout(schema.GroupResource{}, "update", 1).Error()),
+			expectedGRPCStatus: status.New(codes.Unavailable, apierrors.NewServerTimeout(schema.GroupResource{}, "update", 1).Error()),
 		},
 		{
-			name: "will return Aborted if apierr.IsConflict",
+			name: "will return Aborted if apierrors.IsConflict",
 			givenErrFn: func() error {
-				return apierr.NewConflict(schema.GroupResource{}, "foo", errors.New("foo"))
+				return apierrors.NewConflict(schema.GroupResource{}, "foo", errors.New("foo"))
 			},
 			expectedErrFn: func() error {
-				err := apierr.NewConflict(schema.GroupResource{}, "foo", errors.New("foo"))
+				err := apierrors.NewConflict(schema.GroupResource{}, "foo", errors.New("foo"))
 				grpcStatus := status.New(codes.Aborted, err.Error())
 				return grpcStatus.Err()
 			},
-			expectedGRPCStatus: status.New(codes.Aborted, apierr.NewConflict(schema.GroupResource{}, "foo", errors.New("foo")).Error()),
+			expectedGRPCStatus: status.New(codes.Aborted, apierrors.NewConflict(schema.GroupResource{}, "foo", errors.New("foo")).Error()),
 		},
 		{
-			name: "will return ResourceExhausted if apierr.IsTooManyRequests",
+			name: "will return ResourceExhausted if apierrors.IsTooManyRequests",
 			givenErrFn: func() error {
-				return apierr.NewTooManyRequests("foo", 1)
+				return apierrors.NewTooManyRequests("foo", 1)
 			},
 			expectedErrFn: func() error {
-				err := apierr.NewTooManyRequests("foo", 1)
+				err := apierrors.NewTooManyRequests("foo", 1)
 				grpcStatus := status.New(codes.ResourceExhausted, err.Error())
 				return grpcStatus.Err()
 			},
-			expectedGRPCStatus: status.New(codes.ResourceExhausted, apierr.NewTooManyRequests("foo", 1).Error()),
+			expectedGRPCStatus: status.New(codes.ResourceExhausted, apierrors.NewTooManyRequests("foo", 1).Error()),
 		},
 	}
 	for _, c := range cases {

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	v1 "k8s.io/client-go/informers/core/v1"
@@ -348,7 +348,7 @@ func (e *Enforcer) newInformer() cache.SharedIndexInformer {
 func (e *Enforcer) RunPolicyLoader(ctx context.Context, onUpdated func(cm *corev1.ConfigMap) error) error {
 	cm, err := e.clientset.CoreV1().ConfigMaps(e.namespace).Get(ctx, e.configmap, metav1.GetOptions{})
 	if err != nil {
-		if !apierr.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -21,7 +21,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -642,7 +641,7 @@ func (mgr *SettingsManager) updateSecret(callback func(*corev1.Secret) error) er
 	argoCDSecret, err := mgr.getSecret()
 	createSecret := false
 	if err != nil {
-		if !apierr.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		argoCDSecret = &corev1.Secret{
@@ -680,7 +679,7 @@ func (mgr *SettingsManager) updateConfigMap(callback func(*corev1.ConfigMap) err
 	argoCDCM, err := mgr.getConfigMap()
 	createCM := false
 	if err != nil {
-		if !apierr.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		argoCDCM = &corev1.ConfigMap{
@@ -1658,7 +1657,7 @@ func (mgr *SettingsManager) externalServerTLSCertificate() (*tls.Certificate, er
 	var cert tls.Certificate
 	secret, err := mgr.GetSecretByName(externalServerTLSSecretName)
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
#### Description 

[Importas](https://golangci-lint.run/usage/linters/#importas) helps ensure consistency of imports aliases.

This is only for `k8s.io/apimachinery/pkg/api/errors` yet here