### PR TITLE
chore: enable superfluous-else from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -101,18 +101,22 @@ linters-settings:
         disabled: true
       # for better readability, the errors should be last in the list of returned values by a function.
       - name: error-return
+        disabled: false
       # for better readability, error messages should not be capitalized or end with punctuation or a newline.
       - name: error-strings
         disabled: true
       # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
       - name: errorf
+        disabled: false
       # incrementing an integer variable by 1 is recommended to be done using the `++` operator
       - name: increment-decrement
+        disabled: false
       # highlights redundant else-blocks that can be eliminated from the code
       - name: indent-error-flow
         disabled: true
       # This rule suggests a shorter way of writing ranges that do not use the second value.
       - name: range
+        disabled: false
       # receiver names in a method should reflect the struct name (p for Person, for example)
       - name: receiver-naming
         disabled: true
@@ -121,7 +125,7 @@ linters-settings:
         disabled: true
       # redundant else-blocks that can be eliminated from the code.
       - name: superfluous-else
-        disabled: true
+        disabled: false
       # prevent confusing name for variables when using `time` package
       - name: time-naming
         disabled: true
@@ -130,13 +134,16 @@ linters-settings:
         disabled: true
       # spots and proposes to remove unreachable code. also helps to spot errors
       - name: unreachable-code
+        disabled: false
       # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
       - name: unused-parameter
         disabled: true
       # Since Go 1.18, interface{} has an alias: any. This rule proposes to replace instances of interface{} with any.
       - name: use-any
+        disabled: false
       # report when a variable declaration can be simplified
       - name: var-declaration
+        disabled: false
       # warns when initialism, variable or package naming conventions are not followed.
       - name: var-naming
         disabled: true

--- a/cmd/argocd-dex/commands/argocd_dex.go
+++ b/cmd/argocd-dex/commands/argocd_dex.go
@@ -136,9 +136,8 @@ func NewRunDexCommand() *cobra.Command {
 							errors.CheckError(err)
 						}
 						break
-					} else {
-						log.Infof("dex config unmodified")
 					}
+					log.Infof("dex config unmodified")
 				}
 			}
 		},

--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -248,12 +248,11 @@ argocd admin settings rbac can someuser create application 'default/app' --defau
 					fmt.Println("Yes")
 				}
 				os.Exit(0)
-			} else {
-				if !quiet {
-					fmt.Println("No")
-				}
-				os.Exit(1)
 			}
+			if !quiet {
+				fmt.Println("No")
+			}
+			os.Exit(1)
 		},
 	}
 	clientConfig = cli.AddKubectlFlagsToCmd(command)
@@ -321,13 +320,11 @@ argocd admin settings rbac validate --namespace argocd
 				if err := rbac.ValidatePolicy(userPolicy); err == nil {
 					fmt.Printf("Policy is valid.\n")
 					os.Exit(0)
-				} else {
-					fmt.Printf("Policy is invalid: %v\n", err)
-					os.Exit(1)
 				}
-			} else {
-				log.Fatalf("Policy is empty or could not be loaded.")
+				fmt.Printf("Policy is invalid: %v\n", err)
+				os.Exit(1)
 			}
