### PR TITLE
chore: enable importas for k8s.io/apimachinery/pkg/apis/meta/v1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,6 +50,8 @@ linters-settings:
               - errors
   importas:
     alias:
+      - alias: metav1 
+        pkg: k8s.io/apimachinery/pkg/apis/meta/v1
       - alias: stderrors
         pkg: errors
   perfsprint:

--- a/applicationset/controllers/clustereventhandler_test.go
+++ b/applicationset/controllers/clustereventhandler_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,7 +39,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name:  "no application sets should mean no requests",
 			items: []argov1alpha1.ApplicationSet{},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -53,7 +53,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a cluster generator should produce a request",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -67,7 +67,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -83,7 +83,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "multiple cluster generators should produce multiple requests",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -96,7 +96,7 @@ func TestClusterEventHandler(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set2",
 						Namespace: "argocd",
 					},
@@ -110,7 +110,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -127,7 +127,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "non-cluster generator should not match",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "another-namespace",
 					},
@@ -140,7 +140,7 @@ func TestClusterEventHandler(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "app-set-non-cluster",
 						Namespace: "argocd",
 					},
@@ -154,7 +154,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -170,7 +170,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "non-argo cd secret should not match",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "another-namespace",
 					},
@@ -184,7 +184,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-non-argocd-secret",
 				},
