### PR TITLE
docs: add note about comments in policy.csv files

### DIFF
--- a/docs/operator-manual/argocd-rbac-cm-yaml.md
+++ b/docs/operator-manual/argocd-rbac-cm-yaml.md
@@ -1,5 +1,7 @@
 # argocd-rbac-cm.yaml example
 
+**Note**: While policy files are CSV files, ArgoCD ignores lines starting with `#` when parsing the file, allowing for line comments starting with #.
+
 An example of an argocd-rbac-cm.yaml file:
 
 ```yaml


### PR DESCRIPTION
I was wondering why our policy was valid even though it was not a valid CSV file.

Reading the code, I saw https://github.com/argoproj/argo-cd/blob/812650847cfe349c6700060db37e8da615637d3a/util/rbac/rbac.go#L492-L494 in the parsing and decided to add this note to document this behavior.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
