### PR TITLE
chore: enable context-as-argument from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,7 +92,10 @@ linters-settings:
         disabled: true
       # context.Context() should be the first parameter of a function when provided as argument.
       - name: context-as-argument
-        disabled: true
+        disabled: false
+        arguments:
+          # Allow functions with test or bench signatures.
+          - allowTypesBefore: "*testing.T,testing.TB"
       # Basic types should not be used as a key in `context.WithValue`
       - name: context-keys-type
         disabled: true

--- a/applicationset/controllers/requeue_after_test.go
+++ b/applicationset/controllers/requeue_after_test.go
@@ -60,7 +60,7 @@ func TestRequeueAfter(t *testing.T) {
 	scmConfig := generators.NewSCMConfig("", []string{""}, true, nil, true)
 	terminalGenerators := map[string]generators.Generator{
 		"List":                    generators.NewListGenerator(),
-		"Clusters":                generators.NewClusterGenerator(k8sClient, ctx, appClientset, "argocd"),
+		"Clusters":                generators.NewClusterGenerator(ctx, k8sClient, appClientset, "argocd"),
 		"Git":                     generators.NewGitGenerator(mockServer, "namespace"),
 		"SCMProvider":             generators.NewSCMProviderGenerator(fake.NewClientBuilder().WithObjects(&corev1.Secret{}).Build(), scmConfig),
 		"ClusterDecisionResource": generators.NewDuckTypeGenerator(ctx, fakeDynClient, appClientset, "argocd"),

--- a/applicationset/generators/cluster.go
+++ b/applicationset/generators/cluster.go
@@ -33,7 +33,7 @@ type ClusterGenerator struct {
 
 var render = &utils.Render{}
 
-func NewClusterGenerator(c client.Client, ctx context.Context, clientset kubernetes.Interface, namespace string) Generator {
+func NewClusterGenerator(ctx context.Context, c client.Client, clientset kubernetes.Interface, namespace string) Generator {
 	settingsManager := settings.NewSettingsManager(ctx, clientset, namespace)
 
 	g := &ClusterGenerator{

--- a/applicationset/generators/cluster_test.go
+++ b/applicationset/generators/cluster_test.go
@@ -315,7 +315,7 @@ func TestGenerateParams(t *testing.T) {
 				testCase.clientError,
 			}
 
-			clusterGenerator := NewClusterGenerator(cl, context.Background(), appClientset, "namespace")
+			clusterGenerator := NewClusterGenerator(context.Background(), cl, appClientset, "namespace")
 
 			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -853,7 +853,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 				testCase.clientError,
 			}
 
-			clusterGenerator := NewClusterGenerator(cl, context.Background(), appClientset, "namespace")
+			clusterGenerator := NewClusterGenerator(context.Background(), cl, appClientset, "namespace")
 
 			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/applicationset/generators/generator_spec_processor_test.go
+++ b/applicationset/generators/generator_spec_processor_test.go
@@ -342,7 +342,7 @@ func getMockClusterGenerator() Generator {
 	appClientset := kubefake.NewSimpleClientset(runtimeClusters...)
 
 	fakeClient := fake.NewClientBuilder().WithObjects(clusters...).Build()
-	return NewClusterGenerator(fakeClient, context.Background(), appClientset, "namespace")
+	return NewClusterGenerator(context.Background(), fakeClient, appClientset, "namespace")
 }
 
 func getMockGitGenerator() Generator {

--- a/applicationset/generators/matrix_test.go
+++ b/applicationset/generators/matrix_test.go
@@ -644,7 +644,7 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 				fakeClient,
 				testCase.clientError,
 			}
-			clusterGenerator := NewClusterGenerator(cl, context.Background(), appClientset, "namespace")
+			clusterGenerator := NewClusterGenerator(context.Background(), cl, appClientset, "namespace")
 
 			for _, g := range testCaseCopy.baseGenerators {
 				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{
@@ -827,7 +827,7 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 				fakeClient,
 				testCase.clientError,
 			}
-			clusterGenerator := NewClusterGenerator(cl, context.Background(), appClientset, "namespace")
+			clusterGenerator := NewClusterGenerator(context.Background(), cl, appClientset, "namespace")
 
 			for _, g := range testCaseCopy.baseGenerators {
 				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{

--- a/applicationset/generators/plugin.go
+++ b/applicationset/generators/plugin.go
@@ -32,7 +32,7 @@ type PluginGenerator struct {
 	namespace string
 }
 
-func NewPluginGenerator(client client.Client, ctx context.Context, clientset kubernetes.Interface, namespace string) Generator {
+func NewPluginGenerator(ctx context.Context, client client.Client, clientset kubernetes.Interface, namespace string) Generator {
 	g := &PluginGenerator{
 		client:    client,
 		ctx:       ctx,

--- a/applicationset/generators/plugin_test.go
+++ b/applicationset/generators/plugin_test.go
@@ -671,7 +671,7 @@ func TestPluginGenerateParams(t *testing.T) {
 
 			fakeClientWithCache := fake.NewClientBuilder().WithObjects([]client.Object{testCase.configmap, testCase.secret}...).Build()
 
-			pluginGenerator := NewPluginGenerator(fakeClientWithCache, ctx, fakeClient, "default")
+			pluginGenerator := NewPluginGenerator(ctx, fakeClientWithCache, fakeClient, "default")
 
 			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/applicationset/generators/utils.go
+++ b/applicationset/generators/utils.go
@@ -13,12 +13,12 @@ import (
 func GetGenerators(ctx context.Context, c client.Client, k8sClient kubernetes.Interface, namespace string, argoCDService services.Repos, dynamicClient dynamic.Interface, scmConfig SCMConfig) map[string]Generator {
 	terminalGenerators := map[string]Generator{
 		"List":                    NewListGenerator(),
-		"Clusters":                NewClusterGenerator(c, ctx, k8sClient, namespace),
+		"Clusters":                NewClusterGenerator(ctx, c, k8sClient, namespace),
 		"Git":                     NewGitGenerator(argoCDService, namespace),
 		"SCMProvider":             NewSCMProviderGenerator(c, scmConfig),
 		"ClusterDecisionResource": NewDuckTypeGenerator(ctx, dynamicClient, k8sClient, namespace),
 		"PullRequest":             NewPullRequestGenerator(c, scmConfig),
-		"Plugin":                  NewPluginGenerator(c, ctx, k8sClient, namespace),
+		"Plugin":                  NewPluginGenerator(ctx, c, k8sClient, namespace),
 	}
 
 	nestedGenerators := map[string]Generator{

--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -84,7 +84,7 @@ func NewApplicationResourceActionsListCommand(clientOpts *argocdclient.ClientOpt
 		appName, appNs := argo.ParseFromQualifiedName(args[0], "")
 		conn, appIf := headless.NewClientOrDie(clientOpts, c).NewApplicationClientOrDie()
 		defer io.Close(conn)
-		resources, err := getActionableResourcesForApplication(appIf, ctx, &appNs, &appName)
+		resources, err := getActionableResourcesForApplication(ctx, appIf, &appNs, &appName)
 		errors.CheckError(err)
 		filteredObjects, err := util.FilterResources(command.Flags().Changed("group"), resources, group, kind, namespace, resourceName, true)
 		errors.CheckError(err)
@@ -176,7 +176,7 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 
 		conn, appIf := headless.NewClientOrDie(clientOpts, c).NewApplicationClientOrDie()
 		defer io.Close(conn)
-		resources, err := getActionableResourcesForApplication(appIf, ctx, &appNs, &appName)
+		resources, err := getActionableResourcesForApplication(ctx, appIf, &appNs, &appName)
 		errors.CheckError(err)
 		filteredObjects, err := util.FilterResources(command.Flags().Changed("group"), resources, group, kind, namespace, resourceName, all)
 		errors.CheckError(err)
@@ -207,7 +207,7 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 	return command
 }
 
-func getActionableResourcesForApplication(appIf applicationpkg.ApplicationServiceClient, ctx context.Context, appNs *string, appName *string) ([]*v1alpha1.ResourceDiff, error) {
+func getActionableResourcesForApplication(ctx context.Context, appIf applicationpkg.ApplicationServiceClient, appNs *string, appName *string) ([]*v1alpha1.ResourceDiff, error) {
 	resources, err := appIf.ManagedResources(ctx, &applicationpkg.ResourcesQuery{
 		ApplicationName: appName,
 		AppNamespace:    appNs,

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -1024,7 +1024,7 @@ func NewProjectGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 				os.Exit(1)
 			}
 			projName := args[0]
-			detailedProject := getProject(c, clientOpts, ctx, projName)
+			detailedProject := getProject(ctx, c, clientOpts, projName)
 
 			switch output {
 			case "yaml", "json":
@@ -1041,7 +1041,7 @@ func NewProjectGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 	return command
 }
 
-func getProject(c *cobra.Command, clientOpts *argocdclient.ClientOptions, ctx context.Context, projName string) *projectpkg.DetailedProjectsResponse {
+func getProject(ctx context.Context, c *cobra.Command, clientOpts *argocdclient.ClientOptions, projName string) *projectpkg.DetailedProjectsResponse {
 	conn, projIf := headless.NewClientOrDie(clientOpts, c).NewProjectClientOrDie()
 	defer argoio.Close(conn)
 	detailedProject, err := projIf.GetDetailedProject(ctx, &projectpkg.ProjectQuery{Name: projName})

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -174,7 +174,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		}
 	}
 
-	proj, err := argo.GetAppProject(app, listersv1alpha1.NewAppProjectLister(m.projInformer.GetIndexer()), m.namespace, m.settingsMgr, m.db, context.TODO())
+	proj, err := argo.GetAppProject(context.TODO(), app, listersv1alpha1.NewAppProjectLister(m.projInformer.GetIndexer()), m.namespace, m.settingsMgr, m.db)
 	if err != nil {
 		state.Phase = common.OperationError
 		state.Message = fmt.Sprintf("Failed to load application project: %v", err)

--- a/server/applicationset/applicationset_test.go
+++ b/server/applicationset/applicationset_test.go
@@ -528,7 +528,7 @@ func TestUpdateAppSet(t *testing.T) {
 	t.Run("Update merge", func(t *testing.T) {
 		appServer := newTestAppSetServer(appSet)
 
-		updated, err := appServer.updateAppSet(appSet, newAppSet, context.Background(), true)
+		updated, err := appServer.updateAppSet(context.Background(), appSet, newAppSet, true)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
@@ -544,7 +544,7 @@ func TestUpdateAppSet(t *testing.T) {
 	t.Run("Update no merge", func(t *testing.T) {
 		appServer := newTestAppSetServer(appSet)
 
-		updated, err := appServer.updateAppSet(appSet, newAppSet, context.Background(), false)
+		updated, err := appServer.updateAppSet(context.Background(), appSet, newAppSet, false)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -361,12 +361,12 @@ func (s *Server) Delete(ctx context.Context, q *cluster.ClusterQuery) (*cluster.
 			return nil, common.PermissionDeniedAPIError
 		}
 		for _, server := range servers {
-			if err := enforceAndDelete(s, ctx, server, c.Project); err != nil {
+			if err := enforceAndDelete(ctx, s, server, c.Project); err != nil {
 				return nil, fmt.Errorf("failed to enforce and delete cluster server: %w", err)
 			}
 		}
 	} else {
-		if err := enforceAndDelete(s, ctx, q.Server, c.Project); err != nil {
+		if err := enforceAndDelete(ctx, s, q.Server, c.Project); err != nil {
 			return nil, fmt.Errorf("failed to enforce and delete cluster server: %w", err)
 		}
 	}
@@ -374,7 +374,7 @@ func (s *Server) Delete(ctx context.Context, q *cluster.ClusterQuery) (*cluster.
 	return &cluster.ClusterResponse{}, nil
 }
 
-func enforceAndDelete(s *Server, ctx context.Context, server, project string) error {
+func enforceAndDelete(ctx context.Context, s *Server, server, project string) error {
 	if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceClusters, rbacpolicy.ActionDelete, CreateClusterRBACObject(project, server)); err != nil {
 		log.WithField("cluster", server).Warnf("encountered permissions issue while processing request: %v", err)
 		return common.PermissionDeniedAPIError

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -157,7 +157,7 @@ func (s *Server) createToken(ctx context.Context, q *project.ProjectTokenCreateR
 	if err != nil {
 		return nil, err
 	}
-	s.logEvent(prj, ctx, argo.EventReasonResourceCreated, "created token")
+	s.logEvent(ctx, prj, argo.EventReasonResourceCreated, "created token")
 	return &project.ProjectTokenResponse{Token: jwtToken}, nil
 }
 
@@ -241,7 +241,7 @@ func (s *Server) deleteToken(ctx context.Context, q *project.ProjectTokenDeleteR
 	if err != nil {
 		return nil, err
 	}
-	s.logEvent(prj, ctx, argo.EventReasonResourceDeleted, "deleted token")
+	s.logEvent(ctx, prj, argo.EventReasonResourceDeleted, "deleted token")
 
 	return &project.EmptyResponse{}, nil
 }
@@ -279,7 +279,7 @@ func (s *Server) Create(ctx context.Context, q *project.ProjectCreateRequest) (*
 		}
 	}
 	if err == nil {
-		s.logEvent(res, ctx, argo.EventReasonResourceCreated, "created project")
+		s.logEvent(ctx, res, argo.EventReasonResourceCreated, "created project")
 	}
 	return res, err
 }
@@ -305,7 +305,7 @@ func (s *Server) GetDetailedProject(ctx context.Context, q *project.ProjectQuery
 	if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceProjects, rbacpolicy.ActionGet, q.Name); err != nil {
 		return nil, err
 	}
-	proj, repositories, clusters, err := argo.GetAppProjectWithScopedResources(q.Name, listersv1alpha1.NewAppProjectLister(s.projInformer.GetIndexer()), s.ns, s.settingsMgr, s.db, ctx)
+	proj, repositories, clusters, err := argo.GetAppProjectWithScopedResources(ctx, q.Name, listersv1alpha1.NewAppProjectLister(s.projInformer.GetIndexer()), s.ns, s.settingsMgr, s.db)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +439,7 @@ func (s *Server) Update(ctx context.Context, q *project.ProjectUpdateRequest) (*
 
 	res, err := s.appclientset.ArgoprojV1alpha1().AppProjects(s.ns).Update(ctx, q.Project, metav1.UpdateOptions{})
 	if err == nil {
-		s.logEvent(res, ctx, argo.EventReasonResourceUpdated, "updated project")
+		s.logEvent(ctx, res, argo.EventReasonResourceUpdated, "updated project")
 	}
 	return res, err
 }
@@ -471,7 +471,7 @@ func (s *Server) Delete(ctx context.Context, q *project.ProjectQuery) (*project.
 	}
 	err = s.appclientset.ArgoprojV1alpha1().AppProjects(s.ns).Delete(ctx, q.Name, metav1.DeleteOptions{})
 	if err == nil {
-		s.logEvent(p, ctx, argo.EventReasonResourceDeleted, "deleted project")
+		s.logEvent(ctx, p, argo.EventReasonResourceDeleted, "deleted project")
 	}
 	return &project.EmptyResponse{}, err
 }
@@ -492,7 +492,7 @@ func (s *Server) ListEvents(ctx context.Context, q *project.ProjectQuery) (*core
 	return s.kubeclientset.CoreV1().Events(s.ns).List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
 }
 
-func (s *Server) logEvent(a *v1alpha1.AppProject, ctx context.Context, reason string, action string) {
+func (s *Server) logEvent(ctx context.Context, a *v1alpha1.AppProject, reason string, action string) {
 	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -752,7 +752,7 @@ func (s *Server) testRepo(ctx context.Context, repo *v1alpha1.Repository) error 
 }
 
 func (s *Server) isRepoPermittedInProject(ctx context.Context, repo string, projName string) error {
-	proj, err := argo.GetAppProjectByName(projName, applisters.NewAppProjectLister(s.projLister.GetIndexer()), s.namespace, s.settings, s.db, ctx)
+	proj, err := argo.GetAppProjectByName(ctx, projName, applisters.NewAppProjectLister(s.projLister.GetIndexer()), s.namespace, s.settings, s.db)
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1196,19 +1196,19 @@ func (a *ArgoCDServer) newHTTPServer(ctx context.Context, port int, grpcWebHandl
 		registerExtensions(mux, a, metricsReg)
 	}
 
-	mustRegisterGWHandler(versionpkg.RegisterVersionServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(clusterpkg.RegisterClusterServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(applicationpkg.RegisterApplicationServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(applicationsetpkg.RegisterApplicationSetServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(notificationpkg.RegisterNotificationServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(repositorypkg.RegisterRepositoryServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(repocredspkg.RegisterRepoCredsServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(sessionpkg.RegisterSessionServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(settingspkg.RegisterSettingsServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(projectpkg.RegisterProjectServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(accountpkg.RegisterAccountServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(certificatepkg.RegisterCertificateServiceHandler, ctx, gwmux, conn)
-	mustRegisterGWHandler(gpgkeypkg.RegisterGPGKeyServiceHandler, ctx, gwmux, conn)
+	mustRegisterGWHandler(ctx, versionpkg.RegisterVersionServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, clusterpkg.RegisterClusterServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, applicationpkg.RegisterApplicationServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, applicationsetpkg.RegisterApplicationSetServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, notificationpkg.RegisterNotificationServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, repositorypkg.RegisterRepositoryServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, repocredspkg.RegisterRepoCredsServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, sessionpkg.RegisterSessionServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, settingspkg.RegisterSettingsServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, projectpkg.RegisterProjectServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, accountpkg.RegisterAccountServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, certificatepkg.RegisterCertificateServiceHandler, gwmux, conn)
+	mustRegisterGWHandler(ctx, gpgkeypkg.RegisterGPGKeyServiceHandler, gwmux, conn)
 
 	// Swagger UI
 	swagger.ServeSwaggerUI(mux, assets.SwaggerJSON, "/swagger-ui", a.RootPath)
@@ -1458,7 +1458,7 @@ func isMainJsBundle(url *url.URL) bool {
 type registerFunc func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error
 
 // mustRegisterGWHandler is a convenience function to register a gateway handler
-func mustRegisterGWHandler(register registerFunc, ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) {
+func mustRegisterGWHandler(ctx context.Context, register registerFunc, mux *runtime.ServeMux, conn *grpc.ClientConn) {
 	err := register(ctx, mux, conn)
 	if err != nil {
 		panic(err)

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -692,7 +692,7 @@ func APIResourcesToStrings(resources []kube.APIResourceInfo, includeKinds bool) 
 }
 
 // GetAppProjectWithScopedResources returns a project from an application with scoped resources
-func GetAppProjectWithScopedResources(name string, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB, ctx context.Context) (*argoappv1.AppProject, argoappv1.Repositories, []*argoappv1.Cluster, error) {
+func GetAppProjectWithScopedResources(ctx context.Context, name string, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) (*argoappv1.AppProject, argoappv1.Repositories, []*argoappv1.Cluster, error) {
 	projOrig, err := projLister.AppProjects(ns).Get(name)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error getting app project %q: %w", name, err)
@@ -715,7 +715,7 @@ func GetAppProjectWithScopedResources(name string, projLister applicationsv1.App
 }
 
 // GetAppProjectByName returns a project from an application based on name
-func GetAppProjectByName(name string, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB, ctx context.Context) (*argoappv1.AppProject, error) {
+func GetAppProjectByName(ctx context.Context, name string, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) (*argoappv1.AppProject, error) {
 	projOrig, err := projLister.AppProjects(ns).Get(name)
 	if err != nil {
 		return nil, fmt.Errorf("error getting app project %q: %w", name, err)
@@ -746,8 +746,8 @@ func GetAppProjectByName(name string, projLister applicationsv1.AppProjectLister
 
 // GetAppProject returns a project from an application. It will also ensure
 // that the application is allowed to use the project.
-func GetAppProject(app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB, ctx context.Context) (*argoappv1.AppProject, error) {
-	proj, err := GetAppProjectByName(app.Spec.GetProject(), projLister, ns, settingsManager, db, ctx)
+func GetAppProject(ctx context.Context, app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) (*argoappv1.AppProject, error) {
+	proj, err := GetAppProjectByName(ctx, app.Spec.GetProject(), projLister, ns, settingsManager, db)
 	if err != nil {
 		return nil, err
 	}
@@ -1214,7 +1214,7 @@ func IsValidContainerName(name string) bool {
 // If matched, the corresponding labels are returned to be added to the generated event. In case of a conflict
 // between labels on the Application and AppProject, the Application label values are prioritized and added to the event.
 // Furthermore, labels specified in `resource.excludeEventLabelKeys` in argocd-cm are removed from the event labels, if they were included.
-func GetAppEventLabels(app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB, ctx context.Context) map[string]string {
+func GetAppEventLabels(ctx context.Context, app *argoappv1.Application, projLister applicationsv1.AppProjectLister, ns string, settingsManager *settings.SettingsManager, db db.ArgoDB) map[string]string {
 	eventLabels := make(map[string]string)
 
 	// Get all app & app-project labels
@@ -1222,7 +1222,7 @@ func GetAppEventLabels(app *argoappv1.Application, projLister applicationsv1.App
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	proj, err := GetAppProject(app, projLister, ns, settingsManager, db, ctx)
+	proj, err := GetAppProject(ctx, app, projLister, ns, settingsManager, db)
 	if err == nil {
 		for k, v := range proj.Labels {
 			_, found := labels[k]

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -81,7 +81,7 @@ func TestGetAppProjectWithNoProjDefined(t *testing.T) {
 	kubeClient := fake.NewClientset(&cm)
 	settingsMgr := settings.NewSettingsManager(context.Background(), kubeClient, test.FakeArgoCDNamespace)
 	argoDB := db.NewDB("default", settingsMgr, kubeClient)
-	proj, err := GetAppProject(&testApp, applisters.NewAppProjectLister(informer.GetIndexer()), namespace, settingsMgr, argoDB, ctx)
+	proj, err := GetAppProject(ctx, &testApp, applisters.NewAppProjectLister(informer.GetIndexer()), namespace, settingsMgr, argoDB)
 	require.NoError(t, err)
 	assert.Equal(t, proj.Name, projName)
 }
@@ -1699,7 +1699,7 @@ func TestGetAppEventLabels(t *testing.T) {
 			settingsMgr := settings.NewSettingsManager(context.Background(), kubeClient, test.FakeArgoCDNamespace)
 			argoDB := db.NewDB("default", settingsMgr, kubeClient)
 
-			eventLabels := GetAppEventLabels(&app, applisters.NewAppProjectLister(informer.GetIndexer()), test.FakeArgoCDNamespace, settingsMgr, argoDB, ctx)
+			eventLabels := GetAppEventLabels(ctx, &app, applisters.NewAppProjectLister(informer.GetIndexer()), test.FakeArgoCDNamespace, settingsMgr, argoDB)
 			assert.Equal(t, len(tt.expectedEventLabels), len(eventLabels))
 			for ek, ev := range tt.expectedEventLabels {
 				v, found := eventLabels[ek]

--- a/util/grpc/logging.go
+++ b/util/grpc/logging.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func logRequest(entry *logrus.Entry, info string, pbMsg any, ctx context.Context, logClaims bool) {
+func logRequest(ctx context.Context, entry *logrus.Entry, info string, pbMsg any, logClaims bool) {
 	if logClaims {
 		claims := ctx.Value("claims")
 		mapClaims, ok := claims.(jwt.MapClaims)
@@ -65,7 +65,7 @@ func (l *loggingServerStream) SendMsg(m any) error {
 func (l *loggingServerStream) RecvMsg(m any) error {
 	err := l.ServerStream.RecvMsg(m)
 	if err == nil {
-		logRequest(l.entry, l.info, m, l.ServerStream.Context(), l.logClaims)
+		logRequest(l.ServerStream.Context(), l.entry, l.info, m, l.logClaims)
 	}
 	return err
 }
@@ -87,7 +87,7 @@ func PayloadUnaryServerInterceptor(entry *logrus.Entry, logClaims bool, decider 
 			return handler(ctx, req)
 		}
 		logEntry := entry.WithFields(ctx_logrus.Extract(ctx).Data)
-		logRequest(logEntry, "received unary call "+info.FullMethod, req, ctx, logClaims)
+		logRequest(ctx, logEntry, "received unary call "+info.FullMethod, req, logClaims)
 		resp, err := handler(ctx, req)
 		return resp, err
 	}

--- a/util/kube/util.go
+++ b/util/kube/util.go
@@ -21,7 +21,7 @@ type kubeUtil struct {
 type updateFn func(s *corev1.Secret, new bool) error
 
 // NewKubeUtil NewUtil returns a new kubeUtil receiver
-func NewKubeUtil(client kubernetes.Interface, ctx context.Context) *kubeUtil {
+func NewKubeUtil(ctx context.Context, client kubernetes.Interface) *kubeUtil {
 	return &kubeUtil{client: client, ctx: ctx}
 }
 

--- a/util/kube/util_test.go
+++ b/util/kube/util_test.go
@@ -50,7 +50,7 @@ func Test_CreateOrUpdateSecretField(t *testing.T) {
 	client := fake.NewClientset(secret)
 
 	t.Run("Change field in existing secret", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO())
+		ku := NewKubeUtil(context.TODO(), client)
 		err := ku.CreateOrUpdateSecretField("test", "test-secret", "password", "barfoo")
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "test-secret")
@@ -65,7 +65,7 @@ func Test_CreateOrUpdateSecretField(t *testing.T) {
 	})
 
 	t.Run("Change field in non-existing secret", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO())
+		ku := NewKubeUtil(context.TODO(), client)
 		err := ku.CreateOrUpdateSecretField("test", "nonexist-secret", "password", "foobaz")
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "nonexist-secret")
@@ -80,7 +80,7 @@ func Test_CreateOrUpdateSecretField(t *testing.T) {
 	})
 
 	t.Run("Change field in existing secret with labels", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO()).WithAnnotations(annotations).WithLabels(labels)
+		ku := NewKubeUtil(context.TODO(), client).WithAnnotations(annotations).WithLabels(labels)
 		err := ku.CreateOrUpdateSecretField("test", "test-secret", "password", "barfoo")
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "test-secret")
@@ -95,7 +95,7 @@ func Test_CreateOrUpdateSecretField(t *testing.T) {
 	})
 
 	t.Run("Change field in existing secret with labels", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO()).WithAnnotations(annotations).WithLabels(labels)
+		ku := NewKubeUtil(context.TODO(), client).WithAnnotations(annotations).WithLabels(labels)
 		err := ku.CreateOrUpdateSecretField("test", "nonexisting-secret", "password", "barfoo")
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "nonexisting-secret")
@@ -136,7 +136,7 @@ func Test_CreateOrUpdateSecretData(t *testing.T) {
 	client := fake.NewClientset(secret)
 
 	t.Run("Change data in existing secret with merge", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO())
+		ku := NewKubeUtil(context.TODO(), client)
 		err := ku.CreateOrUpdateSecretData("test", "test-secret", data1, true)
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "test-secret")
@@ -147,7 +147,7 @@ func Test_CreateOrUpdateSecretData(t *testing.T) {
 	})
 
 	t.Run("Change data in non-existing secret with merge", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO())
+		ku := NewKubeUtil(context.TODO(), client)
 		err := ku.CreateOrUpdateSecretData("test", "nonexist-secret", data1, true)
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "nonexist-secret")
@@ -157,7 +157,7 @@ func Test_CreateOrUpdateSecretData(t *testing.T) {
 	})
 
 	t.Run("Change data in existing secret without merge", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO())
+		ku := NewKubeUtil(context.TODO(), client)
 		err := ku.CreateOrUpdateSecretData("test", "test-secret", data2, false)
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "test-secret")
@@ -169,7 +169,7 @@ func Test_CreateOrUpdateSecretData(t *testing.T) {
 	})
 
 	t.Run("Change data in non-existing secret without merge", func(t *testing.T) {
-		ku := NewKubeUtil(client, context.TODO())
+		ku := NewKubeUtil(context.TODO(), client)
 		err := ku.CreateOrUpdateSecretData("test", "nonexist-secret", data2, false)
 		require.NoError(t, err)
 		s, err := getSecret(client, "test", "nonexist-secret")

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -2176,7 +2176,7 @@ func (mgr *SettingsManager) InitializeSettings(insecureModeEnabled bool) (*ArgoC
 				if err != nil {
 					return err
 				}
-				ku := kube.NewKubeUtil(mgr.clientset, mgr.ctx)
+				ku := kube.NewKubeUtil(mgr.ctx, mgr.clientset)
 				err = ku.CreateOrUpdateSecretField(mgr.namespace, initialPasswordSecretName, initialPasswordSecretField, initialPassword)
 				if err != nil {
 					return err


### PR DESCRIPTION
#### Description 

[context-as-argument](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument): By [convention](https://go.dev/wiki/CodeReviewComments#contexts), context.Context should be the first parameter of a function. This rule spots function declarations that do not follow the convention.


⚠️ This includes breaking changes for some public functions