@@ -195,7 +195,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a matrix generator with a cluster generator should produce a request",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -215,7 +215,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -231,7 +231,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a matrix generator with non cluster generator should not match",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -251,7 +251,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -265,7 +265,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a matrix generator with a nested matrix generator containing a cluster generator should produce a request",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -301,7 +301,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -317,7 +317,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a matrix generator with a nested matrix generator containing non cluster generator should not match",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -352,7 +352,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -366,7 +366,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a merge generator with a cluster generator should produce a request",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -386,7 +386,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -402,7 +402,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a matrix generator with non cluster generator should not match",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -422,7 +422,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -436,7 +436,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a merge generator with a nested merge generator containing a cluster generator should produce a request",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -472,7 +472,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{
@@ -488,7 +488,7 @@ func TestClusterEventHandler(t *testing.T) {
 			name: "a merge generator with a nested merge generator containing non cluster generator should not match",
 			items: []argov1alpha1.ApplicationSet{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-app-set",
 						Namespace: "argocd",
 					},
@@ -523,7 +523,7 @@ func TestClusterEventHandler(t *testing.T) {
 				},
 			},
 			secret: corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "argocd",
 					Name:      "my-secret",
 					Labels: map[string]string{

--- a/applicationset/utils/selector.go
+++ b/applicationset/utils/selector.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -90,7 +90,7 @@ func everything() Selector {
 // LabelSelectorAsSelector converts the LabelSelector api type into a struct that implements
 // labels.Selector
 // Note: This function should be kept in sync with the selector methods in pkg/labels/selector.go
-func LabelSelectorAsSelector(ps *v1.LabelSelector) (Selector, error) {
+func LabelSelectorAsSelector(ps *metav1.LabelSelector) (Selector, error) {
 	if ps == nil {
 		return nothing(), nil
 	}
@@ -108,13 +108,13 @@ func LabelSelectorAsSelector(ps *v1.LabelSelector) (Selector, error) {
 	for _, expr := range ps.MatchExpressions {
 		var op selection.Operator
 		switch expr.Operator {
-		case v1.LabelSelectorOpIn:
+		case metav1.LabelSelectorOpIn:
 			op = selection.In
-		case v1.LabelSelectorOpNotIn:
+		case metav1.LabelSelectorOpNotIn:
 			op = selection.NotIn
-		case v1.LabelSelectorOpExists:
+		case metav1.LabelSelectorOpExists:
 			op = selection.Exists
-		case v1.LabelSelectorOpDoesNotExist:
+		case metav1.LabelSelectorOpDoesNotExist:
 			op = selection.DoesNotExist
 		default:
 			return nil, fmt.Errorf("%q is not a valid pod selector operator", expr.Operator)

--- a/cmd/argocd/commands/admin/admin.go
+++ b/cmd/argocd/commands/admin/admin.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -242,7 +242,7 @@ func getAdditionalNamespaces(ctx context.Context, argocdClientsets *argoCDClient
 	applicationNamespaces := make([]string, 0)
 	applicationsetNamespaces := make([]string, 0)
 
-	un, err := argocdClientsets.configMaps.Get(ctx, common.ArgoCDCmdParamsConfigMapName, v1.GetOptions{})
+	un, err := argocdClientsets.configMaps.Get(ctx, common.ArgoCDCmdParamsConfigMapName, metav1.GetOptions{})
 	errors.CheckError(err)
 	var cm apiv1.ConfigMap
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &cm)

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -284,7 +284,7 @@ func NewReconcileCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command 
 					overrides := clientcmd.ConfigOverrides{}
 					repoServerName := clientOpts.RepoServerName
 					repoServerServiceLabelSelector := common.LabelKeyComponentRepoServer + "=" + common.LabelValueComponentRepoServer
-					repoServerServices, err := kubeClientset.CoreV1().Services(namespace).List(context.Background(), v1.ListOptions{LabelSelector: repoServerServiceLabelSelector})
+					repoServerServices, err := kubeClientset.CoreV1().Services(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: repoServerServiceLabelSelector})
 					errors.CheckError(err)
 					if len(repoServerServices.Items) > 0 {
 						if repoServerServicelabel, ok := repoServerServices.Items[0].Labels[common.LabelKeyAppName]; ok && repoServerServicelabel != "" {
@@ -337,7 +337,7 @@ func saveToFile(err error, outputFormat string, result reconcileResults, outputP
 }
 
 func getReconcileResults(ctx context.Context, appClientset appclientset.Interface, namespace string, selector string) ([]appReconcileResult, error) {
-	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(ctx, v1.ListOptions{LabelSelector: selector})
+	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return nil, fmt.Errorf("error listing namespaced apps: %w", err)
 	}
@@ -371,7 +371,7 @@ func reconcileApplications(
 		appClientset,
 		1*time.Hour,
 		appinformers.WithNamespace(namespace),
-		appinformers.WithTweakListOptions(func(options *v1.ListOptions) {}),
+		appinformers.WithTweakListOptions(func(options *metav1.ListOptions) {}),
 	)
 
 	appInformer := appInformerFactory.Argoproj().V1alpha1().Applications().Informer()
@@ -405,7 +405,7 @@ func reconcileApplications(
 	appStateManager := controller.NewAppStateManager(
 		argoDB, appClientset, repoServerClient, namespace, kubeutil.NewKubectl(), settingsMgr, stateCache, projInformer, server, cache, time.Second, argo.NewResourceTracking(), false, 0, serverSideDiff, ignoreNormalizerOpts)
 
-	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(ctx, v1.ListOptions{LabelSelector: selector})
+	appsList, err := appClientset.ArgoprojV1alpha1().Applications(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return nil, fmt.Errorf("error listing namespaced apps: %w", err)
 	}

--- a/cmd/argocd/commands/admin/backup.go
+++ b/cmd/argocd/commands/admin/backup.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
@@ -61,28 +61,28 @@ func NewExportCommand() *cobra.Command {
 			}
 
 			acdClients := newArgoCDClientsets(config, namespace)
-			acdConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDConfigMapName, v1.GetOptions{})
+			acdConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
 			errors.CheckError(err)
 			export(writer, *acdConfigMap, namespace)
-			acdRBACConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDRBACConfigMapName, v1.GetOptions{})
+			acdRBACConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDRBACConfigMapName, metav1.GetOptions{})
 			errors.CheckError(err)
 			export(writer, *acdRBACConfigMap, namespace)
-			acdKnownHostsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDKnownHostsConfigMapName, v1.GetOptions{})
+			acdKnownHostsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDKnownHostsConfigMapName, metav1.GetOptions{})
 			errors.CheckError(err)
 			export(writer, *acdKnownHostsConfigMap, namespace)
-			acdTLSCertsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDTLSCertsConfigMapName, v1.GetOptions{})
+			acdTLSCertsConfigMap, err := acdClients.configMaps.Get(ctx, common.ArgoCDTLSCertsConfigMapName, metav1.GetOptions{})
 			errors.CheckError(err)
 			export(writer, *acdTLSCertsConfigMap, namespace)
 
 			referencedSecrets := getReferencedSecrets(*acdConfigMap)
-			secrets, err := acdClients.secrets.List(ctx, v1.ListOptions{})
+			secrets, err := acdClients.secrets.List(ctx, metav1.ListOptions{})
 			errors.CheckError(err)
 			for _, secret := range secrets.Items {
 				if isArgoCDSecret(referencedSecrets, secret) {
 					export(writer, secret, namespace)
 				}
 			}
-			projects, err := acdClients.projects.List(ctx, v1.ListOptions{})
+			projects, err := acdClients.projects.List(ctx, metav1.ListOptions{})
 			errors.CheckError(err)
 			for _, proj := range projects.Items {
 				export(writer, proj, namespace)
@@ -97,7 +97,7 @@ func NewExportCommand() *cobra.Command {
 				applicationsetNamespaces = additionalNamespaces.applicationsetNamespaces
 			}
 
-			applications, err := acdClients.applications.List(ctx, v1.ListOptions{})
+			applications, err := acdClients.applications.List(ctx, metav1.ListOptions{})
 			errors.CheckError(err)
 			for _, app := range applications.Items {
 				// Export application only if it is in one of the enabled namespaces
@@ -105,7 +105,7 @@ func NewExportCommand() *cobra.Command {
 					export(writer, app, namespace)
 				}
 			}
-			applicationSets, err := acdClients.applicationSets.List(ctx, v1.ListOptions{})
+			applicationSets, err := acdClients.applicationSets.List(ctx, metav1.ListOptions{})
 			if err != nil && !apierr.IsNotFound(err) {
 				if apierr.IsForbidden(err) {
 					log.Warn(err)
@@ -188,7 +188,7 @@ func NewImportCommand() *cobra.Command {
 			// items in this map indicates the resource should be pruned since it no longer appears
 			// in the backup
 			pruneObjects := make(map[kube.ResourceKey]unstructured.Unstructured)
-			configMaps, err := acdClients.configMaps.List(ctx, v1.ListOptions{})
+			configMaps, err := acdClients.configMaps.List(ctx, metav1.ListOptions{})
 			errors.CheckError(err)
 			// referencedSecrets holds any secrets referenced in the argocd-cm configmap. These
 			// secrets need to be imported too
@@ -202,26 +202,26 @@ func NewImportCommand() *cobra.Command {
 				}
 			}
 
-			secrets, err := acdClients.secrets.List(ctx, v1.ListOptions{})
+			secrets, err := acdClients.secrets.List(ctx, metav1.ListOptions{})
 			errors.CheckError(err)
 			for _, secret := range secrets.Items {
 				if isArgoCDSecret(referencedSecrets, secret) {
 					pruneObjects[kube.ResourceKey{Group: "", Kind: "Secret", Name: secret.GetName(), Namespace: secret.GetNamespace()}] = secret
 				}
 			}
-			applications, err := acdClients.applications.List(ctx, v1.ListOptions{})
+			applications, err := acdClients.applications.List(ctx, metav1.ListOptions{})
 			errors.CheckError(err)
 			for _, app := range applications.Items {
 				if secutil.IsNamespaceEnabled(app.GetNamespace(), namespace, applicationNamespaces) {
 					pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.ApplicationKind, Name: app.GetName(), Namespace: app.GetNamespace()}] = app
 				}
 			}
-			projects, err := acdClients.projects.List(ctx, v1.ListOptions{})
+			projects, err := acdClients.projects.List(ctx, metav1.ListOptions{})
 			errors.CheckError(err)
 			for _, proj := range projects.Items {
 				pruneObjects[kube.ResourceKey{Group: application.Group, Kind: application.AppProjectKind, Name: proj.GetName(), Namespace: proj.GetNamespace()}] = proj
 			}
-			applicationSets, err := acdClients.applicationSets.List(ctx, v1.ListOptions{})
+			applicationSets, err := acdClients.applicationSets.List(ctx, metav1.ListOptions{})
 			if apierr.IsForbidden(err) || apierr.IsNotFound(err) {
 				log.Warnf("argoproj.io/ApplicationSet: %v\n", err)
 			} else {
@@ -278,7 +278,7 @@ func NewImportCommand() *cobra.Command {
 				if !exists {
 					isForbidden := false
 					if !dryRun {
-						_, err = dynClient.Create(ctx, bakObj, v1.CreateOptions{})
+						_, err = dynClient.Create(ctx, bakObj, metav1.CreateOptions{})
 						if apierr.IsForbidden(err) || apierr.IsNotFound(err) {
 							isForbidden = true
 							log.Warnf("%s/%s %s: %v", gvk.Group, gvk.Kind, bakObj.GetName(), err)
@@ -297,7 +297,7 @@ func NewImportCommand() *cobra.Command {
 					isForbidden := false
 					if !dryRun {
 						newLive := updateLive(bakObj, &liveObj, stopOperation)
-						_, err = dynClient.Update(ctx, newLive, v1.UpdateOptions{})
+						_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
 						if apierr.IsForbidden(err) || apierr.IsNotFound(err) {
 							isForbidden = true
 							log.Warnf("%s/%s %s: %v", gvk.Group, gvk.Kind, bakObj.GetName(), err)
@@ -328,7 +328,7 @@ func NewImportCommand() *cobra.Command {
 							if finalizers := liveObj.GetFinalizers(); len(finalizers) > 0 {
 								newLive := liveObj.DeepCopy()
 								newLive.SetFinalizers(nil)
-								_, err = dynClient.Update(ctx, newLive, v1.UpdateOptions{})
+								_, err = dynClient.Update(ctx, newLive, metav1.UpdateOptions{})
 								if err != nil && !apierr.IsNotFound(err) {
 									errors.CheckError(err)
 								}
@@ -344,7 +344,7 @@ func NewImportCommand() *cobra.Command {
 					if !dryRun {
 						canPrune := promptUtil.Confirm(fmt.Sprintf("Are you sure you want to prune %s/%s %s ? [y/n]", key.Group, key.Kind, key.Name))
 						if canPrune {
-							err = dynClient.Delete(ctx, key.Name, v1.DeleteOptions{})
+							err = dynClient.Delete(ctx, key.Name, metav1.DeleteOptions{})
 							if apierr.IsForbidden(err) || apierr.IsNotFound(err) {
 								isForbidden = true
 								log.Warnf("%s/%s %s: %v\n", key.Group, key.Kind, key.Name, err)

--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -14,7 +14,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -86,7 +86,7 @@ func loadClusters(ctx context.Context, kubeClient *kubernetes.Clientset, appClie
 	if err != nil {
 		return nil, err
 	}
-	appItems, err := appClient.ArgoprojV1alpha1().Applications(namespace).List(ctx, v1.ListOptions{})
+	appItems, err := appClient.ArgoprojV1alpha1().Applications(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func loadClusters(ctx context.Context, kubeClient *kubernetes.Clientset, appClie
 
 func getControllerReplicas(ctx context.Context, kubeClient *kubernetes.Clientset, namespace string, appControllerName string) (int, error) {
 	appControllerPodLabelSelector := common.LabelKeyAppName + "=" + appControllerName
-	controllerPods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{
+	controllerPods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: appControllerPodLabelSelector,
 	})
 	if err != nil {
@@ -276,7 +276,7 @@ func runClusterNamespacesCommand(ctx context.Context, clientConfig clientcmd.Cli
 	if err != nil {
 		return fmt.Errorf("error listing clusters: %w", err)
 	}
-	appItems, err := appClient.ArgoprojV1alpha1().Applications(namespace).List(ctx, v1.ListOptions{})
+	appItems, err := appClient.ArgoprojV1alpha1().Applications(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error listing application: %w", err)
 	}
@@ -671,7 +671,7 @@ func NewGenClusterConfigCommand(pathOpts *clientcmd.PathOptions) *cobra.Command 
 			secName, err := db.URIToSecretName("cluster", clst.Server)
 			errors.CheckError(err)
 
-			secret, err := kubeClientset.CoreV1().Secrets(ArgoCDNamespace).Get(ctx, secName, v1.GetOptions{})
+			secret, err := kubeClientset.CoreV1().Secrets(ArgoCDNamespace).Get(ctx, secName, metav1.GetOptions{})
 			errors.CheckError(err)
 
 			errors.CheckError(PrintResources(outputFormat, os.Stdout, secret))

--- a/cmd/argocd/commands/admin/initial_password.go
+++ b/cmd/argocd/commands/admin/initial_password.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -28,7 +28,7 @@ func NewInitialPasswordCommand() *cobra.Command {
 			errors.CheckError(err)
 
 			kubeClientset := kubernetes.NewForConfigOrDie(config)
-			secret, err := kubeClientset.CoreV1().Secrets(namespace).Get(context.Background(), initialPasswordSecretName, v1.GetOptions{})
+			secret, err := kubeClientset.CoreV1().Secrets(namespace).Get(context.Background(), initialPasswordSecretName, metav1.GetOptions{})
 			errors.CheckError(err)
 
 			if initialPass, ok := secret.Data["password"]; ok {

--- a/cmd/argocd/commands/admin/project.go
+++ b/cmd/argocd/commands/admin/project.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -123,7 +123,7 @@ func saveProject(ctx context.Context, updated v1alpha1.AppProject, orig v1alpha1
 	}
 	_ = cli.PrintDiff(updated.Name, target, live)
 	if !dryRun {
-		_, err = projectsIf.Update(ctx, &updated, v1.UpdateOptions{})
+		_, err = projectsIf.Update(ctx, &updated, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("error while updating project:  %w", err)
 		}
@@ -199,7 +199,7 @@ func NewUpdatePolicyRuleCommand() *cobra.Command {
 }
 
 func updateProjects(ctx context.Context, projIf appclient.AppProjectInterface, projectGlob string, rolePattern string, action string, modification func(string, string) string, dryRun bool) error {
-	projects, err := projIf.List(ctx, v1.ListOptions{})
+	projects, err := projIf.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error listing the projects: %w", err)
 	}

--- a/cmd/argocd/commands/admin/project_test.go
+++ b/cmd/argocd/commands/admin/project_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
@@ -21,7 +21,7 @@ func newProj(name string, roleNames ...string) *v1alpha1.AppProject {
 	for i := range roleNames {
 		roles = append(roles, v1alpha1.ProjectRole{Name: roleNames[i]})
 	}
-	return &v1alpha1.AppProject{ObjectMeta: v1.ObjectMeta{
+	return &v1alpha1.AppProject{ObjectMeta: metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
 	}, Spec: v1alpha1.AppProjectSpec{
@@ -39,11 +39,11 @@ func TestUpdateProjects_FindMatchingProject(t *testing.T) {
 	err = updateProjects(ctx, clientset.ArgoprojV1alpha1().AppProjects(namespace), "ba*", "*", "set", modification, false)
 	require.NoError(t, err)
 
-	fooProj, err := clientset.ArgoprojV1alpha1().AppProjects(namespace).Get(ctx, "foo", v1.GetOptions{})
+	fooProj, err := clientset.ArgoprojV1alpha1().AppProjects(namespace).Get(ctx, "foo", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, fooProj.Spec.Roles[0].Policies)
 
-	barProj, err := clientset.ArgoprojV1alpha1().AppProjects(namespace).Get(ctx, "bar", v1.GetOptions{})
+	barProj, err := clientset.ArgoprojV1alpha1().AppProjects(namespace).Get(ctx, "bar", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, []string{"p, proj:bar:test, *, set, bar/*, allow"}, barProj.Spec.Roles[0].Policies)
 }
@@ -58,7 +58,7 @@ func TestUpdateProjects_FindMatchingRole(t *testing.T) {
 	err = updateProjects(ctx, clientset.ArgoprojV1alpha1().AppProjects(namespace), "*", "fo*", "set", modification, false)
 	require.NoError(t, err)
 
-	proj, err := clientset.ArgoprojV1alpha1().AppProjects(namespace).Get(ctx, "proj", v1.GetOptions{})
+	proj, err := clientset.ArgoprojV1alpha1().AppProjects(namespace).Get(ctx, "proj", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, []string{"p, proj:proj:foo, *, set, proj/*, allow"}, proj.Spec.Roles[0].Policies)
 	assert.Empty(t, proj.Spec.Roles[1].Policies)

--- a/cmd/argocd/commands/admin/redis_initial_password.go
+++ b/cmd/argocd/commands/admin/redis_initial_password.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -80,7 +79,7 @@ func NewRedisInitialPasswordCommand() *cobra.Command {
 			}
 
 			fmt.Printf("Argo CD Redis secret state confirmed: secret name %s.\n", redisInitialCredentials)
-			secret, err = kubeClientset.CoreV1().Secrets(namespace).Get(context.Background(), redisInitialCredentials, v1.GetOptions{})
+			secret, err = kubeClientset.CoreV1().Secrets(namespace).Get(context.Background(), redisInitialCredentials, metav1.GetOptions{})
 			errors.CheckError(err)
 
 			if _, ok := secret.Data[redisInitialCredentialsKey]; ok {

--- a/cmd/argocd/commands/admin/repo.go
+++ b/cmd/argocd/commands/admin/repo.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	cmdutil "github.com/argoproj/argo-cd/v2/cmd/util"
@@ -138,11 +138,11 @@ func NewGenRepoSpecCommand() *cobra.Command {
 			}
 
 			argoCDCM := &apiv1.ConfigMap{
-				TypeMeta: v1.TypeMeta{
+				TypeMeta: metav1.TypeMeta{
 					Kind:       "ConfigMap",
 					APIVersion: "v1",
 				},
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: ArgoCDNamespace,
 					Labels: map[string]string{
@@ -157,7 +157,7 @@ func NewGenRepoSpecCommand() *cobra.Command {
 			_, err := argoDB.CreateRepository(ctx, &repoOpts.Repo)
 			errors.CheckError(err)
 
-			secret, err := kubeClientset.CoreV1().Secrets(ArgoCDNamespace).Get(ctx, db.RepoURLToSecretName(repoSecretPrefix, repoOpts.Repo.Repo, repoOpts.Repo.Project), v1.GetOptions{})
+			secret, err := kubeClientset.CoreV1().Secrets(ArgoCDNamespace).Get(ctx, db.RepoURLToSecretName(repoSecretPrefix, repoOpts.Repo.Repo, repoOpts.Repo.Project), metav1.GetOptions{})
 			errors.CheckError(err)
 
 			errors.CheckError(PrintResources(outputFormat, os.Stdout, secret))

--- a/cmd/argocd/commands/admin/settings.go
+++ b/cmd/argocd/commands/admin/settings.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -52,7 +52,7 @@ func collectLogs(callback func()) string {
 	return out.String()
 }
 
-func setSettingsMeta(obj v1.Object) {
+func setSettingsMeta(obj metav1.Object) {
 	obj.SetNamespace("default")
 	labels := obj.GetLabels()
 	if labels == nil {
@@ -72,7 +72,7 @@ func (opts *settingsOpts) createSettingsManager(ctx context.Context) (*settings.
 			return nil, err
 		}
 
-		argocdCM, err = realClientset.CoreV1().ConfigMaps(ns).Get(ctx, common.ArgoCDConfigMapName, v1.GetOptions{})
+		argocdCM, err = realClientset.CoreV1().ConfigMaps(ns).Get(ctx, common.ArgoCDConfigMapName, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -104,13 +104,13 @@ func (opts *settingsOpts) createSettingsManager(ctx context.Context) (*settings.
 		if err != nil {
 			return nil, err
 		}
-		argocdSecret, err = realClientset.CoreV1().Secrets(ns).Get(ctx, common.ArgoCDSecretName, v1.GetOptions{})
+		argocdSecret, err = realClientset.CoreV1().Secrets(ns).Get(ctx, common.ArgoCDSecretName, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		argocdSecret = &corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: common.ArgoCDSecretName,
 			},
 			Data: map[string][]byte{

--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
@@ -402,7 +402,7 @@ func getPolicyFromConfigMap(cm *corev1.ConfigMap) (string, string, string) {
 
 // getPolicyConfigMap fetches the RBAC config map from K8s cluster
 func getPolicyConfigMap(ctx context.Context, client kubernetes.Interface, namespace string) (*corev1.ConfigMap, error) {
-	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, common.ArgoCDRBACConfigMapName, v1.GetOptions{})
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, common.ArgoCDRBACConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/argocd/commands/headless/headless.go
+++ b/cmd/argocd/commands/headless/headless.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeUtil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
@@ -129,7 +129,7 @@ func (c *forwardRepoClientset) NewRepoServerClient() (io.Closer, repoapiclient.R
 		}
 		repoServerName := c.repoServerName
 		repoServererviceLabelSelector := common.LabelKeyComponentRepoServer + "=" + common.LabelValueComponentRepoServer
-		repoServerServices, err := c.kubeClientset.CoreV1().Services(c.namespace).List(context.Background(), metaV1.ListOptions{LabelSelector: repoServererviceLabelSelector})
+		repoServerServices, err := c.kubeClientset.CoreV1().Services(c.namespace).List(context.Background(), metav1.ListOptions{LabelSelector: repoServererviceLabelSelector})
 		if err != nil {
 			c.err = err
 			return

--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
@@ -603,11 +603,11 @@ func constructAppsBaseOnName(appName string, labels, annotations, args []string,
 	}
 	appName, appNs := argo.ParseFromQualifiedName(appName, "")
 	app = &argoappv1.Application{
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: application.Group + "/v1alpha1",
 		},
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: appNs,
 		},

--- a/cmd/util/project.go
+++ b/cmd/util/project.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
@@ -52,31 +52,31 @@ func AddProjFlags(command *cobra.Command, opts *ProjectOpts) {
 		"Destination server, namespace and target service account (e.g. https://192.168.99.100:8443,default,default-sa)")
 }
 
-func getGroupKindList(values []string) []v1.GroupKind {
-	var res []v1.GroupKind
+func getGroupKindList(values []string) []metav1.GroupKind {
+	var res []metav1.GroupKind
 	for _, val := range values {
 		if parts := strings.Split(val, "/"); len(parts) == 2 {
-			res = append(res, v1.GroupKind{Group: parts[0], Kind: parts[1]})
+			res = append(res, metav1.GroupKind{Group: parts[0], Kind: parts[1]})
 		} else if len(parts) == 1 {
-			res = append(res, v1.GroupKind{Kind: parts[0]})
+			res = append(res, metav1.GroupKind{Kind: parts[0]})
 		}
 	}
 	return res
 }
 
-func (opts *ProjectOpts) GetAllowedClusterResources() []v1.GroupKind {
+func (opts *ProjectOpts) GetAllowedClusterResources() []metav1.GroupKind {
 	return getGroupKindList(opts.allowedClusterResources)
 }
 
-func (opts *ProjectOpts) GetDeniedClusterResources() []v1.GroupKind {
+func (opts *ProjectOpts) GetDeniedClusterResources() []metav1.GroupKind {
 	return getGroupKindList(opts.deniedClusterResources)
 }
 
-func (opts *ProjectOpts) GetAllowedNamespacedResources() []v1.GroupKind {
+func (opts *ProjectOpts) GetAllowedNamespacedResources() []metav1.GroupKind {
 	return getGroupKindList(opts.allowedNamespacedResources)
 }
 
-func (opts *ProjectOpts) GetDeniedNamespacedResources() []v1.GroupKind {
+func (opts *ProjectOpts) GetDeniedNamespacedResources() []metav1.GroupKind {
 	return getGroupKindList(opts.deniedNamespacedResources)
 }
 
@@ -199,7 +199,7 @@ func SetProjSpecOptions(flags *pflag.FlagSet, spec *v1alpha1.AppProjectSpec, pro
 
 func ConstructAppProj(fileURL string, args []string, opts ProjectOpts, c *cobra.Command) (*v1alpha1.AppProject, error) {
 	proj := v1alpha1.AppProject{
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			Kind:       application.AppProjectKind,
 			APIVersion: application.Group + "/v1alpha1",
 		},

--- a/cmd/util/project_test.go
+++ b/cmd/util/project_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
@@ -18,10 +18,10 @@ func TestProjectOpts_ResourceLists(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t,
-		[]v1.GroupKind{{Kind: "ConfigMap"}}, opts.GetAllowedNamespacedResources(),
-		[]v1.GroupKind{{Group: "apps", Kind: "DaemonSet"}}, opts.GetDeniedNamespacedResources(),
-		[]v1.GroupKind{{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}}, opts.GetAllowedClusterResources(),
-		[]v1.GroupKind{{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}}, opts.GetDeniedClusterResources(),
+		[]metav1.GroupKind{{Kind: "ConfigMap"}}, opts.GetAllowedNamespacedResources(),
+		[]metav1.GroupKind{{Group: "apps", Kind: "DaemonSet"}}, opts.GetDeniedNamespacedResources(),
+		[]metav1.GroupKind{{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}}, opts.GetAllowedClusterResources(),
+		[]metav1.GroupKind{{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}}, opts.GetDeniedClusterResources(),
 	)
 }
 

--- a/cmpserver/plugin/config_test.go
+++ b/cmpserver/plugin/config_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/common"
 )
@@ -130,10 +130,10 @@ spec:
     command: [command]
 `,
 			expected: &PluginConfig{
-				TypeMeta: v1.TypeMeta{
+				TypeMeta: metav1.TypeMeta{
 					Kind: ConfigManagementPluginKind,
 				},
-				Metadata: v1.ObjectMeta{
+				Metadata: metav1.ObjectMeta{
 					Name: "name",
 				},
 				Spec: PluginConfigSpec{
@@ -177,10 +177,10 @@ func Test_PluginConfig_Address(t *testing.T) {
 		{
 			name: "no version specified",
 			config: &PluginConfig{
-				TypeMeta: v1.TypeMeta{
+				TypeMeta: metav1.TypeMeta{
 					Kind: ConfigManagementPluginKind,
 				},
-				Metadata: v1.ObjectMeta{
+				Metadata: metav1.ObjectMeta{
 					Name: "name",
 				},
 			},
@@ -189,10 +189,10 @@ func Test_PluginConfig_Address(t *testing.T) {
 		{
 			name: "version specified",
 			config: &PluginConfig{
-				TypeMeta: v1.TypeMeta{
+				TypeMeta: metav1.TypeMeta{
 					Kind: ConfigManagementPluginKind,
 				},
-				Metadata: v1.ObjectMeta{
+				Metadata: metav1.ObjectMeta{
 					Name: "name",
 				},
 				Spec: PluginConfigSpec{

--- a/common/common.go
+++ b/common/common.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -455,7 +455,7 @@ SetOptionalRedisPasswordFromKubeConfig sets the optional Redis password if it ex
 We specify kubeClient as kubernetes.Interface to allow for mocking in tests, but this should be treated as a kubernetes.Clientset param.
 */
 func SetOptionalRedisPasswordFromKubeConfig(ctx context.Context, kubeClient kubernetes.Interface, namespace string, redisOptions *redis.Options) error {
-	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, RedisInitialCredentials, v1.GetOptions{})
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, RedisInitialCredentials, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get secret %s/%s: %w", namespace, RedisInitialCredentials, err)
 	}

--- a/controller/hook.go
+++ b/controller/hook.go
@@ -8,7 +8,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/sync/hook"
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 
@@ -76,7 +76,7 @@ func (ctrl *ApplicationController) executePostDeleteHooks(app *v1alpha1.Applicat
 	}
 	createdCnt := 0
 	for _, obj := range expectedHook {
-		_, err = ctrl.kubectl.CreateResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), obj, v1.CreateOptions{})
+		_, err = ctrl.kubectl.CreateResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), obj, metav1.CreateOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -159,7 +159,7 @@ func (ctrl *ApplicationController) cleanupPostDeleteHooks(liveObjs map[kube.Reso
 					continue
 				}
 				logCtx.Infof("Deleting post-delete hook %s/%s", obj.GetNamespace(), obj.GetName())
-				err = ctrl.kubectl.DeleteResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), v1.DeleteOptions{})
+				err = ctrl.kubectl.DeleteResource(context.Background(), config, obj.GroupVersionKind(), obj.GetName(), obj.GetNamespace(), metav1.DeleteOptions{})
 				if err != nil {
 					return false, err
 				}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -19,7 +19,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/managedfields"
@@ -275,14 +275,14 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		})
 	}
 
-	prunePropagationPolicy := v1.DeletePropagationForeground
+	prunePropagationPolicy := metav1.DeletePropagationForeground
 	switch {
 	case syncOp.SyncOptions.HasOption("PrunePropagationPolicy=background"):
-		prunePropagationPolicy = v1.DeletePropagationBackground
+		prunePropagationPolicy = metav1.DeletePropagationBackground
 	case syncOp.SyncOptions.HasOption("PrunePropagationPolicy=foreground"):
-		prunePropagationPolicy = v1.DeletePropagationForeground
+		prunePropagationPolicy = metav1.DeletePropagationForeground
 	case syncOp.SyncOptions.HasOption("PrunePropagationPolicy=orphan"):
-		prunePropagationPolicy = v1.DeletePropagationOrphan
+		prunePropagationPolicy = metav1.DeletePropagationOrphan
 	}
 
 	openAPISchema, err := m.getOpenAPISchema(clst.Server)
@@ -344,7 +344,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 	opts := []sync.SyncOpt{
 		sync.WithLogr(logutils.NewLogrusLogger(logEntry)),
 		sync.WithHealthOverride(lua.ResourceHealthOverrides(resourceOverrides)),
-		sync.WithPermissionValidator(func(un *unstructured.Unstructured, res *v1.APIResource) error {
+		sync.WithPermissionValidator(func(un *unstructured.Unstructured, res *metav1.APIResource) error {
 			if !proj.IsGroupKindPermitted(un.GroupVersionKind().GroupKind(), res.Namespaced) {
 				return fmt.Errorf("resource %s:%s is not permitted in project %s", un.GroupVersionKind().Group, un.GroupVersionKind().Kind, proj.Name)
 			}

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -29,7 +29,7 @@ func TestPersistRevisionHistory(t *testing.T) {
 	app.Status.History = nil
 
 	defaultProject := &v1alpha1.AppProject{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: test.FakeArgoCDNamespace,
 			Name:      "default",
 		},
@@ -54,7 +54,7 @@ func TestPersistRevisionHistory(t *testing.T) {
 	// Ensure we record spec.source into sync result
 	assert.Equal(t, app.Spec.GetSource(), opState.SyncResult.Source)
 
-	updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, v1.GetOptions{})
+	updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Len(t, updatedApp.Status.History, 1)
 	assert.Equal(t, app.Spec.GetSource(), updatedApp.Status.History[0].Source)
@@ -75,7 +75,7 @@ func TestPersistManagedNamespaceMetadataState(t *testing.T) {
 	}
 
 	defaultProject := &v1alpha1.AppProject{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: test.FakeArgoCDNamespace,
 			Name:      "default",
 		},
@@ -106,7 +106,7 @@ func TestPersistRevisionHistoryRollback(t *testing.T) {
 	app.Status.OperationState = nil
 	app.Status.History = nil
 	defaultProject := &v1alpha1.AppProject{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: test.FakeArgoCDNamespace,
 			Name:      "default",
 		},
@@ -143,7 +143,7 @@ func TestPersistRevisionHistoryRollback(t *testing.T) {
 	// Ensure we record opState's source into sync result
 	assert.Equal(t, source, opState.SyncResult.Source)
 
-	updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, v1.GetOptions{})
+	updatedApp, err := ctrl.applicationClientset.ArgoprojV1alpha1().Applications(app.Namespace).Get(context.Background(), app.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Len(t, updatedApp.Status.History, 1)
 	assert.Equal(t, source, updatedApp.Status.History[0].Source)
@@ -156,7 +156,7 @@ func TestSyncComparisonError(t *testing.T) {
 	app.Status.History = nil
 
 	defaultProject := &v1alpha1.AppProject{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: test.FakeArgoCDNamespace,
 			Name:      "default",
 		},
@@ -202,7 +202,7 @@ func TestAppStateManager_SyncAppState(t *testing.T) {
 		app.Status.History = nil
 
 		project := &v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: test.FakeArgoCDNamespace,
 				Name:      "default",
 			},
@@ -270,7 +270,7 @@ func TestSyncWindowDeniesSync(t *testing.T) {
 		app.Status.History = nil
 
 		project := &v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: test.FakeArgoCDNamespace,
 				Name:      "default",
 			},
@@ -654,7 +654,7 @@ func TestDeriveServiceAccountMatchingNamespaces(t *testing.T) {
 
 	setup := func(destinationServiceAccounts []v1alpha1.ApplicationDestinationServiceAccount, destinationNamespace, destinationServerURL, applicationNamespace string) *fixture {
 		project := &v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "argocd-ns",
 				Name:      "testProj",
 			},
@@ -663,7 +663,7 @@ func TestDeriveServiceAccountMatchingNamespaces(t *testing.T) {
 			},
 		}
 		app := &v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: applicationNamespace,
 				Name:      "testApp",
 			},
@@ -1000,7 +1000,7 @@ func TestDeriveServiceAccountMatchingServers(t *testing.T) {
 
 	setup := func(destinationServiceAccounts []v1alpha1.ApplicationDestinationServiceAccount, destinationNamespace, destinationServerURL, applicationNamespace string) *fixture {
 		project := &v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "argocd-ns",
 				Name:      "testProj",
 			},
@@ -1009,7 +1009,7 @@ func TestDeriveServiceAccountMatchingServers(t *testing.T) {
 			},
 		}
 		app := &v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: applicationNamespace,
 				Name:      "testApp",
 			},
@@ -1279,7 +1279,7 @@ func TestSyncWithImpersonate(t *testing.T) {
 		app.Status.OperationState = nil
 		app.Status.History = nil
 		project := &v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: test.FakeArgoCDNamespace,
 				Name:      "default",
 			},
@@ -1297,7 +1297,7 @@ func TestSyncWithImpersonate(t *testing.T) {
 		additionalObjs := []runtime.Object{}
 		if serviceAccountName != "" {
 			syncServiceAccount := &corev1.ServiceAccount{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceAccountName,
 					Namespace: test.FakeDestNamespace,
 				},

--- a/hack/gen-resources/generators/application_generator.go
+++ b/hack/gen-resources/generators/application_generator.go
@@ -12,8 +12,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/hack/gen-resources/util"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -90,7 +89,7 @@ func (pg *ApplicationGenerator) Generate(opts *util.GenerateOpts) error {
 		log.Printf("Pick destination %q", destination)
 		log.Printf("Create application")
 		_, err = applications.Create(context.TODO(), &v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "application-",
 				Namespace:    opts.Namespace,
 				Labels:       labels,
@@ -100,7 +99,7 @@ func (pg *ApplicationGenerator) Generate(opts *util.GenerateOpts) error {
 				Destination: *destination,
 				Source:      source,
 			},
-		}, v1.CreateOptions{})
+		}, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -111,7 +110,7 @@ func (pg *ApplicationGenerator) Generate(opts *util.GenerateOpts) error {
 func (ag *ApplicationGenerator) Clean(opts *util.GenerateOpts) error {
 	log.Printf("Clean applications")
 	applications := ag.argoClientSet.ArgoprojV1alpha1().Applications(opts.Namespace)
-	return applications.DeleteCollection(context.TODO(), v1.DeleteOptions{}, v1.ListOptions{
+	return applications.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/generated-by=argocd-generator",
 	})
 }

--- a/hack/gen-resources/generators/cluster_generator.go
+++ b/hack/gen-resources/generators/cluster_generator.go
@@ -9,23 +9,18 @@ import (
 	"strings"
 	"time"
 
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/argoproj/argo-cd/v2/util/helm"
-
 	"gopkg.in/yaml.v2"
-
-	"k8s.io/client-go/kubernetes/scheme"
-
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/argoproj/argo-cd/v2/hack/gen-resources/util"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/db"
+	"github.com/argoproj/argo-cd/v2/util/helm"
 )
 
 const POD_PREFIX = "vcluster"
@@ -152,7 +147,7 @@ func (cg *ClusterGenerator) installVCluster(opts *util.GenerateOpts, namespace s
 }
 
 func (cg *ClusterGenerator) getClusterServerUri(namespace string, releaseSuffix string) (string, error) {
-	pod, err := cg.clientSet.CoreV1().Pods(namespace).Get(context.TODO(), POD_PREFIX+"-"+releaseSuffix+"-0", v12.GetOptions{})
+	pod, err := cg.clientSet.CoreV1().Pods(namespace).Get(context.TODO(), POD_PREFIX+"-"+releaseSuffix+"-0", metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -255,7 +250,7 @@ func (cg *ClusterGenerator) Generate(opts *util.GenerateOpts) error {
 
 func (cg *ClusterGenerator) Clean(opts *util.GenerateOpts) error {
 	log.Printf("Clean clusters")
-	namespaces, err := cg.clientSet.CoreV1().Namespaces().List(context.TODO(), v12.ListOptions{})
+	namespaces, err := cg.clientSet.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -263,7 +258,7 @@ func (cg *ClusterGenerator) Clean(opts *util.GenerateOpts) error {
 	for _, ns := range namespaces.Items {
 		if strings.HasPrefix(ns.Name, POD_PREFIX) {
 			log.Printf("Delete namespace %s", ns.Name)
-			err = cg.clientSet.CoreV1().Namespaces().Delete(context.TODO(), ns.Name, v12.DeleteOptions{})
+			err = cg.clientSet.CoreV1().Namespaces().Delete(context.TODO(), ns.Name, metav1.DeleteOptions{})
 			if err != nil {
 				log.Printf("Delete namespace failed due: %s", err.Error())
 			}
@@ -271,7 +266,7 @@ func (cg *ClusterGenerator) Clean(opts *util.GenerateOpts) error {
 	}
 
 	secrets := cg.clientSet.CoreV1().Secrets(opts.Namespace)
-	return secrets.DeleteCollection(context.TODO(), v12.DeleteOptions{}, v12.ListOptions{
+	return secrets.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/generated-by=argocd-generator",
 	})
 }

--- a/hack/gen-resources/generators/project_generator.go
+++ b/hack/gen-resources/generators/project_generator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/hack/gen-resources/util"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -25,7 +25,7 @@ func (pg *ProjectGenerator) Generate(opts *util.GenerateOpts) error {
 	for i := 0; i < opts.ProjectOpts.Samples; i++ {
 		log.Printf("Generate project #%v", i)
 		_, err := projects.Create(context.TODO(), &v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "project-",
 				Namespace:    opts.Namespace,
 				Labels:       labels,
@@ -33,7 +33,7 @@ func (pg *ProjectGenerator) Generate(opts *util.GenerateOpts) error {
 			Spec: v1alpha1.AppProjectSpec{
 				Description: "generated-project",
 			},
-		}, v1.CreateOptions{})
+		}, metav1.CreateOptions{})
 		if err != nil {
 			log.Printf("Project #%v failed to generate", i)
 			return fmt.Errorf("error in generated-project: %w", err)
@@ -45,7 +45,7 @@ func (pg *ProjectGenerator) Generate(opts *util.GenerateOpts) error {
 func (pg *ProjectGenerator) Clean(opts *util.GenerateOpts) error {
 	log.Printf("Clean projects")
 	projects := pg.clientSet.ArgoprojV1alpha1().AppProjects(opts.Namespace)
-	return projects.DeleteCollection(context.TODO(), v1.DeleteOptions{}, v1.ListOptions{
+	return projects.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/generated-by=argocd-generator",
 	})
 }

--- a/hack/gen-resources/generators/repo_generator.go
+++ b/hack/gen-resources/generators/repo_generator.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 
 	v1 "k8s.io/api/core/v1"
-	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/hack/gen-resources/util"
 
@@ -89,7 +89,7 @@ func (rg *RepoGenerator) Generate(opts *util.GenerateOpts) error {
 	rg.bar.NewOption(0, int64(len(repos)))
 	for _, repo := range repos {
 		_, err = secrets.Create(context.TODO(), &v1.Secret{
-			ObjectMeta: v1meta.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "repo-",
 				Namespace:    opts.Namespace,
 				Labels: map[string]string{
@@ -105,7 +105,7 @@ func (rg *RepoGenerator) Generate(opts *util.GenerateOpts) error {
 				"url":     []byte(repo.Url),
 				"project": []byte("default"),
 			},
-		}, v1meta.CreateOptions{})
+		}, metav1.CreateOptions{})
 		rg.bar.Increment()
 		rg.bar.Play()
 	}
@@ -119,7 +119,7 @@ func (rg *RepoGenerator) Generate(opts *util.GenerateOpts) error {
 func (rg *RepoGenerator) Clean(opts *util.GenerateOpts) error {
 	log.Printf("Clean repos")
 	secrets := rg.clientSet.CoreV1().Secrets(opts.Namespace)
-	return secrets.DeleteCollection(context.TODO(), v1meta.DeleteOptions{}, v1meta.ListOptions{
+	return secrets.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/generated-by=argocd-generator",
 	})
 }

--- a/notification_controller/controller/controller.go
+++ b/notification_controller/controller/controller.go
@@ -24,7 +24,7 @@ import (
 	"github.com/argoproj/notifications-engine/pkg/subscriptions"
 	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -78,7 +78,7 @@ func NewController(
 	appProjInformer := newInformer(newAppProjClient(client, namespace), namespace, []string{namespace}, "")
 	var notificationConfigNamespace string
 	if selfServiceNotificationEnabled {
-		notificationConfigNamespace = v1.NamespaceAll
+		notificationConfigNamespace = metav1.NamespaceAll
 	} else {
 		notificationConfigNamespace = namespace
 	}
@@ -93,7 +93,7 @@ func NewController(
 		appProjInformer:   appProjInformer,
 		apiFactory:        apiFactory,
 	}
-	skipProcessingOpt := controller.WithSkipProcessing(func(obj v1.Object) (bool, string) {
+	skipProcessingOpt := controller.WithSkipProcessing(func(obj metav1.Object) (bool, string) {
 		app, ok := (obj).(*unstructured.Unstructured)
 		if !ok {
 			return false, ""
@@ -125,7 +125,7 @@ func checkAppNotInAdditionalNamespaces(app *unstructured.Unstructured, namespace
 	return namespace != app.GetNamespace() && !glob.MatchStringInList(applicationNamespaces, app.GetNamespace(), glob.REGEXP)
 }
 
-func (c *notificationController) alterDestinations(obj v1.Object, destinations services.Destinations, cfg api.Config) services.Destinations {
+func (c *notificationController) alterDestinations(obj metav1.Object, destinations services.Destinations, cfg api.Config) services.Destinations {
 	app, ok := (obj).(*unstructured.Unstructured)
 	if !ok {
 		return destinations
@@ -141,7 +141,7 @@ func (c *notificationController) alterDestinations(obj v1.Object, destinations s
 func newInformer(resClient dynamic.ResourceInterface, controllerNamespace string, applicationNamespaces []string, selector string) cache.SharedIndexInformer {
 	informer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
-			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				// We are only interested in apps that exist in namespaces the
 				// user wants to be enabled.
 				options.LabelSelector = selector
@@ -158,7 +158,7 @@ func newInformer(resClient dynamic.ResourceInterface, controllerNamespace string
 				appList.Items = newItems
 				return appList, nil
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = selector
 				return resClient.Watch(context.TODO(), options)
 			},

--- a/server/badge/badge.go
+++ b/server/badge/badge.go
@@ -11,7 +11,7 @@ import (
 	healthutil "github.com/argoproj/gitops-engine/pkg/health"
 	"k8s.io/apimachinery/pkg/api/errors"
 	validation "k8s.io/apimachinery/pkg/api/validation"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
@@ -125,7 +125,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Sample url: http://localhost:8080/api/badge?name=123
 	if name, ok := r.URL.Query()["name"]; ok && enabled && !notFound {
 		if argo.IsValidAppName(name[0]) {
-			if app, err := h.appClientset.ArgoprojV1alpha1().Applications(reqNs).Get(context.Background(), name[0], v1.GetOptions{}); err == nil {
+			if app, err := h.appClientset.ArgoprojV1alpha1().Applications(reqNs).Get(context.Background(), name[0], metav1.GetOptions{}); err == nil {
 				health = app.Status.Health.Status
 				status = app.Status.Sync.Status
 				applicationName = name[0]
@@ -148,7 +148,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		if apps, err := h.appClientset.ArgoprojV1alpha1().Applications(reqNs).List(context.Background(), v1.ListOptions{}); err == nil {
+		if apps, err := h.appClientset.ArgoprojV1alpha1().Applications(reqNs).List(context.Background(), metav1.ListOptions{}); err == nil {
 			applicationSet := argo.FilterByProjects(apps.Items, projects)
 			for _, a := range applicationSet {
 				if a.Status.Sync.Status != appv1.SyncStatusCodeSynced {

--- a/server/badge/badge_test.go
+++ b/server/badge/badge_test.go
@@ -17,14 +17,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 func argoCDSecret() *corev1.Secret {
 	return &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{Name: "argocd-secret", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "argocd-secret", Namespace: "default"},
 		Data: map[string][]byte{
 			"admin.password":   []byte("test"),
 			"server.secretkey": []byte("test"),
@@ -34,7 +34,7 @@ func argoCDSecret() *corev1.Secret {
 
 func argoCDCm() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
 			Namespace: "default",
 			Labels: map[string]string{
@@ -49,7 +49,7 @@ func argoCDCm() *corev1.ConfigMap {
 
 func testApp() *v1alpha1.Application {
 	return &v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "test-app", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "default"},
 		Status: v1alpha1.ApplicationStatus{
 			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
 			Health: v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
@@ -64,7 +64,7 @@ func testApp() *v1alpha1.Application {
 
 func testApp2() *v1alpha1.Application {
 	return &v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "test-app", Namespace: "argocd-test"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "argocd-test"},
 		Status: v1alpha1.ApplicationStatus{
 			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
 			Health: v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
@@ -79,7 +79,7 @@ func testApp2() *v1alpha1.Application {
 
 func testApp3() *v1alpha1.Application {
 	return &v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "test-app", Namespace: "argocd-test"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-app", Namespace: "argocd-test"},
 		Status: v1alpha1.ApplicationStatus{
 			Sync:   v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeSynced},
 			Health: v1alpha1.HealthStatus{Status: health.HealthStatusHealthy},
@@ -94,7 +94,7 @@ func testApp3() *v1alpha1.Application {
 
 func testProject() *v1alpha1.AppProject {
 	return &v1alpha1.AppProject{
-		ObjectMeta: v1.ObjectMeta{Name: "test-project", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-project", Namespace: "default"},
 		Spec:       v1alpha1.AppProjectSpec{},
 	}
 }
@@ -341,7 +341,7 @@ func TestHandlerFeatureIsEnabledKeepFullRevisionAndWidthIsEnabled(t *testing.T) 
 
 func createApplicationFeatureProjectIsEnabled(healthStatus health.HealthStatusCode, syncStatus v1alpha1.SyncStatusCode, appName, projectName, namespace string) *v1alpha1.Application {
 	return &v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: appName, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
 		Status: v1alpha1.ApplicationStatus{
 			Sync:   v1alpha1.SyncStatus{Status: syncStatus},
 			Health: v1alpha1.HealthStatus{Status: healthStatus},

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 
@@ -182,7 +182,7 @@ func (s *Server) Create(ctx context.Context, q *cluster.ClusterCreateRequest) (*
 		ServerVersion: serverVersion,
 		ConnectionState: appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusSuccessful,
-			ModifiedAt: &v1.Time{Time: time.Now()},
+			ModifiedAt: &metav1.Time{Time: time.Now()},
 		},
 	})
 	if err != nil {
@@ -338,7 +338,7 @@ func (s *Server) Update(ctx context.Context, q *cluster.ClusterUpdateRequest) (*
 		ServerVersion: serverVersion,
 		ConnectionState: appv1.ConnectionState{
 			Status:     appv1.ConnectionStatusSuccessful,
-			ModifiedAt: &v1.Time{Time: time.Now()},
+			ModifiedAt: &metav1.Time{Time: time.Now()},
 		},
 	})
 	if err != nil {
@@ -458,7 +458,7 @@ func (s *Server) RotateAuth(ctx context.Context, q *cluster.ClusterQuery) (*clus
 			ServerVersion: serverVersion,
 			ConnectionState: appv1.ConnectionState{
 				Status:     appv1.ConnectionStatusSuccessful,
-				ModifiedAt: &v1.Time{Time: time.Now()},
+				ModifiedAt: &metav1.Time{Time: time.Now()},
 			},
 		})
 		if err != nil {
@@ -501,7 +501,7 @@ func (s *Server) InvalidateCache(ctx context.Context, q *cluster.ClusterQuery) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify access for cluster: %w", err)
 	}
-	now := v1.Now()
+	now := metav1.Now()
 	cls.RefreshRequestedAt = &now
 	cls, err = s.db.UpdateCluster(ctx, cls)
 	if err != nil {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
@@ -184,7 +183,7 @@ func TestUpdateCluster_RejectInvalidParams(t *testing.T) {
 	db.On("ListClusters", mock.Anything).Return(
 		func(ctx context.Context) *v1alpha1.ClusterList {
 			return &v1alpha1.ClusterList{
-				ListMeta: v1.ListMeta{},
+				ListMeta: metav1.ListMeta{},
 				Items:    clusters,
 			}
 		},
@@ -255,7 +254,7 @@ func TestGetCluster_UrlEncodedName(t *testing.T) {
 		Namespaces: []string{"default", "kube-system"},
 	}
 	mockClusterList := v1alpha1.ClusterList{
-		ListMeta: v1.ListMeta{},
+		ListMeta: metav1.ListMeta{},
 		Items: []v1alpha1.Cluster{
 			mockCluster,
 		},
@@ -285,7 +284,7 @@ func TestGetCluster_NameWithUrlEncodingButShouldNotBeUnescaped(t *testing.T) {
 		Namespaces: []string{"default", "kube-system"},
 	}
 	mockClusterList := v1alpha1.ClusterList{
-		ListMeta: v1.ListMeta{},
+		ListMeta: metav1.ListMeta{},
 		Items: []v1alpha1.Cluster{
 			mockCluster,
 		},
@@ -355,7 +354,7 @@ func TestUpdateCluster_NoFieldsPaths(t *testing.T) {
 	}
 
 	clusterList := v1alpha1.ClusterList{
-		ListMeta: v1.ListMeta{},
+		ListMeta: metav1.ListMeta{},
 		Items:    clusters,
 	}
 
@@ -629,7 +628,7 @@ func TestListCluster(t *testing.T) {
 	}
 
 	mockClusterList := v1alpha1.ClusterList{
-		ListMeta: v1.ListMeta{},
+		ListMeta: metav1.ListMeta{},
 		Items:    []v1alpha1.Cluster{fooCluster, barCluster, bazCluster},
 	}
 
@@ -649,7 +648,7 @@ func TestListCluster(t *testing.T) {
 				Name: fooCluster.Name,
 			},
 			want: &v1alpha1.ClusterList{
-				ListMeta: v1.ListMeta{},
+				ListMeta: metav1.ListMeta{},
 				Items:    []v1alpha1.Cluster{fooCluster},
 			},
 		},
@@ -659,7 +658,7 @@ func TestListCluster(t *testing.T) {
 				Server: barCluster.Server,
 			},
 			want: &v1alpha1.ClusterList{
-				ListMeta: v1.ListMeta{},
+				ListMeta: metav1.ListMeta{},
 				Items:    []v1alpha1.Cluster{barCluster},
 			},
 		},
@@ -672,7 +671,7 @@ func TestListCluster(t *testing.T) {
 				},
 			},
 			want: &v1alpha1.ClusterList{
-				ListMeta: v1.ListMeta{},
+				ListMeta: metav1.ListMeta{},
 				Items:    []v1alpha1.Cluster{fooCluster},
 			},
 		},
@@ -685,7 +684,7 @@ func TestListCluster(t *testing.T) {
 				},
 			},
 			want: &v1alpha1.ClusterList{
-				ListMeta: v1.ListMeta{},
+				ListMeta: metav1.ListMeta{},
 				Items:    []v1alpha1.Cluster{bazCluster},
 			},
 		},
@@ -698,7 +697,7 @@ func TestListCluster(t *testing.T) {
 				},
 			},
 			want: &v1alpha1.ClusterList{
-				ListMeta: v1.ListMeta{},
+				ListMeta: metav1.ListMeta{},
 				Items:    []v1alpha1.Cluster{barCluster},
 			},
 		},
@@ -729,7 +728,7 @@ func TestGetClusterAndVerifyAccess(t *testing.T) {
 			Namespaces: []string{"default", "kube-system"},
 		}
 		mockClusterList := v1alpha1.ClusterList{
-			ListMeta: v1.ListMeta{},
+			ListMeta: metav1.ListMeta{},
 			Items: []v1alpha1.Cluster{
 				mockCluster,
 			},
@@ -755,7 +754,7 @@ func TestGetClusterAndVerifyAccess(t *testing.T) {
 			Namespaces: []string{"default", "kube-system"},
 		}
 		mockClusterList := v1alpha1.ClusterList{
-			ListMeta: v1.ListMeta{},
+			ListMeta: metav1.ListMeta{},
 			Items: []v1alpha1.Cluster{
 				mockCluster,
 			},
@@ -782,7 +781,7 @@ func TestNoClusterEnumeration(t *testing.T) {
 		Namespaces: []string{"default", "kube-system"},
 	}
 	mockClusterList := v1alpha1.ClusterList{
-		ListMeta: v1.ListMeta{},
+		ListMeta: metav1.ListMeta{},
 		Items: []v1alpha1.Cluster{
 			mockCluster,
 		},

--- a/server/extension/extension_test.go
+++ b/server/extension/extension_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/server/extension"
@@ -274,8 +274,8 @@ func TestCallExtension(t *testing.T) {
 
 	getApp := func(destName, destServer, projName string) *v1alpha1.Application {
 		return &v1alpha1.Application{
-			TypeMeta:   v1.TypeMeta{},
-			ObjectMeta: v1.ObjectMeta{},
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
 			Spec: v1alpha1.ApplicationSpec{
 				Destination: v1alpha1.ApplicationDestination{
 					Name:   destName,
@@ -312,7 +312,7 @@ func TestCallExtension(t *testing.T) {
 			destinations = append(destinations, destination)
 		}
 		return &v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: prjName,
 			},
 			Spec: v1alpha1.AppProjectSpec{

--- a/server/notification/notification_test.go
+++ b/server/notification/notification_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/notification/k8s"
 	"github.com/argoproj/argo-cd/v2/util/notification/settings"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/kubectl/pkg/scheme"
@@ -36,7 +36,7 @@ func TestNotificationServer(t *testing.T) {
 	cm.Namespace = testNamespace
 
 	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-notifications-cm",
 		},
@@ -47,7 +47,7 @@ func TestNotificationServer(t *testing.T) {
 		},
 	},
 		&corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "argocd-notifications-secret",
 				Namespace: testNamespace,
 			},

--- a/server/project/project_test.go
+++ b/server/project/project_test.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	k8scache "k8s.io/client-go/tools/cache"
 
@@ -42,7 +41,7 @@ var testEnableEventList = argo.DefaultEnableEventList()
 
 func TestProjectServer(t *testing.T) {
 	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
 			Labels: map[string]string{
@@ -50,7 +49,7 @@ func TestProjectServer(t *testing.T) {
 			},
 		},
 	}, &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,
 		},
@@ -62,7 +61,7 @@ func TestProjectServer(t *testing.T) {
 	settingsMgr := settings.NewSettingsManager(context.Background(), kubeclientset, testNamespace)
 	enforcer := newEnforcer(kubeclientset)
 	existingProj := v1alpha1.AppProject{
-		ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: testNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
 		Spec: v1alpha1.AppProjectSpec{
 			Destinations: []v1alpha1.ApplicationDestination{
 				{Namespace: "ns1", Server: "https://server1"},
@@ -72,7 +71,7 @@ func TestProjectServer(t *testing.T) {
 		},
 	}
 	existingApp := v1alpha1.Application{
-		ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		Spec:       v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}, Project: "test", Destination: v1alpha1.ApplicationDestination{Namespace: "ns3", Server: "https://server3"}},
 	}
 
@@ -98,7 +97,7 @@ func TestProjectServer(t *testing.T) {
 		err := projectServer.NormalizeProjs()
 		require.NoError(t, err)
 
-		appList, err := projectServer.appclientset.ArgoprojV1alpha1().AppProjects(projectWithRole.Namespace).List(context.Background(), v1.ListOptions{})
+		appList, err := projectServer.appclientset.ArgoprojV1alpha1().AppProjects(projectWithRole.Namespace).List(context.Background(), metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), appList.Items[0].Status.JWTTokensByRole[roleName].Items[0].IssuedAt)
 		assert.ElementsMatch(t, appList.Items[0].Status.JWTTokensByRole[roleName].Items, appList.Items[0].Spec.Roles[0].JWTTokens)
@@ -164,7 +163,7 @@ func TestProjectServer(t *testing.T) {
 
 	t.Run("TestRemoveDestinationSuccessful", func(t *testing.T) {
 		existingApp := v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec:       v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}, Project: "test", Destination: v1alpha1.ApplicationDestination{Namespace: "ns3", Server: "https://server3"}},
 		}
 
@@ -181,7 +180,7 @@ func TestProjectServer(t *testing.T) {
 
 	t.Run("TestRemoveDestinationUsedByApp", func(t *testing.T) {
 		existingApp := v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec:       v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}, Project: "test", Destination: v1alpha1.ApplicationDestination{Namespace: "ns1", Server: "https://server1"}},
 		}
 
@@ -201,7 +200,7 @@ func TestProjectServer(t *testing.T) {
 
 	t.Run("TestRemoveSourceSuccessful", func(t *testing.T) {
 		existingApp := v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec:       v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}, Project: "test"},
 		}
 
@@ -218,7 +217,7 @@ func TestProjectServer(t *testing.T) {
 
 	t.Run("TestRemoveSourceUsedByApp", func(t *testing.T) {
 		existingApp := v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec:       v1alpha1.ApplicationSpec{Project: "test", Source: &v1alpha1.ApplicationSource{RepoURL: "https://github.com/argoproj/argo-cd.git"}},
 		}
 
@@ -240,7 +239,7 @@ func TestProjectServer(t *testing.T) {
 		proj := existingProj.DeepCopy()
 		proj.Spec.SourceRepos = []string{"https://github.com/argoproj/argo-cd.git", "https://github.com/argoproj/*"}
 		existingApp := v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec:       v1alpha1.ApplicationSpec{Project: "test", Source: &v1alpha1.ApplicationSource{RepoURL: "https://github.com/argoproj/argo-cd.git"}},
 		}
 		argoDB := db.NewDB("default", settingsMgr, kubeclientset)
@@ -262,7 +261,7 @@ func TestProjectServer(t *testing.T) {
 			{Namespace: "org1-*", Server: "https://server1"},
 		}
 		existingApp := v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec: v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}, Project: "test", Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://server1",
 				Namespace: "org1-team1",
@@ -295,7 +294,7 @@ func TestProjectServer(t *testing.T) {
 
 	t.Run("TestDeleteDefaultProjectFailure", func(t *testing.T) {
 		defaultProj := v1alpha1.AppProject{
-			ObjectMeta: v1.ObjectMeta{Name: "default", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "default"},
 			Spec:       v1alpha1.AppProjectSpec{},
 		}
 		argoDB := db.NewDB("default", settingsMgr, kubeclientset)
@@ -308,7 +307,7 @@ func TestProjectServer(t *testing.T) {
 
 	t.Run("TestDeleteProjectReferencedByApp", func(t *testing.T) {
 		existingApp := v1alpha1.Application{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec:       v1alpha1.ApplicationSpec{Project: "test"},
 		}
 

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8scache "k8s.io/client-go/tools/cache"
@@ -44,7 +43,7 @@ const testNamespace = "default"
 
 var (
 	argocdCM = corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
 			Labels: map[string]string{
@@ -53,7 +52,7 @@ var (
 		},
 	}
 	argocdSecret = corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,
 		},

--- a/test/e2e/admin_test.go
+++ b/test/e2e/admin_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
@@ -71,9 +71,9 @@ func TestBackupExportImport(t *testing.T) {
 		Then().
 		AndCLIOutput(func(output string, err error) {
 			require.NoError(t, err, "import finished with error")
-			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Get(context.Background(), "exported-app1", v1.GetOptions{})
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Get(context.Background(), "exported-app1", metav1.GetOptions{})
 			require.NoError(t, err, "failed getting test namespace application after import")
-			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), "exported-app-other-namespace", v1.GetOptions{})
+			_, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), "exported-app-other-namespace", metav1.GetOptions{})
 			require.NoError(t, err, "failed getting app namespace application after import")
 		})
 }

--- a/test/e2e/app_autosync_ns_test.go
+++ b/test/e2e/app_autosync_ns_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"testing"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -40,7 +39,7 @@ func TestNSAutoSyncSelfHealDisabled(t *testing.T) {
 		When().
 		And(func() {
 			errors.FailOnErr(fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Patch(context.Background(),
-				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), v1.PatchOptions{}))
+				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), metav1.PatchOptions{}))
 		}).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync))
@@ -66,7 +65,7 @@ func TestNSAutoSyncSelfHealEnabled(t *testing.T) {
 		// app should be auto-synced once k8s change detected
 		And(func() {
 			errors.FailOnErr(fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Patch(context.Background(),
-				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), v1.PatchOptions{}))
+				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), metav1.PatchOptions{}))
 		}).
 		Refresh(RefreshTypeNormal).
 		Then().

--- a/test/e2e/app_autosync_test.go
+++ b/test/e2e/app_autosync_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -35,7 +35,7 @@ func TestAutoSyncSelfHealDisabled(t *testing.T) {
 		When().
 		And(func() {
 			errors.FailOnErr(fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Patch(context.Background(),
-				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), v1.PatchOptions{}))
+				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), metav1.PatchOptions{}))
 		}).
 		Refresh(RefreshTypeNormal).
 		Then().
@@ -60,7 +60,7 @@ func TestAutoSyncSelfHealEnabled(t *testing.T) {
 		// app should be auto-synced once k8s change detected
 		And(func() {
 			errors.FailOnErr(fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Patch(context.Background(),
-				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), v1.PatchOptions{}))
+				"guestbook-ui", types.MergePatchType, []byte(`{"spec": {"revisionHistoryLimit": 0}}`), metav1.PatchOptions{}))
 		}).
 		Refresh(RefreshTypeNormal).
 		Then().

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	client "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -112,7 +112,7 @@ func (a *Actions) CreateFromPartialFile(data string, flags ...string) *Actions {
 func (a *Actions) CreateFromFile(handler func(app *Application), flags ...string) *Actions {
 	a.context.t.Helper()
 	app := &Application{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      a.context.AppName(),
 			Namespace: a.context.AppNamespace(),
 		},
@@ -169,7 +169,7 @@ func (a *Actions) CreateFromFile(handler func(app *Application), flags ...string
 func (a *Actions) CreateMultiSourceAppFromFile(flags ...string) *Actions {
 	a.context.t.Helper()
 	app := &Application{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      a.context.AppName(),
 			Namespace: a.context.AppNamespace(),
 		},

--- a/test/e2e/fixture/app/consequences.go
+++ b/test/e2e/fixture/app/consequences.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/health"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
@@ -108,7 +108,7 @@ func (c *Consequences) app() *Application {
 }
 
 func (c *Consequences) get() (*Application, error) {
-	return fixture.AppClientset.ArgoprojV1alpha1().Applications(c.context.AppNamespace()).Get(context.Background(), c.context.AppName(), v1.GetOptions{})
+	return fixture.AppClientset.ArgoprojV1alpha1().Applications(c.context.AppNamespace()).Get(context.Background(), c.context.AppName(), metav1.GetOptions{})
 }
 
 func (c *Consequences) resource(kind, name, namespace string) ResourceStatus {

--- a/test/e2e/fixture/applicationsets/utils/fixture.go
+++ b/test/e2e/fixture/applicationsets/utils/fixture.go
@@ -15,7 +15,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -112,12 +112,12 @@ func EnsureCleanState(t *testing.T) {
 
 	fixtureClient := GetE2EFixtureK8sClient()
 
-	policy := v1.DeletePropagationForeground
+	policy := metav1.DeletePropagationForeground
 
 	fixture.RunFunctionsInParallelAndCheckErrors(t, []func() error{
 		func() error {
 			// Delete the applicationset-e2e namespace, if it exists
-			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), ApplicationsResourcesNamespace, v1.DeleteOptions{PropagationPolicy: &policy})
+			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), ApplicationsResourcesNamespace, metav1.DeleteOptions{PropagationPolicy: &policy})
 			if err != nil && !apierr.IsNotFound(err) { // 'not found' error is expected
 				return err
 			}
@@ -125,7 +125,7 @@ func EnsureCleanState(t *testing.T) {
 		},
 		func() error {
 			// Delete the argocd-e2e-external namespace, if it exists
-			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), string(ArgoCDExternalNamespace), v1.DeleteOptions{PropagationPolicy: &policy})
+			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), string(ArgoCDExternalNamespace), metav1.DeleteOptions{PropagationPolicy: &policy})
 			if err != nil && !apierr.IsNotFound(err) { // 'not found' error is expected
 				return err
 			}
@@ -133,7 +133,7 @@ func EnsureCleanState(t *testing.T) {
 		},
 		func() error {
 			// Delete the argocd-e2e-external namespace, if it exists
-			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), string(ArgoCDExternalNamespace2), v1.DeleteOptions{PropagationPolicy: &policy})
+			err := fixtureClient.KubeClientset.CoreV1().Namespaces().Delete(context.Background(), string(ArgoCDExternalNamespace2), metav1.DeleteOptions{PropagationPolicy: &policy})
 			if err != nil && !apierr.IsNotFound(err) { // 'not found' error is expected
 				return err
 			}
@@ -142,25 +142,25 @@ func EnsureCleanState(t *testing.T) {
 		// delete resources
 		func() error {
 			// kubectl delete applicationsets --all
-			return fixtureClient.AppSetClientset.DeleteCollection(context.Background(), v1.DeleteOptions{PropagationPolicy: &policy}, v1.ListOptions{})
+			return fixtureClient.AppSetClientset.DeleteCollection(context.Background(), metav1.DeleteOptions{PropagationPolicy: &policy}, metav1.ListOptions{})
 		},
 		func() error {
 			// kubectl delete apps --all
-			return fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).DeleteCollection(context.Background(), v1.DeleteOptions{PropagationPolicy: &policy}, v1.ListOptions{})
+			return fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).DeleteCollection(context.Background(), metav1.DeleteOptions{PropagationPolicy: &policy}, metav1.ListOptions{})
 		},
 		func() error {
 			// kubectl delete secrets -l e2e.argoproj.io=true
 			return fixtureClient.KubeClientset.CoreV1().Secrets(TestNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{LabelSelector: TestingLabel + "=true"})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{LabelSelector: TestingLabel + "=true"})
 		},
 	})
 
 	// First we wait up to 30 seconds for all the ApplicationSets to delete, but we don't fail if they don't.
 	// Why? We want to give Argo CD time to delete the Application's child resources, before we remove the finalizers below.
 	_ = waitForSuccess(func() error {
-		list, err := fixtureClient.AppSetClientset.List(context.Background(), v1.ListOptions{})
+		list, err := fixtureClient.AppSetClientset.List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -174,14 +174,14 @@ func EnsureCleanState(t *testing.T) {
 
 	// Remove finalizers from Argo CD Application resources in the namespace
 	err := waitForSuccess(func() error {
-		appList, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).List(context.Background(), v1.ListOptions{})
+		appList, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
 		for _, app := range appList.Items {
 			t.Log("Removing finalizer for: ", app.Name)
 			app.Finalizers = []string{}
-			_, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).Update(context.TODO(), &app, v1.UpdateOptions{})
+			_, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).Update(context.TODO(), &app, metav1.UpdateOptions{})
 			if err != nil {
 				return err
 			}
@@ -211,13 +211,13 @@ func waitForExpectedClusterState() error {
 		OrphanedResources:        nil,
 		SourceRepos:              []string{"*"},
 		Destinations:             []v1alpha1.ApplicationDestination{{Namespace: "*", Server: "*"}},
-		ClusterResourceWhitelist: []v1.GroupKind{{Group: "*", Kind: "*"}},
+		ClusterResourceWhitelist: []metav1.GroupKind{{Group: "*", Kind: "*"}},
 		SourceNamespaces:         []string{string(ArgoCDExternalNamespace), string(ArgoCDExternalNamespace2)},
 	})
 
 	// Wait up to 60 seconds for all the ApplicationSets to delete
 	if err := waitForSuccess(func() error {
-		list, err := fixtureClient.AppSetClientset.List(context.Background(), v1.ListOptions{})
+		list, err := fixtureClient.AppSetClientset.List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -233,7 +233,7 @@ func waitForExpectedClusterState() error {
 
 	// Wait up to 60 seconds for all the Applications to delete
 	if err := waitForSuccess(func() error {
-		appList, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).List(context.Background(), v1.ListOptions{})
+		appList, err := fixtureClient.AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -260,15 +260,15 @@ func waitForExpectedClusterState() error {
 }
 
 func SetProjectSpec(fixtureClient *E2EFixtureK8sClient, project string, spec v1alpha1.AppProjectSpec) {
-	proj, err := fixtureClient.AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Get(context.Background(), project, v1.GetOptions{})
+	proj, err := fixtureClient.AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Get(context.Background(), project, metav1.GetOptions{})
 	errors.CheckError(err)
 	proj.Spec = spec
-	_, err = fixtureClient.AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Update(context.Background(), proj, v1.UpdateOptions{})
+	_, err = fixtureClient.AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Update(context.Background(), proj, metav1.UpdateOptions{})
 	errors.CheckError(err)
 }
 
 func cleanUpNamespace(fixtureClient *E2EFixtureK8sClient, namespace string) error {
-	_, err := fixtureClient.KubeClientset.CoreV1().Namespaces().Get(context.Background(), namespace, v1.GetOptions{})
+	_, err := fixtureClient.KubeClientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 
 	msg := ""
 

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -17,7 +17,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -391,7 +391,7 @@ func configMapsEquivalent(a *corev1.ConfigMap, b *corev1.ConfigMap) bool {
 
 // Updates a given config map in argocd-e2e namespace
 func updateGenericConfigMap(name string, updater func(cm *corev1.ConfigMap) error) error {
-	cm, err := KubeClientset.CoreV1().ConfigMaps(TestNamespace()).Get(context.Background(), name, v1.GetOptions{})
+	cm, err := KubeClientset.CoreV1().ConfigMaps(TestNamespace()).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -404,7 +404,7 @@ func updateGenericConfigMap(name string, updater func(cm *corev1.ConfigMap) erro
 		return err
 	}
 	if !configMapsEquivalent(cm, oldCm) {
-		_, err = KubeClientset.CoreV1().ConfigMaps(TestNamespace()).Update(context.Background(), cm, v1.UpdateOptions{})
+		_, err = KubeClientset.CoreV1().ConfigMaps(TestNamespace()).Update(context.Background(), cm, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
@@ -565,12 +565,12 @@ func SetRepos(repos ...settings.RepositoryCredentials) error {
 }
 
 func SetProjectSpec(project string, spec v1alpha1.AppProjectSpec) error {
-	proj, err := AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Get(context.Background(), project, v1.GetOptions{})
+	proj, err := AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Get(context.Background(), project, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	proj.Spec = spec
-	_, err = AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Update(context.Background(), proj, v1.UpdateOptions{})
+	_, err = AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Update(context.Background(), proj, metav1.UpdateOptions{})
 	return err
 }
 
@@ -621,57 +621,57 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 	})
 
 	start := time.Now()
-	policy := v1.DeletePropagationBackground
+	policy := metav1.DeletePropagationBackground
 
 	RunFunctionsInParallelAndCheckErrors(t, []func() error{
 		func() error {
 			// kubectl delete apps ...
 			return AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{})
 		},
 		func() error {
 			// kubectl delete apps ...
 			return AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{})
 		},
 		func() error {
 			// kubectl delete appprojects --field-selector metadata.name!=default
 			return AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{FieldSelector: "metadata.name!=default"})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{FieldSelector: "metadata.name!=default"})
 		},
 		func() error {
 			// kubectl delete secrets -l argocd.argoproj.io/secret-type=repo-config
 			return KubeClientset.CoreV1().Secrets(TestNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeRepository})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeRepository})
 		},
 		func() error {
 			// kubectl delete secrets -l argocd.argoproj.io/secret-type=repo-creds
 			return KubeClientset.CoreV1().Secrets(TestNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeRepoCreds})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeRepoCreds})
 		},
 		func() error {
 			// kubectl delete secrets -l argocd.argoproj.io/secret-type=cluster
 			return KubeClientset.CoreV1().Secrets(TestNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeCluster})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{LabelSelector: common.LabelKeySecretType + "=" + common.LabelValueSecretTypeCluster})
 		},
 		func() error {
 			// kubectl delete secrets -l e2e.argoproj.io=true
 			return KubeClientset.CoreV1().Secrets(TestNamespace()).DeleteCollection(
 				context.Background(),
-				v1.DeleteOptions{PropagationPolicy: &policy},
-				v1.ListOptions{LabelSelector: TestingLabel + "=true"})
+				metav1.DeleteOptions{PropagationPolicy: &policy},
+				metav1.ListOptions{LabelSelector: TestingLabel + "=true"})
 		},
 	})
 
@@ -680,7 +680,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 			// delete old namespaces which were created by tests
 			namespaces, err := KubeClientset.CoreV1().Namespaces().List(
 				context.Background(),
-				v1.ListOptions{
+				metav1.ListOptions{
 					LabelSelector: TestingLabel + "=true",
 					FieldSelector: "status.phase=Active",
 				},
@@ -699,7 +699,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 				}
 			}
 
-			namespaces, err = KubeClientset.CoreV1().Namespaces().List(context.Background(), v1.ListOptions{})
+			namespaces, err = KubeClientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				return err
 			}
@@ -728,7 +728,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 			// delete old ClusterRoles which were created by tests
 			clusterRoles, err := KubeClientset.RbacV1().ClusterRoles().List(
 				context.Background(),
-				v1.ListOptions{
+				metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("%s=%s", TestingLabel, "true"),
 				},
 			)
@@ -746,7 +746,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 				}
 			}
 
-			clusterRoles, err = KubeClientset.RbacV1().ClusterRoles().List(context.Background(), v1.ListOptions{})
+			clusterRoles, err = KubeClientset.RbacV1().ClusterRoles().List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				return err
 			}
@@ -768,7 +768,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 		},
 		func() error {
 			// delete old ClusterRoleBindings which were created by tests
-			clusterRoleBindings, err := KubeClientset.RbacV1().ClusterRoleBindings().List(context.Background(), v1.ListOptions{})
+			clusterRoleBindings, err := KubeClientset.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				return err
 			}
@@ -827,7 +827,7 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 				OrphanedResources:        nil,
 				SourceRepos:              []string{"*"},
 				Destinations:             []v1alpha1.ApplicationDestination{{Namespace: "*", Server: "*"}},
-				ClusterResourceWhitelist: []v1.GroupKind{{Group: "*", Kind: "*"}},
+				ClusterResourceWhitelist: []metav1.GroupKind{{Group: "*", Kind: "*"}},
 				SourceNamespaces:         []string{AppNamespace()},
 			})
 			if err != nil {
@@ -838,19 +838,19 @@ func EnsureCleanState(t *testing.T, opts ...TestOption) {
 			_, err = AppClientset.ArgoprojV1alpha1().AppProjects(TestNamespace()).Create(
 				context.Background(),
 				&v1alpha1.AppProject{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "gpg",
 					},
 					Spec: v1alpha1.AppProjectSpec{
 						OrphanedResources:        nil,
 						SourceRepos:              []string{"*"},
 						Destinations:             []v1alpha1.ApplicationDestination{{Namespace: "*", Server: "*"}},
-						ClusterResourceWhitelist: []v1.GroupKind{{Group: "*", Kind: "*"}},
+						ClusterResourceWhitelist: []metav1.GroupKind{{Group: "*", Kind: "*"}},
 						SignatureKeys:            []v1alpha1.SignatureKey{{KeyID: GpgGoodKeyID}},
 						SourceNamespaces:         []string{AppNamespace()},
 					},
 				},
-				v1.CreateOptions{},
+				metav1.CreateOptions{},
 			)
 			return err
 		},

--- a/test/e2e/fixture/project/actions.go
+++ b/test/e2e/fixture/project/actions.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
@@ -52,10 +52,10 @@ func (a *Actions) AddSource(repo string) *Actions {
 }
 
 func (a *Actions) UpdateProject(updater func(project *v1alpha1.AppProject)) *Actions {
-	proj, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Get(context.TODO(), a.context.name, v1.GetOptions{})
+	proj, err := fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Get(context.TODO(), a.context.name, metav1.GetOptions{})
 	require.NoError(a.context.t, err)
 	updater(proj)
-	_, err = fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Update(context.TODO(), proj, v1.UpdateOptions{})
+	_, err = fixture.AppClientset.ArgoprojV1alpha1().AppProjects(fixture.TestNamespace()).Update(context.TODO(), proj, metav1.UpdateOptions{})
 	require.NoError(a.context.t, err)
 	return a
 }

--- a/test/e2e/sync_options_test.go
+++ b/test/e2e/sync_options_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -74,7 +74,7 @@ func TestSyncWithStatusIgnored(t *testing.T) {
 		When().
 		And(func() {
 			errors.FailOnErr(fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Patch(context.Background(),
-				"guestbook-ui", types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/status/observedGeneration", "value": 2 }]`), v1.PatchOptions{}))
+				"guestbook-ui", types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/status/observedGeneration", "value": 2 }]`), metav1.PatchOptions{}))
 		}).
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced))

--- a/util/argo/audit_logger_test.go
+++ b/util/argo/audit_logger_test.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -45,7 +45,7 @@ func TestLogAppProjEvent(t *testing.T) {
 	assert.NotNil(t, logger)
 
 	proj := argoappv1.AppProject{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:            "default",
 			Namespace:       "argocd",
 			ResourceVersion: "1",
@@ -86,7 +86,7 @@ func TestLogAppEvent(t *testing.T) {
 	assert.NotNil(t, logger)
 
 	app := argoappv1.Application{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:            "testapp",
 			Namespace:       "argocd",
 			ResourceVersion: "1",

--- a/util/argo/managedfields/managed_fields.go
+++ b/util/argo/managedfields/managed_fields.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 	"sigs.k8s.io/structured-merge-diff/v4/typed"
@@ -70,7 +70,7 @@ func Normalize(live, config *unstructured.Unstructured, trustedManagers []string
 // normalize will check if the modified set has fields that are present
 // in the managed fields entry. If so, it will remove the fields from
 // the live and config objects so it is ignored in diffs.
-func normalize(mf v1.ManagedFieldsEntry, tr *typedResults) error {
+func normalize(mf metav1.ManagedFieldsEntry, tr *typedResults) error {
 	mfs := &fieldpath.Set{}
 	err := mfs.FromJSON(bytes.NewReader(mf.FieldsV1.Raw))
 	if err != nil {

--- a/util/kube/portforwarder.go
+++ b/util/kube/portforwarder.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
@@ -42,7 +42,7 @@ func PortForward(targetPort int, namespace string, overrides *clientcmd.ConfigOv
 	var pod *corev1.Pod
 
 	for _, podSelector := range podSelectors {
-		pods, err := clientSet.CoreV1().Pods(namespace).List(context.Background(), v1.ListOptions{
+		pods, err := clientSet.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 			LabelSelector: podSelector,
 		})
 		if err != nil {

--- a/util/notification/settings/settings_test.go
+++ b/util/notification/settings/settings_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient/mocks"
@@ -24,7 +24,7 @@ const (
 
 func TestInitGetVars(t *testing.T) {
 	notificationsCm := corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-notifications-cm",
 		},
@@ -36,7 +36,7 @@ func TestInitGetVars(t *testing.T) {
 		},
 	}
 	notificationsSecret := corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-notifications-secret",
 			Namespace: testNamespace,
 		},
@@ -45,14 +45,14 @@ func TestInitGetVars(t *testing.T) {
 		},
 	}
 	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-notifications-cm",
 		},
 		Data: notificationsCm.Data,
 	},
 		&corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "argocd-notifications-secret",
 				Namespace: testNamespace,
 			},


### PR DESCRIPTION
#### Description 

[Importas](https://golangci-lint.run/usage/linters/#importas) helps ensure consistency of imports aliases.

This is only for `k8s.io/apimachinery/pkg/apis/meta/v1` yet here