### PR TITLE
chore: use dario.cat/mergo instead of github.com/imdario/mergo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,6 +49,10 @@ linters-settings:
         - github.com/golang-jwt/jwt/v4:
             recommendations:
               - github.com/golang-jwt/jwt/v5
+        - github.com/imdario/mergo:
+            recommendations:
+              - dario.cat/mergo
+            reason: "`github.com/imdario/mergo` has been renamed."
         - github.com/pkg/errors:
             recommendations:
               - errors

--- a/applicationset/generators/generator_spec_processor.go
+++ b/applicationset/generators/generator_spec_processor.go
@@ -13,7 +13,7 @@ import (
 
 	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/applicationset/generators/matrix.go
+++ b/applicationset/generators/matrix.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/argoproj/argo-cd/v2/applicationset/utils"

--- a/applicationset/generators/merge.go
+++ b/applicationset/generators/merge.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/argoproj/argo-cd/v2/applicationset/utils"

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/argoproj/gitops-engine/pkg/health"
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	. "github.com/argoproj/gitops-engine/pkg/utils/testing"
-	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	code.gitea.io/sdk/gitea v0.19.0
+	dario.cat/mergo v1.0.1
 	github.com/Azure/kubelogin v0.1.6
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/Masterminds/sprig/v3 v3.3.0
@@ -54,7 +55,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/imdario/mergo v0.3.16
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/itchyny/gojq v0.12.17
 	github.com/jeremywohl/flatten v1.0.1
@@ -113,7 +113,6 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
@@ -142,6 +141,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect


### PR DESCRIPTION
#### Description 

[gomodguard](https://golangci-lint.run/usage/linters/#gomodguard) allows to block some dependencies.

This ensure that `github.com/imdario/mergo` is not used anymore as it has been renamed `dario.cat/mergo`