+			log.Fatalf("Policy is empty or could not be loaded.")
 		},
 	}
 	clientConfig = cli.AddKubectlFlagsToCmd(command)

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -405,11 +405,11 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 
 			if sourceName != "" {
 				sourceNameToPosition := getSourceNameToPositionMap(app)
-				if pos, ok := sourceNameToPosition[sourceName]; !ok {
+				pos, ok := sourceNameToPosition[sourceName]
+				if !ok {
 					log.Fatalf("Unknown source name '%s'", sourceName)
-				} else {
-					sourcePosition = int(pos)
 				}
+				sourcePosition = int(pos)
 			}
 
 			// check for source position if --show-params is set
@@ -840,11 +840,11 @@ func NewApplicationSetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 
 			if sourceName != "" {
 				sourceNameToPosition := getSourceNameToPositionMap(app)
-				if pos, ok := sourceNameToPosition[sourceName]; !ok {
+				pos, ok := sourceNameToPosition[sourceName]
+				if !ok {
 					log.Fatalf("Unknown source name '%s'", sourceName)
-				} else {
-					sourcePosition = int(pos)
 				}
+				sourcePosition = int(pos)
 			}
 
 			if app.Spec.HasMultipleSources() {
@@ -953,11 +953,11 @@ func NewApplicationUnsetCommand(clientOpts *argocdclient.ClientOptions) *cobra.C
 
 			if sourceName != "" {
 				sourceNameToPosition := getSourceNameToPositionMap(app)
-				if pos, ok := sourceNameToPosition[sourceName]; !ok {
+				pos, ok := sourceNameToPosition[sourceName]
+				if !ok {
 					log.Fatalf("Unknown source name '%s'", sourceName)
-				} else {
-					sourcePosition = int(pos)
 				}
+				sourcePosition = int(pos)
 			}
 
 			if app.Spec.HasMultipleSources() {
@@ -1271,11 +1271,11 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				sourceNameToPosition := getSourceNameToPositionMap(app)
 
 				for _, name := range sourceNames {
-					if pos, ok := sourceNameToPosition[name]; !ok {
+					pos, ok := sourceNameToPosition[name]
+					if !ok {
 						log.Fatalf("Unknown source name '%s'", name)
-					} else {
-						sourcePositions = append(sourcePositions, pos)
 					}
+					sourcePositions = append(sourcePositions, pos)
 				}
 			}
 
@@ -2033,11 +2033,11 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				sourceNameToPosition := getSourceNameToPositionMap(app)
 
 				for _, name := range sourceNames {
-					if pos, ok := sourceNameToPosition[name]; !ok {
+					pos, ok := sourceNameToPosition[name]
+					if !ok {
 						log.Fatalf("Unknown source name '%s'", name)
-					} else {
-						sourcePositions = append(sourcePositions, pos)
 					}
+					sourcePositions = append(sourcePositions, pos)
 				}
 			}
 
@@ -3004,11 +3004,11 @@ func NewApplicationManifestsCommand(clientOpts *argocdclient.ClientOptions) *cob
 				sourceNameToPosition := getSourceNameToPositionMap(app)
 
 				for _, name := range sourceNames {
-					if pos, ok := sourceNameToPosition[name]; !ok {
+					pos, ok := sourceNameToPosition[name]
+					if !ok {
 						log.Fatalf("Unknown source name '%s'", name)
-					} else {
-						sourcePositions = append(sourcePositions, pos)
 					}
+					sourcePositions = append(sourcePositions, pos)
 				}
 			}
 
@@ -3339,11 +3339,11 @@ func NewApplicationRemoveSourceCommand(clientOpts *argocdclient.ClientOptions) *
 
 			if sourceName != "" {
 				sourceNameToPosition := getSourceNameToPositionMap(app)
-				if pos, ok := sourceNameToPosition[sourceName]; !ok {
+				pos, ok := sourceNameToPosition[sourceName]
+				if !ok {
 					log.Fatalf("Unknown source name '%s'", sourceName)
-				} else {
-					sourcePosition = int(pos)
 				}
+				sourcePosition = int(pos)
 			}
 
 			if !app.Spec.HasMultipleSources() {

--- a/cmd/argocd/commands/cert.go
+++ b/cmd/argocd/commands/cert.go
@@ -106,9 +106,8 @@ func NewCertAddTLSCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command
 				if subjectMap[x509cert.Subject.String()] != nil {
 					fmt.Printf("ERROR: Cert with subject '%s' already seen in the input stream.\n", x509cert.Subject.String())
 					continue
-				} else {
-					subjectMap[x509cert.Subject.String()] = x509cert
 				}
+				subjectMap[x509cert.Subject.String()] = x509cert
 			}
 
 			serverName := args[0]

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -254,11 +254,10 @@ func NewProjectRemoveSignatureKeyCommand(clientOpts *argocdclient.ClientOptions)
 			}
 			if index == -1 {
 				log.Fatal("Specified signature key is not configured for project")
-			} else {
-				proj.Spec.SignatureKeys = append(proj.Spec.SignatureKeys[:index], proj.Spec.SignatureKeys[index+1:]...)
-				_, err = projIf.Update(ctx, &projectpkg.ProjectUpdateRequest{Project: proj})
-				errors.CheckError(err)
 			}
+			proj.Spec.SignatureKeys = append(proj.Spec.SignatureKeys[:index], proj.Spec.SignatureKeys[index+1:]...)
+			_, err = projIf.Update(ctx, &projectpkg.ProjectUpdateRequest{Project: proj})
+			errors.CheckError(err)
 		},
 	}
 
@@ -352,11 +351,10 @@ func NewProjectRemoveDestinationCommand(clientOpts *argocdclient.ClientOptions) 
 			}
 			if index == -1 {
 				log.Fatal("Specified destination does not exist in project")
-			} else {
-				proj.Spec.Destinations = append(proj.Spec.Destinations[:index], proj.Spec.Destinations[index+1:]...)
-				_, err = projIf.Update(ctx, &projectpkg.ProjectUpdateRequest{Project: proj})
-				errors.CheckError(err)
 			}
+			proj.Spec.Destinations = append(proj.Spec.Destinations[:index], proj.Spec.Destinations[index+1:]...)
+			_, err = projIf.Update(ctx, &projectpkg.ProjectUpdateRequest{Project: proj})
+			errors.CheckError(err)
 		},
 	}
 
