### PR TITLE
chore: use sigs.k8s.io/yaml/goyaml.v* instead of gopkg.in/yaml.v*

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,6 +56,14 @@ linters-settings:
         - github.com/pkg/errors:
             recommendations:
               - errors
+        - gopkg.in/yaml.v2:
+            recommendations:
+              - sigs.k8s.io/yaml
+            reason: "`sigs.k8s.io/yaml/goyaml.v2` can be used instead."
+        - gopkg.in/yaml.v3:
+            recommendations:
+              - sigs.k8s.io/yaml
+            reason: "`sigs.k8s.io/yaml/goyaml.v3` can be used instead."
   importas:
     alias:
       - alias: jwtgo 

--- a/applicationset/utils/createOrUpdate_test.go
+++ b/applicationset/utils/createOrUpdate_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/argo/normalizers"

--- a/cmpserver/plugin/plugin_test.go
+++ b/cmpserver/plugin/plugin_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
-	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/argoproj/argo-cd/v2/cmpserver/apiclient"
 	repoclient "github.com/argoproj/argo-cd/v2/reposerver/apiclient"

--- a/commitserver/commit/hydratorhelper.go
+++ b/commitserver/commit/hydratorhelper.go
@@ -8,8 +8,8 @@ import (
 	"text/template"
 
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"github.com/argoproj/argo-cd/v2/commitserver/apiclient"
 	"github.com/argoproj/argo-cd/v2/util/io/files"

--- a/go.mod
+++ b/go.mod
@@ -93,8 +93,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28
 	google.golang.org/grpc v1.69.2
 	google.golang.org/protobuf v1.36.1
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.2
 	k8s.io/apimachinery v0.31.0
@@ -160,6 +158,8 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241104194629-dd2ea8efbc28 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/retry.v1 v1.0.3 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )

--- a/hack/gen-docs/main.go
+++ b/hack/gen-docs/main.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/argoproj/notifications-engine/pkg/docs"
 )

--- a/hack/gen-resources/generators/cluster_generator.go
+++ b/hack/gen-resources/generators/cluster_generator.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/argoproj/argo-cd/v2/hack/gen-resources/util"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/hack/gen-resources/util/gen_options_parser.go
+++ b/hack/gen-resources/util/gen_options_parser.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 type SourceOpts struct {

--- a/server/extension/extension.go
+++ b/server/extension/extension.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/felixge/httpsnoop"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	applisters "github.com/argoproj/argo-cd/v2/pkg/client/listers/application/v1alpha1"

--- a/server/server.go
+++ b/server/server.go
@@ -54,7 +54,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
-	"gopkg.in/yaml.v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -62,6 +61,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"

--- a/test/e2e/fixture/admin/utils/backup.go
+++ b/test/e2e/fixture/admin/utils/backup.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 type ExportedResources []unstructured.Unstructured

--- a/util/argo/resource_tracking_test.go
+++ b/util/argo/resource_tracking_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/argoproj/argo-cd/v2/common"
 )

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/argoproj/pkg/sync"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/argoproj/argo-cd/v2/util/cache"
 	argoio "github.com/argoproj/argo-cd/v2/util/io"

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"github.com/argoproj/argo-cd/v2/util/io"
 )


### PR DESCRIPTION
#### Description 

[gomodguard](https://golangci-lint.run/usage/linters/#gomodguard) allows to block some dependencies.

This ensure than `gopkg.in/yaml.v2` and `gopkg.in/yaml.v3` are not used anymore as `sigs.k8s.io/yaml` provides them both