### PR TITLE
fix: Logs API stops functioning when a pod fails

### DIFF
--- a/server/application/logs.go
+++ b/server/application/logs.go
@@ -39,8 +39,7 @@ func parseLogsStream(podName string, stream io.ReadCloser, ch chan logEntry) {
 		timeStampStr := parts[0]
 		logTime, err := time.Parse(time.RFC3339Nano, timeStampStr)
 		if err != nil {
-			if strings.HasPrefix(line, "unable to retrieve container logs for ") ||
-				strings.HasPrefix(line, "Unable to retrieve container logs for ") {
+			if strings.HasPrefix(strings.ToLower(line), "unable to retrieve container logs for ") {
 				ch <- logEntry{line: line, podName: podName, timeStamp: time.Now()}
 				break
 			}

--- a/server/application/logs.go
+++ b/server/application/logs.go
@@ -39,6 +39,10 @@ func parseLogsStream(podName string, stream io.ReadCloser, ch chan logEntry) {
 		timeStampStr := parts[0]
 		logTime, err := time.Parse(time.RFC3339Nano, timeStampStr)
 		if err != nil {
+			if strings.HasPrefix(line, "unable to retrieve container logs for ") {
+				ch <- logEntry{line: line, podName: podName, timeStamp: time.Now()}
+				break
+			}
 			ch <- logEntry{err: err}
 			break
 		}

--- a/server/application/logs.go
+++ b/server/application/logs.go
@@ -39,7 +39,8 @@ func parseLogsStream(podName string, stream io.ReadCloser, ch chan logEntry) {
 		timeStampStr := parts[0]
 		logTime, err := time.Parse(time.RFC3339Nano, timeStampStr)
 		if err != nil {
-			if strings.HasPrefix(line, "unable to retrieve container logs for ") {
+			if strings.HasPrefix(line, "unable to retrieve container logs for ") ||
+				strings.HasPrefix(line, "Unable to retrieve container logs for ") {
 				ch <- logEntry{line: line, podName: podName, timeStamp: time.Now()}
 				break
 			}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Closes: #21286

When a pod is in a Failed, Completed, or Error state, the Kubernetes API sometimes returns a log message like:

`unable to retrieve container logs for containerd://a0002996fc1eb2a973c4708fa4f4f5f1b9e643114322c71fe54dbbfef27148d5`. 

The current log parsing logic assumes logs always begin with a timestamp, which causes issues when encountering this specific log format.

* Added an exception to handle cases where the log message begins with the string `unable to retrieve container logs for`.
* For these cases, the log stream is cleanly stopped, and a log entry is sent with the message and the current timestamp.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
