### PR TITLE
chore: Fix data race detection failures in application tests

### DIFF
--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -78,7 +78,7 @@ func (b broadcasterMock) Subscribe(ch chan *appv1.ApplicationWatchEvent, filters
 	// Simulate the broadcaster notifying the subscriber of an application update.
 	// The second parameter to Subscribe is filters. For the purposes of tests, we ignore the filters. Future tests
 	// might require implementing those.
-	return func() {
+	go func() {
 		for _, obj := range b.objects {
 			app, ok := obj.(*appsv1.Application)
 			if ok {
@@ -91,7 +91,8 @@ func (b broadcasterMock) Subscribe(ch chan *appv1.ApplicationWatchEvent, filters
 				ch <- &appsv1.ApplicationWatchEvent{Type: watch.Added, Application: *clonedApp}
 			}
 		}
-	}
+	}()
+	return func() {}
 }
 
 func (broadcasterMock) OnAdd(interface{}, bool)           {}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -48,7 +48,6 @@ import (
 	appinformer "github.com/argoproj/argo-cd/v2/pkg/client/informers/externalversions"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
-	appmocks "github.com/argoproj/argo-cd/v2/server/application/mocks"
 	servercache "github.com/argoproj/argo-cd/v2/server/cache"
 	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
 	"github.com/argoproj/argo-cd/v2/test"
@@ -70,6 +69,34 @@ const (
 )
 
 var testEnableEventList []string = argo.DefaultEnableEventList()
+
+type broadcasterMock struct {
+	objects []runtime.Object
+}
+
+func (b broadcasterMock) Subscribe(ch chan *appv1.ApplicationWatchEvent, filters ...func(event *appv1.ApplicationWatchEvent) bool) func() {
+	// Simulate the broadcaster notifying the subscriber of an application update.
+	// The second parameter to Subscribe is filters. For the purposes of tests, we ignore the filters. Future tests
+	// might require implementing those.
+	return func() {
+		for _, obj := range b.objects {
+			app, ok := obj.(*appsv1.Application)
+			if ok {
+				oldVersion, err := strconv.Atoi(app.ResourceVersion)
+				if err != nil {
+					oldVersion = 0
+				}
+				clonedApp := app.DeepCopy()
+				clonedApp.ResourceVersion = strconv.Itoa(oldVersion + 1)
+				ch <- &appsv1.ApplicationWatchEvent{Type: watch.Added, Application: *clonedApp}
+			}
+		}
+	}
+}
+
+func (broadcasterMock) OnAdd(interface{}, bool)           {}
+func (broadcasterMock) OnUpdate(interface{}, interface{}) {}
+func (broadcasterMock) OnDelete(interface{})              {}
 
 func fakeRepo() *appsv1.Repository {
 	return &appsv1.Repository{
@@ -227,30 +254,9 @@ func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer),
 		panic("Timed out waiting for caches to sync")
 	}
 
-	broadcaster := new(appmocks.Broadcaster)
-	broadcaster.On("Subscribe", mock.Anything, mock.Anything).Return(func() {}).Run(func(args mock.Arguments) {
-		// Simulate the broadcaster notifying the subscriber of an application update.
-		// The second parameter to Subscribe is filters. For the purposes of tests, we ignore the filters. Future tests
-		// might require implementing those.
-		go func() {
-			events := args.Get(0).(chan *appsv1.ApplicationWatchEvent)
-			for _, obj := range objects {
-				app, ok := obj.(*appsv1.Application)
-				if ok {
-					oldVersion, err := strconv.Atoi(app.ResourceVersion)
-					if err != nil {
-						oldVersion = 0
-					}
-					clonedApp := app.DeepCopy()
-					clonedApp.ResourceVersion = strconv.Itoa(oldVersion + 1)
-					events <- &appsv1.ApplicationWatchEvent{Type: watch.Added, Application: *clonedApp}
-				}
-			}
-		}()
-	})
-	broadcaster.On("OnAdd", mock.Anything, mock.Anything).Return()
-	broadcaster.On("OnUpdate", mock.Anything, mock.Anything).Return()
-	broadcaster.On("OnDelete", mock.Anything).Return()
+	broadcaster := broadcasterMock{
+		objects: objects,
+	}
 
 	appStateCache := appstate.NewCache(cache.NewCache(cache.NewInMemoryCache(time.Hour)), time.Hour)
 	// pre-populate the app cache
@@ -410,30 +416,9 @@ func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rb
 		panic("Timed out waiting for caches to sync")
 	}
 
-	broadcaster := new(appmocks.Broadcaster)
-	broadcaster.On("Subscribe", mock.Anything, mock.Anything).Return(func() {}).Run(func(args mock.Arguments) {
-		// Simulate the broadcaster notifying the subscriber of an application update.
-		// The second parameter to Subscribe is filters. For the purposes of tests, we ignore the filters. Future tests
-		// might require implementing those.
-		go func() {
-			events := args.Get(0).(chan *appsv1.ApplicationWatchEvent)
-			for _, obj := range objects {
-				app, ok := obj.(*appsv1.Application)
-				if ok {
-					oldVersion, err := strconv.Atoi(app.ResourceVersion)
-					if err != nil {
-						oldVersion = 0
-					}
-					clonedApp := app.DeepCopy()
-					clonedApp.ResourceVersion = strconv.Itoa(oldVersion + 1)
-					events <- &appsv1.ApplicationWatchEvent{Type: watch.Added, Application: *clonedApp}
-				}
-			}
-		}()
-	})
-	broadcaster.On("OnAdd", mock.Anything, mock.Anything).Return()
-	broadcaster.On("OnUpdate", mock.Anything, mock.Anything).Return()
-	broadcaster.On("OnDelete", mock.Anything).Return()
+	broadcaster := broadcasterMock{
+		objects: objects,
+	}
 
 	appStateCache := appstate.NewCache(cache.NewCache(cache.NewInMemoryCache(time.Hour)), time.Hour)
 	// pre-populate the app cache


### PR DESCRIPTION
Previously a data race would occur when using the generated Broadcaster mock between:

* Calling SetInferredName on ApplicationDestination during the invoked business logic.
* Accessing ApplicationDestination properties during the invocation of the Broadcaster mock callbacks when the mock
attempts to record the call parameters (where it attempts to stringify parameters).

In other words the data race was a false positive caused by the tests themselves.

This change replaces the use of the generated mock with a simple manually implemented one.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
