### PR TITLE
chore: enable errorf of perfsprint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     - gomodguard
     - gosimple
     - govet
+    - importas
     - ineffassign
     - misspell
     - perfsprint
@@ -47,13 +48,17 @@ linters-settings:
         - github.com/pkg/errors:
             recommendations:
               - errors
+  importas:
+    alias:
+      - alias: stderrors
+        pkg: errors
   perfsprint:
     # Optimizes even if it requires an int or uint type cast.
     int-conversion: true
     # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
     err-error: true
     # Optimizes `fmt.Errorf`.
-    errorf: false
+    errorf: true
     # Optimizes `fmt.Sprintf` with only one argument.
     sprintf1: true
     # Optimizes into strings concatenation.

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -1864,7 +1865,7 @@ func TestRequeueGeneratorFails(t *testing.T) {
 	generatorMock.On("GetTemplate", &generator).
 		Return(&v1alpha1.ApplicationSetTemplate{})
 	generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything).
-		Return([]map[string]interface{}{}, fmt.Errorf("Simulated error generating params that could be related to an external service/API call"))
+		Return([]map[string]interface{}{}, errors.New("Simulated error generating params that could be related to an external service/API call"))
 
 	metrics := appsetmetrics.NewFakeAppsetMetrics(client)
 
@@ -1969,7 +1970,7 @@ func TestValidateGeneratedApplications(t *testing.T) {
 					},
 				},
 			},
-			validationErrors: map[int]error{0: fmt.Errorf("application destination spec is invalid: application destination can't have both name and server defined: my-cluster my-server")},
+			validationErrors: map[int]error{0: errors.New("application destination spec is invalid: application destination can't have both name and server defined: my-cluster my-server")},
 		},
 		{
 			name: "project mismatch should return error",
@@ -1991,7 +1992,7 @@ func TestValidateGeneratedApplications(t *testing.T) {
 					},
 				},
 			},
-			validationErrors: map[int]error{0: fmt.Errorf("application references project DOES-NOT-EXIST which does not exist")},
+			validationErrors: map[int]error{0: errors.New("application references project DOES-NOT-EXIST which does not exist")},
 		},
 		{
 			name: "valid app should return true",
@@ -2035,7 +2036,7 @@ func TestValidateGeneratedApplications(t *testing.T) {
 					},
 				},
 			},
