### PR TITLE
chore: use github.com/evanphx/json-patch/v5

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,8 +14,10 @@ linters:
     - gocritic
     - gofumpt
     - goimports
+    - gomodguard
     - gosimple
     - govet
+    - importas
     - ineffassign
     - misspell
     - perfsprint
@@ -40,6 +42,16 @@ linters-settings:
       - typeSwitchVar
   goimports:
     local-prefixes: github.com/argoproj/argo-cd/v2
+  gomodguard:
+    blocked:
+      modules:
+        - github.com/evanphx/json-patch:
+            recommendations:
+              - github.com/evanphx/json-patch/v5
+  importas:
+    alias:
+      - alias: jsonpatch 
+        pkg: github.com/evanphx/json-patch/v5
   perfsprint:
     # Optimizes even if it requires an int or uint type cast.
     int-conversion: true

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -22,7 +22,7 @@ import (
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
 	resourceutil "github.com/argoproj/gitops-engine/pkg/sync/resource"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 	v1 "k8s.io/api/core/v1"

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -17,7 +17,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/sync"
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/cyphar/filepath-securejoin v0.3.6
 	github.com/dustin/go-humanize v1.0.1
-	github.com/evanphx/json-patch v5.9.0+incompatible
+	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/expr-lang/expr v1.16.9
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/fsnotify/fsnotify v1.8.0
@@ -192,7 +192,7 @@ require (
 	github.com/dlclark/regexp2 v1.11.4
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -21,7 +21,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	textutils "github.com/argoproj/gitops-engine/pkg/utils/text"
 	"github.com/argoproj/pkg/sync"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/go-jsonnet"

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -18,7 +18,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/gitops-engine/pkg/utils/text"
 	"github.com/argoproj/pkg/sync"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1028,7 +1028,9 @@ func (s *Server) Patch(ctx context.Context, q *application.ApplicationPatchReque
 		if err != nil {
 			return nil, fmt.Errorf("error decoding json patch: %w", err)
 		}
-		patchApp, err = patch.Apply(jsonApp)
+		options := jsonpatch.NewApplyOptions()
+		options.EnsurePathExistsOnAdd = true
+		patchApp, err = patch.ApplyWithOptions(jsonApp, options)
 		if err != nil {
 			return nil, fmt.Errorf("error applying patch: %w", err)
 		}

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -1032,8 +1032,9 @@ func Patch(path string, jsonPatch string) {
 	}
 
 	log.WithFields(log.Fields{"bytes": string(bytes)}).Info("JSON")
-
-	bytes, err = patch.Apply(bytes)
+	options := jsonpatch.NewApplyOptions()
+	options.EnsurePathExistsOnAdd = true
+	bytes, err = patch.ApplyWithOptions(bytes, options)
 	CheckError(err)
 
 	if isYaml {

--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/argoproj/gitops-engine/pkg/diff"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/itchyny/gojq"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -225,7 +225,7 @@ func (n *ignoreNormalizer) Normalize(un *unstructured.Unstructured) error {
 }
 
 func shouldLogError(e error) bool {
-	if strings.Contains(e.Error(), "Unable to remove nonexistent key") {
+	if strings.Contains(e.Error(), "unable to remove nonexistent key") {
 		return false
 	}
 	if strings.Contains(e.Error(), "remove operation does not apply: doc is missing path") {

--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -56,7 +56,9 @@ type jsonPatchNormalizerPatch struct {
 }
 
 func (np *jsonPatchNormalizerPatch) Apply(data []byte) ([]byte, error) {
-	patchedData, err := np.patch.Apply(data)
+	options := jsonpatch.NewApplyOptions()
+	options.EnsurePathExistsOnAdd = true
+	patchedData, err := np.patch.ApplyWithOptions(data, options)
 	if err != nil {
 		return nil, err
 	}

--- a/util/notification/settings/legacy.go
+++ b/util/notification/settings/legacy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/argoproj/notifications-engine/pkg/subscriptions"
 	"github.com/argoproj/notifications-engine/pkg/triggers"
 	"github.com/argoproj/notifications-engine/pkg/util/text"
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"


### PR DESCRIPTION
#### Description 

[gomodguard](https://golangci-lint.run/usage/linters/#gomodguard) allows to block some dependencies.

This ensure that `github.com/evanphx/json-patch/v5` is used instead of `github.com/evanphx/json-patch`