### PR TITLE
fix: Policy/policy.open-cluster-management.io stuck in progressing status when no clusters match the policy (#21296)

### DIFF
--- a/resource_customizations/policy.open-cluster-management.io/Policy/health.lua
+++ b/resource_customizations/policy.open-cluster-management.io/Policy/health.lua
@@ -1,9 +1,24 @@
 hs = {}
-if obj.status == nil or obj.status.compliant == nil then
+if obj.status == nil then
   hs.status = "Progressing"
   hs.message = "Waiting for the status to be reported"
   return hs
 end
+
+-- A policy will not have a compliant field but will have a placement key set if
+-- it is not being applied to any clusters
+if obj.status.compliant == nil and #obj.status.placement > 0 and obj.status.status == nil then
+  hs.status = "Healthy"
+  hs.message = "No clusters match this policy"
+  return hs
+end
+
+if obj.status.compliant == nil then
+  hs.status = "Progressing"
+  hs.message = "Waiting for the status to be reported"
+  return hs
+end
+
 if obj.status.compliant == "Compliant" then
   hs.status = "Healthy"
 else

--- a/resource_customizations/policy.open-cluster-management.io/Policy/health_test.yaml
+++ b/resource_customizations/policy.open-cluster-management.io/Policy/health_test.yaml
@@ -15,3 +15,11 @@ tests:
       status: Healthy
       message: All templates are compliant
     inputPath: testdata/healthy_replicated.yaml
+  - healthStatus:
+      status: Progressing
+      message: Waiting for the status to be reported
+    inputPath: testdata/progressing_no_status.yaml
+  - healthStatus:
+      status: Healthy
+      message: No clusters match this policy
+    inputPath: testdata/healthy_with_placement_empty_compliant.yaml

--- a/resource_customizations/policy.open-cluster-management.io/Policy/testdata/healthy_with_placement_empty_compliant.yaml
+++ b/resource_customizations/policy.open-cluster-management.io/Policy/testdata/healthy_with_placement_empty_compliant.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    argocd.argoproj.io/instance: acm
+  name: acm-hub-ca-policy
+  namespace: open-cluster-management
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: acm-hub-ca-config-policy
+      spec:
+        namespaceSelector:
+          include:
+          - default
+        object-templates:
+        - complianceType: mustonlyhave
+          objectDefinition:
+            apiVersion: v1
+            data:
+              hub-kube-root-ca.crt: '{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt"
+                | base64enc hub}}'
+              hub-openshift-service-ca.crt: '{{hub fromConfigMap "" "openshift-service-ca.crt"
+                "service-ca.crt" | base64enc hub}}'
+            kind: Secret
+            metadata:
+              name: hub-ca
+              namespace: golang-external-secrets
+            type: Opaque
+        - complianceType: mustonlyhave
+          objectDefinition:
+            apiVersion: v1
+            data:
+              hub-kube-root-ca.crt: |
+                {{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | autoindent hub}}
+              hub-openshift-service-ca.crt: |
+                {{hub fromConfigMap "" "openshift-service-ca.crt" "service-ca.crt" | autoindent hub}}
+            kind: ConfigMap
+            metadata:
+              name: trusted-hub-bundle
+              namespace: imperative
+        remediationAction: enforce
+        severity: medium
+  remediationAction: enforce
+status:
+  placement:
+  - placementBinding: acm-hub-ca-policy-placement-binding
+    placementRule: acm-hub-ca-policy-placement

--- a/resource_customizations/policy.open-cluster-management.io/Policy/testdata/progressing_no_status.yaml
+++ b/resource_customizations/policy.open-cluster-management.io/Policy/testdata/progressing_no_status.yaml
@@ -1,0 +1,51 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    argocd.argoproj.io/instance: acm
+  name: acm-hub-ca-policy
+  namespace: open-cluster-management
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: acm-hub-ca-config-policy
+      spec:
+        namespaceSelector:
+          include:
+          - default
+        object-templates:
+        - complianceType: mustonlyhave
+          objectDefinition:
+            apiVersion: v1
+            data:
+              hub-kube-root-ca.crt: '{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt"
+                | base64enc hub}}'
+              hub-openshift-service-ca.crt: '{{hub fromConfigMap "" "openshift-service-ca.crt"
+                "service-ca.crt" | base64enc hub}}'
+            kind: Secret
+            metadata:
+              name: hub-ca
+              namespace: golang-external-secrets
+            type: Opaque
+        - complianceType: mustonlyhave
+          objectDefinition:
+            apiVersion: v1
+            data:
+              hub-kube-root-ca.crt: |
+                {{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | autoindent hub}}
+              hub-openshift-service-ca.crt: |
+                {{hub fromConfigMap "" "openshift-service-ca.crt" "service-ca.crt" | autoindent hub}}
+            kind: ConfigMap
+            metadata:
+              name: trusted-hub-bundle
+              namespace: imperative
+        remediationAction: enforce
+        severity: medium
+  remediationAction: enforce


### PR DESCRIPTION
When a policy does not apply to a cluster because the placementrule matches no cluster at all then the status will look like the following:

    status:
      placement:
      - placementBinding: group-one-placement-binding
        placementRule: group-one-placement

Without this change the above will show up as progressing even though there is really nothing to progress.

Let's take care of this case by returning healthy when there is no compliant field but the array under placement is non-zero, which means that its placement resolution has happened and there is nothing to do.

Fixes: #21296

Ideally this should be backported to release-2.13 (only)
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [n/a] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [no] Does this PR require documentation updates?
* [n/a] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [n/a] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
