### PR TITLE
chore: import k8s.io/api/core/v1 as corev1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,6 +56,8 @@ linters-settings:
     alias:
       - alias: jwtgo 
         pkg: github.com/golang-jwt/jwt/v5
+      - alias: corev1
+        pkg: k8s.io/api/core/v1
       - alias: metav1 
         pkg: k8s.io/apimachinery/pkg/apis/meta/v1
       - alias: stderrors

--- a/applicationset/generators/plugin_test.go
+++ b/applicationset/generators/plugin_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,8 +27,8 @@ import (
 func TestPluginGenerateParams(t *testing.T) {
 	testCases := []struct {
 		name            string
-		configmap       *v1.ConfigMap
-		secret          *v1.Secret
+		configmap       *corev1.ConfigMap
+		secret          *corev1.Secret
 		inputParameters map[string]apiextensionsv1.JSON
 		values          map[string]string
 		gotemplate      bool
@@ -38,7 +38,7 @@ func TestPluginGenerateParams(t *testing.T) {
 	}{
 		{
 			name: "simple case",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -48,7 +48,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -94,7 +94,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "simple case with values",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -104,7 +104,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -156,7 +156,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "simple case with gotemplate",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -166,7 +166,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -216,7 +216,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "simple case with appended params",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -226,7 +226,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -272,7 +272,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "no params",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -282,7 +282,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -322,7 +322,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "empty return",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -332,7 +332,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -349,7 +349,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "wrong return",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -359,7 +359,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -376,7 +376,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "external secret",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -386,7 +386,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin-secret:plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "plugin-secret",
 					Namespace: "default",
@@ -432,7 +432,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "no secret",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -442,7 +442,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token":   "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{},
+			secret: &corev1.Secret{},
 			inputParameters: map[string]apiextensionsv1.JSON{
 				"pkey1": {Raw: []byte(`"val1"`)},
 				"pkey2": {Raw: []byte(`"val2"`)},
@@ -480,8 +480,8 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name:      "no configmap",
-			configmap: &v1.ConfigMap{},
-			secret: &v1.Secret{
+			configmap: &corev1.ConfigMap{},
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -527,7 +527,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "no baseUrl",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -536,7 +536,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"token": "$plugin.token",
 				},
 			},
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "argocd-secret",
 					Namespace: "default",
@@ -582,7 +582,7 @@ func TestPluginGenerateParams(t *testing.T) {
 		},
 		{
 			name: "no token",
-			configmap: &v1.ConfigMap{
+			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "first-plugin-cm",
 					Namespace: "default",
@@ -591,7 +591,7 @@ func TestPluginGenerateParams(t *testing.T) {
 					"baseUrl": "http://127.0.0.1",
 				},
 			},
-			secret: &v1.Secret{},
+			secret: &corev1.Secret{},
 			inputParameters: map[string]apiextensionsv1.JSON{
 				"pkey1": {Raw: []byte(`"val1"`)},
 				"pkey2": {Raw: []byte(`"val2"`)},

--- a/cmd/argocd/commands/admin/admin.go
+++ b/cmd/argocd/commands/admin/admin.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -98,7 +98,7 @@ func newArgoCDClientsets(config *rest.Config, namespace string) *argoCDClientset
 // getReferencedSecrets examines the argocd-cm config for any referenced repo secrets and returns a
 // map of all referenced secrets.
 func getReferencedSecrets(un unstructured.Unstructured) map[string]bool {
-	var cm apiv1.ConfigMap
+	var cm corev1.ConfigMap
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &cm)
 	errors.CheckError(err)
 	referencedSecrets := make(map[string]bool)
@@ -192,8 +192,8 @@ func isArgoCDConfigMap(name string) bool {
 func specsEqual(left, right unstructured.Unstructured) bool {
 	leftAnnotation := left.GetAnnotations()
 	rightAnnotation := right.GetAnnotations()
-	delete(leftAnnotation, apiv1.LastAppliedConfigAnnotation)
-	delete(rightAnnotation, apiv1.LastAppliedConfigAnnotation)
+	delete(leftAnnotation, corev1.LastAppliedConfigAnnotation)
+	delete(rightAnnotation, corev1.LastAppliedConfigAnnotation)
 	if !reflect.DeepEqual(leftAnnotation, rightAnnotation) {
 		return false
 	}
@@ -244,7 +244,7 @@ func getAdditionalNamespaces(ctx context.Context, argocdClientsets *argoCDClient
 
 	un, err := argocdClientsets.configMaps.Get(ctx, common.ArgoCDCmdParamsConfigMapName, metav1.GetOptions{})
 	errors.CheckError(err)
-	var cm apiv1.ConfigMap
+	var cm corev1.ConfigMap
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &cm)
 	errors.CheckError(err)
 

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -453,5 +453,5 @@ func reconcileApplications(
 }
 
 func newLiveStateCache(argoDB db.ArgoDB, appInformer kubecache.SharedIndexInformer, settingsMgr *settings.SettingsManager, server *metrics.MetricsServer) cache.LiveStateCache {
-	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, kubeutil.NewKubectl(), server, func(managedByApp map[string]bool, ref apiv1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
+	return cache.NewLiveStateCache(argoDB, appInformer, settingsMgr, kubeutil.NewKubectl(), server, func(managedByApp map[string]bool, ref corev1.ObjectReference) {}, &sharding.ClusterSharding{}, argo.NewResourceTracking())
 }

--- a/cmd/argocd/commands/admin/backup_test.go
+++ b/cmd/argocd/commands/admin/backup_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -13,7 +13,7 @@ import (
 )
 
 func newBackupObject(trackingValue string, trackingLabel bool, trackingAnnotation bool) *unstructured.Unstructured {
-	cm := v1.ConfigMap{
+	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-configmap",
 			Namespace: "namespace",

--- a/cmd/argocd/commands/admin/generatespec_utils.go
+++ b/cmd/argocd/commands/admin/generatespec_utils.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	ioutil "github.com/argoproj/argo-cd/v2/util/io"
@@ -38,7 +38,7 @@ func getOutWriter(inline bool, filePath string) (io.Writer, io.Closer, error) {
 // PrintResources prints a single resource in YAML or JSON format to stdout according to the output format
 func PrintResources(output string, out io.Writer, resources ...any) error {
 	for i, resource := range resources {
-		if secret, ok := resource.(*v1.Secret); ok {
+		if secret, ok := resource.(*corev1.Secret); ok {
 			convertSecretData(secret)
 		}
 		filteredResource, err := omitFields(resource)
@@ -97,7 +97,7 @@ func omitFields(resource any) (any, error) {
 }
 
 // convertSecretData converts kubernetes secret's data to stringData
-func convertSecretData(secret *v1.Secret) {
+func convertSecretData(secret *corev1.Secret) {
 	secret.Kind = kube.SecretKind
 	secret.APIVersion = "v1"
 	secret.StringData = map[string]string{}

--- a/cmd/argocd/commands/admin/generatespec_utils_test.go
+++ b/cmd/argocd/commands/admin/generatespec_utils_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,7 +38,7 @@ func TestGetOutWriter_InlineOn(t *testing.T) {
 
 func TestPrintResources_Secret_YAML(t *testing.T) {
 	out := bytes.Buffer{}
-	err := PrintResources("yaml", &out, &v1.Secret{
+	err := PrintResources("yaml", &out, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-secret"},
 		Data:       map[string][]byte{"my-secret-key": []byte("my-secret-data")},
 	})

--- a/cmd/argocd/commands/admin/repo.go
+++ b/cmd/argocd/commands/admin/repo.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -137,7 +137,7 @@ func NewGenRepoSpecCommand() *cobra.Command {
 				repoOpts.Repo.Password = cli.PromptPassword(repoOpts.Repo.Password)
 			}
 
-			argoCDCM := &apiv1.ConfigMap{
+			argoCDCM := &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ConfigMap",
 					APIVersion: "v1",

--- a/cmd/argocd/commands/admin/settings_rbac_test.go
+++ b/cmd/argocd/commands/admin/settings_rbac_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
@@ -147,7 +147,7 @@ func Test_PolicyFromK8s(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, err)
-	kubeclientset := fake.NewClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-rbac-cm",
 			Namespace: "argocd",
@@ -280,7 +280,7 @@ p, role:user, logs, get, .*/.*, allow
 p, role:user, exec, create, .*/.*, allow
 `
 
-	kubeclientset := fake.NewClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-rbac-cm",
 			Namespace: "argocd",

--- a/cmd/argocd/commands/admin/settings_test.go
+++ b/cmd/argocd/commands/admin/settings_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -44,7 +44,7 @@ func captureStdout(callback func()) (string, error) {
 func newSettingsManager(data map[string]string) *settings.SettingsManager {
 	ctx := context.Background()
 
-	clientset := fake.NewClientset(&v1.ConfigMap{
+	clientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      common.ArgoCDConfigMapName,
@@ -53,7 +53,7 @@ func newSettingsManager(data map[string]string) *settings.SettingsManager {
 			},
 		},
 		Data: data,
-	}, &v1.Secret{
+	}, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      common.ArgoCDSecretName,

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -12,13 +12,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
-
-	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
-
-	v1 "k8s.io/api/core/v1"
-
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/yaml"
 
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
@@ -37,20 +46,7 @@ import (
 	versionpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-
-	"github.com/argoproj/gitops-engine/pkg/health"
-	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	k8swatch "k8s.io/apimachinery/pkg/watch"
+	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 )
 
 func Test_getInfos(t *testing.T) {
@@ -2071,7 +2067,7 @@ func (c *fakeAppServiceClient) List(ctx context.Context, in *applicationpkg.Appl
 	return nil, nil
 }
 
-func (c *fakeAppServiceClient) ListResourceEvents(ctx context.Context, in *applicationpkg.ApplicationResourceEventsQuery, opts ...grpc.CallOption) (*v1.EventList, error) {
+func (c *fakeAppServiceClient) ListResourceEvents(ctx context.Context, in *applicationpkg.ApplicationResourceEventsQuery, opts ...grpc.CallOption) (*corev1.EventList, error) {
 	return nil, nil
 }
 

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -25,7 +25,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -353,7 +353,7 @@ func (ctrl *ApplicationController) onKubectlRun(command string) (kube.CleanupFun
 	}, nil
 }
 
-func isSelfReferencedApp(app *appv1.Application, ref v1.ObjectReference) bool {
+func isSelfReferencedApp(app *appv1.Application, ref corev1.ObjectReference) bool {
 	gvk := ref.GroupVersionKind()
 	return ref.UID == app.UID &&
 		ref.Name == app.Name &&
@@ -412,7 +412,7 @@ func (ctrl *ApplicationController) getAppProj(app *appv1.Application) (*appv1.Ap
 	return proj, nil
 }
 
-func (ctrl *ApplicationController) handleObjectUpdated(managedByApp map[string]bool, ref v1.ObjectReference) {
+func (ctrl *ApplicationController) handleObjectUpdated(managedByApp map[string]bool, ref corev1.ObjectReference) {
 	// if namespaced resource is not managed by any app it might be orphaned resource of some other apps
 	if len(managedByApp) == 0 && ref.Namespace != "" {
 		// retrieve applications which monitor orphaned resources in the same namespace and refresh them unless resource is denied in app project
@@ -673,10 +673,10 @@ func (ctrl *ApplicationController) getAppHosts(a *appv1.Application, appNodes []
 		logCtx = logCtx.WithField("time_ms", time.Since(ts.StartTime).Milliseconds())
 		logCtx.Debug("Finished getting app hosts")
 	}()
-	supportedResourceNames := map[v1.ResourceName]bool{
-		v1.ResourceCPU:     true,
-		v1.ResourceStorage: true,
-		v1.ResourceMemory:  true,
+	supportedResourceNames := map[corev1.ResourceName]bool{
+		corev1.ResourceCPU:     true,
+		corev1.ResourceStorage: true,
+		corev1.ResourceMemory:  true,
 	}
 	appPods := map[kube.ResourceKey]bool{}
 	for _, node := range appNodes {
@@ -716,7 +716,7 @@ func (ctrl *ApplicationController) getAppHosts(a *appv1.Application, appNodes []
 
 		neighbors := allPodsByNode[nodeName]
 
-		resources := map[v1.ResourceName]appv1.HostResourceInfo{}
+		resources := map[corev1.ResourceName]appv1.HostResourceInfo{}
 		for name, resource := range node.Capacity {
 			info := resources[name]
 			info.ResourceName = name
@@ -738,7 +738,7 @@ func (ctrl *ApplicationController) getAppHosts(a *appv1.Application, appNodes []
 
 		for _, pod := range neighbors {
 			for name, resource := range pod.ResourceRequests {
-				if !supportedResourceNames[name] || pod.Phase == v1.PodSucceeded || pod.Phase == v1.PodFailed {
+				if !supportedResourceNames[name] || pod.Phase == corev1.PodSucceeded || pod.Phase == corev1.PodFailed {
 					continue
 				}
 				info := resources[name]
@@ -1029,7 +1029,7 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 				Message: err.Error(),
 			})
 			message := fmt.Sprintf("Unable to delete application resources: %v", err.Error())
-			ctrl.logAppEvent(app, argo.EventInfo{Reason: argo.EventReasonStatusRefreshed, Type: v1.EventTypeWarning}, message, context.TODO())
+			ctrl.logAppEvent(app, argo.EventInfo{Reason: argo.EventReasonStatusRefreshed, Type: corev1.EventTypeWarning}, message, context.TODO())
 		}
 		ts.AddCheckpoint("finalize_application_deletion_ms")
 	}
@@ -1559,10 +1559,10 @@ func (ctrl *ApplicationController) setOperationState(app *appv1.Application, sta
 			messages = append(messages, "to", state.SyncResult.Revision)
 		}
 		if state.Phase.Successful() {
-			eventInfo.Type = v1.EventTypeNormal
+			eventInfo.Type = corev1.EventTypeNormal
 			messages = append(messages, "succeeded")
 		} else {
-			eventInfo.Type = v1.EventTypeWarning
+			eventInfo.Type = corev1.EventTypeWarning
 			messages = append(messages, "failed:", state.Message)
 		}
 		ctrl.logAppEvent(app, eventInfo, strings.Join(messages, " "), context.TODO())
@@ -1996,11 +1996,11 @@ func (ctrl *ApplicationController) persistAppStatus(orig *appv1.Application, new
 	logCtx := getAppLog(orig)
 	if orig.Status.Sync.Status != newStatus.Sync.Status {
 		message := fmt.Sprintf("Updated sync status: %s -> %s", orig.Status.Sync.Status, newStatus.Sync.Status)
-		ctrl.logAppEvent(orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: v1.EventTypeNormal}, message, context.TODO())
+		ctrl.logAppEvent(orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: corev1.EventTypeNormal}, message, context.TODO())
 	}
 	if orig.Status.Health.Status != newStatus.Health.Status {
 		message := fmt.Sprintf("Updated health status: %s -> %s", orig.Status.Health.Status, newStatus.Health.Status)
-		ctrl.logAppEvent(orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: v1.EventTypeNormal}, message, context.TODO())
+		ctrl.logAppEvent(orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: corev1.EventTypeNormal}, message, context.TODO())
 	}
 	var newAnnotations map[string]string
 	if orig.GetAnnotations() != nil {
@@ -2183,7 +2183,7 @@ func (ctrl *ApplicationController) autoSync(app *appv1.Application, syncStatus *
 		target = desiredCommitSHA
 	}
 	message := fmt.Sprintf("Initiated automated sync to '%s'", target)
-	ctrl.logAppEvent(app, argo.EventInfo{Reason: argo.EventReasonOperationStarted, Type: v1.EventTypeNormal}, message, context.TODO())
+	ctrl.logAppEvent(app, argo.EventInfo{Reason: argo.EventReasonOperationStarted, Type: corev1.EventTypeNormal}, message, context.TODO())
 	logCtx.Info(message)
 	return nil, setOpTime
 }

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -20,7 +20,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -155,18 +155,18 @@ type LiveStateCache interface {
 	Init() error
 }
 
-type ObjectUpdatedHandler = func(managedByApp map[string]bool, ref v1.ObjectReference)
+type ObjectUpdatedHandler = func(managedByApp map[string]bool, ref corev1.ObjectReference)
 
 type PodInfo struct {
 	NodeName         string
-	ResourceRequests v1.ResourceList
-	Phase            v1.PodPhase
+	ResourceRequests corev1.ResourceList
+	Phase            corev1.PodPhase
 }
 
 type NodeInfo struct {
 	Name       string
-	Capacity   v1.ResourceList
-	SystemInfo v1.NodeSystemInfo
+	Capacity   corev1.ResourceList
+	SystemInfo corev1.NodeSystemInfo
 }
 
 type ResourceInfo struct {
@@ -576,7 +576,7 @@ func (c *liveStateCache) getCluster(server string) (clustercache.ClusterCache, e
 
 	_ = clusterCache.OnResourceUpdated(func(newRes *clustercache.Resource, oldRes *clustercache.Resource, namespaceResources map[kube.ResourceKey]*clustercache.Resource) {
 		toNotify := make(map[string]bool)
-		var ref v1.ObjectReference
+		var ref corev1.ObjectReference
 		if newRes != nil {
 			ref = newRes.Ref
 		} else {

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -72,7 +72,7 @@ func TestHandleModEvent_ClusterExcluded(t *testing.T) {
 	clustersCache := liveStateCache{
 		db:          nil,
 		appInformer: nil,
-		onObjectUpdated: func(managedByApp map[string]bool, ref v1.ObjectReference) {
+		onObjectUpdated: func(managedByApp map[string]bool, ref corev1.ObjectReference) {
 		},
 		kubectl:       nil,
 		settingsMgr:   &argosettings.SettingsManager{},
@@ -279,7 +279,7 @@ func TestIsRetryableError(t *testing.T) {
 func Test_asResourceNode_owner_refs(t *testing.T) {
 	resNode := asResourceNode(&cache.Resource{
 		ResourceVersion: "",
-		Ref: v1.ObjectReference{
+		Ref: corev1.ObjectReference{
 			APIVersion: "v1",
 		},
 		OwnerRefs: []metav1.OwnerReference{
@@ -335,7 +335,7 @@ func Test_getAppRecursive(t *testing.T) {
 		{
 			name: "ok: cm1->app1",
 			r: &cache.Resource{
-				Ref: v1.ObjectReference{
+				Ref: corev1.ObjectReference{
 					Name: "cm1",
 				},
 				OwnerRefs: []metav1.OwnerReference{
@@ -355,7 +355,7 @@ func Test_getAppRecursive(t *testing.T) {
 		{
 			name: "ok: cm1->cm2->app1",
 			r: &cache.Resource{
-				Ref: v1.ObjectReference{
+				Ref: corev1.ObjectReference{
 					Name: "cm1",
 				},
 				OwnerRefs: []metav1.OwnerReference{
@@ -364,7 +364,7 @@ func Test_getAppRecursive(t *testing.T) {
 			},
 			ns: map[kube.ResourceKey]*cache.Resource{
 				kube.NewResourceKey("", "", "", "cm2"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm2",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -383,7 +383,7 @@ func Test_getAppRecursive(t *testing.T) {
 		{
 			name: "cm1->cm2->app1 & cm1->cm3->app1",
 			r: &cache.Resource{
-				Ref: v1.ObjectReference{
+				Ref: corev1.ObjectReference{
 					Name: "cm1",
 				},
 				OwnerRefs: []metav1.OwnerReference{
@@ -393,7 +393,7 @@ func Test_getAppRecursive(t *testing.T) {
 			},
 			ns: map[kube.ResourceKey]*cache.Resource{
 				kube.NewResourceKey("", "", "", "cm2"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm2",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -401,7 +401,7 @@ func Test_getAppRecursive(t *testing.T) {
 					},
 				},
 				kube.NewResourceKey("", "", "", "cm3"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm3",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -422,7 +422,7 @@ func Test_getAppRecursive(t *testing.T) {
 			// Issue #11699, fixed #12667.
 			name: "ok: cm1->cm2 & cm1->cm3->cm2 & cm1->cm3->app1",
 			r: &cache.Resource{
-				Ref: v1.ObjectReference{
+				Ref: corev1.ObjectReference{
 					Name: "cm1",
 				},
 				OwnerRefs: []metav1.OwnerReference{
@@ -432,12 +432,12 @@ func Test_getAppRecursive(t *testing.T) {
 			},
 			ns: map[kube.ResourceKey]*cache.Resource{
 				kube.NewResourceKey("", "", "", "cm2"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm2",
 					},
 				},
 				kube.NewResourceKey("", "", "", "cm3"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm3",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -457,7 +457,7 @@ func Test_getAppRecursive(t *testing.T) {
 		{
 			name: "cycle: cm1<->cm2",
 			r: &cache.Resource{
-				Ref: v1.ObjectReference{
+				Ref: corev1.ObjectReference{
 					Name: "cm1",
 				},
 				OwnerRefs: []metav1.OwnerReference{
@@ -466,7 +466,7 @@ func Test_getAppRecursive(t *testing.T) {
 			},
 			ns: map[kube.ResourceKey]*cache.Resource{
 				kube.NewResourceKey("", "", "", "cm1"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm1",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -474,7 +474,7 @@ func Test_getAppRecursive(t *testing.T) {
 					},
 				},
 				kube.NewResourceKey("", "", "", "cm2"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm2",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -488,7 +488,7 @@ func Test_getAppRecursive(t *testing.T) {
 		{
 			name: "cycle: cm1->cm2->cm3->cm1",
 			r: &cache.Resource{
-				Ref: v1.ObjectReference{
+				Ref: corev1.ObjectReference{
 					Name: "cm1",
 				},
 				OwnerRefs: []metav1.OwnerReference{
@@ -497,7 +497,7 @@ func Test_getAppRecursive(t *testing.T) {
 			},
 			ns: map[kube.ResourceKey]*cache.Resource{
 				kube.NewResourceKey("", "", "", "cm1"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm1",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -505,7 +505,7 @@ func Test_getAppRecursive(t *testing.T) {
 					},
 				},
 				kube.NewResourceKey("", "", "", "cm2"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm2",
 					},
 					OwnerRefs: []metav1.OwnerReference{
@@ -513,7 +513,7 @@ func Test_getAppRecursive(t *testing.T) {
 					},
 				},
 				kube.NewResourceKey("", "", "", "cm3"): {
-					Ref: v1.ObjectReference{
+					Ref: corev1.ObjectReference{
 						Name: "cm3",
 					},
 					OwnerRefs: []metav1.OwnerReference{

--- a/controller/cache/info.go
+++ b/controller/cache/info.go
@@ -6,12 +6,12 @@ import (
 	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/gitops-engine/pkg/utils/text"
 	"github.com/cespare/xxhash/v2"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	resourcehelper "k8s.io/kubectl/pkg/util/resource"
@@ -72,18 +72,18 @@ func populateNodeInfo(un *unstructured.Unstructured, res *ResourceInfo, customLa
 	}
 }
 
-func getIngress(un *unstructured.Unstructured) []v1.LoadBalancerIngress {
+func getIngress(un *unstructured.Unstructured) []corev1.LoadBalancerIngress {
 	ingress, ok, err := unstructured.NestedSlice(un.Object, "status", "loadBalancer", "ingress")
 	if !ok || err != nil {
 		return nil
 	}
-	res := make([]v1.LoadBalancerIngress, 0)
+	res := make([]corev1.LoadBalancerIngress, 0)
 	for _, item := range ingress {
 		if lbIngress, ok := item.(map[string]any); ok {
 			if hostname := lbIngress["hostname"]; hostname != nil {
-				res = append(res, v1.LoadBalancerIngress{Hostname: fmt.Sprintf("%s", hostname)})
+				res = append(res, corev1.LoadBalancerIngress{Hostname: fmt.Sprintf("%s", hostname)})
 			} else if ip := lbIngress["ip"]; ip != nil {
-				res = append(res, v1.LoadBalancerIngress{IP: fmt.Sprintf("%s", ip)})
+				res = append(res, corev1.LoadBalancerIngress{IP: fmt.Sprintf("%s", ip)})
 			}
 		}
 	}
@@ -92,8 +92,8 @@ func getIngress(un *unstructured.Unstructured) []v1.LoadBalancerIngress {
 
 func populateServiceInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 	targetLabels, _, _ := unstructured.NestedStringMap(un.Object, "spec", "selector")
-	ingress := make([]v1.LoadBalancerIngress, 0)
-	if serviceType, ok, err := unstructured.NestedString(un.Object, "spec", "type"); ok && err == nil && serviceType == string(v1.ServiceTypeLoadBalancer) {
+	ingress := make([]corev1.LoadBalancerIngress, 0)
+	if serviceType, ok, err := unstructured.NestedString(un.Object, "spec", "type"); ok && err == nil && serviceType == string(corev1.ServiceTypeLoadBalancer) {
 		ingress = getIngress(un)
 	}
 
@@ -296,18 +296,18 @@ func populateIstioServiceEntryInfo(un *unstructured.Unstructured, res *ResourceI
 	}
 }
 
-func isPodInitializedConditionTrue(status *v1.PodStatus) bool {
+func isPodInitializedConditionTrue(status *corev1.PodStatus) bool {
 	for _, condition := range status.Conditions {
-		if condition.Type != v1.PodInitialized {
+		if condition.Type != corev1.PodInitialized {
 			continue
 		}
 
-		return condition.Status == v1.ConditionTrue
+		return condition.Status == corev1.ConditionTrue
 	}
 	return false
 }
 
-func isRestartableInitContainer(initContainer *v1.Container) bool {
+func isRestartableInitContainer(initContainer *corev1.Container) bool {
 	if initContainer == nil {
 		return false
 	}
@@ -315,15 +315,15 @@ func isRestartableInitContainer(initContainer *v1.Container) bool {
 		return false
 	}
 
-	return *initContainer.RestartPolicy == v1.ContainerRestartPolicyAlways
+	return *initContainer.RestartPolicy == corev1.ContainerRestartPolicyAlways
 }
 
-func isPodPhaseTerminal(phase v1.PodPhase) bool {
-	return phase == v1.PodFailed || phase == v1.PodSucceeded
+func isPodPhaseTerminal(phase corev1.PodPhase) bool {
+	return phase == corev1.PodFailed || phase == corev1.PodSucceeded
 }
 
 func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
-	pod := v1.Pod{}
+	pod := corev1.Pod{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &pod)
 	if err != nil {
 		return
@@ -353,12 +353,12 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 
 	// If the Pod carries {type:PodScheduled, reason:SchedulingGated}, set reason to 'SchedulingGated'.
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == v1.PodScheduled && condition.Reason == v1.PodReasonSchedulingGated {
-			reason = v1.PodReasonSchedulingGated
+		if condition.Type == corev1.PodScheduled && condition.Reason == corev1.PodReasonSchedulingGated {
+			reason = corev1.PodReasonSchedulingGated
 		}
 	}
 
-	initContainers := make(map[string]*v1.Container)
+	initContainers := make(map[string]*corev1.Container)
 	for i := range pod.Spec.InitContainers {
 		initContainers[pod.Spec.InitContainers[i].Name] = &pod.Spec.InitContainers[i]
 		if isRestartableInitContainer(&pod.Spec.InitContainers[i]) {
@@ -463,7 +463,7 @@ func populatePodInfo(un *unstructured.Unstructured, res *ResourceInfo) {
 }
 
 func populateHostNodeInfo(un *unstructured.Unstructured, res *ResourceInfo) {
-	node := v1.Node{}
+	node := corev1.Node{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &node)
 	if err != nil {
 		return

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -5,13 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
@@ -310,7 +309,7 @@ func TestGetPodInfo(t *testing.T) {
 		assert.Equal(t, []string{"bar"}, info.Images)
 		assert.Equal(t, &PodInfo{
 			NodeName:         "minikube",
-			ResourceRequests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+			ResourceRequests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
 		}, info.PodInfo)
 		assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{Labels: map[string]string{"app": "guestbook"}}, info.NetworkingInfo)
 	})
@@ -907,8 +906,8 @@ status:
 	populateNodeInfo(node, info, []string{})
 	assert.Equal(t, &NodeInfo{
 		Name:       "minikube",
-		Capacity:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("6091320Ki"), v1.ResourceCPU: resource.MustParse("6")},
-		SystemInfo: v1.NodeSystemInfo{Architecture: "amd64", OperatingSystem: "linux", OSImage: "Ubuntu 20.04 LTS"},
+		Capacity:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("6091320Ki"), corev1.ResourceCPU: resource.MustParse("6")},
+		SystemInfo: corev1.NodeSystemInfo{Architecture: "amd64", OperatingSystem: "linux", OSImage: "Ubuntu 20.04 LTS"},
 	}, info.NodeInfo)
 }
 
@@ -918,7 +917,7 @@ func TestGetServiceInfo(t *testing.T) {
 	assert.Empty(t, info.Info)
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
 		TargetLabels: map[string]string{"app": "guestbook"},
-		Ingress:      []v1.LoadBalancerIngress{{Hostname: "localhost"}},
+		Ingress:      []corev1.LoadBalancerIngress{{Hostname: "localhost"}},
 	}, info.NetworkingInfo)
 }
 
@@ -928,7 +927,7 @@ func TestGetLinkAnnotatedServiceInfo(t *testing.T) {
 	assert.Empty(t, info.Info)
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
 		TargetLabels: map[string]string{"app": "guestbook"},
-		Ingress:      []v1.LoadBalancerIngress{{Hostname: "localhost"}},
+		Ingress:      []corev1.LoadBalancerIngress{{Hostname: "localhost"}},
 		ExternalURLs: []string{"http://my-grafana.example.com/pre-generated-link"},
 	}, info.NetworkingInfo)
 }
@@ -986,7 +985,7 @@ func TestGetIngressInfo(t *testing.T) {
 			return strings.Compare(info.NetworkingInfo.TargetRefs[j].Name, info.NetworkingInfo.TargetRefs[i].Name) < 0
 		})
 		assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-			Ingress: []v1.LoadBalancerIngress{{IP: "107.178.210.11"}},
+			Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
 			TargetRefs: []v1alpha1.ResourceRef{{
 				Namespace: "default",
 				Group:     "",
@@ -1011,7 +1010,7 @@ func TestGetLinkAnnotatedIngressInfo(t *testing.T) {
 		return strings.Compare(info.NetworkingInfo.TargetRefs[j].Name, info.NetworkingInfo.TargetRefs[i].Name) < 0
 	})
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-		Ingress: []v1.LoadBalancerIngress{{IP: "107.178.210.11"}},
+		Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
 		TargetRefs: []v1alpha1.ResourceRef{{
 			Namespace: "default",
 			Group:     "",
@@ -1035,7 +1034,7 @@ func TestGetIngressInfoWildCardPath(t *testing.T) {
 		return strings.Compare(info.NetworkingInfo.TargetRefs[j].Name, info.NetworkingInfo.TargetRefs[i].Name) < 0
 	})
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-		Ingress: []v1.LoadBalancerIngress{{IP: "107.178.210.11"}},
+		Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
 		TargetRefs: []v1alpha1.ResourceRef{{
 			Namespace: "default",
 			Group:     "",
@@ -1059,7 +1058,7 @@ func TestGetIngressInfoWithoutTls(t *testing.T) {
 		return strings.Compare(info.NetworkingInfo.TargetRefs[j].Name, info.NetworkingInfo.TargetRefs[i].Name) < 0
 	})
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-		Ingress: []v1.LoadBalancerIngress{{IP: "107.178.210.11"}},
+		Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
 		TargetRefs: []v1alpha1.ResourceRef{{
 			Namespace: "default",
 			Group:     "",
@@ -1101,7 +1100,7 @@ func TestGetIngressInfoWithHost(t *testing.T) {
 	populateNodeInfo(ingress, info, []string{})
 
 	assert.Equal(t, &v1alpha1.ResourceNetworkingInfo{
-		Ingress: []v1.LoadBalancerIngress{{IP: "107.178.210.11"}},
+		Ingress: []corev1.LoadBalancerIngress{{IP: "107.178.210.11"}},
 		TargetRefs: []v1alpha1.ResourceRef{{
 			Namespace: "default",
 			Group:     "",

--- a/controller/clusterinfoupdater_test.go
+++ b/controller/clusterinfoupdater_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -44,7 +44,7 @@ func TestClusterSecretUpdater(t *testing.T) {
 		{&now, errors.New("sync failed"), v1alpha1.ConnectionStatusFailed},
 	}
 
-	emptyArgoCDConfigMap := &v1.ConfigMap{
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: fakeNamespace,
@@ -54,7 +54,7 @@ func TestClusterSecretUpdater(t *testing.T) {
 		},
 		Data: map[string]string{},
 	}
-	argoCDSecret := &v1.Secret{
+	argoCDSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDSecretName,
 			Namespace: fakeNamespace,

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	slices "golang.org/x/exp/slices"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -420,8 +420,8 @@ func getOrUpdateShardNumberForController(shardMappingData []shardApplicationCont
 }
 
 // generateDefaultShardMappingCM creates a default shard mapping configMap. Assigns current controller to shard 0.
-func generateDefaultShardMappingCM(namespace, hostname string, replicas, shard int) (*v1.ConfigMap, error) {
-	shardingCM := &v1.ConfigMap{
+func generateDefaultShardMappingCM(namespace, hostname string, replicas, shard int) (*corev1.ConfigMap, error) {
+	shardingCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDAppControllerShardConfigMapName,
 			Namespace: namespace,

--- a/controller/sharding/sharding_test.go
+++ b/controller/sharding/sharding_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -497,7 +497,7 @@ func Test_generateDefaultShardMappingCM_NoPredefinedShard(t *testing.T) {
 	expectedMappingCM, err := json.Marshal(expectedMapping)
 	require.NoError(t, err)
 
-	expectedShadingCM := &v1.ConfigMap{
+	expectedShadingCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDAppControllerShardConfigMapName,
 			Namespace: "test",
@@ -532,7 +532,7 @@ func Test_generateDefaultShardMappingCM_PredefinedShard(t *testing.T) {
 	expectedMappingCM, err := json.Marshal(expectedMapping)
 	require.NoError(t, err)
 
-	expectedShadingCM := &v1.ConfigMap{
+	expectedShadingCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDAppControllerShardConfigMapName,
 			Namespace: "test",

--- a/controller/state.go
+++ b/controller/state.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	synccommon "github.com/argoproj/gitops-engine/pkg/sync/common"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/argoproj/gitops-engine/pkg/diff"
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -664,7 +664,7 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 			// targetNsExists == true implies that it already exists as a target, so no need to add the namespace to the
 			// targetObjs array.
 			if isManagedNamespace(liveObj, app) && !targetNsExists {
-				nsSpec := &v1.Namespace{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: kubeutil.NamespaceKind}, ObjectMeta: metav1.ObjectMeta{Name: liveObj.GetName()}}
+				nsSpec := &corev1.Namespace{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: kubeutil.NamespaceKind}, ObjectMeta: metav1.ObjectMeta{Name: liveObj.GetName()}}
 				managedNs, err := kubeutil.ToUnstructured(nsSpec)
 				if err != nil {
 					conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: err.Error(), LastTransitionTime: &now})

--- a/hack/dev-mounter/main.go
+++ b/hack/dev-mounter/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/argoproj/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -50,7 +50,7 @@ func newCommand() *cobra.Command {
 			}
 
 			handledConfigMap := func(obj any) {
-				cm, ok := obj.(*v1.ConfigMap)
+				cm, ok := obj.(*corev1.ConfigMap)
 				if !ok {
 					return
 				}

--- a/hack/gen-catalog/main.go
+++ b/hack/gen-catalog/main.go
@@ -9,19 +9,18 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra/doc"
-
-	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/admin"
-
 	"github.com/argoproj/notifications-engine/pkg/services"
 	"github.com/argoproj/notifications-engine/pkg/triggers"
 	"github.com/argoproj/notifications-engine/pkg/util/misc"
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
+	"github.com/spf13/cobra/doc"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v2/cmd/argocd/commands/admin"
 )
 
 func main() {
@@ -44,7 +43,7 @@ func newCatalogCommand() *cobra.Command {
 	return &cobra.Command{
 		Use: "catalog",
 		Run: func(c *cobra.Command, args []string) {
-			cm := v1.ConfigMap{
+			cm := corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ConfigMap",
 					APIVersion: "v1",

--- a/hack/gen-resources/generators/cluster_generator.go
+++ b/hack/gen-resources/generators/cluster_generator.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -72,7 +72,7 @@ func (cg *ClusterGenerator) getClusterCredentials(namespace string, releaseSuffi
 	}
 
 	var stdout, stderr, stdin bytes.Buffer
-	option := &v1.PodExecOptions{
+	option := &corev1.PodExecOptions{
 		Command:   cmd,
 		Container: "syncer",
 		Stdin:     true,

--- a/hack/gen-resources/generators/repo_generator.go
+++ b/hack/gen-resources/generators/repo_generator.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"net/http"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/hack/gen-resources/util"
@@ -88,7 +88,7 @@ func (rg *RepoGenerator) Generate(opts *util.GenerateOpts) error {
 	secrets := rg.clientSet.CoreV1().Secrets(opts.Namespace)
 	rg.bar.NewOption(0, int64(len(repos)))
 	for _, repo := range repos {
-		_, err = secrets.Create(context.TODO(), &v1.Secret{
+		_, err = secrets.Create(context.TODO(), &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "repo-",
 				Namespace:    opts.Namespace,

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -26,7 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1790,29 +1790,29 @@ type InfoItem struct {
 // ResourceNetworkingInfo holds networking resource related information
 // TODO: describe members of this type
 type ResourceNetworkingInfo struct {
-	TargetLabels map[string]string        `json:"targetLabels,omitempty" protobuf:"bytes,1,opt,name=targetLabels"`
-	TargetRefs   []ResourceRef            `json:"targetRefs,omitempty" protobuf:"bytes,2,opt,name=targetRefs"`
-	Labels       map[string]string        `json:"labels,omitempty" protobuf:"bytes,3,opt,name=labels"`
-	Ingress      []v1.LoadBalancerIngress `json:"ingress,omitempty" protobuf:"bytes,4,opt,name=ingress"`
+	TargetLabels map[string]string            `json:"targetLabels,omitempty" protobuf:"bytes,1,opt,name=targetLabels"`
+	TargetRefs   []ResourceRef                `json:"targetRefs,omitempty" protobuf:"bytes,2,opt,name=targetRefs"`
+	Labels       map[string]string            `json:"labels,omitempty" protobuf:"bytes,3,opt,name=labels"`
+	Ingress      []corev1.LoadBalancerIngress `json:"ingress,omitempty" protobuf:"bytes,4,opt,name=ingress"`
 	// ExternalURLs holds list of URLs which should be available externally. List is populated for ingress resources using rules hostnames.
 	ExternalURLs []string `json:"externalURLs,omitempty" protobuf:"bytes,5,opt,name=externalURLs"`
 }
 
 // TODO: describe this type
 type HostResourceInfo struct {
-	ResourceName         v1.ResourceName `json:"resourceName,omitempty" protobuf:"bytes,1,name=resourceName"`
-	RequestedByApp       int64           `json:"requestedByApp,omitempty" protobuf:"bytes,2,name=requestedByApp"`
-	RequestedByNeighbors int64           `json:"requestedByNeighbors,omitempty" protobuf:"bytes,3,name=requestedByNeighbors"`
-	Capacity             int64           `json:"capacity,omitempty" protobuf:"bytes,4,name=capacity"`
+	ResourceName         corev1.ResourceName `json:"resourceName,omitempty" protobuf:"bytes,1,name=resourceName"`
+	RequestedByApp       int64               `json:"requestedByApp,omitempty" protobuf:"bytes,2,name=requestedByApp"`
+	RequestedByNeighbors int64               `json:"requestedByNeighbors,omitempty" protobuf:"bytes,3,name=requestedByNeighbors"`
+	Capacity             int64               `json:"capacity,omitempty" protobuf:"bytes,4,name=capacity"`
 }
 
 // HostInfo holds host name and resources metrics
 // TODO: describe purpose of this type
 // TODO: describe members of this type
 type HostInfo struct {
-	Name          string             `json:"name,omitempty" protobuf:"bytes,1,name=name"`
-	ResourcesInfo []HostResourceInfo `json:"resourcesInfo,omitempty" protobuf:"bytes,2,name=resourcesInfo"`
-	SystemInfo    v1.NodeSystemInfo  `json:"systemInfo,omitempty" protobuf:"bytes,3,opt,name=systemInfo"`
+	Name          string                `json:"name,omitempty" protobuf:"bytes,1,name=name"`
+	ResourcesInfo []HostResourceInfo    `json:"resourcesInfo,omitempty" protobuf:"bytes,2,name=resourcesInfo"`
+	SystemInfo    corev1.NodeSystemInfo `json:"systemInfo,omitempty" protobuf:"bytes,3,opt,name=systemInfo"`
 }
 
 // ApplicationTree holds nodes which belongs to the application

--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -31,16 +31,16 @@ const (
 )
 
 // return an AccountServer which returns fake data
-func newTestAccountServer(ctx context.Context, opts ...func(cm *v1.ConfigMap, secret *v1.Secret)) (*Server, *session.Server) {
+func newTestAccountServer(ctx context.Context, opts ...func(cm *corev1.ConfigMap, secret *corev1.Secret)) (*Server, *session.Server) {
 	return newTestAccountServerExt(ctx, func(claims jwt.Claims, rvals ...any) bool {
 		return true
 	}, opts...)
 }
 
-func newTestAccountServerExt(ctx context.Context, enforceFn rbac.ClaimsEnforcerFunc, opts ...func(cm *v1.ConfigMap, secret *v1.Secret)) (*Server, *session.Server) {
+func newTestAccountServerExt(ctx context.Context, enforceFn rbac.ClaimsEnforcerFunc, opts ...func(cm *corev1.ConfigMap, secret *corev1.Secret)) (*Server, *session.Server) {
 	bcrypt, err := password.HashPassword("oldpassword")
 	errors.CheckError(err)
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
 			Namespace: testNamespace,
@@ -50,7 +50,7 @@ func newTestAccountServerExt(ctx context.Context, enforceFn rbac.ClaimsEnforcerF
 		},
 		Data: map[string]string{},
 	}
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,
@@ -140,7 +140,7 @@ func TestUpdatePassword(t *testing.T) {
 }
 
 func TestUpdatePassword_AdminUpdatesAnotherUser(t *testing.T) {
-	accountServer, sessionServer := newTestAccountServer(context.Background(), func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, sessionServer := newTestAccountServer(context.Background(), func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.anotherUser"] = "login"
 	})
 	ctx := adminContext(context.Background())
@@ -158,7 +158,7 @@ func TestUpdatePassword_DoesNotHavePermissions(t *testing.T) {
 	}
 
 	t.Run("LocalAccountUpdatesAnotherAccount", func(t *testing.T) {
-		accountServer, _ := newTestAccountServerExt(context.Background(), enforcer, func(cm *v1.ConfigMap, secret *v1.Secret) {
+		accountServer, _ := newTestAccountServerExt(context.Background(), enforcer, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 			cm.Data["accounts.anotherUser"] = "login"
 		})
 		ctx := adminContext(context.Background())
@@ -175,7 +175,7 @@ func TestUpdatePassword_DoesNotHavePermissions(t *testing.T) {
 }
 
 func TestUpdatePassword_ProjectToken(t *testing.T) {
-	accountServer, _ := newTestAccountServer(context.Background(), func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(context.Background(), func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.anotherUser"] = "login"
 	})
 	ctx := projTokenContext(context.Background())
@@ -184,7 +184,7 @@ func TestUpdatePassword_ProjectToken(t *testing.T) {
 }
 
 func TestUpdatePassword_OldSSOToken(t *testing.T) {
-	accountServer, _ := newTestAccountServer(context.Background(), func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(context.Background(), func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.anotherUser"] = "login"
 	})
 	ctx := ssoAdminContext(context.Background(), time.Now().Add(-2*common.ChangePasswordSSOTokenMaxAge))
@@ -194,7 +194,7 @@ func TestUpdatePassword_OldSSOToken(t *testing.T) {
 }
 
 func TestUpdatePassword_SSOUserUpdatesAnotherUser(t *testing.T) {
-	accountServer, sessionServer := newTestAccountServer(context.Background(), func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, sessionServer := newTestAccountServer(context.Background(), func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.anotherUser"] = "login"
 	})
 	ctx := ssoAdminContext(context.Background(), time.Now())
@@ -217,7 +217,7 @@ func TestListAccounts_NoAccountsConfigured(t *testing.T) {
 
 func TestListAccounts_AccountsAreConfigured(t *testing.T) {
 	ctx := adminContext(context.Background())
-	accountServer, _ := newTestAccountServer(ctx, func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(ctx, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.account1"] = "apiKey"
 		cm.Data["accounts.account2"] = "login, apiKey"
 		cm.Data["accounts.account2.enabled"] = "false"
@@ -235,7 +235,7 @@ func TestListAccounts_AccountsAreConfigured(t *testing.T) {
 
 func TestGetAccount(t *testing.T) {
 	ctx := adminContext(context.Background())
-	accountServer, _ := newTestAccountServer(ctx, func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(ctx, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.account1"] = "apiKey"
 	})
 
@@ -255,7 +255,7 @@ func TestGetAccount(t *testing.T) {
 
 func TestCreateToken_SuccessfullyCreated(t *testing.T) {
 	ctx := adminContext(context.Background())
-	accountServer, _ := newTestAccountServer(ctx, func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(ctx, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.account1"] = "apiKey"
 	})
 
@@ -270,7 +270,7 @@ func TestCreateToken_SuccessfullyCreated(t *testing.T) {
 
 func TestCreateToken_DoesNotHaveCapability(t *testing.T) {
 	ctx := adminContext(context.Background())
-	accountServer, _ := newTestAccountServer(ctx, func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(ctx, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.account1"] = "login"
 	})
 
@@ -280,7 +280,7 @@ func TestCreateToken_DoesNotHaveCapability(t *testing.T) {
 
 func TestCreateToken_UserSpecifiedID(t *testing.T) {
 	ctx := adminContext(context.Background())
-	accountServer, _ := newTestAccountServer(ctx, func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(ctx, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.account1"] = "apiKey"
 	})
 
@@ -294,7 +294,7 @@ func TestCreateToken_UserSpecifiedID(t *testing.T) {
 
 func TestDeleteToken_SuccessfullyRemoved(t *testing.T) {
 	ctx := adminContext(context.Background())
-	accountServer, _ := newTestAccountServer(ctx, func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(ctx, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["accounts.account1"] = "apiKey"
 		secret.Data["accounts.account1.tokens"] = []byte(`[{"id":"123","iat":1583789194,"exp":1583789194}]`)
 	})
@@ -309,7 +309,7 @@ func TestDeleteToken_SuccessfullyRemoved(t *testing.T) {
 }
 
 func TestCanI_GetLogsAllowNoSwitch(t *testing.T) {
-	accountServer, _ := newTestAccountServer(context.Background(), func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(context.Background(), func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 	})
 
 	ctx := projTokenContext(context.Background())
@@ -323,7 +323,7 @@ func TestCanI_GetLogsDenySwitchOn(t *testing.T) {
 		return false
 	}
 
-	accountServer, _ := newTestAccountServerExt(context.Background(), enforcer, func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServerExt(context.Background(), enforcer, func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["server.rbac.log.enforce.enable"] = "true"
 	})
 
@@ -334,7 +334,7 @@ func TestCanI_GetLogsDenySwitchOn(t *testing.T) {
 }
 
 func TestCanI_GetLogsAllowSwitchOn(t *testing.T) {
-	accountServer, _ := newTestAccountServer(context.Background(), func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(context.Background(), func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["server.rbac.log.enforce.enable"] = "true"
 	})
 
@@ -345,7 +345,7 @@ func TestCanI_GetLogsAllowSwitchOn(t *testing.T) {
 }
 
 func TestCanI_GetLogsAllowSwitchOff(t *testing.T) {
-	accountServer, _ := newTestAccountServer(context.Background(), func(cm *v1.ConfigMap, secret *v1.Secret) {
+	accountServer, _ := newTestAccountServer(context.Background(), func(cm *corev1.ConfigMap, secret *corev1.Secret) {
 		cm.Data["server.rbac.log.enforce.enable"] = "false"
 	})
 

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -22,7 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -811,7 +811,7 @@ func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*app
 }
 
 // ListResourceEvents returns a list of event resources
-func (s *Server) ListResourceEvents(ctx context.Context, q *application.ApplicationResourceEventsQuery) (*v1.EventList, error) {
+func (s *Server) ListResourceEvents(ctx context.Context, q *application.ApplicationResourceEventsQuery) (*corev1.EventList, error) {
 	a, _, err := s.getApplicationEnforceRBACInformer(ctx, rbacpolicy.ActionGet, q.GetProject(), q.GetAppNamespace(), q.GetName())
 	if err != nil {
 		return nil, err
@@ -1762,7 +1762,7 @@ func (s *Server) PodLogs(q *application.ApplicationPodLogsQuery, ws application.
 	var streams []chan logEntry
 
 	for _, pod := range pods {
-		stream, err := kubeClientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{
+		stream, err := kubeClientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 			Container:    q.GetContainer(),
 			Follow:       q.GetFollow(),
 			Timestamps:   true,
@@ -2325,7 +2325,7 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 }
 
 func (s *Server) logAppEvent(a *appv1.Application, ctx context.Context, reason string, action string) {
-	eventInfo := argo.EventInfo{Type: v1.EventTypeNormal, Reason: reason}
+	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
 		user = "Unknown user"
@@ -2336,7 +2336,7 @@ func (s *Server) logAppEvent(a *appv1.Application, ctx context.Context, reason s
 }
 
 func (s *Server) logResourceEvent(res *appv1.ResourceNode, ctx context.Context, reason string, action string) {
-	eventInfo := argo.EventInfo{Type: v1.EventTypeNormal, Reason: reason}
+	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
 		user = "Unknown user"

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -27,7 +27,6 @@ import (
 	k8sappsv1 "k8s.io/api/apps/v1"
 	k8sbatchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -169,7 +168,7 @@ func newTestAppServer(t *testing.T, objects ...runtime.Object) *Server {
 
 func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer), additionalConfig map[string]string, objects ...runtime.Object) *Server {
 	t.Helper()
-	kubeclientset := fake.NewClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
@@ -178,7 +177,7 @@ func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer),
 			},
 		},
 		Data: additionalConfig,
-	}, &v1.Secret{
+	}, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,
@@ -334,7 +333,7 @@ func newTestAppServerWithBenchmark(b *testing.B, objects ...runtime.Object) *Ser
 
 func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rbac.Enforcer), objects ...runtime.Object) *Server {
 	b.Helper()
-	kubeclientset := fake.NewClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
@@ -342,7 +341,7 @@ func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rb
 				"app.kubernetes.io/part-of": "argocd",
 			},
 		},
-	}, &v1.Secret{
+	}, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,
@@ -2226,7 +2225,7 @@ func createAppServerWithMaxLodLogs(t *testing.T, podNumber int, maxPodLogsToRend
 	resources := make([]appsv1.ResourceStatus, podNumber)
 
 	for i := 0; i < podNumber; i++ {
-		pod := v1.Pod{
+		pod := corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Pod",

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -216,7 +216,7 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if pod.Status.Phase != v1.PodRunning {
+	if pod.Status.Phase != corev1.PodRunning {
 		http.Error(w, "Pod not running", http.StatusBadRequest)
 		return
 	}
@@ -309,7 +309,7 @@ func startProcess(k8sClient kubernetes.Interface, cfg *rest.Config, namespace, p
 		Namespace(namespace).
 		SubResource("exec")
 
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Container: containerName,
 		Command:   cmd,
 		Stdin:     true,

--- a/server/application/websocket_test.go
+++ b/server/application/websocket_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -34,7 +34,7 @@ func newTestTerminalSession(w http.ResponseWriter, r *http.Request) terminalSess
 
 func newEnforcer() *rbac.Enforcer {
 	additionalConfig := make(map[string]string, 0)
-	kubeclientset := fake.NewClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
@@ -43,7 +43,7 @@ func newEnforcer() *rbac.Enforcer {
 			},
 		},
 		Data: additionalConfig,
-	}, &v1.Secret{
+	}, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,

--- a/server/applicationset/applicationset.go
+++ b/server/applicationset/applicationset.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -496,7 +496,7 @@ func (s *Server) waitSync(appset *v1alpha1.ApplicationSet) {
 }
 
 func (s *Server) logAppSetEvent(a *v1alpha1.ApplicationSet, ctx context.Context, reason string, action string) {
-	eventInfo := argo.EventInfo{Type: v1.EventTypeNormal, Reason: reason}
+	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
 		user = "Unknown user"

--- a/server/applicationset/applicationset_test.go
+++ b/server/applicationset/applicationset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/argoproj/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -72,7 +72,7 @@ func newTestNamespacedAppSetServer(objects ...runtime.Object) *Server {
 }
 
 func newTestAppSetServerWithEnforcerConfigure(f func(*rbac.Enforcer), namespace string, objects ...runtime.Object) *Server {
-	kubeclientset := fake.NewClientset(&v1.ConfigMap{
+	kubeclientset := fake.NewClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      "argocd-cm",
@@ -80,7 +80,7 @@ func newTestAppSetServerWithEnforcerConfigure(f func(*rbac.Enforcer), namespace 
 				"app.kubernetes.io/part-of": "argocd",
 			},
 		},
-	}, &v1.Secret{
+	}, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,

--- a/server/deeplinks/deeplinks_test.go
+++ b/server/deeplinks/deeplinks_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -43,7 +43,7 @@ func TestDeepLinks(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	resourceObj, err := kube.ToUnstructured(&v1.ConfigMap{
+	resourceObj, err := kube.ToUnstructured(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cm",
 			Namespace: "test-cm",

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -476,7 +476,7 @@ func (s *Server) Delete(ctx context.Context, q *project.ProjectQuery) (*project.
 	return &project.EmptyResponse{}, err
 }
 
-func (s *Server) ListEvents(ctx context.Context, q *project.ProjectQuery) (*v1.EventList, error) {
+func (s *Server) ListEvents(ctx context.Context, q *project.ProjectQuery) (*corev1.EventList, error) {
 	if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceProjects, rbacpolicy.ActionGet, q.Name); err != nil {
 		return nil, err
 	}
@@ -493,7 +493,7 @@ func (s *Server) ListEvents(ctx context.Context, q *project.ProjectQuery) (*v1.E
 }
 
 func (s *Server) logEvent(a *v1alpha1.AppProject, ctx context.Context, reason string, action string) {
-	eventInfo := argo.EventInfo{Type: v1.EventTypeNormal, Reason: reason}
+	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
 		user = "Unknown user"

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 
 	// nolint:staticcheck
 	golang_proto "github.com/golang/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
@@ -54,7 +55,6 @@ import (
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -862,7 +862,7 @@ func (a *ArgoCDServer) watchSettings() {
 }
 
 func (a *ArgoCDServer) rbacPolicyLoader(ctx context.Context) {
-	err := a.enf.RunPolicyLoader(ctx, func(cm *v1.ConfigMap) error {
+	err := a.enf.RunPolicyLoader(ctx, func(cm *corev1.ConfigMap) error {
 		var scopes []string
 		if scopesStr, ok := cm.Data[rbac.ConfigMapScopesKey]; len(scopesStr) > 0 && ok {
 			scopes = make([]string, 0)

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1488,7 +1488,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -1601,15 +1601,15 @@ func TestNamespacedNotPermittedResources(t *testing.T) {
 		CheckError(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Delete(context.Background(), "sample-ingress", metav1.DeleteOptions{}))
 	}()
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "guestbook-ui",
 			Annotations: map[string]string{
 				common.AnnotationKeyAppInstance: fmt.Sprintf("%s_%s:Service:%s/guesbook-ui", TestNamespace(), ctx.AppQualifiedName(), DeploymentNamespace()),
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
 				Port:       80,
 				TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 80},
 			}},
@@ -1773,7 +1773,7 @@ func TestNamespacedListResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -1898,7 +1898,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(updatedNamespace, func(app *Application, ns *corev1.Namespace) {
 			assert.Empty(t, app.Status.Conditions)
 
 			delete(ns.Labels, "kubernetes.io/metadata.name")
@@ -1922,7 +1922,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(updatedNamespace, func(app *Application, ns *corev1.Namespace) {
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
@@ -1941,7 +1941,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(updatedNamespace, func(app *Application, ns *corev1.Namespace) {
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Annotations, "argocd.argoproj.io/tracking-id")
@@ -1992,7 +1992,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadataAndNsManifest(t *testing.T) 
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(namespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(namespace, func(app *Application, ns *corev1.Namespace) {
 			delete(ns.Labels, "kubernetes.io/metadata.name")
 			delete(ns.Labels, "argocd.argoproj.io/tracking-id")
 			delete(ns.Labels, "kubectl.kubernetes.io/last-applied-configuration")
@@ -2060,7 +2060,7 @@ metadata:
 			}
 		}).
 		Then().
-		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(updatedNamespace, func(app *Application, ns *corev1.Namespace) {
 			assert.Empty(t, app.Status.Conditions)
 
 			delete(ns.Labels, "kubernetes.io/metadata.name")
@@ -2074,7 +2074,7 @@ metadata:
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(updatedNamespace, func(app *Application, ns *corev1.Namespace) {
 			assert.Empty(t, app.Status.Conditions)
 
 			delete(ns.Labels, "kubernetes.io/metadata.name")
@@ -2093,7 +2093,7 @@ metadata:
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(updatedNamespace, func(app *Application, ns *corev1.Namespace) {
 			assert.Empty(t, app.Status.Conditions)
 
 			delete(ns.Labels, "kubernetes.io/metadata.name")
@@ -2113,7 +2113,7 @@ metadata:
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(updatedNamespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(updatedNamespace, func(app *Application, ns *corev1.Namespace) {
 			assert.Empty(t, app.Status.Conditions)
 
 			delete(ns.Labels, "kubernetes.io/metadata.name")

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -774,7 +774,7 @@ func assetSecretDataHidden(t *testing.T, manifest string) {
 	var lastAppliedConfigAnnotation string
 	annotations := secret.GetAnnotations()
 	if annotations != nil {
-		lastAppliedConfigAnnotation = annotations[v1.LastAppliedConfigAnnotation]
+		lastAppliedConfigAnnotation = annotations[corev1.LastAppliedConfigAnnotation]
 	}
 	if lastAppliedConfigAnnotation != "" {
 		assetSecretDataHidden(t, lastAppliedConfigAnnotation)
@@ -1908,7 +1908,7 @@ func TestOrphanedResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -2017,15 +2017,15 @@ func TestNotPermittedResources(t *testing.T) {
 		CheckError(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Delete(context.Background(), "sample-ingress", metav1.DeleteOptions{}))
 	}()
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "guestbook-ui",
 			Labels: map[string]string{
 				common.LabelKeyAppInstance: ctx.GetName(),
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
 				Port:       80,
 				TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 80},
 			}},
@@ -2177,7 +2177,7 @@ func TestListResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -2587,7 +2587,7 @@ func TestSwitchTrackingMethod(t *testing.T) {
 		And(func() {
 			// Add resource with tracking annotation. This should put the
 			// application OutOfSync.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Annotations: map[string]string{
@@ -2621,7 +2621,7 @@ func TestSwitchTrackingMethod(t *testing.T) {
 			// Add a resource with a tracking annotation. This should not
 			// affect the application, because we now use the tracking method
 			// "label".
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Annotations: map[string]string{
@@ -2638,7 +2638,7 @@ func TestSwitchTrackingMethod(t *testing.T) {
 		And(func() {
 			// Add a resource with the tracking label. The app should become
 			// OutOfSync.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "extra-configmap",
 					Labels: map[string]string{
@@ -2679,7 +2679,7 @@ func TestSwitchTrackingLabel(t *testing.T) {
 		And(func() {
 			// Add extra resource that carries the default tracking label
 			// We expect the app to go out of sync.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Labels: map[string]string{
@@ -2713,7 +2713,7 @@ func TestSwitchTrackingLabel(t *testing.T) {
 		And(func() {
 			// Create resource with the new tracking label, the application
 			// is expected to go out of sync
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Labels: map[string]string{
@@ -2740,7 +2740,7 @@ func TestSwitchTrackingLabel(t *testing.T) {
 			// Add extra resource that carries the default tracking label
 			// We expect the app to stay in sync, because the configured
 			// label is different.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Labels: map[string]string{
@@ -2773,7 +2773,7 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		And(func() {
 			// Add a resource with an annotation that is not referencing the
 			// resource.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "extra-configmap",
 					Annotations: map[string]string{
@@ -2798,7 +2798,7 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		And(func() {
 			// Add a resource with an annotation that is self-referencing the
 			// resource.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &v1.ConfigMap{
+			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Annotations: map[string]string{
@@ -2927,7 +2927,7 @@ func TestInstallationID(t *testing.T) {
 		SetTrackingMethod(string(argo.TrackingMethodAnnotation)).
 		And(func() {
 			_, err := fixture.KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(
-				context.Background(), &v1.ConfigMap{
+				context.Background(), &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-configmap",
 						Annotations: map[string]string{
@@ -2972,7 +2972,7 @@ func TestDeletionConfirmation(t *testing.T) {
 	ctx.
 		And(func() {
 			_, err := fixture.KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(
-				context.Background(), &v1.ConfigMap{
+				context.Background(), &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-configmap",
 						Labels: map[string]string{

--- a/test/e2e/app_sync_options_test.go
+++ b/test/e2e/app_sync_options_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
@@ -48,7 +48,7 @@ func TestNamespaceCreationWithSSA(t *testing.T) {
 		Sync().
 		Then().
 		Expect(Success("")).
-		Expect(Namespace(namespace, func(app *Application, ns *v1.Namespace) {
+		Expect(Namespace(namespace, func(app *Application, ns *corev1.Namespace) {
 			assert.NotContains(t, ns.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 		})).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -108,7 +108,7 @@ func StatusExists() Expectation {
 	}
 }
 
-func Namespace(name string, block func(app *Application, ns *v1.Namespace)) Expectation {
+func Namespace(name string, block func(app *Application, ns *corev1.Namespace)) Expectation {
 	return func(c *Consequences) (state, string) {
 		ns, err := namespace(name)
 		if err != nil {
@@ -245,7 +245,7 @@ func DoesNotExistNow() Expectation {
 	}
 }
 
-func Pod(predicate func(p v1.Pod) bool) Expectation {
+func Pod(predicate func(p corev1.Pod) bool) Expectation {
 	return func(c *Consequences) (state, string) {
 		pods, err := pods()
 		if err != nil {
@@ -260,7 +260,7 @@ func Pod(predicate func(p v1.Pod) bool) Expectation {
 	}
 }
 
-func NotPod(predicate func(p v1.Pod) bool) Expectation {
+func NotPod(predicate func(p corev1.Pod) bool) Expectation {
 	return func(c *Consequences) (state, string) {
 		pods, err := pods()
 		if err != nil {
@@ -275,7 +275,7 @@ func NotPod(predicate func(p v1.Pod) bool) Expectation {
 	}
 }
 
-func pods() (*v1.PodList, error) {
+func pods() (*corev1.PodList, error) {
 	fixture.KubeClientset.CoreV1()
 	pods, err := fixture.KubeClientset.CoreV1().Pods(fixture.DeploymentNamespace()).List(context.Background(), metav1.ListOptions{})
 	return pods, err
@@ -292,7 +292,7 @@ func NoNamespace(name string) Expectation {
 	}
 }
 
-func namespace(name string) (*v1.Namespace, error) {
+func namespace(name string) (*corev1.Namespace, error) {
 	fixture.KubeClientset.CoreV1()
 	return fixture.KubeClientset.CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
 }

--- a/test/e2e/git_submodule_test.go
+++ b/test/e2e/git_submodule_test.go
@@ -3,11 +3,10 @@ package e2e
 import (
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 )
 
@@ -23,7 +22,7 @@ func TestGitSubmoduleSSHSupport(t *testing.T) {
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(Pod(func(p v1.Pod) bool { return p.Name == "pod-in-submodule" }))
+		Expect(Pod(func(p corev1.Pod) bool { return p.Name == "pod-in-submodule" }))
 }
 
 func TestGitSubmoduleHTTPSSupport(t *testing.T) {
@@ -38,7 +37,7 @@ func TestGitSubmoduleHTTPSSupport(t *testing.T) {
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(Pod(func(p v1.Pod) bool { return p.Name == "pod-in-submodule" }))
+		Expect(Pod(func(p corev1.Pod) bool { return p.Name == "pod-in-submodule" }))
 }
 
 func TestGitSubmoduleRemovalSupport(t *testing.T) {
@@ -53,12 +52,12 @@ func TestGitSubmoduleRemovalSupport(t *testing.T) {
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(Pod(func(p v1.Pod) bool { return p.Name == "pod-in-submodule" })).
+		Expect(Pod(func(p corev1.Pod) bool { return p.Name == "pod-in-submodule" })).
 		When().
 		RemoveSubmodule().
 		Refresh(RefreshTypeNormal).
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(NotPod(func(p v1.Pod) bool { return p.Name == "pod-in-submodule" }))
+		Expect(NotPod(func(p corev1.Pod) bool { return p.Name == "pod-in-submodule" }))
 }

--- a/test/e2e/git_test.go
+++ b/test/e2e/git_test.go
@@ -4,11 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 )
 
@@ -64,7 +63,7 @@ func TestGitSemverResolutionUsingConstraint(t *testing.T) {
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(Pod(func(p v1.Pod) bool { return strings.HasPrefix(p.Name, "new-app") }))
+		Expect(Pod(func(p corev1.Pod) bool { return strings.HasPrefix(p.Name, "new-app") }))
 }
 
 func TestGitSemverResolutionUsingConstraintWithLeadingZero(t *testing.T) {
@@ -89,5 +88,5 @@ func TestGitSemverResolutionUsingConstraintWithLeadingZero(t *testing.T) {
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(Pod(func(p v1.Pod) bool { return strings.HasPrefix(p.Name, "new-app") }))
+		Expect(Pod(func(p corev1.Pod) bool { return strings.HasPrefix(p.Name, "new-app") }))
 }

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/argoproj/gitops-engine/pkg/sync/common"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -69,7 +69,7 @@ func TestHelmHookDeletePolicy(t *testing.T) {
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(ResourceResultNumbering(2)).
-		Expect(NotPod(func(p v1.Pod) bool { return p.Name == "hook" }))
+		Expect(NotPod(func(p corev1.Pod) bool { return p.Name == "hook" }))
 }
 
 func TestDeclarativeHelm(t *testing.T) {
@@ -522,10 +522,10 @@ func testHelmWithDependencies(t *testing.T, chartPath string, legacyRepo bool) {
 			CheckError(fixture.SetHelmRepos(settings.HelmRepoCredentials{
 				URL:            RepoURL(RepoURLTypeHelm),
 				Name:           "custom-repo",
-				KeySecret:      &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "helm-repo"}, Key: "keySecret"},
-				CertSecret:     &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "helm-repo"}, Key: "certSecret"},
-				UsernameSecret: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "helm-repo"}, Key: "username"},
-				PasswordSecret: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "helm-repo"}, Key: "password"},
+				KeySecret:      &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "helm-repo"}, Key: "keySecret"},
+				CertSecret:     &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "helm-repo"}, Key: "certSecret"},
+				UsernameSecret: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "helm-repo"}, Key: "username"},
+				PasswordSecret: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "helm-repo"}, Key: "password"},
 			}))
 		})
 	} else {

--- a/test/e2e/hook_test.go
+++ b/test/e2e/hook_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -172,7 +172,7 @@ func TestPostSyncHookPodFailure(t *testing.T) {
 		Expect(ResourceSyncStatusIs("Pod", "pod", SyncStatusCodeSynced)).
 		Expect(ResourceHealthIs("Pod", "pod", health.HealthStatusDegraded)).
 		Expect(ResourceResultNumbering(1)).
-		Expect(NotPod(func(p v1.Pod) bool { return p.Name == "hook" }))
+		Expect(NotPod(func(p corev1.Pod) bool { return p.Name == "hook" }))
 }
 
 func TestSyncFailHookPodFailure(t *testing.T) {
@@ -264,7 +264,7 @@ func TestHookDeletePolicyHookSucceededHookExit0(t *testing.T) {
 		Sync().
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
-		Expect(NotPod(func(p v1.Pod) bool { return p.Name == "hook" }))
+		Expect(NotPod(func(p corev1.Pod) bool { return p.Name == "hook" }))
 }
 
 // make sure that we delete the hook on failure, if policy is set
@@ -280,7 +280,7 @@ func TestHookDeletePolicyHookSucceededHookExit1(t *testing.T) {
 		Then().
 		Expect(OperationPhaseIs(OperationFailed)).
 		Expect(ResourceResultNumbering(2)).
-		Expect(Pod(func(p v1.Pod) bool { return p.Name == "hook" }))
+		Expect(Pod(func(p corev1.Pod) bool { return p.Name == "hook" }))
 }
 
 // make sure that we do NOT delete the hook on success if failure policy is set
@@ -294,7 +294,7 @@ func TestHookDeletePolicyHookFailedHookExit0(t *testing.T) {
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(ResourceResultNumbering(2)).
-		Expect(Pod(func(p v1.Pod) bool { return p.Name == "hook" }))
+		Expect(Pod(func(p corev1.Pod) bool { return p.Name == "hook" }))
 }
 
 // make sure that we do delete the hook on failure if failure policy is set
@@ -310,7 +310,7 @@ func TestHookDeletePolicyHookFailedHookExit1(t *testing.T) {
 		Then().
 		Expect(OperationPhaseIs(OperationFailed)).
 		Expect(ResourceResultNumbering(2)).
-		Expect(NotPod(func(p v1.Pod) bool { return p.Name == "hook" }))
+		Expect(NotPod(func(p corev1.Pod) bool { return p.Name == "hook" }))
 }
 
 // make sure that we can run the hook twice
@@ -328,7 +328,7 @@ func TestHookBeforeHookCreation(t *testing.T) {
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		Expect(ResourceResultNumbering(2)).
 		// the app will be in health+n-sync before this hook has run
-		Expect(Pod(func(p v1.Pod) bool { return p.Name == "hook" })).
+		Expect(Pod(func(p corev1.Pod) bool { return p.Name == "hook" })).
 		And(func(_ *Application) {
 			var err error
 			creationTimestamp1, err = getCreationTimestamp()
@@ -344,7 +344,7 @@ func TestHookBeforeHookCreation(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		Expect(ResourceResultNumbering(2)).
-		Expect(Pod(func(p v1.Pod) bool { return p.Name == "hook" })).
+		Expect(Pod(func(p corev1.Pod) bool { return p.Name == "hook" })).
 		And(func(_ *Application) {
 			creationTimestamp2, err := getCreationTimestamp()
 			CheckError(err)
@@ -389,7 +389,7 @@ func TestHookSkip(t *testing.T) {
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(ResourceResultNumbering(1)).
-		Expect(NotPod(func(p v1.Pod) bool { return p.Name == "pod" }))
+		Expect(NotPod(func(p corev1.Pod) bool { return p.Name == "pod" }))
 }
 
 // make sure that we do NOT name non-hook resources in they are unnamed

--- a/test/e2e/sync_waves_test.go
+++ b/test/e2e/sync_waves_test.go
@@ -3,15 +3,14 @@ package e2e
 import (
 	"testing"
 
+	"github.com/argoproj/gitops-engine/pkg/health"
+	. "github.com/argoproj/gitops-engine/pkg/sync/common"
+	corev1 "k8s.io/api/core/v1"
+
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	"github.com/argoproj/argo-cd/v2/util/errors"
-
-	"github.com/argoproj/gitops-engine/pkg/health"
-	. "github.com/argoproj/gitops-engine/pkg/sync/common"
-
-	v1 "k8s.io/api/core/v1"
 )
 
 func TestFixingDegradedApp(t *testing.T) {
@@ -143,6 +142,6 @@ func TestSyncPruneOrderWithSyncWaves(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
-		Expect(NotPod(func(p v1.Pod) bool { return p.Name == "pod-with-finalizers" })).
+		Expect(NotPod(func(p corev1.Pod) bool { return p.Name == "pod-with-finalizers" })).
 		Expect(ResourceResultNumbering(4))
 }

--- a/test/e2e/sync_with_impersonate_test.go
+++ b/test/e2e/sync_with_impersonate_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -290,7 +290,7 @@ func createTestRoleBinding(roleName, serviceAccountName, namespace string) error
 
 // createTestServiceAccount creates a test ServiceAccount resource.
 func createTestServiceAccount(name, namespace string) error {
-	serviceAccount := &v1.ServiceAccount{
+	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/test/testdata.go
+++ b/test/testdata.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/argoproj/gitops-engine/pkg/utils/testing"
 	"github.com/redis/go-redis/v9"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -101,8 +101,8 @@ func NewConfigMap() *unstructured.Unstructured {
 	return testing.Unstructured(ConfigMapManifest)
 }
 
-func NewFakeConfigMap() *apiv1.ConfigMap {
-	cm := apiv1.ConfigMap{
+func NewFakeConfigMap() *corev1.ConfigMap {
+	cm := corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
@@ -119,8 +119,8 @@ func NewFakeConfigMap() *apiv1.ConfigMap {
 	return &cm
 }
 
-func NewFakeSecret(policy ...string) *apiv1.Secret {
-	secret := apiv1.Secret{
+func NewFakeSecret(policy ...string) *corev1.Secret {
+	secret := corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",

--- a/util/argo/audit_logger.go
+++ b/util/argo/audit_logger.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,16 +64,16 @@ func (l *AuditLogger) logEvent(objMeta ObjectRef, gvk schema.GroupVersionKind, i
 		logCtx = logCtx.WithField("name", objMeta.Name)
 	}
 	t := metav1.Time{Time: time.Now()}
-	event := v1.Event{
+	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%v.%x", objMeta.Name, t.UnixNano()),
 			Labels:      eventLabels,
 			Annotations: logFields,
 		},
-		Source: v1.EventSource{
+		Source: corev1.EventSource{
 			Component: l.component,
 		},
-		InvolvedObject: v1.ObjectReference{
+		InvolvedObject: corev1.ObjectReference{
 			Kind:            gvk.Kind,
 			Name:            objMeta.Name,
 			Namespace:       objMeta.Namespace,

--- a/util/argo/normalizers/knowntypes_normalizer.go
+++ b/util/argo/normalizers/knowntypes_normalizer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -63,7 +63,7 @@ func (n *knownTypesNormalizer) ensureDefaultCRDsConfigured() {
 		n.typeFields[rolloutGK] = []knownTypeField{{
 			fieldPath: []string{"spec", "template", "spec"},
 			newFieldFn: func() any {
-				return &v1.PodSpec{}
+				return &corev1.PodSpec{}
 			},
 		}}
 	}

--- a/util/db/certificate_test.go
+++ b/util/db/certificate_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -245,7 +245,7 @@ const (
 )
 
 func getCertClientset() *fake.Clientset {
-	cm := v1.ConfigMap{
+	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
 			Namespace: testNamespace,
@@ -256,7 +256,7 @@ func getCertClientset() *fake.Clientset {
 		Data: nil,
 	}
 
-	sshCM := v1.ConfigMap{
+	sshCM := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-ssh-known-hosts-cm",
 			Namespace: testNamespace,
@@ -269,7 +269,7 @@ func getCertClientset() *fake.Clientset {
 		},
 	}
 
-	tlsCM := v1.ConfigMap{
+	tlsCM := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-tls-certs-cm",
 			Namespace: testNamespace,

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -106,7 +106,7 @@ func (db *db) CreateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Clust
 		return nil, err
 	}
 
-	clusterSecret := &apiv1.Secret{
+	clusterSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secName,
 		},
@@ -152,7 +152,7 @@ func (db *db) WatchClusters(ctx context.Context,
 		ctx,
 		common.LabelValueSecretTypeCluster,
 
-		func(secret *apiv1.Secret) {
+		func(secret *corev1.Secret) {
 			cluster, err := SecretToCluster(secret)
 			if err != nil {
 				log.Errorf("could not unmarshal cluster secret %s", secret.Name)
@@ -167,7 +167,7 @@ func (db *db) WatchClusters(ctx context.Context,
 			handleAddEvent(cluster)
 		},
 
-		func(oldSecret *apiv1.Secret, newSecret *apiv1.Secret) {
+		func(oldSecret *corev1.Secret, newSecret *corev1.Secret) {
 			oldCluster, err := SecretToCluster(oldSecret)
 			if err != nil {
 				log.Errorf("could not unmarshal cluster secret %s", oldSecret.Name)
@@ -184,7 +184,7 @@ func (db *db) WatchClusters(ctx context.Context,
 			handleModEvent(oldCluster, newCluster)
 		},
 
-		func(secret *apiv1.Secret) {
+		func(secret *corev1.Secret) {
 			if string(secret.Data["server"]) == appv1.KubernetesInternalAPIServerAddr {
 				// change local cluster event to modified or deleted, since it cannot be re-added or deleted
 				handleModEvent(localCls, db.getLocalCluster())
@@ -198,7 +198,7 @@ func (db *db) WatchClusters(ctx context.Context,
 	return err
 }
 
-func (db *db) getClusterSecret(server string) (*apiv1.Secret, error) {
+func (db *db) getClusterSecret(server string) (*corev1.Secret, error) {
 	clusterSecrets, err := db.listSecretsByType(common.LabelValueSecretTypeCluster)
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (db *db) GetCluster(_ context.Context, server string) (*appv1.Cluster, erro
 		return nil, err
 	}
 	if len(res) > 0 {
-		return SecretToCluster(res[0].(*apiv1.Secret))
+		return SecretToCluster(res[0].(*corev1.Secret))
 	}
 	if server == appv1.KubernetesInternalAPIServerAddr {
 		return db.getLocalCluster(), nil
@@ -244,7 +244,7 @@ func (db *db) GetProjectClusters(ctx context.Context, project string) ([]*appv1.
 	}
 	var res []*appv1.Cluster
 	for i := range secrets {
-		cluster, err := SecretToCluster(secrets[i].(*apiv1.Secret))
+		cluster, err := SecretToCluster(secrets[i].(*corev1.Secret))
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert secret to cluster: %w", err)
 		}
@@ -275,7 +275,7 @@ func (db *db) GetClusterServersByName(ctx context.Context, name string) ([]strin
 	}
 	var res []string
 	for i := range secrets {
-		s := secrets[i].(*apiv1.Secret)
+		s := secrets[i].(*corev1.Secret)
 		res = append(res, strings.TrimRight(string(s.Data["server"]), "/"))
 	}
 	return res, nil
@@ -322,7 +322,7 @@ func (db *db) DeleteCluster(ctx context.Context, server string) error {
 }
 
 // clusterToSecret converts a cluster object to string data for serialization to a secret
-func clusterToSecret(c *appv1.Cluster, secret *apiv1.Secret) error {
+func clusterToSecret(c *appv1.Cluster, secret *corev1.Secret) error {
 	data := make(map[string][]byte)
 	data["server"] = []byte(strings.TrimRight(c.Server, "/"))
 	if c.Name == "" {
@@ -350,8 +350,8 @@ func clusterToSecret(c *appv1.Cluster, secret *apiv1.Secret) error {
 	secret.Data = data
 
 	secret.Labels = c.Labels
-	if c.Annotations != nil && c.Annotations[apiv1.LastAppliedConfigAnnotation] != "" {
-		return status.Errorf(codes.InvalidArgument, "annotation %s cannot be set", apiv1.LastAppliedConfigAnnotation)
+	if c.Annotations != nil && c.Annotations[corev1.LastAppliedConfigAnnotation] != "" {
+		return status.Errorf(codes.InvalidArgument, "annotation %s cannot be set", corev1.LastAppliedConfigAnnotation)
 	}
 	secret.Annotations = c.Annotations
 
@@ -369,7 +369,7 @@ func clusterToSecret(c *appv1.Cluster, secret *apiv1.Secret) error {
 }
 
 // SecretToCluster converts a secret into a Cluster object
-func SecretToCluster(s *apiv1.Secret) (*appv1.Cluster, error) {
+func SecretToCluster(s *corev1.Secret) (*appv1.Cluster, error) {
 	var config appv1.ClusterConfig
 	if len(s.Data["config"]) > 0 {
 		err := json.Unmarshal(s.Data["config"], &config)
@@ -412,7 +412,7 @@ func SecretToCluster(s *apiv1.Secret) (*appv1.Cluster, error) {
 	if s.Annotations != nil {
 		annotations = maps.Clone(s.Annotations)
 		// delete system annotations
-		delete(annotations, apiv1.LastAppliedConfigAnnotation)
+		delete(annotations, corev1.LastAppliedConfigAnnotation)
 		delete(annotations, common.AnnotationKeyManagedBy)
 	}
 

--- a/util/db/cluster_norace_test.go
+++ b/util/db/cluster_norace_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -23,7 +23,7 @@ func TestWatchClusters_CreateRemoveCluster(t *testing.T) {
 	// !race:
 	// Intermittent failure when running TestWatchClusters_LocalClusterModifications with -race, likely due to race condition
 	// https://github.com/argoproj/argo-cd/issues/4755
-	emptyArgoCDConfigMap := &v1.ConfigMap{
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: fakeNamespace,
@@ -33,7 +33,7 @@ func TestWatchClusters_CreateRemoveCluster(t *testing.T) {
 		},
 		Data: map[string]string{},
 	}
-	argoCDSecret := &v1.Secret{
+	argoCDSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDSecretName,
 			Namespace: fakeNamespace,
@@ -78,7 +78,7 @@ func TestWatchClusters_LocalClusterModifications(t *testing.T) {
 	// !race:
 	// Intermittent failure when running TestWatchClusters_LocalClusterModifications with -race, likely due to race condition
 	// https://github.com/argoproj/argo-cd/issues/4755
-	emptyArgoCDConfigMap := &v1.ConfigMap{
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: fakeNamespace,
@@ -88,7 +88,7 @@ func TestWatchClusters_LocalClusterModifications(t *testing.T) {
 		},
 		Data: map[string]string{},
 	}
-	argoCDSecret := &v1.Secret{
+	argoCDSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDSecretName,
 			Namespace: fakeNamespace,

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -52,7 +52,7 @@ func Test_URIToSecretName(t *testing.T) {
 func Test_secretToCluster(t *testing.T) {
 	labels := map[string]string{"key1": "val1"}
 	annotations := map[string]string{"key2": "val2"}
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "mycluster",
 			Namespace:   fakeNamespace,
@@ -79,11 +79,11 @@ func Test_secretToCluster(t *testing.T) {
 }
 
 func Test_secretToCluster_LastAppliedConfigurationDropped(t *testing.T) {
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "mycluster",
 			Namespace:   fakeNamespace,
-			Annotations: map[string]string{v1.LastAppliedConfigAnnotation: "val2"},
+			Annotations: map[string]string{corev1.LastAppliedConfigAnnotation: "val2"},
 		},
 		Data: map[string][]byte{
 			"name":   []byte("test"),
@@ -106,7 +106,7 @@ func TestClusterToSecret(t *testing.T) {
 		Project:     "project",
 		Namespaces:  []string{"default"},
 	}
-	s := &v1.Secret{}
+	s := &corev1.Secret{}
 	err := clusterToSecret(cluster, s)
 	require.NoError(t, err)
 
@@ -121,20 +121,20 @@ func TestClusterToSecret(t *testing.T) {
 func TestClusterToSecret_LastAppliedConfigurationRejected(t *testing.T) {
 	cluster := &appv1.Cluster{
 		Server:      "server",
-		Annotations: map[string]string{v1.LastAppliedConfigAnnotation: "val2"},
+		Annotations: map[string]string{corev1.LastAppliedConfigAnnotation: "val2"},
 		Name:        "test",
 		Config:      v1alpha1.ClusterConfig{},
 		Project:     "project",
 		Namespaces:  []string{"default"},
 	}
-	s := &v1.Secret{}
+	s := &corev1.Secret{}
 	err := clusterToSecret(cluster, s)
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 func Test_secretToCluster_NoConfig(t *testing.T) {
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
 			Namespace: fakeNamespace,
@@ -155,7 +155,7 @@ func Test_secretToCluster_NoConfig(t *testing.T) {
 }
 
 func Test_secretToCluster_InvalidConfig(t *testing.T) {
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
 			Namespace: fakeNamespace,
@@ -172,7 +172,7 @@ func Test_secretToCluster_InvalidConfig(t *testing.T) {
 }
 
 func TestUpdateCluster(t *testing.T) {
-	kubeclientset := fake.NewClientset(&v1.Secret{
+	kubeclientset := fake.NewClientset(&corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
 			Namespace: fakeNamespace,
@@ -202,7 +202,7 @@ func TestUpdateCluster(t *testing.T) {
 }
 
 func TestDeleteUnknownCluster(t *testing.T) {
-	kubeclientset := fake.NewClientset(&v1.Secret{
+	kubeclientset := fake.NewClientset(&corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
 			Namespace: fakeNamespace,
@@ -221,7 +221,7 @@ func TestDeleteUnknownCluster(t *testing.T) {
 }
 
 func TestRejectCreationForInClusterWhenDisabled(t *testing.T) {
-	argoCDConfigMapWithInClusterServerAddressDisabled := &v1.ConfigMap{
+	argoCDConfigMapWithInClusterServerAddressDisabled := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: fakeNamespace,
@@ -231,7 +231,7 @@ func TestRejectCreationForInClusterWhenDisabled(t *testing.T) {
 		},
 		Data: map[string]string{"cluster.inClusterEnabled": "false"},
 	}
-	argoCDSecret := &v1.Secret{
+	argoCDSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDSecretName,
 			Namespace: fakeNamespace,
@@ -297,7 +297,7 @@ func runWatchTest(t *testing.T, db ArgoDB, actions []func(old *v1alpha1.Cluster,
 }
 
 func TestListClusters(t *testing.T) {
-	emptyArgoCDConfigMap := &v1.ConfigMap{
+	emptyArgoCDConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: fakeNamespace,
@@ -307,7 +307,7 @@ func TestListClusters(t *testing.T) {
 		},
 		Data: map[string]string{},
 	}
-	argoCDConfigMapWithInClusterServerAddressDisabled := &v1.ConfigMap{
+	argoCDConfigMapWithInClusterServerAddressDisabled := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: fakeNamespace,
@@ -317,7 +317,7 @@ func TestListClusters(t *testing.T) {
 		},
 		Data: map[string]string{"cluster.inClusterEnabled": "false"},
 	}
-	argoCDSecret := &v1.Secret{
+	argoCDSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDSecretName,
 			Namespace: fakeNamespace,
@@ -330,7 +330,7 @@ func TestListClusters(t *testing.T) {
 			"server.secretkey": nil,
 		},
 	}
-	secretForServerWithInClusterAddr := &v1.Secret{
+	secretForServerWithInClusterAddr := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster1",
 			Namespace: fakeNamespace,
@@ -344,7 +344,7 @@ func TestListClusters(t *testing.T) {
 		},
 	}
 
-	secretForServerWithExternalClusterAddr := &v1.Secret{
+	secretForServerWithExternalClusterAddr := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster2",
 			Namespace: fakeNamespace,
@@ -358,7 +358,7 @@ func TestListClusters(t *testing.T) {
 		},
 	}
 
-	invalidSecret := &v1.Secret{
+	invalidSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster3",
 			Namespace: fakeNamespace,
@@ -426,7 +426,7 @@ func TestListClusters(t *testing.T) {
 // on the cluster secrets. The test isn't asserting anything because
 // before the fix it would cause a panic from concurrent map iteration and map write
 func TestClusterRaceConditionClusterSecrets(t *testing.T) {
-	clusterSecret := &v1.Secret{
+	clusterSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mycluster",
 			Namespace: "default",
@@ -440,7 +440,7 @@ func TestClusterRaceConditionClusterSecrets(t *testing.T) {
 		},
 	}
 	kubeClient := fake.NewClientset(
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: "default",
@@ -450,7 +450,7 @@ func TestClusterRaceConditionClusterSecrets(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDSecretName,
 				Namespace: "default",

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -136,7 +136,7 @@ func NewDB(namespace string, settingsMgr *settings.SettingsManager, kubeclientse
 	}
 }
 
-func (db *db) getSecret(name string, cache map[string]*v1.Secret) (*v1.Secret, error) {
+func (db *db) getSecret(name string, cache map[string]*corev1.Secret) (*corev1.Secret, error) {
 	if _, ok := cache[name]; !ok {
 		secret, err := db.settingsMgr.GetSecretByName(name)
 		if err != nil {
@@ -147,7 +147,7 @@ func (db *db) getSecret(name string, cache map[string]*v1.Secret) (*v1.Secret, e
 	return cache[name], nil
 }
 
-func (db *db) unmarshalFromSecretsStr(secrets map[*SecretMaperValidation]*v1.SecretKeySelector, cache map[string]*v1.Secret) error {
+func (db *db) unmarshalFromSecretsStr(secrets map[*SecretMaperValidation]*corev1.SecretKeySelector, cache map[string]*corev1.Secret) error {
 	for dst, src := range secrets {
 		if src != nil {
 			secret, err := db.getSecret(src.Name, cache)

--- a/util/db/db_test.go
+++ b/util/db/db_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	appv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,7 +27,7 @@ const (
 )
 
 func getClientset(config map[string]string, objects ...runtime.Object) *fake.Clientset {
-	secret := v1.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-secret",
 			Namespace: testNamespace,
@@ -37,7 +37,7 @@ func getClientset(config map[string]string, objects ...runtime.Object) *fake.Cli
 			"server.secretkey": []byte("test"),
 		},
 	}
-	cm := v1.ConfigMap{
+	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
 			Namespace: testNamespace,
@@ -292,8 +292,8 @@ func TestGetRepository(t *testing.T) {
 	}
 }
 
-func newManagedSecret() *v1.Secret {
-	return &v1.Secret{
+func newManagedSecret() *corev1.Secret {
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "managed-secret",
 			Namespace: testNamespace,
@@ -347,7 +347,7 @@ func TestDeleteRepositoryUnmanagedSecrets(t *testing.T) {
     key: password
 `,
 	}
-	clientset := getClientset(config, &v1.Secret{
+	clientset := getClientset(config, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "unmanaged-secret",
 			Namespace: testNamespace,
@@ -387,7 +387,7 @@ func TestUpdateRepositoryWithManagedSecrets(t *testing.T) {
     key: sshPrivateKey
 `,
 	}
-	clientset := getClientset(config, &v1.Secret{
+	clientset := getClientset(config, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "managed-secret",
 			Namespace: testNamespace,
@@ -447,7 +447,7 @@ func TestRepositorySecretsTrim(t *testing.T) {
     key: githubAppPrivateKey
 `,
 	}
-	clientset := getClientset(config, &v1.Secret{
+	clientset := getClientset(config, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "managed-secret",
 			Namespace: testNamespace,
@@ -505,7 +505,7 @@ func TestRepositorySecretsTrim(t *testing.T) {
 func TestGetClusterSuccessful(t *testing.T) {
 	server := "my-cluster"
 	name := "my-name"
-	clientset := getClientset(nil, &v1.Secret{
+	clientset := getClientset(nil, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Labels: map[string]string{
@@ -559,7 +559,7 @@ func TestDeleteClusterWithManagedSecret(t *testing.T) {
 	clusterURL := "https://mycluster"
 	clusterName := "cluster-mycluster-3274446258"
 
-	clientset := getClientset(nil, &v1.Secret{
+	clientset := getClientset(nil, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: testNamespace,
@@ -590,7 +590,7 @@ func TestDeleteClusterWithUnmanagedSecret(t *testing.T) {
 	clusterURL := "https://mycluster"
 	clusterName := "mycluster-443"
 
-	clientset := getClientset(nil, &v1.Secret{
+	clientset := getClientset(nil, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: testNamespace,
@@ -662,7 +662,7 @@ func TestListHelmRepositories(t *testing.T) {
     key: key
 `,
 	}
-	clientset := getClientset(config, &v1.Secret{
+	clientset := getClientset(config, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: testNamespace,
@@ -710,7 +710,7 @@ func TestHelmRepositorySecretsTrim(t *testing.T) {
     key: key
 `,
 	}
-	clientset := getClientset(config, &v1.Secret{
+	clientset := getClientset(config, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: testNamespace,
@@ -753,7 +753,7 @@ func TestHelmRepositorySecretsTrim(t *testing.T) {
 }
 
 func TestGetClusterServersByName(t *testing.T) {
-	clientset := getClientset(nil, &v1.Secret{
+	clientset := getClientset(nil, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cluster-secret",
 			Namespace: testNamespace,
@@ -785,7 +785,7 @@ func TestGetClusterServersByName_InClusterNotConfigured(t *testing.T) {
 }
 
 func TestGetClusterServersByName_InClusterConfigured(t *testing.T) {
-	clientset := getClientset(nil, &v1.Secret{
+	clientset := getClientset(nil, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cluster-secret",
 			Namespace: testNamespace,

--- a/util/db/gpgkeys_test.go
+++ b/util/db/gpgkeys_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -18,7 +18,7 @@ import (
 )
 
 // GPG config map with a single key and good mapping
-var gpgCMEmpty = v1.ConfigMap{
+var gpgCMEmpty = corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      common.ArgoCDGPGKeysConfigMapName,
 		Namespace: testNamespace,
@@ -29,7 +29,7 @@ var gpgCMEmpty = v1.ConfigMap{
 }
 
 // GPG config map with a single key and good mapping
-var gpgCMSingleGoodPubkey = v1.ConfigMap{
+var gpgCMSingleGoodPubkey = corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      common.ArgoCDGPGKeysConfigMapName,
 		Namespace: testNamespace,
@@ -43,7 +43,7 @@ var gpgCMSingleGoodPubkey = v1.ConfigMap{
 }
 
 // GPG config map with two keys and good mapping
-var gpgCMMultiGoodPubkey = v1.ConfigMap{
+var gpgCMMultiGoodPubkey = corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      common.ArgoCDGPGKeysConfigMapName,
 		Namespace: testNamespace,
@@ -58,7 +58,7 @@ var gpgCMMultiGoodPubkey = v1.ConfigMap{
 }
 
 // GPG config map with a single key and bad mapping
-var gpgCMSingleKeyWrongId = v1.ConfigMap{
+var gpgCMSingleKeyWrongId = corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      common.ArgoCDGPGKeysConfigMapName,
 		Namespace: testNamespace,
@@ -72,7 +72,7 @@ var gpgCMSingleKeyWrongId = v1.ConfigMap{
 }
 
 // GPG config map with a garbage pub key
-var gpgCMGarbagePubkey = v1.ConfigMap{
+var gpgCMGarbagePubkey = corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      common.ArgoCDGPGKeysConfigMapName,
 		Namespace: testNamespace,
@@ -86,7 +86,7 @@ var gpgCMGarbagePubkey = v1.ConfigMap{
 }
 
 // GPG config map with a wrong key
-var gpgCMGarbageCMKey = v1.ConfigMap{
+var gpgCMGarbageCMKey = corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      common.ArgoCDGPGKeysConfigMapName,
 		Namespace: testNamespace,
@@ -100,8 +100,8 @@ var gpgCMGarbageCMKey = v1.ConfigMap{
 }
 
 // Returns a fake client set for use in tests
-func getGPGKeysClientset(gpgCM v1.ConfigMap) *fake.Clientset {
-	cm := v1.ConfigMap{
+func getGPGKeysClientset(gpgCM corev1.ConfigMap) *fake.Clientset {
+	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
 			Namespace: testNamespace,

--- a/util/db/helmrepository.go
+++ b/util/db/helmrepository.go
@@ -7,7 +7,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -35,12 +35,12 @@ func (db *db) getHelmRepo(repoURL string, helmRepositories []settings.HelmRepoCr
 		Type: "helm",
 		Name: repoInfo.Name,
 	}
-	err := db.unmarshalFromSecretsStr(map[*SecretMaperValidation]*v1.SecretKeySelector{
+	err := db.unmarshalFromSecretsStr(map[*SecretMaperValidation]*corev1.SecretKeySelector{
 		{Dest: &repo.Username, Transform: StripCRLFCharacter}:          repoInfo.UsernameSecret,
 		{Dest: &repo.Password, Transform: StripCRLFCharacter}:          repoInfo.PasswordSecret,
 		{Dest: &repo.TLSClientCertData, Transform: StripCRLFCharacter}: repoInfo.CertSecret,
 		{Dest: &repo.TLSClientCertKey, Transform: StripCRLFCharacter}:  repoInfo.KeySecret,
-	}, make(map[string]*v1.Secret))
+	}, make(map[string]*corev1.Secret))
 	return repo, err
 }
 

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -138,7 +138,7 @@ func (db *db) getRepositories(indexer, project string) ([]*appv1.Repository, err
 	}
 	var res []*appv1.Repository
 	for i := range secrets {
-		repo, err := secretToRepository(secrets[i].(*apiv1.Secret))
+		repo, err := secretToRepository(secrets[i].(*corev1.Secret))
 		if err != nil {
 			return nil, err
 		}

--- a/util/db/repository_legacy.go
+++ b/util/db/repository_legacy.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -311,7 +311,7 @@ func (l *legacyRepositoryBackend) upsertSecret(name string, data map[string][]by
 			if len(data) == 0 {
 				return nil
 			}
-			_, err = l.db.kubeclientset.CoreV1().Secrets(l.db.ns).Create(context.Background(), &apiv1.Secret{
+			_, err = l.db.kubeclientset.CoreV1().Secrets(l.db.ns).Create(context.Background(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 					Annotations: map[string]string{
@@ -387,7 +387,7 @@ func (l *legacyRepositoryBackend) credentialsToRepository(repoInfo settings.Repo
 		GitHubAppEnterpriseBaseURL: repoInfo.GithubAppEnterpriseBaseURL,
 		Proxy:                      repoInfo.Proxy,
 	}
-	err := l.db.unmarshalFromSecretsStr(map[*SecretMaperValidation]*apiv1.SecretKeySelector{
+	err := l.db.unmarshalFromSecretsStr(map[*SecretMaperValidation]*corev1.SecretKeySelector{
 		{Dest: &repo.Username, Transform: StripCRLFCharacter}:             repoInfo.UsernameSecret,
 		{Dest: &repo.Password, Transform: StripCRLFCharacter}:             repoInfo.PasswordSecret,
 		{Dest: &repo.SSHPrivateKey, Transform: StripCRLFCharacter}:        repoInfo.SSHPrivateKeySecret,
@@ -395,7 +395,7 @@ func (l *legacyRepositoryBackend) credentialsToRepository(repoInfo settings.Repo
 		{Dest: &repo.TLSClientCertKey, Transform: StripCRLFCharacter}:     repoInfo.TLSClientCertKeySecret,
 		{Dest: &repo.GithubAppPrivateKey, Transform: StripCRLFCharacter}:  repoInfo.GithubAppPrivateKeySecret,
 		{Dest: &repo.GCPServiceAccountKey, Transform: StripCRLFCharacter}: repoInfo.GCPServiceAccountKey,
-	}, make(map[string]*apiv1.Secret))
+	}, make(map[string]*corev1.Secret))
 	return repo, err
 }
 
@@ -407,7 +407,7 @@ func (l *legacyRepositoryBackend) credentialsToRepositoryCredentials(repoInfo se
 		GitHubAppEnterpriseBaseURL: repoInfo.GithubAppEnterpriseBaseURL,
 		EnableOCI:                  repoInfo.EnableOCI,
 	}
-	err := l.db.unmarshalFromSecretsStr(map[*SecretMaperValidation]*apiv1.SecretKeySelector{
+	err := l.db.unmarshalFromSecretsStr(map[*SecretMaperValidation]*corev1.SecretKeySelector{
 		{Dest: &creds.Username}:             repoInfo.UsernameSecret,
 		{Dest: &creds.Password}:             repoInfo.PasswordSecret,
 		{Dest: &creds.SSHPrivateKey}:        repoInfo.SSHPrivateKeySecret,
@@ -415,17 +415,17 @@ func (l *legacyRepositoryBackend) credentialsToRepositoryCredentials(repoInfo se
 		{Dest: &creds.TLSClientCertKey}:     repoInfo.TLSClientCertKeySecret,
 		{Dest: &creds.GithubAppPrivateKey}:  repoInfo.GithubAppPrivateKeySecret,
 		{Dest: &creds.GCPServiceAccountKey}: repoInfo.GCPServiceAccountKey,
-	}, make(map[string]*apiv1.Secret))
+	}, make(map[string]*corev1.Secret))
 	return creds, err
 }
 
 // Set data to be stored in a given secret used for repository credentials and templates.
 // The name of the secret is a combination of the prefix given, and a calculated value
 // from the repository or template URL.
-func (l *legacyRepositoryBackend) setSecretData(prefix string, url string, secretsData map[string]map[string][]byte, secretKey *apiv1.SecretKeySelector, value string, defaultKeyName string) *apiv1.SecretKeySelector {
+func (l *legacyRepositoryBackend) setSecretData(prefix string, url string, secretsData map[string]map[string][]byte, secretKey *corev1.SecretKeySelector, value string, defaultKeyName string) *corev1.SecretKeySelector {
 	if secretKey == nil && value != "" {
-		secretKey = &apiv1.SecretKeySelector{
-			LocalObjectReference: apiv1.LocalObjectReference{Name: RepoURLToSecretName(prefix, url, "")},
+		secretKey = &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: RepoURLToSecretName(prefix, url, "")},
 			Key:                  defaultKeyName,
 		}
 	}

--- a/util/db/secrets.go
+++ b/util/db/secrets.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -23,7 +23,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util"
 )
 
-func (db *db) listSecretsByType(types ...string) ([]*apiv1.Secret, error) {
+func (db *db) listSecretsByType(types ...string) ([]*corev1.Secret, error) {
 	labelSelector := labels.NewSelector()
 	req, err := labels.NewRequirement(common.LabelKeySecretType, selection.Equals, types)
 	if err != nil {
@@ -46,7 +46,7 @@ func (db *db) listSecretsByType(types ...string) ([]*apiv1.Secret, error) {
 	return secrets, nil
 }
 
-func boolOrFalse(secret *apiv1.Secret, key string) (bool, error) {
+func boolOrFalse(secret *corev1.Secret, key string) (bool, error) {
 	val, present := secret.Data[key]
 	if !present {
 		return false, nil
@@ -55,7 +55,7 @@ func boolOrFalse(secret *apiv1.Secret, key string) (bool, error) {
 	return strconv.ParseBool(string(val))
 }
 
-func intOrZero(secret *apiv1.Secret, key string) (int64, error) {
+func intOrZero(secret *corev1.Secret, key string) (int64, error) {
 	val, present := secret.Data[key]
 	if !present {
 		return 0, nil
@@ -64,29 +64,29 @@ func intOrZero(secret *apiv1.Secret, key string) (int64, error) {
 	return strconv.ParseInt(string(val), 10, 64)
 }
 
-func updateSecretBool(secret *apiv1.Secret, key string, value bool) {
+func updateSecretBool(secret *corev1.Secret, key string, value bool) {
 	if _, present := secret.Data[key]; present || value {
 		secret.Data[key] = []byte(strconv.FormatBool(value))
 	}
 }
 
-func updateSecretInt(secret *apiv1.Secret, key string, value int64) {
+func updateSecretInt(secret *corev1.Secret, key string, value int64) {
 	if _, present := secret.Data[key]; present || value != 0 {
 		secret.Data[key] = []byte(strconv.FormatInt(value, 10))
 	}
 }
 
-func updateSecretString(secret *apiv1.Secret, key, value string) {
+func updateSecretString(secret *corev1.Secret, key, value string) {
 	if _, present := secret.Data[key]; present || len(value) > 0 {
 		secret.Data[key] = []byte(value)
 	}
 }
 
-func (db *db) createSecret(ctx context.Context, secret *apiv1.Secret) (*apiv1.Secret, error) {
+func (db *db) createSecret(ctx context.Context, secret *corev1.Secret) (*corev1.Secret, error) {
 	return db.kubeclientset.CoreV1().Secrets(db.ns).Create(ctx, secret, metav1.CreateOptions{})
 }
 
-func addSecretMetadata(secret *apiv1.Secret, secretType string) {
+func addSecretMetadata(secret *corev1.Secret, secretType string) {
 	if secret.Annotations == nil {
 		secret.Annotations = map[string]string{}
 	}
@@ -98,7 +98,7 @@ func addSecretMetadata(secret *apiv1.Secret, secretType string) {
 	secret.Labels[common.LabelKeySecretType] = secretType
 }
 
-func (db *db) deleteSecret(ctx context.Context, secret *apiv1.Secret) error {
+func (db *db) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
 	var err error
 
 	canDelete := secret.Annotations != nil && secret.Annotations[common.AnnotationKeyManagedBy] == common.AnnotationValueManagedByArgoCD
@@ -114,9 +114,9 @@ func (db *db) deleteSecret(ctx context.Context, secret *apiv1.Secret) error {
 
 func (db *db) watchSecrets(ctx context.Context,
 	secretType string,
-	handleAddEvent func(secret *apiv1.Secret),
-	handleModEvent func(oldSecret *apiv1.Secret, newSecret *apiv1.Secret),
-	handleDeleteEvent func(secret *apiv1.Secret),
+	handleAddEvent func(secret *corev1.Secret),
+	handleModEvent func(oldSecret *corev1.Secret, newSecret *corev1.Secret),
+	handleDeleteEvent func(secret *corev1.Secret),
 ) {
 	secretListOptions := func(options *metav1.ListOptions) {
 		labelSelector := fields.ParseSelectorOrDie(common.LabelKeySecretType + "=" + secretType)
@@ -124,18 +124,18 @@ func (db *db) watchSecrets(ctx context.Context,
 	}
 	secretEventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
-			if secretObj, ok := obj.(*apiv1.Secret); ok {
+			if secretObj, ok := obj.(*corev1.Secret); ok {
 				handleAddEvent(secretObj)
 			}
 		},
 		DeleteFunc: func(obj any) {
-			if secretObj, ok := obj.(*apiv1.Secret); ok {
+			if secretObj, ok := obj.(*corev1.Secret); ok {
 				handleDeleteEvent(secretObj)
 			}
 		},
 		UpdateFunc: func(oldObj, newObj any) {
-			if oldSecretObj, ok := oldObj.(*apiv1.Secret); ok {
-				if newSecretObj, ok := newObj.(*apiv1.Secret); ok {
+			if oldSecretObj, ok := oldObj.(*corev1.Secret); ok {
+				if newSecretObj, ok := newObj.(*corev1.Secret); ok {
 					handleModEvent(oldSecretObj, newSecretObj)
 				}
 			}

--- a/util/helm/helm_test.go
+++ b/util/helm/helm_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -43,10 +43,10 @@ func TestHelmTemplateParams(t *testing.T) {
 
 	for _, obj := range objs {
 		if obj.GetKind() == "Service" && obj.GetName() == "test-minio" {
-			var svc apiv1.Service
+			var svc corev1.Service
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &svc)
 			require.NoError(t, err)
-			assert.Equal(t, apiv1.ServiceTypeLoadBalancer, svc.Spec.Type)
+			assert.Equal(t, corev1.ServiceTypeLoadBalancer, svc.Spec.Type)
 			assert.Equal(t, int32(1234), svc.Spec.Ports[0].TargetPort.IntVal)
 			assert.Equal(t, "true", svc.ObjectMeta.Annotations["prometheus.io/scrape"])
 		}

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -147,7 +147,7 @@ func TestSetSvcLabel(t *testing.T) {
 	require.NoError(t, err)
 	log.Println(string(manifestBytes))
 
-	var s apiv1.Service
+	var s corev1.Service
 	err = json.Unmarshal(manifestBytes, &s)
 	require.NoError(t, err)
 
@@ -176,7 +176,7 @@ func TestSetAppInstanceAnnotation(t *testing.T) {
 	require.NoError(t, err)
 	log.Println(string(manifestBytes))
 
-	var s apiv1.Service
+	var s corev1.Service
 	err = json.Unmarshal(manifestBytes, &s)
 	require.NoError(t, err)
 

--- a/util/kube/util.go
+++ b/util/kube/util.go
@@ -3,7 +3,7 @@ package kube
 import (
 	"context"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -18,7 +18,7 @@ type kubeUtil struct {
 
 // updateFn will be called to set data for secret s. new will be true if the
 // secret was created by the caller, or false if it has existed before.
-type updateFn func(s *apiv1.Secret, new bool) error
+type updateFn func(s *corev1.Secret, new bool) error
 
 // NewKubeUtil NewUtil returns a new kubeUtil receiver
 func NewKubeUtil(client kubernetes.Interface, ctx context.Context) *kubeUtil {
@@ -30,7 +30,7 @@ func NewKubeUtil(client kubernetes.Interface, ctx context.Context) *kubeUtil {
 // the receiver. If the secret is updated, labels and annotations will not be
 // touched.
 func (ku *kubeUtil) CreateOrUpdateSecret(ns string, name string, update updateFn) error {
-	var s *apiv1.Secret
+	var s *corev1.Secret
 	var err error
 	var new bool
 
@@ -43,7 +43,7 @@ func (ku *kubeUtil) CreateOrUpdateSecret(ns string, name string, update updateFn
 	}
 
 	if new {
-		s = &apiv1.Secret{
+		s = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        name,
 				Namespace:   ns,
@@ -70,7 +70,7 @@ func (ku *kubeUtil) CreateOrUpdateSecret(ns string, name string, update updateFn
 
 // CreateOrUpdateSecretField creates or updates a secret name in namespace ns, with given value for given field
 func (ku *kubeUtil) CreateOrUpdateSecretField(ns string, name string, field string, value string) error {
-	err := ku.CreateOrUpdateSecret(ns, name, func(s *apiv1.Secret, new bool) error {
+	err := ku.CreateOrUpdateSecret(ns, name, func(s *corev1.Secret, new bool) error {
 		s.Data[field] = []byte(value)
 		return nil
 	})
@@ -80,7 +80,7 @@ func (ku *kubeUtil) CreateOrUpdateSecretField(ns string, name string, field stri
 // CreateOrUpdateSecretData creates or updates a secret name in namespace ns, with given data.
 // If merge is true, merges data with the existing data, otherwise overwrites it.
 func (ku *kubeUtil) CreateOrUpdateSecretData(ns string, name string, data map[string][]byte, merge bool) error {
-	err := ku.CreateOrUpdateSecret(ns, name, func(s *apiv1.Secret, new bool) error {
+	err := ku.CreateOrUpdateSecret(ns, name, func(s *corev1.Secret, new bool) error {
 		if !merge || new {
 			s.Data = data
 		} else {

--- a/util/kube/util_test.go
+++ b/util/kube/util_test.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 // nolint:unparam
-func getSecret(client kubernetes.Interface, ns, name string) (*apiv1.Secret, error) {
+func getSecret(client kubernetes.Interface, ns, name string) (*corev1.Secret, error) {
 	s, err := client.CoreV1().Secrets(ns).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func getSecret(client kubernetes.Interface, ns, name string) (*apiv1.Secret, err
 }
 
 func Test_CreateOrUpdateSecretField(t *testing.T) {
-	secret := &apiv1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
@@ -113,7 +113,7 @@ func Test_CreateOrUpdateSecretField(t *testing.T) {
 }
 
 func Test_CreateOrUpdateSecretData(t *testing.T) {
-	secret := &apiv1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",

--- a/util/notification/settings/legacy.go
+++ b/util/notification/settings/legacy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/argoproj/notifications-engine/pkg/util/text"
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -157,7 +157,7 @@ func (c *legacyServicesConfig) merge(cfg *api.Config) {
 }
 
 // ApplyLegacyConfig settings specified using deprecated config map and secret keys
-func ApplyLegacyConfig(cfg *api.Config, context map[string]string, cm *v1.ConfigMap, secret *v1.Secret) error {
+func ApplyLegacyConfig(cfg *api.Config, context map[string]string, cm *corev1.ConfigMap, secret *corev1.Secret) error {
 	if notifiersData, ok := secret.Data["notifiers.yaml"]; ok && len(notifiersData) > 0 {
 		log.Warn("Key 'notifiers.yaml' in Secret is deprecated, please migrate to new settings")
 		legacyServices := &legacyServicesConfig{}

--- a/util/notification/settings/legacy_test.go
+++ b/util/notification/settings/legacy_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/argoproj/notifications-engine/pkg/triggers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -36,8 +36,8 @@ triggers:
 `
 	err := ApplyLegacyConfig(&cfg,
 		context,
-		&v1.ConfigMap{Data: map[string]string{"config.yaml": configYAML}},
-		&v1.Secret{Data: map[string][]byte{}},
+		&corev1.ConfigMap{Data: map[string]string{"config.yaml": configYAML}},
+		&corev1.Secret{Data: map[string][]byte{}},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"my-trigger1"}, cfg.DefaultTriggers)
@@ -82,8 +82,8 @@ slack:
   token: my-token
 `
 	err := ApplyLegacyConfig(&cfg, context,
-		&v1.ConfigMap{Data: map[string]string{"config.yaml": configYAML}},
-		&v1.Secret{Data: map[string][]byte{"notifiers.yaml": []byte(notifiersYAML)}},
+		&corev1.ConfigMap{Data: map[string]string{"config.yaml": configYAML}},
+		&corev1.Secret{Data: map[string][]byte{"notifiers.yaml": []byte(notifiersYAML)}},
 	)
 
 	require.NoError(t, err)

--- a/util/notification/settings/settings.go
+++ b/util/notification/settings/settings.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/argoproj/notifications-engine/pkg/api"
 	"github.com/argoproj/notifications-engine/pkg/services"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
@@ -18,7 +18,7 @@ func GetFactorySettings(argocdService service.Service, secretName, configMapName
 	return api.Settings{
 		SecretName:    secretName,
 		ConfigMapName: configMapName,
-		InitGetVars: func(cfg *api.Config, configMap *v1.ConfigMap, secret *v1.Secret) (api.GetVars, error) {
+		InitGetVars: func(cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
 			if selfServiceNotificationEnabled {
 				return initGetVarsWithoutSecret(argocdService, cfg, configMap, secret)
 			}
@@ -32,7 +32,7 @@ func GetFactorySettingsForCLI(argocdService *service.Service, secretName, config
 	return api.Settings{
 		SecretName:    secretName,
 		ConfigMapName: configMapName,
-		InitGetVars: func(cfg *api.Config, configMap *v1.ConfigMap, secret *v1.Secret) (api.GetVars, error) {
+		InitGetVars: func(cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
 			if *argocdService == nil {
 				return nil, errors.New("argocdService is not initialized")
 			}
@@ -45,7 +45,7 @@ func GetFactorySettingsForCLI(argocdService *service.Service, secretName, config
 	}
 }
 
-func getContext(cfg *api.Config, configMap *v1.ConfigMap, secret *v1.Secret) (map[string]string, error) {
+func getContext(cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (map[string]string, error) {
 	context := map[string]string{}
 	if contextYaml, ok := configMap.Data["context"]; ok {
 		if err := yaml.Unmarshal([]byte(contextYaml), &context); err != nil {
@@ -58,7 +58,7 @@ func getContext(cfg *api.Config, configMap *v1.ConfigMap, secret *v1.Secret) (ma
 	return context, nil
 }
 
-func initGetVarsWithoutSecret(argocdService service.Service, cfg *api.Config, configMap *v1.ConfigMap, secret *v1.Secret) (api.GetVars, error) {
+func initGetVarsWithoutSecret(argocdService service.Service, cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
 	context, err := getContext(cfg, configMap, secret)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func initGetVarsWithoutSecret(argocdService service.Service, cfg *api.Config, co
 	}, nil
 }
 
-func initGetVars(argocdService service.Service, cfg *api.Config, configMap *v1.ConfigMap, secret *v1.Secret) (api.GetVars, error) {
+func initGetVars(argocdService service.Service, cfg *api.Config, configMap *corev1.ConfigMap, secret *corev1.Secret) (api.GetVars, error) {
 	context, err := getContext(cfg, configMap, secret)
 	if err != nil {
 		return nil, err

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -345,7 +345,7 @@ func (e *Enforcer) newInformer() cache.SharedIndexInformer {
 }
 
 // RunPolicyLoader runs the policy loader which watches policy updates from the configmap and reloads them
-func (e *Enforcer) RunPolicyLoader(ctx context.Context, onUpdated func(cm *apiv1.ConfigMap) error) error {
+func (e *Enforcer) RunPolicyLoader(ctx context.Context, onUpdated func(cm *corev1.ConfigMap) error) error {
 	cm, err := e.clientset.CoreV1().ConfigMaps(e.namespace).Get(ctx, e.configmap, metav1.GetOptions{})
 	if err != nil {
 		if !apierr.IsNotFound(err) {
@@ -361,12 +361,12 @@ func (e *Enforcer) RunPolicyLoader(ctx context.Context, onUpdated func(cm *apiv1
 	return nil
 }
 
-func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *apiv1.ConfigMap) error) {
+func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *corev1.ConfigMap) error) {
 	cmInformer := e.newInformer()
 	_, err := cmInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
-				if cm, ok := obj.(*apiv1.ConfigMap); ok {
+				if cm, ok := obj.(*corev1.ConfigMap); ok {
 					err := e.syncUpdate(cm, onUpdated)
 					if err != nil {
 						log.Error(err)
@@ -376,8 +376,8 @@ func (e *Enforcer) runInformer(ctx context.Context, onUpdated func(cm *apiv1.Con
 				}
 			},
 			UpdateFunc: func(old, new any) {
-				oldCM := old.(*apiv1.ConfigMap)
-				newCM := new.(*apiv1.ConfigMap)
+				oldCM := old.(*corev1.ConfigMap)
+				newCM := new.(*corev1.ConfigMap)
 				if oldCM.ResourceVersion == newCM.ResourceVersion {
 					return
 				}
@@ -430,7 +430,7 @@ func PolicyCSV(data map[string]string) string {
 }
 
 // syncUpdate updates the enforcer
-func (e *Enforcer) syncUpdate(cm *apiv1.ConfigMap, onUpdated func(cm *apiv1.ConfigMap) error) error {
+func (e *Enforcer) syncUpdate(cm *corev1.ConfigMap, onUpdated func(cm *corev1.ConfigMap) error) error {
 	e.SetDefaultRole(cm.Data[ConfigMapPolicyDefaultKey])
 	e.SetMatchMode(cm.Data[ConfigMapMatchModeKey])
 	policyCSV := PolicyCSV(cm.Data)

--- a/util/rbac/rbac_norace_test.go
+++ b/util/rbac/rbac_norace_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -32,7 +32,7 @@ func TestPolicyInformer(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go enf.runInformer(ctx, func(cm *apiv1.ConfigMap) error {
+	go enf.runInformer(ctx, func(cm *corev1.ConfigMap) error {
 		return nil
 	})
 

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -22,12 +22,12 @@ const (
 	fakeNamespace     = "fake-ns"
 )
 
-var noOpUpdate = func(cm *apiv1.ConfigMap) error {
+var noOpUpdate = func(cm *corev1.ConfigMap) error {
 	return nil
 }
 
-func fakeConfigMap() *apiv1.ConfigMap {
-	cm := apiv1.ConfigMap{
+func fakeConfigMap() *corev1.ConfigMap {
+	cm := corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",

--- a/util/settings/accounts.go
+++ b/util/settings/accounts.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -95,8 +95,8 @@ func (a *Account) HasCapability(capability AccountCapability) bool {
 }
 
 func (mgr *SettingsManager) saveAccount(name string, account Account) error {
-	return mgr.updateSecret(func(secret *v1.Secret) error {
-		return mgr.updateConfigMap(func(cm *v1.ConfigMap) error {
+	return mgr.updateSecret(func(secret *corev1.Secret) error {
+		return mgr.updateConfigMap(func(cm *corev1.ConfigMap) error {
 			return saveAccount(secret, cm, name, account)
 		})
 	})
@@ -156,7 +156,7 @@ func (mgr *SettingsManager) GetAccounts() (map[string]Account, error) {
 	return parseAccounts(secret, cm)
 }
 
-func updateAccountMap(cm *v1.ConfigMap, key string, val string, defVal string) {
+func updateAccountMap(cm *corev1.ConfigMap, key string, val string, defVal string) {
 	existingVal := cm.Data[key]
 	if existingVal != val {
 		if val == "" || val == defVal {
@@ -167,7 +167,7 @@ func updateAccountMap(cm *v1.ConfigMap, key string, val string, defVal string) {
 	}
 }
 
-func updateAccountSecret(secret *v1.Secret, key string, val string, defVal string) {
+func updateAccountSecret(secret *corev1.Secret, key string, val string, defVal string) {
 	existingVal := string(secret.Data[key])
 	if existingVal != val {
 		if val == "" || val == defVal {
@@ -178,7 +178,7 @@ func updateAccountSecret(secret *v1.Secret, key string, val string, defVal strin
 	}
 }
 
-func saveAccount(secret *v1.Secret, cm *v1.ConfigMap, name string, account Account) error {
+func saveAccount(secret *corev1.Secret, cm *corev1.ConfigMap, name string, account Account) error {
 	tokens, err := json.Marshal(account.Tokens)
 	if err != nil {
 		return err
@@ -198,7 +198,7 @@ func saveAccount(secret *v1.Secret, cm *v1.ConfigMap, name string, account Accou
 	return nil
 }
 
-func parseAdminAccount(secret *v1.Secret, cm *v1.ConfigMap) (*Account, error) {
+func parseAdminAccount(secret *corev1.Secret, cm *corev1.ConfigMap) (*Account, error) {
 	adminAccount := &Account{Enabled: true, Capabilities: []AccountCapability{AccountCapabilityLogin}}
 	if adminPasswordHash, ok := secret.Data[settingAdminPasswordHashKey]; ok {
 		adminAccount.PasswordHash = string(adminPasswordHash)
@@ -227,7 +227,7 @@ func parseAdminAccount(secret *v1.Secret, cm *v1.ConfigMap) (*Account, error) {
 	return adminAccount, nil
 }
 
-func parseAccounts(secret *v1.Secret, cm *v1.ConfigMap) (map[string]Account, error) {
+func parseAccounts(secret *corev1.Secret, cm *corev1.ConfigMap) (map[string]Account, error) {
 	adminAccount, err := parseAdminAccount(secret, cm)
 	if err != nil {
 		return nil, err

--- a/util/settings/accounts_test.go
+++ b/util/settings/accounts_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -26,7 +26,7 @@ func TestGetAccounts_NoAccountsConfigured(t *testing.T) {
 }
 
 func TestGetAccounts_HasConfiguredAccounts(t *testing.T) {
-	_, settingsManager := fixtures(map[string]string{"accounts.test": "apiKey"}, func(secret *v1.Secret) {
+	_, settingsManager := fixtures(map[string]string{"accounts.test": "apiKey"}, func(secret *corev1.Secret) {
 		secret.Data["accounts.test.tokens"] = []byte(`[{"id":"123","iat":1583789194,"exp":1583789194}]`)
 	})
 	accounts, err := settingsManager.GetAccounts()
@@ -77,13 +77,13 @@ func TestGetAccount_WithInvalidToken(t *testing.T) {
 		"accounts.invaliduser": "apiKey",
 		"accounts.user2":       "apiKey",
 	},
-		func(secret *v1.Secret) {
+		func(secret *corev1.Secret) {
 			secret.Data["accounts.user1.tokens"] = []byte(`[{"id":"1","iat":158378932,"exp":1583789194}]`)
 		},
-		func(secret *v1.Secret) {
+		func(secret *corev1.Secret) {
 			secret.Data["accounts.invaliduser.tokens"] = []byte("Invalid token")
 		},
-		func(secret *v1.Secret) {
+		func(secret *corev1.Secret) {
 			secret.Data["accounts.user2.tokens"] = []byte(`[{"id":"2","iat":1583789194,"exp":1583784545}]`)
 		},
 	)
@@ -94,7 +94,7 @@ func TestGetAccount_WithInvalidToken(t *testing.T) {
 
 func TestGetAdminAccount(t *testing.T) {
 	mTime := time.Now().Format(time.RFC3339)
-	_, settingsManager := fixtures(nil, func(secret *v1.Secret) {
+	_, settingsManager := fixtures(nil, func(secret *corev1.Secret) {
 		secret.Data["admin.password"] = []byte("admin-password")
 		secret.Data["admin.passwordMtime"] = []byte(mTime)
 	})

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,12 +202,12 @@ type OIDCConfig struct {
 
 // DEPRECATED. Helm repository credentials are now managed using RepoCredentials
 type HelmRepoCredentials struct {
-	URL            string                   `json:"url,omitempty"`
-	Name           string                   `json:"name,omitempty"`
-	UsernameSecret *apiv1.SecretKeySelector `json:"usernameSecret,omitempty"`
-	PasswordSecret *apiv1.SecretKeySelector `json:"passwordSecret,omitempty"`
-	CertSecret     *apiv1.SecretKeySelector `json:"certSecret,omitempty"`
-	KeySecret      *apiv1.SecretKeySelector `json:"keySecret,omitempty"`
+	URL            string                    `json:"url,omitempty"`
+	Name           string                    `json:"name,omitempty"`
+	UsernameSecret *corev1.SecretKeySelector `json:"usernameSecret,omitempty"`
+	PasswordSecret *corev1.SecretKeySelector `json:"passwordSecret,omitempty"`
+	CertSecret     *corev1.SecretKeySelector `json:"certSecret,omitempty"`
+	KeySecret      *corev1.SecretKeySelector `json:"keySecret,omitempty"`
 }
 
 // KustomizeVersion holds information about additional Kustomize version
@@ -229,7 +229,7 @@ type KustomizeSettings struct {
 var (
 	ByClusterURLIndexer     = "byClusterURL"
 	byClusterURLIndexerFunc = func(obj any) ([]string, error) {
-		s, ok := obj.(*apiv1.Secret)
+		s, ok := obj.(*corev1.Secret)
 		if !ok {
 			return nil, nil
 		}
@@ -246,7 +246,7 @@ var (
 	}
 	ByClusterNameIndexer     = "byClusterName"
 	byClusterNameIndexerFunc = func(obj any) ([]string, error) {
-		s, ok := obj.(*apiv1.Secret)
+		s, ok := obj.(*corev1.Secret)
 		if !ok {
 			return nil, nil
 		}
@@ -266,7 +266,7 @@ var (
 	ByProjectRepoWriteIndexer = "byProjectRepoWrite"
 	byProjectIndexerFunc      = func(secretType string) func(obj any) ([]string, error) {
 		return func(obj any) ([]string, error) {
-			s, ok := obj.(*apiv1.Secret)
+			s, ok := obj.(*corev1.Secret)
 			if !ok {
 				return nil, nil
 			}
@@ -318,11 +318,11 @@ type Repository struct {
 	// helm only
 	Name string `json:"name,omitempty"`
 	// Name of the secret storing the username used to access the repo
-	UsernameSecret *apiv1.SecretKeySelector `json:"usernameSecret,omitempty"`
+	UsernameSecret *corev1.SecretKeySelector `json:"usernameSecret,omitempty"`
 	// Name of the secret storing the password used to access the repo
-	PasswordSecret *apiv1.SecretKeySelector `json:"passwordSecret,omitempty"`
+	PasswordSecret *corev1.SecretKeySelector `json:"passwordSecret,omitempty"`
 	// Name of the secret storing the SSH private key used to access the repo. Git only
-	SSHPrivateKeySecret *apiv1.SecretKeySelector `json:"sshPrivateKeySecret,omitempty"`
+	SSHPrivateKeySecret *corev1.SecretKeySelector `json:"sshPrivateKeySecret,omitempty"`
 	// Whether to connect the repository in an insecure way (deprecated)
 	InsecureIgnoreHostKey bool `json:"insecureIgnoreHostKey,omitempty"`
 	// Whether to connect the repository in an insecure way
@@ -330,13 +330,13 @@ type Repository struct {
 	// Whether the repo is git-lfs enabled. Git only.
 	EnableLFS bool `json:"enableLfs,omitempty"`
 	// Name of the secret storing the TLS client cert data
-	TLSClientCertDataSecret *apiv1.SecretKeySelector `json:"tlsClientCertDataSecret,omitempty"`
+	TLSClientCertDataSecret *corev1.SecretKeySelector `json:"tlsClientCertDataSecret,omitempty"`
 	// Name of the secret storing the TLS client cert's key data
-	TLSClientCertKeySecret *apiv1.SecretKeySelector `json:"tlsClientCertKeySecret,omitempty"`
+	TLSClientCertKeySecret *corev1.SecretKeySelector `json:"tlsClientCertKeySecret,omitempty"`
 	// Whether the repo is helm-oci enabled. Git only.
 	EnableOci bool `json:"enableOci,omitempty"`
 	// Github App Private Key PEM data
-	GithubAppPrivateKeySecret *apiv1.SecretKeySelector `json:"githubAppPrivateKeySecret,omitempty"`
+	GithubAppPrivateKeySecret *corev1.SecretKeySelector `json:"githubAppPrivateKeySecret,omitempty"`
 	// Github App ID of the app used to access the repo
 	GithubAppId int64 `json:"githubAppID,omitempty"`
 	// Github App Installation ID of the installed GitHub App
@@ -348,7 +348,7 @@ type Repository struct {
 	// NoProxy specifies a list of targets where the proxy isn't used, applies only in cases where the proxy is applied
 	NoProxy string `json:"noProxy,omitempty"`
 	// GCPServiceAccountKey specifies the service account key in JSON format to be used for getting credentials to Google Cloud Source repos
-	GCPServiceAccountKey *apiv1.SecretKeySelector `json:"gcpServiceAccountKey,omitempty"`
+	GCPServiceAccountKey *corev1.SecretKeySelector `json:"gcpServiceAccountKey,omitempty"`
 	// ForceHttpBasicAuth determines whether Argo CD should force use of basic auth for HTTP connected repositories
 	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty"`
 }
@@ -358,17 +358,17 @@ type RepositoryCredentials struct {
 	// The URL pattern the repository URL has to match
 	URL string `json:"url,omitempty"`
 	// Name of the secret storing the username used to access the repo
-	UsernameSecret *apiv1.SecretKeySelector `json:"usernameSecret,omitempty"`
+	UsernameSecret *corev1.SecretKeySelector `json:"usernameSecret,omitempty"`
 	// Name of the secret storing the password used to access the repo
-	PasswordSecret *apiv1.SecretKeySelector `json:"passwordSecret,omitempty"`
+	PasswordSecret *corev1.SecretKeySelector `json:"passwordSecret,omitempty"`
 	// Name of the secret storing the SSH private key used to access the repo. Git only
-	SSHPrivateKeySecret *apiv1.SecretKeySelector `json:"sshPrivateKeySecret,omitempty"`
+	SSHPrivateKeySecret *corev1.SecretKeySelector `json:"sshPrivateKeySecret,omitempty"`
 	// Name of the secret storing the TLS client cert data
-	TLSClientCertDataSecret *apiv1.SecretKeySelector `json:"tlsClientCertDataSecret,omitempty"`
+	TLSClientCertDataSecret *corev1.SecretKeySelector `json:"tlsClientCertDataSecret,omitempty"`
 	// Name of the secret storing the TLS client cert's key data
-	TLSClientCertKeySecret *apiv1.SecretKeySelector `json:"tlsClientCertKeySecret,omitempty"`
+	TLSClientCertKeySecret *corev1.SecretKeySelector `json:"tlsClientCertKeySecret,omitempty"`
 	// Github App Private Key PEM data
-	GithubAppPrivateKeySecret *apiv1.SecretKeySelector `json:"githubAppPrivateKeySecret,omitempty"`
+	GithubAppPrivateKeySecret *corev1.SecretKeySelector `json:"githubAppPrivateKeySecret,omitempty"`
 	// Github App ID of the app used to access the repo
 	GithubAppId int64 `json:"githubAppID,omitempty"`
 	// Github App Installation ID of the installed GitHub App
@@ -380,7 +380,7 @@ type RepositoryCredentials struct {
 	// the type of the repositoryCredentials, "git" or "helm", assumed to be "git" if empty or absent
 	Type string `json:"type,omitempty"`
 	// GCPServiceAccountKey specifies the service account key in JSON format to be used for getting credentials to Google Cloud Source repos
-	GCPServiceAccountKey *apiv1.SecretKeySelector `json:"gcpServiceAccountKey,omitempty"`
+	GCPServiceAccountKey *corev1.SecretKeySelector `json:"gcpServiceAccountKey,omitempty"`
 	// ForceHttpBasicAuth determines whether Argo CD should force use of basic auth for HTTP connected repositories
 	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty"`
 }
@@ -638,14 +638,14 @@ func (mgr *SettingsManager) GetSecretsInformer() (cache.SharedIndexInformer, err
 	return mgr.secretsInformer, nil
 }
 
-func (mgr *SettingsManager) updateSecret(callback func(*apiv1.Secret) error) error {
+func (mgr *SettingsManager) updateSecret(callback func(*corev1.Secret) error) error {
 	argoCDSecret, err := mgr.getSecret()
 	createSecret := false
 	if err != nil {
 		if !apierr.IsNotFound(err) {
 			return err
 		}
-		argoCDSecret = &apiv1.Secret{
+		argoCDSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: common.ArgoCDSecretName,
 			},
@@ -676,14 +676,14 @@ func (mgr *SettingsManager) updateSecret(callback func(*apiv1.Secret) error) err
 	return mgr.ResyncInformers()
 }
 
-func (mgr *SettingsManager) updateConfigMap(callback func(*apiv1.ConfigMap) error) error {
+func (mgr *SettingsManager) updateConfigMap(callback func(*corev1.ConfigMap) error) error {
 	argoCDCM, err := mgr.getConfigMap()
 	createCM := false
 	if err != nil {
 		if !apierr.IsNotFound(err) {
 			return err
 		}
-		argoCDCM = &apiv1.ConfigMap{
+		argoCDCM = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: common.ArgoCDConfigMapName,
 			},
@@ -716,14 +716,14 @@ func (mgr *SettingsManager) updateConfigMap(callback func(*apiv1.ConfigMap) erro
 	return mgr.ResyncInformers()
 }
 
-func (mgr *SettingsManager) getConfigMap() (*apiv1.ConfigMap, error) {
+func (mgr *SettingsManager) getConfigMap() (*corev1.ConfigMap, error) {
 	return mgr.GetConfigMapByName(common.ArgoCDConfigMapName)
 }
 
 // Returns the ConfigMap with the given name from the cluster.
 // The ConfigMap must be labeled with "app.kubernetes.io/part-of: argocd" in
 // order to be retrievable.
-func (mgr *SettingsManager) GetConfigMapByName(configMapName string) (*apiv1.ConfigMap, error) {
+func (mgr *SettingsManager) GetConfigMapByName(configMapName string) (*corev1.ConfigMap, error) {
 	err := mgr.ensureSynced(false)
 	if err != nil {
 		return nil, err
@@ -739,12 +739,12 @@ func (mgr *SettingsManager) GetConfigMapByName(configMapName string) (*apiv1.Con
 	return cmCopy, err
 }
 
-func (mgr *SettingsManager) getSecret() (*apiv1.Secret, error) {
+func (mgr *SettingsManager) getSecret() (*corev1.Secret, error) {
 	return mgr.GetSecretByName(common.ArgoCDSecretName)
 }
 
 // Returns the Secret with the given name from the cluster.
-func (mgr *SettingsManager) GetSecretByName(secretName string) (*apiv1.Secret, error) {
+func (mgr *SettingsManager) GetSecretByName(secretName string) (*corev1.Secret, error) {
 	err := mgr.ensureSynced(false)
 	if err != nil {
 		return nil, err
@@ -760,7 +760,7 @@ func (mgr *SettingsManager) GetSecretByName(secretName string) (*apiv1.Secret, e
 	return secretCopy, err
 }
 
-func (mgr *SettingsManager) getSecrets() ([]*apiv1.Secret, error) {
+func (mgr *SettingsManager) getSecrets() ([]*corev1.Secret, error) {
 	err := mgr.ensureSynced(false)
 	if err != nil {
 		return nil, err
@@ -1256,7 +1256,7 @@ func (mgr *SettingsManager) GetRepositories() ([]Repository, error) {
 }
 
 func (mgr *SettingsManager) SaveRepositories(repos []Repository) error {
-	return mgr.updateConfigMap(func(argoCDCM *apiv1.ConfigMap) error {
+	return mgr.updateConfigMap(func(argoCDCM *corev1.ConfigMap) error {
 		if len(repos) > 0 {
 			yamlStr, err := yaml.Marshal(repos)
 			if err != nil {
@@ -1271,7 +1271,7 @@ func (mgr *SettingsManager) SaveRepositories(repos []Repository) error {
 }
 
 func (mgr *SettingsManager) SaveRepositoryCredentials(creds []RepositoryCredentials) error {
-	return mgr.updateConfigMap(func(argoCDCM *apiv1.ConfigMap) error {
+	return mgr.updateConfigMap(func(argoCDCM *corev1.ConfigMap) error {
 		if len(creds) > 0 {
 			yamlStr, err := yaml.Marshal(creds)
 			if err != nil {
@@ -1489,7 +1489,7 @@ func (mgr *SettingsManager) ensureSynced(forceResync bool) error {
 	return mgr.initialize(ctx)
 }
 
-func getDownloadBinaryUrlsFromConfigMap(argoCDCM *apiv1.ConfigMap) map[string]string {
+func getDownloadBinaryUrlsFromConfigMap(argoCDCM *corev1.ConfigMap) map[string]string {
 	binaryUrls := map[string]string{}
 	for _, archType := range []string{"darwin-amd64", "darwin-arm64", "windows-amd64", "linux-amd64", "linux-arm64", "linux-ppc64le", "linux-s390x"} {
 		if val, ok := argoCDCM.Data[settingsBinaryUrlsKey+"."+archType]; ok {
@@ -1500,7 +1500,7 @@ func getDownloadBinaryUrlsFromConfigMap(argoCDCM *apiv1.ConfigMap) map[string]st
 }
 
 // updateSettingsFromConfigMap transfers settings from a Kubernetes configmap into an ArgoCDSettings struct.
-func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *apiv1.ConfigMap) {
+func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *corev1.ConfigMap) {
 	settings.DexConfig = argoCDCM.Data[settingDexConfigKey]
 	settings.OIDCConfigRAW = argoCDCM.Data[settingsOIDCConfigKey]
 	settings.KustomizeBuildOptions = argoCDCM.Data[kustomizeBuildOptionsKey]
@@ -1592,7 +1592,7 @@ func validateExternalURL(u string) error {
 }
 
 // updateSettingsFromSecret transfers settings from a Kubernetes secret into an ArgoCDSettings struct.
-func (mgr *SettingsManager) updateSettingsFromSecret(settings *ArgoCDSettings, argoCDSecret *apiv1.Secret, secrets []*apiv1.Secret) error {
+func (mgr *SettingsManager) updateSettingsFromSecret(settings *ArgoCDSettings, argoCDSecret *corev1.Secret, secrets []*corev1.Secret) error {
 	var errs []error
 	secretKey, ok := argoCDSecret.Data[settingServerSignatureKey]
 	if ok {
@@ -1675,7 +1675,7 @@ func (mgr *SettingsManager) externalServerTLSCertificate() (*tls.Certificate, er
 
 // SaveSettings serializes ArgoCDSettings and upserts it into K8s secret/configmap
 func (mgr *SettingsManager) SaveSettings(settings *ArgoCDSettings) error {
-	err := mgr.updateConfigMap(func(argoCDCM *apiv1.ConfigMap) error {
+	err := mgr.updateConfigMap(func(argoCDCM *corev1.ConfigMap) error {
 		if settings.URL != "" {
 			argoCDCM.Data[settingURLKey] = settings.URL
 		} else {
@@ -1710,7 +1710,7 @@ func (mgr *SettingsManager) SaveSettings(settings *ArgoCDSettings) error {
 		return err
 	}
 
-	return mgr.updateSecret(func(argoCDSecret *apiv1.Secret) error {
+	return mgr.updateSecret(func(argoCDSecret *corev1.Secret) error {
 		argoCDSecret.Data[settingServerSignatureKey] = settings.ServerSignature
 		if settings.WebhookGitHubSecret != "" {
 			argoCDSecret.Data[settingsWebhookGitHubSecretKey] = []byte(settings.WebhookGitHubSecret)

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -12,22 +12,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	testutil "github.com/argoproj/argo-cd/v2/test"
 	"github.com/argoproj/argo-cd/v2/util/test"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
-func fixtures(data map[string]string, opts ...func(secret *v1.Secret)) (*fake.Clientset, *SettingsManager) {
-	cm := &v1.ConfigMap{
+func fixtures(data map[string]string, opts ...func(secret *corev1.Secret)) (*fake.Clientset, *SettingsManager) {
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: "default",
@@ -37,7 +36,7 @@ func fixtures(data map[string]string, opts ...func(secret *v1.Secret)) (*fake.Cl
 		},
 		Data: data,
 	}
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDSecretName,
 			Namespace: "default",
@@ -57,7 +56,7 @@ func fixtures(data map[string]string, opts ...func(secret *v1.Secret)) (*fake.Cl
 }
 
 func TestDocumentedArgoCDConfigMapIsValid(t *testing.T) {
-	var argocdCM *v1.ConfigMap
+	var argocdCM *corev1.ConfigMap
 	settings := ArgoCDSettings{}
 	data, err := os.ReadFile("../../docs/operator-manual/argocd-cm.yaml")
 	require.NoError(t, err)
@@ -86,7 +85,7 @@ func TestGetConfigMapByName(t *testing.T) {
 
 func TestGetSecretByName(t *testing.T) {
 	t.Run("data is never nil", func(t *testing.T) {
-		_, settingsManager := fixtures(nil, func(secret *v1.Secret) { secret.Data = nil })
+		_, settingsManager := fixtures(nil, func(secret *corev1.Secret) { secret.Data = nil })
 		secret, err := settingsManager.GetSecretByName(common.ArgoCDSecretName)
 		require.NoError(t, err)
 		assert.NotNil(t, secret.Data)
@@ -235,7 +234,7 @@ func TestInClusterServerAddressEnabled(t *testing.T) {
 
 func TestInClusterServerAddressEnabledByDefault(t *testing.T) {
 	kubeClient := fake.NewClientset(
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: "default",
@@ -245,7 +244,7 @@ func TestInClusterServerAddressEnabledByDefault(t *testing.T) {
 			},
 			Data: map[string]string{},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDSecretName,
 				Namespace: "default",
@@ -957,7 +956,7 @@ func TestSettingsManager_GetHelp(t *testing.T) {
 func TestSettingsManager_GetSettings(t *testing.T) {
 	t.Run("UserSessionDurationNotProvided", func(t *testing.T) {
 		kubeClient := fake.NewClientset(
-			&v1.ConfigMap{
+			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -967,7 +966,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 				},
 				Data: nil,
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -987,7 +986,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 	})
 	t.Run("UserSessionDurationInvalidFormat", func(t *testing.T) {
 		kubeClient := fake.NewClientset(
-			&v1.ConfigMap{
+			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -999,7 +998,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 					"users.session.duration": "10hh",
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1019,7 +1018,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 	})
 	t.Run("UserSessionDurationProvided", func(t *testing.T) {
 		kubeClient := fake.NewClientset(
-			&v1.ConfigMap{
+			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -1031,7 +1030,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 					"users.session.duration": "10h",
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1053,7 +1052,7 @@ func TestSettingsManager_GetSettings(t *testing.T) {
 
 func TestGetOIDCConfig(t *testing.T) {
 	kubeClient := fake.NewClientset(
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: "default",
@@ -1065,7 +1064,7 @@ func TestGetOIDCConfig(t *testing.T) {
 				"oidc.config": "\n  requestedIDTokenClaims: {\"groups\": {\"essential\": true}}\n",
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDSecretName,
 				Namespace: "default",
@@ -1133,7 +1132,7 @@ func Test_validateExternalURL(t *testing.T) {
 
 func TestGetOIDCSecretTrim(t *testing.T) {
 	kubeClient := fake.NewClientset(
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: "default",
@@ -1145,7 +1144,7 @@ func TestGetOIDCSecretTrim(t *testing.T) {
 				"oidc.config": "\n  name: Okta\n  clientSecret: test-secret\r\n \n  clientID: aaaabbbbccccddddeee\n",
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.ArgoCDSecretName,
 				Namespace: "default",
@@ -1179,7 +1178,7 @@ func getCNFromCertificate(cert *tls.Certificate) string {
 func Test_GetTLSConfiguration(t *testing.T) {
 	t.Run("Valid external TLS secret with success", func(t *testing.T) {
 		kubeClient := fake.NewClientset(
-			&v1.ConfigMap{
+			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -1191,7 +1190,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 					"oidc.config": "\n  name: Okta\n  clientSecret: test-secret\r\n \n  clientID: aaaabbbbccccddddeee\n",
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1204,7 +1203,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 					"server.secretkey": nil,
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      externalServerTLSSecretName,
 					Namespace: "default",
@@ -1225,7 +1224,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 
 	t.Run("Valid external TLS secret overrides argocd-secret", func(t *testing.T) {
 		kubeClient := fake.NewClientset(
-			&v1.ConfigMap{
+			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -1237,7 +1236,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 					"oidc.config": "\n  name: Okta\n  clientSecret: test-secret\r\n \n  clientID: aaaabbbbccccddddeee\n",
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1252,7 +1251,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 					"tls.key":          []byte(testutil.MustLoadFileToString("../../test/fixture/certs/argocd-e2e-server.key")),
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      externalServerTLSSecretName,
 					Namespace: "default",
@@ -1272,7 +1271,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 	})
 	t.Run("Invalid external TLS secret", func(t *testing.T) {
 		kubeClient := fake.NewClientset(
-			&v1.ConfigMap{
+			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -1284,7 +1283,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 					"oidc.config": "\n  name: Okta\n  clientSecret: test-secret\r\n \n  clientID: aaaabbbbccccddddeee\n",
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1297,7 +1296,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 					"server.secretkey": nil,
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      externalServerTLSSecretName,
 					Namespace: "default",
@@ -1315,7 +1314,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 	})
 	t.Run("No external TLS secret", func(t *testing.T) {
 		kubeClient := fake.NewClientset(
-			&v1.ConfigMap{
+			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -1327,7 +1326,7 @@ func Test_GetTLSConfiguration(t *testing.T) {
 					"oidc.config": "\n  name: Okta\n  clientSecret: test-secret\r\n \n  clientID: aaaabbbbccccddddeee\n",
 				},
 			},
-			&v1.Secret{
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1386,7 +1385,7 @@ requestedScopes: ["openid", "profile", "email"]
 # Optional set of OIDC claims to request on the ID token.
 requestedIDTokenClaims: {"groups": {"essential": true}}`,
 	}
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: "default",
@@ -1396,7 +1395,7 @@ requestedIDTokenClaims: {"groups": {"essential": true}}`,
 		},
 		Data: data,
 	}
-	argocdSecret := &v1.Secret{
+	argocdSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ArgoCDSecretName,
 			Namespace: "default",
@@ -1407,7 +1406,7 @@ requestedIDTokenClaims: {"groups": {"essential": true}}`,
 			"webhook.github.secret": []byte("$ext:webhook.github.secret"),
 		},
 	}
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ext",
 			Namespace: "default",
@@ -1458,7 +1457,7 @@ func TestGetEnableManifestGeneration(t *testing.T) {
 	for i := range testCases {
 		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
-			cm := &v1.ConfigMap{
+			cm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -1468,7 +1467,7 @@ func TestGetEnableManifestGeneration(t *testing.T) {
 				},
 				Data: tc.data,
 			}
-			argocdSecret := &v1.Secret{
+			argocdSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1516,7 +1515,7 @@ func TestGetHelmSettings(t *testing.T) {
 	for i := range testCases {
 		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
-			cm := &v1.ConfigMap{
+			cm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDConfigMapName,
 					Namespace: "default",
@@ -1526,7 +1525,7 @@ func TestGetHelmSettings(t *testing.T) {
 				},
 				Data: tc.data,
 			}
-			argocdSecret := &v1.Secret{
+			argocdSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDSecretName,
 					Namespace: "default",
@@ -1536,7 +1535,7 @@ func TestGetHelmSettings(t *testing.T) {
 					"server.secretkey": nil,
 				},
 			}
-			secret := &v1.Secret{
+			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "acme",
 					Namespace: "default",

--- a/util/util.go
+++ b/util/util.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // MakeSignature generates a cryptographically-secure pseudo-random token, based on a given number of random bytes, for signing purposes.
@@ -23,8 +23,8 @@ func MakeSignature(size int) ([]byte, error) {
 //
 // This function takes a slice of pointers to Secrets and returns a new slice
 // containing deep copies of the original secrets.
-func SecretCopy(secrets []*apiv1.Secret) []*apiv1.Secret {
-	secretsCopy := make([]*apiv1.Secret, len(secrets))
+func SecretCopy(secrets []*corev1.Secret) []*corev1.Secret {
+	secretsCopy := make([]*corev1.Secret, len(secrets))
 	for i, secret := range secrets {
 		secretsCopy[i] = secret.DeepCopy()
 	}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/util"
@@ -44,31 +44,31 @@ func TestParseRevision(t *testing.T) {
 
 func TestSecretCopy(t *testing.T) {
 	type args struct {
-		secrets []*apiv1.Secret
+		secrets []*corev1.Secret
 	}
 	tests := []struct {
 		name string
 		args args
-		want []*apiv1.Secret
+		want []*corev1.Secret
 	}{
-		{name: "nil", args: args{secrets: nil}, want: []*apiv1.Secret{}},
+		{name: "nil", args: args{secrets: nil}, want: []*corev1.Secret{}},
 		{
-			name: "Three", args: args{secrets: []*apiv1.Secret{
+			name: "Three", args: args{secrets: []*corev1.Secret{
 				{ObjectMeta: metav1.ObjectMeta{Name: "one"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "two"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "three"}},
 			}},
-			want: []*apiv1.Secret{
+			want: []*corev1.Secret{
 				{ObjectMeta: metav1.ObjectMeta{Name: "one"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "two"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "three"}},
 			},
 		},
 		{
-			name: "One", args: args{secrets: []*apiv1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "one"}}}},
-			want: []*apiv1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "one"}}},
+			name: "One", args: args{secrets: []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "one"}}}},
+			want: []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "one"}}},
 		},
-		{name: "Zero", args: args{secrets: []*apiv1.Secret{}}, want: []*apiv1.Secret{}},
+		{name: "Zero", args: args{secrets: []*corev1.Secret{}}, want: []*corev1.Secret{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### Description 

[Importas](https://golangci-lint.run/usage/linters/#importas) helps ensure consistency of imports aliases.

This defines `corev1` as alias for  `k8s.io/apimachinery/pkg/api/errors`