### PR TITLE
chore: add script to bump major version

### DIFF
--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           set -ue
           CURRENT_VERSION=$(grep 'module github.com/argoproj/argo-cd' go.mod | awk '{print $2}' | sed 's/.*\/v//')
-          echo "::set-output name=MAJOR_VERSION::$CURRENT_VERSION"
+          echo "MAJOR_VERSION=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Run script to bump the version
         run: |

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -19,12 +19,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Get the current major version from go.mod and save it as a variable.
-      - name: Get current major version
-        id: get-current-major-version
+      - name: Get target version
+        id: get-target-version
         run: |
           set -ue
           CURRENT_VERSION=$(grep 'module github.com/argoproj/argo-cd' go.mod | awk '{print $2}' | sed 's/.*\/v//')
-          echo "MAJOR_VERSION=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "TARGET_VERSION=$((CURRENT_VERSION + 1))" >> $GITHUB_OUTPUT
 
       - name: Run script to bump the version
         run: |
@@ -33,10 +33,10 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
-          commit-message: "Bump major version to ${{ steps.get-current-major-version.outputs.MAJOR_VERSION }}"
-          title: "Bump major version to ${{ steps.get-current-major-version.outputs.MAJOR_VERSION }}"
+          commit-message: "Bump major version to ${{ steps.get-target-version.outputs.TARGET_VERSION }}"
+          title: "Bump major version to ${{ steps.get-target-version.outputs.TARGET_VERSION }}"
           body: |
-            Congrats! You've just bumped the major version to ${{ steps.get-current-major-version.outputs.MAJOR_VERSION }}.
+            Congrats! You've just bumped the major version to ${{ steps.get-target-version.outputs.TARGET_VERSION }}.
             
             Next steps:
             - [ ] Merge this PR

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -1,0 +1,33 @@
+name: Bump major version
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  prepare-release:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    name: Automatically update major version
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694  # v4.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run script to bump the version
+        run: |
+          hack/bump-major-version.sh
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
+        with:
+          commit-message: "Bump major version"
+          title: "Bump major version"
+          body: Bumping major version
+          branch: bump-major-version
+          branch-suffix: random
+          signoff: true

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -18,6 +18,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Get the current major version from go.mod and save it as a variable.
+      - name: Get current major version
+        id: get-current-major-version
+        run: |
+          set -ue
+          CURRENT_VERSION=$(grep 'module github.com/argoproj/argo-cd' go.mod | awk '{print $2}' | sed 's/.*\/v//')
+          echo "::set-output name=MAJOR_VERSION::$CURRENT_VERSION"
+
       - name: Run script to bump the version
         run: |
           hack/bump-major-version.sh
@@ -25,9 +33,14 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
-          commit-message: "Bump major version"
-          title: "Bump major version"
-          body: Bumping major version
+          commit-message: "Bump major version to ${{ steps.get-current-major-version.outputs.MAJOR_VERSION }}"
+          title: "Bump major version to ${{ steps.get-current-major-version.outputs.MAJOR_VERSION }}"
+          body: |
+            Congrats! You've just bumped the major version to ${{ steps.get-current-major-version.outputs.MAJOR_VERSION }}.
+            
+            Next steps:
+            - [ ] Merge this PR
+            - [ ] Add an upgrade guide to the docs for this version
           branch: bump-major-version
           branch-suffix: random
           signoff: true

--- a/hack/bump-major-version.sh
+++ b/hack/bump-major-version.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
 # This script bumps the major version of Argo CD. Before cutting a new major release, run this script and open a PR.
-# If you have to make _any_ manual changes to the PR, this script should be updated to automate those.
-
-# This script is intended to be run from the root of the repository.
 
 # Get the current version from go.mod.
 CURRENT_VERSION=$(grep 'module github.com/argoproj/argo-cd' go.mod | awk '{print $2}' | sed 's/.*\/v//')


### PR DESCRIPTION
The PR for bumping major versions touches hundreds of files. To ease the review process, I want a script we can run and be confident that the only changes are the ones made by the script.

I've validated the script by running it locally, then running codegen, lint, and unit tests.

You can see an example of the generated PR here: https://github.com/crenshaw-dev/argo-cd/pull/30