@@ -456,11 +454,10 @@ func NewProjectRemoveOrphanedIgnoreCommand(clientOpts *argocdclient.ClientOption
 			}
 			if index == -1 {
 				log.Fatal("Specified resource does not exist in the orphaned ignore of project")
-			} else {
-				proj.Spec.OrphanedResources.Ignore = append(proj.Spec.OrphanedResources.Ignore[:index], proj.Spec.OrphanedResources.Ignore[index+1:]...)
-				_, err = projIf.Update(ctx, &projectpkg.ProjectUpdateRequest{Project: proj})
-				errors.CheckError(err)
 			}
+			proj.Spec.OrphanedResources.Ignore = append(proj.Spec.OrphanedResources.Ignore[:index], proj.Spec.OrphanedResources.Ignore[index+1:]...)
+			_, err = projIf.Update(ctx, &projectpkg.ProjectUpdateRequest{Project: proj})
+			errors.CheckError(err)
 		},
 	}
 	command.Flags().StringVar(&name, "name", "", "Resource name pattern")

--- a/cmd/util/project.go
+++ b/cmd/util/project.go
@@ -86,12 +86,11 @@ func (opts *ProjectOpts) GetDestinations() []v1alpha1.ApplicationDestination {
 		parts := strings.Split(destStr, ",")
 		if len(parts) != 2 {
 			log.Fatalf("Expected destination of the form: server,namespace. Received: %s", destStr)
-		} else {
-			destinations = append(destinations, v1alpha1.ApplicationDestination{
-				Server:    parts[0],
-				Namespace: parts[1],
-			})
 		}
+		destinations = append(destinations, v1alpha1.ApplicationDestination{
+			Server:    parts[0],
+			Namespace: parts[1],
+		})
 	}
 	return destinations
 }
@@ -102,13 +101,12 @@ func (opts *ProjectOpts) GetDestinationServiceAccounts() []v1alpha1.ApplicationD
 		parts := strings.Split(destStr, ",")
 		if len(parts) != 3 {
 			log.Fatalf("Expected destination service account of the form: server,namespace, defaultServiceAccount. Received: %s", destStr)
-		} else {
-			destinationServiceAccounts = append(destinationServiceAccounts, v1alpha1.ApplicationDestinationServiceAccount{
-				Server:                parts[0],
-				Namespace:             parts[1],
-				DefaultServiceAccount: parts[2],
-			})
 		}
+		destinationServiceAccounts = append(destinationServiceAccounts, v1alpha1.ApplicationDestinationServiceAccount{
+			Server:                parts[0],
+			Namespace:             parts[1],
+			DefaultServiceAccount: parts[2],
+		})
 	}
 	return destinationServiceAccounts
 }

--- a/reposerver/gpgwatcher.go
+++ b/reposerver/gpgwatcher.go
@@ -51,11 +51,10 @@ func StartGPGWatcher(sourcePath string) error {
 									log.Infof("Retrying to re-create watcher, attempt %d of %d", attempt, maxRecreateRetries)
 									time.Sleep(1 * time.Second)
 									continue
-								} else {
-									log.Errorf("Maximum retries exceeded.")
-									close(done)
-									return
 								}
+								log.Errorf("Maximum retries exceeded.")
+								close(done)
+								return
 							}
 							break
 						}

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -279,9 +279,8 @@ func InteractiveEdit(filePattern string, data []byte, save func(input []byte) er
 		if string(updated) == "" || string(updated) == string(data) {
 			errors.CheckError(stderrors.New("edit cancelled, no valid changes were saved"))
 			break
-		} else {
-			data = stripComments(updated)
 		}
+		data = stripComments(updated)
 
 		err = save(data)
 		if err == nil {

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -137,11 +137,11 @@ var (
 
 func init() {
 	if countStr := os.Getenv(common.EnvGitAttemptsCount); countStr != "" {
-		if cnt, err := strconv.Atoi(countStr); err != nil {
+		cnt, err := strconv.Atoi(countStr)
+		if err != nil {
 			panic(fmt.Sprintf("Invalid value in %s env variable: %v", common.EnvGitAttemptsCount, err))
-		} else {
-			maxAttemptsCount = int(math.Max(float64(cnt), 1))
 		}
+		maxAttemptsCount = int(math.Max(float64(cnt), 1))
 	}
 
 	maxRetryDuration = env.ParseDurationFromEnv(common.EnvGitRetryMaxDuration, common.DefaultGitRetryMaxDuration, 0, math.MaxInt64)


### PR DESCRIPTION
#### Description 

[superfluous-else](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else): To improve the readability of code, it is recommended to reduce the indentation as much as possible. This rule highlights redundant else-blocks that can be eliminated from the code.