-			validationErrors: map[int]error{0: fmt.Errorf("application destination spec is invalid: unable to find destination server: there are no clusters with this name: nonexistent-cluster")},
+			validationErrors: map[int]error{0: errors.New("application destination spec is invalid: unable to find destination server: there are no clusters with this name: nonexistent-cluster")},
 		},
 	} {
 		t.Run(cc.name, func(t *testing.T) {

--- a/applicationset/controllers/template/template_test.go
+++ b/applicationset/controllers/template/template_test.go
@@ -1,7 +1,7 @@
 package template
 
 import (
-	"fmt"
+	"errors"
 	"maps"
 	"testing"
 
@@ -53,7 +53,7 @@ func TestGenerateApplications(t *testing.T) {
 		},
 		{
 			name:                "Handles error from the generator",
-			generateParamsError: fmt.Errorf("error"),
+			generateParamsError: errors.New("error"),
 			expectErr:           true,
 			expectedReason:      v1alpha1.ApplicationSetReasonApplicationParamsGenerationError,
 		},
@@ -68,7 +68,7 @@ func TestGenerateApplications(t *testing.T) {
 				},
 				Spec: v1alpha1.ApplicationSpec{},
 			},
-			rendererError:  fmt.Errorf("error"),
+			rendererError:  errors.New("error"),
 			expectErr:      true,
 			expectedReason: v1alpha1.ApplicationSetReasonRenderTemplateParamsError,
 		},

--- a/applicationset/generators/cluster_test.go
+++ b/applicationset/generators/cluster_test.go
@@ -2,7 +2,7 @@ package generators
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +27,7 @@ type possiblyErroringFakeCtrlRuntimeClient struct {
 
 func (p *possiblyErroringFakeCtrlRuntimeClient) List(ctx context.Context, secretList client.ObjectList, opts ...client.ListOption) error {
 	if p.shouldError {
-		return fmt.Errorf("could not list Secrets")
+		return errors.New("could not list Secrets")
 	}
 	return p.Client.List(ctx, secretList, opts...)
 }
@@ -227,7 +227,7 @@ func TestGenerateParams(t *testing.T) {
 			values:        nil,
 			expected:      nil,
 			clientError:   true,
-			expectedError: fmt.Errorf("error getting cluster secrets: could not list Secrets"),
+			expectedError: errors.New("error getting cluster secrets: could not list Secrets"),
 		},
 		{
 			name:     "flat mode without selectors",
@@ -677,7 +677,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 			values:        nil,
 			expected:      nil,
 			clientError:   true,
-			expectedError: fmt.Errorf("error getting cluster secrets: could not list Secrets"),
+			expectedError: errors.New("error getting cluster secrets: could not list Secrets"),
 		},
 		{
 			name:       "Clusters with flat list mode and no selector",

--- a/applicationset/generators/duck_type.go
+++ b/applicationset/generators/duck_type.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -96,13 +97,13 @@ func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.A
 	// Validate the fields
 	if kind == "" || versionIdx < 1 {
 		log.Warningf("kind=%v, resourceName=%v, versionIdx=%v", kind, resourceName, versionIdx)
-		return nil, fmt.Errorf("There is a problem with the apiVersion, kind or resourceName provided")
+		return nil, errors.New("There is a problem with the apiVersion, kind or resourceName provided")
 	}
 
 	if (resourceName == "" && labelSelector.MatchLabels == nil && labelSelector.MatchExpressions == nil) ||
 		(resourceName != "" && (labelSelector.MatchExpressions != nil || labelSelector.MatchLabels != nil)) {
 		log.Warningf("You must choose either resourceName=%v, labelSelector.matchLabels=%v or labelSelect.matchExpressions=%v", resourceName, labelSelector.MatchLabels, labelSelector.MatchExpressions)
-		return nil, fmt.Errorf("There is a problem with the definition of the ClusterDecisionResource generator")
+		return nil, errors.New("There is a problem with the definition of the ClusterDecisionResource generator")
 	}
 
 	// Split up the apiVersion
@@ -130,7 +131,7 @@ func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.A
 
 	if len(duckResources.Items) == 0 {
 		log.Warning("no resource found, make sure you clusterDecisionResource is defined correctly")
-		return nil, fmt.Errorf("no clusterDecisionResources found")
+		return nil, errors.New("no clusterDecisionResources found")
 	}
 
 	// Override the duck type in the status of the resource

--- a/applicationset/generators/duck_type_test.go
+++ b/applicationset/generators/duck_type_test.go
@@ -2,7 +2,7 @@ package generators
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -160,7 +160,7 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 			resource:      duckType,
 			values:        nil,
 			expected:      []map[string]interface{}{},
-			expectedError: fmt.Errorf("There is a problem with the definition of the ClusterDecisionResource generator"),
+			expectedError: errors.New("There is a problem with the definition of the ClusterDecisionResource generator"),
 		},
 		/*** This does not work with the FAKE runtime client, fieldSelectors are broken.
 		{
@@ -271,7 +271,7 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 			resource:      duckType,
 			values:        nil,
 			expected:      nil,
-			expectedError: fmt.Errorf("There is a problem with the definition of the ClusterDecisionResource generator"),
+			expectedError: errors.New("There is a problem with the definition of the ClusterDecisionResource generator"),
 		},
 	}
 
@@ -456,7 +456,7 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 			resource:      duckType,
 			values:        nil,
 			expected:      []map[string]interface{}{},
-			expectedError: fmt.Errorf("There is a problem with the definition of the ClusterDecisionResource generator"),
+			expectedError: errors.New("There is a problem with the definition of the ClusterDecisionResource generator"),
 		},
 		/*** This does not work with the FAKE runtime client, fieldSelectors are broken.
 		{
@@ -567,7 +567,7 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 			resource:      duckType,
 			values:        nil,
 			expected:      nil,
-			expectedError: fmt.Errorf("There is a problem with the definition of the ClusterDecisionResource generator"),
+			expectedError: errors.New("There is a problem with the definition of the ClusterDecisionResource generator"),
 		},
 	}
 

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -307,9 +308,9 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 			name:          "handles error from repo server",
 			directories:   []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps:      []string{},
-			repoError:     fmt.Errorf("error"),
+			repoError:     errors.New("error"),
 			expected:      []map[string]interface{}{},
-			expectedError: fmt.Errorf("error generating params from git: error getting directories from repo: error"),
+			expectedError: errors.New("error generating params from git: error getting directories from repo: error"),
 		},
 	}
 
@@ -608,9 +609,9 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 			name:          "handles error from repo server",
 			directories:   []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps:      []string{},
-			repoError:     fmt.Errorf("error"),
+			repoError:     errors.New("error"),
 			expected:      []map[string]interface{}{},
-			expectedError: fmt.Errorf("error generating params from git: error getting directories from repo: error"),
+			expectedError: errors.New("error generating params from git: error getting directories from repo: error"),
 		},
 	}
 
@@ -808,9 +809,9 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			name:             "handles error during getting repo paths",
 			files:            []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{},
-			repoPathsError:   fmt.Errorf("paths error"),
+			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]interface{}{},
-			expectedError:    fmt.Errorf("error generating params from git: paths error"),
+			expectedError:    errors.New("error generating params from git: paths error"),
 		},
 		{
 			name:  "test invalid JSON file returns error",
@@ -820,7 +821,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]interface{}{},
-			expectedError:  fmt.Errorf("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",
@@ -1120,9 +1121,9 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			name:             "handles error during getting repo paths",
 			files:            []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{},
-			repoPathsError:   fmt.Errorf("paths error"),
+			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]interface{}{},
-			expectedError:    fmt.Errorf("error generating params from git: paths error"),
+			expectedError:    errors.New("error generating params from git: paths error"),
 		},
 		{
 			name:  "test invalid JSON file returns error",
@@ -1132,7 +1133,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 			},
 			repoPathsError: nil,
 			expected:       []map[string]interface{}{},
-			expectedError:  fmt.Errorf("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}"),
+			expectedError:  errors.New("error generating params from git: unable to process file 'cluster-config/production/config.json': unable to parse file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}"),
 		},
 		{
 			name:  "test JSON array",
@@ -1464,7 +1465,7 @@ func TestGitGenerator_GenerateParams(t *testing.T) {
 			},
 			callGetDirectories: false,
 			expected:           []map[string]interface{}{{"path": "app1", "path.basename": "app1", "path.basenameNormalized": "app1", "path[0]": "app1", "values.foo": "bar"}},
-			expectedError:      fmt.Errorf("error getting project project: appprojects.argoproj.io \"project\" not found"),
+			expectedError:      errors.New("error getting project project: appprojects.argoproj.io \"project\" not found"),
 		},
 	}
 	for _, testCase := range cases {

--- a/applicationset/generators/interface.go
+++ b/applicationset/generators/interface.go
@@ -1,7 +1,7 @@
 package generators
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +27,7 @@ type Generator interface {
 }
 
 var (
-	EmptyAppSetGeneratorError = fmt.Errorf("ApplicationSet is empty")
+	EmptyAppSetGeneratorError = errors.New("ApplicationSet is empty")
 	NoRequeueAfter            time.Duration
 )
 

--- a/applicationset/generators/list.go
+++ b/applicationset/generators/list.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -54,7 +55,7 @@ func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.Appli
 				if key == "values" {
 					values, ok := (value).(map[string]interface{})
 					if !ok {
-						return nil, fmt.Errorf("error parsing values map")
+						return nil, errors.New("error parsing values map")
 					}
 					for k, v := range values {
 						value, ok := v.(string)

--- a/applicationset/generators/matrix.go
+++ b/applicationset/generators/matrix.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,9 +17,9 @@ import (
 var _ Generator = (*MatrixGenerator)(nil)
 
 var (
-	ErrMoreThanTwoGenerators      = fmt.Errorf("found more than two generators, Matrix support only two")
-	ErrLessThanTwoGenerators      = fmt.Errorf("found less than two generators, Matrix support only two")
-	ErrMoreThenOneInnerGenerators = fmt.Errorf("found more than one generator in matrix.Generators")
+	ErrMoreThanTwoGenerators      = errors.New("found more than two generators, Matrix support only two")
+	ErrLessThanTwoGenerators      = errors.New("found less than two generators, Matrix support only two")
+	ErrMoreThenOneInnerGenerators = errors.New("found more than one generator in matrix.Generators")
 )
 
 type MatrixGenerator struct {
@@ -125,7 +126,7 @@ func (m *MatrixGenerator) getParams(appSetBaseGenerator argoprojiov1alpha1.Appli
 	}
 
 	if len(t) == 0 {
-		return nil, fmt.Errorf("child generator generated no parameters")
+		return nil, errors.New("child generator generated no parameters")
 	}
 
 	if len(t) > 1 {

--- a/applicationset/generators/merge.go
+++ b/applicationset/generators/merge.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,9 +18,9 @@ import (
 var _ Generator = (*MergeGenerator)(nil)
 
 var (
-	ErrLessThanTwoGeneratorsInMerge = fmt.Errorf("found less than two generators, Merge requires two or more")
-	ErrNoMergeKeys                  = fmt.Errorf("no merge keys were specified, Merge requires at least one")
-	ErrNonUniqueParamSets           = fmt.Errorf("the parameters from a generator were not unique by the given mergeKeys, Merge requires all param sets to be unique")
+	ErrLessThanTwoGeneratorsInMerge = errors.New("found less than two generators, Merge requires two or more")
+	ErrNoMergeKeys                  = errors.New("no merge keys were specified, Merge requires at least one")
+	ErrNonUniqueParamSets           = errors.New("the parameters from a generator were not unique by the given mergeKeys, Merge requires all param sets to be unique")
 )
 
 type MergeGenerator struct {
@@ -182,7 +183,7 @@ func (m *MergeGenerator) getParams(appSetBaseGenerator argoprojiov1alpha1.Applic
 	}
 
 	if len(t) == 0 {
-		return nil, fmt.Errorf("child generator generated no parameters")
+		return nil, errors.New("child generator generated no parameters")
 	}
 
 	if len(t) > 1 {

--- a/applicationset/generators/plugin.go
+++ b/applicationset/generators/plugin.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -194,12 +195,12 @@ func (g *PluginGenerator) getConfigMap(ctx context.Context, configMapRef string)
 
 	baseUrl, ok := cm.Data["baseUrl"]
 	if !ok || baseUrl == "" {
-		return nil, fmt.Errorf("baseUrl not found in ConfigMap")
+		return nil, errors.New("baseUrl not found in ConfigMap")
 	}
 
 	token, ok := cm.Data["token"]
 	if !ok || token == "" {
-		return nil, fmt.Errorf("token not found in ConfigMap")
+		return nil, errors.New("token not found in ConfigMap")
 	}
 
 	return cm.Data, nil

--- a/applicationset/generators/plugin_test.go
+++ b/applicationset/generators/plugin_test.go
@@ -3,6 +3,7 @@ package generators
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -371,7 +372,7 @@ func TestPluginGenerateParams(t *testing.T) {
 			gotemplate:      false,
 			content:         []byte(`wrong body ...`),
 			expected:        []map[string]interface{}{},
-			expectedError:   fmt.Errorf("error listing params: error get api 'set': invalid character 'w' looking for beginning of value: wrong body ..."),
+			expectedError:   errors.New("error listing params: error get api 'set': invalid character 'w' looking for beginning of value: wrong body ..."),
 		},
 		{
 			name: "external secret",
@@ -475,7 +476,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					},
 				},
 			},
-			expectedError: fmt.Errorf("error getting plugin from generator: error fetching Secret token: error fetching secret default/argocd-secret: secrets \"argocd-secret\" not found"),
+			expectedError: errors.New("error getting plugin from generator: error fetching Secret token: error fetching secret default/argocd-secret: secrets \"argocd-secret\" not found"),
 		},
 		{
 			name:      "no configmap",
@@ -522,7 +523,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					},
 				},
 			},
-			expectedError: fmt.Errorf("error getting plugin from generator: error fetching ConfigMap: configmaps \"\" not found"),
+			expectedError: errors.New("error getting plugin from generator: error fetching ConfigMap: configmaps \"\" not found"),
 		},
 		{
 			name: "no baseUrl",
@@ -577,7 +578,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					},
 				},
 			},
-			expectedError: fmt.Errorf("error getting plugin from generator: error fetching ConfigMap: baseUrl not found in ConfigMap"),
+			expectedError: errors.New("error getting plugin from generator: error fetching ConfigMap: baseUrl not found in ConfigMap"),
 		},
 		{
 			name: "no token",
@@ -624,7 +625,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					},
 				},
 			},
-			expectedError: fmt.Errorf("error getting plugin from generator: error fetching ConfigMap: token not found in ConfigMap"),
+			expectedError: errors.New("error getting plugin from generator: error fetching ConfigMap: token not found in ConfigMap"),
 		},
 	}
 

--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -205,7 +206,7 @@ func (g *PullRequestGenerator) selectServiceProvider(ctx context.Context, genera
 		}
 		return pullrequest.NewAzureDevOpsService(ctx, token, providerConfig.API, providerConfig.Organization, providerConfig.Project, providerConfig.Repo, providerConfig.Labels)
 	}
-	return nil, fmt.Errorf("no Pull Request provider implementation configured")
+	return nil, errors.New("no Pull Request provider implementation configured")
 }
 
 func (g *PullRequestGenerator) github(ctx context.Context, cfg *argoprojiov1alpha1.PullRequestGeneratorGithub, applicationSetInfo *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error) {

--- a/applicationset/generators/pull_request_test.go
+++ b/applicationset/generators/pull_request_test.go
@@ -2,7 +2,7 @@ package generators
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,11 +125,11 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 				return pullrequest.NewFakeService(
 					ctx,
 					nil,
-					fmt.Errorf("fake error"),
+					errors.New("fake error"),
 				)
 			},
 			expected:    nil,
-			expectedErr: fmt.Errorf("error listing repos: fake error"),
+			expectedErr: errors.New("error listing repos: fake error"),
 		},
 		{
 			selectFunc: func(context.Context, *argoprojiov1alpha1.PullRequestGenerator, *argoprojiov1alpha1.ApplicationSet) (pullrequest.PullRequestService, error) {

--- a/applicationset/generators/scm_provider.go
+++ b/applicationset/generators/scm_provider.go
@@ -226,7 +226,7 @@ func (g *SCMProviderGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha
 			return nil, fmt.Errorf("error initializing AWS codecommit service: %w", awsErr)
 		}
 	} else {
-		return nil, fmt.Errorf("no SCM provider implementation configured")
+		return nil, errors.New("no SCM provider implementation configured")
 	}
 
 	// Find all the available repos.

--- a/applicationset/services/internal/http/client_test.go
+++ b/applicationset/services/internal/http/client_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -109,7 +110,7 @@ func TestClientDo(t *testing.T) {
 			clientOptionFns: nil,
 			expected:        []map[string]interface{}(nil),
 			expectedCode:    http.StatusUnauthorized,
-			expectedError:   fmt.Errorf("API error with status code 401: "),
+			expectedError:   errors.New("API error with status code 401: "),
 		},
 	} {
 		cc := c

--- a/applicationset/services/pull_request/bitbucket_cloud.go
+++ b/applicationset/services/pull_request/bitbucket_cloud.go
@@ -3,6 +3,7 @@ package pull_request
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -114,12 +115,12 @@ func (b *BitbucketCloudService) List(_ context.Context) ([]*PullRequest, error) 
 
 	resp, ok := response.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("unknown type returned from bitbucket pull requests")
+		return nil, errors.New("unknown type returned from bitbucket pull requests")
 	}
 
 	repoArray, ok := resp["values"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("unknown type returned from response values")
+		return nil, errors.New("unknown type returned from response values")
 	}
 
 	jsonStr, err := json.Marshal(repoArray)

--- a/applicationset/services/repo_service_test.go
+++ b/applicationset/services/repo_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -39,7 +40,7 @@ func TestGetDirectories(t *testing.T) {
 	}{
 		{name: "ErrorGettingRepos", fields: fields{
 			getRepository: func(ctx context.Context, url, project string) (*v1alpha1.Repository, error) {
-				return nil, fmt.Errorf("unable to get repos")
+				return nil, errors.New("unable to get repos")
 			},
 		}, args: args{}, want: nil, wantErr: assert.Error},
 		{name: "ErrorGettingDirs", fields: fields{
@@ -48,7 +49,7 @@ func TestGetDirectories(t *testing.T) {
 			},
 			repoServerClientFuncs: []func(*repo_mocks.RepoServerServiceClient){
 				func(client *repo_mocks.RepoServerServiceClient) {
-					client.On("GetGitDirectories", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("unable to get dirs"))
+					client.On("GetGitDirectories", mock.Anything, mock.Anything).Return(nil, errors.New("unable to get dirs"))
 				},
 			},
 		}, args: args{}, want: nil, wantErr: assert.Error},
@@ -70,7 +71,7 @@ func TestGetDirectories(t *testing.T) {
 			},
 			repoServerClientFuncs: []func(*repo_mocks.RepoServerServiceClient){
 				func(client *repo_mocks.RepoServerServiceClient) {
-					client.On("GetGitDirectories", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("revision HEAD is not signed"))
+					client.On("GetGitDirectories", mock.Anything, mock.Anything).Return(nil, errors.New("revision HEAD is not signed"))
 				},
 			},
 		}, args: args{}, want: nil, wantErr: assert.Error},
@@ -122,7 +123,7 @@ func TestGetFiles(t *testing.T) {
 	}{
 		{name: "ErrorGettingRepos", fields: fields{
 			getRepository: func(ctx context.Context, url, project string) (*v1alpha1.Repository, error) {
-				return nil, fmt.Errorf("unable to get repos")
+				return nil, errors.New("unable to get repos")
 			},
 		}, args: args{}, want: nil, wantErr: assert.Error},
 		{name: "ErrorGettingFiles", fields: fields{
@@ -131,7 +132,7 @@ func TestGetFiles(t *testing.T) {
 			},
 			repoServerClientFuncs: []func(*repo_mocks.RepoServerServiceClient){
 				func(client *repo_mocks.RepoServerServiceClient) {
-					client.On("GetGitFiles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("unable to get files"))
+					client.On("GetGitFiles", mock.Anything, mock.Anything).Return(nil, errors.New("unable to get files"))
 				},
 			},
 		}, args: args{}, want: nil, wantErr: assert.Error},
@@ -159,7 +160,7 @@ func TestGetFiles(t *testing.T) {
 			},
 			repoServerClientFuncs: []func(*repo_mocks.RepoServerServiceClient){
 				func(client *repo_mocks.RepoServerServiceClient) {
-					client.On("GetGitFiles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("revision HEAD is not signed"))
+					client.On("GetGitFiles", mock.Anything, mock.Anything).Return(nil, errors.New("revision HEAD is not signed"))
 				},
 			},
 		}, args: args{}, want: nil, wantErr: assert.Error},

--- a/applicationset/services/scm_provider/azure_devops.go
+++ b/applicationset/services/scm_provider/azure_devops.go
@@ -59,7 +59,7 @@ var (
 
 func NewAzureDevOpsProvider(ctx context.Context, accessToken string, org string, url string, project string, allBranches bool) (*AzureDevOpsProvider, error) {
 	if accessToken == "" {
-		return nil, fmt.Errorf("no access token provided")
+		return nil, errors.New("no access token provided")
 	}
 
 	devOpsURL, err := getValidDevOpsURL(url, org)

--- a/applicationset/services/scm_provider/azure_devops_test.go
+++ b/applicationset/services/scm_provider/azure_devops_test.go
@@ -2,6 +2,7 @@ package scm_provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestAzureDevopsRepoHasPath(t *testing.T) {
 	}{
 		{
 			name:        "RepoHasPath when Azure DevOps client factory fails returns error",
-			clientError: fmt.Errorf("Client factory error"),
+			clientError: errors.New("Client factory error"),
 		},
 		{
 			name:      "RepoHasPath when found returns true",
@@ -62,7 +63,7 @@ func TestAzureDevopsRepoHasPath(t *testing.T) {
 		{
 			name:             "RepoHasPath when unknown Azure DevOps error occurs returns error",
 			pathFound:        false,
-			azureDevopsError: fmt.Errorf("Undefined error from Azure Devops"),
+			azureDevopsError: errors.New("Undefined error from Azure Devops"),
 			returnError:      true,
 			errorMessage:     "failed to check for path existence",
 		},
@@ -133,7 +134,7 @@ func TestGetDefaultBranchOnDisabledRepo(t *testing.T) {
 		},
 		{
 			name:              "other error when calling azure devops returns error",
-			azureDevOpsError:  fmt.Errorf("some unknown error"),
+			azureDevOpsError:  errors.New("some unknown error"),
 			shouldReturnError: true,
 		},
 	}
@@ -192,7 +193,7 @@ func TestGetAllBranchesOnDisabledRepo(t *testing.T) {
 		},
 		{
 			name:              "other error when calling azure devops returns error",
-			azureDevOpsError:  fmt.Errorf("some unknown error"),
+			azureDevOpsError:  errors.New("some unknown error"),
 			shouldReturnError: true,
 		},
 	}
@@ -280,11 +281,11 @@ func TestAzureDevOpsGetBranchesDefultBranchOnly(t *testing.T) {
 		},
 		{
 			name:                "GetBranches AllBranches false when request fails returns error and empty result",
-			getBranchesApiError: fmt.Errorf("Remote Azure Devops GetBranches error"),
+			getBranchesApiError: errors.New("Remote Azure Devops GetBranches error"),
 		},
 		{
 			name:        "GetBranches AllBranches false when Azure DevOps client fails returns error",
-			clientError: fmt.Errorf("Could not get Azure Devops API client"),
+			clientError: errors.New("Could not get Azure Devops API client"),
 		},
 		{
 			name:           "GetBranches AllBranches false when branch returned with long commit SHA",
@@ -352,7 +353,7 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 		},
 		{
 			name:                "GetBranches when Azure DevOps request fails returns error and empty result",
-			getBranchesApiError: fmt.Errorf("Remote Azure Devops GetBranches error"),
+			getBranchesApiError: errors.New("Remote Azure Devops GetBranches error"),
 			allBranches:         true,
 		},
 		{
@@ -362,7 +363,7 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 		},
 		{
 			name:        "GetBranches when git client retrievel fails returns error",
-			clientError: fmt.Errorf("Could not get Azure Devops API client"),
+			clientError: errors.New("Could not get Azure Devops API client"),
 			allBranches: true,
 		},
 		{
@@ -447,7 +448,7 @@ func TestGetAzureDevopsRepositories(t *testing.T) {
 		},
 		{
 			name:                 "ListRepos when Azure DevOps request fails returns error",
-			getRepositoriesError: fmt.Errorf("Could not get repos"),
+			getRepositoriesError: errors.New("Could not get repos"),
 		},
 		{
 			name:         "ListRepos when repo has no name returns empty list",

--- a/applicationset/services/scm_provider/bitbucket_cloud.go
+++ b/applicationset/services/scm_provider/bitbucket_cloud.go
@@ -2,6 +2,7 @@ package scm_provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -155,17 +156,17 @@ func (g *BitBucketCloudProvider) listBranches(repo *Repository) ([]bitbucket.Rep
 func findCloneURL(cloneProtocol string, repo *bitbucket.Repository) (*string, error) {
 	cloneLinks, ok := repo.Links["clone"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("unknown type returned from repo links")
+		return nil, errors.New("unknown type returned from repo links")
 	}
 	for _, link := range cloneLinks {
 		linkEntry, ok := link.(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("unknown type returned from clone link")
+			return nil, errors.New("unknown type returned from clone link")
 		}
 		if linkEntry["name"] == cloneProtocol {
 			url, ok := linkEntry["href"].(string)
 			if !ok {
-				return nil, fmt.Errorf("could not find href for clone link")
+				return nil, errors.New("could not find href for clone link")
 			}
 			return &url, nil
 		}

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -128,7 +129,7 @@ func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) 
 		return fmt.Errorf("error while wrapping using MutateFn: %w", err)
 	}
 	if newKey := client.ObjectKeyFromObject(obj); key != newKey {
-		return fmt.Errorf("MutateFn cannot mutate object name and/or object namespace")
+		return stderrors.New("MutateFn cannot mutate object name and/or object namespace")
 	}
 	return nil
 }

--- a/applicationset/utils/map_test.go
+++ b/applicationset/utils/map_test.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func TestCombineStringMaps(t *testing.T) {
 			left:        map[string]interface{}{"foo": "bar", "a": "fail"},
 			right:       map[string]interface{}{"a": "b", "c": "d"},
 			expected:    map[string]string{"a": "b", "foo": "bar"},
-			expectedErr: fmt.Errorf("found duplicate key a with different value, a: fail ,b: b"),
+			expectedErr: errors.New("found duplicate key a with different value, a: fail ,b: b"),
 		},
 		{
 			name:        "pass if keys & values are the same",

--- a/applicationset/utils/utils.go
+++ b/applicationset/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -251,7 +252,7 @@ func isNillable(v reflect.Value) bool {
 
 func (r *Render) RenderTemplateParams(tmpl *argoappsv1.Application, syncPolicy *argoappsv1.ApplicationSetSyncPolicy, params map[string]interface{}, useGoTemplate bool, goTemplateOptions []string) (*argoappsv1.Application, error) {
 	if tmpl == nil {
-		return nil, fmt.Errorf("application template is empty")
+		return nil, errors.New("application template is empty")
 	}
 
 	if len(params) == 0 {
@@ -282,7 +283,7 @@ func (r *Render) RenderTemplateParams(tmpl *argoappsv1.Application, syncPolicy *
 
 func (r *Render) RenderGeneratorParams(gen *argoappsv1.ApplicationSetGenerator, params map[string]interface{}, useGoTemplate bool, goTemplateOptions []string) (*argoappsv1.ApplicationSetGenerator, error) {
 	if gen == nil {
-		return nil, fmt.Errorf("generator is empty")
+		return nil, errors.New("generator is empty")
 	}
 
 	if len(params) == 0 {

--- a/cmd/argocd-k8s-auth/commands/aws_test.go
+++ b/cmd/argocd-k8s-auth/commands/aws_test.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -35,7 +35,7 @@ func TestGetSignedRequestWithRetry(t *testing.T) {
 		mock := &signedRequestMock{
 			returnFunc: func(m *signedRequestMock) (string, error) {
 				if m.getSignedRequestCalls < 3 {
-					return "", fmt.Errorf("some error")
+					return "", errors.New("some error")
 				}
 				return "token", nil
 			},
@@ -53,7 +53,7 @@ func TestGetSignedRequestWithRetry(t *testing.T) {
 		t.Parallel()
 		mock := &signedRequestMock{
 			returnFunc: func(m *signedRequestMock) (string, error) {
-				return "", fmt.Errorf("some error")
+				return "", errors.New("some error")
 			},
 		}
 

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -106,7 +107,7 @@ func NewGenAppSpecCommand() *cobra.Command {
 			apps, err := cmdutil.ConstructApps(fileURL, appName, labels, annotations, args, appOpts, c.Flags())
 			errors.CheckError(err)
 			if len(apps) > 1 {
-				errors.CheckError(fmt.Errorf("failed to generate spec, more than one application is not supported"))
+				errors.CheckError(stderrors.New("failed to generate spec, more than one application is not supported"))
 			}
 			app := apps[0]
 			if app.Name == "" {
@@ -378,7 +379,7 @@ func reconcileApplications(
 	go appInformer.Run(ctx.Done())
 	go projInformer.Run(ctx.Done())
 	if !kubecache.WaitForCacheSync(ctx.Done(), appInformer.HasSynced, projInformer.HasSynced) {
-		return nil, fmt.Errorf("failed to sync cache")
+		return nil, stderrors.New("failed to sync cache")
 	}
 
 	appLister := appInformerFactory.Argoproj().V1alpha1().Applications().Lister()

--- a/cmd/argocd/commands/admin/project.go
+++ b/cmd/argocd/commands/admin/project.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -96,10 +97,10 @@ func getModification(modification string, resource string, scope string, permiss
 	switch modification {
 	case "set":
 		if scope == "" {
-			return nil, fmt.Errorf("Flag --group cannot be empty if permission should be set in role")
+			return nil, stderrors.New("Flag --group cannot be empty if permission should be set in role")
 		}
 		if permission == "" {
-			return nil, fmt.Errorf("Flag --permission cannot be empty if permission should be set in role")
+			return nil, stderrors.New("Flag --permission cannot be empty if permission should be set in role")
 		}
 		return func(proj string, action string) string {
 			return fmt.Sprintf("%s, %s, %s/%s, %s", resource, action, proj, scope, permission)

--- a/cmd/argocd/commands/admin/repo.go
+++ b/cmd/argocd/commands/admin/repo.go
@@ -1,7 +1,7 @@
 package admin
 
 import (
-	"fmt"
+	stderrors "errors"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -92,7 +92,7 @@ func NewGenRepoSpecCommand() *cobra.Command {
 					}
 					repoOpts.Repo.SSHPrivateKey = string(keyData)
 				} else {
-					err := fmt.Errorf("--ssh-private-key-path is only supported for SSH repositories")
+					err := stderrors.New("--ssh-private-key-path is only supported for SSH repositories")
 					errors.CheckError(err)
 				}
 			}
@@ -100,7 +100,7 @@ func NewGenRepoSpecCommand() *cobra.Command {
 			// tls-client-cert-path and tls-client-cert-key-key-path must always be
 			// specified together
 			if (repoOpts.TlsClientCertPath != "" && repoOpts.TlsClientCertKeyPath == "") || (repoOpts.TlsClientCertPath == "" && repoOpts.TlsClientCertKeyPath != "") {
-				err := fmt.Errorf("--tls-client-cert-path and --tls-client-cert-key-path must be specified together")
+				err := stderrors.New("--tls-client-cert-path and --tls-client-cert-key-path must be specified together")
 				errors.CheckError(err)
 			}
 
@@ -114,7 +114,7 @@ func NewGenRepoSpecCommand() *cobra.Command {
 					repoOpts.Repo.TLSClientCertData = string(tlsCertData)
 					repoOpts.Repo.TLSClientCertKey = string(tlsCertKey)
 				} else {
-					err := fmt.Errorf("--tls-client-cert-path is only supported for HTTPS repositories")
+					err := stderrors.New("--tls-client-cert-path is only supported for HTTPS repositories")
 					errors.CheckError(err)
 				}
 			}
@@ -128,7 +128,7 @@ func NewGenRepoSpecCommand() *cobra.Command {
 			repoOpts.Repo.EnableOCI = repoOpts.EnableOci
 
 			if repoOpts.Repo.Type == "helm" && repoOpts.Repo.Name == "" {
-				errors.CheckError(fmt.Errorf("must specify --name for repos of type 'helm'"))
+				errors.CheckError(stderrors.New("must specify --name for repos of type 'helm'"))
 			}
 
 			// If the user set a username, but didn't supply password via --password,

--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -64,7 +65,7 @@ func setSettingsMeta(obj v1.Object) {
 func (opts *settingsOpts) createSettingsManager(ctx context.Context) (*settings.SettingsManager, error) {
 	var argocdCM *corev1.ConfigMap
 	if opts.argocdCMPath == "" && !opts.loadClusterSettings {
-		return nil, fmt.Errorf("either --argocd-cm-path must be provided or --load-cluster-settings must be set to true")
+		return nil, stderrors.New("either --argocd-cm-path must be provided or --load-cluster-settings must be set to true")
 	} else if opts.argocdCMPath == "" {
 		realClientset, ns, err := opts.getK8sClient()
 		if err != nil {

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	std_errors "errors"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -400,7 +400,7 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			errors.CheckError(err)
 
 			if sourceName != "" && sourcePosition != -1 {
-				errors.CheckError(fmt.Errorf("Only one of source-position and source-name can be specified."))
+				errors.CheckError(stderrors.New("Only one of source-position and source-name can be specified."))
 			}
 
 			if sourceName != "" {
@@ -415,10 +415,10 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 			// check for source position if --show-params is set
 			if app.Spec.HasMultipleSources() && showParams {
 				if sourcePosition <= 0 {
-					errors.CheckError(fmt.Errorf("Source position should be specified and must be greater than 0 for applications with multiple sources"))
+					errors.CheckError(stderrors.New("Source position should be specified and must be greater than 0 for applications with multiple sources"))
 				}
 				if len(app.Spec.GetSources()) < sourcePosition {
-					errors.CheckError(fmt.Errorf("Source position should be less than the number of sources in the application"))
+					errors.CheckError(stderrors.New("Source position should be less than the number of sources in the application"))
 				}
 			}
 
@@ -563,7 +563,7 @@ func NewApplicationLogsCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				for {
 					msg, err := stream.Recv()
 					if err != nil {
-						if std_errors.Is(err, io.EOF) {
+						if stderrors.Is(err, io.EOF) {
 							return
 						}
 						st, ok := status.FromError(err)
@@ -835,7 +835,7 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 
 			sourceName = appOpts.SourceName
 			if sourceName != "" && sourcePosition != -1 {
-				errors.CheckError(fmt.Errorf("Only one of source-position and source-name can be specified."))
+				errors.CheckError(stderrors.New("Only one of source-position and source-name can be specified."))
 			}
 
 			if sourceName != "" {
@@ -849,10 +849,10 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 
 			if app.Spec.HasMultipleSources() {
 				if sourcePosition <= 0 {
-					errors.CheckError(fmt.Errorf("Source position should be specified and must be greater than 0 for applications with multiple sources"))
+					errors.CheckError(stderrors.New("Source position should be specified and must be greater than 0 for applications with multiple sources"))
 				}
 				if len(app.Spec.GetSources()) < sourcePosition {
-					errors.CheckError(fmt.Errorf("Source position should be less than the number of sources in the application"))
+					errors.CheckError(stderrors.New("Source position should be less than the number of sources in the application"))
 				}
 			}
 
@@ -948,7 +948,7 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 
 			sourceName = appOpts.SourceName
 			if sourceName != "" && sourcePosition != -1 {
-				errors.CheckError(fmt.Errorf("Only one of source-position and source-name can be specified."))
+				errors.CheckError(stderrors.New("Only one of source-position and source-name can be specified."))
 			}
 
 			if sourceName != "" {
@@ -962,10 +962,10 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 
 			if app.Spec.HasMultipleSources() {
 				if sourcePosition <= 0 {
-					errors.CheckError(fmt.Errorf("Source position should be specified and must be greater than 0 for applications with multiple sources"))
+					errors.CheckError(stderrors.New("Source position should be specified and must be greater than 0 for applications with multiple sources"))
 				}
 				if len(app.Spec.GetSources()) < sourcePosition {
-					errors.CheckError(fmt.Errorf("Source position should be less than the number of sources in the application"))
+					errors.CheckError(stderrors.New("Source position should be less than the number of sources in the application"))
 				}
 			}
 
@@ -1245,15 +1245,15 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 			}
 
 			if len(sourceNames) > 0 && len(sourcePositions) > 0 {
-				errors.CheckError(fmt.Errorf("Only one of source-positions and source-names can be specified."))
+				errors.CheckError(stderrors.New("Only one of source-positions and source-names can be specified."))
 			}
 
 			if len(sourcePositions) > 0 && len(revisions) != len(sourcePositions) {
-				errors.CheckError(fmt.Errorf("While using --revisions and --source-positions, length of values for both flags should be same."))
+				errors.CheckError(stderrors.New("While using --revisions and --source-positions, length of values for both flags should be same."))
 			}
 
 			if len(sourceNames) > 0 && len(revisions) != len(sourceNames) {
-				errors.CheckError(fmt.Errorf("While using --revisions and --source-names, length of values for both flags should be same."))
+				errors.CheckError(stderrors.New("While using --revisions and --source-names, length of values for both flags should be same."))
 			}
 
 			clientset := headless.NewClientOrDie(clientOpts, c)
@@ -2972,15 +2972,15 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 			}
 
 			if len(sourceNames) > 0 && len(sourcePositions) > 0 {
-				errors.CheckError(fmt.Errorf("Only one of source-positions and source-names can be specified."))
+				errors.CheckError(stderrors.New("Only one of source-positions and source-names can be specified."))
 			}
 
 			if len(sourcePositions) > 0 && len(revisions) != len(sourcePositions) {
-				errors.CheckError(fmt.Errorf("While using --revisions and --source-positions, length of values for both flags should be same."))
+				errors.CheckError(stderrors.New("While using --revisions and --source-positions, length of values for both flags should be same."))
 			}
 
 			if len(sourceNames) > 0 && len(revisions) != len(sourceNames) {
-				errors.CheckError(fmt.Errorf("While using --revisions and --source-names, length of values for both flags should be same."))
+				errors.CheckError(stderrors.New("While using --revisions and --source-names, length of values for both flags should be same."))
 			}
 
 			for _, pos := range sourcePositions {
@@ -3262,7 +3262,7 @@ func NewApplicationAddSourceCommand(clientOpts *argocdclient.ClientOptions) *cob
 			errors.CheckError(err)
 
 			if c.Flags() == nil {
-				errors.CheckError(fmt.Errorf("ApplicationSource needs atleast repoUrl, path or chart or ref field. No source to add."))
+				errors.CheckError(stderrors.New("ApplicationSource needs atleast repoUrl, path or chart or ref field. No source to add."))
 			}
 
 			if len(app.Spec.Sources) > 0 {
@@ -3317,7 +3317,7 @@ func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *
 			}
 
 			if sourceName == "" && sourcePosition <= 0 {
-				errors.CheckError(fmt.Errorf("Value of source-position must be greater than 0"))
+				errors.CheckError(stderrors.New("Value of source-position must be greater than 0"))
 			}
 
 			argocdClient := headless.NewClientOrDie(clientOpts, c)
@@ -3334,7 +3334,7 @@ func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *
 			errors.CheckError(err)
 
 			if sourceName != "" && sourcePosition != -1 {
-				errors.CheckError(fmt.Errorf("Only one of source-position and source-name can be specified."))
+				errors.CheckError(stderrors.New("Only one of source-position and source-name can be specified."))
 			}
 
 			if sourceName != "" {
@@ -3347,11 +3347,11 @@ func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *
 			}
 
 			if !app.Spec.HasMultipleSources() {
-				errors.CheckError(fmt.Errorf("Application does not have multiple sources configured"))
+				errors.CheckError(stderrors.New("Application does not have multiple sources configured"))
 			}
 
 			if len(app.Spec.GetSources()) == 1 {
-				errors.CheckError(fmt.Errorf("Cannot remove the only source remaining in the app"))
+				errors.CheckError(stderrors.New("Cannot remove the only source remaining in the app"))
 			}
 
 			if len(app.Spec.GetSources()) < sourcePosition {

--- a/cmd/argocd/commands/cert.go
+++ b/cmd/argocd/commands/cert.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"crypto/x509"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"sort"
@@ -167,13 +168,13 @@ func NewCertAddSSHCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 					sshKnownHostsLists, err = certutil.ParseSSHKnownHostsFromStream(os.Stdin)
 				}
 			} else {
-				err = fmt.Errorf("You need to specify --batch or specify --help for usage instructions")
+				err = stderrors.New("You need to specify --batch or specify --help for usage instructions")
 			}
 
 			errors.CheckError(err)
 
 			if len(sshKnownHostsLists) == 0 {
-				errors.CheckError(fmt.Errorf("No valid SSH known hosts data found."))
+				errors.CheckError(stderrors.New("No valid SSH known hosts data found."))
 			}
 
 			for _, knownHostsEntry := range sshKnownHostsLists {
@@ -234,7 +235,7 @@ func NewCertRemoveCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 			// remove all certificates, but it's less likely that it happens by
 			// accident.
 			if hostNamePattern == "*" {
-				err := fmt.Errorf("A single wildcard is not allowed as REPOSERVER name.")
+				err := stderrors.New("A single wildcard is not allowed as REPOSERVER name.")
 				errors.CheckError(err)
 			}
 

--- a/cmd/argocd/commands/context.go
+++ b/cmd/argocd/commands/context.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path"
@@ -85,7 +86,7 @@ func deleteContext(context, configPath string) error {
 	localCfg, err := localconfig.ReadLocalConfig(configPath)
 	errors.CheckError(err)
 	if localCfg == nil {
-		return fmt.Errorf("Nothing to logout from")
+		return stderrors.New("Nothing to logout from")
 	}
 
 	serverName, ok := localCfg.RemoveContext(context)
@@ -104,7 +105,7 @@ func deleteContext(context, configPath string) error {
 		}
 		err = localconfig.ValidateLocalConfig(*localCfg)
 		if err != nil {
-			return fmt.Errorf("Error in logging out")
+			return stderrors.New("Error in logging out")
 		}
 		err = localconfig.WriteLocalConfig(*localCfg, configPath)
 		errors.CheckError(err)

--- a/cmd/argocd/commands/gpg.go
+++ b/cmd/argocd/commands/gpg.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 	"strings"
@@ -96,7 +97,7 @@ func NewGPGGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			ctx := c.Context()
 
 			if len(args) != 1 {
-				errors.CheckError(fmt.Errorf("Missing KEYID argument"))
+				errors.CheckError(stderrors.New("Missing KEYID argument"))
 			}
 			conn, gpgIf := headless.NewClientOrDie(clientOpts, c).NewGPGKeyClientOrDie()
 			defer argoio.Close(conn)
@@ -136,7 +137,7 @@ func NewGPGAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			ctx := c.Context()
 
 			if fromFile == "" {
-				errors.CheckError(fmt.Errorf("--from is mandatory"))
+				errors.CheckError(stderrors.New("--from is mandatory"))
 			}
 			keyData, err := os.ReadFile(fromFile)
 			if err != nil {
@@ -166,7 +167,7 @@ func NewGPGDeleteCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command 
 			ctx := c.Context()
 
 			if len(args) != 1 {
-				errors.CheckError(fmt.Errorf("Missing KEYID argument"))
+				errors.CheckError(stderrors.New("Missing KEYID argument"))
 			}
 
 			keyId := args[0]

--- a/cmd/argocd/commands/repo.go
+++ b/cmd/argocd/commands/repo.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -118,7 +119,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 					}
 					repoOpts.Repo.SSHPrivateKey = string(keyData)
 				} else {
-					err := fmt.Errorf("--ssh-private-key-path is only supported for SSH repositories.")
+					err := stderrors.New("--ssh-private-key-path is only supported for SSH repositories.")
 					errors.CheckError(err)
 				}
 			}
@@ -126,7 +127,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			// tls-client-cert-path and tls-client-cert-key-key-path must always be
 			// specified together
 			if (repoOpts.TlsClientCertPath != "" && repoOpts.TlsClientCertKeyPath == "") || (repoOpts.TlsClientCertPath == "" && repoOpts.TlsClientCertKeyPath != "") {
-				err := fmt.Errorf("--tls-client-cert-path and --tls-client-cert-key-path must be specified together")
+				err := stderrors.New("--tls-client-cert-path and --tls-client-cert-key-path must be specified together")
 				errors.CheckError(err)
 			}
 
@@ -140,7 +141,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 					repoOpts.Repo.TLSClientCertData = string(tlsCertData)
 					repoOpts.Repo.TLSClientCertKey = string(tlsCertKey)
 				} else {
-					err := fmt.Errorf("--tls-client-cert-path is only supported for HTTPS repositories")
+					err := stderrors.New("--tls-client-cert-path is only supported for HTTPS repositories")
 					errors.CheckError(err)
 				}
 			}
@@ -152,7 +153,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 					errors.CheckError(err)
 					repoOpts.Repo.GithubAppPrivateKey = string(githubAppPrivateKey)
 				} else {
-					err := fmt.Errorf("--github-app-private-key-path is only supported for HTTPS repositories")
+					err := stderrors.New("--github-app-private-key-path is only supported for HTTPS repositories")
 					errors.CheckError(err)
 				}
 			}
@@ -163,7 +164,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 					errors.CheckError(err)
 					repoOpts.Repo.GCPServiceAccountKey = string(gcpServiceAccountKey)
 				} else {
-					err := fmt.Errorf("--gcp-service-account-key-path is only supported for HTTPS repositories")
+					err := stderrors.New("--gcp-service-account-key-path is only supported for HTTPS repositories")
 					errors.CheckError(err)
 				}
 			}
@@ -183,7 +184,7 @@ func NewRepoAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			repoOpts.Repo.ForceHttpBasicAuth = repoOpts.ForceHttpBasicAuth
 
 			if repoOpts.Repo.Type == "helm" && repoOpts.Repo.Name == "" {
-				errors.CheckError(fmt.Errorf("Must specify --name for repos of type 'helm'"))
+				errors.CheckError(stderrors.New("Must specify --name for repos of type 'helm'"))
 			}
 
 			conn, repoIf := headless.NewClientOrDie(clientOpts, c).NewRepoClientOrDie()
@@ -317,7 +318,7 @@ func NewRepoListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			case "hard":
 				forceRefresh = true
 			default:
-				err := fmt.Errorf("--refresh must be one of: 'hard'")
+				err := stderrors.New("--refresh must be one of: 'hard'")
 				errors.CheckError(err)
 			}
 			repos, err := repoIf.ListRepositories(ctx, &repositorypkg.RepoQuery{ForceRefresh: forceRefresh})
@@ -369,7 +370,7 @@ func NewRepoGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
 			case "hard":
 				forceRefresh = true
 			default:
-				err := fmt.Errorf("--refresh must be one of: 'hard'")
+				err := stderrors.New("--refresh must be one of: 'hard'")
 				errors.CheckError(err)
 			}
 			repo, err := repoIf.Get(ctx, &repositorypkg.RepoQuery{Repo: repoURL, ForceRefresh: forceRefresh, AppProject: project})

--- a/cmd/argocd/commands/repocreds.go
+++ b/cmd/argocd/commands/repocreds.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -104,7 +105,7 @@ func NewRepoCredsAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 					}
 					repo.SSHPrivateKey = string(keyData)
 				} else {
-					err := fmt.Errorf("--ssh-private-key-path is only supported for SSH repositories.")
+					err := stderrors.New("--ssh-private-key-path is only supported for SSH repositories.")
 					errors.CheckError(err)
 				}
 			}
@@ -112,7 +113,7 @@ func NewRepoCredsAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 			// tls-client-cert-path and tls-client-cert-key-key-path must always be
 			// specified together
 			if (tlsClientCertPath != "" && tlsClientCertKeyPath == "") || (tlsClientCertPath == "" && tlsClientCertKeyPath != "") {
-				err := fmt.Errorf("--tls-client-cert-path and --tls-client-cert-key-path must be specified together")
+				err := stderrors.New("--tls-client-cert-path and --tls-client-cert-key-path must be specified together")
 				errors.CheckError(err)
 			}
 
@@ -126,7 +127,7 @@ func NewRepoCredsAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 					repo.TLSClientCertData = string(tlsCertData)
 					repo.TLSClientCertKey = string(tlsCertKey)
 				} else {
-					err := fmt.Errorf("--tls-client-cert-path is only supported for HTTPS repositories")
+					err := stderrors.New("--tls-client-cert-path is only supported for HTTPS repositories")
 					errors.CheckError(err)
 				}
 			}
@@ -138,7 +139,7 @@ func NewRepoCredsAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 					errors.CheckError(err)
 					repo.GithubAppPrivateKey = string(githubAppPrivateKey)
 				} else {
-					err := fmt.Errorf("--github-app-private-key-path is only supported for HTTPS repositories")
+					err := stderrors.New("--github-app-private-key-path is only supported for HTTPS repositories")
 					errors.CheckError(err)
 				}
 			}
@@ -150,7 +151,7 @@ func NewRepoCredsAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 					errors.CheckError(err)
 					repo.GCPServiceAccountKey = string(gcpServiceAccountKey)
 				} else {
-					err := fmt.Errorf("--gcp-service-account-key-path is only supported for HTTPS repositories")
+					err := stderrors.New("--gcp-service-account-key-path is only supported for HTTPS repositories")
 					errors.CheckError(err)
 				}
 			}

--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bufio"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -636,7 +637,7 @@ func constructAppsFromFileUrl(fileURL, appName string, labels, annotations, args
 			app.Name = appName
 		}
 		if app.Name == "" {
-			return nil, fmt.Errorf("app.Name is empty. --name argument can be used to provide app.Name")
+			return nil, stderrors.New("app.Name is empty. --name argument can be used to provide app.Name")
 		}
 
 		mergeLabels(app, labels)
@@ -895,10 +896,10 @@ func FilterResources(groupChanged bool, resources []*argoappv1.ResourceDiff, gro
 		filteredObjects = append(filteredObjects, deepCopy)
 	}
 	if len(filteredObjects) == 0 {
-		return nil, fmt.Errorf("No matching resource found")
+		return nil, stderrors.New("No matching resource found")
 	}
 	if len(filteredObjects) > 1 && !all {
-		return nil, fmt.Errorf("Multiple resources match inputs. Use the --all flag to patch multiple resources")
+		return nil, stderrors.New("Multiple resources match inputs. Use the --all flag to patch multiple resources")
 	}
 	return filteredObjects, nil
 }

--- a/cmd/util/cluster.go
+++ b/cmd/util/cluster.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"sort"
@@ -131,7 +132,7 @@ func GetKubePublicEndpoint(client kubernetes.Interface) (string, error) {
 	}
 	kubeconfig, ok := clusterInfo.Data["kubeconfig"]
 	if !ok {
-		return "", fmt.Errorf("cluster-info does not contain a public kubeconfig")
+		return "", stderrors.New("cluster-info does not contain a public kubeconfig")
 	}
 	// Parse Kubeconfig and get server address
 	config := &clientcmdapiv1.Config{}
@@ -140,7 +141,7 @@ func GetKubePublicEndpoint(client kubernetes.Interface) (string, error) {
 		return "", fmt.Errorf("failed to parse cluster-info kubeconfig: %w", err)
 	}
 	if len(config.Clusters) == 0 {
-		return "", fmt.Errorf("cluster-info kubeconfig does not have any clusters")
+		return "", stderrors.New("cluster-info kubeconfig does not have any clusters")
 	}
 
 	return config.Clusters[0].Cluster.Server, nil

--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -82,13 +83,13 @@ func ReadPluginConfig(filePath string) (*PluginConfig, error) {
 
 func ValidatePluginConfig(config PluginConfig) error {
 	if config.Metadata.Name == "" {
-		return fmt.Errorf("invalid plugin configuration file. metadata.name should be non-empty.")
+		return errors.New("invalid plugin configuration file. metadata.name should be non-empty.")
 	}
 	if config.TypeMeta.Kind != ConfigManagementPluginKind {
 		return fmt.Errorf("invalid plugin configuration file. kind should be %s, found %s", ConfigManagementPluginKind, config.TypeMeta.Kind)
 	}
 	if len(config.Spec.Generate.Command) == 0 {
-		return fmt.Errorf("invalid plugin configuration file. spec.generate command should be non-empty")
+		return errors.New("invalid plugin configuration file. spec.generate command should be non-empty")
 	}
 	// discovery field is optional as apps can now specify plugin names directly
 	return nil

--- a/cmpserver/plugin/plugin.go
+++ b/cmpserver/plugin/plugin.go
@@ -63,7 +63,7 @@ func (s *Service) Init(workDir string) error {
 
 func runCommand(ctx context.Context, command Command, path string, env []string) (string, error) {
 	if len(command.Command) == 0 {
-		return "", fmt.Errorf("Command is empty")
+		return "", errors.New("Command is empty")
 	}
 	cmd := exec.CommandContext(ctx, command.Command[0], append(command.Command[1:], command.Args...)...)
 
@@ -212,7 +212,7 @@ func (s *Service) generateManifestGeneric(stream GenerateManifestStream) error {
 
 	appPath := filepath.Clean(filepath.Join(workDir, metadata.AppRelPath))
 	if !strings.HasPrefix(appPath, workDir) {
-		return fmt.Errorf("illegal appPath: out of workDir bound")
+		return errors.New("illegal appPath: out of workDir bound")
 	}
 	response, err := s.generateManifest(ctx, appPath, metadata.GetEnv())
 	if err != nil {
@@ -384,7 +384,7 @@ func (s *Service) GetParametersAnnouncement(stream apiclient.ConfigManagementPlu
 	}
 	appPath := filepath.Clean(filepath.Join(workDir, metadata.AppRelPath))
 	if !strings.HasPrefix(appPath, workDir) {
-		return fmt.Errorf("illegal appPath: out of workDir bound")
+		return errors.New("illegal appPath: out of workDir bound")
 	}
 
 	repoResponse, err := getParametersAnnouncement(bufferedCtx, appPath, s.initConstants.PluginConfig.Spec.Parameters.Static, s.initConstants.PluginConfig.Spec.Parameters.Dynamic, metadata.GetEnv())

--- a/commitserver/commit/commit.go
+++ b/commitserver/commit/commit.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -78,16 +79,16 @@ func (s *Service) CommitHydratedManifests(ctx context.Context, r *apiclient.Comm
 // the changes. It returns the output of the git commands and an error if one occurred.
 func (s *Service) handleCommitRequest(logCtx *log.Entry, r *apiclient.CommitHydratedManifestsRequest) (string, string, error) {
 	if r.Repo == nil {
-		return "", "", fmt.Errorf("repo is required")
+		return "", "", errors.New("repo is required")
 	}
 	if r.Repo.Repo == "" {
-		return "", "", fmt.Errorf("repo URL is required")
+		return "", "", errors.New("repo URL is required")
 	}
 	if r.TargetBranch == "" {
-		return "", "", fmt.Errorf("target branch is required")
+		return "", "", errors.New("target branch is required")
 	}
 	if r.SyncBranch == "" {
-		return "", "", fmt.Errorf("sync branch is required")
+		return "", "", errors.New("sync branch is required")
 	}
 
 	logCtx = logCtx.WithField("repo", r.Repo.Repo)

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
-	goerrors "errors"
+	stderrors "errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -1728,7 +1728,7 @@ func (ctrl *ApplicationController) processAppRefreshQueueItem() (processNext boo
 		comparisonLevel == CompareWithLatestForceResolve, localManifests, hasMultipleSources, false)
 	ts.AddCheckpoint("compare_app_state_ms")
 
-	if goerrors.Is(err, CompareStateRepoError) {
+	if stderrors.Is(err, CompareStateRepoError) {
 		logCtx.Warnf("Ignoring temporary failed attempt to compare app state against repo: %v", err)
 		return // short circuit if git error is encountered
 	}
@@ -2162,7 +2162,7 @@ func (ctrl *ApplicationController) autoSync(app *appv1.Application, syncStatus *
 	ts.AddCheckpoint("set_app_operation_ms")
 	setOpTime := time.Since(start)
 	if err != nil {
-		if goerrors.Is(err, argo.ErrAnotherOperationInProgress) {
+		if stderrors.Is(err, argo.ErrAnotherOperationInProgress) {
 			// skipping auto-sync because another operation is in progress and was not noticed due to stale data in informer
 			// it is safe to skip auto-sync because it is already running
 			logCtx.Warnf("Failed to initiate auto-sync to %s: %v", desiredCommitSHA, err)

--- a/controller/clusterinfoupdater_test.go
+++ b/controller/clusterinfoupdater_test.go
@@ -41,7 +41,7 @@ func TestClusterSecretUpdater(t *testing.T) {
 	}{
 		{nil, nil, v1alpha1.ConnectionStatusUnknown},
 		{&now, nil, v1alpha1.ConnectionStatusSuccessful},
-		{&now, fmt.Errorf("sync failed"), v1alpha1.ConnectionStatusFailed},
+		{&now, errors.New("sync failed"), v1alpha1.ConnectionStatusFailed},
 	}
 
 	emptyArgoCDConfigMap := &v1.ConfigMap{

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -3,6 +3,7 @@ package sharding
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -471,7 +472,7 @@ func GetClusterSharding(kubeClient kubernetes.Interface, settingsMgr *settings.S
 		if appControllerDeployment != nil && appControllerDeployment.Spec.Replicas != nil {
 			replicasCount = int(*appControllerDeployment.Spec.Replicas)
 		} else {
-			return nil, fmt.Errorf("(dynamic cluster distribution) failed to get app controller deployment replica count")
+			return nil, stderrors.New("(dynamic cluster distribution) failed to get app controller deployment replica count")
 		}
 	} else {
 		replicasCount = env.ParseNumFromEnv(common.EnvControllerReplicas, 0, 0, math.MaxInt32)

--- a/controller/sharding/sharding_test.go
+++ b/controller/sharding/sharding_test.go
@@ -958,7 +958,7 @@ func TestGetClusterSharding(t *testing.T) {
 			useDynamicSharding: true,
 			expectedShard:      0,
 			expectedReplicas:   1,
-			expectedErr:        fmt.Errorf("(dynamic cluster distribution) failed to get app controller deployment: deployments.apps \"missing-deployment\" not found"),
+			expectedErr:        errors.New("(dynamic cluster distribution) failed to get app controller deployment: deployments.apps \"missing-deployment\" not found"),
 		},
 	}
 

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -62,7 +62,7 @@ func TestCompareAppStateEmpty(t *testing.T) {
 // TestCompareAppStateRepoError tests the case when CompareAppState notices a repo error
 func TestCompareAppStateRepoError(t *testing.T) {
 	app := newFakeApp()
-	ctrl := newFakeController(&fakeData{manifestResponses: make([]*apiclient.ManifestResponse, 3)}, fmt.Errorf("test repo error"))
+	ctrl := newFakeController(&fakeData{manifestResponses: make([]*apiclient.ManifestResponse, 3)}, errors.New("test repo error"))
 	sources := make([]argoappv1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"context"
-	goerrors "errors"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -200,7 +200,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 
 	// ignore error if CompareStateRepoError, this shouldn't happen as noRevisionCache is true
 	compareResult, err := m.CompareAppState(app, proj, revisions, sources, false, true, syncOp.Manifests, isMultiSourceRevision, rollback)
-	if err != nil && !goerrors.Is(err, CompareStateRepoError) {
+	if err != nil && !stderrors.Is(err, CompareStateRepoError) {
 		state.Phase = common.OperationError
 		state.Message = err.Error()
 		return

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -558,7 +558,7 @@ func (c *client) tlsConfig() (*tls.Config, error) {
 	if len(c.CertPEMData) > 0 {
 		cp := tls_util.BestEffortSystemCertPool()
 		if !cp.AppendCertsFromPEM(c.CertPEMData) {
-			return nil, fmt.Errorf("credentials: failed to append certificates")
+			return nil, errors.New("credentials: failed to append certificates")
 		}
 		tlsConfig.RootCAs = cp
 	}

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -121,7 +121,7 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 		grpc.UnknownServiceHandler(func(srv interface{}, stream grpc.ServerStream) error {
 			fullMethodName, ok := grpc.MethodFromServerStream(stream)
 			if !ok {
-				return fmt.Errorf("Unable to get method name from stream context.")
+				return errors.New("Unable to get method name from stream context.")
 			}
 			msg := make([]byte, 0)
 			err := stream.RecvMsg(&msg)

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -2659,7 +2660,7 @@ func (w *SyncWindow) scheduleOffsetByTimeZone() time.Duration {
 // AddWindow adds a sync window with the given parameters to the AppProject
 func (s *AppProjectSpec) AddWindow(knd string, sch string, dur string, app []string, ns []string, cl []string, ms bool, timeZone string) error {
 	if len(knd) == 0 || len(sch) == 0 || len(dur) == 0 {
-		return fmt.Errorf("cannot create window: require kind, schedule, duration and one or more of applications, namespaces and clusters")
+		return errors.New("cannot create window: require kind, schedule, duration and one or more of applications, namespaces and clusters")
 	}
 
 	window := &SyncWindow{
@@ -2866,7 +2867,7 @@ func (w SyncWindow) active(currentTime time.Time) (bool, error) {
 // Update updates a sync window's settings with the given parameter
 func (w *SyncWindow) Update(s string, d string, a []string, n []string, c []string, tz string) error {
 	if len(s) == 0 && len(d) == 0 && len(a) == 0 && len(n) == 0 && len(c) == 0 {
-		return fmt.Errorf("cannot update: require one or more of schedule, duration, application, namespace, or cluster")
+		return errors.New("cannot update: require one or more of schedule, duration, application, namespace, or cluster")
 	}
 
 	if len(s) > 0 {

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -169,7 +169,7 @@ func helmIndexRefsKey(repo string) string {
 func (c *Cache) SetHelmIndex(repo string, indexData []byte) error {
 	if indexData == nil {
 		// Logged as warning upstream
-		return fmt.Errorf("helm index data is nil, skipping cache")
+		return errors.New("helm index data is nil, skipping cache")
 	}
 	return c.cache.SetItem(
 		helmIndexRefsKey(repo),

--- a/reposerver/gpgwatcher.go
+++ b/reposerver/gpgwatcher.go
@@ -1,6 +1,7 @@
 package reposerver
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"time"
@@ -86,5 +87,5 @@ func StartGPGWatcher(sourcePath string) error {
 		return fmt.Errorf("failed to add a new source to the watcher: %w", err)
 	}
 	<-done
-	return fmt.Errorf("Abnormal termination of GPG watcher, refusing to continue.")
+	return errors.New("Abnormal termination of GPG watcher, refusing to continue.")
 }

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -497,7 +497,7 @@ func resolveReferencedSources(hasMultipleSources bool, source *v1alpha1.Applicat
 				return nil, fmt.Errorf("source referenced %q, which is not one of the available sources (%s)", refVar, strings.Join(refKeys, ", "))
 			}
 			if refSourceMapping.Chart != "" {
-				return nil, fmt.Errorf("source has a 'chart' field defined, but Helm charts are not yet not supported for 'ref' sources")
+				return nil, errors.New("source has a 'chart' field defined, but Helm charts are not yet not supported for 'ref' sources")
 			}
 			normalizedRepoURL := git.NormalizeGitURL(refSourceMapping.Repo.Repo)
 			_, ok = repoRefs[normalizedRepoURL]
@@ -743,7 +743,7 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 							return
 						}
 						if refSourceMapping.Chart != "" {
-							ch.errCh <- fmt.Errorf("source has a 'chart' field defined, but Helm charts are not yet not supported for 'ref' sources")
+							ch.errCh <- errors.New("source has a 'chart' field defined, but Helm charts are not yet not supported for 'ref' sources")
 							return
 						}
 						normalizedRepoURL := git.NormalizeGitURL(refSourceMapping.Repo.Repo)
@@ -1494,7 +1494,7 @@ func GenerateManifests(ctx context.Context, appPath, repoRoot, revision string, 
 					targets = append(targets, unstructuredObj)
 					return nil
 				}
-				return fmt.Errorf("resource list item has unexpected type")
+				return errors.New("resource list item has unexpected type")
 			})
 			if err != nil {
 				return nil, err
@@ -1960,7 +1960,7 @@ func getPluginParamEnvs(envVars []string, plugin *v1alpha1.ApplicationSourcePlug
 	for i, v := range env {
 		parsedVar, err := v1alpha1.NewEnvEntry(v)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse env vars")
+			return nil, errors.New("failed to parse env vars")
 		}
 		parsedEnv[i] = parsedVar
 	}

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3399,7 +3399,7 @@ func TestErrorGetGitDirectories(t *testing.T) {
 		{name: "InvalidResolveRevision", fields: fields{service: func() *Service {
 			s, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 				gitClient.On("Checkout", mock.Anything, mock.Anything).Return("", nil)
-				gitClient.On("LsRemote", mock.Anything).Return("", fmt.Errorf("ah error"))
+				gitClient.On("LsRemote", mock.Anything).Return("", errors.New("ah error"))
 				gitClient.On("Root").Return(root)
 				paths.On("GetPath", mock.Anything).Return(".", nil)
 				paths.On("GetPathIfExists", mock.Anything).Return(".", nil)
@@ -3416,7 +3416,7 @@ func TestErrorGetGitDirectories(t *testing.T) {
 		{name: "ErrorVerifyCommit", fields: fields{service: func() *Service {
 			s, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 				gitClient.On("Checkout", mock.Anything, mock.Anything).Return("", nil)
-				gitClient.On("LsRemote", mock.Anything).Return("", fmt.Errorf("ah error"))
+				gitClient.On("LsRemote", mock.Anything).Return("", errors.New("ah error"))
 				gitClient.On("VerifyCommitSignature", mock.Anything).Return("", fmt.Errorf("revision %s is not signed", "sadfsadf"))
 				gitClient.On("Root").Return(root)
 				paths.On("GetPath", mock.Anything).Return(".", nil)
@@ -3541,7 +3541,7 @@ func TestErrorGetGitFiles(t *testing.T) {
 		{name: "InvalidResolveRevision", fields: fields{service: func() *Service {
 			s, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 				gitClient.On("Checkout", mock.Anything, mock.Anything).Return("", nil)
-				gitClient.On("LsRemote", mock.Anything).Return("", fmt.Errorf("ah error"))
+				gitClient.On("LsRemote", mock.Anything).Return("", errors.New("ah error"))
 				gitClient.On("Root").Return(root)
 				paths.On("GetPath", mock.Anything).Return(".", nil)
 				paths.On("GetPathIfExists", mock.Anything).Return(".", nil)
@@ -3644,7 +3644,7 @@ func TestErrorUpdateRevisionForPaths(t *testing.T) {
 		{name: "InvalidResolveRevision", fields: fields{service: func() *Service {
 			s, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 				gitClient.On("Checkout", mock.Anything, mock.Anything).Return("", nil)
-				gitClient.On("LsRemote", mock.Anything).Return("", fmt.Errorf("ah error"))
+				gitClient.On("LsRemote", mock.Anything).Return("", errors.New("ah error"))
 				gitClient.On("Root").Return(root)
 				paths.On("GetPath", mock.Anything).Return(".", nil)
 				paths.On("GetPathIfExists", mock.Anything).Return(".", nil)
@@ -3663,7 +3663,7 @@ func TestErrorUpdateRevisionForPaths(t *testing.T) {
 			s, _, _ := newServiceWithOpt(t, func(gitClient *gitmocks.Client, helmClient *helmmocks.Client, paths *iomocks.TempPaths) {
 				gitClient.On("Checkout", mock.Anything, mock.Anything).Return("", nil)
 				gitClient.On("LsRemote", "HEAD").Once().Return("632039659e542ed7de0c170a4fcc1c571b288fc0", nil)
-				gitClient.On("LsRemote", mock.Anything).Return("", fmt.Errorf("ah error"))
+				gitClient.On("LsRemote", mock.Anything).Return("", errors.New("ah error"))
 				gitClient.On("Root").Return(root)
 				paths.On("GetPath", mock.Anything).Return(".", nil)
 				paths.On("GetPathIfExists", mock.Anything).Return(".", nil)
@@ -4105,7 +4105,7 @@ func TestVerifyCommitSignature(t *testing.T) {
 		t.Setenv("ARGOCD_GPG_ENABLED", "true")
 		mockGitClient := &gitmocks.Client{}
 		mockGitClient.On("VerifyCommitSignature", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return("", fmt.Errorf("UNKNOWN signature: gpg: Unknown signature from ABCDEFGH"))
+			Return("", errors.New("UNKNOWN signature: gpg: Unknown signature from ABCDEFGH"))
 		err := verifyCommitSignature(true, mockGitClient, "abcd1234", repo)
 		assert.EqualError(t, err, "UNKNOWN signature: gpg: Unknown signature from ABCDEFGH")
 	})
@@ -4114,7 +4114,7 @@ func TestVerifyCommitSignature(t *testing.T) {
 		t.Setenv("ARGOCD_GPG_ENABLED", "true")
 		mockGitClient := &gitmocks.Client{}
 		mockGitClient.On("VerifyCommitSignature", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return("", fmt.Errorf("error verifying signature of commit 'abcd1234' in repo 'https://github.com/example/repo.git': failed to verify signature"))
+			Return("", errors.New("error verifying signature of commit 'abcd1234' in repo 'https://github.com/example/repo.git': failed to verify signature"))
 		err := verifyCommitSignature(true, mockGitClient, "abcd1234", repo)
 		assert.EqualError(t, err, "error verifying signature of commit 'abcd1234' in repo 'https://github.com/example/repo.git': failed to verify signature")
 	})

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2,7 +2,7 @@ package application
 
 import (
 	"context"
-	coreerrors "errors"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -2066,7 +2066,7 @@ func TestGetCachedAppState(t *testing.T) {
 	})
 
 	t.Run("NonCacheErrorDoesNotTriggerRefresh", func(t *testing.T) {
-		randomError := coreerrors.New("random error")
+		randomError := stderrors.New("random error")
 		err := appServer.getCachedAppState(context.Background(), testApp, func() error {
 			return randomError
 		})

--- a/server/applicationset/applicationset.go
+++ b/server/applicationset/applicationset.go
@@ -3,6 +3,7 @@ package applicationset
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -184,7 +185,7 @@ func (s *Server) Create(ctx context.Context, q *applicationset.ApplicationSetCre
 	appset := q.GetApplicationset()
 
 	if appset == nil {
-		return nil, fmt.Errorf("error creating ApplicationSets: ApplicationSets is nil in request")
+		return nil, errors.New("error creating ApplicationSets: ApplicationSets is nil in request")
 	}
 
 	projectName, err := s.validateAppSet(appset)
@@ -370,7 +371,7 @@ func (s *Server) Generate(ctx context.Context, q *applicationset.ApplicationSetG
 	appset := q.GetApplicationSet()
 
 	if appset == nil {
-		return nil, fmt.Errorf("error creating ApplicationSets: ApplicationSets is nil in request")
+		return nil, errors.New("error creating ApplicationSets: ApplicationSets is nil in request")
 	}
 	namespace := s.appsetNamespaceOrDefault(appset.Namespace)
 
@@ -429,13 +430,13 @@ func (s *Server) buildApplicationSetTree(a *v1alpha1.ApplicationSet) (*v1alpha1.
 
 func (s *Server) validateAppSet(appset *v1alpha1.ApplicationSet) (string, error) {
 	if appset == nil {
-		return "", fmt.Errorf("ApplicationSet cannot be validated for nil value")
+		return "", errors.New("ApplicationSet cannot be validated for nil value")
 	}
 
 	projectName := appset.Spec.Template.Spec.Project
 
 	if strings.Contains(projectName, "{{") {
-		return "", fmt.Errorf("the Argo CD API does not currently support creating ApplicationSets with templated `project` fields")
+		return "", errors.New("the Argo CD API does not currently support creating ApplicationSets with templated `project` fields")
 	}
 
 	if err := appsetutils.CheckInvalidGenerators(appset); err != nil {

--- a/server/extension/extension.go
+++ b/server/extension/extension.go
@@ -411,7 +411,7 @@ func proxyKey(extName, cName, cServer string) ProxyKey {
 
 func parseAndValidateConfig(s *settings.ArgoCDSettings) (*ExtensionConfigs, error) {
 	if len(s.ExtensionConfig) == 0 {
-		return nil, fmt.Errorf("no extensions configurations found")
+		return nil, errors.New("no extensions configurations found")
 	}
 
 	configs := ExtensionConfigs{}
@@ -461,10 +461,10 @@ func validateConfigs(configs *ExtensionConfigs) error {
 	exts := make(map[string]struct{})
 	for _, ext := range configs.Extensions {
 		if ext.Name == "" {
-			return fmt.Errorf("extensions.name must be configured")
+			return errors.New("extensions.name must be configured")
 		}
 		if !nameSafeRegex.MatchString(ext.Name) {
-			return fmt.Errorf("invalid extensions.name: only alphanumeric characters, hyphens, and underscores are allowed")
+			return errors.New("invalid extensions.name: only alphanumeric characters, hyphens, and underscores are allowed")
 		}
 		if _, found := exts[ext.Name]; found {
 			return fmt.Errorf("duplicated extension found in the configs for %q", ext.Name)
@@ -476,23 +476,23 @@ func validateConfigs(configs *ExtensionConfigs) error {
 		}
 		for _, svc := range ext.Backend.Services {
 			if svc.URL == "" {
-				return fmt.Errorf("extensions.backend.services.url must be configured")
+				return errors.New("extensions.backend.services.url must be configured")
 			}
 			if svcTotal > 1 && svc.Cluster == nil {
-				return fmt.Errorf("extensions.backend.services.cluster must be configured when defining more than one service per extension")
+				return errors.New("extensions.backend.services.cluster must be configured when defining more than one service per extension")
 			}
 			if svc.Cluster != nil {
 				if svc.Cluster.Name == "" && svc.Cluster.Server == "" {
-					return fmt.Errorf("cluster.name or cluster.server must be defined when cluster is provided in the configuration")
+					return errors.New("cluster.name or cluster.server must be defined when cluster is provided in the configuration")
 				}
 			}
 			if len(svc.Headers) > 0 {
 				for _, header := range svc.Headers {
 					if header.Name == "" {
-						return fmt.Errorf("header.name must be defined when providing service headers in the configuration")
+						return errors.New("header.name must be defined when providing service headers in the configuration")
 					}
 					if header.Value == "" {
-						return fmt.Errorf("header.value must be defined when providing service headers in the configuration")
+						return errors.New("header.value must be defined when providing service headers in the configuration")
 					}
 				}
 			}
@@ -654,7 +654,7 @@ func appendProxy(registry ProxyRegistry,
 // If all validations are satified it will return the Application resource
 func (m *Manager) authorize(ctx context.Context, rr *RequestResources, extName string) (*v1alpha1.Application, error) {
 	if m.rbac == nil {
-		return nil, fmt.Errorf("rbac enforcer not set in extension manager")
+		return nil, errors.New("rbac enforcer not set in extension manager")
 	}
 	appRBACName := security.RBACName(rr.ApplicationNamespace, rr.ProjectName, rr.ApplicationNamespace, rr.ApplicationName)
 	if err := m.rbac.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacpolicy.ActionGet, appRBACName); err != nil {
@@ -690,7 +690,7 @@ func (m *Manager) authorize(ctx context.Context, rr *RequestResources, extName s
 		return nil, fmt.Errorf("error validating project destinations: %w", err)
 	}
 	if !permitted {
-		return nil, fmt.Errorf("the provided project is not allowed to access the cluster configured in the Application destination")
+		return nil, errors.New("the provided project is not allowed to access the cluster configured in the Application destination")
 	}
 
 	return app, nil

--- a/server/gpgkey/gpgkey.go
+++ b/server/gpgkey/gpgkey.go
@@ -2,6 +2,7 @@ package gpgkey
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -60,7 +61,7 @@ func (s *Server) Get(ctx context.Context, q *gpgkeypkg.GnuPGPublicKeyQuery) (*ap
 
 	keyID := gpg.KeyID(q.KeyID)
 	if keyID == "" {
-		return nil, fmt.Errorf("KeyID is malformed or empty")
+		return nil, errors.New("KeyID is malformed or empty")
 	}
 
 	keys, err := s.db.ListConfiguredGPGPublicKeys(ctx)
@@ -83,7 +84,7 @@ func (s *Server) Create(ctx context.Context, q *gpgkeypkg.GnuPGPublicKeyCreateRe
 
 	keyData := strings.TrimSpace(q.Publickey.KeyData)
 	if keyData == "" {
-		return nil, fmt.Errorf("Submitted key data is empty")
+		return nil, errors.New("Submitted key data is empty")
 	}
 
 	added, skipped, err := s.db.AddGPGPublicKey(ctx, q.Publickey.KeyData)

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"testing"
@@ -384,12 +385,12 @@ func extractKubeConfigValues() (string, string, error) {
 
 	context, ok := config.Contexts[config.CurrentContext]
 	if !ok || context == nil {
-		return "", "", fmt.Errorf("no context")
+		return "", "", stderrors.New("no context")
 	}
 
 	cluster, ok := config.Clusters[context.Cluster]
 	if !ok || cluster == nil {
-		return "", "", fmt.Errorf("no cluster")
+		return "", "", stderrors.New("no cluster")
 	}
 
 	var kubeConfigDefault string
@@ -407,7 +408,7 @@ func extractKubeConfigValues() (string, string, error) {
 		}
 
 		if kubeConfigDefault == "" {
-			return "", "", fmt.Errorf("unable to retrieve kube config path")
+			return "", "", stderrors.New("unable to retrieve kube config path")
 		}
 	}
 

--- a/test/e2e/fixture/cluster/consequences.go
+++ b/test/e2e/fixture/cluster/consequences.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	clusterpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/cluster"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -46,7 +46,7 @@ func (c *Consequences) get() (*v1alpha1.Cluster, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("cluster not found")
+	return nil, errors.New("cluster not found")
 }
 
 func (c *Consequences) Given() *Context {

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -3,7 +3,7 @@ package fixture
 import (
 	"bufio"
 	"context"
-	goerrors "errors"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path"
@@ -218,7 +218,7 @@ func init() {
 	}
 	f, err := os.Open(rf)
 	if err != nil {
-		if goerrors.Is(err, os.ErrNotExist) {
+		if stderrors.Is(err, os.ErrNotExist) {
 			return
 		} else {
 			panic(fmt.Sprintf("Could not read record file %s: %v", rf, err))

--- a/test/e2e/fixture/repos/consequences.go
+++ b/test/e2e/fixture/repos/consequences.go
@@ -2,7 +2,7 @@ package repos
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	repositorypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/repository"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -46,7 +46,7 @@ func (c *Consequences) get() (*v1alpha1.Repository, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("repo not found")
+	return nil, errors.New("repo not found")
 }
 
 func (c *Consequences) Given() *Context {

--- a/util/app/discovery/discovery.go
+++ b/util/app/discovery/discovery.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -118,7 +119,7 @@ func DetectConfigManagementPlugin(ctx context.Context, appPath, repoPath, plugin
 			}
 		}
 		if !connFound {
-			return nil, nil, fmt.Errorf("could not find plugin supporting the given repository")
+			return nil, nil, errors.New("could not find plugin supporting the given repository")
 		}
 	}
 	return conn, cmpClient, nil

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -3,6 +3,7 @@ package argo
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -464,7 +465,7 @@ func GetRefSources(ctx context.Context, sources argoappv1.ApplicationSources, pr
 				}
 				refKey := "$" + source.Ref
 				if _, ok := refKeys[refKey]; ok {
-					return nil, fmt.Errorf("invalid sources: multiple sources had the same `ref` key")
+					return nil, errors.New("invalid sources: multiple sources had the same `ref` key")
 				}
 				refKeys[refKey] = true
 			}
@@ -1016,7 +1017,7 @@ func getDestinationServer(ctx context.Context, db db.ArgoDB, clusterName string)
 
 func getDestinationServerName(ctx context.Context, db db.ArgoDB, server string) (string, error) {
 	if db == nil {
-		return "", fmt.Errorf("there are no clusters registered in the database")
+		return "", errors.New("there are no clusters registered in the database")
 	}
 
 	cluster, err := db.GetCluster(ctx, server)

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -833,7 +833,7 @@ func TestValidatePermissions(t *testing.T) {
 			},
 		}
 		db := &dbmocks.ArgoDB{}
-		db.On("GetCluster", context.Background(), spec.Destination.Server).Return(nil, fmt.Errorf("Unknown error occurred"))
+		db.On("GetCluster", context.Background(), spec.Destination.Server).Return(nil, errors.New("Unknown error occurred"))
 		conditions, err := ValidatePermissions(context.Background(), &spec, &proj, db)
 		require.NoError(t, err)
 		assert.Len(t, conditions, 1)
@@ -970,7 +970,7 @@ func TestValidateDestination(t *testing.T) {
 		}
 
 		db := &dbmocks.ArgoDB{}
-		db.On("GetClusterServersByName", context.Background(), mock.Anything).Return(nil, fmt.Errorf("an error occurred"))
+		db.On("GetClusterServersByName", context.Background(), mock.Anything).Return(nil, errors.New("an error occurred"))
 
 		err := ValidateDestination(context.Background(), &dest, db)
 		require.ErrorContains(t, err, "an error occurred")

--- a/util/argo/diff/diff.go
+++ b/util/argo/diff/diff.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -340,7 +341,7 @@ func StateDiffs(lives, configs []*unstructured.Unstructured, diffConfig DiffConf
 func diffArrayCached(configArray []*unstructured.Unstructured, liveArray []*unstructured.Unstructured, cachedDiff []*v1alpha1.ResourceDiff, opts ...diff.Option) (*diff.DiffResultList, error) {
 	numItems := len(configArray)
 	if len(liveArray) != numItems {
-		return nil, fmt.Errorf("left and right arrays have mismatched lengths")
+		return nil, errors.New("left and right arrays have mismatched lengths")
 	}
 
 	diffByKey := map[kube.ResourceKey]*v1alpha1.ResourceDiff{}
@@ -411,7 +412,7 @@ func (c *diffConfig) DiffFromCache(appName string) (bool, []*v1alpha1.ResourceDi
 // the diff. None of the attributes in the lives and targets params will be modified.
 func preDiffNormalize(lives, targets []*unstructured.Unstructured, diffConfig DiffConfig) (*NormalizationResult, error) {
 	if diffConfig == nil {
-		return nil, fmt.Errorf("preDiffNormalize error: diffConfig can not be nil")
+		return nil, errors.New("preDiffNormalize error: diffConfig can not be nil")
 	}
 	err := diffConfig.Validate()
 	if err != nil {

--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -82,7 +82,7 @@ func (np *jqNormalizerPatch) Apply(data []byte) ([]byte, error) {
 	iter := np.code.RunWithContext(ctx, dataJson)
 	first, ok := iter.Next()
 	if !ok {
-		return nil, fmt.Errorf("JQ patch did not return any data")
+		return nil, errors.New("JQ patch did not return any data")
 	}
 	if err, ok = first.(error); ok {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -92,7 +92,7 @@ func (np *jqNormalizerPatch) Apply(data []byte) ([]byte, error) {
 	}
 	_, ok = iter.Next()
 	if ok {
-		return nil, fmt.Errorf("JQ patch returned multiple objects")
+		return nil, errors.New("JQ patch returned multiple objects")
 	}
 
 	patchedData, err := json.Marshal(first)
@@ -184,7 +184,7 @@ func NewIgnoreNormalizer(ignore []v1alpha1.ResourceIgnoreDifferences, overrides 
 // Normalize removes fields from supplied resource using json paths from matching items of specified resources ignored differences list
 func (n *ignoreNormalizer) Normalize(un *unstructured.Unstructured) error {
 	if un == nil {
-		return fmt.Errorf("invalid argument: unstructured is nil")
+		return errors.New("invalid argument: unstructured is nil")
 	}
 	matched := make([]normalizerPatch, 0)
 	for _, patch := range n.patches {

--- a/util/argo/normalizers/diff_normalizer_test.go
+++ b/util/argo/normalizers/diff_normalizer_test.go
@@ -2,7 +2,7 @@ package normalizers
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -250,7 +250,7 @@ func TestNormalizeExpectedErrorAreSilenced(t *testing.T) {
 	_, err = jqPatch.Apply(deploymentData)
 	assert.False(t, shouldLogError(err))
 
-	assert.True(t, shouldLogError(fmt.Errorf("An error that should not be ignored")))
+	assert.True(t, shouldLogError(errors.New("An error that should not be ignored")))
 }
 
 func TestJqPathExpressionFailWithTimeout(t *testing.T) {

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	WrongResourceTrackingFormat = fmt.Errorf("wrong resource tracking format, should be <application-name>:<group>/<kind>:<namespace>/<name>")
+	WrongResourceTrackingFormat = errors.New("wrong resource tracking format, should be <application-name>:<group>/<kind>:<namespace>/<name>")
 	LabelMaxLength              = 63
 	OkEndPattern                = regexp.MustCompile("[a-zA-Z0-9]$")
 )

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -270,7 +271,7 @@ func (c *Cache) generateFullKey(key string) string {
 // Sets or deletes an item in cache
 func (c *Cache) SetItem(key string, item interface{}, opts *CacheActionOpts) error {
 	if item == nil {
-		return fmt.Errorf("cannot set nil item in cache")
+		return errors.New("cannot set nil item in cache")
 	}
 	if opts == nil {
 		opts = &CacheActionOpts{}

--- a/util/cert/cert.go
+++ b/util/cert/cert.go
@@ -246,7 +246,7 @@ func IsValidSSHKnownHostsEntry(line string) bool {
 func TokenizeSSHKnownHostsEntry(knownHostsEntry string) (string, string, []byte, error) {
 	knownHostsToken := strings.SplitN(knownHostsEntry, " ", 3)
 	if len(knownHostsToken) != 3 {
-		return "", "", nil, fmt.Errorf("error while tokenizing input data")
+		return "", "", nil, errors.New("error while tokenizing input data")
 	}
 	return knownHostsToken[0], knownHostsToken[1], []byte(knownHostsToken[2]), nil
 }
@@ -332,7 +332,7 @@ func GetCertificateForConnect(serverName string) ([]string, error) {
 	}
 
 	if len(certificates) == 0 {
-		return nil, fmt.Errorf("no certificates found in existing file")
+		return nil, errors.New("no certificates found in existing file")
 	}
 
 	return certificates, nil

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	stderrors "errors"
 	"flag"
 	"fmt"
 	"os"
@@ -276,7 +277,7 @@ func InteractiveEdit(filePattern string, data []byte, save func(input []byte) er
 		updated, err := os.ReadFile(tempFile)
 		errors.CheckError(err)
 		if string(updated) == "" || string(updated) == string(data) {
-			errors.CheckError(fmt.Errorf("edit cancelled, no valid changes were saved"))
+			errors.CheckError(stderrors.New("edit cancelled, no valid changes were saved"))
 			break
 		} else {
 			data = stripComments(updated)

--- a/util/cmp/stream.go
+++ b/util/cmp/stream.go
@@ -41,7 +41,7 @@ func ReceiveRepoStream(ctx context.Context, receiver StreamReceiver, destDir str
 		return nil, fmt.Errorf("error receiving stream header: %w", err)
 	}
 	if header == nil || header.GetMetadata() == nil {
-		return nil, fmt.Errorf("error getting stream metadata: metadata is nil")
+		return nil, errors.New("error getting stream metadata: metadata is nil")
 	}
 	metadata := header.GetMetadata()
 
@@ -186,7 +186,7 @@ func receiveFile(ctx context.Context, receiver StreamReceiver, checksum, dst str
 		}
 		f := req.GetFile()
 		if f == nil {
-			return nil, fmt.Errorf("stream request file is nil")
+			return nil, errors.New("stream request file is nil")
 		}
 		_, err = file.Write(f.Chunk)
 		if err != nil {
@@ -198,7 +198,7 @@ func receiveFile(ctx context.Context, receiver StreamReceiver, checksum, dst str
 		}
 	}
 	if hex.EncodeToString(hasher.Sum(nil)) != checksum {
-		return nil, fmt.Errorf("file checksum validation error")
+		return nil, errors.New("file checksum validation error")
 	}
 
 	_, err = file.Seek(0, io.SeekStart)

--- a/util/cmp/stream_test.go
+++ b/util/cmp/stream_test.go
@@ -2,7 +2,7 @@ package cmp_test
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -30,7 +30,7 @@ func (m *streamMock) Recv() (*pluginclient.AppStreamRequest, error) {
 	case <-m.done:
 		return nil, io.EOF
 	case <-time.After(500 * time.Millisecond):
-		return nil, fmt.Errorf("timeout receiving message mock")
+		return nil, errors.New("timeout receiving message mock")
 	}
 }
 

--- a/util/db/certificate.go
+++ b/util/db/certificate.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -270,7 +271,7 @@ func (db *db) CreateRepoCertificate(ctx context.Context, certificates *appsv1.Re
 
 			// We should have at least one valid PEM entry
 			if len(pemData) == 0 {
-				return nil, fmt.Errorf("No valid PEM data received.")
+				return nil, errors.New("No valid PEM data received.")
 			}
 
 			// Make sure we have valid X509 certificates in the data

--- a/util/db/gpgkeys.go
+++ b/util/db/gpgkeys.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -38,7 +39,7 @@ func validatePGPKey(keyData string) (*appsv1.GnuPGPublicKey, error) {
 
 	// Each key/value pair in the config map must exactly contain one public key, with the (short) GPG key ID as key
 	if len(parsed) != 1 {
-		return nil, fmt.Errorf("More than one key found in input data")
+		return nil, errors.New("More than one key found in input data")
 	}
 
 	var retKey *appsv1.GnuPGPublicKey = nil
@@ -51,7 +52,7 @@ func validatePGPKey(keyData string) (*appsv1.GnuPGPublicKey, error) {
 		retKey.KeyData = keyData
 		return retKey, nil
 	} else {
-		return nil, fmt.Errorf("Could not find the GPG key")
+		return nil, errors.New("Could not find the GPG key")
 	}
 }
 

--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -1,6 +1,7 @@
 package dex
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -113,12 +114,12 @@ func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTls b
 	}
 	connectors, ok := dexCfg["connectors"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("malformed Dex configuration found")
+		return nil, errors.New("malformed Dex configuration found")
 	}
 	for i, connectorIf := range connectors {
 		connector, ok := connectorIf.(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("malformed Dex configuration found")
+			return nil, errors.New("malformed Dex configuration found")
 		}
 		connectorType := connector["type"].(string)
 		if !needsRedirectURI(connectorType) {
@@ -126,7 +127,7 @@ func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTls b
 		}
 		connectorCfg, ok := connector["config"].(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("malformed Dex configuration found")
+			return nil, errors.New("malformed Dex configuration found")
 		}
 		connectorCfg["redirectURI"] = dexRedirectURL
 		connector["config"] = connectorCfg

--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
+	stderrors "errors"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -47,7 +47,7 @@ func TLSConfig(tlsConfig *DexTLSConfig) *tls.Config {
 		RootCAs:            tlsConfig.RootCAs,
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			if !bytes.Equal(rawCerts[0], tlsConfig.Certificate) {
-				return fmt.Errorf("dex server certificate does not match")
+				return stderrors.New("dex server certificate does not match")
 			}
 			return nil
 		},

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -41,7 +41,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/proxy"
 )
 
-var ErrInvalidRepoURL = fmt.Errorf("repo URL is invalid")
+var ErrInvalidRepoURL = errors.New("repo URL is invalid")
 
 type RevisionMetadata struct {
 	Author  string
@@ -784,7 +784,7 @@ func (m *nativeGitClient) VerifyCommitSignature(revision string) (string, error)
 	out, err := m.runGnuPGWrapper("git-verify-wrapper.sh", revision)
 	if err != nil {
 		log.Errorf("error verifying commit signature: %v", err)
-		return "", fmt.Errorf("permission denied")
+		return "", errors.New("permission denied")
 	}
 	return out, nil
 }
@@ -807,7 +807,7 @@ func (m *nativeGitClient) ChangedFiles(revision string, targetRevision string) (
 	}
 
 	if !IsCommitSHA(revision) || !IsCommitSHA(targetRevision) {
-		return []string{}, fmt.Errorf("invalid revision provided, must be SHA")
+		return []string{}, errors.New("invalid revision provided, must be SHA")
 	}
 
 	out, err := m.runCmd("diff", "--name-only", fmt.Sprintf("%s..%s", revision, targetRevision))

--- a/util/gpg/gpg.go
+++ b/util/gpg/gpg.go
@@ -3,6 +3,7 @@ package gpg
 import (
 	"bufio"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -521,12 +522,12 @@ func GetInstalledPGPKeys(kids []string) ([]*appsv1.GnuPGPublicKey, error) {
 
 			// Next line should be the key ID, no prefix
 			if !scanner.Scan() {
-				return nil, fmt.Errorf("Invalid output from gpg, end of text after primary key")
+				return nil, errors.New("Invalid output from gpg, end of text after primary key")
 			}
 
 			token = keyIdMatch.FindStringSubmatch(scanner.Text())
 			if len(token) != 2 {
-				return nil, fmt.Errorf("Invalid output from gpg, no key ID for primary key")
+				return nil, errors.New("Invalid output from gpg, no key ID for primary key")
 			}
 
 			key.Fingerprint = token[1]
@@ -539,11 +540,11 @@ func GetInstalledPGPKeys(kids []string) ([]*appsv1.GnuPGPublicKey, error) {
 
 			// Next line should be UID
 			if !scanner.Scan() {
-				return nil, fmt.Errorf("Invalid output from gpg, end of text after key ID")
+				return nil, errors.New("Invalid output from gpg, end of text after key ID")
 			}
 
 			if !strings.HasPrefix(scanner.Text(), "uid ") {
-				return nil, fmt.Errorf("Invalid output from gpg, no identity for primary key")
+				return nil, errors.New("Invalid output from gpg, no identity for primary key")
 			}
 
 			token = uidMatch.FindStringSubmatch(scanner.Text())

--- a/util/grpc/errors_test.go
+++ b/util/grpc/errors_test.go
@@ -51,7 +51,7 @@ func Test_kubeErrToGRPC(t *testing.T) {
 			Group:    "apps",
 			Resource: "Deployment",
 		}
-		return apierr.NewForbidden(gr, "some-app", fmt.Errorf("authentication error"))
+		return apierr.NewForbidden(gr, "some-app", errors.New("authentication error"))
 	}
 	newUnauthorizedError := func() error {
 		return apierr.NewUnauthorized("unauthenticated")
@@ -60,10 +60,10 @@ func Test_kubeErrToGRPC(t *testing.T) {
 		{
 			name: "will return standard error if not grpc status",
 			givenErrFn: func() error {
-				return fmt.Errorf("standard error")
+				return errors.New("standard error")
 			},
 			expectedErrFn: func() error {
-				return fmt.Errorf("standard error")
+				return errors.New("standard error")
 			},
 			expectedGRPCStatus: nil,
 		},

--- a/util/healthz/healthz_test.go
+++ b/util/healthz/healthz_test.go
@@ -1,7 +1,7 @@
 package healthz
 
 import (
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 	"testing"
@@ -25,7 +25,7 @@ func TestHealthCheck(t *testing.T) {
 		mux := http.NewServeMux()
 		ServeHealthCheck(mux, func(r *http.Request) error {
 			if sentinel {
-				return fmt.Errorf("This is a dummy error")
+				return errors.New("This is a dummy error")
 			}
 			return nil
 		})

--- a/util/helm/index.go
+++ b/util/helm/index.go
@@ -47,7 +47,7 @@ func (e Entries) MaxVersion(constraints *semver.Constraints) (*semver.Version, e
 		}
 	}
 	if len(versions) == 0 {
-		return nil, fmt.Errorf("constraint not found in index")
+		return nil, errors.New("constraint not found in index")
 	}
 	maxVersion := versions[0]
 	for _, v := range versions {

--- a/util/io/path/resolved.go
+++ b/util/io/path/resolved.go
@@ -35,7 +35,7 @@ func resolveSymbolicLinkRecursive(path string, maxDepth int) (string, error) {
 	}
 
 	if maxDepth == 0 {
-		return "", fmt.Errorf("maximum nesting level reached")
+		return "", errors.New("maximum nesting level reached")
 	}
 
 	// If we resolved to a relative symlink, make sure we use the absolute
@@ -70,7 +70,7 @@ func isURLSchemeAllowed(scheme string, allowed []string) bool {
 // Instead, we log the concrete error details.
 func resolveFailure(path string, err error) error {
 	log.Errorf("failed to resolve path '%s': %v", path, err)
-	return fmt.Errorf("internal error: failed to resolve path. Check logs for more details")
+	return errors.New("internal error: failed to resolve path. Check logs for more details")
 }
 
 func ResolveFileOrDirectoryPath(appPath, repoRoot, dir string) (ResolvedFileOrDirectoryPath, error) {
@@ -176,7 +176,7 @@ func resolveFileOrDirectory(appPath string, repoRoot string, fileOrDirectory str
 	resolvedToRoot := path+string(os.PathSeparator) == requiredRootPath
 	if resolvedToRoot {
 		if !allowResolveToRoot {
-			return "", resolveFailure(path, fmt.Errorf("path resolved to repository root, which is not allowed"))
+			return "", resolveFailure(path, errors.New("path resolved to repository root, which is not allowed"))
 		}
 	} else {
 		// Make sure that the resolved path to file is within the repository's root path

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -1,6 +1,7 @@
 package kustomize
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -304,7 +305,7 @@ func (k *kustomize) Build(opts *v1alpha1.ApplicationSourceKustomize, kustomizeOp
 			// components only supported in kustomize >= v3.7.0
 			// https://github.com/kubernetes-sigs/kustomize/blob/master/examples/components.md
 			if getSemverSafe().LessThan(semver.MustParse("v3.7.0")) {
-				return nil, nil, nil, fmt.Errorf("kustomize components require kustomize v3.7.0 and above")
+				return nil, nil, nil, errors.New("kustomize components require kustomize v3.7.0 and above")
 			}
 
 			// add components

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -1,6 +1,7 @@
 package localconfig
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -131,7 +132,7 @@ func DeleteLocalConfig(configPath string) error {
 func (l *LocalConfig) ResolveContext(name string) (*Context, error) {
 	if name == "" {
 		if l.CurrentContext == "" {
-			return nil, fmt.Errorf("Local config: current-context unset")
+			return nil, errors.New("Local config: current-context unset")
 		}
 		name = l.CurrentContext
 	}

--- a/util/localconfig/localconfig_test.go
+++ b/util/localconfig/localconfig_test.go
@@ -3,7 +3,7 @@
 package localconfig
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -43,13 +43,13 @@ func TestFilePermission(t *testing.T) {
 			name:          "Test config file with permission 0700",
 			testfile:      ".config_0700",
 			perm:          0o700,
-			expectedError: fmt.Errorf("config file has incorrect permission flags:-rwx------.change the file permission either to 0400 or 0600."),
+			expectedError: errors.New("config file has incorrect permission flags:-rwx------.change the file permission either to 0400 or 0600."),
 		},
 		{
 			name:          "Test config file with permission 0777",
 			testfile:      ".config_0777",
 			perm:          0o777,
-			expectedError: fmt.Errorf("config file has incorrect permission flags:-rwxrwxrwx.change the file permission either to 0400 or 0600."),
+			expectedError: errors.New("config file has incorrect permission flags:-rwxrwxrwx.change the file permission either to 0400 or 0600."),
 		},
 		{
 			name:          "Test config file with permission 0600",
@@ -67,7 +67,7 @@ func TestFilePermission(t *testing.T) {
 			name:          "Test config file with permission 0300",
 			testfile:      ".config_0300",
 			perm:          0o300,
-			expectedError: fmt.Errorf("config file has incorrect permission flags:--wx------.change the file permission either to 0400 or 0600."),
+			expectedError: errors.New("config file has incorrect permission flags:--wx------.change the file permission either to 0400 or 0600."),
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {

--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -189,7 +189,7 @@ func (vm VM) ExecuteResourceAction(obj *unstructured.Unstructured, script string
 
 		jsonString := bytes.NewBuffer(jsonBytes).String()
 		if len(jsonString) < 2 {
-			return nil, fmt.Errorf("Lua output was not a valid json object or array")
+			return nil, errors.New("Lua output was not a valid json object or array")
 		}
 		// The output from Lua is either an object (old-style action output) or an array (new-style action output).
 		// Check whether the string starts with an opening square bracket and ends with a closing square bracket,
@@ -293,7 +293,7 @@ func cleanReturnedArray(newObj, obj []interface{}) []interface{} {
 
 func (vm VM) ExecuteResourceActionDiscovery(obj *unstructured.Unstructured, scripts []string) ([]appv1.ResourceAction, error) {
 	if len(scripts) == 0 {
-		return nil, fmt.Errorf("no action discovery script provided")
+		return nil, errors.New("no action discovery script provided")
 	}
 	availableActionsMap := make(map[string]appv1.ResourceAction)
 

--- a/util/manifeststream/stream.go
+++ b/util/manifeststream/stream.go
@@ -45,7 +45,7 @@ func SendApplicationManifestQueryWithFiles(ctx context.Context, stream Applicati
 		return fmt.Errorf("failed to compress files: %w", err)
 	}
 	if filesWritten == 0 {
-		return fmt.Errorf("no files to send")
+		return errors.New("no files to send")
 	}
 
 	err = stream.Send(&applicationpkg.ApplicationManifestQueryWithFilesWrapper{
@@ -107,7 +107,7 @@ func ReceiveApplicationManifestQueryWithFiles(stream ApplicationStreamReceiver) 
 		return nil, fmt.Errorf("failed to receive header: %w", err)
 	}
 	if header == nil || header.GetQuery() == nil {
-		return nil, fmt.Errorf("error getting stream query: query is nil")
+		return nil, errors.New("error getting stream query: query is nil")
 	}
 	return header.GetQuery(), nil
 }
@@ -142,7 +142,7 @@ func SendRepoStream(repoStream RepoStreamSender, appStream ApplicationStreamRece
 			return fmt.Errorf("stream Recv error: %w", err)
 		}
 		if part == nil || part.GetChunk() == nil {
-			return fmt.Errorf("error getting stream chunk: chunk is nil")
+			return errors.New("error getting stream chunk: chunk is nil")
 		}
 
 		err = repoStream.Send(&apiclient.ManifestRequestWithFiles{
@@ -166,7 +166,7 @@ func ReceiveManifestFileStream(ctx context.Context, receiver RepoStreamReceiver,
 		return nil, nil, fmt.Errorf("failed to receive header: %w", err)
 	}
 	if header == nil || header.GetRequest() == nil {
-		return nil, nil, fmt.Errorf("error getting stream request: request is nil")
+		return nil, nil, errors.New("error getting stream request: request is nil")
 	}
 	request := header.GetRequest()
 
@@ -175,7 +175,7 @@ func ReceiveManifestFileStream(ctx context.Context, receiver RepoStreamReceiver,
 		return nil, nil, fmt.Errorf("failed to receive header: %w", err)
 	}
 	if header2 == nil || header2.GetMetadata() == nil {
-		return nil, nil, fmt.Errorf("error getting stream metadata: metadata is nil")
+		return nil, nil, errors.New("error getting stream metadata: metadata is nil")
 	}
 	metadata := header2.GetMetadata()
 
@@ -223,7 +223,7 @@ func receiveFile(ctx context.Context, receiver RepoStreamReceiver, checksum stri
 		}
 		c := req.GetChunk()
 		if c == nil {
-			return nil, fmt.Errorf("stream request chunk is nil")
+			return nil, errors.New("stream request chunk is nil")
 		}
 		size += len(c.Chunk)
 		if size > int(maxSize) {

--- a/util/manifeststream/stream_test.go
+++ b/util/manifeststream/stream_test.go
@@ -2,7 +2,7 @@ package manifeststream_test
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"math"
 	"os"
@@ -32,7 +32,7 @@ func (m *applicationStreamMock) Recv() (*applicationpkg.ApplicationManifestQuery
 	case <-m.done:
 		return nil, io.EOF
 	case <-time.After(500 * time.Millisecond):
-		return nil, fmt.Errorf("timeout receiving message mock")
+		return nil, errors.New("timeout receiving message mock")
 	}
 }
 
@@ -62,7 +62,7 @@ func (m *repoStreamMock) Recv() (*apiclient.ManifestRequestWithFiles, error) {
 	case <-m.done:
 		return nil, io.EOF
 	case <-time.After(500 * time.Millisecond):
-		return nil, fmt.Errorf("timeout receiving message mock")
+		return nil, errors.New("timeout receiving message mock")
 	}
 }
 

--- a/util/notification/settings/settings.go
+++ b/util/notification/settings/settings.go
@@ -1,7 +1,7 @@
 package settings
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/argoproj/notifications-engine/pkg/api"
 	"github.com/argoproj/notifications-engine/pkg/services"
@@ -34,7 +34,7 @@ func GetFactorySettingsForCLI(argocdService *service.Service, secretName, config
 		ConfigMapName: configMapName,
 		InitGetVars: func(cfg *api.Config, configMap *v1.ConfigMap, secret *v1.Secret) (api.GetVars, error) {
 			if *argocdService == nil {
-				return nil, fmt.Errorf("argocdService is not initialized")
+				return nil, errors.New("argocdService is not initialized")
 			}
 
 			if selfServiceNotificationEnabled {

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -33,7 +33,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
-var InvalidRedirectURLError = fmt.Errorf("invalid return URL")
+var InvalidRedirectURLError = errors.New("invalid return URL")
 
 const (
 	GrantTypeAuthorizationCode  = "authorization_code"

--- a/util/password/password.go
+++ b/util/password/password.go
@@ -2,7 +2,7 @@ package password
 
 import (
 	"crypto/subtle"
-	"fmt"
+	"errors"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -35,7 +35,7 @@ var preferredHashers = []PasswordHasher{
 func hashPasswordWithHashers(password string, hashers []PasswordHasher) (string, error) {
 	// Even though good hashers will disallow blank passwords, let's be explicit that ALL BLANK PASSWORDS ARE INVALID.  Full stop.
 	if password == "" {
-		return "", fmt.Errorf("blank passwords are not allowed")
+		return "", errors.New("blank passwords are not allowed")
 	}
 	return hashers[0].HashPassword(password)
 }

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -265,7 +265,7 @@ func (mgr *SessionManager) Parse(tokenString string) (jwt.Claims, string, error)
 	}
 
 	if account.PasswordMtime != nil && issuedAt.Before(*account.PasswordMtime) {
-		return nil, "", fmt.Errorf("account password has changed since token issued")
+		return nil, "", errors.New("account password has changed since token issued")
 	}
 
 	newToken := ""
@@ -536,7 +536,7 @@ func (mgr *SessionManager) VerifyToken(tokenString string) (jwt.Claims, string, 
 			return nil, "", fmt.Errorf("cannot access settings while verifying the token: %w", err)
 		}
 		if argoSettings == nil {
-			return nil, "", fmt.Errorf("settings are not available while verifying the token")
+			return nil, "", errors.New("settings are not available while verifying the token")
 		}
 
 		idToken, err := prov.Verify(tokenString, argoSettings)
@@ -573,7 +573,7 @@ func (mgr *SessionManager) provider() (oidcutil.Provider, error) {
 		return nil, err
 	}
 	if !settings.IsSSOConfigured() {
-		return nil, fmt.Errorf("SSO is not configured")
+		return nil, errors.New("SSO is not configured")
 	}
 	mgr.prov = oidcutil.NewOIDCProvider(settings.IssuerURL(), mgr.client)
 	return mgr.prov, nil

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -1431,7 +1431,7 @@ func (mgr *SettingsManager) initialize(ctx context.Context) error {
 	}()
 
 	if !cache.WaitForCacheSync(ctx.Done(), cmInformer.HasSynced, secretsInformer.HasSynced) {
-		return fmt.Errorf("Timed out waiting for settings cache to sync")
+		return errors.New("Timed out waiting for settings cache to sync")
 	}
 	log.Info("Configmap/secret informer synced")
 
@@ -1586,7 +1586,7 @@ func validateExternalURL(u string) error {
 		return fmt.Errorf("Failed to parse URL: %w", err)
 	}
 	if URL.Scheme != "http" && URL.Scheme != "https" {
-		return fmt.Errorf("URL must include http or https protocol")
+		return errors.New("URL must include http or https protocol")
 	}
 	return nil
 }

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -208,7 +208,7 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 
 func generate(opts CertOptions) ([]byte, crypto.PrivateKey, error) {
 	if len(opts.Hosts) == 0 {
-		return nil, nil, fmt.Errorf("hosts not supplied")
+		return nil, nil, errors.New("hosts not supplied")
 	}
 
 	var privateKey crypto.PrivateKey
@@ -256,7 +256,7 @@ func generate(opts CertOptions) ([]byte, crypto.PrivateKey, error) {
 	}
 
 	if opts.Organization == "" {
-		return nil, nil, fmt.Errorf("organization not supplied")
+		return nil, nil, errors.New("organization not supplied")
 	}
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
@@ -366,7 +366,7 @@ func LoadX509Cert(path string) (*x509.Certificate, error) {
 	}
 	block, _ := pem.Decode(bytes)
 	if block == nil {
-		return nil, fmt.Errorf("could not decode PEM")
+		return nil, errors.New("could not decode PEM")
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {


### PR DESCRIPTION
#### Description

enables and fixes errorf rule of [perfsprint](https://golangci-lint.run/usage/linters/#perfsprint) linter issues.