### PR TITLE
chore: enable duplicated-imports from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,6 +93,9 @@ linters-settings:
       # Importing with `.` makes the programs much harder to understand
       - name: dot-imports
         disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
+      - name: duplicated-imports
+        disabled: false
       # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
       - name: empty-block
         disabled: true

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/applicationset/services/mocks"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func Test_generateParamsFromGitFile(t *testing.T) {
@@ -182,7 +181,7 @@ foo:
 func TestGitGenerateParamsFromDirectories(t *testing.T) {
 	cases := []struct {
 		name            string
-		directories     []argoprojiov1alpha1.GitDirectoryGeneratorItem
+		directories     []v1alpha1.GitDirectoryGeneratorItem
 		pathParamPrefix string
 		repoApps        []string
 		repoError       error
@@ -192,7 +191,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 	}{
 		{
 			name:        "happy flow - created apps",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps: []string{
 				"app1",
 				"app2",
@@ -209,7 +208,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 		},
 		{
 			name:            "It prefixes path parameters with PathParamPrefix",
-			directories:     []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories:     []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			pathParamPrefix: "myRepo",
 			repoApps: []string{
 				"app1",
@@ -227,7 +226,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 		},
 		{
 			name:        "It filters application according to the paths",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*"}, {Path: "p1/*/*"}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*"}, {Path: "p1/*/*"}},
 			repoApps: []string{
 				"app1",
 				"p1/app2",
@@ -243,7 +242,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 		},
 		{
 			name:        "It filters application according to the paths with Exclude",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*", Exclude: true}, {Path: "*"}, {Path: "*/*"}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*", Exclude: true}, {Path: "*"}, {Path: "*/*"}},
 			repoApps: []string{
 				"app1",
 				"app2",
@@ -261,7 +260,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 		},
 		{
 			name:        "Expecting same exclude behavior with different order",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}, {Path: "*/*"}, {Path: "p1/*", Exclude: true}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}, {Path: "*/*"}, {Path: "p1/*", Exclude: true}},
 			repoApps: []string{
 				"app1",
 				"app2",
@@ -279,7 +278,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 		},
 		{
 			name:        "Value variable interpolation",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}, {Path: "*/*"}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}, {Path: "*/*"}},
 			repoApps: []string{
 				"app1",
 				"p1/app2",
@@ -298,7 +297,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 		},
 		{
 			name:          "handles empty response from repo server",
-			directories:   []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories:   []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps:      []string{},
 			repoError:     nil,
 			expected:      []map[string]any{},
@@ -306,7 +305,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 		},
 		{
 			name:          "handles error from repo server",
-			directories:   []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories:   []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps:      []string{},
 			repoError:     errors.New("error"),
 			expected:      []map[string]any{},
@@ -325,13 +324,13 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 			argoCDServiceMock.On("GetDirectories", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(testCaseCopy.repoApps, testCaseCopy.repoError)
 
 			gitGenerator := NewGitGenerator(&argoCDServiceMock, "")
-			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
+			applicationSetInfo := v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "set",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
-					Generators: []argoprojiov1alpha1.ApplicationSetGenerator{{
-						Git: &argoprojiov1alpha1.GitGenerator{
+				Spec: v1alpha1.ApplicationSetSpec{
+					Generators: []v1alpha1.ApplicationSetGenerator{{
+						Git: &v1alpha1.GitGenerator{
 							RepoURL:         "RepoURL",
 							Revision:        "Revision",
 							Directories:     testCaseCopy.directories,
@@ -345,7 +344,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 			scheme := runtime.NewScheme()
 			err := v1alpha1.AddToScheme(scheme)
 			require.NoError(t, err)
-			appProject := argoprojiov1alpha1.AppProject{}
+			appProject := v1alpha1.AppProject{}
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
@@ -366,7 +365,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 	cases := []struct {
 		name            string
-		directories     []argoprojiov1alpha1.GitDirectoryGeneratorItem
+		directories     []v1alpha1.GitDirectoryGeneratorItem
 		pathParamPrefix string
 		repoApps        []string
 		repoError       error
@@ -375,7 +374,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 	}{
 		{
 			name:        "happy flow - created apps",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps: []string{
 				"app1",
 				"app2",
@@ -419,7 +418,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 		},
 		{
 			name:            "It prefixes path parameters with PathParamPrefix",
-			directories:     []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories:     []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			pathParamPrefix: "myRepo",
 			repoApps: []string{
 				"app1",
@@ -470,7 +469,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 		},
 		{
 			name:        "It filters application according to the paths",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*"}, {Path: "p1/*/*"}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*"}, {Path: "p1/*/*"}},
 			repoApps: []string{
 				"app1",
 				"p1/app2",
@@ -507,7 +506,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 		},
 		{
 			name:        "It filters application according to the paths with Exclude",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*", Exclude: true}, {Path: "*"}, {Path: "*/*"}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "p1/*", Exclude: true}, {Path: "*"}, {Path: "*/*"}},
 			repoApps: []string{
 				"app1",
 				"app2",
@@ -553,7 +552,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 		},
 		{
 			name:        "Expecting same exclude behavior with different order",
-			directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}, {Path: "*/*"}, {Path: "p1/*", Exclude: true}},
+			directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}, {Path: "*/*"}, {Path: "p1/*", Exclude: true}},
 			repoApps: []string{
 				"app1",
 				"app2",
@@ -599,7 +598,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 		},
 		{
 			name:          "handles empty response from repo server",
-			directories:   []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories:   []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps:      []string{},
 			repoError:     nil,
 			expected:      []map[string]any{},
@@ -607,7 +606,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 		},
 		{
 			name:          "handles error from repo server",
-			directories:   []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+			directories:   []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 			repoApps:      []string{},
 			repoError:     errors.New("error"),
 			expected:      []map[string]any{},
@@ -626,14 +625,14 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 			argoCDServiceMock.On("GetDirectories", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(testCaseCopy.repoApps, testCaseCopy.repoError)
 
 			gitGenerator := NewGitGenerator(&argoCDServiceMock, "")
-			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
+			applicationSetInfo := v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "set",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+				Spec: v1alpha1.ApplicationSetSpec{
 					GoTemplate: true,
-					Generators: []argoprojiov1alpha1.ApplicationSetGenerator{{
-						Git: &argoprojiov1alpha1.GitGenerator{
+					Generators: []v1alpha1.ApplicationSetGenerator{{
+						Git: &v1alpha1.GitGenerator{
 							RepoURL:         "RepoURL",
 							Revision:        "Revision",
 							Directories:     testCaseCopy.directories,
@@ -646,7 +645,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 			scheme := runtime.NewScheme()
 			err := v1alpha1.AddToScheme(scheme)
 			require.NoError(t, err)
-			appProject := argoprojiov1alpha1.AppProject{}
+			appProject := v1alpha1.AppProject{}
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
@@ -668,7 +667,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 	cases := []struct {
 		name string
 		// files is the list of paths/globs to match
-		files []argoprojiov1alpha1.GitFileGeneratorItem
+		files []v1alpha1.GitFileGeneratorItem
 		// repoFileContents maps repo path to the literal contents of that path
 		repoFileContents map[string][]byte
 		// if repoPathsError is non-nil, the call to GetPaths(...) will return this error value
@@ -679,7 +678,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 	}{
 		{
 			name:  "happy flow: create params from git files",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.json": []byte(`{
    "cluster": {
@@ -739,7 +738,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 		},
 		{
 			name:  "Value variable interpolation",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.json": []byte(`{
    "cluster": {
@@ -807,7 +806,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 		},
 		{
 			name:             "handles error during getting repo paths",
-			files:            []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files:            []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{},
 			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]any{},
@@ -815,7 +814,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 		},
 		{
 			name:  "test invalid JSON file returns error",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.json": []byte(`invalid json file`),
 			},
@@ -825,7 +824,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 		},
 		{
 			name:  "test JSON array",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.json": []byte(`
 [
@@ -880,7 +879,7 @@ func TestGitGenerateParamsFromFiles(t *testing.T) {
 		},
 		{
 			name:  "Test YAML flow",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.yaml": []byte(`
 cluster:
@@ -934,7 +933,7 @@ cluster:
 		},
 		{
 			name:  "test YAML array",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.yaml": []byte(`
 - cluster:
@@ -991,13 +990,13 @@ cluster:
 				Return(testCaseCopy.repoFileContents, testCaseCopy.repoPathsError)
 
 			gitGenerator := NewGitGenerator(&argoCDServiceMock, "")
-			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
+			applicationSetInfo := v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "set",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
-					Generators: []argoprojiov1alpha1.ApplicationSetGenerator{{
-						Git: &argoprojiov1alpha1.GitGenerator{
+				Spec: v1alpha1.ApplicationSetSpec{
+					Generators: []v1alpha1.ApplicationSetGenerator{{
+						Git: &v1alpha1.GitGenerator{
 							RepoURL:  "RepoURL",
 							Revision: "Revision",
 							Files:    testCaseCopy.files,
@@ -1010,7 +1009,7 @@ cluster:
 			scheme := runtime.NewScheme()
 			err := v1alpha1.AddToScheme(scheme)
 			require.NoError(t, err)
-			appProject := argoprojiov1alpha1.AppProject{}
+			appProject := v1alpha1.AppProject{}
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
@@ -1033,7 +1032,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 	cases := []struct {
 		name string
 		// files is the list of paths/globs to match
-		files []argoprojiov1alpha1.GitFileGeneratorItem
+		files []v1alpha1.GitFileGeneratorItem
 		// repoFileContents maps repo path to the literal contents of that path
 		repoFileContents map[string][]byte
 		// if repoPathsError is non-nil, the call to GetPaths(...) will return this error value
@@ -1043,7 +1042,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 	}{
 		{
 			name:  "happy flow: create params from git files",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.json": []byte(`{
    "cluster": {
@@ -1119,7 +1118,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 		},
 		{
 			name:             "handles error during getting repo paths",
-			files:            []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files:            []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{},
 			repoPathsError:   errors.New("paths error"),
 			expected:         []map[string]any{},
@@ -1127,7 +1126,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 		},
 		{
 			name:  "test invalid JSON file returns error",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.json": []byte(`invalid json file`),
 			},
@@ -1137,7 +1136,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 		},
 		{
 			name:  "test JSON array",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.json"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.json": []byte(`
 [
@@ -1206,7 +1205,7 @@ func TestGitGenerateParamsFromFilesGoTemplate(t *testing.T) {
 		},
 		{
 			name:  "Test YAML flow",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.yaml": []byte(`
 cluster:
@@ -1276,7 +1275,7 @@ cluster:
 		},
 		{
 			name:  "test YAML array",
-			files: []argoprojiov1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
+			files: []v1alpha1.GitFileGeneratorItem{{Path: "**/config.yaml"}},
 			repoFileContents: map[string][]byte{
 				"cluster-config/production/config.yaml": []byte(`
 - cluster:
@@ -1347,14 +1346,14 @@ cluster:
 				Return(testCaseCopy.repoFileContents, testCaseCopy.repoPathsError)
 
 			gitGenerator := NewGitGenerator(&argoCDServiceMock, "")
-			applicationSetInfo := argoprojiov1alpha1.ApplicationSet{
+			applicationSetInfo := v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "set",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+				Spec: v1alpha1.ApplicationSetSpec{
 					GoTemplate: true,
-					Generators: []argoprojiov1alpha1.ApplicationSetGenerator{{
-						Git: &argoprojiov1alpha1.GitGenerator{
+					Generators: []v1alpha1.ApplicationSetGenerator{{
+						Git: &v1alpha1.GitGenerator{
 							RepoURL:  "RepoURL",
 							Revision: "Revision",
 							Files:    testCaseCopy.files,
@@ -1366,7 +1365,7 @@ cluster:
 			scheme := runtime.NewScheme()
 			err := v1alpha1.AddToScheme(scheme)
 			require.NoError(t, err)
-			appProject := argoprojiov1alpha1.AppProject{}
+			appProject := v1alpha1.AppProject{}
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
@@ -1388,7 +1387,7 @@ cluster:
 func TestGitGenerator_GenerateParams(t *testing.T) {
 	cases := []struct {
 		name               string
-		directories        []argoprojiov1alpha1.GitDirectoryGeneratorItem
+		directories        []v1alpha1.GitDirectoryGeneratorItem
 		pathParamPrefix    string
 		repoApps           []string
 		repoPathsError     error
@@ -1396,7 +1395,7 @@ func TestGitGenerator_GenerateParams(t *testing.T) {
 		values             map[string]string
 		expected           []map[string]any
 		expectedError      error
-		appset             argoprojiov1alpha1.ApplicationSet
+		appset             v1alpha1.ApplicationSet
 		callGetDirectories bool
 	}{
 		{
@@ -1405,25 +1404,25 @@ func TestGitGenerator_GenerateParams(t *testing.T) {
 				"app1",
 			},
 			repoPathsError: nil,
-			appset: argoprojiov1alpha1.ApplicationSet{
+			appset: v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "set",
 					Namespace: "namespace",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
-					Generators: []argoprojiov1alpha1.ApplicationSetGenerator{{
-						Git: &argoprojiov1alpha1.GitGenerator{
+				Spec: v1alpha1.ApplicationSetSpec{
+					Generators: []v1alpha1.ApplicationSetGenerator{{
+						Git: &v1alpha1.GitGenerator{
 							RepoURL:         "RepoURL",
 							Revision:        "Revision",
-							Directories:     []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+							Directories:     []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 							PathParamPrefix: "",
 							Values: map[string]string{
 								"foo": "bar",
 							},
 						},
 					}},
-					Template: argoprojiov1alpha1.ApplicationSetTemplate{
-						Spec: argoprojiov1alpha1.ApplicationSpec{
+					Template: v1alpha1.ApplicationSetTemplate{
+						Spec: v1alpha1.ApplicationSpec{
 							Project: "{{.project}}",
 						},
 					},
@@ -1439,25 +1438,25 @@ func TestGitGenerator_GenerateParams(t *testing.T) {
 				"app1",
 			},
 			repoPathsError: nil,
-			appset: argoprojiov1alpha1.ApplicationSet{
+			appset: v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "set",
 					Namespace: "namespace",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
-					Generators: []argoprojiov1alpha1.ApplicationSetGenerator{{
-						Git: &argoprojiov1alpha1.GitGenerator{
+				Spec: v1alpha1.ApplicationSetSpec{
+					Generators: []v1alpha1.ApplicationSetGenerator{{
+						Git: &v1alpha1.GitGenerator{
 							RepoURL:         "RepoURL",
 							Revision:        "Revision",
-							Directories:     []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+							Directories:     []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 							PathParamPrefix: "",
 							Values: map[string]string{
 								"foo": "bar",
 							},
 						},
 					}},
-					Template: argoprojiov1alpha1.ApplicationSetTemplate{
-						Spec: argoprojiov1alpha1.ApplicationSpec{
+					Template: v1alpha1.ApplicationSetTemplate{
+						Spec: v1alpha1.ApplicationSpec{
 							Project: "project",
 						},
 					},
@@ -1479,7 +1478,7 @@ func TestGitGenerator_GenerateParams(t *testing.T) {
 		scheme := runtime.NewScheme()
 		err := v1alpha1.AddToScheme(scheme)
 		require.NoError(t, err)
-		appProject := argoprojiov1alpha1.AppProject{}
+		appProject := v1alpha1.AppProject{}
 
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 

--- a/applicationset/generators/matrix_test.go
+++ b/applicationset/generators/matrix_test.go
@@ -20,29 +20,28 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argoprojiov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 )
 
 func TestMatrixGenerate(t *testing.T) {
-	gitGenerator := &argoprojiov1alpha1.GitGenerator{
+	gitGenerator := &v1alpha1.GitGenerator{
 		RepoURL:     "RepoURL",
 		Revision:    "Revision",
-		Directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+		Directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 	}
 
-	listGenerator := &argoprojiov1alpha1.ListGenerator{
+	listGenerator := &v1alpha1.ListGenerator{
 		Elements: []apiextensionsv1.JSON{{Raw: []byte(`{"cluster": "Cluster","url": "Url", "templated": "test-{{path.basenameNormalized}}"}`)}},
 	}
 
 	testCases := []struct {
 		name           string
-		baseGenerators []argoprojiov1alpha1.ApplicationSetNestedGenerator
+		baseGenerators []v1alpha1.ApplicationSetNestedGenerator
 		expectedErr    error
 		expected       []map[string]any
 	}{
 		{
 			name: "happy flow - generate params",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -57,9 +56,9 @@ func TestMatrixGenerate(t *testing.T) {
 		},
 		{
 			name: "happy flow - generate params from two lists",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
-					List: &argoprojiov1alpha1.ListGenerator{
+					List: &v1alpha1.ListGenerator{
 						Elements: []apiextensionsv1.JSON{
 							{Raw: []byte(`{"a": "1"}`)},
 							{Raw: []byte(`{"a": "2"}`)},
@@ -67,7 +66,7 @@ func TestMatrixGenerate(t *testing.T) {
 					},
 				},
 				{
-					List: &argoprojiov1alpha1.ListGenerator{
+					List: &v1alpha1.ListGenerator{
 						Elements: []apiextensionsv1.JSON{
 							{Raw: []byte(`{"b": "1"}`)},
 							{Raw: []byte(`{"b": "2"}`)},
@@ -84,7 +83,7 @@ func TestMatrixGenerate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is less than two base generators",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -93,7 +92,7 @@ func TestMatrixGenerate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is more than two base generators",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					List: listGenerator,
 				},
@@ -108,7 +107,7 @@ func TestMatrixGenerate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is more than one inner generator in the first base generator",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git:  gitGenerator,
 					List: listGenerator,
@@ -121,7 +120,7 @@ func TestMatrixGenerate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is more than one inner generator in the second base generator",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					List: listGenerator,
 				},
@@ -139,15 +138,15 @@ func TestMatrixGenerate(t *testing.T) {
 
 		t.Run(testCaseCopy.name, func(t *testing.T) {
 			genMock := &generatorMock{}
-			appSet := &argoprojiov1alpha1.ApplicationSet{
+			appSet := &v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "set",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{},
+				Spec: v1alpha1.ApplicationSetSpec{},
 			}
 
 			for _, g := range testCaseCopy.baseGenerators {
-				gitGeneratorSpec := argoprojiov1alpha1.ApplicationSetGenerator{
+				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{
 					Git:  g.Git,
 					List: g.List,
 				}
@@ -165,7 +164,7 @@ func TestMatrixGenerate(t *testing.T) {
 				}, nil)
 
 				genMock.On("GetTemplate", &gitGeneratorSpec).
-					Return(&argoprojiov1alpha1.ApplicationSetTemplate{})
+					Return(&v1alpha1.ApplicationSetTemplate{})
 			}
 
 			matrixGenerator := NewMatrixGenerator(
@@ -175,10 +174,10 @@ func TestMatrixGenerate(t *testing.T) {
 				},
 			)
 
-			got, err := matrixGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
-				Matrix: &argoprojiov1alpha1.MatrixGenerator{
+			got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
 					Generators: testCaseCopy.baseGenerators,
-					Template:   argoprojiov1alpha1.ApplicationSetTemplate{},
+					Template:   v1alpha1.ApplicationSetTemplate{},
 				},
 			}, appSet, nil)
 
@@ -193,25 +192,25 @@ func TestMatrixGenerate(t *testing.T) {
 }
 
 func TestMatrixGenerateGoTemplate(t *testing.T) {
-	gitGenerator := &argoprojiov1alpha1.GitGenerator{
+	gitGenerator := &v1alpha1.GitGenerator{
 		RepoURL:     "RepoURL",
 		Revision:    "Revision",
-		Directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+		Directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 	}
 
-	listGenerator := &argoprojiov1alpha1.ListGenerator{
+	listGenerator := &v1alpha1.ListGenerator{
 		Elements: []apiextensionsv1.JSON{{Raw: []byte(`{"cluster": "Cluster","url": "Url"}`)}},
 	}
 
 	testCases := []struct {
 		name           string
-		baseGenerators []argoprojiov1alpha1.ApplicationSetNestedGenerator
+		baseGenerators []v1alpha1.ApplicationSetNestedGenerator
 		expectedErr    error
 		expected       []map[string]any
 	}{
 		{
 			name: "happy flow - generate params",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -242,9 +241,9 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 		},
 		{
 			name: "happy flow - generate params from two lists",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
-					List: &argoprojiov1alpha1.ListGenerator{
+					List: &v1alpha1.ListGenerator{
 						Elements: []apiextensionsv1.JSON{
 							{Raw: []byte(`{"a": "1"}`)},
 							{Raw: []byte(`{"a": "2"}`)},
@@ -252,7 +251,7 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 					},
 				},
 				{
-					List: &argoprojiov1alpha1.ListGenerator{
+					List: &v1alpha1.ListGenerator{
 						Elements: []apiextensionsv1.JSON{
 							{Raw: []byte(`{"b": "1"}`)},
 							{Raw: []byte(`{"b": "2"}`)},
@@ -269,16 +268,16 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 		},
 		{
 			name: "parameter override: first list elements take precedence",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
-					List: &argoprojiov1alpha1.ListGenerator{
+					List: &v1alpha1.ListGenerator{
 						Elements: []apiextensionsv1.JSON{
 							{Raw: []byte(`{"booleanFalse": false, "booleanTrue": true, "stringFalse": "false", "stringTrue": "true"}`)},
 						},
 					},
 				},
 				{
-					List: &argoprojiov1alpha1.ListGenerator{
+					List: &v1alpha1.ListGenerator{
 						Elements: []apiextensionsv1.JSON{
 							{Raw: []byte(`{"booleanFalse": true, "booleanTrue": false, "stringFalse": "true", "stringTrue": "false"}`)},
 						},
@@ -291,7 +290,7 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is less than two base generators",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -300,7 +299,7 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is more than two base generators",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					List: listGenerator,
 				},
@@ -315,7 +314,7 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is more than one inner generator in the first base generator",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git:  gitGenerator,
 					List: listGenerator,
@@ -328,7 +327,7 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 		},
 		{
 			name: "returns error if there is more than one inner generator in the second base generator",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					List: listGenerator,
 				},
@@ -346,17 +345,17 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 
 		t.Run(testCaseCopy.name, func(t *testing.T) {
 			genMock := &generatorMock{}
-			appSet := &argoprojiov1alpha1.ApplicationSet{
+			appSet := &v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "set",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+				Spec: v1alpha1.ApplicationSetSpec{
 					GoTemplate: true,
 				},
 			}
 
 			for _, g := range testCaseCopy.baseGenerators {
-				gitGeneratorSpec := argoprojiov1alpha1.ApplicationSetGenerator{
+				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{
 					Git:  g.Git,
 					List: g.List,
 				}
@@ -378,7 +377,7 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 				}, nil)
 
 				genMock.On("GetTemplate", &gitGeneratorSpec).
-					Return(&argoprojiov1alpha1.ApplicationSetTemplate{})
+					Return(&v1alpha1.ApplicationSetTemplate{})
 			}
 
 			matrixGenerator := NewMatrixGenerator(
@@ -388,10 +387,10 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 				},
 			)
 
-			got, err := matrixGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
-				Matrix: &argoprojiov1alpha1.MatrixGenerator{
+			got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
 					Generators: testCaseCopy.baseGenerators,
-					Template:   argoprojiov1alpha1.ApplicationSetTemplate{},
+					Template:   v1alpha1.ApplicationSetTemplate{},
 				},
 			}, appSet, nil)
 
@@ -406,31 +405,31 @@ func TestMatrixGenerateGoTemplate(t *testing.T) {
 }
 
 func TestMatrixGetRequeueAfter(t *testing.T) {
-	gitGenerator := &argoprojiov1alpha1.GitGenerator{
+	gitGenerator := &v1alpha1.GitGenerator{
 		RepoURL:     "RepoURL",
 		Revision:    "Revision",
-		Directories: []argoprojiov1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
+		Directories: []v1alpha1.GitDirectoryGeneratorItem{{Path: "*"}},
 	}
 
-	listGenerator := &argoprojiov1alpha1.ListGenerator{
+	listGenerator := &v1alpha1.ListGenerator{
 		Elements: []apiextensionsv1.JSON{{Raw: []byte(`{"cluster": "Cluster","url": "Url"}`)}},
 	}
 
-	pullRequestGenerator := &argoprojiov1alpha1.PullRequestGenerator{}
+	pullRequestGenerator := &v1alpha1.PullRequestGenerator{}
 
-	scmGenerator := &argoprojiov1alpha1.SCMProviderGenerator{}
+	scmGenerator := &v1alpha1.SCMProviderGenerator{}
 
-	duckTypeGenerator := &argoprojiov1alpha1.DuckTypeGenerator{}
+	duckTypeGenerator := &v1alpha1.DuckTypeGenerator{}
 
 	testCases := []struct {
 		name               string
-		baseGenerators     []argoprojiov1alpha1.ApplicationSetNestedGenerator
+		baseGenerators     []v1alpha1.ApplicationSetNestedGenerator
 		gitGetRequeueAfter time.Duration
 		expected           time.Duration
 	}{
 		{
 			name: "return NoRequeueAfter if all the inner baseGenerators returns it",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -443,7 +442,7 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 		},
 		{
 			name: "returns the minimal time",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -456,7 +455,7 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 		},
 		{
 			name: "returns the minimal time for pull request",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -469,7 +468,7 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 		},
 		{
 			name: "returns the default time if no requeueAfterSeconds is provided",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -481,7 +480,7 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 		},
 		{
 			name: "returns the default time for duck type generator",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -493,7 +492,7 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 		},
 		{
 			name: "returns the default time for scm generator",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -512,7 +511,7 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 			mock := &generatorMock{}
 
 			for _, g := range testCaseCopy.baseGenerators {
-				gitGeneratorSpec := argoprojiov1alpha1.ApplicationSetGenerator{
+				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{
 					Git:                     g.Git,
 					List:                    g.List,
 					PullRequest:             g.PullRequest,
@@ -532,10 +531,10 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 				},
 			)
 
-			got := matrixGenerator.GetRequeueAfter(&argoprojiov1alpha1.ApplicationSetGenerator{
-				Matrix: &argoprojiov1alpha1.MatrixGenerator{
+			got := matrixGenerator.GetRequeueAfter(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
 					Generators: testCaseCopy.baseGenerators,
-					Template:   argoprojiov1alpha1.ApplicationSetTemplate{},
+					Template:   v1alpha1.ApplicationSetTemplate{},
 				},
 			})
 
@@ -545,16 +544,16 @@ func TestMatrixGetRequeueAfter(t *testing.T) {
 }
 
 func TestInterpolatedMatrixGenerate(t *testing.T) {
-	interpolatedGitGenerator := &argoprojiov1alpha1.GitGenerator{
+	interpolatedGitGenerator := &v1alpha1.GitGenerator{
 		RepoURL:  "RepoURL",
 		Revision: "Revision",
-		Files: []argoprojiov1alpha1.GitFileGeneratorItem{
+		Files: []v1alpha1.GitFileGeneratorItem{
 			{Path: "examples/git-generator-files-discovery/cluster-config/dev/config.json"},
 			{Path: "examples/git-generator-files-discovery/cluster-config/prod/config.json"},
 		},
 	}
 
-	interpolatedClusterGenerator := &argoprojiov1alpha1.ClusterGenerator{
+	interpolatedClusterGenerator := &v1alpha1.ClusterGenerator{
 		Selector: metav1.LabelSelector{
 			MatchLabels:      map[string]string{"environment": "{{path.basename}}"},
 			MatchExpressions: nil,
@@ -562,14 +561,14 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 	}
 	testCases := []struct {
 		name           string
-		baseGenerators []argoprojiov1alpha1.ApplicationSetNestedGenerator
+		baseGenerators []v1alpha1.ApplicationSetNestedGenerator
 		expectedErr    error
 		expected       []map[string]any
 		clientError    bool
 	}{
 		{
 			name: "happy flow - generate interpolated params",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: interpolatedGitGenerator,
 				},
@@ -637,7 +636,7 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 
 		t.Run(testCaseCopy.name, func(t *testing.T) {
 			genMock := &generatorMock{}
-			appSet := &argoprojiov1alpha1.ApplicationSet{}
+			appSet := &v1alpha1.ApplicationSet{}
 
 			appClientset := kubefake.NewSimpleClientset(runtimeClusters...)
 			fakeClient := fake.NewClientBuilder().WithObjects(clusters...).Build()
@@ -648,7 +647,7 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 			clusterGenerator := NewClusterGenerator(cl, context.Background(), appClientset, "namespace")
 
 			for _, g := range testCaseCopy.baseGenerators {
-				gitGeneratorSpec := argoprojiov1alpha1.ApplicationSetGenerator{
+				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{
 					Git:      g.Git,
 					Clusters: g.Clusters,
 				}
@@ -665,7 +664,7 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 					},
 				}, nil)
 				genMock.On("GetTemplate", &gitGeneratorSpec).
-					Return(&argoprojiov1alpha1.ApplicationSetTemplate{})
+					Return(&v1alpha1.ApplicationSetTemplate{})
 			}
 			matrixGenerator := NewMatrixGenerator(
 				map[string]Generator{
@@ -674,10 +673,10 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 				},
 			)
 
-			got, err := matrixGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
-				Matrix: &argoprojiov1alpha1.MatrixGenerator{
+			got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
 					Generators: testCaseCopy.baseGenerators,
-					Template:   argoprojiov1alpha1.ApplicationSetTemplate{},
+					Template:   v1alpha1.ApplicationSetTemplate{},
 				},
 			}, appSet, nil)
 
@@ -692,16 +691,16 @@ func TestInterpolatedMatrixGenerate(t *testing.T) {
 }
 
 func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
-	interpolatedGitGenerator := &argoprojiov1alpha1.GitGenerator{
+	interpolatedGitGenerator := &v1alpha1.GitGenerator{
 		RepoURL:  "RepoURL",
 		Revision: "Revision",
-		Files: []argoprojiov1alpha1.GitFileGeneratorItem{
+		Files: []v1alpha1.GitFileGeneratorItem{
 			{Path: "examples/git-generator-files-discovery/cluster-config/dev/config.json"},
 			{Path: "examples/git-generator-files-discovery/cluster-config/prod/config.json"},
 		},
 	}
 
-	interpolatedClusterGenerator := &argoprojiov1alpha1.ClusterGenerator{
+	interpolatedClusterGenerator := &v1alpha1.ClusterGenerator{
 		Selector: metav1.LabelSelector{
 			MatchLabels:      map[string]string{"environment": "{{.path.basename}}"},
 			MatchExpressions: nil,
@@ -709,14 +708,14 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 	}
 	testCases := []struct {
 		name           string
-		baseGenerators []argoprojiov1alpha1.ApplicationSetNestedGenerator
+		baseGenerators []v1alpha1.ApplicationSetNestedGenerator
 		expectedErr    error
 		expected       []map[string]any
 		clientError    bool
 	}{
 		{
 			name: "happy flow - generate interpolated params",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: interpolatedGitGenerator,
 				},
@@ -816,8 +815,8 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 
 		t.Run(testCaseCopy.name, func(t *testing.T) {
 			genMock := &generatorMock{}
-			appSet := &argoprojiov1alpha1.ApplicationSet{
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+			appSet := &v1alpha1.ApplicationSet{
+				Spec: v1alpha1.ApplicationSetSpec{
 					GoTemplate: true,
 				},
 			}
@@ -831,7 +830,7 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 			clusterGenerator := NewClusterGenerator(cl, context.Background(), appClientset, "namespace")
 
 			for _, g := range testCaseCopy.baseGenerators {
-				gitGeneratorSpec := argoprojiov1alpha1.ApplicationSetGenerator{
+				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{
 					Git:      g.Git,
 					Clusters: g.Clusters,
 				}
@@ -852,7 +851,7 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 					},
 				}, nil)
 				genMock.On("GetTemplate", &gitGeneratorSpec).
-					Return(&argoprojiov1alpha1.ApplicationSetTemplate{})
+					Return(&v1alpha1.ApplicationSetTemplate{})
 			}
 			matrixGenerator := NewMatrixGenerator(
 				map[string]Generator{
@@ -861,10 +860,10 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 				},
 			)
 
-			got, err := matrixGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
-				Matrix: &argoprojiov1alpha1.MatrixGenerator{
+			got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
 					Generators: testCaseCopy.baseGenerators,
-					Template:   argoprojiov1alpha1.ApplicationSetTemplate{},
+					Template:   v1alpha1.ApplicationSetTemplate{},
 				},
 			}, appSet, nil)
 
@@ -879,28 +878,28 @@ func TestInterpolatedMatrixGenerateGoTemplate(t *testing.T) {
 }
 
 func TestMatrixGenerateListElementsYaml(t *testing.T) {
-	gitGenerator := &argoprojiov1alpha1.GitGenerator{
+	gitGenerator := &v1alpha1.GitGenerator{
 		RepoURL:  "RepoURL",
 		Revision: "Revision",
-		Files: []argoprojiov1alpha1.GitFileGeneratorItem{
+		Files: []v1alpha1.GitFileGeneratorItem{
 			{Path: "config.yaml"},
 		},
 	}
 
-	listGenerator := &argoprojiov1alpha1.ListGenerator{
+	listGenerator := &v1alpha1.ListGenerator{
 		Elements:     []apiextensionsv1.JSON{},
 		ElementsYaml: "{{ .foo.bar | toJson }}",
 	}
 
 	testCases := []struct {
 		name           string
-		baseGenerators []argoprojiov1alpha1.ApplicationSetNestedGenerator
+		baseGenerators []v1alpha1.ApplicationSetNestedGenerator
 		expectedErr    error
 		expected       []map[string]any
 	}{
 		{
 			name: "happy flow - generate params",
-			baseGenerators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+			baseGenerators: []v1alpha1.ApplicationSetNestedGenerator{
 				{
 					Git: gitGenerator,
 				},
@@ -972,17 +971,17 @@ func TestMatrixGenerateListElementsYaml(t *testing.T) {
 
 		t.Run(testCaseCopy.name, func(t *testing.T) {
 			genMock := &generatorMock{}
-			appSet := &argoprojiov1alpha1.ApplicationSet{
+			appSet := &v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "set",
 				},
-				Spec: argoprojiov1alpha1.ApplicationSetSpec{
+				Spec: v1alpha1.ApplicationSetSpec{
 					GoTemplate: true,
 				},
 			}
 
 			for _, g := range testCaseCopy.baseGenerators {
-				gitGeneratorSpec := argoprojiov1alpha1.ApplicationSetGenerator{
+				gitGeneratorSpec := v1alpha1.ApplicationSetGenerator{
 					Git:  g.Git,
 					List: g.List,
 				}
@@ -1012,7 +1011,7 @@ func TestMatrixGenerateListElementsYaml(t *testing.T) {
 					},
 				}}, nil)
 				genMock.On("GetTemplate", &gitGeneratorSpec).
-					Return(&argoprojiov1alpha1.ApplicationSetTemplate{})
+					Return(&v1alpha1.ApplicationSetTemplate{})
 			}
 
 			matrixGenerator := NewMatrixGenerator(
@@ -1022,10 +1021,10 @@ func TestMatrixGenerateListElementsYaml(t *testing.T) {
 				},
 			)
 
-			got, err := matrixGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
-				Matrix: &argoprojiov1alpha1.MatrixGenerator{
+			got, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
+				Matrix: &v1alpha1.MatrixGenerator{
 					Generators: testCaseCopy.baseGenerators,
-					Template:   argoprojiov1alpha1.ApplicationSetTemplate{},
+					Template:   v1alpha1.ApplicationSetTemplate{},
 				},
 			}, appSet, nil)
 
@@ -1043,19 +1042,19 @@ type generatorMock struct {
 	mock.Mock
 }
 
-func (g *generatorMock) GetTemplate(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) *argoprojiov1alpha1.ApplicationSetTemplate {
+func (g *generatorMock) GetTemplate(appSetGenerator *v1alpha1.ApplicationSetGenerator) *v1alpha1.ApplicationSetTemplate {
 	args := g.Called(appSetGenerator)
 
-	return args.Get(0).(*argoprojiov1alpha1.ApplicationSetTemplate)
+	return args.Get(0).(*v1alpha1.ApplicationSetTemplate)
 }
 
-func (g *generatorMock) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *generatorMock) GenerateParams(appSetGenerator *v1alpha1.ApplicationSetGenerator, appSet *v1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
 	args := g.Called(appSetGenerator, appSet)
 
 	return args.Get(0).([]map[string]any), args.Error(1)
 }
 
-func (g *generatorMock) GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator) time.Duration {
+func (g *generatorMock) GetRequeueAfter(appSetGenerator *v1alpha1.ApplicationSetGenerator) time.Duration {
 	args := g.Called(appSetGenerator)
 
 	return args.Get(0).(time.Duration)
@@ -1078,11 +1077,11 @@ func TestGitGenerator_GenerateParams_list_x_git_matrix_generator(t *testing.T) {
 	listGeneratorMock.On("GenerateParams", mock.AnythingOfType("*v1alpha1.ApplicationSetGenerator"), mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything).Return([]map[string]any{
 		{"some": "value"},
 	}, nil)
-	listGeneratorMock.On("GetTemplate", mock.AnythingOfType("*v1alpha1.ApplicationSetGenerator")).Return(&argoprojiov1alpha1.ApplicationSetTemplate{})
+	listGeneratorMock.On("GetTemplate", mock.AnythingOfType("*v1alpha1.ApplicationSetGenerator")).Return(&v1alpha1.ApplicationSetTemplate{})
 
-	gitGeneratorSpec := &argoprojiov1alpha1.GitGenerator{
+	gitGeneratorSpec := &v1alpha1.GitGenerator{
 		RepoURL: "https://git.example.com",
-		Files: []argoprojiov1alpha1.GitFileGeneratorItem{
+		Files: []v1alpha1.GitFileGeneratorItem{
 			{Path: "some/path.json"},
 		},
 	}
@@ -1098,10 +1097,10 @@ func TestGitGenerator_GenerateParams_list_x_git_matrix_generator(t *testing.T) {
 		"Git":  gitGenerator,
 	})
 
-	matrixGeneratorSpec := &argoprojiov1alpha1.MatrixGenerator{
-		Generators: []argoprojiov1alpha1.ApplicationSetNestedGenerator{
+	matrixGeneratorSpec := &v1alpha1.MatrixGenerator{
+		Generators: []v1alpha1.ApplicationSetNestedGenerator{
 			{
-				List: &argoprojiov1alpha1.ListGenerator{
+				List: &v1alpha1.ListGenerator{
 					Elements: []apiextensionsv1.JSON{
 						{
 							Raw: []byte(`{"some": "value"}`),
@@ -1118,13 +1117,13 @@ func TestGitGenerator_GenerateParams_list_x_git_matrix_generator(t *testing.T) {
 	scheme := runtime.NewScheme()
 	err := v1alpha1.AddToScheme(scheme)
 	require.NoError(t, err)
-	appProject := argoprojiov1alpha1.AppProject{}
+	appProject := v1alpha1.AppProject{}
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
-	params, err := matrixGenerator.GenerateParams(&argoprojiov1alpha1.ApplicationSetGenerator{
+	params, err := matrixGenerator.GenerateParams(&v1alpha1.ApplicationSetGenerator{
 		Matrix: matrixGeneratorSpec,
-	}, &argoprojiov1alpha1.ApplicationSet{}, client)
+	}, &v1alpha1.ApplicationSet{}, client)
 	require.NoError(t, err)
 	assert.Equal(t, []map[string]any{{
 		"path":                    "some",

--- a/cmd/argocd/commands/app_test.go
+++ b/cmd/argocd/commands/app_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
-	k8swatch "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/yaml"
 
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
@@ -2290,10 +2289,10 @@ func (c *fakeAcdClient) WatchApplicationWithRetry(ctx context.Context, appName s
 
 	go func() {
 		modifiedEvent := new(v1alpha1.ApplicationWatchEvent)
-		modifiedEvent.Type = k8swatch.Modified
+		modifiedEvent.Type = watch.Modified
 		appEventsCh <- modifiedEvent
 		deletedEvent := new(v1alpha1.ApplicationWatchEvent)
-		deletedEvent.Type = k8swatch.Deleted
+		deletedEvent.Type = watch.Deleted
 		appEventsCh <- deletedEvent
 	}()
 	return appEventsCh

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/controller/testdata"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/test"
 	"github.com/argoproj/argo-cd/v2/util/argo"
@@ -45,7 +44,7 @@ func TestCompareAppStateEmpty(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -53,7 +52,7 @@ func TestCompareAppStateEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
 	assert.NotNil(t, compRes.syncStatus)
-	assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 	assert.Empty(t, compRes.resources)
 	assert.Empty(t, compRes.managedResources)
 	assert.Empty(t, app.Status.Conditions)
@@ -63,7 +62,7 @@ func TestCompareAppStateEmpty(t *testing.T) {
 func TestCompareAppStateRepoError(t *testing.T) {
 	app := newFakeApp()
 	ctrl := newFakeController(&fakeData{manifestResponses: make([]*apiclient.ManifestResponse, 3)}, errors.New("test repo error"))
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -81,13 +80,13 @@ func TestCompareAppStateRepoError(t *testing.T) {
 	compRes, err = ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false, false)
 	assert.NotNil(t, compRes)
 	require.NoError(t, err)
-	assert.Equal(t, argoappv1.SyncStatusCodeUnknown, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeUnknown, compRes.syncStatus.Status)
 }
 
 // TestCompareAppStateNamespaceMetadataDiffers tests comparison when managed namespace metadata differs
 func TestCompareAppStateNamespaceMetadataDiffers(t *testing.T) {
 	app := newFakeApp()
-	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &argoappv1.ManagedNamespaceMetadata{
+	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &v1alpha1.ManagedNamespaceMetadata{
 		Labels: map[string]string{
 			"foo": "bar",
 		},
@@ -95,8 +94,8 @@ func TestCompareAppStateNamespaceMetadataDiffers(t *testing.T) {
 			"foo": "bar",
 		},
 	}
-	app.Status.OperationState = &argoappv1.OperationState{
-		SyncResult: &argoappv1.SyncOperationResult{},
+	app.Status.OperationState = &v1alpha1.OperationState{
+		SyncResult: &v1alpha1.SyncOperationResult{},
 	}
 
 	data := fakeData{
@@ -109,7 +108,7 @@ func TestCompareAppStateNamespaceMetadataDiffers(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -117,7 +116,7 @@ func TestCompareAppStateNamespaceMetadataDiffers(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
 	assert.NotNil(t, compRes.syncStatus)
-	assert.Equal(t, argoappv1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
 	assert.Empty(t, compRes.resources)
 	assert.Empty(t, compRes.managedResources)
 	assert.Empty(t, app.Status.Conditions)
@@ -131,7 +130,7 @@ func TestCompareAppStateNamespaceMetadataDiffersToManifest(t *testing.T) {
 	ns.SetAnnotations(map[string]string{"bar": "bat"})
 
 	app := newFakeApp()
-	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &argoappv1.ManagedNamespaceMetadata{
+	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &v1alpha1.ManagedNamespaceMetadata{
 		Labels: map[string]string{
 			"foo": "bar",
 		},
@@ -139,8 +138,8 @@ func TestCompareAppStateNamespaceMetadataDiffersToManifest(t *testing.T) {
 			"foo": "bar",
 		},
 	}
-	app.Status.OperationState = &argoappv1.OperationState{
-		SyncResult: &argoappv1.SyncOperationResult{},
+	app.Status.OperationState = &v1alpha1.OperationState{
+		SyncResult: &v1alpha1.SyncOperationResult{},
 	}
 
 	liveNs := ns.DeepCopy()
@@ -158,7 +157,7 @@ func TestCompareAppStateNamespaceMetadataDiffersToManifest(t *testing.T) {
 		},
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -166,7 +165,7 @@ func TestCompareAppStateNamespaceMetadataDiffersToManifest(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
 	assert.NotNil(t, compRes.syncStatus)
-	assert.Equal(t, argoappv1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
 	assert.Len(t, compRes.resources, 1)
 	assert.Len(t, compRes.managedResources, 1)
 	assert.NotNil(t, compRes.diffResultList)
@@ -192,7 +191,7 @@ func TestCompareAppStateNamespaceMetadata(t *testing.T) {
 	ns.SetAnnotations(map[string]string{"bar": "bat"})
 
 	app := newFakeApp()
-	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &argoappv1.ManagedNamespaceMetadata{
+	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &v1alpha1.ManagedNamespaceMetadata{
 		Labels: map[string]string{
 			"foo": "bar",
 		},
@@ -200,8 +199,8 @@ func TestCompareAppStateNamespaceMetadata(t *testing.T) {
 			"foo": "bar",
 		},
 	}
-	app.Status.OperationState = &argoappv1.OperationState{
-		SyncResult: &argoappv1.SyncOperationResult{},
+	app.Status.OperationState = &v1alpha1.OperationState{
+		SyncResult: &v1alpha1.SyncOperationResult{},
 	}
 
 	data := fakeData{
@@ -216,7 +215,7 @@ func TestCompareAppStateNamespaceMetadata(t *testing.T) {
 		},
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -224,7 +223,7 @@ func TestCompareAppStateNamespaceMetadata(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
 	assert.NotNil(t, compRes.syncStatus)
-	assert.Equal(t, argoappv1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
 	assert.Len(t, compRes.resources, 1)
 	assert.Len(t, compRes.managedResources, 1)
 	assert.NotNil(t, compRes.diffResultList)
@@ -244,7 +243,7 @@ func TestCompareAppStateNamespaceMetadata(t *testing.T) {
 // TestCompareAppStateNamespaceMetadataIsTheSame tests comparison when managed namespace metadata is the same
 func TestCompareAppStateNamespaceMetadataIsTheSame(t *testing.T) {
 	app := newFakeApp()
-	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &argoappv1.ManagedNamespaceMetadata{
+	app.Spec.SyncPolicy.ManagedNamespaceMetadata = &v1alpha1.ManagedNamespaceMetadata{
 		Labels: map[string]string{
 			"foo": "bar",
 		},
@@ -252,9 +251,9 @@ func TestCompareAppStateNamespaceMetadataIsTheSame(t *testing.T) {
 			"foo": "bar",
 		},
 	}
-	app.Status.OperationState = &argoappv1.OperationState{
-		SyncResult: &argoappv1.SyncOperationResult{
-			ManagedNamespaceMetadata: &argoappv1.ManagedNamespaceMetadata{
+	app.Status.OperationState = &v1alpha1.OperationState{
+		SyncResult: &v1alpha1.SyncOperationResult{
+			ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 				Labels: map[string]string{
 					"foo": "bar",
 				},
@@ -275,7 +274,7 @@ func TestCompareAppStateNamespaceMetadataIsTheSame(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -283,7 +282,7 @@ func TestCompareAppStateNamespaceMetadataIsTheSame(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
 	assert.NotNil(t, compRes.syncStatus)
-	assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 	assert.Empty(t, compRes.resources)
 	assert.Empty(t, compRes.managedResources)
 	assert.Empty(t, app.Status.Conditions)
@@ -303,7 +302,7 @@ func TestCompareAppStateMissing(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -311,7 +310,7 @@ func TestCompareAppStateMissing(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
 	assert.NotNil(t, compRes.syncStatus)
-	assert.Equal(t, argoappv1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
 	assert.Len(t, compRes.resources, 1)
 	assert.Len(t, compRes.managedResources, 1)
 	assert.Empty(t, app.Status.Conditions)
@@ -335,14 +334,14 @@ func TestCompareAppStateExtra(t *testing.T) {
 		},
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
 	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false, false)
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
-	assert.Equal(t, argoappv1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeOutOfSync, compRes.syncStatus.Status)
 	assert.Len(t, compRes.resources, 1)
 	assert.Len(t, compRes.managedResources, 1)
 	assert.Empty(t, app.Status.Conditions)
@@ -366,14 +365,14 @@ func TestCompareAppStateHook(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
 	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false, false)
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
-	assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 	assert.Empty(t, compRes.resources)
 	assert.Empty(t, compRes.managedResources)
 	assert.Len(t, compRes.reconciliationResult.Hooks, 1)
@@ -398,14 +397,14 @@ func TestCompareAppStateSkipHook(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
 	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, sources, false, false, nil, false, false)
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
-	assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 	assert.Len(t, compRes.resources, 1)
 	assert.Len(t, compRes.managedResources, 1)
 	assert.Empty(t, compRes.reconciliationResult.Hooks)
@@ -429,7 +428,7 @@ func TestCompareAppStateCompareOptionIgnoreExtraneous(t *testing.T) {
 	}
 	ctrl := newFakeController(&data, nil)
 
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -437,7 +436,7 @@ func TestCompareAppStateCompareOptionIgnoreExtraneous(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotNil(t, compRes)
-	assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 	assert.Empty(t, compRes.resources)
 	assert.Empty(t, compRes.managedResources)
 	assert.Empty(t, app.Status.Conditions)
@@ -462,7 +461,7 @@ func TestCompareAppStateExtraHook(t *testing.T) {
 		},
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -470,7 +469,7 @@ func TestCompareAppStateExtraHook(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotNil(t, compRes)
-	assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 	assert.Len(t, compRes.resources, 1)
 	assert.Len(t, compRes.managedResources, 1)
 	assert.Empty(t, compRes.reconciliationResult.Hooks)
@@ -580,7 +579,7 @@ func TestCompareAppStateDuplicatedNamespacedResources(t *testing.T) {
 		},
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -590,15 +589,15 @@ func TestCompareAppStateDuplicatedNamespacedResources(t *testing.T) {
 	assert.NotNil(t, compRes)
 	assert.Len(t, app.Status.Conditions, 1)
 	assert.NotNil(t, app.Status.Conditions[0].LastTransitionTime)
-	assert.Equal(t, argoappv1.ApplicationConditionRepeatedResourceWarning, app.Status.Conditions[0].Type)
+	assert.Equal(t, v1alpha1.ApplicationConditionRepeatedResourceWarning, app.Status.Conditions[0].Type)
 	assert.Equal(t, "Resource /Pod/fake-dest-ns/my-pod appeared 2 times among application resources.", app.Status.Conditions[0].Message)
 	assert.Len(t, compRes.resources, 4)
 }
 
 func TestCompareAppStateManagedNamespaceMetadataWithLiveNsDoesNotGetPruned(t *testing.T) {
 	app := newFakeApp()
-	app.Spec.SyncPolicy = &argoappv1.SyncPolicy{
-		ManagedNamespaceMetadata: &argoappv1.ManagedNamespaceMetadata{
+	app.Spec.SyncPolicy = &v1alpha1.SyncPolicy{
+		ManagedNamespaceMetadata: &v1alpha1.ManagedNamespaceMetadata{
 			Labels:      nil,
 			Annotations: nil,
 		},
@@ -637,14 +636,14 @@ func TestCompareAppStateManagedNamespaceMetadataWithLiveNsDoesNotGetPruned(t *te
 	assert.Len(t, compRes.managedResources, 1)
 }
 
-var defaultProj = argoappv1.AppProject{
+var defaultProj = v1alpha1.AppProject{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "default",
 		Namespace: test.FakeArgoCDNamespace,
 	},
-	Spec: argoappv1.AppProjectSpec{
+	Spec: v1alpha1.AppProjectSpec{
 		SourceRepos: []string{"*"},
-		Destinations: []argoappv1.ApplicationDestination{
+		Destinations: []v1alpha1.ApplicationDestination{
 			{
 				Server:    "*",
 				Namespace: "*",
@@ -656,10 +655,10 @@ var defaultProj = argoappv1.AppProject{
 // TestCompareAppStateWithManifestGeneratePath tests that it compares revisions when the manifest-generate-path annotation is set.
 func TestCompareAppStateWithManifestGeneratePath(t *testing.T) {
 	app := newFakeApp()
-	app.SetAnnotations(map[string]string{argoappv1.AnnotationKeyManifestGeneratePaths: "."})
-	app.Status.Sync = argoappv1.SyncStatus{
+	app.SetAnnotations(map[string]string{v1alpha1.AnnotationKeyManifestGeneratePaths: "."})
+	app.Status.Sync = v1alpha1.SyncStatus{
 		Revision: "abc123",
-		Status:   argoappv1.SyncStatusCodeSynced,
+		Status:   v1alpha1.SyncStatusCodeSynced,
 	}
 
 	data := fakeData{
@@ -678,7 +677,7 @@ func TestCompareAppStateWithManifestGeneratePath(t *testing.T) {
 	compRes, err := ctrl.appStateManager.CompareAppState(app, &defaultProj, revisions, app.Spec.GetSources(), false, false, nil, false, false)
 	require.NoError(t, err)
 	assert.NotNil(t, compRes)
-	assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 	assert.Equal(t, "abc123", compRes.syncStatus.Revision)
 }
 
@@ -707,7 +706,7 @@ func TestSetHealth(t *testing.T) {
 		},
 	}, nil)
 
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -744,7 +743,7 @@ func TestPreserveStatusTimestamp(t *testing.T) {
 		},
 	}, nil)
 
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -782,7 +781,7 @@ func TestSetHealthSelfReferencedApp(t *testing.T) {
 		},
 	}, nil)
 
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -795,15 +794,15 @@ func TestSetHealthSelfReferencedApp(t *testing.T) {
 
 func TestSetManagedResourcesWithOrphanedResources(t *testing.T) {
 	proj := defaultProj.DeepCopy()
-	proj.Spec.OrphanedResources = &argoappv1.OrphanedResourcesMonitorSettings{}
+	proj.Spec.OrphanedResources = &v1alpha1.OrphanedResourcesMonitorSettings{}
 
 	app := newFakeApp()
 	ctrl := newFakeController(&fakeData{
 		apps: []runtime.Object{app, proj},
 		namespacedResources: map[kube.ResourceKey]namespacedResource{
 			kube.NewResourceKey("apps", kube.DeploymentKind, app.Namespace, "guestbook"): {
-				ResourceNode: argoappv1.ResourceNode{
-					ResourceRef: argoappv1.ResourceRef{Kind: kube.DeploymentKind, Name: "guestbook", Namespace: app.Namespace},
+				ResourceNode: v1alpha1.ResourceNode{
+					ResourceRef: v1alpha1.ResourceRef{Kind: kube.DeploymentKind, Name: "guestbook", Namespace: app.Namespace},
 				},
 				AppName: "",
 			},
@@ -820,7 +819,7 @@ func TestSetManagedResourcesWithOrphanedResources(t *testing.T) {
 
 func TestSetManagedResourcesWithResourcesOfAnotherApp(t *testing.T) {
 	proj := defaultProj.DeepCopy()
-	proj.Spec.OrphanedResources = &argoappv1.OrphanedResourcesMonitorSettings{}
+	proj.Spec.OrphanedResources = &v1alpha1.OrphanedResourcesMonitorSettings{}
 
 	app1 := newFakeApp()
 	app1.Name = "app1"
@@ -831,8 +830,8 @@ func TestSetManagedResourcesWithResourcesOfAnotherApp(t *testing.T) {
 		apps: []runtime.Object{app1, app2, proj},
 		namespacedResources: map[kube.ResourceKey]namespacedResource{
 			kube.NewResourceKey("apps", kube.DeploymentKind, app2.Namespace, "guestbook"): {
-				ResourceNode: argoappv1.ResourceNode{
-					ResourceRef: argoappv1.ResourceRef{Kind: kube.DeploymentKind, Name: "guestbook", Namespace: app2.Namespace},
+				ResourceNode: v1alpha1.ResourceNode{
+					ResourceRef: v1alpha1.ResourceRef{Kind: kube.DeploymentKind, Name: "guestbook", Namespace: app2.Namespace},
 				},
 				AppName: "app2",
 			},
@@ -847,7 +846,7 @@ func TestSetManagedResourcesWithResourcesOfAnotherApp(t *testing.T) {
 
 func TestReturnUnknownComparisonStateOnSettingLoadError(t *testing.T) {
 	proj := defaultProj.DeepCopy()
-	proj.Spec.OrphanedResources = &argoappv1.OrphanedResourcesMonitorSettings{}
+	proj.Spec.OrphanedResources = &v1alpha1.OrphanedResourcesMonitorSettings{}
 
 	app := newFakeApp()
 
@@ -858,7 +857,7 @@ func TestReturnUnknownComparisonStateOnSettingLoadError(t *testing.T) {
 		},
 	}, nil)
 
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -867,12 +866,12 @@ func TestReturnUnknownComparisonStateOnSettingLoadError(t *testing.T) {
 
 	assert.Equal(t, health.HealthStatusUnknown, compRes.healthStatus.Status)
 	assert.False(t, compRes.healthStatus.LastTransitionTime.IsZero())
-	assert.Equal(t, argoappv1.SyncStatusCodeUnknown, compRes.syncStatus.Status)
+	assert.Equal(t, v1alpha1.SyncStatusCodeUnknown, compRes.syncStatus.Status)
 }
 
 func TestSetManagedResourcesKnownOrphanedResourceExceptions(t *testing.T) {
 	proj := defaultProj.DeepCopy()
-	proj.Spec.OrphanedResources = &argoappv1.OrphanedResourcesMonitorSettings{}
+	proj.Spec.OrphanedResources = &v1alpha1.OrphanedResourcesMonitorSettings{}
 	proj.Spec.SourceNamespaces = []string{"default"}
 
 	app := newFakeApp()
@@ -882,13 +881,13 @@ func TestSetManagedResourcesKnownOrphanedResourceExceptions(t *testing.T) {
 		apps: []runtime.Object{app, proj},
 		namespacedResources: map[kube.ResourceKey]namespacedResource{
 			kube.NewResourceKey("apps", kube.DeploymentKind, app.Namespace, "guestbook"): {
-				ResourceNode: argoappv1.ResourceNode{ResourceRef: argoappv1.ResourceRef{Group: "apps", Kind: kube.DeploymentKind, Name: "guestbook", Namespace: app.Namespace}},
+				ResourceNode: v1alpha1.ResourceNode{ResourceRef: v1alpha1.ResourceRef{Group: "apps", Kind: kube.DeploymentKind, Name: "guestbook", Namespace: app.Namespace}},
 			},
 			kube.NewResourceKey("", kube.ServiceAccountKind, app.Namespace, "default"): {
-				ResourceNode: argoappv1.ResourceNode{ResourceRef: argoappv1.ResourceRef{Kind: kube.ServiceAccountKind, Name: "default", Namespace: app.Namespace}},
+				ResourceNode: v1alpha1.ResourceNode{ResourceRef: v1alpha1.ResourceRef{Kind: kube.ServiceAccountKind, Name: "default", Namespace: app.Namespace}},
 			},
 			kube.NewResourceKey("", kube.ServiceKind, app.Namespace, "kubernetes"): {
-				ResourceNode: argoappv1.ResourceNode{ResourceRef: argoappv1.ResourceRef{Kind: kube.ServiceAccountKind, Name: "kubernetes", Namespace: app.Namespace}},
+				ResourceNode: v1alpha1.ResourceNode{ResourceRef: v1alpha1.ResourceRef{Kind: kube.ServiceAccountKind, Name: "kubernetes", Namespace: app.Namespace}},
 			},
 		},
 	}, nil)
@@ -911,7 +910,7 @@ func Test_appStateManager_persistRevisionHistory(t *testing.T) {
 		app.Spec.RevisionHistoryLimit = &i
 	}
 	addHistory := func() {
-		err := manager.persistRevisionHistory(app, "my-revision", argoappv1.ApplicationSource{}, []string{}, []argoappv1.ApplicationSource{}, false, metav1.Time{}, v1alpha1.OperationInitiator{})
+		err := manager.persistRevisionHistory(app, "my-revision", v1alpha1.ApplicationSource{}, []string{}, []v1alpha1.ApplicationSource{}, false, metav1.Time{}, v1alpha1.OperationInitiator{})
 		require.NoError(t, err)
 	}
 	addHistory()
@@ -947,7 +946,7 @@ func Test_appStateManager_persistRevisionHistory(t *testing.T) {
 	assert.Len(t, app.Status.History, 9)
 
 	metav1NowTime := metav1.NewTime(time.Now())
-	err := manager.persistRevisionHistory(app, "my-revision", argoappv1.ApplicationSource{}, []string{}, []argoappv1.ApplicationSource{}, false, metav1NowTime, v1alpha1.OperationInitiator{})
+	err := manager.persistRevisionHistory(app, "my-revision", v1alpha1.ApplicationSource{}, []string{}, []v1alpha1.ApplicationSource{}, false, metav1NowTime, v1alpha1.OperationInitiator{})
 	require.NoError(t, err)
 	assert.Equal(t, app.Status.History.LastRevisionHistory().DeployStartedAt, &metav1NowTime)
 }
@@ -962,20 +961,20 @@ func mustReadFile(path string) string {
 	return string(b)
 }
 
-var signedProj = argoappv1.AppProject{
+var signedProj = v1alpha1.AppProject{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "default",
 		Namespace: test.FakeArgoCDNamespace,
 	},
-	Spec: argoappv1.AppProjectSpec{
+	Spec: v1alpha1.AppProjectSpec{
 		SourceRepos: []string{"*"},
-		Destinations: []argoappv1.ApplicationDestination{
+		Destinations: []v1alpha1.ApplicationDestination{
 			{
 				Server:    "*",
 				Namespace: "*",
 			},
 		},
-		SignatureKeys: []argoappv1.SignatureKey{
+		SignatureKeys: []v1alpha1.SignatureKey{
 			{
 				KeyID: "4AEE18F83AFDEB23",
 			},
@@ -1000,7 +999,7 @@ func TestSignedResponseNoSignatureRequired(t *testing.T) {
 			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 		}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "")
@@ -1008,7 +1007,7 @@ func TestSignedResponseNoSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Empty(t, app.Status.Conditions)
@@ -1027,7 +1026,7 @@ func TestSignedResponseNoSignatureRequired(t *testing.T) {
 			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 		}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "")
@@ -1035,7 +1034,7 @@ func TestSignedResponseNoSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Empty(t, app.Status.Conditions)
@@ -1059,7 +1058,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 		}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "")
@@ -1067,7 +1066,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Empty(t, app.Status.Conditions)
@@ -1086,7 +1085,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 		}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "abc123")
@@ -1094,7 +1093,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Len(t, app.Status.Conditions, 1)
@@ -1113,7 +1112,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 		}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "abc123")
@@ -1121,7 +1120,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Len(t, app.Status.Conditions, 1)
@@ -1140,7 +1139,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 		}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "abc123")
@@ -1148,7 +1147,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Len(t, app.Status.Conditions, 1)
@@ -1170,7 +1169,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		ctrl := newFakeController(&data, nil)
 		testProj := signedProj
 		testProj.Spec.SignatureKeys[0].KeyID = "4AEE18F83AFDEB24"
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "abc123")
@@ -1178,7 +1177,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Len(t, app.Status.Conditions, 1)
@@ -1200,7 +1199,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		// it doesn't matter for our test whether local manifests are valid
 		localManifests := []string{"foobar"}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "abc123")
@@ -1208,7 +1207,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeUnknown, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeUnknown, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Len(t, app.Status.Conditions, 1)
@@ -1230,7 +1229,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 			managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 		}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "abc123")
@@ -1238,7 +1237,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Empty(t, app.Status.Conditions)
@@ -1260,7 +1259,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		// it doesn't matter for our test whether local manifests are valid
 		localManifests := []string{""}
 		ctrl := newFakeController(&data, nil)
-		sources := make([]argoappv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		sources = append(sources, app.Spec.GetSource())
 		revisions := make([]string, 0)
 		revisions = append(revisions, "abc123")
@@ -1268,7 +1267,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, compRes)
 		assert.NotNil(t, compRes.syncStatus)
-		assert.Equal(t, argoappv1.SyncStatusCodeSynced, compRes.syncStatus.Status)
+		assert.Equal(t, v1alpha1.SyncStatusCodeSynced, compRes.syncStatus.Status)
 		assert.Empty(t, compRes.resources)
 		assert.Empty(t, compRes.managedResources)
 		assert.Empty(t, app.Status.Conditions)
@@ -1276,7 +1275,7 @@ func TestSignedResponseSignatureRequired(t *testing.T) {
 }
 
 func TestComparisonResult_GetHealthStatus(t *testing.T) {
-	status := &argoappv1.HealthStatus{Status: health.HealthStatusMissing}
+	status := &v1alpha1.HealthStatus{Status: health.HealthStatusMissing}
 	res := comparisonResult{
 		healthStatus: status,
 	}
@@ -1285,7 +1284,7 @@ func TestComparisonResult_GetHealthStatus(t *testing.T) {
 }
 
 func TestComparisonResult_GetSyncStatus(t *testing.T) {
-	status := &argoappv1.SyncStatus{Status: argoappv1.SyncStatusCodeOutOfSync}
+	status := &v1alpha1.SyncStatus{Status: v1alpha1.SyncStatusCodeOutOfSync}
 	res := comparisonResult{
 		syncStatus: status,
 	}
@@ -1477,8 +1476,8 @@ func TestUseDiffCache(t *testing.T) {
 		testName             string
 		noCache              bool
 		manifestInfos        []*apiclient.ManifestResponse
-		sources              []argoappv1.ApplicationSource
-		app                  *argoappv1.Application
+		sources              []v1alpha1.ApplicationSource
+		app                  *v1alpha1.Application
 		manifestRevisions    []string
 		statusRefreshTimeout time.Duration
 		expectedUseCache     bool
@@ -1500,8 +1499,8 @@ func TestUseDiffCache(t *testing.T) {
 			},
 		}
 	}
-	sources := func() []argoappv1.ApplicationSource {
-		return []argoappv1.ApplicationSource{
+	sources := func() []v1alpha1.ApplicationSource {
+		return []v1alpha1.ApplicationSource{
 			{
 				RepoURL:        "https://some-repo.com",
 				Path:           "argocd/httpbin",
@@ -1510,41 +1509,41 @@ func TestUseDiffCache(t *testing.T) {
 		}
 	}
 
-	app := func(namespace string, revision string, refresh bool, a *argoappv1.Application) *argoappv1.Application {
-		app := &argoappv1.Application{
+	app := func(namespace string, revision string, refresh bool, a *v1alpha1.Application) *v1alpha1.Application {
+		app := &v1alpha1.Application{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "httpbin",
 				Namespace: namespace,
 			},
-			Spec: argoappv1.ApplicationSpec{
-				Source: &argoappv1.ApplicationSource{
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://some-repo.com",
 					Path:           "argocd/httpbin",
 					TargetRevision: "HEAD",
 				},
-				Destination: argoappv1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: "httpbin",
 				},
 				Project: "default",
-				SyncPolicy: &argoappv1.SyncPolicy{
+				SyncPolicy: &v1alpha1.SyncPolicy{
 					SyncOptions: []string{
 						"CreateNamespace=true",
 						"ServerSideApply=true",
 					},
 				},
 			},
-			Status: argoappv1.ApplicationStatus{
-				Resources: []argoappv1.ResourceStatus{},
-				Sync: argoappv1.SyncStatus{
-					Status: argoappv1.SyncStatusCodeSynced,
-					ComparedTo: argoappv1.ComparedTo{
-						Source: argoappv1.ApplicationSource{
+			Status: v1alpha1.ApplicationStatus{
+				Resources: []v1alpha1.ResourceStatus{},
+				Sync: v1alpha1.SyncStatus{
+					Status: v1alpha1.SyncStatusCodeSynced,
+					ComparedTo: v1alpha1.ComparedTo{
+						Source: v1alpha1.ApplicationSource{
 							RepoURL:        "https://some-repo.com",
 							Path:           "argocd/httpbin",
 							TargetRevision: "HEAD",
 						},
-						Destination: argoappv1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "httpbin",
 						},
@@ -1559,7 +1558,7 @@ func TestUseDiffCache(t *testing.T) {
 		}
 		if refresh {
 			annotations := make(map[string]string)
-			annotations[argoappv1.AnnotationKeyRefresh] = string(argoappv1.RefreshTypeNormal)
+			annotations[v1alpha1.AnnotationKeyRefresh] = string(v1alpha1.RefreshTypeNormal)
 			app.SetAnnotations(annotations)
 		}
 		if a != nil {
@@ -1601,10 +1600,10 @@ func TestUseDiffCache(t *testing.T) {
 			noCache:       false,
 			manifestInfos: manifestInfos("rev1"),
 			sources:       sources(),
-			app: app("httpbin", "", false, &argoappv1.Application{
-				Spec: argoappv1.ApplicationSpec{
+			app: app("httpbin", "", false, &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
 					Source: nil,
-					Sources: argoappv1.ApplicationSources{
+					Sources: v1alpha1.ApplicationSources{
 						{
 							RepoURL: "multisource repo1",
 						},
@@ -1613,13 +1612,13 @@ func TestUseDiffCache(t *testing.T) {
 						},
 					},
 				},
-				Status: argoappv1.ApplicationStatus{
-					Resources: []argoappv1.ResourceStatus{},
-					Sync: argoappv1.SyncStatus{
-						Status: argoappv1.SyncStatusCodeSynced,
-						ComparedTo: argoappv1.ComparedTo{
-							Source: argoappv1.ApplicationSource{},
-							Sources: argoappv1.ApplicationSources{
+				Status: v1alpha1.ApplicationStatus{
+					Resources: []v1alpha1.ResourceStatus{},
+					Sync: v1alpha1.SyncStatus{
+						Status: v1alpha1.SyncStatusCodeSynced,
+						ComparedTo: v1alpha1.ComparedTo{
+							Source: v1alpha1.ApplicationSource{},
+							Sources: v1alpha1.ApplicationSources{
 								{
 									RepoURL: "multisource repo1",
 								},
@@ -1700,9 +1699,9 @@ func TestUseDiffCache(t *testing.T) {
 			noCache:       false,
 			manifestInfos: manifestInfos("rev1"),
 			sources:       sources(),
-			app: app("httpbin", "rev1", false, &argoappv1.Application{
-				Spec: argoappv1.ApplicationSpec{
-					Source: &argoappv1.ApplicationSource{
+			app: app("httpbin", "rev1", false, &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL: "new-repo",
 					},
 				},
@@ -1717,9 +1716,9 @@ func TestUseDiffCache(t *testing.T) {
 			noCache:       false,
 			manifestInfos: manifestInfos("rev1"),
 			sources:       sources(),
-			app: app("httpbin", "rev1", false, &argoappv1.Application{
-				Spec: argoappv1.ApplicationSpec{
-					IgnoreDifferences: []argoappv1.ResourceIgnoreDifferences{
+			app: app("httpbin", "rev1", false, &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					IgnoreDifferences: []v1alpha1.ResourceIgnoreDifferences{
 						{
 							Group:             "app/v1",
 							Kind:              "application",
@@ -1743,20 +1742,20 @@ func TestUseDiffCache(t *testing.T) {
 			noCache:       false,
 			manifestInfos: manifestInfos("rev1"),
 			sources:       sources(),
-			app: app("httpbin", "rev1", false, &argoappv1.Application{
-				Spec: argoappv1.ApplicationSpec{
-					Destination: argoappv1.ApplicationDestination{
+			app: app("httpbin", "rev1", false, &v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Name:      "httpbin",
 						Namespace: "httpbin",
 					},
 				},
-				Status: argoappv1.ApplicationStatus{
-					Resources: []argoappv1.ResourceStatus{},
-					Sync: argoappv1.SyncStatus{
-						Status: argoappv1.SyncStatusCodeSynced,
-						ComparedTo: argoappv1.ComparedTo{
-							Destination: argoappv1.ApplicationDestination{
+				Status: v1alpha1.ApplicationStatus{
+					Resources: []v1alpha1.ResourceStatus{},
+					Sync: v1alpha1.SyncStatus{
+						Status: v1alpha1.SyncStatusCodeSynced,
+						ComparedTo: v1alpha1.ComparedTo{
+							Destination: v1alpha1.ApplicationDestination{
 								Server:    "https://kubernetes.default.svc",
 								Namespace: "httpbin",
 							},
@@ -1804,7 +1803,7 @@ func TestCompareAppStateDefaultRevisionUpdated(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")
@@ -1827,7 +1826,7 @@ func TestCompareAppStateRevisionUpdatedWithHelmSource(t *testing.T) {
 		managedLiveObjs: make(map[kube.ResourceKey]*unstructured.Unstructured),
 	}
 	ctrl := newFakeController(&data, nil)
-	sources := make([]argoappv1.ApplicationSource, 0)
+	sources := make([]v1alpha1.ApplicationSource, 0)
 	sources = append(sources, app.Spec.GetSource())
 	revisions := make([]string, 0)
 	revisions = append(revisions, "")

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/cache/mocks"
 	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
@@ -46,7 +45,7 @@ func TestCache_GetRevisionMetadata(t *testing.T) {
 	require.ErrorIs(t, err, ErrCacheMiss)
 	mockCache.RedisClient.AssertCalled(t, "Get", mock.Anything, mock.Anything)
 	// populate cache
-	err = cache.SetRevisionMetadata("my-repo-url", "my-revision", &RevisionMetadata{Message: "my-message"})
+	err = cache.SetRevisionMetadata("my-repo-url", "my-revision", &v1alpha1.RevisionMetadata{Message: "my-message"})
 	require.NoError(t, err)
 	// cache miss
 	_, err = cache.GetRevisionMetadata("other-repo-url", "my-revision")
@@ -57,7 +56,7 @@ func TestCache_GetRevisionMetadata(t *testing.T) {
 	// cache hit
 	value, err := cache.GetRevisionMetadata("my-repo-url", "my-revision")
 	require.NoError(t, err)
-	assert.Equal(t, &RevisionMetadata{Message: "my-message"}, value)
+	assert.Equal(t, &v1alpha1.RevisionMetadata{Message: "my-message"}, value)
 	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 4})
 }
 
@@ -93,43 +92,43 @@ func TestCache_GetManifests(t *testing.T) {
 	// cache miss
 	q := &apiclient.ManifestRequest{}
 	value := &CachedManifestResponse{}
-	err := cache.GetManifests("my-revision", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
+	err := cache.GetManifests("my-revision", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
 	require.ErrorIs(t, err, ErrCacheMiss)
 	// populate cache
 	res := &CachedManifestResponse{ManifestResponse: &apiclient.ManifestResponse{SourceType: "my-source-type"}}
-	err = cache.SetManifests("my-revision", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", res, nil, "")
+	err = cache.SetManifests("my-revision", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", res, nil, "")
 	require.NoError(t, err)
 	t.Run("expect cache miss because of changed revision", func(t *testing.T) {
-		err = cache.GetManifests("other-revision", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
+		err = cache.GetManifests("other-revision", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})
 	t.Run("expect cache miss because of changed path", func(t *testing.T) {
-		err = cache.GetManifests("my-revision", &ApplicationSource{Path: "other-path"}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
+		err = cache.GetManifests("my-revision", &v1alpha1.ApplicationSource{Path: "other-path"}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})
 	t.Run("expect cache miss because of changed namespace", func(t *testing.T) {
-		err = cache.GetManifests("my-revision", &ApplicationSource{}, q.RefSources, q, "other-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
+		err = cache.GetManifests("my-revision", &v1alpha1.ApplicationSource{}, q.RefSources, q, "other-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})
 	t.Run("expect cache miss because of changed app label key", func(t *testing.T) {
-		err = cache.GetManifests("my-revision", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "other-app-label-key", "my-app-label-value", value, nil, "")
+		err = cache.GetManifests("my-revision", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "other-app-label-key", "my-app-label-value", value, nil, "")
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})
 	t.Run("expect cache miss because of changed app label value", func(t *testing.T) {
-		err = cache.GetManifests("my-revision", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "other-app-label-value", value, nil, "")
+		err = cache.GetManifests("my-revision", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "other-app-label-value", value, nil, "")
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})
 	t.Run("expect cache miss because of changed referenced source", func(t *testing.T) {
-		err = cache.GetManifests("my-revision", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "other-app-label-value", value, map[string]string{"my-referenced-source": "my-referenced-revision"}, "")
+		err = cache.GetManifests("my-revision", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "other-app-label-value", value, map[string]string{"my-referenced-source": "my-referenced-revision"}, "")
 		require.ErrorIs(t, err, ErrCacheMiss)
 	})
 	t.Run("expect cache hit", func(t *testing.T) {
 		err = cache.SetManifests(
-			"my-revision1", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value",
+			"my-revision1", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value",
 			&CachedManifestResponse{ManifestResponse: &apiclient.ManifestResponse{SourceType: "my-source-type", Revision: "my-revision2"}}, nil, "")
 		require.NoError(t, err)
 
-		err = cache.GetManifests("my-revision1", &ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
+		err = cache.GetManifests("my-revision1", &v1alpha1.ApplicationSource{}, q.RefSources, q, "my-namespace", "", "my-app-label-key", "my-app-label-value", value, nil, "")
 		require.NoError(t, err)
 
 		assert.Equal(t, "my-source-type", value.ManifestResponse.SourceType)
@@ -145,20 +144,20 @@ func TestCache_GetAppDetails(t *testing.T) {
 	mockCache := fixtures.mockCache
 	// cache miss
 	value := &apiclient.RepoAppDetailsResponse{}
-	emptyRefSources := map[string]*RefTarget{}
-	err := cache.GetAppDetails("my-revision", &ApplicationSource{}, emptyRefSources, value, "", nil)
+	emptyRefSources := map[string]*v1alpha1.RefTarget{}
+	err := cache.GetAppDetails("my-revision", &v1alpha1.ApplicationSource{}, emptyRefSources, value, "", nil)
 	require.ErrorIs(t, err, ErrCacheMiss)
 	res := &apiclient.RepoAppDetailsResponse{Type: "my-type"}
-	err = cache.SetAppDetails("my-revision", &ApplicationSource{}, emptyRefSources, res, "", nil)
+	err = cache.SetAppDetails("my-revision", &v1alpha1.ApplicationSource{}, emptyRefSources, res, "", nil)
 	require.NoError(t, err)
 	// cache miss
-	err = cache.GetAppDetails("other-revision", &ApplicationSource{}, emptyRefSources, value, "", nil)
+	err = cache.GetAppDetails("other-revision", &v1alpha1.ApplicationSource{}, emptyRefSources, value, "", nil)
 	require.ErrorIs(t, err, ErrCacheMiss)
 	// cache miss
-	err = cache.GetAppDetails("my-revision", &ApplicationSource{Path: "other-path"}, emptyRefSources, value, "", nil)
+	err = cache.GetAppDetails("my-revision", &v1alpha1.ApplicationSource{Path: "other-path"}, emptyRefSources, value, "", nil)
 	require.ErrorIs(t, err, ErrCacheMiss)
 	// cache hit
-	err = cache.GetAppDetails("my-revision", &ApplicationSource{}, emptyRefSources, value, "", nil)
+	err = cache.GetAppDetails("my-revision", &v1alpha1.ApplicationSource{}, emptyRefSources, value, "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, &apiclient.RepoAppDetailsResponse{Type: "my-type"}, value)
 	mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalSets: 1, ExternalGets: 4})
@@ -185,7 +184,7 @@ func TestCachedManifestResponse_HashBehavior(t *testing.T) {
 		Revision:  "revision",
 		Manifests: []string{"sample-text"},
 	}
-	appSrc := &ApplicationSource{}
+	appSrc := &v1alpha1.ApplicationSource{}
 	appKey := "key"
 	appValue := "value"
 
@@ -600,14 +599,14 @@ func TestRevisionChartDetails(t *testing.T) {
 		t.Cleanup(fixtures.mockCache.StopRedisCallback)
 		details, err := fixtures.cache.GetRevisionChartDetails("test-repo", "test-revision", "v1.0.0")
 		require.ErrorIs(t, err, ErrCacheMiss)
-		assert.Equal(t, &appv1.ChartDetails{}, details)
+		assert.Equal(t, &v1alpha1.ChartDetails{}, details)
 		fixtures.mockCache.AssertCacheCalledTimes(t, &mocks.CacheCallCounts{ExternalGets: 1})
 	})
 	t.Run("GetRevisionChartDetails cache miss local", func(t *testing.T) {
 		fixtures := newFixtures()
 		t.Cleanup(fixtures.mockCache.StopRedisCallback)
 		cache := fixtures.cache
-		expectedItem := &appv1.ChartDetails{
+		expectedItem := &v1alpha1.ChartDetails{
 			Description: "test-chart",
 			Home:        "v1.0.0",
 			Maintainers: []string{"test-maintainer"},
@@ -627,7 +626,7 @@ func TestRevisionChartDetails(t *testing.T) {
 		fixtures := newFixtures()
 		t.Cleanup(fixtures.mockCache.StopRedisCallback)
 		cache := fixtures.cache
-		expectedItem := &appv1.ChartDetails{
+		expectedItem := &v1alpha1.ChartDetails{
 			Description: "test-chart",
 			Home:        "v1.0.0",
 			Maintainers: []string{"test-maintainer"},
@@ -646,7 +645,7 @@ func TestRevisionChartDetails(t *testing.T) {
 	t.Run("SetRevisionChartDetails", func(t *testing.T) {
 		fixtures := newFixtures()
 		t.Cleanup(fixtures.mockCache.StopRedisCallback)
-		expectedItem := &appv1.ChartDetails{
+		expectedItem := &v1alpha1.ChartDetails{
 			Description: "test-chart",
 			Home:        "v1.0.0",
 			Maintainers: []string{"test-maintainer"},

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -48,7 +48,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/reposerver/metrics"
 	"github.com/argoproj/argo-cd/v2/util/app/discovery"
 	apppathutil "github.com/argoproj/argo-cd/v2/util/app/path"
-	argopath "github.com/argoproj/argo-cd/v2/util/app/path"
 	"github.com/argoproj/argo-cd/v2/util/argo"
 	"github.com/argoproj/argo-cd/v2/util/cmp"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -360,9 +359,9 @@ func (s *Service) runRepoOperation(
 		}
 		defer io.Close(closer)
 		if !s.initConstants.AllowOutOfBoundsSymlinks {
-			err := argopath.CheckOutOfBoundsSymlinks(chartPath)
+			err := apppathutil.CheckOutOfBoundsSymlinks(chartPath)
 			if err != nil {
-				oobError := &argopath.OutOfBoundsSymlinkError{}
+				oobError := &apppathutil.OutOfBoundsSymlinkError{}
 				if errors.As(err, &oobError) {
 					log.WithFields(log.Fields{
 						common.SecurityField: common.SecurityHigh,
@@ -390,9 +389,9 @@ func (s *Service) runRepoOperation(
 		defer io.Close(closer)
 
 		if !s.initConstants.AllowOutOfBoundsSymlinks {
-			err := argopath.CheckOutOfBoundsSymlinks(gitClient.Root())
+			err := apppathutil.CheckOutOfBoundsSymlinks(gitClient.Root())
 			if err != nil {
-				oobError := &argopath.OutOfBoundsSymlinkError{}
+				oobError := &apppathutil.OutOfBoundsSymlinkError{}
 				if errors.As(err, &oobError) {
 					log.WithFields(log.Fields{
 						common.SecurityField: common.SecurityHigh,
@@ -444,7 +443,7 @@ func (s *Service) runRepoOperation(
 					return nil, err
 				}
 			}
-			appPath, err := argopath.Path(gitClient.Root(), source.Path)
+			appPath, err := apppathutil.Path(gitClient.Root(), source.Path)
 			if err != nil {
 				return nil, err
 			}
@@ -604,9 +603,9 @@ func (s *Service) GenerateManifestWithFiles(stream apiclient.RepoServerService_G
 	}
 
 	if !s.initConstants.AllowOutOfBoundsSymlinks {
-		err := argopath.CheckOutOfBoundsSymlinks(workDir)
+		err := apppathutil.CheckOutOfBoundsSymlinks(workDir)
 		if err != nil {
-			oobError := &argopath.OutOfBoundsSymlinkError{}
+			oobError := &apppathutil.OutOfBoundsSymlinkError{}
 			if errors.As(err, &oobError) {
 				log.WithFields(log.Fields{
 					common.SecurityField: common.SecurityHigh,
@@ -620,7 +619,7 @@ func (s *Service) GenerateManifestWithFiles(stream apiclient.RepoServerService_G
 	}
 
 	promise := s.runManifestGen(stream.Context(), workDir, "streamed", metadata.Checksum, func() (*operationContext, error) {
-		appPath, err := argopath.Path(workDir, req.ApplicationSource.Path)
+		appPath, err := apppathutil.Path(workDir, req.ApplicationSource.Path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get app path: %w", err)
 		}
@@ -782,9 +781,9 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 
 							// Symlink check must happen after acquiring lock.
 							if !s.initConstants.AllowOutOfBoundsSymlinks {
-								err := argopath.CheckOutOfBoundsSymlinks(gitClient.Root())
+								err := apppathutil.CheckOutOfBoundsSymlinks(gitClient.Root())
 								if err != nil {
-									oobError := &argopath.OutOfBoundsSymlinkError{}
+									oobError := &apppathutil.OutOfBoundsSymlinkError{}
 									if errors.As(err, &oobError) {
 										log.WithFields(log.Fields{
 											common.SecurityField: common.SecurityHigh,

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/reposerver/cache"
 	repositorymocks "github.com/argoproj/argo-cd/v2/reposerver/cache/mocks"
@@ -206,9 +205,9 @@ func newServiceWithCommitSHA(t *testing.T, root, revision string) *Service {
 func TestGenerateYamlManifestInDir(t *testing.T) {
 	service := newService(t, "../../manifests/base")
 
-	src := argoappv1.ApplicationSource{Path: "."}
+	src := v1alpha1.ApplicationSource{Path: "."}
 	q := apiclient.ManifestRequest{
-		Repo:               &argoappv1.Repository{},
+		Repo:               &v1alpha1.Repository{},
 		ApplicationSource:  &src,
 		ProjectName:        "something",
 		ProjectSourceRepos: []string{"*"},
@@ -279,7 +278,7 @@ func Test_GenerateManifests_NoOutOfBoundsAccess(t *testing.T) {
 			}
 
 			q := apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{}, ApplicationSource: &argoappv1.ApplicationSource{}, ProjectName: "something",
+				Repo: &v1alpha1.Repository{}, ApplicationSource: &v1alpha1.ApplicationSource{}, ProjectName: "something",
 				ProjectSourceRepos: []string{"*"},
 			}
 			res, err := GenerateManifests(context.Background(), repoDir, "", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
@@ -297,7 +296,7 @@ func TestGenerateManifests_MissingSymlinkDestination(t *testing.T) {
 	require.NoError(t, err)
 
 	q := apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: &argoappv1.ApplicationSource{}, ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &v1alpha1.ApplicationSource{}, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 	_, err = GenerateManifests(context.Background(), repoDir, "", "", &q, false, &git.NoopCredsStore{}, resource.MustParse("0"), nil)
@@ -307,10 +306,10 @@ func TestGenerateManifests_MissingSymlinkDestination(t *testing.T) {
 func TestGenerateManifests_K8SAPIResetCache(t *testing.T) {
 	service := newService(t, "../../manifests/base")
 
-	src := argoappv1.ApplicationSource{Path: "."}
+	src := v1alpha1.ApplicationSource{Path: "."}
 	q := apiclient.ManifestRequest{
 		KubeVersion:        "v1.16.0",
-		Repo:               &argoappv1.Repository{},
+		Repo:               &v1alpha1.Repository{},
 		ApplicationSource:  &src,
 		ProjectName:        "something",
 		ProjectSourceRepos: []string{"*"},
@@ -335,9 +334,9 @@ func TestGenerateManifests_K8SAPIResetCache(t *testing.T) {
 func TestGenerateManifests_EmptyCache(t *testing.T) {
 	service, gitMocks, mockCache := newServiceWithMocks(t, "../../manifests/base", false)
 
-	src := argoappv1.ApplicationSource{Path: "."}
+	src := v1alpha1.ApplicationSource{Path: "."}
 	q := apiclient.ManifestRequest{
-		Repo:               &argoappv1.Repository{},
+		Repo:               &v1alpha1.Repository{},
 		ApplicationSource:  &src,
 		ProjectName:        "something",
 		ProjectSourceRepos: []string{"*"},
@@ -391,8 +390,8 @@ func TestGenerateManifest_RefOnlyShortCircuit(t *testing.T) {
 		remote:         repoRemote,
 		addEmptyCommit: true,
 	})
-	src := argoappv1.ApplicationSource{RepoURL: repoRemote, TargetRevision: "HEAD", Ref: "test-ref"}
-	repo := &argoappv1.Repository{
+	src := v1alpha1.ApplicationSource{RepoURL: repoRemote, TargetRevision: "HEAD", Ref: "test-ref"}
+	repo := &v1alpha1.Repository{
 		Repo: repoRemote,
 	}
 	q := apiclient.ManifestRequest{
@@ -457,10 +456,10 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 			valuesFiles:  map[string]map[string]string{"test.yaml": {"testval": "test"}},
 		},
 	})
-	src := argoappv1.ApplicationSource{RepoURL: repoRemote, Path: ".", TargetRevision: "HEAD", Helm: &argoappv1.ApplicationSourceHelm{
+	src := v1alpha1.ApplicationSource{RepoURL: repoRemote, Path: ".", TargetRevision: "HEAD", Helm: &v1alpha1.ApplicationSourceHelm{
 		ValueFiles: []string{"$ref/test.yaml"},
 	}}
-	repo := &argoappv1.Repository{
+	repo := &v1alpha1.Repository{
 		Repo: repoRemote,
 	}
 	q := apiclient.ManifestRequest{
@@ -470,7 +469,7 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 		ApplicationSource:  &src,
 		ProjectName:        "default",
 		ProjectSourceRepos: []string{"*"},
-		RefSources:         map[string]*argoappv1.RefTarget{"$ref": {TargetRevision: "HEAD", Repo: *repo}},
+		RefSources:         map[string]*v1alpha1.RefTarget{"$ref": {TargetRevision: "HEAD", Repo: *repo}},
 	}
 	err = cacheMocks.cacheutilCache.SetItem("git-refs|"+repoRemote, [][2]string{{"HEAD", revision}}, nil)
 	require.NoError(t, err)
@@ -486,9 +485,9 @@ func TestGenerateManifestsHelmWithRefs_CachedNoLsRemote(t *testing.T) {
 func TestHelmManifestFromChartRepo(t *testing.T) {
 	root := t.TempDir()
 	service, gitMocks, mockCache := newServiceWithMocks(t, root, false)
-	source := &argoappv1.ApplicationSource{Chart: "my-chart", TargetRevision: ">= 1.0.0"}
+	source := &v1alpha1.ApplicationSource{Chart: "my-chart", TargetRevision: ">= 1.0.0"}
 	request := &apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: source, NoCache: true, ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: source, NoCache: true, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 	response, err := service.GenerateManifest(context.Background(), request)
@@ -511,22 +510,22 @@ func TestHelmManifestFromChartRepo(t *testing.T) {
 
 func TestHelmChartReferencingExternalValues(t *testing.T) {
 	service := newService(t, ".")
-	spec := argoappv1.ApplicationSpec{
-		Sources: []argoappv1.ApplicationSource{
-			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &argoappv1.ApplicationSourceHelm{
+	spec := v1alpha1.ApplicationSpec{
+		Sources: []v1alpha1.ApplicationSource{
+			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles: []string{"$ref/testdata/my-chart/my-chart-values.yaml"},
 			}},
 			{Ref: "ref", RepoURL: "https://git.example.com/test/repo"},
 		},
 	}
-	refSources, err := argo.GetRefSources(context.Background(), spec.Sources, spec.Project, func(ctx context.Context, url string, project string) (*argoappv1.Repository, error) {
-		return &argoappv1.Repository{
+	refSources, err := argo.GetRefSources(context.Background(), spec.Sources, spec.Project, func(ctx context.Context, url string, project string) (*v1alpha1.Repository, error) {
+		return &v1alpha1.Repository{
 			Repo: "https://git.example.com/test/repo",
 		}, nil
 	}, []string{}, false)
 	require.NoError(t, err)
 	request := &apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 	response, err := service.GenerateManifest(context.Background(), request)
@@ -543,9 +542,9 @@ func TestHelmChartReferencingExternalValues(t *testing.T) {
 }
 
 func TestHelmChartReferencingExternalValues_InvalidRefs(t *testing.T) {
-	spec := argoappv1.ApplicationSpec{
-		Sources: []argoappv1.ApplicationSource{
-			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &argoappv1.ApplicationSourceHelm{
+	spec := v1alpha1.ApplicationSpec{
+		Sources: []v1alpha1.ApplicationSource{
+			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles: []string{"$ref/testdata/my-chart/my-chart-values.yaml"},
 			}},
 			{RepoURL: "https://git.example.com/test/repo"},
@@ -555,8 +554,8 @@ func TestHelmChartReferencingExternalValues_InvalidRefs(t *testing.T) {
 	// Empty refsource
 	service := newService(t, ".")
 
-	getRepository := func(ctx context.Context, url string, project string) (*argoappv1.Repository, error) {
-		return &argoappv1.Repository{
+	getRepository := func(ctx context.Context, url string, project string) (*v1alpha1.Repository, error) {
+		return &v1alpha1.Repository{
 			Repo: "https://git.example.com/test/repo",
 		}, nil
 	}
@@ -565,7 +564,7 @@ func TestHelmChartReferencingExternalValues_InvalidRefs(t *testing.T) {
 	require.NoError(t, err)
 
 	request := &apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 	response, err := service.GenerateManifest(context.Background(), request)
@@ -580,7 +579,7 @@ func TestHelmChartReferencingExternalValues_InvalidRefs(t *testing.T) {
 	require.NoError(t, err)
 
 	request = &apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 	response, err = service.GenerateManifest(context.Background(), request)
@@ -596,7 +595,7 @@ func TestHelmChartReferencingExternalValues_InvalidRefs(t *testing.T) {
 	require.NoError(t, err)
 
 	request = &apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 	response, err = service.GenerateManifest(context.Background(), request)
@@ -617,10 +616,10 @@ func TestHelmChartReferencingExternalValues_OutOfBounds_Symlink(t *testing.T) {
 	// Create a regular file to reference from another source
 	err = os.WriteFile("./testdata/oob-symlink/values.yaml", []byte("foo: bar"), 0o644)
 	require.NoError(t, err)
-	spec := argoappv1.ApplicationSpec{
+	spec := v1alpha1.ApplicationSpec{
 		Project: "default",
-		Sources: []argoappv1.ApplicationSource{
-			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &argoappv1.ApplicationSourceHelm{
+		Sources: []v1alpha1.ApplicationSource{
+			{RepoURL: "https://helm.example.com", Chart: "my-chart", TargetRevision: ">= 1.0.0", Helm: &v1alpha1.ApplicationSourceHelm{
 				// Reference `ref` but do not use the oob symlink. The mere existence of the link should be enough to
 				// cause an error.
 				ValueFiles: []string{"$ref/testdata/oob-symlink/values.yaml"},
@@ -628,13 +627,13 @@ func TestHelmChartReferencingExternalValues_OutOfBounds_Symlink(t *testing.T) {
 			{Ref: "ref", RepoURL: "https://git.example.com/test/repo"},
 		},
 	}
-	refSources, err := argo.GetRefSources(context.Background(), spec.Sources, spec.Project, func(ctx context.Context, url string, project string) (*argoappv1.Repository, error) {
-		return &argoappv1.Repository{
+	refSources, err := argo.GetRefSources(context.Background(), spec.Sources, spec.Project, func(ctx context.Context, url string, project string) (*v1alpha1.Repository, error) {
+		return &v1alpha1.Repository{
 			Repo: "https://git.example.com/test/repo",
 		}, nil
 	}, []string{}, false)
 	require.NoError(t, err)
-	request := &apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true}
+	request := &apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: &spec.Sources[0], NoCache: true, RefSources: refSources, HasMultipleSources: true}
 	_, err = service.GenerateManifest(context.Background(), request)
 	require.Error(t, err)
 }
@@ -642,10 +641,10 @@ func TestHelmChartReferencingExternalValues_OutOfBounds_Symlink(t *testing.T) {
 func TestGenerateManifestsUseExactRevision(t *testing.T) {
 	service, gitClient, _ := newServiceWithMocks(t, ".", false)
 
-	src := argoappv1.ApplicationSource{Path: "./testdata/recurse", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
+	src := v1alpha1.ApplicationSource{Path: "./testdata/recurse", Directory: &v1alpha1.ApplicationSourceDirectory{Recurse: true}}
 
 	q := apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: &src, Revision: "abc", ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &src, Revision: "abc", ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 
@@ -658,10 +657,10 @@ func TestGenerateManifestsUseExactRevision(t *testing.T) {
 func TestRecurseManifestsInDir(t *testing.T) {
 	service := newService(t, ".")
 
-	src := argoappv1.ApplicationSource{Path: "./testdata/recurse", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
+	src := v1alpha1.ApplicationSource{Path: "./testdata/recurse", Directory: &v1alpha1.ApplicationSourceDirectory{Recurse: true}}
 
 	q := apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{}, ApplicationSource: &src, ProjectName: "something",
+		Repo: &v1alpha1.Repository{}, ApplicationSource: &src, ProjectName: "something",
 		ProjectSourceRepos: []string{"*"},
 	}
 
@@ -673,9 +672,9 @@ func TestRecurseManifestsInDir(t *testing.T) {
 func TestInvalidManifestsInDir(t *testing.T) {
 	service := newService(t, ".")
 
-	src := argoappv1.ApplicationSource{Path: "./testdata/invalid-manifests", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
+	src := v1alpha1.ApplicationSource{Path: "./testdata/invalid-manifests", Directory: &v1alpha1.ApplicationSourceDirectory{Recurse: true}}
 
-	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src}
+	q := apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: &src}
 
 	_, err := service.GenerateManifest(context.Background(), &q)
 	require.Error(t, err)
@@ -684,8 +683,8 @@ func TestInvalidManifestsInDir(t *testing.T) {
 func TestInvalidMetadata(t *testing.T) {
 	service := newService(t, ".")
 
-	src := argoappv1.ApplicationSource{Path: "./testdata/invalid-metadata", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
-	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, AppLabelKey: "test", AppName: "invalid-metadata", TrackingMethod: "annotation+label"}
+	src := v1alpha1.ApplicationSource{Path: "./testdata/invalid-metadata", Directory: &v1alpha1.ApplicationSourceDirectory{Recurse: true}}
+	q := apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: &src, AppLabelKey: "test", AppName: "invalid-metadata", TrackingMethod: "annotation+label"}
 	_, err := service.GenerateManifest(context.Background(), &q)
 	assert.ErrorContains(t, err, "contains non-string value in the map under key \"invalid\"")
 }
@@ -694,8 +693,8 @@ func TestNilMetadataAccessors(t *testing.T) {
 	service := newService(t, ".")
 	expected := "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"argocd.argoproj.io/tracking-id\":\"nil-metadata-accessors:/ConfigMap:/my-map\"},\"labels\":{\"test\":\"nil-metadata-accessors\"},\"name\":\"my-map\"},\"stringData\":{\"foo\":\"bar\"}}"
 
-	src := argoappv1.ApplicationSource{Path: "./testdata/nil-metadata-accessors", Directory: &argoappv1.ApplicationSourceDirectory{Recurse: true}}
-	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, AppLabelKey: "test", AppName: "nil-metadata-accessors", TrackingMethod: "annotation+label"}
+	src := v1alpha1.ApplicationSource{Path: "./testdata/nil-metadata-accessors", Directory: &v1alpha1.ApplicationSourceDirectory{Recurse: true}}
+	q := apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: &src, AppLabelKey: "test", AppName: "nil-metadata-accessors", TrackingMethod: "annotation+label"}
 	res, err := service.GenerateManifest(context.Background(), &q)
 	require.NoError(t, err)
 	assert.Len(t, res.Manifests, 1)
@@ -706,13 +705,13 @@ func TestGenerateJsonnetManifestInDir(t *testing.T) {
 	service := newService(t, ".")
 
 	q := apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{},
-		ApplicationSource: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./testdata/jsonnet",
-			Directory: &argoappv1.ApplicationSourceDirectory{
-				Jsonnet: argoappv1.ApplicationSourceJsonnet{
-					ExtVars: []argoappv1.JsonnetVar{{Name: "extVarString", Value: "extVarString"}, {Name: "extVarCode", Value: "\"extVarCode\"", Code: true}},
-					TLAs:    []argoappv1.JsonnetVar{{Name: "tlaString", Value: "tlaString"}, {Name: "tlaCode", Value: "\"tlaCode\"", Code: true}},
+			Directory: &v1alpha1.ApplicationSourceDirectory{
+				Jsonnet: v1alpha1.ApplicationSourceJsonnet{
+					ExtVars: []v1alpha1.JsonnetVar{{Name: "extVarString", Value: "extVarString"}, {Name: "extVarCode", Value: "\"extVarCode\"", Code: true}},
+					TLAs:    []v1alpha1.JsonnetVar{{Name: "tlaString", Value: "tlaString"}, {Name: "tlaCode", Value: "\"tlaCode\"", Code: true}},
 					Libs:    []string{"testdata/jsonnet/vendor"},
 				},
 			},
@@ -729,13 +728,13 @@ func TestGenerateJsonnetManifestInRootDir(t *testing.T) {
 	service := newService(t, "testdata/jsonnet-1")
 
 	q := apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{},
-		ApplicationSource: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: ".",
-			Directory: &argoappv1.ApplicationSourceDirectory{
-				Jsonnet: argoappv1.ApplicationSourceJsonnet{
-					ExtVars: []argoappv1.JsonnetVar{{Name: "extVarString", Value: "extVarString"}, {Name: "extVarCode", Value: "\"extVarCode\"", Code: true}},
-					TLAs:    []argoappv1.JsonnetVar{{Name: "tlaString", Value: "tlaString"}, {Name: "tlaCode", Value: "\"tlaCode\"", Code: true}},
+			Directory: &v1alpha1.ApplicationSourceDirectory{
+				Jsonnet: v1alpha1.ApplicationSourceJsonnet{
+					ExtVars: []v1alpha1.JsonnetVar{{Name: "extVarString", Value: "extVarString"}, {Name: "extVarCode", Value: "\"extVarCode\"", Code: true}},
+					TLAs:    []v1alpha1.JsonnetVar{{Name: "tlaString", Value: "tlaString"}, {Name: "tlaCode", Value: "\"tlaCode\"", Code: true}},
 					Libs:    []string{"."},
 				},
 			},
@@ -752,11 +751,11 @@ func TestGenerateJsonnetLibOutside(t *testing.T) {
 	service := newService(t, ".")
 
 	q := apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{},
-		ApplicationSource: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./testdata/jsonnet",
-			Directory: &argoappv1.ApplicationSourceDirectory{
-				Jsonnet: argoappv1.ApplicationSourceJsonnet{
+			Directory: &v1alpha1.ApplicationSourceDirectory{
+				Jsonnet: v1alpha1.ApplicationSourceJsonnet{
 					Libs: []string{"../../../testdata/jsonnet/vendor"},
 				},
 			},
@@ -835,9 +834,9 @@ func TestManifestGenErrorCacheByNumRequests(t *testing.T) {
 				fmt.Printf("%d )-------------------------------------------\n", invocationCount)
 
 				manifestRequest := &apiclient.ManifestRequest{
-					Repo:    &argoappv1.Repository{},
+					Repo:    &v1alpha1.Repository{},
 					AppName: "test",
-					ApplicationSource: &argoappv1.ApplicationSource{
+					ApplicationSource: &v1alpha1.ApplicationSource{
 						Path: "./testdata/invalid-helm",
 					},
 				}
@@ -926,9 +925,9 @@ func TestManifestGenErrorCacheFileContentsChange(t *testing.T) {
 		}
 
 		res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: ".",
 			},
 			ProjectName:        "something",
@@ -984,9 +983,9 @@ func TestManifestGenErrorCacheByMinutesElapsed(t *testing.T) {
 			// 1) Put the cache into the failure state
 			for x := 0; x < 2; x++ {
 				res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-					Repo:    &argoappv1.Repository{},
+					Repo:    &v1alpha1.Repository{},
 					AppName: "test",
-					ApplicationSource: &argoappv1.ApplicationSource{
+					ApplicationSource: &v1alpha1.ApplicationSource{
 						Path: "./testdata/invalid-helm",
 					},
 				})
@@ -1002,9 +1001,9 @@ func TestManifestGenErrorCacheByMinutesElapsed(t *testing.T) {
 			// 2) Jump forward X-1 minutes in time, where X is the expiration boundary
 			currentTime = currentTime.Add(time.Duration(tt.PauseGenerationOnFailureForMinutes-1) * time.Minute)
 			res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo:    &argoappv1.Repository{},
+				Repo:    &v1alpha1.Repository{},
 				AppName: "test",
-				ApplicationSource: &argoappv1.ApplicationSource{
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Path: "./testdata/invalid-helm",
 				},
 			})
@@ -1017,9 +1016,9 @@ func TestManifestGenErrorCacheByMinutesElapsed(t *testing.T) {
 			currentTime = currentTime.Add(2 * time.Minute)
 
 			res, err = service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo:    &argoappv1.Repository{},
+				Repo:    &v1alpha1.Repository{},
 				AppName: "test",
-				ApplicationSource: &argoappv1.ApplicationSource{
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Path: "./testdata/invalid-helm",
 				},
 			})
@@ -1044,9 +1043,9 @@ func TestManifestGenErrorCacheRespectsNoCache(t *testing.T) {
 	// 1) Put the cache into the failure state
 	for x := 0; x < 2; x++ {
 		res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: "./testdata/invalid-helm",
 			},
 		})
@@ -1061,9 +1060,9 @@ func TestManifestGenErrorCacheRespectsNoCache(t *testing.T) {
 
 	// 2) Call generateManifest with NoCache enabled
 	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./testdata/invalid-helm",
 		},
 		NoCache: true,
@@ -1075,9 +1074,9 @@ func TestManifestGenErrorCacheRespectsNoCache(t *testing.T) {
 
 	// 4) Call generateManifest
 	res, err = service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./testdata/invalid-helm",
 		},
 	})
@@ -1091,11 +1090,11 @@ func TestGenerateHelmWithValues(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata/redis")
 
 	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: ".",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles:   []string{"values-production.yaml"},
 				ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 			},
@@ -1128,11 +1127,11 @@ func TestHelmWithMissingValueFiles(t *testing.T) {
 	missingValuesFile := "values-prod-overrides.yaml"
 
 	req := &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: ".",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles: []string{"values-production.yaml", missingValuesFile},
 			},
 		},
@@ -1154,11 +1153,11 @@ func TestGenerateHelmWithEnvVars(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata/redis")
 
 	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "production",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: ".",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles: []string{"values-$ARGOCD_APP_NAME.yaml"},
 			},
 		},
@@ -1190,11 +1189,11 @@ func TestGenerateHelmWithEnvVars(t *testing.T) {
 func TestGenerateHelmWithValuesDirectoryTraversal(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata")
 	_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./redis",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles:   []string{"../minio/values.yaml"},
 				ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 			},
@@ -1207,9 +1206,9 @@ func TestGenerateHelmWithValuesDirectoryTraversal(t *testing.T) {
 	// Test the case where the path is "."
 	service = newService(t, "./testdata")
 	_, err = service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./my-chart",
 		},
 		ProjectName:        "something",
@@ -1220,8 +1219,8 @@ func TestGenerateHelmWithValuesDirectoryTraversal(t *testing.T) {
 
 func TestChartRepoWithOutOfBoundsSymlink(t *testing.T) {
 	service := newService(t, ".")
-	source := &argoappv1.ApplicationSource{Chart: "out-of-bounds-chart", TargetRevision: ">= 1.0.0"}
-	request := &apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: source, NoCache: true}
+	source := &v1alpha1.ApplicationSource{Chart: "out-of-bounds-chart", TargetRevision: ">= 1.0.0"}
+	request := &apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: source, NoCache: true}
 	_, err := service.GenerateManifest(context.Background(), request)
 	assert.ErrorContains(t, err, "chart contains out-of-bounds symlinks")
 }
@@ -1230,15 +1229,15 @@ func TestChartRepoWithOutOfBoundsSymlink(t *testing.T) {
 // (`~/go/src/github.com/argoproj/argo-cd/reposerver/repository`), so it is allowed
 func TestHelmManifestFromChartRepoWithValueFile(t *testing.T) {
 	service := newService(t, ".")
-	source := &argoappv1.ApplicationSource{
+	source := &v1alpha1.ApplicationSource{
 		Chart:          "my-chart",
 		TargetRevision: ">= 1.0.0",
-		Helm: &argoappv1.ApplicationSourceHelm{
+		Helm: &v1alpha1.ApplicationSourceHelm{
 			ValueFiles: []string{"./my-chart-values.yaml"},
 		},
 	}
 	request := &apiclient.ManifestRequest{
-		Repo:               &argoappv1.Repository{},
+		Repo:               &v1alpha1.Repository{},
 		ApplicationSource:  source,
 		NoCache:            true,
 		ProjectName:        "something",
@@ -1261,14 +1260,14 @@ func TestHelmManifestFromChartRepoWithValueFile(t *testing.T) {
 // (`~/go/src/github.com/argoproj/argo-cd/reposerver/repository`), so it is not allowed
 func TestHelmManifestFromChartRepoWithValueFileOutsideRepo(t *testing.T) {
 	service := newService(t, ".")
-	source := &argoappv1.ApplicationSource{
+	source := &v1alpha1.ApplicationSource{
 		Chart:          "my-chart",
 		TargetRevision: ">= 1.0.0",
-		Helm: &argoappv1.ApplicationSourceHelm{
+		Helm: &v1alpha1.ApplicationSourceHelm{
 			ValueFiles: []string{"../my-chart-2/my-chart-2-values.yaml"},
 		},
 	}
-	request := &apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: source, NoCache: true}
+	request := &apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: source, NoCache: true}
 	_, err := service.GenerateManifest(context.Background(), request)
 	require.Error(t, err)
 }
@@ -1276,15 +1275,15 @@ func TestHelmManifestFromChartRepoWithValueFileOutsideRepo(t *testing.T) {
 func TestHelmManifestFromChartRepoWithValueFileLinks(t *testing.T) {
 	t.Run("Valid symlink", func(t *testing.T) {
 		service := newService(t, ".")
-		source := &argoappv1.ApplicationSource{
+		source := &v1alpha1.ApplicationSource{
 			Chart:          "my-chart",
 			TargetRevision: ">= 1.0.0",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles: []string{"my-chart-link.yaml"},
 			},
 		}
 		request := &apiclient.ManifestRequest{
-			Repo: &argoappv1.Repository{}, ApplicationSource: source, NoCache: true, ProjectName: "something",
+			Repo: &v1alpha1.Repository{}, ApplicationSource: source, NoCache: true, ProjectName: "something",
 			ProjectSourceRepos: []string{"*"},
 		}
 		_, err := service.GenerateManifest(context.Background(), request)
@@ -1296,18 +1295,18 @@ func TestGenerateHelmWithURL(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata/redis")
 
 	_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: ".",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles:   []string{"https://raw.githubusercontent.com/argoproj/argocd-example-apps/master/helm-guestbook/values.yaml"},
 				ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 			},
 		},
 		ProjectName:        "something",
 		ProjectSourceRepos: []string{"*"},
-		HelmOptions:        &argoappv1.HelmOptions{ValuesFileSchemes: []string{"https"}},
+		HelmOptions:        &v1alpha1.HelmOptions{ValuesFileSchemes: []string{"https"}},
 	})
 	require.NoError(t, err)
 }
@@ -1318,11 +1317,11 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	t.Run("Values file with relative path pointing outside repo root", func(t *testing.T) {
 		service := newService(t, "../../util/helm/testdata/redis")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: ".",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValueFiles:   []string{"../minio/values.yaml"},
 					ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 				},
@@ -1336,11 +1335,11 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	t.Run("Values file with relative path pointing inside repo root", func(t *testing.T) {
 		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: "./my-chart",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValueFiles:   []string{"../my-chart/my-chart-values.yaml"},
 					ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 				},
@@ -1354,11 +1353,11 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	t.Run("Values file with absolute path stays within repo root", func(t *testing.T) {
 		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: "./my-chart",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValueFiles:   []string{"/my-chart/my-chart-values.yaml"},
 					ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 				},
@@ -1372,11 +1371,11 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	t.Run("Values file with absolute path using back-references outside repo root", func(t *testing.T) {
 		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: "./my-chart",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValueFiles:   []string{"/../../../my-chart-values.yaml"},
 					ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 				},
@@ -1390,11 +1389,11 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	t.Run("Remote values file from forbidden protocol", func(t *testing.T) {
 		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: "./my-chart",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValueFiles:   []string{"file://../../../../my-chart-values.yaml"},
 					ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
 				},
@@ -1408,15 +1407,15 @@ func TestGenerateHelmWithValuesDirectoryTraversalOutsideRepo(t *testing.T) {
 	t.Run("Remote values file from custom allowed protocol", func(t *testing.T) {
 		service := newService(t, "./testdata")
 		_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:    &argoappv1.Repository{},
+			Repo:    &v1alpha1.Repository{},
 			AppName: "test",
-			ApplicationSource: &argoappv1.ApplicationSource{
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: "./my-chart",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValueFiles: []string{"s3://my-bucket/my-chart-values.yaml"},
 				},
 			},
-			HelmOptions:        &argoappv1.HelmOptions{ValuesFileSchemes: []string{"s3"}},
+			HelmOptions:        &v1alpha1.HelmOptions{ValuesFileSchemes: []string{"s3"}},
 			ProjectName:        "something",
 			ProjectSourceRepos: []string{"*"},
 		})
@@ -1443,14 +1442,14 @@ func TestGenerateHelmWithAbsoluteFileParameter(t *testing.T) {
 	}()
 
 	_, err = service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./util/helm/testdata/redis",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles:   []string{"values-production.yaml"},
 				ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
-				FileParameters: []argoappv1.HelmFileParameter{{
+				FileParameters: []v1alpha1.HelmFileParameter{{
 					Name: "passwordContent",
 					Path: externalSecretPath,
 				}},
@@ -1470,15 +1469,15 @@ func TestGenerateHelmWithFileParameter(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata")
 
 	res, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-		Repo:    &argoappv1.Repository{},
+		Repo:    &v1alpha1.Repository{},
 		AppName: "test",
-		ApplicationSource: &argoappv1.ApplicationSource{
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path: "./redis",
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles:   []string{"values-production.yaml"},
 				Values:       `cluster: {slaveCount: 10}`,
 				ValuesObject: &runtime.RawExtension{Raw: []byte(`cluster: {slaveCount: 2}`)},
-				FileParameters: []argoappv1.HelmFileParameter{{
+				FileParameters: []v1alpha1.HelmFileParameter{{
 					Name: "passwordContent",
 					Path: "../external/external-secret.txt",
 				}},
@@ -1496,8 +1495,8 @@ func TestGenerateNullList(t *testing.T) {
 
 	t.Run("null list", func(t *testing.T) {
 		res1, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:               &argoappv1.Repository{},
-			ApplicationSource:  &argoappv1.ApplicationSource{Path: "./testdata/null-list"},
+			Repo:               &v1alpha1.Repository{},
+			ApplicationSource:  &v1alpha1.ApplicationSource{Path: "./testdata/null-list"},
 			NoCache:            true,
 			ProjectName:        "something",
 			ProjectSourceRepos: []string{"*"},
@@ -1509,8 +1508,8 @@ func TestGenerateNullList(t *testing.T) {
 
 	t.Run("empty list", func(t *testing.T) {
 		res1, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:               &argoappv1.Repository{},
-			ApplicationSource:  &argoappv1.ApplicationSource{Path: "./testdata/empty-list"},
+			Repo:               &v1alpha1.Repository{},
+			ApplicationSource:  &v1alpha1.ApplicationSource{Path: "./testdata/empty-list"},
 			NoCache:            true,
 			ProjectName:        "something",
 			ProjectSourceRepos: []string{"*"},
@@ -1522,8 +1521,8 @@ func TestGenerateNullList(t *testing.T) {
 
 	t.Run("weird list", func(t *testing.T) {
 		res1, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-			Repo:               &argoappv1.Repository{},
-			ApplicationSource:  &argoappv1.ApplicationSource{Path: "./testdata/weird-list"},
+			Repo:               &v1alpha1.Repository{},
+			ApplicationSource:  &v1alpha1.ApplicationSource{Path: "./testdata/weird-list"},
 			NoCache:            true,
 			ProjectName:        "something",
 			ProjectSourceRepos: []string{"*"},
@@ -1534,23 +1533,23 @@ func TestGenerateNullList(t *testing.T) {
 }
 
 func TestIdentifyAppSourceTypeByAppDirWithKustomizations(t *testing.T) {
-	sourceType, err := GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yaml", "./testdata", "testapp", map[string]bool{}, []string{}, []string{})
+	sourceType, err := GetAppSourceType(context.Background(), &v1alpha1.ApplicationSource{}, "./testdata/kustomization_yaml", "./testdata", "testapp", map[string]bool{}, []string{}, []string{})
 	require.NoError(t, err)
-	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
+	assert.Equal(t, v1alpha1.ApplicationSourceTypeKustomize, sourceType)
 
-	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/kustomization_yml", "./testdata", "testapp", map[string]bool{}, []string{}, []string{})
+	sourceType, err = GetAppSourceType(context.Background(), &v1alpha1.ApplicationSource{}, "./testdata/kustomization_yml", "./testdata", "testapp", map[string]bool{}, []string{}, []string{})
 	require.NoError(t, err)
-	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
+	assert.Equal(t, v1alpha1.ApplicationSourceTypeKustomize, sourceType)
 
-	sourceType, err = GetAppSourceType(context.Background(), &argoappv1.ApplicationSource{}, "./testdata/Kustomization", "./testdata", "testapp", map[string]bool{}, []string{}, []string{})
+	sourceType, err = GetAppSourceType(context.Background(), &v1alpha1.ApplicationSource{}, "./testdata/Kustomization", "./testdata", "testapp", map[string]bool{}, []string{}, []string{})
 	require.NoError(t, err)
-	assert.Equal(t, argoappv1.ApplicationSourceTypeKustomize, sourceType)
+	assert.Equal(t, v1alpha1.ApplicationSourceTypeKustomize, sourceType)
 }
 
 func TestGenerateFromUTF16(t *testing.T) {
 	q := apiclient.ManifestRequest{
-		Repo:               &argoappv1.Repository{},
-		ApplicationSource:  &argoappv1.ApplicationSource{},
+		Repo:               &v1alpha1.Repository{},
+		ApplicationSource:  &v1alpha1.ApplicationSource{},
 		ProjectName:        "something",
 		ProjectSourceRepos: []string{"*"},
 	}
@@ -1562,7 +1561,7 @@ func TestGenerateFromUTF16(t *testing.T) {
 func TestListApps(t *testing.T) {
 	service := newService(t, "./testdata")
 
-	res, err := service.ListApps(context.Background(), &apiclient.ListAppsRequest{Repo: &argoappv1.Repository{}})
+	res, err := service.ListApps(context.Background(), &apiclient.ListAppsRequest{Repo: &v1alpha1.Repository{}})
 	require.NoError(t, err)
 
 	expectedApps := map[string]string{
@@ -1594,8 +1593,8 @@ func TestGetAppDetailsHelm(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata/dependency")
 
 	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-		Repo: &argoappv1.Repository{},
-		Source: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{
 			Path: ".",
 		},
 	})
@@ -1611,8 +1610,8 @@ func TestGetAppDetailsHelmUsesCache(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata/dependency")
 
 	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-		Repo: &argoappv1.Repository{},
-		Source: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{
 			Path: ".",
 		},
 	})
@@ -1628,8 +1627,8 @@ func TestGetAppDetailsHelm_WithNoValuesFile(t *testing.T) {
 	service := newService(t, "../../util/helm/testdata/api-versions")
 
 	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-		Repo: &argoappv1.Repository{},
-		Source: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{
 			Path: ".",
 		},
 	})
@@ -1646,8 +1645,8 @@ func TestGetAppDetailsKustomize(t *testing.T) {
 	service := newService(t, "../../util/kustomize/testdata/kustomization_yaml")
 
 	res, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-		Repo: &argoappv1.Repository{},
-		Source: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{
 			Path: ".",
 		},
 	})
@@ -1661,7 +1660,7 @@ func TestGetAppDetailsKustomize(t *testing.T) {
 
 func TestGetHelmCharts(t *testing.T) {
 	service := newService(t, "../..")
-	res, err := service.GetHelmCharts(context.Background(), &apiclient.HelmChartsRequest{Repo: &argoappv1.Repository{}})
+	res, err := service.GetHelmCharts(context.Background(), &apiclient.HelmChartsRequest{Repo: &v1alpha1.Repository{}})
 
 	// fix flakiness
 	sort.Slice(res.Items, func(i, j int) bool {
@@ -1692,7 +1691,7 @@ func TestGetRevisionMetadata(t *testing.T) {
 	}, nil)
 
 	res, err := service.GetRevisionMetadata(context.Background(), &apiclient.RepoServerRevisionMetadataRequest{
-		Repo:           &argoappv1.Repository{},
+		Repo:           &v1alpha1.Repository{},
 		Revision:       "c0b400fc458875d925171398f9ba9eabd5529923",
 		CheckSignature: true,
 	})
@@ -1706,7 +1705,7 @@ func TestGetRevisionMetadata(t *testing.T) {
 
 	// Check for truncated revision value
 	res, err = service.GetRevisionMetadata(context.Background(), &apiclient.RepoServerRevisionMetadataRequest{
-		Repo:           &argoappv1.Repository{},
+		Repo:           &v1alpha1.Repository{},
 		Revision:       "c0b400f",
 		CheckSignature: true,
 	})
@@ -1720,7 +1719,7 @@ func TestGetRevisionMetadata(t *testing.T) {
 
 	// Cache hit - signature info should not be in result
 	res, err = service.GetRevisionMetadata(context.Background(), &apiclient.RepoServerRevisionMetadataRequest{
-		Repo:           &argoappv1.Repository{},
+		Repo:           &v1alpha1.Repository{},
 		Revision:       "c0b400fc458875d925171398f9ba9eabd5529923",
 		CheckSignature: false,
 	})
@@ -1729,7 +1728,7 @@ func TestGetRevisionMetadata(t *testing.T) {
 
 	// Enforce cache miss - signature info should not be in result
 	res, err = service.GetRevisionMetadata(context.Background(), &apiclient.RepoServerRevisionMetadataRequest{
-		Repo:           &argoappv1.Repository{},
+		Repo:           &v1alpha1.Repository{},
 		Revision:       "da52afd3b2df1ec49470603d8bbb46954dab1091",
 		CheckSignature: false,
 	})
@@ -1738,7 +1737,7 @@ func TestGetRevisionMetadata(t *testing.T) {
 
 	// Cache hit on previous entry that did not have signature info
 	res, err = service.GetRevisionMetadata(context.Background(), &apiclient.RepoServerRevisionMetadataRequest{
-		Repo:           &argoappv1.Repository{},
+		Repo:           &v1alpha1.Repository{},
 		Revision:       "da52afd3b2df1ec49470603d8bbb46954dab1091",
 		CheckSignature: true,
 	})
@@ -1751,9 +1750,9 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 	{
 		service := newServiceWithSignature(t, "../../manifests/base")
 
-		src := argoappv1.ApplicationSource{Path: "."}
+		src := v1alpha1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{
-			Repo:               &argoappv1.Repository{},
+			Repo:               &v1alpha1.Repository{},
 			ApplicationSource:  &src,
 			VerifySignature:    true,
 			ProjectName:        "something",
@@ -1768,9 +1767,9 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 	{
 		service := newServiceWithSignature(t, "../../manifests/base")
 
-		src := argoappv1.ApplicationSource{Path: "."}
+		src := v1alpha1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{
-			Repo: &argoappv1.Repository{}, ApplicationSource: &src, ProjectName: "something",
+			Repo: &v1alpha1.Repository{}, ApplicationSource: &src, ProjectName: "something",
 			ProjectSourceRepos: []string{"*"},
 		}
 
@@ -1782,9 +1781,9 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 	{
 		service := newService(t, "../../manifests/base")
 
-		src := argoappv1.ApplicationSource{Path: "."}
+		src := v1alpha1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{
-			Repo: &argoappv1.Repository{}, ApplicationSource: &src, VerifySignature: true, ProjectName: "something",
+			Repo: &v1alpha1.Repository{}, ApplicationSource: &src, VerifySignature: true, ProjectName: "something",
 			ProjectSourceRepos: []string{"*"},
 		}
 
@@ -1796,9 +1795,9 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 	{
 		service := newService(t, "../../manifests/base")
 
-		src := argoappv1.ApplicationSource{Path: "."}
+		src := v1alpha1.ApplicationSource{Path: "."}
 		q := apiclient.ManifestRequest{
-			Repo: &argoappv1.Repository{}, ApplicationSource: &src, VerifySignature: true, ProjectName: "something",
+			Repo: &v1alpha1.Repository{}, ApplicationSource: &src, VerifySignature: true, ProjectName: "something",
 			ProjectSourceRepos: []string{"*"},
 		}
 
@@ -1809,20 +1808,20 @@ func TestGetSignatureVerificationResult(t *testing.T) {
 }
 
 func Test_newEnv(t *testing.T) {
-	assert.Equal(t, &argoappv1.Env{
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_NAME", Value: "my-app-name"},
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_NAMESPACE", Value: "my-namespace"},
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_REVISION", Value: "my-revision"},
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT", Value: "my-revi"},
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT_8", Value: "my-revis"},
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_SOURCE_REPO_URL", Value: "https://github.com/my-org/my-repo"},
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_SOURCE_PATH", Value: "my-path"},
-		&argoappv1.EnvEntry{Name: "ARGOCD_APP_SOURCE_TARGET_REVISION", Value: "my-target-revision"},
+	assert.Equal(t, &v1alpha1.Env{
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAME", Value: "my-app-name"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAMESPACE", Value: "my-namespace"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION", Value: "my-revision"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT", Value: "my-revi"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT_8", Value: "my-revis"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_REPO_URL", Value: "https://github.com/my-org/my-repo"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_PATH", Value: "my-path"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_TARGET_REVISION", Value: "my-target-revision"},
 	}, newEnv(&apiclient.ManifestRequest{
 		AppName:   "my-app-name",
 		Namespace: "my-namespace",
-		Repo:      &argoappv1.Repository{Repo: "https://github.com/my-org/my-repo"},
-		ApplicationSource: &argoappv1.ApplicationSource{
+		Repo:      &v1alpha1.Repository{Repo: "https://github.com/my-org/my-repo"},
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path:           "my-path",
 			TargetRevision: "my-target-revision",
 		},
@@ -1833,11 +1832,11 @@ func TestService_newHelmClientResolveRevision(t *testing.T) {
 	service := newService(t, ".")
 
 	t.Run("EmptyRevision", func(t *testing.T) {
-		_, _, err := service.newHelmClientResolveRevision(&argoappv1.Repository{}, "", "", true)
+		_, _, err := service.newHelmClientResolveRevision(&v1alpha1.Repository{}, "", "", true)
 		assert.EqualError(t, err, "invalid revision '': improper constraint: ")
 	})
 	t.Run("InvalidRevision", func(t *testing.T) {
-		_, _, err := service.newHelmClientResolveRevision(&argoappv1.Repository{}, "???", "", true)
+		_, _, err := service.newHelmClientResolveRevision(&v1alpha1.Repository{}, "???", "", true)
 		assert.EqualError(t, err, "invalid revision '???': improper constraint: ???", true)
 	})
 }
@@ -1848,8 +1847,8 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			t.Helper()
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-				Repo: &argoappv1.Repository{},
-				Source: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				Source: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 			})
@@ -1862,8 +1861,8 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "single-global", func(t *testing.T, path string) {
 			t.Helper()
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-				Repo: &argoappv1.Repository{},
-				Source: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				Source: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				AppName: "testapp",
@@ -1877,8 +1876,8 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
 			t.Helper()
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-				Repo: &argoappv1.Repository{},
-				Source: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				Source: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				AppName: "testapp",
@@ -1892,8 +1891,8 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			t.Helper()
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-				Repo: &argoappv1.Repository{},
-				Source: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				Source: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				AppName: "testapp",
@@ -1907,8 +1906,8 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			t.Helper()
 			details, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-				Repo: &argoappv1.Repository{},
-				Source: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				Source: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				AppName: "unmergeable",
@@ -1922,8 +1921,8 @@ func TestGetAppDetailsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "multi", func(t *testing.T, path string) {
 			t.Helper()
 			_, err := service.GetAppDetails(context.Background(), &apiclient.RepoServerAppDetailsQuery{
-				Repo: &argoappv1.Repository{},
-				Source: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				Source: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				AppName: "broken",
@@ -1965,8 +1964,8 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 			t.Helper()
 			service := newService(t, ".")
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				ProjectName:        "something",
@@ -1995,8 +1994,8 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 			t.Helper()
 			service := newService(t, ".")
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				ProjectName:        "something",
@@ -2025,8 +2024,8 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
 			t.Helper()
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				AppName:            "testapp",
@@ -2056,8 +2055,8 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
 			t.Helper()
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Path:  "",
 					Chart: "",
 					Ref:   "test",
@@ -2078,8 +2077,8 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 		runWithTempTestdata(t, "single-app-only", func(t *testing.T, path string) {
 			t.Helper()
 			manifests, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Path: path,
 				},
 				AppName:            "testapp2",
@@ -2108,12 +2107,12 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 		service := newService(t, ".")
 		runWithTempTestdata(t, "single-global", func(t *testing.T, path string) {
 			t.Helper()
-			source := &argoappv1.ApplicationSource{
+			source := &v1alpha1.ApplicationSource{
 				Path: path,
 			}
 			sourceCopy := source.DeepCopy() // make a copy in case GenerateManifest mutates it.
 			_, err := service.GenerateManifest(context.Background(), &apiclient.ManifestRequest{
-				Repo:               &argoappv1.Repository{},
+				Repo:               &v1alpha1.Repository{},
 				ApplicationSource:  sourceCopy,
 				AppName:            "test",
 				ProjectName:        "something",
@@ -2124,7 +2123,7 @@ func TestGenerateManifestsWithAppParameterFile(t *testing.T) {
 			// Try to pull from the cache with a `source` that does not include any overrides. Overrides should not be
 			// part of the cache key, because you can't get the overrides without a repo operation. And avoiding repo
 			// operations is the point of the cache.
-			err = service.cache.GetManifests(mock.Anything, source, argoappv1.RefTargetRevisionMapping{}, &argoappv1.ClusterInfo{}, "", "", "", "test", res, nil, "")
+			err = service.cache.GetManifests(mock.Anything, source, v1alpha1.RefTargetRevisionMapping{}, &v1alpha1.ClusterInfo{}, "", "", "", "test", res, nil, "")
 			require.NoError(t, err)
 		})
 	})
@@ -2147,8 +2146,8 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 			name: "Case: Git tag hash matches latest commit SHA (regular tag)",
 			ctx:  context.Background(),
 			manifestRequest: &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					TargetRevision: regularGitTagHash,
 				},
 				NoCache:            true,
@@ -2163,8 +2162,8 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 			name: "Case: Git tag hash does not match latest commit SHA (annotated tag)",
 			ctx:  context.Background(),
 			manifestRequest: &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					TargetRevision: annotatedGitTaghash,
 				},
 				NoCache:            true,
@@ -2179,8 +2178,8 @@ func TestGenerateManifestWithAnnotatedAndRegularGitTagHashes(t *testing.T) {
 			name: "Case: Git tag hash is invalid",
 			ctx:  context.Background(),
 			manifestRequest: &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					TargetRevision: invalidGitTaghash,
 				},
 				NoCache:            true,
@@ -2209,21 +2208,21 @@ func TestGenerateManifestWithAnnotatedTagsAndMultiSourceApp(t *testing.T) {
 
 	service := newServiceWithCommitSHA(t, ".", annotatedGitTaghash)
 
-	refSources := map[string]*argoappv1.RefTarget{}
+	refSources := map[string]*v1alpha1.RefTarget{}
 
-	refSources["$global"] = &argoappv1.RefTarget{
+	refSources["$global"] = &v1alpha1.RefTarget{
 		TargetRevision: annotatedGitTaghash,
 	}
 
-	refSources["$default"] = &argoappv1.RefTarget{
+	refSources["$default"] = &v1alpha1.RefTarget{
 		TargetRevision: annotatedGitTaghash,
 	}
 
 	manifestRequest := &apiclient.ManifestRequest{
-		Repo: &argoappv1.Repository{},
-		ApplicationSource: &argoappv1.ApplicationSource{
+		Repo: &v1alpha1.Repository{},
+		ApplicationSource: &v1alpha1.ApplicationSource{
 			TargetRevision: annotatedGitTaghash,
-			Helm: &argoappv1.ApplicationSourceHelm{
+			Helm: &v1alpha1.ApplicationSourceHelm{
 				ValueFiles: []string{"$global/values.yaml", "$default/secrets.yaml"},
 			},
 		},
@@ -2245,12 +2244,12 @@ func TestGenerateMultiSourceHelmWithFileParameter(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		refSources      map[string]*argoappv1.RefTarget
+		refSources      map[string]*v1alpha1.RefTarget
 		expectedContent string
 		expectedErr     bool
 	}{{
 		name: "Successfully resolve multi-source ref for helm set-file",
-		refSources: map[string]*argoappv1.RefTarget{
+		refSources: map[string]*v1alpha1.RefTarget{
 			"$global": {
 				TargetRevision: "HEAD",
 			},
@@ -2259,7 +2258,7 @@ func TestGenerateMultiSourceHelmWithFileParameter(t *testing.T) {
 		expectedErr:     false,
 	}, {
 		name:            "Failed to resolve multi-source ref for helm set-file",
-		refSources:      map[string]*argoappv1.RefTarget{},
+		refSources:      map[string]*v1alpha1.RefTarget{},
 		expectedContent: "DOES-NOT-EXIST",
 		expectedErr:     true,
 	}}
@@ -2268,14 +2267,14 @@ func TestGenerateMultiSourceHelmWithFileParameter(t *testing.T) {
 		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			manifestRequest := &apiclient.ManifestRequest{
-				Repo: &argoappv1.Repository{},
-				ApplicationSource: &argoappv1.ApplicationSource{
+				Repo: &v1alpha1.Repository{},
+				ApplicationSource: &v1alpha1.ApplicationSource{
 					Ref:            "$global",
 					Path:           "./redis",
 					TargetRevision: "HEAD",
-					Helm: &argoappv1.ApplicationSourceHelm{
+					Helm: &v1alpha1.ApplicationSourceHelm{
 						ValueFiles: []string{"$global/redis/values-production.yaml"},
-						FileParameters: []argoappv1.HelmFileParameter{{
+						FileParameters: []v1alpha1.HelmFileParameter{{
 							Name: "passwordContent",
 							Path: "$global/external/external-secret.txt",
 						}},
@@ -2337,7 +2336,7 @@ func TestFindResources(t *testing.T) {
 	for i := range testCases {
 		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
-			objs, err := findManifests(&log.Entry{}, "testdata/app-include-exclude", ".", nil, argoappv1.ApplicationSourceDirectory{
+			objs, err := findManifests(&log.Entry{}, "testdata/app-include-exclude", ".", nil, v1alpha1.ApplicationSourceDirectory{
 				Recurse: true,
 				Include: tc.include,
 				Exclude: tc.exclude,
@@ -2353,7 +2352,7 @@ func TestFindResources(t *testing.T) {
 }
 
 func TestFindManifests_Exclude(t *testing.T) {
-	objs, err := findManifests(&log.Entry{}, "testdata/app-include-exclude", ".", nil, argoappv1.ApplicationSourceDirectory{
+	objs, err := findManifests(&log.Entry{}, "testdata/app-include-exclude", ".", nil, v1alpha1.ApplicationSourceDirectory{
 		Recurse: true,
 		Exclude: "subdir/deploymentSub.yaml",
 	}, map[string]bool{}, resource.MustParse("0"))
@@ -2365,7 +2364,7 @@ func TestFindManifests_Exclude(t *testing.T) {
 }
 
 func TestFindManifests_Exclude_NothingMatches(t *testing.T) {
-	objs, err := findManifests(&log.Entry{}, "testdata/app-include-exclude", ".", nil, argoappv1.ApplicationSourceDirectory{
+	objs, err := findManifests(&log.Entry{}, "testdata/app-include-exclude", ".", nil, v1alpha1.ApplicationSourceDirectory{
 		Recurse: true,
 		Exclude: "nothing.yaml",
 	}, map[string]bool{}, resource.MustParse("0"))
@@ -2695,7 +2694,7 @@ func Test_getPotentiallyValidManifests(t *testing.T) {
 
 func Test_findManifests(t *testing.T) {
 	logCtx := log.WithField("test", "test")
-	noRecurse := argoappv1.ApplicationSourceDirectory{Recurse: false}
+	noRecurse := v1alpha1.ApplicationSourceDirectory{Recurse: false}
 
 	t.Run("unreadable file throws error", func(t *testing.T) {
 		appDir := t.TempDir()
@@ -2723,7 +2722,7 @@ func Test_findManifests(t *testing.T) {
 	})
 
 	t.Run("recursion when recursion is enabled", func(t *testing.T) {
-		recurse := argoappv1.ApplicationSourceDirectory{Recurse: true}
+		recurse := v1alpha1.ApplicationSourceDirectory{Recurse: true}
 		manifests, err := findManifests(logCtx, "./testdata/recurse", "./testdata/recurse", nil, recurse, nil, resource.MustParse("0"))
 		assert.Len(t, manifests, 4)
 		require.NoError(t, err)
@@ -2853,7 +2852,7 @@ func Test_findManifests(t *testing.T) {
 func TestTestRepoOCI(t *testing.T) {
 	service := newService(t, ".")
 	_, err := service.TestRepository(context.Background(), &apiclient.TestRepositoryRequest{
-		Repo: &argoappv1.Repository{
+		Repo: &v1alpha1.Repository{
 			Repo:      "https://demo.goharbor.io",
 			Type:      "helm",
 			EnableOCI: true,
@@ -2875,8 +2874,8 @@ func Test_getHelmDependencyRepos(t *testing.T) {
 
 func TestResolveRevision(t *testing.T) {
 	service := newService(t, ".")
-	repo := &argoappv1.Repository{Repo: "https://github.com/argoproj/argo-cd"}
-	app := &argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{}}}
+	repo := &v1alpha1.Repository{Repo: "https://github.com/argoproj/argo-cd"}
+	app := &v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}}}
 	resolveRevisionResponse, err := service.ResolveRevision(context.Background(), &apiclient.ResolveRevisionRequest{
 		Repo:              repo,
 		App:               app,
@@ -2895,8 +2894,8 @@ func TestResolveRevision(t *testing.T) {
 
 func TestResolveRevisionNegativeScenarios(t *testing.T) {
 	service := newService(t, ".")
-	repo := &argoappv1.Repository{Repo: "https://github.com/argoproj/argo-cd"}
-	app := &argoappv1.Application{Spec: argoappv1.ApplicationSpec{Source: &argoappv1.ApplicationSource{}}}
+	repo := &v1alpha1.Repository{Repo: "https://github.com/argoproj/argo-cd"}
+	app := &v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}}}
 	resolveRevisionResponse, err := service.ResolveRevision(context.Background(), &apiclient.ResolveRevisionRequest{
 		Repo:              repo,
 		App:               app,
@@ -3118,9 +3117,9 @@ func Test_populateHelmAppDetails(t *testing.T) {
 	emptyTempPaths := io.NewRandomizedTempPaths(t.TempDir())
 	res := apiclient.RepoAppDetailsResponse{}
 	q := apiclient.RepoServerAppDetailsQuery{
-		Repo: &argoappv1.Repository{},
-		Source: &argoappv1.ApplicationSource{
-			Helm: &argoappv1.ApplicationSourceHelm{ValueFiles: []string{"exclude.yaml", "has-the-word-values.yaml"}},
+		Repo: &v1alpha1.Repository{},
+		Source: &v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{ValueFiles: []string{"exclude.yaml", "has-the-word-values.yaml"}},
 		},
 	}
 	appPath, err := filepath.Abs("./testdata/values-files/")
@@ -3135,7 +3134,7 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 	emptyTempPaths := io.NewRandomizedTempPaths(t.TempDir())
 	t.Run("inbound", func(t *testing.T) {
 		res := apiclient.RepoAppDetailsResponse{}
-		q := apiclient.RepoServerAppDetailsQuery{Repo: &argoappv1.Repository{}, Source: &argoappv1.ApplicationSource{}}
+		q := apiclient.RepoServerAppDetailsQuery{Repo: &v1alpha1.Repository{}, Source: &v1alpha1.ApplicationSource{}}
 		err := populateHelmAppDetails(&res, "./testdata/in-bounds-values-file-link/", "./testdata/in-bounds-values-file-link/", &q, emptyTempPaths)
 		require.NoError(t, err)
 		assert.NotEmpty(t, res.Helm.Values)
@@ -3144,7 +3143,7 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 
 	t.Run("out of bounds", func(t *testing.T) {
 		res := apiclient.RepoAppDetailsResponse{}
-		q := apiclient.RepoServerAppDetailsQuery{Repo: &argoappv1.Repository{}, Source: &argoappv1.ApplicationSource{}}
+		q := apiclient.RepoServerAppDetailsQuery{Repo: &v1alpha1.Repository{}, Source: &v1alpha1.ApplicationSource{}}
 		err := populateHelmAppDetails(&res, "./testdata/out-of-bounds-values-file-link/", "./testdata/out-of-bounds-values-file-link/", &q, emptyTempPaths)
 		require.NoError(t, err)
 		assert.Empty(t, res.Helm.Values)
@@ -3153,8 +3152,8 @@ func Test_populateHelmAppDetails_values_symlinks(t *testing.T) {
 }
 
 func TestGetHelmRepos_OCIDependenciesWithHelmRepo(t *testing.T) {
-	src := argoappv1.ApplicationSource{Path: "."}
-	q := apiclient.ManifestRequest{Repos: []*argoappv1.Repository{}, ApplicationSource: &src, HelmRepoCreds: []*argoappv1.RepoCreds{
+	src := v1alpha1.ApplicationSource{Path: "."}
+	q := apiclient.ManifestRequest{Repos: []*v1alpha1.Repository{}, ApplicationSource: &src, HelmRepoCreds: []*v1alpha1.RepoCreds{
 		{URL: "example.com", Username: "test", Password: "test", EnableOCI: true},
 	}}
 
@@ -3168,8 +3167,8 @@ func TestGetHelmRepos_OCIDependenciesWithHelmRepo(t *testing.T) {
 }
 
 func TestGetHelmRepos_OCIDependenciesWithRepo(t *testing.T) {
-	src := argoappv1.ApplicationSource{Path: "."}
-	q := apiclient.ManifestRequest{Repos: []*argoappv1.Repository{{Repo: "example.com", Username: "test", Password: "test", EnableOCI: true}}, ApplicationSource: &src, HelmRepoCreds: []*argoappv1.RepoCreds{}}
+	src := v1alpha1.ApplicationSource{Path: "."}
+	q := apiclient.ManifestRequest{Repos: []*v1alpha1.Repository{{Repo: "example.com", Username: "test", Password: "test", EnableOCI: true}}, ApplicationSource: &src, HelmRepoCreds: []*v1alpha1.RepoCreds{}}
 
 	helmRepos, err := getHelmRepos("./testdata/oci-dependencies", q.Repos, q.HelmRepoCreds)
 	require.NoError(t, err)
@@ -3181,8 +3180,8 @@ func TestGetHelmRepos_OCIDependenciesWithRepo(t *testing.T) {
 }
 
 func TestGetHelmRepo_NamedRepos(t *testing.T) {
-	src := argoappv1.ApplicationSource{Path: "."}
-	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, Repos: []*argoappv1.Repository{{
+	src := v1alpha1.ApplicationSource{Path: "."}
+	q := apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: &src, Repos: []*v1alpha1.Repository{{
 		Name:     "custom-repo",
 		Repo:     "https://example.com",
 		Username: "test",
@@ -3197,8 +3196,8 @@ func TestGetHelmRepo_NamedRepos(t *testing.T) {
 }
 
 func TestGetHelmRepo_NamedReposAlias(t *testing.T) {
-	src := argoappv1.ApplicationSource{Path: "."}
-	q := apiclient.ManifestRequest{Repo: &argoappv1.Repository{}, ApplicationSource: &src, Repos: []*argoappv1.Repository{{
+	src := v1alpha1.ApplicationSource{Path: "."}
+	q := apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: &src, Repos: []*v1alpha1.Repository{{
 		Name:     "custom-repo-alias",
 		Repo:     "https://example.com",
 		Username: "test-alias",
@@ -3222,25 +3221,25 @@ func Test_getResolvedValueFiles(t *testing.T) {
 	testCases := []struct {
 		name         string
 		rawPath      string
-		env          *argoappv1.Env
-		refSources   map[string]*argoappv1.RefTarget
+		env          *v1alpha1.Env
+		refSources   map[string]*v1alpha1.RefTarget
 		expectedPath string
 		expectedErr  bool
 	}{
 		{
 			name:         "simple path",
 			rawPath:      "values.yaml",
-			env:          &argoappv1.Env{},
-			refSources:   map[string]*argoappv1.RefTarget{},
+			env:          &v1alpha1.Env{},
+			refSources:   map[string]*v1alpha1.RefTarget{},
 			expectedPath: path.Join(tempDir, "main-repo", "values.yaml"),
 		},
 		{
 			name:    "simple ref",
 			rawPath: "$ref/values.yaml",
-			env:     &argoappv1.Env{},
-			refSources: map[string]*argoappv1.RefTarget{
+			env:     &v1alpha1.Env{},
+			refSources: map[string]*v1alpha1.RefTarget{
 				"$ref": {
-					Repo: argoappv1.Repository{
+					Repo: v1alpha1.Repository{
 						Repo: "https://github.com/org/repo1",
 					},
 				},
@@ -3250,10 +3249,10 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		{
 			name:    "only ref",
 			rawPath: "$ref",
-			env:     &argoappv1.Env{},
-			refSources: map[string]*argoappv1.RefTarget{
+			env:     &v1alpha1.Env{},
+			refSources: map[string]*v1alpha1.RefTarget{
 				"$ref": {
-					Repo: argoappv1.Repository{
+					Repo: v1alpha1.Repository{
 						Repo: "https://github.com/org/repo1",
 					},
 				},
@@ -3263,10 +3262,10 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		{
 			name:    "attempted traversal",
 			rawPath: "$ref/../values.yaml",
-			env:     &argoappv1.Env{},
-			refSources: map[string]*argoappv1.RefTarget{
+			env:     &v1alpha1.Env{},
+			refSources: map[string]*v1alpha1.RefTarget{
 				"$ref": {
-					Repo: argoappv1.Repository{
+					Repo: v1alpha1.Repository{
 						Repo: "https://github.com/org/repo1",
 					},
 				},
@@ -3279,17 +3278,17 @@ func Test_getResolvedValueFiles(t *testing.T) {
 			// ref targets were introduced.
 			name:         "ref doesn't exist",
 			rawPath:      "$ref/values.yaml",
-			env:          &argoappv1.Env{},
-			refSources:   map[string]*argoappv1.RefTarget{},
+			env:          &v1alpha1.Env{},
+			refSources:   map[string]*v1alpha1.RefTarget{},
 			expectedPath: path.Join(tempDir, "main-repo", "values.yaml"),
 		},
 		{
 			name:    "repo doesn't exist",
 			rawPath: "$ref/values.yaml",
-			env:     &argoappv1.Env{},
-			refSources: map[string]*argoappv1.RefTarget{
+			env:     &v1alpha1.Env{},
+			refSources: map[string]*v1alpha1.RefTarget{
 				"$ref": {
-					Repo: argoappv1.Repository{
+					Repo: v1alpha1.Repository{
 						Repo: "https://github.com/org/repo2",
 					},
 				},
@@ -3299,15 +3298,15 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		{
 			name:    "env var is resolved",
 			rawPath: "$ref/$APP_PATH/values.yaml",
-			env: &argoappv1.Env{
-				&argoappv1.EnvEntry{
+			env: &v1alpha1.Env{
+				&v1alpha1.EnvEntry{
 					Name:  "APP_PATH",
 					Value: "app-path",
 				},
 			},
-			refSources: map[string]*argoappv1.RefTarget{
+			refSources: map[string]*v1alpha1.RefTarget{
 				"$ref": {
-					Repo: argoappv1.Repository{
+					Repo: v1alpha1.Repository{
 						Repo: "https://github.com/org/repo1",
 					},
 				},
@@ -3317,15 +3316,15 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		{
 			name:    "traversal in env var is blocked",
 			rawPath: "$ref/$APP_PATH/values.yaml",
-			env: &argoappv1.Env{
-				&argoappv1.EnvEntry{
+			env: &v1alpha1.Env{
+				&v1alpha1.EnvEntry{
 					Name:  "APP_PATH",
 					Value: "..",
 				},
 			},
-			refSources: map[string]*argoappv1.RefTarget{
+			refSources: map[string]*v1alpha1.RefTarget{
 				"$ref": {
-					Repo: argoappv1.Repository{
+					Repo: v1alpha1.Repository{
 						Repo: "https://github.com/org/repo1",
 					},
 				},
@@ -3335,20 +3334,20 @@ func Test_getResolvedValueFiles(t *testing.T) {
 		{
 			name:    "env var prefix",
 			rawPath: "$APP_PATH/values.yaml",
-			env: &argoappv1.Env{
-				&argoappv1.EnvEntry{
+			env: &v1alpha1.Env{
+				&v1alpha1.EnvEntry{
 					Name:  "APP_PATH",
 					Value: "app-path",
 				},
 			},
-			refSources:   map[string]*argoappv1.RefTarget{},
+			refSources:   map[string]*v1alpha1.RefTarget{},
 			expectedPath: path.Join(tempDir, "main-repo", "app-path", "values.yaml"),
 		},
 		{
 			name:         "unresolved env var",
 			rawPath:      "$APP_PATH/values.yaml",
-			env:          &argoappv1.Env{},
-			refSources:   map[string]*argoappv1.RefTarget{},
+			env:          &v1alpha1.Env{},
+			refSources:   map[string]*v1alpha1.RefTarget{},
 			expectedPath: path.Join(tempDir, "main-repo", "values.yaml"),
 		},
 	}
@@ -3408,7 +3407,7 @@ func TestErrorGetGitDirectories(t *testing.T) {
 		}()}, args: args{
 			ctx: context.TODO(),
 			request: &apiclient.GitDirectoriesRequest{
-				Repo:             &argoappv1.Repository{Repo: "not-a-valid-url"},
+				Repo:             &v1alpha1.Repository{Repo: "not-a-valid-url"},
 				SubmoduleEnabled: false,
 				Revision:         "sadfsadf",
 			},
@@ -3426,7 +3425,7 @@ func TestErrorGetGitDirectories(t *testing.T) {
 		}()}, args: args{
 			ctx: context.TODO(),
 			request: &apiclient.GitDirectoriesRequest{
-				Repo:             &argoappv1.Repository{Repo: "not-a-valid-url"},
+				Repo:             &v1alpha1.Repository{Repo: "not-a-valid-url"},
 				SubmoduleEnabled: false,
 				Revision:         "sadfsadf",
 				VerifyCommit:     true,
@@ -3459,7 +3458,7 @@ func TestGetGitDirectories(t *testing.T) {
 		paths.On("GetPathIfExists", mock.Anything).Return(root, nil)
 	}, root)
 	dirRequest := &apiclient.GitDirectoriesRequest{
-		Repo:             &argoappv1.Repository{Repo: "a-url.com"},
+		Repo:             &v1alpha1.Repository{Repo: "a-url.com"},
 		SubmoduleEnabled: false,
 		Revision:         "HEAD",
 	}
@@ -3493,7 +3492,7 @@ func TestGetGitDirectoriesWithHiddenDirSupported(t *testing.T) {
 	}, root)
 	s.initConstants.IncludeHiddenDirectories = true
 	dirRequest := &apiclient.GitDirectoriesRequest{
-		Repo:             &argoappv1.Repository{Repo: "a-url.com"},
+		Repo:             &v1alpha1.Repository{Repo: "a-url.com"},
 		SubmoduleEnabled: false,
 		Revision:         "HEAD",
 	}
@@ -3550,7 +3549,7 @@ func TestErrorGetGitFiles(t *testing.T) {
 		}()}, args: args{
 			ctx: context.TODO(),
 			request: &apiclient.GitFilesRequest{
-				Repo:             &argoappv1.Repository{Repo: "not-a-valid-url"},
+				Repo:             &v1alpha1.Repository{Repo: "not-a-valid-url"},
 				SubmoduleEnabled: false,
 				Revision:         "sadfsadf",
 			},
@@ -3587,7 +3586,7 @@ func TestGetGitFiles(t *testing.T) {
 		paths.On("GetPathIfExists", mock.Anything).Return(root, nil)
 	}, root)
 	filesRequest := &apiclient.GitFilesRequest{
-		Repo:             &argoappv1.Repository{Repo: "a-url.com"},
+		Repo:             &v1alpha1.Repository{Repo: "a-url.com"},
 		SubmoduleEnabled: false,
 		Revision:         "HEAD",
 	}
@@ -3653,7 +3652,7 @@ func TestErrorUpdateRevisionForPaths(t *testing.T) {
 		}()}, args: args{
 			ctx: context.TODO(),
 			request: &apiclient.UpdateRevisionForPathsRequest{
-				Repo:           &argoappv1.Repository{Repo: "not-a-valid-url"},
+				Repo:           &v1alpha1.Repository{Repo: "not-a-valid-url"},
 				Revision:       "sadfsadf",
 				SyncedRevision: "HEAD",
 				Paths:          []string{"."},
@@ -3672,7 +3671,7 @@ func TestErrorUpdateRevisionForPaths(t *testing.T) {
 		}()}, args: args{
 			ctx: context.TODO(),
 			request: &apiclient.UpdateRevisionForPathsRequest{
-				Repo:           &argoappv1.Repository{Repo: "not-a-valid-url"},
+				Repo:           &v1alpha1.Repository{Repo: "not-a-valid-url"},
 				Revision:       "HEAD",
 				SyncedRevision: "sadfsadf",
 				Paths:          []string{"."},
@@ -3723,7 +3722,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		}(), args: args{
 			ctx: context.TODO(),
 			request: &apiclient.UpdateRevisionForPathsRequest{
-				Repo:  &argoappv1.Repository{Repo: "a-url.com"},
+				Repo:  &v1alpha1.Repository{Repo: "a-url.com"},
 				Paths: []string{},
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{}, wantErr: assert.NoError},
@@ -3742,7 +3741,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		}(), args: args{
 			ctx: context.TODO(),
 			request: &apiclient.UpdateRevisionForPathsRequest{
-				Repo:           &argoappv1.Repository{Repo: "a-url.com"},
+				Repo:           &v1alpha1.Repository{Repo: "a-url.com"},
 				Revision:       "HEAD",
 				SyncedRevision: "SYNCEDHEAD",
 				Paths:          []string{"."},
@@ -3770,7 +3769,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		}(), args: args{
 			ctx: context.TODO(),
 			request: &apiclient.UpdateRevisionForPathsRequest{
-				Repo:           &argoappv1.Repository{Repo: "a-url.com"},
+				Repo:           &v1alpha1.Repository{Repo: "a-url.com"},
 				Revision:       "HEAD",
 				SyncedRevision: "SYNCEDHEAD",
 				Paths:          []string{"."},
@@ -3799,7 +3798,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		}(), args: args{
 			ctx: context.TODO(),
 			request: &apiclient.UpdateRevisionForPathsRequest{
-				Repo:           &argoappv1.Repository{Repo: "a-url.com"},
+				Repo:           &v1alpha1.Repository{Repo: "a-url.com"},
 				Revision:       "HEAD",
 				SyncedRevision: "SYNCEDHEAD",
 				Paths:          []string{"."},
@@ -3808,7 +3807,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				AppName:           "no-change-update-cache",
 				Namespace:         "default",
 				TrackingMethod:    "annotation+label",
-				ApplicationSource: &argoappv1.ApplicationSource{Path: "."},
+				ApplicationSource: &v1alpha1.ApplicationSource{Path: "."},
 				KubeVersion:       "v1.16.0",
 			},
 		}, want: &apiclient.UpdateRevisionForPathsResponse{
@@ -3837,7 +3836,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 		}(), args: args{
 			ctx: context.TODO(),
 			request: &apiclient.UpdateRevisionForPathsRequest{
-				Repo:           &argoappv1.Repository{Repo: "a-url.com"},
+				Repo:           &v1alpha1.Repository{Repo: "a-url.com"},
 				Revision:       "HEAD",
 				SyncedRevision: "SYNCEDHEAD",
 				Paths:          []string{"."},
@@ -3846,7 +3845,7 @@ func TestUpdateRevisionForPaths(t *testing.T) {
 				AppName:           "no-change-update-cache",
 				Namespace:         "default",
 				TrackingMethod:    "annotation+label",
-				ApplicationSource: &argoappv1.ApplicationSource{Path: ".", Helm: &argoappv1.ApplicationSourceHelm{ReleaseName: "test"}},
+				ApplicationSource: &v1alpha1.ApplicationSource{Path: ".", Helm: &v1alpha1.ApplicationSourceHelm{ReleaseName: "test"}},
 				KubeVersion:       "v1.16.0",
 
 				HasMultipleSources: true,
@@ -4056,7 +4055,7 @@ func TestGetRevisionChartDetails(t *testing.T) {
 		root := t.TempDir()
 		service := newService(t, root)
 		repoUrl := "file://" + root
-		err := service.cache.SetRevisionChartDetails(repoUrl, "my-chart", "1.1.0", &argoappv1.ChartDetails{
+		err := service.cache.SetRevisionChartDetails(repoUrl, "my-chart", "1.1.0", &v1alpha1.ChartDetails{
 			Description: "test-description",
 			Home:        "test-home",
 			Maintainers: []string{"test-maintainer"},
@@ -4137,17 +4136,17 @@ func Test_GenerateManifests_Commands(t *testing.T) {
 			Namespace:   "test-namespace",
 			KubeVersion: "1.2.3",
 			ApiVersions: []string{"v1/Test", "v2/Test"},
-			Repo:        &argoappv1.Repository{},
-			ApplicationSource: &argoappv1.ApplicationSource{
+			Repo:        &v1alpha1.Repository{},
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: ".",
-				Helm: &argoappv1.ApplicationSourceHelm{
-					FileParameters: []argoappv1.HelmFileParameter{
+				Helm: &v1alpha1.ApplicationSourceHelm{
+					FileParameters: []v1alpha1.HelmFileParameter{
 						{
 							Name: "test-file-param-name",
 							Path: "test-file-param.yaml",
 						},
 					},
-					Parameters: []argoappv1.HelmParameter{
+					Parameters: []v1alpha1.HelmParameter{
 						{
 							Name: "test-param-name",
 							// Use build env var to test substitution.
@@ -4208,8 +4207,8 @@ func Test_GenerateManifests_Commands(t *testing.T) {
 		q := apiclient.ManifestRequest{
 			AppName:   "test-app",
 			Namespace: "test-namespace",
-			Repo:      &argoappv1.Repository{},
-			ApplicationSource: &argoappv1.ApplicationSource{
+			Repo:      &v1alpha1.Repository{},
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: ".",
 			},
 			ProjectName:        "something",
@@ -4256,10 +4255,10 @@ images:
 			Namespace:   "test-namespace",
 			KubeVersion: "1.2.3",
 			ApiVersions: []string{"v1/Test", "v2/Test"},
-			Repo:        &argoappv1.Repository{},
-			ApplicationSource: &argoappv1.ApplicationSource{
+			Repo:        &v1alpha1.Repository{},
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: ".",
-				Kustomize: &argoappv1.ApplicationSourceKustomize{
+				Kustomize: &v1alpha1.ApplicationSourceKustomize{
 					APIVersions: []string{"v1", "v2"},
 					CommonAnnotations: map[string]string{
 						// Use build env var to test substitution.
@@ -4272,7 +4271,7 @@ images:
 					Components:             []string{"component"},
 					ForceCommonAnnotations: true,
 					ForceCommonLabels:      true,
-					Images: argoappv1.KustomizeImages{
+					Images: v1alpha1.KustomizeImages{
 						"image=override",
 					},
 					KubeVersion:          "5.6.7",
@@ -4280,7 +4279,7 @@ images:
 					NamePrefix:           "test-prefix",
 					NameSuffix:           "test-suffix",
 					Namespace:            "override-namespace",
-					Replicas: argoappv1.KustomizeReplicas{
+					Replicas: v1alpha1.KustomizeReplicas{
 						{
 							Name:  "guestbook-ui",
 							Count: intstr.Parse("1337"),
@@ -4315,10 +4314,10 @@ func Test_SkipSchemaValidation(t *testing.T) {
 
 		q := apiclient.ManifestRequest{
 			AppName: "test-app",
-			Repo:    &argoappv1.Repository{},
-			ApplicationSource: &argoappv1.ApplicationSource{
+			Repo:    &v1alpha1.Repository{},
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: ".",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					SkipSchemaValidation: true,
 				},
 			},
@@ -4334,10 +4333,10 @@ func Test_SkipSchemaValidation(t *testing.T) {
 
 		q := apiclient.ManifestRequest{
 			AppName: "test-app",
-			Repo:    &argoappv1.Repository{},
-			ApplicationSource: &argoappv1.ApplicationSource{
+			Repo:    &v1alpha1.Repository{},
+			ApplicationSource: &v1alpha1.ApplicationSource{
 				Path: ".",
-				Helm: &argoappv1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					SkipSchemaValidation: false,
 				},
 			},

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -39,7 +39,6 @@ import (
 	argocommon "github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	appclientset "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
 	applisters "github.com/argoproj/argo-cd/v2/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
@@ -47,7 +46,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/server/deeplinks"
 	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
 	"github.com/argoproj/argo-cd/v2/util/argo"
-	argoutil "github.com/argoproj/argo-cd/v2/util/argo"
 	"github.com/argoproj/argo-cd/v2/util/collections"
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/env"
@@ -63,7 +61,7 @@ import (
 	applicationType "github.com/argoproj/argo-cd/v2/pkg/apis/application"
 )
 
-type AppResourceTreeFn func(ctx context.Context, app *appv1.Application) (*appv1.ApplicationTree, error)
+type AppResourceTreeFn func(ctx context.Context, app *v1alpha1.Application) (*v1alpha1.ApplicationTree, error)
 
 const (
 	backgroundPropagationPolicy string = "background"
@@ -149,7 +147,7 @@ func NewServer(
 //
 // If the user does provide a "project," we can respond more specifically. If the user does not have access to the given
 // app name in the given project, we return "permission denied." If the app exists, but the project is different from
-func (s *Server) getAppEnforceRBAC(ctx context.Context, action, project, namespace, name string, getApp func() (*appv1.Application, error)) (*appv1.Application, *appv1.AppProject, error) {
+func (s *Server) getAppEnforceRBAC(ctx context.Context, action, project, namespace, name string, getApp func() (*v1alpha1.Application, error)) (*v1alpha1.Application, *v1alpha1.AppProject, error) {
 	user := session.Username(ctx)
 	if user == "" {
 		user = "Unknown user"
@@ -231,9 +229,9 @@ func (s *Server) getAppEnforceRBAC(ctx context.Context, action, project, namespa
 // getApplicationEnforceRBACInformer uses an informer to get an Application. If the app does not exist, permission is
 // denied, or any other error occurs when getting the app, we return a permission denied error to obscure any sensitive
 // information.
-func (s *Server) getApplicationEnforceRBACInformer(ctx context.Context, action, project, namespace, name string) (*appv1.Application, *appv1.AppProject, error) {
+func (s *Server) getApplicationEnforceRBACInformer(ctx context.Context, action, project, namespace, name string) (*v1alpha1.Application, *v1alpha1.AppProject, error) {
 	namespaceOrDefault := s.appNamespaceOrDefault(namespace)
-	return s.getAppEnforceRBAC(ctx, action, project, namespaceOrDefault, name, func() (*appv1.Application, error) {
+	return s.getAppEnforceRBAC(ctx, action, project, namespaceOrDefault, name, func() (*v1alpha1.Application, error) {
 		return s.appLister.Applications(namespaceOrDefault).Get(name)
 	})
 }
@@ -241,9 +239,9 @@ func (s *Server) getApplicationEnforceRBACInformer(ctx context.Context, action, 
 // getApplicationEnforceRBACClient uses a client to get an Application. If the app does not exist, permission is denied,
 // or any other error occurs when getting the app, we return a permission denied error to obscure any sensitive
 // information.
-func (s *Server) getApplicationEnforceRBACClient(ctx context.Context, action, project, namespace, name, resourceVersion string) (*appv1.Application, *appv1.AppProject, error) {
+func (s *Server) getApplicationEnforceRBACClient(ctx context.Context, action, project, namespace, name, resourceVersion string) (*v1alpha1.Application, *v1alpha1.AppProject, error) {
 	namespaceOrDefault := s.appNamespaceOrDefault(namespace)
-	return s.getAppEnforceRBAC(ctx, action, project, namespaceOrDefault, name, func() (*appv1.Application, error) {
+	return s.getAppEnforceRBAC(ctx, action, project, namespaceOrDefault, name, func() (*v1alpha1.Application, error) {
 		if !s.isNamespaceEnabled(namespaceOrDefault) {
 			return nil, security.NamespaceNotPermittedError(namespaceOrDefault)
 		}
@@ -254,12 +252,12 @@ func (s *Server) getApplicationEnforceRBACClient(ctx context.Context, action, pr
 }
 
 // List returns list of applications
-func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*appv1.ApplicationList, error) {
+func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*v1alpha1.ApplicationList, error) {
 	selector, err := labels.Parse(q.GetSelector())
 	if err != nil {
 		return nil, fmt.Errorf("error parsing the selector: %w", err)
 	}
-	var apps []*appv1.Application
+	var apps []*v1alpha1.Application
 	if q.GetAppNamespace() == "" {
 		apps, err = s.appLister.List(selector)
 	} else {
@@ -272,16 +270,16 @@ func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*ap
 	filteredApps := apps
 	// Filter applications by name
 	if q.Name != nil {
-		filteredApps = argoutil.FilterByNameP(filteredApps, *q.Name)
+		filteredApps = argo.FilterByNameP(filteredApps, *q.Name)
 	}
 
 	// Filter applications by projects
-	filteredApps = argoutil.FilterByProjectsP(filteredApps, getProjectsFromApplicationQuery(*q))
+	filteredApps = argo.FilterByProjectsP(filteredApps, getProjectsFromApplicationQuery(*q))
 
 	// Filter applications by source repo URL
-	filteredApps = argoutil.FilterByRepoP(filteredApps, q.GetRepo())
+	filteredApps = argo.FilterByRepoP(filteredApps, q.GetRepo())
 
-	newItems := make([]appv1.Application, 0)
+	newItems := make([]v1alpha1.Application, 0)
 	for _, a := range filteredApps {
 		// Skip any application that is neither in the control plane's namespace
 		// nor in the list of enabled namespaces.
@@ -298,7 +296,7 @@ func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*ap
 		return newItems[i].Name < newItems[j].Name
 	})
 
-	appList := appv1.ApplicationList{
+	appList := v1alpha1.ApplicationList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: s.appInformer.LastSyncResourceVersion(),
 		},
@@ -308,7 +306,7 @@ func (s *Server) List(ctx context.Context, q *application.ApplicationQuery) (*ap
 }
 
 // Create creates an application
-func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateRequest) (*appv1.Application, error) {
+func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateRequest) (*v1alpha1.Application, error) {
 	if q.GetApplication() == nil {
 		return nil, errors.New("error creating application: application is nil in request")
 	}
@@ -393,11 +391,11 @@ func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateReq
 	return updated, nil
 }
 
-func (s *Server) queryRepoServer(ctx context.Context, proj *appv1.AppProject, action func(
+func (s *Server) queryRepoServer(ctx context.Context, proj *v1alpha1.AppProject, action func(
 	client apiclient.RepoServerServiceClient,
-	helmRepos []*appv1.Repository,
-	helmCreds []*appv1.RepoCreds,
-	helmOptions *appv1.HelmOptions,
+	helmRepos []*v1alpha1.Repository,
+	helmCreds []*v1alpha1.RepoCreds,
+	helmOptions *v1alpha1.HelmOptions,
 	enabledSourceTypes map[string]bool,
 ) error,
 ) error {
@@ -451,7 +449,7 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 
 	manifestInfos := make([]*apiclient.ManifestResponse, 0)
 	err = s.queryRepoServer(ctx, proj, func(
-		client apiclient.RepoServerServiceClient, helmRepos []*appv1.Repository, helmCreds []*appv1.RepoCreds, helmOptions *appv1.HelmOptions, enableGenerateManifests map[string]bool,
+		client apiclient.RepoServerServiceClient, helmRepos []*v1alpha1.Repository, helmCreds []*v1alpha1.RepoCreds, helmOptions *v1alpha1.HelmOptions, enableGenerateManifests map[string]bool,
 	) error {
 		appInstanceLabelKey, err := s.settingsMgr.GetAppInstanceLabelKey()
 		if err != nil {
@@ -473,7 +471,7 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 			return fmt.Errorf("error getting API resources: %w", err)
 		}
 
-		sources := make([]appv1.ApplicationSource, 0)
+		sources := make([]v1alpha1.ApplicationSource, 0)
 		appSpec := a.Spec.DeepCopy()
 		if a.Spec.HasMultipleSources() {
 			numOfSources := int64(len(a.Spec.GetSources()))
@@ -531,7 +529,7 @@ func (s *Server) GetManifests(ctx context.Context, q *application.ApplicationMan
 				ApiVersions:                     argo.APIResourcesToStrings(apiResources, true),
 				HelmRepoCreds:                   helmCreds,
 				HelmOptions:                     helmOptions,
-				TrackingMethod:                  string(argoutil.GetTrackingMethod(s.settingsMgr)),
+				TrackingMethod:                  string(argo.GetTrackingMethod(s.settingsMgr)),
 				EnabledSourceTypes:              enableGenerateManifests,
 				ProjectName:                     proj.Name,
 				ProjectSourceRepos:              proj.Spec.SourceRepos,
@@ -595,7 +593,7 @@ func (s *Server) GetManifestsWithFiles(stream application.ApplicationService_Get
 
 	var manifestInfo *apiclient.ManifestResponse
 	err = s.queryRepoServer(ctx, proj, func(
-		client apiclient.RepoServerServiceClient, helmRepos []*appv1.Repository, helmCreds []*appv1.RepoCreds, helmOptions *appv1.HelmOptions, enableGenerateManifests map[string]bool,
+		client apiclient.RepoServerServiceClient, helmRepos []*v1alpha1.Repository, helmCreds []*v1alpha1.RepoCreds, helmOptions *v1alpha1.HelmOptions, enableGenerateManifests map[string]bool,
 	) error {
 		appInstanceLabelKey, err := s.settingsMgr.GetAppInstanceLabelKey()
 		if err != nil {
@@ -651,7 +649,7 @@ func (s *Server) GetManifestsWithFiles(stream application.ApplicationService_Get
 			ApiVersions:                     argo.APIResourcesToStrings(apiResources, true),
 			HelmRepoCreds:                   helmCreds,
 			HelmOptions:                     helmOptions,
-			TrackingMethod:                  string(argoutil.GetTrackingMethod(s.settingsMgr)),
+			TrackingMethod:                  string(argo.GetTrackingMethod(s.settingsMgr)),
 			EnabledSourceTypes:              enableGenerateManifests,
 			ProjectName:                     proj.Name,
 			ProjectSourceRepos:              proj.Spec.SourceRepos,
@@ -704,7 +702,7 @@ func (s *Server) GetManifestsWithFiles(stream application.ApplicationService_Get
 }
 
 // Get returns an application by name
-func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*appv1.Application, error) {
+func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*v1alpha1.Application, error) {
 	appName := q.GetName()
 	appNs := s.appNamespaceOrDefault(q.GetAppNamespace())
 
@@ -730,31 +728,31 @@ func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*app
 		return a, nil
 	}
 
-	refreshType := appv1.RefreshTypeNormal
-	if *q.Refresh == string(appv1.RefreshTypeHard) {
-		refreshType = appv1.RefreshTypeHard
+	refreshType := v1alpha1.RefreshTypeNormal
+	if *q.Refresh == string(v1alpha1.RefreshTypeHard) {
+		refreshType = v1alpha1.RefreshTypeHard
 	}
 	appIf := s.appclientset.ArgoprojV1alpha1().Applications(appNs)
 
 	// subscribe early with buffered channel to ensure we don't miss events
-	events := make(chan *appv1.ApplicationWatchEvent, watchAPIBufferSize)
-	unsubscribe := s.appBroadcaster.Subscribe(events, func(event *appv1.ApplicationWatchEvent) bool {
+	events := make(chan *v1alpha1.ApplicationWatchEvent, watchAPIBufferSize)
+	unsubscribe := s.appBroadcaster.Subscribe(events, func(event *v1alpha1.ApplicationWatchEvent) bool {
 		return event.Application.Name == appName && event.Application.Namespace == appNs
 	})
 	defer unsubscribe()
 
-	app, err := argoutil.RefreshApp(appIf, appName, refreshType)
+	app, err := argo.RefreshApp(appIf, appName, refreshType)
 	if err != nil {
 		return nil, fmt.Errorf("error refreshing the app: %w", err)
 	}
 
-	if refreshType == appv1.RefreshTypeHard {
+	if refreshType == v1alpha1.RefreshTypeHard {
 		// force refresh cached application details
 		if err := s.queryRepoServer(ctx, proj, func(
 			client apiclient.RepoServerServiceClient,
-			helmRepos []*appv1.Repository,
-			_ []*appv1.RepoCreds,
-			helmOptions *appv1.HelmOptions,
+			helmRepos []*v1alpha1.Repository,
+			_ []*v1alpha1.RepoCreds,
+			helmOptions *v1alpha1.HelmOptions,
 			enabledSourceTypes map[string]bool,
 		) error {
 			source := app.Spec.GetSource()
@@ -777,7 +775,7 @@ func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*app
 				KustomizeOptions:   kustomizeOptions,
 				Repos:              helmRepos,
 				NoCache:            true,
-				TrackingMethod:     string(argoutil.GetTrackingMethod(s.settingsMgr)),
+				TrackingMethod:     string(argo.GetTrackingMethod(s.settingsMgr)),
 				EnabledSourceTypes: enabledSourceTypes,
 				HelmOptions:        helmOptions,
 			})
@@ -802,7 +800,7 @@ func (s *Server) Get(ctx context.Context, q *application.ApplicationQuery) (*app
 				if annotations == nil {
 					annotations = make(map[string]string)
 				}
-				if _, ok := annotations[appv1.AnnotationKeyRefresh]; !ok {
+				if _, ok := annotations[v1alpha1.AnnotationKeyRefresh]; !ok {
 					return &event.Application, nil
 				}
 			}
@@ -876,7 +874,7 @@ func (s *Server) ListResourceEvents(ctx context.Context, q *application.Applicat
 
 // validateAndUpdateApp validates and updates the application. currentProject is the name of the project the app
 // currently is under. If not specified, we assume that the app is under the project specified in the app spec.
-func (s *Server) validateAndUpdateApp(ctx context.Context, newApp *appv1.Application, merge bool, validate bool, action string, currentProject string) (*appv1.Application, error) {
+func (s *Server) validateAndUpdateApp(ctx context.Context, newApp *v1alpha1.Application, merge bool, validate bool, action string, currentProject string) (*v1alpha1.Application, error) {
 	s.projectLock.RLock(newApp.Spec.GetProject())
 	defer s.projectLock.RUnlock(newApp.Spec.GetProject())
 
@@ -906,7 +904,7 @@ var informerSyncTimeout = 2 * time.Second
 // eventually consistent, it is possible that it doesn't reflect an application change immediately
 // after a mutating API call (create/update). This function should be called after a creates &
 // update to give a probable (but not guaranteed) chance of being up-to-date after the create/update.
-func (s *Server) waitSync(app *appv1.Application) {
+func (s *Server) waitSync(app *v1alpha1.Application) {
 	logCtx := log.WithField("application", app.Name)
 	deadline := time.Now().Add(informerSyncTimeout)
 	minVersion, err := strconv.Atoi(app.ResourceVersion)
@@ -930,7 +928,7 @@ func (s *Server) waitSync(app *appv1.Application) {
 	logCtx.Warnf("waitSync failed: timed out")
 }
 
-func (s *Server) updateApp(app *appv1.Application, newApp *appv1.Application, ctx context.Context, merge bool) (*appv1.Application, error) {
+func (s *Server) updateApp(app *v1alpha1.Application, newApp *v1alpha1.Application, ctx context.Context, merge bool) (*v1alpha1.Application, error) {
 	for i := 0; i < 10; i++ {
 		app.Spec = newApp.Spec
 		if merge {
@@ -963,7 +961,7 @@ func (s *Server) updateApp(app *appv1.Application, newApp *appv1.Application, ct
 }
 
 // Update updates an application
-func (s *Server) Update(ctx context.Context, q *application.ApplicationUpdateRequest) (*appv1.Application, error) {
+func (s *Server) Update(ctx context.Context, q *application.ApplicationUpdateRequest) (*v1alpha1.Application, error) {
 	if q.GetApplication() == nil {
 		return nil, errors.New("error updating application: application is nil in request")
 	}
@@ -980,7 +978,7 @@ func (s *Server) Update(ctx context.Context, q *application.ApplicationUpdateReq
 }
 
 // UpdateSpec updates an application spec and filters out any invalid parameter overrides
-func (s *Server) UpdateSpec(ctx context.Context, q *application.ApplicationUpdateSpecRequest) (*appv1.ApplicationSpec, error) {
+func (s *Server) UpdateSpec(ctx context.Context, q *application.ApplicationUpdateSpecRequest) (*v1alpha1.ApplicationSpec, error) {
 	if q.GetSpec() == nil {
 		return nil, errors.New("error updating application spec: spec is nil in request")
 	}
@@ -1002,7 +1000,7 @@ func (s *Server) UpdateSpec(ctx context.Context, q *application.ApplicationUpdat
 }
 
 // Patch patches an application
-func (s *Server) Patch(ctx context.Context, q *application.ApplicationPatchRequest) (*appv1.Application, error) {
+func (s *Server) Patch(ctx context.Context, q *application.ApplicationPatchRequest) (*v1alpha1.Application, error) {
 	app, _, err := s.getApplicationEnforceRBACClient(ctx, rbacpolicy.ActionGet, q.GetProject(), q.GetAppNamespace(), q.GetName(), "")
 	if err != nil {
 		return nil, err
@@ -1038,7 +1036,7 @@ func (s *Server) Patch(ctx context.Context, q *application.ApplicationPatchReque
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Patch type '%s' is not supported", q.GetPatchType()))
 	}
 
-	newApp := &appv1.Application{}
+	newApp := &v1alpha1.Application{}
 	err = json.Unmarshal(patchApp, newApp)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling patched app: %w", err)
@@ -1046,7 +1044,7 @@ func (s *Server) Patch(ctx context.Context, q *application.ApplicationPatchReque
 	return s.validateAndUpdateApp(ctx, newApp, false, true, rbacpolicy.ActionUpdate, q.GetProject())
 }
 
-func (s *Server) getAppProject(ctx context.Context, a *appv1.Application, logCtx *log.Entry) (*appv1.AppProject, error) {
+func (s *Server) getAppProject(ctx context.Context, a *v1alpha1.Application, logCtx *log.Entry) (*v1alpha1.AppProject, error) {
 	proj, err := argo.GetAppProject(a, applisters.NewAppProjectLister(s.projInformer.GetIndexer()), s.ns, s.settingsMgr, s.db, ctx)
 	if err == nil {
 		return proj, nil
@@ -1059,7 +1057,7 @@ func (s *Server) getAppProject(ctx context.Context, a *appv1.Application, logCtx
 		return nil, vagueError
 	}
 
-	var applicationNotAllowedToUseProjectErr *appv1.ErrApplicationNotAllowedToUseProject
+	var applicationNotAllowedToUseProjectErr *v1alpha1.ErrApplicationNotAllowedToUseProject
 	if errors.As(err, &applicationNotAllowedToUseProjectErr) {
 		logCtx.WithFields(map[string]any{
 			"project":                a.Spec.Project,
@@ -1133,7 +1131,7 @@ func (s *Server) Delete(ctx context.Context, q *application.ApplicationDeleteReq
 	return &application.ApplicationResponse{}, nil
 }
 
-func (s *Server) isApplicationPermitted(selector labels.Selector, minVersion int, claims any, appName, appNs string, projects map[string]bool, a appv1.Application) bool {
+func (s *Server) isApplicationPermitted(selector labels.Selector, minVersion int, claims any, appName, appNs string, projects map[string]bool, a v1alpha1.Application) bool {
 	if len(projects) > 0 && !projects[a.Spec.GetProject()] {
 		return false
 	}
@@ -1183,13 +1181,13 @@ func (s *Server) Watch(q *application.ApplicationQuery, ws application.Applicati
 
 	// sendIfPermitted is a helper to send the application to the client's streaming channel if the
 	// caller has RBAC privileges permissions to view it
-	sendIfPermitted := func(a appv1.Application, eventType watch.EventType) {
+	sendIfPermitted := func(a v1alpha1.Application, eventType watch.EventType) {
 		permitted := s.isApplicationPermitted(selector, minVersion, claims, appName, appNs, projects, a)
 		if !permitted {
 			return
 		}
 		s.inferResourcesStatusHealth(&a)
-		err := ws.Send(&appv1.ApplicationWatchEvent{
+		err := ws.Send(&v1alpha1.ApplicationWatchEvent{
 			Type:        eventType,
 			Application: a,
 		})
@@ -1199,7 +1197,7 @@ func (s *Server) Watch(q *application.ApplicationQuery, ws application.Applicati
 		}
 	}
 
-	events := make(chan *appv1.ApplicationWatchEvent, watchAPIBufferSize)
+	events := make(chan *v1alpha1.ApplicationWatchEvent, watchAPIBufferSize)
 	// Mimic watch API behavior: send ADDED events if no resource version provided
 	// If watch API is executed for one application when emit event even if resource version is provided
 	// This is required since single app watch API is used for during operations like app syncing and it is
@@ -1228,7 +1226,7 @@ func (s *Server) Watch(q *application.ApplicationQuery, ws application.Applicati
 	}
 }
 
-func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Application, proj *appv1.AppProject, validate bool) error {
+func (s *Server) validateAndNormalizeApp(ctx context.Context, app *v1alpha1.Application, proj *v1alpha1.AppProject, validate bool) error {
 	if app.GetName() == "" {
 		return errors.New("resource name may not be empty")
 	}
@@ -1270,10 +1268,10 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 		return status.Errorf(codes.InvalidArgument, "application destination spec for %s is invalid: %s", app.Name, err.Error())
 	}
 
-	var conditions []appv1.ApplicationCondition
+	var conditions []v1alpha1.ApplicationCondition
 
 	if validate {
-		conditions := make([]appv1.ApplicationCondition, 0)
+		conditions := make([]v1alpha1.ApplicationCondition, 0)
 		condition, err := argo.ValidateRepo(ctx, app, s.repoClientset, s.db, s.kubectl, proj, s.settingsMgr)
 		if err != nil {
 			return fmt.Errorf("error validating the repo: %w", err)
@@ -1296,7 +1294,7 @@ func (s *Server) validateAndNormalizeApp(ctx context.Context, app *appv1.Applica
 	return nil
 }
 
-func (s *Server) getApplicationClusterConfig(ctx context.Context, a *appv1.Application) (*rest.Config, error) {
+func (s *Server) getApplicationClusterConfig(ctx context.Context, a *v1alpha1.Application) (*rest.Config, error) {
 	if err := argo.ValidateDestination(ctx, &a.Spec.Destination, s.db); err != nil {
 		return nil, fmt.Errorf("error validating destination: %w", err)
 	}
@@ -1313,20 +1311,20 @@ func (s *Server) getApplicationClusterConfig(ctx context.Context, a *appv1.Appli
 }
 
 // getCachedAppState loads the cached state and trigger app refresh if cache is missing
-func (s *Server) getCachedAppState(ctx context.Context, a *appv1.Application, getFromCache func() error) error {
+func (s *Server) getCachedAppState(ctx context.Context, a *v1alpha1.Application, getFromCache func() error) error {
 	err := getFromCache()
 	if err != nil && errors.Is(err, servercache.ErrCacheMiss) {
-		conditions := a.Status.GetConditions(map[appv1.ApplicationConditionType]bool{
-			appv1.ApplicationConditionComparisonError:  true,
-			appv1.ApplicationConditionInvalidSpecError: true,
+		conditions := a.Status.GetConditions(map[v1alpha1.ApplicationConditionType]bool{
+			v1alpha1.ApplicationConditionComparisonError:  true,
+			v1alpha1.ApplicationConditionInvalidSpecError: true,
 		})
 		if len(conditions) > 0 {
-			return errors.New(argoutil.FormatAppConditions(conditions))
+			return errors.New(argo.FormatAppConditions(conditions))
 		}
 		_, err = s.Get(ctx, &application.ApplicationQuery{
 			Name:         ptr.To(a.GetName()),
 			AppNamespace: ptr.To(a.GetNamespace()),
-			Refresh:      ptr.To(string(appv1.RefreshTypeNormal)),
+			Refresh:      ptr.To(string(v1alpha1.RefreshTypeNormal)),
 		})
 		if err != nil {
 			return fmt.Errorf("error getting application by query: %w", err)
@@ -1336,8 +1334,8 @@ func (s *Server) getCachedAppState(ctx context.Context, a *appv1.Application, ge
 	return err
 }
 
-func (s *Server) getAppResources(ctx context.Context, a *appv1.Application) (*appv1.ApplicationTree, error) {
-	var tree appv1.ApplicationTree
+func (s *Server) getAppResources(ctx context.Context, a *v1alpha1.Application) (*v1alpha1.ApplicationTree, error) {
+	var tree v1alpha1.ApplicationTree
 	err := s.getCachedAppState(ctx, a, func() error {
 		return s.cache.GetAppResourcesTree(a.InstanceName(s.ns), &tree)
 	})
@@ -1347,7 +1345,7 @@ func (s *Server) getAppResources(ctx context.Context, a *appv1.Application) (*ap
 	return &tree, nil
 }
 
-func (s *Server) getAppLiveResource(ctx context.Context, action string, q *application.ApplicationResourceRequest) (*appv1.ResourceNode, *rest.Config, *appv1.Application, error) {
+func (s *Server) getAppLiveResource(ctx context.Context, action string, q *application.ApplicationResourceRequest) (*v1alpha1.ResourceNode, *rest.Config, *v1alpha1.Application, error) {
 	a, _, err := s.getApplicationEnforceRBACInformer(ctx, action, q.GetProject(), q.GetAppNamespace(), q.GetName())
 	if err != nil && errors.Is(err, argocommon.PermissionDeniedAPIError) && (action == rbacpolicy.ActionDelete || action == rbacpolicy.ActionUpdate) {
 		// If users dont have permission on the whole applications, maybe they have fine-grained access to the specific resources
@@ -1490,7 +1488,7 @@ func (s *Server) DeleteResource(ctx context.Context, q *application.ApplicationR
 	return &application.ApplicationResponse{}, nil
 }
 
-func (s *Server) ResourceTree(ctx context.Context, q *application.ResourcesQuery) (*appv1.ApplicationTree, error) {
+func (s *Server) ResourceTree(ctx context.Context, q *application.ResourcesQuery) (*v1alpha1.ApplicationTree, error) {
 	a, _, err := s.getApplicationEnforceRBACInformer(ctx, rbacpolicy.ActionGet, q.GetProject(), q.GetAppNamespace(), q.GetApplicationName())
 	if err != nil {
 		return nil, err
@@ -1507,7 +1505,7 @@ func (s *Server) WatchResourceTree(q *application.ResourcesQuery, ws application
 
 	cacheKey := argo.AppInstanceName(q.GetApplicationName(), q.GetAppNamespace(), s.ns)
 	return s.cache.OnAppResourcesTreeChanged(ws.Context(), cacheKey, func() error {
-		var tree appv1.ApplicationTree
+		var tree v1alpha1.ApplicationTree
 		err := s.cache.GetAppResourcesTree(cacheKey, &tree)
 		if err != nil {
 			return fmt.Errorf("error getting app resource tree: %w", err)
@@ -1516,7 +1514,7 @@ func (s *Server) WatchResourceTree(q *application.ResourcesQuery, ws application
 	})
 }
 
-func (s *Server) RevisionMetadata(ctx context.Context, q *application.RevisionMetadataQuery) (*appv1.RevisionMetadata, error) {
+func (s *Server) RevisionMetadata(ctx context.Context, q *application.RevisionMetadataQuery) (*v1alpha1.RevisionMetadata, error) {
 	a, proj, err := s.getApplicationEnforceRBACInformer(ctx, rbacpolicy.ActionGet, q.GetProject(), q.GetAppNamespace(), q.GetName())
 	if err != nil {
 		return nil, err
@@ -1544,7 +1542,7 @@ func (s *Server) RevisionMetadata(ctx context.Context, q *application.RevisionMe
 }
 
 // RevisionChartDetails returns the helm chart metadata, as fetched from the reposerver
-func (s *Server) RevisionChartDetails(ctx context.Context, q *application.RevisionMetadataQuery) (*appv1.ChartDetails, error) {
+func (s *Server) RevisionChartDetails(ctx context.Context, q *application.RevisionMetadataQuery) (*v1alpha1.ChartDetails, error) {
 	a, _, err := s.getApplicationEnforceRBACInformer(ctx, rbacpolicy.ActionGet, q.GetProject(), q.GetAppNamespace(), q.GetName())
 	if err != nil {
 		return nil, err
@@ -1579,7 +1577,7 @@ func (s *Server) RevisionChartDetails(ctx context.Context, q *application.Revisi
 // we use the source(s) currently configured for the app. If the version ID is specified, we find the source for that
 // version ID. If the version ID is not found, we return an error. If the source index is out of bounds for whichever
 // source we choose (configured sources or sources for a specific version), we return an error.
-func getAppSourceBySourceIndexAndVersionId(a *appv1.Application, sourceIndexMaybe *int32, versionIdMaybe *int32) (appv1.ApplicationSource, error) {
+func getAppSourceBySourceIndexAndVersionId(a *v1alpha1.Application, sourceIndexMaybe *int32, versionIdMaybe *int32) (v1alpha1.ApplicationSource, error) {
 	// Start with all the app's configured sources.
 	sources := a.Spec.GetSources()
 
@@ -1589,7 +1587,7 @@ func getAppSourceBySourceIndexAndVersionId(a *appv1.Application, sourceIndexMayb
 		var err error
 		sources, err = getSourcesByVersionId(a, versionId)
 		if err != nil {
-			return appv1.ApplicationSource{}, fmt.Errorf("error getting source by version ID: %w", err)
+			return v1alpha1.ApplicationSource{}, fmt.Errorf("error getting source by version ID: %w", err)
 		}
 	}
 
@@ -1601,9 +1599,9 @@ func getAppSourceBySourceIndexAndVersionId(a *appv1.Application, sourceIndexMayb
 		sourceIndex = int(*sourceIndexMaybe)
 		if sourceIndex >= len(sources) {
 			if len(sources) == 1 {
-				return appv1.ApplicationSource{}, fmt.Errorf("source index %d not found because there is only 1 source", sourceIndex)
+				return v1alpha1.ApplicationSource{}, fmt.Errorf("source index %d not found because there is only 1 source", sourceIndex)
 			}
-			return appv1.ApplicationSource{}, fmt.Errorf("source index %d not found because there are only %d sources", sourceIndex, len(sources))
+			return v1alpha1.ApplicationSource{}, fmt.Errorf("source index %d not found because there are only %d sources", sourceIndex, len(sources))
 		}
 	}
 
@@ -1614,20 +1612,20 @@ func getAppSourceBySourceIndexAndVersionId(a *appv1.Application, sourceIndexMayb
 
 // getRevisionHistoryByVersionId returns the revision history for a specific version ID.
 // If the version ID is not found, it returns an empty revision history and false.
-func getRevisionHistoryByVersionId(histories v1alpha1.RevisionHistories, versionId int64) (appv1.RevisionHistory, bool) {
+func getRevisionHistoryByVersionId(histories v1alpha1.RevisionHistories, versionId int64) (v1alpha1.RevisionHistory, bool) {
 	for _, h := range histories {
 		if h.ID == versionId {
 			return h, true
 		}
 	}
-	return appv1.RevisionHistory{}, false
+	return v1alpha1.RevisionHistory{}, false
 }
 
 // getSourcesByVersionId returns the sources for a specific version ID. If there is no history, it returns an error.
 // If the version ID is not found, it returns an error. If the version ID is found, and there are multiple sources,
 // it returns the sources for that version ID. If the version ID is found, and there is only one source, it returns
 // a slice with just the single source.
-func getSourcesByVersionId(a *appv1.Application, versionId int64) ([]appv1.ApplicationSource, error) {
+func getSourcesByVersionId(a *v1alpha1.Application, versionId int64) ([]v1alpha1.ApplicationSource, error) {
 	if len(a.Status.History) == 0 {
 		return nil, fmt.Errorf("version ID %d not found because the app has no history", versionId)
 	}
@@ -1657,7 +1655,7 @@ func (s *Server) ManagedResources(ctx context.Context, q *application.ResourcesQ
 		return nil, err
 	}
 
-	items := make([]*appv1.ResourceDiff, 0)
+	items := make([]*v1alpha1.ResourceDiff, 0)
 	err = s.getCachedAppState(ctx, a, func() error {
 		return s.cache.GetAppManagedResources(a.InstanceName(s.ns), &items)
 	})
@@ -1851,8 +1849,8 @@ func (s *Server) PodLogs(q *application.ApplicationPodLogsQuery, ws application.
 }
 
 // from all of the treeNodes, get the pod who meets the criteria or whose parents meets the criteria
-func getSelectedPods(treeNodes []appv1.ResourceNode, q *application.ApplicationPodLogsQuery) []appv1.ResourceNode {
-	var pods []appv1.ResourceNode
+func getSelectedPods(treeNodes []v1alpha1.ResourceNode, q *application.ApplicationPodLogsQuery) []v1alpha1.ResourceNode {
+	var pods []v1alpha1.ResourceNode
 	isTheOneMap := make(map[string]bool)
 	for _, treeNode := range treeNodes {
 		if treeNode.Kind == kube.PodKind && treeNode.Group == "" && treeNode.UID != "" {
@@ -1865,7 +1863,7 @@ func getSelectedPods(treeNodes []appv1.ResourceNode, q *application.ApplicationP
 }
 
 // check is currentNode is matching with group, kind, and name, or if any of its parents matches
-func isTheSelectedOne(currentNode *appv1.ResourceNode, q *application.ApplicationPodLogsQuery, resourceNodes []appv1.ResourceNode, isTheOneMap map[string]bool) bool {
+func isTheSelectedOne(currentNode *v1alpha1.ResourceNode, q *application.ApplicationPodLogsQuery, resourceNodes []v1alpha1.ResourceNode, isTheOneMap map[string]bool) bool {
 	exist, value := isTheOneMap[currentNode.UID]
 	if exist {
 		return value
@@ -1905,7 +1903,7 @@ func isTheSelectedOne(currentNode *appv1.ResourceNode, q *application.Applicatio
 }
 
 // Sync syncs an application to its target state
-func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncRequest) (*appv1.Application, error) {
+func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncRequest) (*v1alpha1.Application, error) {
 	a, proj, err := s.getApplicationEnforceRBACClient(ctx, rbacpolicy.ActionGet, syncReq.GetProject(), syncReq.GetAppNamespace(), syncReq.GetName(), "")
 	if err != nil {
 		return nil, err
@@ -1942,8 +1940,8 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 		return nil, err
 	}
 
-	var retry *appv1.RetryStrategy
-	var syncOptions appv1.SyncOptions
+	var retry *v1alpha1.RetryStrategy
+	var syncOptions v1alpha1.SyncOptions
 	if a.Spec.SyncPolicy != nil {
 		syncOptions = a.Spec.SyncPolicy.SyncOptions
 		retry = a.Spec.SyncPolicy.Retry
@@ -1960,7 +1958,7 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 		return nil, status.Errorf(codes.FailedPrecondition, "Cannot use local sync when signature keys are required.")
 	}
 
-	resources := []appv1.SyncOperationResource{}
+	resources := []v1alpha1.SyncOperationResource{}
 	if syncReq.GetResources() != nil {
 		for _, r := range syncReq.GetResources() {
 			if r != nil {
@@ -1968,8 +1966,8 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 			}
 		}
 	}
-	op := appv1.Operation{
-		Sync: &appv1.SyncOperation{
+	op := v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{
 			Revision:     revision,
 			Prune:        syncReq.GetPrune(),
 			DryRun:       syncReq.GetDryRun(),
@@ -1980,7 +1978,7 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 			Sources:      a.Spec.Sources,
 			Revisions:    sourceRevisions,
 		},
-		InitiatedBy: appv1.OperationInitiator{Username: session.Username(ctx)},
+		InitiatedBy: v1alpha1.OperationInitiator{Username: session.Username(ctx)},
 		Info:        syncReq.Infos,
 	}
 	if retry != nil {
@@ -2011,7 +2009,7 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 	return a, nil
 }
 
-func (s *Server) resolveSourceRevisions(ctx context.Context, a *appv1.Application, syncReq *application.ApplicationSyncRequest) (string, string, []string, []string, error) {
+func (s *Server) resolveSourceRevisions(ctx context.Context, a *v1alpha1.Application, syncReq *application.ApplicationSyncRequest) (string, string, []string, []string, error) {
 	if a.Spec.HasMultipleSources() {
 		numOfSources := int64(len(a.Spec.GetSources()))
 		sourceRevisions := make([]string, numOfSources)
@@ -2053,7 +2051,7 @@ func (s *Server) resolveSourceRevisions(ctx context.Context, a *appv1.Applicatio
 	}
 }
 
-func (s *Server) Rollback(ctx context.Context, rollbackReq *application.ApplicationRollbackRequest) (*appv1.Application, error) {
+func (s *Server) Rollback(ctx context.Context, rollbackReq *application.ApplicationRollbackRequest) (*v1alpha1.Application, error) {
 	a, _, err := s.getApplicationEnforceRBACClient(ctx, rbacpolicy.ActionSync, rollbackReq.GetProject(), rollbackReq.GetAppNamespace(), rollbackReq.GetName(), "")
 	if err != nil {
 		return nil, err
@@ -2068,7 +2066,7 @@ func (s *Server) Rollback(ctx context.Context, rollbackReq *application.Applicat
 		return nil, status.Errorf(codes.FailedPrecondition, "rollback cannot be initiated when auto-sync is enabled")
 	}
 
-	var deploymentInfo *appv1.RevisionHistory
+	var deploymentInfo *v1alpha1.RevisionHistory
 	for _, info := range a.Status.History {
 		if info.ID == rollbackReq.GetId() {
 			deploymentInfo = &info
@@ -2085,24 +2083,24 @@ func (s *Server) Rollback(ctx context.Context, rollbackReq *application.Applicat
 		return nil, status.Errorf(codes.FailedPrecondition, "cannot rollback to revision deployed with Argo CD v0.11 or lower. sync to revision instead.")
 	}
 
-	var syncOptions appv1.SyncOptions
+	var syncOptions v1alpha1.SyncOptions
 	if a.Spec.SyncPolicy != nil {
 		syncOptions = a.Spec.SyncPolicy.SyncOptions
 	}
 
 	// Rollback is just a convenience around Sync
-	op := appv1.Operation{
-		Sync: &appv1.SyncOperation{
+	op := v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{
 			Revision:     deploymentInfo.Revision,
 			Revisions:    deploymentInfo.Revisions,
 			DryRun:       rollbackReq.GetDryRun(),
 			Prune:        rollbackReq.GetPrune(),
 			SyncOptions:  syncOptions,
-			SyncStrategy: &appv1.SyncStrategy{Apply: &appv1.SyncStrategyApply{}},
+			SyncStrategy: &v1alpha1.SyncStrategy{Apply: &v1alpha1.SyncStrategyApply{}},
 			Source:       &deploymentInfo.Source,
 			Sources:      deploymentInfo.Sources,
 		},
-		InitiatedBy: appv1.OperationInitiator{Username: session.Username(ctx)},
+		InitiatedBy: v1alpha1.OperationInitiator{Username: session.Username(ctx)},
 	}
 	appName := rollbackReq.GetName()
 	appNs := s.appNamespaceOrDefault(rollbackReq.GetAppNamespace())
@@ -2146,16 +2144,16 @@ func (s *Server) ListLinks(ctx context.Context, req *application.ListAppLinksReq
 	return finalList, nil
 }
 
-func (s *Server) getObjectsForDeepLinks(ctx context.Context, app *appv1.Application, proj *appv1.AppProject) (cluster *unstructured.Unstructured, project *unstructured.Unstructured, err error) {
+func (s *Server) getObjectsForDeepLinks(ctx context.Context, app *v1alpha1.Application, proj *v1alpha1.AppProject) (cluster *unstructured.Unstructured, project *unstructured.Unstructured, err error) {
 	// sanitize project jwt tokens
-	proj.Status = appv1.AppProjectStatus{}
+	proj.Status = v1alpha1.AppProjectStatus{}
 
 	project, err = kube.ToUnstructured(proj)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	getProjectClusters := func(project string) ([]*appv1.Cluster, error) {
+	getProjectClusters := func(project string) ([]*v1alpha1.Cluster, error) {
 		return s.db.GetProjectClusters(ctx, project)
 	}
 
@@ -2228,7 +2226,7 @@ func (s *Server) ListResourceLinks(ctx context.Context, req *application.Applica
 	return finalList, nil
 }
 
-func getAmbiguousRevision(app *appv1.Application, syncReq *application.ApplicationSyncRequest, sourceIndex int) string {
+func getAmbiguousRevision(app *v1alpha1.Application, syncReq *application.ApplicationSyncRequest, sourceIndex int) string {
 	ambiguousRevision := ""
 	if app.Spec.HasMultipleSources() {
 		for i, pos := range syncReq.SourcePositions {
@@ -2250,7 +2248,7 @@ func getAmbiguousRevision(app *appv1.Application, syncReq *application.Applicati
 
 // resolveRevision resolves the revision specified either in the sync request, or the
 // application source, into a concrete revision that will be used for a sync operation.
-func (s *Server) resolveRevision(ctx context.Context, app *appv1.Application, syncReq *application.ApplicationSyncRequest, sourceIndex int) (string, string, error) {
+func (s *Server) resolveRevision(ctx context.Context, app *v1alpha1.Application, syncReq *application.ApplicationSyncRequest, sourceIndex int) (string, string, error) {
 	if syncReq.Manifests != nil {
 		return "", "", nil
 	}
@@ -2324,7 +2322,7 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 	return nil, status.Errorf(codes.Internal, "Failed to terminate app. Too many conflicts")
 }
 
-func (s *Server) logAppEvent(a *appv1.Application, ctx context.Context, reason string, action string) {
+func (s *Server) logAppEvent(a *v1alpha1.Application, ctx context.Context, reason string, action string) {
 	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
@@ -2335,7 +2333,7 @@ func (s *Server) logAppEvent(a *appv1.Application, ctx context.Context, reason s
 	s.auditLogger.LogAppEvent(a, eventInfo, message, user, eventLabels)
 }
 
-func (s *Server) logResourceEvent(res *appv1.ResourceNode, ctx context.Context, reason string, action string) {
+func (s *Server) logResourceEvent(res *v1alpha1.ResourceNode, ctx context.Context, reason string, action string) {
 	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
@@ -2359,7 +2357,7 @@ func (s *Server) ListResourceActions(ctx context.Context, q *application.Applica
 	if err != nil {
 		return nil, fmt.Errorf("error getting available actions: %w", err)
 	}
-	actionsPtr := []*appv1.ResourceAction{}
+	actionsPtr := []*v1alpha1.ResourceAction{}
 	for i := range availableActions {
 		actionsPtr = append(actionsPtr, &availableActions[i])
 	}
@@ -2367,7 +2365,7 @@ func (s *Server) ListResourceActions(ctx context.Context, q *application.Applica
 	return &application.ResourceActionsListResponse{Actions: actionsPtr}, nil
 }
 
-func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacRequest string, q *application.ApplicationResourceRequest) (obj *unstructured.Unstructured, res *appv1.ResourceNode, app *appv1.Application, config *rest.Config, err error) {
+func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacRequest string, q *application.ApplicationResourceRequest) (obj *unstructured.Unstructured, res *v1alpha1.ResourceNode, app *v1alpha1.Application, config *rest.Config, err error) {
 	if q.GetKind() == applicationType.ApplicationKind && q.GetGroup() == applicationType.Group && q.GetName() == q.GetResourceName() {
 		app, _, err = s.getApplicationEnforceRBACInformer(ctx, rbacRequest, q.GetProject(), q.GetAppNamespace(), q.GetName())
 		if err != nil {
@@ -2394,7 +2392,7 @@ func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacReque
 	return
 }
 
-func (s *Server) getAvailableActions(resourceOverrides map[string]appv1.ResourceOverride, obj *unstructured.Unstructured) ([]appv1.ResourceAction, error) {
+func (s *Server) getAvailableActions(resourceOverrides map[string]v1alpha1.ResourceOverride, obj *unstructured.Unstructured) ([]v1alpha1.ResourceAction, error) {
 	luaVM := lua.VM{
 		ResourceOverrides: resourceOverrides,
 	}
@@ -2404,7 +2402,7 @@ func (s *Server) getAvailableActions(resourceOverrides map[string]appv1.Resource
 		return nil, fmt.Errorf("error getting Lua discovery script: %w", err)
 	}
 	if len(discoveryScripts) == 0 {
-		return []appv1.ResourceAction{}, nil
+		return []v1alpha1.ResourceAction{}, nil
 	}
 	availableActions, err := luaVM.ExecuteResourceActionDiscovery(obj, discoveryScripts)
 	if err != nil {
@@ -2453,7 +2451,7 @@ func (s *Server) RunResourceAction(ctx context.Context, q *application.ResourceA
 		return nil, fmt.Errorf("error executing Lua resource action: %w", err)
 	}
 
-	var app *appv1.Application
+	var app *v1alpha1.Application
 	// Only bother getting the app if we know we're going to need it for a resource permission check.
 	if len(newObjects) > 0 {
 		// No need for an RBAC check, we checked above that the user is allowed to run this action.
@@ -2568,8 +2566,8 @@ func (s *Server) patchResource(ctx context.Context, config *rest.Config, liveObj
 	return &application.ApplicationResponse{}, nil
 }
 
-func (s *Server) verifyResourcePermitted(app *appv1.Application, proj *appv1.AppProject, obj *unstructured.Unstructured) error {
-	permitted, err := proj.IsResourcePermitted(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.GroupVersionKind().Kind}, obj.GetNamespace(), app.Spec.Destination, func(project string) ([]*appv1.Cluster, error) {
+func (s *Server) verifyResourcePermitted(app *v1alpha1.Application, proj *v1alpha1.AppProject, obj *unstructured.Unstructured) error {
+	permitted, err := proj.IsResourcePermitted(schema.GroupKind{Group: obj.GroupVersionKind().Group, Kind: obj.GroupVersionKind().Kind}, obj.GetNamespace(), app.Spec.Destination, func(project string) ([]*v1alpha1.Cluster, error) {
 		clusters, err := s.db.GetProjectClusters(context.TODO(), project)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get project clusters: %w", err)
@@ -2652,11 +2650,11 @@ func (s *Server) GetApplicationSyncWindows(ctx context.Context, q *application.A
 	return res, nil
 }
 
-func (s *Server) inferResourcesStatusHealth(app *appv1.Application) {
-	if app.Status.ResourceHealthSource == appv1.ResourceHealthLocationAppTree {
-		tree := &appv1.ApplicationTree{}
+func (s *Server) inferResourcesStatusHealth(app *v1alpha1.Application) {
+	if app.Status.ResourceHealthSource == v1alpha1.ResourceHealthLocationAppTree {
+		tree := &v1alpha1.ApplicationTree{}
 		if err := s.cache.GetAppResourcesTree(app.Name, tree); err == nil {
-			healthByKey := map[kube.ResourceKey]*appv1.HealthStatus{}
+			healthByKey := map[kube.ResourceKey]*v1alpha1.HealthStatus{}
 			for _, node := range tree.Nodes {
 				healthByKey[kube.NewResourceKey(node.Group, node.Kind, node.Namespace, node.Name)] = node.Health
 			}
@@ -2668,7 +2666,7 @@ func (s *Server) inferResourcesStatusHealth(app *appv1.Application) {
 	}
 }
 
-func convertSyncWindows(w *appv1.SyncWindows) []*application.ApplicationSyncWindow {
+func convertSyncWindows(w *v1alpha1.SyncWindows) []*application.ApplicationSyncWindow {
 	if w != nil {
 		var windows []*application.ApplicationSyncWindow
 		for _, w := range *w {
@@ -2690,11 +2688,11 @@ func convertSyncWindows(w *appv1.SyncWindows) []*application.ApplicationSyncWind
 func getPropagationPolicyFinalizer(policy string) string {
 	switch strings.ToLower(policy) {
 	case backgroundPropagationPolicy:
-		return appv1.BackgroundPropagationPolicyFinalizer
+		return v1alpha1.BackgroundPropagationPolicyFinalizer
 	case foregroundPropagationPolicy:
-		return appv1.ForegroundPropagationPolicyFinalizer
+		return v1alpha1.ForegroundPropagationPolicyFinalizer
 	case "":
-		return appv1.ResourcesFinalizerName
+		return v1alpha1.ResourcesFinalizerName
 	default:
 		return ""
 	}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -41,8 +41,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
-	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	apps "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
 	appinformer "github.com/argoproj/argo-cd/v2/pkg/client/informers/externalversions"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
@@ -53,7 +52,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/argo"
 	"github.com/argoproj/argo-cd/v2/util/assets"
 	"github.com/argoproj/argo-cd/v2/util/cache"
-	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	"github.com/argoproj/argo-cd/v2/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/errors"
@@ -73,13 +71,13 @@ type broadcasterMock struct {
 	objects []runtime.Object
 }
 
-func (b broadcasterMock) Subscribe(ch chan *appv1.ApplicationWatchEvent, filters ...func(event *appv1.ApplicationWatchEvent) bool) func() {
+func (b broadcasterMock) Subscribe(ch chan *v1alpha1.ApplicationWatchEvent, filters ...func(event *v1alpha1.ApplicationWatchEvent) bool) func() {
 	// Simulate the broadcaster notifying the subscriber of an application update.
 	// The second parameter to Subscribe is filters. For the purposes of tests, we ignore the filters. Future tests
 	// might require implementing those.
 	go func() {
 		for _, obj := range b.objects {
-			app, ok := obj.(*appsv1.Application)
+			app, ok := obj.(*v1alpha1.Application)
 			if ok {
 				oldVersion, err := strconv.Atoi(app.ResourceVersion)
 				if err != nil {
@@ -87,7 +85,7 @@ func (b broadcasterMock) Subscribe(ch chan *appv1.ApplicationWatchEvent, filters
 				}
 				clonedApp := app.DeepCopy()
 				clonedApp.ResourceVersion = strconv.Itoa(oldVersion + 1)
-				ch <- &appsv1.ApplicationWatchEvent{Type: watch.Added, Application: *clonedApp}
+				ch <- &v1alpha1.ApplicationWatchEvent{Type: watch.Added, Application: *clonedApp}
 			}
 		}
 	}()
@@ -98,17 +96,17 @@ func (broadcasterMock) OnAdd(any, bool)   {}
 func (broadcasterMock) OnUpdate(any, any) {}
 func (broadcasterMock) OnDelete(any)      {}
 
-func fakeRepo() *appsv1.Repository {
-	return &appsv1.Repository{
+func fakeRepo() *v1alpha1.Repository {
+	return &v1alpha1.Repository{
 		Repo: fakeRepoURL,
 	}
 }
 
-func fakeCluster() *appsv1.Cluster {
-	return &appsv1.Cluster{
+func fakeCluster() *v1alpha1.Cluster {
+	return &v1alpha1.Cluster{
 		Server: "https://cluster-api.example.com",
 		Name:   "fake-cluster",
-		Config: appsv1.ClusterConfig{},
+		Config: v1alpha1.ClusterConfig{},
 	}
 }
 
@@ -140,12 +138,12 @@ func fakeRepoServerClient(isHelm bool) *mocks.RepoServerServiceClient {
 	mockRepoServiceClient.On("GenerateManifest", mock.Anything, mock.Anything).Return(&apiclient.ManifestResponse{}, nil)
 	mockRepoServiceClient.On("GetAppDetails", mock.Anything, mock.Anything).Return(&apiclient.RepoAppDetailsResponse{}, nil)
 	mockRepoServiceClient.On("TestRepository", mock.Anything, mock.Anything).Return(&apiclient.TestRepositoryResponse{}, nil)
-	mockRepoServiceClient.On("GetRevisionMetadata", mock.Anything, mock.Anything).Return(&appsv1.RevisionMetadata{}, nil)
+	mockRepoServiceClient.On("GetRevisionMetadata", mock.Anything, mock.Anything).Return(&v1alpha1.RevisionMetadata{}, nil)
 	mockWithFilesClient := &mocks.RepoServerService_GenerateManifestWithFilesClient{}
 	mockWithFilesClient.On("Send", mock.Anything).Return(nil)
 	mockWithFilesClient.On("CloseAndRecv").Return(&apiclient.ManifestResponse{}, nil)
 	mockRepoServiceClient.On("GenerateManifestWithFiles", mock.Anything, mock.Anything).Return(mockWithFilesClient, nil)
-	mockRepoServiceClient.On("GetRevisionChartDetails", mock.Anything, mock.Anything).Return(&appsv1.ChartDetails{}, nil)
+	mockRepoServiceClient.On("GetRevisionChartDetails", mock.Anything, mock.Anything).Return(&v1alpha1.ChartDetails{}, nil)
 
 	if isHelm {
 		mockRepoServiceClient.On("ResolveRevision", mock.Anything, mock.Anything).Return(fakeResolveRevisionResponseHelm(), nil)
@@ -196,30 +194,30 @@ func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer),
 
 	mockRepoClient := &mocks.Clientset{RepoServerServiceClient: fakeRepoServerClient(false)}
 
-	defaultProj := &appsv1.AppProject{
+	defaultProj := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "default"},
-		Spec: appsv1.AppProjectSpec{
+		Spec: v1alpha1.AppProjectSpec{
 			SourceRepos:  []string{"*"},
-			Destinations: []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+			Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 		},
 	}
 
-	myProj := &appsv1.AppProject{
+	myProj := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-proj", Namespace: "default"},
-		Spec: appsv1.AppProjectSpec{
+		Spec: v1alpha1.AppProjectSpec{
 			SourceRepos:  []string{"*"},
-			Destinations: []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+			Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 		},
 	}
-	projWithSyncWindows := &appsv1.AppProject{
+	projWithSyncWindows := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: "proj-maint", Namespace: "default"},
-		Spec: appsv1.AppProjectSpec{
+		Spec: v1alpha1.AppProjectSpec{
 			SourceRepos:  []string{"*"},
-			Destinations: []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
-			SyncWindows:  appsv1.SyncWindows{},
+			Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+			SyncWindows:  v1alpha1.SyncWindows{},
 		},
 	}
-	matchingWindow := &appsv1.SyncWindow{
+	matchingWindow := &v1alpha1.SyncWindow{
 		Kind:         "allow",
 		Schedule:     "* * * * *",
 		Duration:     "1h",
@@ -261,16 +259,16 @@ func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer),
 	appStateCache := appstate.NewCache(cache.NewCache(cache.NewInMemoryCache(time.Hour)), time.Hour)
 	// pre-populate the app cache
 	for _, obj := range objects {
-		app, ok := obj.(*appsv1.Application)
+		app, ok := obj.(*v1alpha1.Application)
 		if ok {
-			err := appStateCache.SetAppManagedResources(app.Name, []*appsv1.ResourceDiff{})
+			err := appStateCache.SetAppManagedResources(app.Name, []*v1alpha1.ResourceDiff{})
 			require.NoError(t, err)
 
 			// Pre-populate the resource tree based on the app's resources.
-			nodes := make([]appsv1.ResourceNode, len(app.Status.Resources))
+			nodes := make([]v1alpha1.ResourceNode, len(app.Status.Resources))
 			for i, res := range app.Status.Resources {
-				nodes[i] = appsv1.ResourceNode{
-					ResourceRef: appsv1.ResourceRef{
+				nodes[i] = v1alpha1.ResourceNode{
+					ResourceRef: v1alpha1.ResourceRef{
 						Group:     res.Group,
 						Kind:      res.Kind,
 						Version:   res.Version,
@@ -280,7 +278,7 @@ func newTestAppServerWithEnforcerConfigure(t *testing.T, f func(*rbac.Enforcer),
 					},
 				}
 			}
-			err = appStateCache.SetAppResourcesTree(app.Name, &appsv1.ApplicationTree{
+			err = appStateCache.SetAppResourcesTree(app.Name, &v1alpha1.ApplicationTree{
 				Nodes: nodes,
 			})
 			require.NoError(t, err)
@@ -360,29 +358,29 @@ func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rb
 
 	mockRepoClient := &mocks.Clientset{RepoServerServiceClient: fakeRepoServerClient(false)}
 
-	defaultProj := &appsv1.AppProject{
+	defaultProj := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "default"},
-		Spec: appsv1.AppProjectSpec{
+		Spec: v1alpha1.AppProjectSpec{
 			SourceRepos:  []string{"*"},
-			Destinations: []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+			Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 		},
 	}
-	myProj := &appsv1.AppProject{
+	myProj := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-proj", Namespace: "default"},
-		Spec: appsv1.AppProjectSpec{
+		Spec: v1alpha1.AppProjectSpec{
 			SourceRepos:  []string{"*"},
-			Destinations: []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+			Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 		},
 	}
-	projWithSyncWindows := &appsv1.AppProject{
+	projWithSyncWindows := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: "proj-maint", Namespace: "default"},
-		Spec: appsv1.AppProjectSpec{
+		Spec: v1alpha1.AppProjectSpec{
 			SourceRepos:  []string{"*"},
-			Destinations: []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
-			SyncWindows:  appsv1.SyncWindows{},
+			Destinations: []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+			SyncWindows:  v1alpha1.SyncWindows{},
 		},
 	}
-	matchingWindow := &appsv1.SyncWindow{
+	matchingWindow := &v1alpha1.SyncWindow{
 		Kind:         "allow",
 		Schedule:     "* * * * *",
 		Duration:     "1h",
@@ -423,16 +421,16 @@ func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rb
 	appStateCache := appstate.NewCache(cache.NewCache(cache.NewInMemoryCache(time.Hour)), time.Hour)
 	// pre-populate the app cache
 	for _, obj := range objects {
-		app, ok := obj.(*appsv1.Application)
+		app, ok := obj.(*v1alpha1.Application)
 		if ok {
-			err := appStateCache.SetAppManagedResources(app.Name, []*appsv1.ResourceDiff{})
+			err := appStateCache.SetAppManagedResources(app.Name, []*v1alpha1.ResourceDiff{})
 			require.NoError(b, err)
 
 			// Pre-populate the resource tree based on the app's resources.
-			nodes := make([]appsv1.ResourceNode, len(app.Status.Resources))
+			nodes := make([]v1alpha1.ResourceNode, len(app.Status.Resources))
 			for i, res := range app.Status.Resources {
-				nodes[i] = appsv1.ResourceNode{
-					ResourceRef: appsv1.ResourceRef{
+				nodes[i] = v1alpha1.ResourceNode{
+					ResourceRef: v1alpha1.ResourceRef{
 						Group:     res.Group,
 						Kind:      res.Kind,
 						Version:   res.Version,
@@ -442,7 +440,7 @@ func newTestAppServerWithEnforcerConfigureWithBenchmark(b *testing.B, f func(*rb
 					},
 				}
 			}
-			err = appStateCache.SetAppResourcesTree(app.Name, &appsv1.ApplicationTree{
+			err = appStateCache.SetAppResourcesTree(app.Name, &v1alpha1.ApplicationTree{
 				Nodes: nodes,
 			})
 			require.NoError(b, err)
@@ -539,20 +537,20 @@ spec:
     server: https://cluster-api.example.com
 `
 
-func newTestAppWithDestName(opts ...func(app *appsv1.Application)) *appsv1.Application {
+func newTestAppWithDestName(opts ...func(app *v1alpha1.Application)) *v1alpha1.Application {
 	return createTestApp(fakeAppWithDestName, opts...)
 }
 
-func newTestApp(opts ...func(app *appsv1.Application)) *appsv1.Application {
+func newTestApp(opts ...func(app *v1alpha1.Application)) *v1alpha1.Application {
 	return createTestApp(fakeApp, opts...)
 }
 
-func newTestAppWithAnnotations(opts ...func(app *appsv1.Application)) *appsv1.Application {
+func newTestAppWithAnnotations(opts ...func(app *v1alpha1.Application)) *v1alpha1.Application {
 	return createTestApp(fakeAppWithAnnotations, opts...)
 }
 
-func createTestApp(testApp string, opts ...func(app *appsv1.Application)) *appsv1.Application {
-	var app appsv1.Application
+func createTestApp(testApp string, opts ...func(app *v1alpha1.Application)) *v1alpha1.Application {
+	var app v1alpha1.Application
 	err := yaml.Unmarshal([]byte(testApp), &app)
 	if err != nil {
 		panic(err)
@@ -618,7 +616,7 @@ type TestResourceTreeServer struct {
 	ctx context.Context
 }
 
-func (t *TestResourceTreeServer) Send(tree *appsv1.ApplicationTree) error {
+func (t *TestResourceTreeServer) Send(tree *v1alpha1.ApplicationTree) error {
 	return nil
 }
 
@@ -702,9 +700,9 @@ func TestNoAppEnumeration(t *testing.T) {
 			Namespace: "test",
 		},
 	}
-	testApp := newTestApp(func(app *appsv1.Application) {
+	testApp := newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "test"
-		app.Status.Resources = []appsv1.ResourceStatus{
+		app.Status.Resources = []v1alpha1.ResourceStatus{
 			{
 				Group:     deployment.GroupVersionKind().Group,
 				Kind:      deployment.GroupVersionKind().Kind,
@@ -714,20 +712,20 @@ func TestNoAppEnumeration(t *testing.T) {
 				Status:    "Synced",
 			},
 		}
-		app.Status.History = []appsv1.RevisionHistory{
+		app.Status.History = []v1alpha1.RevisionHistory{
 			{
 				ID: 0,
-				Source: appsv1.ApplicationSource{
+				Source: v1alpha1.ApplicationSource{
 					TargetRevision: "something-old",
 				},
 			},
 		}
 	})
-	testHelmApp := newTestApp(func(app *appsv1.Application) {
+	testHelmApp := newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "test-helm"
 		app.Spec.Source.Path = ""
 		app.Spec.Source.Chart = "test"
-		app.Status.Resources = []appsv1.ResourceStatus{
+		app.Status.Resources = []v1alpha1.ResourceStatus{
 			{
 				Group:     deployment.GroupVersionKind().Group,
 				Kind:      deployment.GroupVersionKind().Kind,
@@ -737,26 +735,26 @@ func TestNoAppEnumeration(t *testing.T) {
 				Status:    "Synced",
 			},
 		}
-		app.Status.History = []appsv1.RevisionHistory{
+		app.Status.History = []v1alpha1.RevisionHistory{
 			{
 				ID: 0,
-				Source: appsv1.ApplicationSource{
+				Source: v1alpha1.ApplicationSource{
 					TargetRevision: "something-old",
 				},
 			},
 		}
 	})
-	testAppMulti := newTestApp(func(app *appsv1.Application) {
+	testAppMulti := newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "test-multi"
-		app.Spec.Sources = appsv1.ApplicationSources{
-			appsv1.ApplicationSource{
+		app.Spec.Sources = v1alpha1.ApplicationSources{
+			v1alpha1.ApplicationSource{
 				TargetRevision: "something-old",
 			},
-			appsv1.ApplicationSource{
+			v1alpha1.ApplicationSource{
 				TargetRevision: "something-old",
 			},
 		}
-		app.Status.Resources = []appsv1.ResourceStatus{
+		app.Status.Resources = []v1alpha1.ResourceStatus{
 			{
 				Group:     deployment.GroupVersionKind().Group,
 				Kind:      deployment.GroupVersionKind().Kind,
@@ -766,14 +764,14 @@ func TestNoAppEnumeration(t *testing.T) {
 				Status:    "Synced",
 			},
 		}
-		app.Status.History = []appsv1.RevisionHistory{
+		app.Status.History = []v1alpha1.RevisionHistory{
 			{
 				ID: 1,
-				Sources: appsv1.ApplicationSources{
-					appsv1.ApplicationSource{
+				Sources: v1alpha1.ApplicationSources{
+					v1alpha1.ApplicationSource{
 						TargetRevision: "something-old",
 					},
-					appsv1.ApplicationSource{
+					v1alpha1.ApplicationSource{
 						TargetRevision: "something-old",
 					},
 				},
@@ -825,24 +823,24 @@ func TestNoAppEnumeration(t *testing.T) {
 	})
 
 	t.Run("UpdateSpec", func(t *testing.T) {
-		_, err := appServer.UpdateSpec(adminCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("test"), Spec: &appsv1.ApplicationSpec{
-			Destination: appsv1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
-			Source:      &appsv1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
+		_, err := appServer.UpdateSpec(adminCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("test"), Spec: &v1alpha1.ApplicationSpec{
+			Destination: v1alpha1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
 		}})
 		require.NoError(t, err)
-		_, err = appServer.UpdateSpec(noRoleCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("test"), Spec: &appsv1.ApplicationSpec{
-			Destination: appsv1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
-			Source:      &appsv1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
+		_, err = appServer.UpdateSpec(noRoleCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("test"), Spec: &v1alpha1.ApplicationSpec{
+			Destination: v1alpha1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
 		}})
 		require.EqualError(t, err, common.PermissionDeniedAPIError.Error(), "error message must be _only_ the permission error, to avoid leaking information about app existence")
-		_, err = appServer.UpdateSpec(adminCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("doest-not-exist"), Spec: &appsv1.ApplicationSpec{
-			Destination: appsv1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
-			Source:      &appsv1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
+		_, err = appServer.UpdateSpec(adminCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("doest-not-exist"), Spec: &v1alpha1.ApplicationSpec{
+			Destination: v1alpha1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
 		}})
 		require.EqualError(t, err, common.PermissionDeniedAPIError.Error(), "error message must be _only_ the permission error, to avoid leaking information about app existence")
-		_, err = appServer.UpdateSpec(adminCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("doest-not-exist"), Project: ptr.To("test"), Spec: &appsv1.ApplicationSpec{
-			Destination: appsv1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
-			Source:      &appsv1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
+		_, err = appServer.UpdateSpec(adminCtx, &application.ApplicationUpdateSpecRequest{Name: ptr.To("doest-not-exist"), Project: ptr.To("test"), Spec: &v1alpha1.ApplicationSpec{
+			Destination: v1alpha1.ApplicationDestination{Namespace: "default", Server: "https://cluster-api.example.com"},
+			Source:      &v1alpha1.ApplicationSource{RepoURL: "https://some-fake-source", Path: "."},
 		}})
 		assert.EqualError(t, err, "rpc error: code = NotFound desc = applications.argoproj.io \"doest-not-exist\" not found", "when the request specifies a project, we can return the standard k8s error message")
 	})
@@ -1090,7 +1088,7 @@ func setSyncRunningOperationState(t *testing.T, appServer *Server) {
 	app, err := appIf.Get(context.Background(), "test", metav1.GetOptions{})
 	require.NoError(t, err)
 	// This sets the status that would be set by the controller usually.
-	app.Status.OperationState = &appsv1.OperationState{Phase: synccommon.OperationRunning, Operation: appsv1.Operation{Sync: &appsv1.SyncOperation{}}}
+	app.Status.OperationState = &v1alpha1.OperationState{Phase: synccommon.OperationRunning, Operation: v1alpha1.Operation{Sync: &v1alpha1.SyncOperation{}}}
 	_, err = appIf.Update(context.Background(), app, metav1.UpdateOptions{})
 	require.NoError(t, err)
 }
@@ -1108,15 +1106,15 @@ func unsetSyncRunningOperationState(t *testing.T, appServer *Server) {
 }
 
 func TestListAppsInNamespaceWithLabels(t *testing.T) {
-	appServer := newTestAppServer(t, newTestApp(func(app *appsv1.Application) {
+	appServer := newTestAppServer(t, newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App1"
 		app.ObjectMeta.Namespace = "test-namespace"
 		app.SetLabels(map[string]string{"key1": "value1", "key2": "value1"})
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App2"
 		app.ObjectMeta.Namespace = "test-namespace"
 		app.SetLabels(map[string]string{"key1": "value2"})
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App3"
 		app.ObjectMeta.Namespace = "test-namespace"
 		app.SetLabels(map[string]string{"key1": "value3"})
@@ -1129,13 +1127,13 @@ func TestListAppsInNamespaceWithLabels(t *testing.T) {
 }
 
 func TestListAppsInDefaultNSWithLabels(t *testing.T) {
-	appServer := newTestAppServer(t, newTestApp(func(app *appsv1.Application) {
+	appServer := newTestAppServer(t, newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App1"
 		app.SetLabels(map[string]string{"key1": "value1", "key2": "value1"})
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App2"
 		app.SetLabels(map[string]string{"key1": "value2"})
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App3"
 		app.SetLabels(map[string]string{"key1": "value3"})
 	}))
@@ -1227,13 +1225,13 @@ func testListAppsWithLabels(t *testing.T, appQuery application.ApplicationQuery,
 }
 
 func TestListAppWithProjects(t *testing.T) {
-	appServer := newTestAppServer(t, newTestApp(func(app *appsv1.Application) {
+	appServer := newTestAppServer(t, newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App1"
 		app.Spec.Project = "test-project1"
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App2"
 		app.Spec.Project = "test-project2"
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "App3"
 		app.Spec.Project = "test-project3"
 	}))
@@ -1278,11 +1276,11 @@ func TestListAppWithProjects(t *testing.T) {
 }
 
 func TestListApps(t *testing.T) {
-	appServer := newTestAppServer(t, newTestApp(func(app *appsv1.Application) {
+	appServer := newTestAppServer(t, newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "bcd"
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "abc"
-	}), newTestApp(func(app *appsv1.Application) {
+	}), newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "def"
 	}))
 
@@ -1308,7 +1306,7 @@ func TestCoupleAppsListApps(t *testing.T) {
 	for projectId := 0; projectId < 100; projectId++ {
 		projectName := fmt.Sprintf("proj-%d", projectId)
 		for appId := 0; appId < 100; appId++ {
-			objects = append(objects, newTestApp(func(app *appsv1.Application) {
+			objects = append(objects, newTestApp(func(app *v1alpha1.Application) {
 				app.Name = fmt.Sprintf("app-%d-%d", projectId, appId)
 				app.Spec.Project = projectName
 			}))
@@ -1338,10 +1336,10 @@ g, group-49, role:test3
 	assert.Len(t, names, 300)
 }
 
-func generateTestApp(num int) []*appsv1.Application {
-	apps := []*appsv1.Application{}
+func generateTestApp(num int) []*v1alpha1.Application {
+	apps := []*v1alpha1.Application{}
 	for i := 0; i < num; i++ {
-		apps = append(apps, newTestApp(func(app *appsv1.Application) {
+		apps = append(apps, newTestApp(func(app *v1alpha1.Application) {
 			app.Name = fmt.Sprintf("test-app%.6d", i)
 		}))
 	}
@@ -1498,8 +1496,8 @@ func TestCreateAppWithDestName(t *testing.T) {
 func TestCreateAppWithOperation(t *testing.T) {
 	appServer := newTestAppServer(t)
 	testApp := newTestAppWithDestName()
-	testApp.Operation = &appsv1.Operation{
-		Sync: &appsv1.SyncOperation{
+	testApp.Operation = &v1alpha1.Operation{
+		Sync: &v1alpha1.SyncOperation{
 			Manifests: []string{
 				"test",
 			},
@@ -1567,7 +1565,7 @@ func TestDeleteApp(t *testing.T) {
 		return true, nil, nil
 	})
 	fakeAppCs.AddReactor("get", "applications", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &appsv1.Application{Spec: appsv1.ApplicationSpec{Source: &appsv1.ApplicationSource{}}}, nil
+		return true, &v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}}}, nil
 	})
 	appServer.appclientset = fakeAppCs
 
@@ -1778,7 +1776,7 @@ func TestSyncAndTerminate(t *testing.T) {
 	assert.Regexp(t, ".*initiated sync to HEAD \\([0-9A-Fa-f]{40}\\).*", event.Message)
 
 	// set status.operationState to pretend that an operation has started by controller
-	app.Status.OperationState = &appsv1.OperationState{
+	app.Status.OperationState = &v1alpha1.OperationState{
 		Operation: *app.Operation,
 		Phase:     synccommon.OperationRunning,
 		StartedAt: metav1.NewTime(time.Now()),
@@ -1850,7 +1848,7 @@ func TestSyncGit(t *testing.T) {
 
 func TestRollbackApp(t *testing.T) {
 	testApp := newTestApp()
-	testApp.Status.History = []appsv1.RevisionHistory{{
+	testApp.Status.History = []v1alpha1.RevisionHistory{{
 		ID:       1,
 		Revision: "abc",
 		Source:   *testApp.Spec.Source.DeepCopy(),
@@ -2008,7 +2006,7 @@ func TestGetCachedAppState(t *testing.T) {
 	testApp := newTestApp()
 	testApp.ObjectMeta.ResourceVersion = "1"
 	testApp.Spec.Project = "test-proj"
-	testProj := &appsv1.AppProject{
+	testProj := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-proj",
 			Namespace: testNamespace,
@@ -2017,7 +2015,7 @@ func TestGetCachedAppState(t *testing.T) {
 	appServer := newTestAppServer(t, testApp, testProj)
 	fakeClientSet := appServer.appclientset.(*apps.Clientset)
 	fakeClientSet.AddReactor("get", "applications", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &appsv1.Application{Spec: appsv1.ApplicationSpec{Source: &appsv1.ApplicationSource{}}}, nil
+		return true, &v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}}}, nil
 	})
 	t.Run("NoError", func(t *testing.T) {
 		err := appServer.getCachedAppState(context.Background(), testApp, func() error {
@@ -2043,7 +2041,7 @@ func TestGetCachedAppState(t *testing.T) {
 				return true, testApp, nil
 			})
 			fakeClientSet.AddReactor("get", "applications", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-				return true, &appsv1.Application{Spec: appsv1.ApplicationSpec{Source: &appsv1.ApplicationSource{}}}, nil
+				return true, &v1alpha1.Application{Spec: v1alpha1.ApplicationSpec{Source: &v1alpha1.ApplicationSource{}}}, nil
 			})
 			fakeClientSet.Unlock()
 			fakeClientSet.AddWatchReactor("applications", func(action kubetesting.Action) (handled bool, ret watch.Interface, err error) {
@@ -2105,14 +2103,14 @@ func TestSplitStatusPatch(t *testing.T) {
 }
 
 func TestLogsGetSelectedPod(t *testing.T) {
-	deployment := appsv1.ResourceRef{Group: "", Version: "v1", Kind: "Deployment", Name: "deployment", UID: "1"}
-	rs := appsv1.ResourceRef{Group: "", Version: "v1", Kind: "ReplicaSet", Name: "rs", UID: "2"}
-	podRS := appsv1.ResourceRef{Group: "", Version: "v1", Kind: "Pod", Name: "podrs", UID: "3"}
-	pod := appsv1.ResourceRef{Group: "", Version: "v1", Kind: "Pod", Name: "pod", UID: "4"}
-	treeNodes := []appsv1.ResourceNode{
+	deployment := v1alpha1.ResourceRef{Group: "", Version: "v1", Kind: "Deployment", Name: "deployment", UID: "1"}
+	rs := v1alpha1.ResourceRef{Group: "", Version: "v1", Kind: "ReplicaSet", Name: "rs", UID: "2"}
+	podRS := v1alpha1.ResourceRef{Group: "", Version: "v1", Kind: "Pod", Name: "podrs", UID: "3"}
+	pod := v1alpha1.ResourceRef{Group: "", Version: "v1", Kind: "Pod", Name: "pod", UID: "4"}
+	treeNodes := []v1alpha1.ResourceNode{
 		{ResourceRef: deployment, ParentRefs: nil},
-		{ResourceRef: rs, ParentRefs: []appsv1.ResourceRef{deployment}},
-		{ResourceRef: podRS, ParentRefs: []appsv1.ResourceRef{rs}},
+		{ResourceRef: rs, ParentRefs: []v1alpha1.ResourceRef{deployment}},
+		{ResourceRef: podRS, ParentRefs: []v1alpha1.ResourceRef{rs}},
 		{ResourceRef: pod, ParentRefs: nil},
 	}
 	appName := "appName"
@@ -2222,7 +2220,7 @@ func TestMaxPodLogsRender(t *testing.T) {
 func createAppServerWithMaxLodLogs(t *testing.T, podNumber int, maxPodLogsToRender ...int64) (*Server, context.Context) {
 	t.Helper()
 	runtimeObjects := make([]runtime.Object, podNumber+1)
-	resources := make([]appsv1.ResourceStatus, podNumber)
+	resources := make([]v1alpha1.ResourceStatus, podNumber)
 
 	for i := 0; i < podNumber; i++ {
 		pod := corev1.Pod{
@@ -2235,7 +2233,7 @@ func createAppServerWithMaxLodLogs(t *testing.T, podNumber int, maxPodLogsToRend
 				Namespace: "test",
 			},
 		}
-		resources[i] = appsv1.ResourceStatus{
+		resources[i] = v1alpha1.ResourceStatus{
 			Group:     pod.GroupVersionKind().Group,
 			Kind:      pod.GroupVersionKind().Kind,
 			Version:   pod.GroupVersionKind().Version,
@@ -2246,7 +2244,7 @@ func createAppServerWithMaxLodLogs(t *testing.T, podNumber int, maxPodLogsToRend
 		runtimeObjects[i] = kube.MustToUnstructured(&pod)
 	}
 
-	testApp := newTestApp(func(app *appsv1.Application) {
+	testApp := newTestApp(func(app *v1alpha1.Application) {
 		app.Name = "test"
 		app.Status.Resources = resources
 	})
@@ -2278,7 +2276,7 @@ func refreshAnnotationRemover(t *testing.T, ctx context.Context, patched *int32,
 		a, err := appServer.appLister.Applications(appNs).Get(aName)
 		require.NoError(t, err)
 		a = a.DeepCopy()
-		if a.GetAnnotations() != nil && a.GetAnnotations()[appsv1.AnnotationKeyRefresh] != "" {
+		if a.GetAnnotations() != nil && a.GetAnnotations()[v1alpha1.AnnotationKeyRefresh] != "" {
 			a.SetAnnotations(map[string]string{})
 			a.SetResourceVersion("999")
 			_, err = appServer.appclientset.ArgoprojV1alpha1().Applications(a.Namespace).Update(
@@ -2306,7 +2304,7 @@ func TestGetAppRefresh_NormalRefresh(t *testing.T) {
 
 	_, err := appServer.Get(context.Background(), &application.ApplicationQuery{
 		Name:    &testApp.Name,
-		Refresh: ptr.To(string(appsv1.RefreshTypeNormal)),
+		Refresh: ptr.To(string(v1alpha1.RefreshTypeNormal)),
 	})
 	require.NoError(t, err)
 
@@ -2341,7 +2339,7 @@ func TestGetAppRefresh_HardRefresh(t *testing.T) {
 
 	_, err := appServer.Get(context.Background(), &application.ApplicationQuery{
 		Name:    &testApp.Name,
-		Refresh: ptr.To(string(appsv1.RefreshTypeHard)),
+		Refresh: ptr.To(string(v1alpha1.RefreshTypeHard)),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, getAppDetailsQuery)
@@ -2358,11 +2356,11 @@ func TestGetAppRefresh_HardRefresh(t *testing.T) {
 }
 
 func TestInferResourcesStatusHealth(t *testing.T) {
-	cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
+	cacheClient := cache.NewCache(cache.NewInMemoryCache(1 * time.Hour))
 
 	testApp := newTestApp()
-	testApp.Status.ResourceHealthSource = appsv1.ResourceHealthLocationAppTree
-	testApp.Status.Resources = []appsv1.ResourceStatus{{
+	testApp.Status.ResourceHealthSource = v1alpha1.ResourceHealthLocationAppTree
+	testApp.Status.Resources = []v1alpha1.ResourceStatus{{
 		Group:     "apps",
 		Kind:      "Deployment",
 		Name:      "guestbook",
@@ -2375,14 +2373,14 @@ func TestInferResourcesStatusHealth(t *testing.T) {
 	}}
 	appServer := newTestAppServer(t, testApp)
 	appStateCache := appstate.NewCache(cacheClient, time.Minute)
-	err := appStateCache.SetAppResourcesTree(testApp.Name, &appsv1.ApplicationTree{Nodes: []appsv1.ResourceNode{{
-		ResourceRef: appsv1.ResourceRef{
+	err := appStateCache.SetAppResourcesTree(testApp.Name, &v1alpha1.ApplicationTree{Nodes: []v1alpha1.ResourceNode{{
+		ResourceRef: v1alpha1.ResourceRef{
 			Group:     "apps",
 			Kind:      "Deployment",
 			Name:      "guestbook",
 			Namespace: "default",
 		},
-		Health: &appsv1.HealthStatus{
+		Health: &v1alpha1.HealthStatus{
 			Status: health.HealthStatusDegraded,
 		},
 	}}})
@@ -2398,7 +2396,7 @@ func TestInferResourcesStatusHealth(t *testing.T) {
 }
 
 func TestRunNewStyleResourceAction(t *testing.T) {
-	cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
+	cacheClient := cache.NewCache(cache.NewInMemoryCache(1 * time.Hour))
 
 	group := "batch"
 	kind := "CronJob"
@@ -2408,7 +2406,7 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 	action := "create-job"
 	uid := "1"
 
-	resources := []appsv1.ResourceStatus{{
+	resources := []v1alpha1.ResourceStatus{{
 		Group:     group,
 		Kind:      kind,
 		Name:      resourceName,
@@ -2418,8 +2416,8 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 
 	appStateCache := appstate.NewCache(cacheClient, time.Minute)
 
-	nodes := []appsv1.ResourceNode{{
-		ResourceRef: appsv1.ResourceRef{
+	nodes := []v1alpha1.ResourceNode{{
+		ResourceRef: v1alpha1.ResourceRef{
 			Group:     group,
 			Kind:      kind,
 			Version:   version,
@@ -2429,11 +2427,11 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 		},
 	}}
 
-	createJobDenyingProj := &appsv1.AppProject{
+	createJobDenyingProj := &v1alpha1.AppProject{
 		ObjectMeta: metav1.ObjectMeta{Name: "createJobDenyingProj", Namespace: "default"},
-		Spec: appsv1.AppProjectSpec{
+		Spec: v1alpha1.AppProjectSpec{
 			SourceRepos:                []string{"*"},
-			Destinations:               []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+			Destinations:               []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 			NamespaceResourceWhitelist: []metav1.GroupKind{{Group: "never", Kind: "mind"}},
 		},
 	}
@@ -2475,13 +2473,13 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 	t.Run("CreateOperationNotPermitted", func(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Spec.Project = "createJobDenyingProj"
-		testApp.Status.ResourceHealthSource = appsv1.ResourceHealthLocationAppTree
+		testApp.Status.ResourceHealthSource = v1alpha1.ResourceHealthLocationAppTree
 		testApp.Status.Resources = resources
 
 		appServer := newTestAppServer(t, testApp, createJobDenyingProj, kube.MustToUnstructured(&cronJob))
 		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute, time.Minute)
 
-		err := appStateCache.SetAppResourcesTree(testApp.Name, &appsv1.ApplicationTree{Nodes: nodes})
+		err := appStateCache.SetAppResourcesTree(testApp.Name, &v1alpha1.ApplicationTree{Nodes: nodes})
 		require.NoError(t, err)
 
 		appResponse, runErr := appServer.RunResourceAction(context.Background(), &application.ResourceActionRunRequest{
@@ -2501,13 +2499,13 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 
 	t.Run("CreateOperationPermitted", func(t *testing.T) {
 		testApp := newTestApp()
-		testApp.Status.ResourceHealthSource = appsv1.ResourceHealthLocationAppTree
+		testApp.Status.ResourceHealthSource = v1alpha1.ResourceHealthLocationAppTree
 		testApp.Status.Resources = resources
 
 		appServer := newTestAppServer(t, testApp, kube.MustToUnstructured(&cronJob))
 		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute, time.Minute)
 
-		err := appStateCache.SetAppResourcesTree(testApp.Name, &appsv1.ApplicationTree{Nodes: nodes})
+		err := appStateCache.SetAppResourcesTree(testApp.Name, &v1alpha1.ApplicationTree{Nodes: nodes})
 		require.NoError(t, err)
 
 		appResponse, runErr := appServer.RunResourceAction(context.Background(), &application.ResourceActionRunRequest{
@@ -2527,7 +2525,7 @@ func TestRunNewStyleResourceAction(t *testing.T) {
 }
 
 func TestRunOldStyleResourceAction(t *testing.T) {
-	cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
+	cacheClient := cache.NewCache(cache.NewInMemoryCache(1 * time.Hour))
 
 	group := "apps"
 	kind := "Deployment"
@@ -2537,7 +2535,7 @@ func TestRunOldStyleResourceAction(t *testing.T) {
 	action := "pause"
 	uid := "2"
 
-	resources := []appsv1.ResourceStatus{{
+	resources := []v1alpha1.ResourceStatus{{
 		Group:     group,
 		Kind:      kind,
 		Name:      resourceName,
@@ -2547,8 +2545,8 @@ func TestRunOldStyleResourceAction(t *testing.T) {
 
 	appStateCache := appstate.NewCache(cacheClient, time.Minute)
 
-	nodes := []appsv1.ResourceNode{{
-		ResourceRef: appsv1.ResourceRef{
+	nodes := []v1alpha1.ResourceNode{{
+		ResourceRef: v1alpha1.ResourceRef{
 			Group:     group,
 			Kind:      kind,
 			Version:   version,
@@ -2571,14 +2569,14 @@ func TestRunOldStyleResourceAction(t *testing.T) {
 
 	t.Run("DefaultPatchOperation", func(t *testing.T) {
 		testApp := newTestApp()
-		testApp.Status.ResourceHealthSource = appsv1.ResourceHealthLocationAppTree
+		testApp.Status.ResourceHealthSource = v1alpha1.ResourceHealthLocationAppTree
 		testApp.Status.Resources = resources
 
 		// appServer := newTestAppServer(t, testApp, returnDeployment())
 		appServer := newTestAppServer(t, testApp, kube.MustToUnstructured(&deployment))
 		appServer.cache = servercache.NewCache(appStateCache, time.Minute, time.Minute, time.Minute)
 
-		err := appStateCache.SetAppResourcesTree(testApp.Name, &appsv1.ApplicationTree{Nodes: nodes})
+		err := appStateCache.SetAppResourcesTree(testApp.Name, &v1alpha1.ApplicationTree{Nodes: nodes})
 		require.NoError(t, err)
 
 		appResponse, runErr := appServer.RunResourceAction(context.Background(), &application.ResourceActionRunRequest{
@@ -2720,11 +2718,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-1"},
 			},
 		}
@@ -2744,11 +2742,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-2"},
 			},
 		}
@@ -2767,11 +2765,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-1"},
 			},
 		}
@@ -2791,11 +2789,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{},
 			},
 		}
@@ -2814,11 +2812,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-1"},
 			},
 		}
@@ -2836,11 +2834,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-1"},
 			},
 		}
@@ -2855,11 +2853,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-2"},
 			},
 		}
@@ -2875,11 +2873,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-2"},
 			},
 		}
@@ -2898,11 +2896,11 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 		testApp := newTestApp()
 		testApp.Namespace = "argocd-1"
 		testApp.Spec.Project = "other-ns"
-		otherNsProj := &appsv1.AppProject{
+		otherNsProj := &v1alpha1.AppProject{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "default"},
-			Spec: appsv1.AppProjectSpec{
+			Spec: v1alpha1.AppProjectSpec{
 				SourceRepos:      []string{"*"},
-				Destinations:     []appsv1.ApplicationDestination{{Server: "*", Namespace: "*"}},
+				Destinations:     []v1alpha1.ApplicationDestination{{Server: "*", Namespace: "*"}},
 				SourceNamespaces: []string{"argocd-1"},
 			},
 		}
@@ -2918,9 +2916,9 @@ func TestAppNamespaceRestrictions(t *testing.T) {
 }
 
 func TestGetAmbiguousRevision_MultiSource(t *testing.T) {
-	app := &appv1.Application{
-		Spec: appv1.ApplicationSpec{
-			Sources: []appv1.ApplicationSource{
+	app := &v1alpha1.Application{
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: []v1alpha1.ApplicationSource{
 				{
 					TargetRevision: "revision1",
 				},
@@ -2946,8 +2944,8 @@ func TestGetAmbiguousRevision_MultiSource(t *testing.T) {
 	assert.Equal(t, expected, result, "Expected ambiguous revision to be %s, but got %s", expected, result)
 
 	// Test when app.Spec.HasMultipleSources() is false
-	app.Spec = appv1.ApplicationSpec{
-		Source: &appv1.ApplicationSource{
+	app.Spec = v1alpha1.ApplicationSpec{
+		Source: &v1alpha1.ApplicationSource{
 			TargetRevision: "revision3",
 		},
 		Sources: nil,
@@ -2961,9 +2959,9 @@ func TestGetAmbiguousRevision_MultiSource(t *testing.T) {
 }
 
 func TestGetAmbiguousRevision_SingleSource(t *testing.T) {
-	app := &appv1.Application{
-		Spec: appv1.ApplicationSpec{
-			Source: &appv1.ApplicationSource{
+	app := &v1alpha1.Application{
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
 				TargetRevision: "revision1",
 			},
 		},
@@ -2983,9 +2981,9 @@ func TestServer_ResolveSourceRevisions_MultiSource(t *testing.T) {
 	s := newTestAppServer(t)
 
 	ctx := context.Background()
-	a := &appv1.Application{
-		Spec: appv1.ApplicationSpec{
-			Sources: []appv1.ApplicationSource{
+	a := &v1alpha1.Application{
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: []v1alpha1.ApplicationSource{
 				{
 					RepoURL: "https://github.com/example/repo.git",
 				},
@@ -3011,9 +3009,9 @@ func TestServer_ResolveSourceRevisions_SingleSource(t *testing.T) {
 	s := newTestAppServer(t)
 
 	ctx := context.Background()
-	a := &appv1.Application{
-		Spec: appv1.ApplicationSpec{
-			Source: &appv1.ApplicationSource{
+	a := &v1alpha1.Application{
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL: "https://github.com/example/repo.git",
 			},
 		},
@@ -3037,8 +3035,8 @@ func Test_RevisionMetadata(t *testing.T) {
 
 	singleSourceApp := newTestApp()
 	singleSourceApp.Name = "single-source-app"
-	singleSourceApp.Spec = appv1.ApplicationSpec{
-		Source: &appv1.ApplicationSource{
+	singleSourceApp.Spec = v1alpha1.ApplicationSpec{
+		Source: &v1alpha1.ApplicationSource{
 			RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 			Path:           "helm-guestbook",
 			TargetRevision: "HEAD",
@@ -3047,8 +3045,8 @@ func Test_RevisionMetadata(t *testing.T) {
 
 	multiSourceApp := newTestApp()
 	multiSourceApp.Name = "multi-source-app"
-	multiSourceApp.Spec = appv1.ApplicationSpec{
-		Sources: []appv1.ApplicationSource{
+	multiSourceApp.Spec = v1alpha1.ApplicationSpec{
+		Sources: []v1alpha1.ApplicationSource{
 			{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				Path:           "helm-guestbook",
@@ -3062,14 +3060,14 @@ func Test_RevisionMetadata(t *testing.T) {
 		},
 	}
 
-	singleSourceHistory := []appv1.RevisionHistory{
+	singleSourceHistory := []v1alpha1.RevisionHistory{
 		{
 			ID:       1,
 			Source:   singleSourceApp.Spec.GetSource(),
 			Revision: "a",
 		},
 	}
-	multiSourceHistory := []appv1.RevisionHistory{
+	multiSourceHistory := []v1alpha1.RevisionHistory{
 		{
 			ID:        1,
 			Sources:   multiSourceApp.Spec.GetSources(),

--- a/server/application/terminal.go
+++ b/server/application/terminal.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 
-	util_session "github.com/argoproj/argo-cd/v2/util/session"
-
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	applisters "github.com/argoproj/argo-cd/v2/pkg/client/listers/application/v1alpha1"
 	servercache "github.com/argoproj/argo-cd/v2/server/cache"
@@ -26,7 +24,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/db"
 	"github.com/argoproj/argo-cd/v2/util/rbac"
 	"github.com/argoproj/argo-cd/v2/util/security"
-	sessionmgr "github.com/argoproj/argo-cd/v2/util/session"
+	util_session "github.com/argoproj/argo-cd/v2/util/session"
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
@@ -48,7 +46,7 @@ type TerminalOptions struct {
 }
 
 // NewHandler returns a new terminal handler.
-func NewHandler(appLister applisters.ApplicationLister, namespace string, enabledNamespaces []string, db db.ArgoDB, cache *servercache.Cache, appResourceTree AppResourceTreeFn, allowedShells []string, sessionManager *sessionmgr.SessionManager, terminalOptions *TerminalOptions) *terminalHandler {
+func NewHandler(appLister applisters.ApplicationLister, namespace string, enabledNamespaces []string, db db.ArgoDB, cache *servercache.Cache, appResourceTree AppResourceTreeFn, allowedShells []string, sessionManager *util_session.SessionManager, terminalOptions *TerminalOptions) *terminalHandler {
 	return &terminalHandler{
 		appLister:         appLister,
 		db:                db,
@@ -164,7 +162,7 @@ func (s *terminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fieldLog := log.WithFields(log.Fields{
-		"application": app, "userName": sessionmgr.Username(ctx), "container": container,
+		"application": app, "userName": util_session.Username(ctx), "container": container,
 		"podName": podName, "namespace": namespace, "project": project, "appNamespace": appNamespace,
 	})
 

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -19,7 +19,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/common"
 	repositorypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/repository"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	applisters "github.com/argoproj/argo-cd/v2/pkg/client/listers/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	servercache "github.com/argoproj/argo-cd/v2/server/cache"
@@ -71,7 +70,7 @@ func NewServer(
 	}
 }
 
-func (s *Server) getRepo(ctx context.Context, url, project string) (*appsv1.Repository, error) {
+func (s *Server) getRepo(ctx context.Context, url, project string) (*v1alpha1.Repository, error) {
 	repo, err := s.db.GetRepository(ctx, url, project)
 	if err != nil {
 		return nil, common.PermissionDeniedAPIError
@@ -79,7 +78,7 @@ func (s *Server) getRepo(ctx context.Context, url, project string) (*appsv1.Repo
 	return repo, nil
 }
 
-func (s *Server) getWriteRepo(ctx context.Context, url, project string) (*appsv1.Repository, error) {
+func (s *Server) getWriteRepo(ctx context.Context, url, project string) (*v1alpha1.Repository, error) {
 	repo, err := s.db.GetWriteRepository(ctx, url, project)
 	if err != nil {
 		return nil, common.PermissionDeniedAPIError
@@ -97,15 +96,15 @@ func createRBACObject(project string, repo string) string {
 // Get the connection state for a given repository URL by connecting to the
 // repo and evaluate the results. Unless forceRefresh is set to true, the
 // result may be retrieved out of the cache.
-func (s *Server) getConnectionState(ctx context.Context, url string, project string, forceRefresh bool) appsv1.ConnectionState {
+func (s *Server) getConnectionState(ctx context.Context, url string, project string, forceRefresh bool) v1alpha1.ConnectionState {
 	if !forceRefresh {
 		if connectionState, err := s.cache.GetRepoConnectionState(url, project); err == nil {
 			return connectionState
 		}
 	}
 	now := metav1.Now()
-	connectionState := appsv1.ConnectionState{
-		Status:     appsv1.ConnectionStatusSuccessful,
+	connectionState := v1alpha1.ConnectionState{
+		Status:     v1alpha1.ConnectionStatusSuccessful,
 		ModifiedAt: &now,
 	}
 	var err error
@@ -114,7 +113,7 @@ func (s *Server) getConnectionState(ctx context.Context, url string, project str
 		err = s.testRepo(ctx, repo)
 	}
 	if err != nil {
-		connectionState.Status = appsv1.ConnectionStatusFailed
+		connectionState.Status = v1alpha1.ConnectionStatusFailed
 		if errors.IsCredentialsConfigurationError(err) {
 			connectionState.Message = "Configuration error - please check the server logs"
 			log.Warnf("could not retrieve repo: %s", err.Error())
@@ -131,12 +130,12 @@ func (s *Server) getConnectionState(ctx context.Context, url string, project str
 
 // List returns list of repositories
 // Deprecated: Use ListRepositories instead
-func (s *Server) List(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.RepositoryList, error) {
+func (s *Server) List(ctx context.Context, q *repositorypkg.RepoQuery) (*v1alpha1.RepositoryList, error) {
 	return s.ListRepositories(ctx, q)
 }
 
 // Get return the requested configured repository by URL and the state of its connections.
-func (s *Server) Get(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.Repository, error) {
+func (s *Server) Get(ctx context.Context, q *repositorypkg.RepoQuery) (*v1alpha1.Repository, error) {
 	// ListRepositories normalizes the repo, sanitizes it, and augments it with connection details.
 	repo, err := getRepository(ctx, s.ListRepositories, q)
 	if err != nil {
@@ -158,7 +157,7 @@ func (s *Server) Get(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.R
 	return repo, nil
 }
 
-func (s *Server) GetWrite(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.Repository, error) {
+func (s *Server) GetWrite(ctx context.Context, q *repositorypkg.RepoQuery) (*v1alpha1.Repository, error) {
 	if !s.hydratorEnabled {
 		return nil, status.Error(codes.Unimplemented, "hydrator is disabled")
 	}
@@ -184,7 +183,7 @@ func (s *Server) GetWrite(ctx context.Context, q *repositorypkg.RepoQuery) (*app
 }
 
 // ListRepositories returns a list of all configured repositories and the state of their connections
-func (s *Server) ListRepositories(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.RepositoryList, error) {
+func (s *Server) ListRepositories(ctx context.Context, q *repositorypkg.RepoQuery) (*v1alpha1.RepositoryList, error) {
 	repos, err := s.db.ListRepositories(ctx)
 	if err != nil {
 		return nil, err
@@ -193,12 +192,12 @@ func (s *Server) ListRepositories(ctx context.Context, q *repositorypkg.RepoQuer
 	if err != nil {
 		return nil, err
 	}
-	return &appsv1.RepositoryList{Items: items}, nil
+	return &v1alpha1.RepositoryList{Items: items}, nil
 }
 
 // ListWriteRepositories returns a list of all configured repositories where the user has write access and the state of
 // their connections
-func (s *Server) ListWriteRepositories(ctx context.Context, q *repositorypkg.RepoQuery) (*appsv1.RepositoryList, error) {
+func (s *Server) ListWriteRepositories(ctx context.Context, q *repositorypkg.RepoQuery) (*v1alpha1.RepositoryList, error) {
 	if !s.hydratorEnabled {
 		return nil, status.Error(codes.Unimplemented, "hydrator is disabled")
 	}
@@ -211,18 +210,18 @@ func (s *Server) ListWriteRepositories(ctx context.Context, q *repositorypkg.Rep
 	if err != nil {
 		return nil, err
 	}
-	return &appsv1.RepositoryList{Items: items}, nil
+	return &v1alpha1.RepositoryList{Items: items}, nil
 }
 
 // ListRepositoriesByAppProject returns a list of all configured repositories and the state of their connections. It
 // normalizes, sanitizes, and filters out repositories that the user does not have access to in the specified project.
 // It also sorts the repositories by project and repo name.
-func (s *Server) prepareRepoList(ctx context.Context, resourceType string, repos []*appsv1.Repository, forceRefresh bool) (appsv1.Repositories, error) {
-	items := appsv1.Repositories{}
+func (s *Server) prepareRepoList(ctx context.Context, resourceType string, repos []*v1alpha1.Repository, forceRefresh bool) (v1alpha1.Repositories, error) {
+	items := v1alpha1.Repositories{}
 	for _, repo := range repos {
 		items = append(items, repo.Normalize().Sanitized())
 	}
-	items = items.Filter(func(r *appsv1.Repository) bool {
+	items = items.Filter(func(r *v1alpha1.Repository) bool {
 		return s.enf.Enforce(ctx.Value("claims"), resourceType, rbacpolicy.ActionGet, createRBACObject(r.Project, r.Repo))
 	})
 	err := kube.RunAllAsync(len(items), func(i int) error {
@@ -373,7 +372,7 @@ func (s *Server) GetAppDetails(ctx context.Context, q *repositorypkg.RepoAppDeta
 		return nil, err
 	}
 
-	refSources := make(appsv1.RefTargetRevisionMapping)
+	refSources := make(v1alpha1.RefTargetRevisionMapping)
 	if app != nil && app.Spec.HasMultipleSources() {
 		// Store the map of all sources having ref field into a map for applications with sources field
 		refSources, err = argo.GetRefSources(ctx, app.Spec.Sources, q.AppProject, s.db.GetRepository, []string{}, false)
@@ -412,12 +411,12 @@ func (s *Server) GetHelmCharts(ctx context.Context, q *repositorypkg.RepoQuery) 
 
 // Create creates a repository or repository credential set
 // Deprecated: Use CreateRepository() instead
-func (s *Server) Create(ctx context.Context, q *repositorypkg.RepoCreateRequest) (*appsv1.Repository, error) {
+func (s *Server) Create(ctx context.Context, q *repositorypkg.RepoCreateRequest) (*v1alpha1.Repository, error) {
 	return s.CreateRepository(ctx, q)
 }
 
 // CreateRepository creates a repository configuration
-func (s *Server) CreateRepository(ctx context.Context, q *repositorypkg.RepoCreateRequest) (*appsv1.Repository, error) {
+func (s *Server) CreateRepository(ctx context.Context, q *repositorypkg.RepoCreateRequest) (*v1alpha1.Repository, error) {
 	if q.Repo == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "missing payload in request")
 	}
@@ -426,7 +425,7 @@ func (s *Server) CreateRepository(ctx context.Context, q *repositorypkg.RepoCrea
 		return nil, err
 	}
 
-	var repo *appsv1.Repository
+	var repo *v1alpha1.Repository
 	var err error
 
 	// check we can connect to the repo, copying any existing creds (not supported for project scoped repositories)
@@ -447,7 +446,7 @@ func (s *Server) CreateRepository(ctx context.Context, q *repositorypkg.RepoCrea
 	}
 
 	r := q.Repo
-	r.ConnectionState = appsv1.ConnectionState{Status: appsv1.ConnectionStatusSuccessful}
+	r.ConnectionState = v1alpha1.ConnectionState{Status: v1alpha1.ConnectionStatusSuccessful}
 	repo, err = s.db.CreateRepository(ctx, r)
 	if status.Convert(err).Code() == codes.AlreadyExists {
 		// act idempotent if existing spec matches new spec
@@ -471,11 +470,11 @@ func (s *Server) CreateRepository(ctx context.Context, q *repositorypkg.RepoCrea
 	if err != nil {
 		return nil, err
 	}
-	return &appsv1.Repository{Repo: repo.Repo, Type: repo.Type, Name: repo.Name}, nil
+	return &v1alpha1.Repository{Repo: repo.Repo, Type: repo.Type, Name: repo.Name}, nil
 }
 
 // CreateWriteRepository creates a repository configuration with write credentials
-func (s *Server) CreateWriteRepository(ctx context.Context, q *repositorypkg.RepoCreateRequest) (*appsv1.Repository, error) {
+func (s *Server) CreateWriteRepository(ctx context.Context, q *repositorypkg.RepoCreateRequest) (*v1alpha1.Repository, error) {
 	if !s.hydratorEnabled {
 		return nil, status.Error(codes.Unimplemented, "hydrator is disabled")
 	}
@@ -515,17 +514,17 @@ func (s *Server) CreateWriteRepository(ctx context.Context, q *repositorypkg.Rep
 	if err != nil {
 		return nil, err
 	}
-	return &appsv1.Repository{Repo: repo.Repo, Type: repo.Type, Name: repo.Name}, nil
+	return &v1alpha1.Repository{Repo: repo.Repo, Type: repo.Type, Name: repo.Name}, nil
 }
 
 // Update updates a repository or credential set
 // Deprecated: Use UpdateRepository() instead
-func (s *Server) Update(ctx context.Context, q *repositorypkg.RepoUpdateRequest) (*appsv1.Repository, error) {
+func (s *Server) Update(ctx context.Context, q *repositorypkg.RepoUpdateRequest) (*v1alpha1.Repository, error) {
 	return s.UpdateRepository(ctx, q)
 }
 
 // UpdateRepository updates a repository configuration
-func (s *Server) UpdateRepository(ctx context.Context, q *repositorypkg.RepoUpdateRequest) (*appsv1.Repository, error) {
+func (s *Server) UpdateRepository(ctx context.Context, q *repositorypkg.RepoUpdateRequest) (*v1alpha1.Repository, error) {
 	if q.Repo == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "missing payload in request")
 	}
@@ -544,11 +543,11 @@ func (s *Server) UpdateRepository(ctx context.Context, q *repositorypkg.RepoUpda
 		return nil, err
 	}
 	_, err = s.db.UpdateRepository(ctx, q.Repo)
-	return &appsv1.Repository{Repo: q.Repo.Repo, Type: q.Repo.Type, Name: q.Repo.Name}, err
+	return &v1alpha1.Repository{Repo: q.Repo.Repo, Type: q.Repo.Type, Name: q.Repo.Name}, err
 }
 
 // UpdateWriteRepository updates a repository configuration with write credentials
-func (s *Server) UpdateWriteRepository(ctx context.Context, q *repositorypkg.RepoUpdateRequest) (*appsv1.Repository, error) {
+func (s *Server) UpdateWriteRepository(ctx context.Context, q *repositorypkg.RepoUpdateRequest) (*v1alpha1.Repository, error) {
 	if !s.hydratorEnabled {
 		return nil, status.Error(codes.Unimplemented, "hydrator is disabled")
 	}
@@ -571,7 +570,7 @@ func (s *Server) UpdateWriteRepository(ctx context.Context, q *repositorypkg.Rep
 		return nil, err
 	}
 	_, err = s.db.UpdateWriteRepository(ctx, q.Repo)
-	return &appsv1.Repository{Repo: q.Repo.Repo, Type: q.Repo.Type, Name: q.Repo.Name}, err
+	return &v1alpha1.Repository{Repo: q.Repo.Repo, Type: q.Repo.Type, Name: q.Repo.Name}, err
 }
 
 // Delete removes a repository from the configuration
@@ -622,7 +621,7 @@ func (s *Server) DeleteWriteRepository(ctx context.Context, q *repositorypkg.Rep
 // getRepository fetches a single repository which the user has access to. If only one repository can be found which
 // matches the same URL, that will be returned (this is for backward compatibility reasons). If multiple repositories
 // are matched, a repository is only returned if it matches the app project of the incoming request.
-func getRepository(ctx context.Context, listRepositories func(context.Context, *repositorypkg.RepoQuery) (*v1alpha1.RepositoryList, error), q *repositorypkg.RepoQuery) (*appsv1.Repository, error) {
+func getRepository(ctx context.Context, listRepositories func(context.Context, *repositorypkg.RepoQuery) (*v1alpha1.RepositoryList, error), q *repositorypkg.RepoQuery) (*v1alpha1.Repository, error) {
 	repositories, err := listRepositories(ctx, q)
 	if err != nil {
 		return nil, err
@@ -665,7 +664,7 @@ func (s *Server) ValidateAccess(ctx context.Context, q *repositorypkg.RepoAccess
 		return nil, err
 	}
 
-	repo := &appsv1.Repository{
+	repo := &v1alpha1.Repository{
 		Repo:                       q.Repo,
 		Type:                       q.Type,
 		Name:                       q.Name,
@@ -713,7 +712,7 @@ func (s *Server) ValidateWriteAccess(ctx context.Context, q *repositorypkg.RepoA
 		return nil, err
 	}
 
-	repo := &appsv1.Repository{
+	repo := &v1alpha1.Repository{
 		Repo:                       q.Repo,
 		Type:                       q.Type,
 		Name:                       q.Name,
@@ -739,7 +738,7 @@ func (s *Server) ValidateWriteAccess(ctx context.Context, q *repositorypkg.RepoA
 	return &repositorypkg.RepoResponse{}, nil
 }
 
-func (s *Server) testRepo(ctx context.Context, repo *appsv1.Repository) error {
+func (s *Server) testRepo(ctx context.Context, repo *v1alpha1.Repository) error {
 	conn, repoClient, err := s.repoClientset.NewRepoServerClient()
 	if err != nil {
 		return fmt.Errorf("failed to connect to repo-server: %w", err)
@@ -757,7 +756,7 @@ func (s *Server) isRepoPermittedInProject(ctx context.Context, repo string, proj
 	if err != nil {
 		return err
 	}
-	if !proj.IsSourcePermitted(appsv1.ApplicationSource{RepoURL: repo}) {
+	if !proj.IsSourcePermitted(v1alpha1.ApplicationSource{RepoURL: repo}) {
 		return status.Errorf(codes.PermissionDenied, "repository '%s' not permitted in project '%s'", repo, projName)
 	}
 	return nil

--- a/server/repository/repository_test.go
+++ b/server/repository/repository_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/repository"
-	repositorypkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/repository"
 	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	fakeapps "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
 	appinformer "github.com/argoproj/argo-cd/v2/pkg/client/informers/externalversions"
@@ -1153,7 +1152,7 @@ func TestDeleteRepository(t *testing.T) {
 			s := NewServer(&repoServerClientset, db, enforcer, newFixtures().Cache, appLister, projLister, testNamespace, settingsMgr, false)
 			resp, err := s.DeleteRepository(context.TODO(), &repository.RepoQuery{Repo: repo, AppProject: "default"})
 			require.NoError(t, err)
-			assert.Equal(t, repositorypkg.RepoResponse{}, *resp)
+			assert.Equal(t, repository.RepoResponse{}, *resp)
 		})
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/test"
 	"github.com/argoproj/argo-cd/v2/util/assets"
 	"github.com/argoproj/argo-cd/v2/util/cache"
-	cacheutil "github.com/argoproj/argo-cd/v2/util/cache"
 	appstatecache "github.com/argoproj/argo-cd/v2/util/cache/appstate"
 	"github.com/argoproj/argo-cd/v2/util/oidc"
 	"github.com/argoproj/argo-cd/v2/util/rbac"
@@ -80,7 +79,7 @@ func fakeServer(t *testing.T) (*FakeArgoCDServer, func()) {
 		ContentSecurityPolicy: "frame-ancestors 'self';",
 		Cache: servercache.NewCache(
 			appstatecache.NewCache(
-				cacheutil.NewCache(cacheutil.NewInMemoryCache(1*time.Hour)),
+				cache.NewCache(cache.NewInMemoryCache(1*time.Hour)),
 				1*time.Minute,
 			),
 			1*time.Minute,

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -29,7 +29,6 @@ import (
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	accountFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/account"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	projectFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/project"
@@ -48,7 +47,7 @@ func TestNamespacedGetLogsAllowNoSwitch(t *testing.T) {
 }
 
 func TestNamespacedGetLogsDenySwitchOn(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 
 	accountFixture.Given(t).
 		Name("test").
@@ -79,7 +78,7 @@ func TestNamespacedGetLogsDenySwitchOn(t *testing.T) {
 		}, "app-creator")
 
 	ctx := GivenWithSameState(t)
-	ctx.SetAppNamespace(ArgoCDAppNamespace)
+	ctx.SetAppNamespace(fixture.ArgoCDAppNamespace)
 	ctx.
 		Path("guestbook-logs").
 		SetTrackingMethod("annotation").
@@ -90,13 +89,13 @@ func TestNamespacedGetLogsDenySwitchOn(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			_, err := RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			_, err := fixture.RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			assert.ErrorContains(t, err, "permission denied")
 		})
 }
 
 func TestNamespacedGetLogsAllowSwitchOnNS(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 
 	accountFixture.Given(t).
 		Name("test").
@@ -132,7 +131,7 @@ func TestNamespacedGetLogsAllowSwitchOnNS(t *testing.T) {
 		}, "app-creator")
 
 	ctx := GivenWithSameState(t)
-	ctx.SetAppNamespace(AppNamespace())
+	ctx.SetAppNamespace(fixture.AppNamespace())
 	ctx.
 		Path("guestbook-logs").
 		SetTrackingMethod("annotation").
@@ -143,24 +142,24 @@ func TestNamespacedGetLogsAllowSwitchOnNS(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Pod")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Pod")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Service")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Service")
 			require.NoError(t, err)
 			assert.NotContains(t, out, "Hi")
 		})
 }
 
 func TestNamespacedGetLogsAllowSwitchOff(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 
 	accountFixture.Given(t).
 		Name("test").
@@ -190,7 +189,7 @@ func TestNamespacedGetLogsAllowSwitchOff(t *testing.T) {
 			},
 		}, "app-creator")
 	ctx := GivenWithSameState(t)
-	ctx.SetAppNamespace(AppNamespace())
+	ctx.SetAppNamespace(fixture.AppNamespace())
 	ctx.
 		Path("guestbook-logs").
 		SetTrackingMethod("annotation").
@@ -201,25 +200,25 @@ func TestNamespacedGetLogsAllowSwitchOff(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Pod")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Pod")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Service")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", ctx.AppQualifiedName(), "--kind", "Service")
 			require.NoError(t, err)
 			assert.NotContains(t, out, "Hi")
 		})
 }
 
 func TestNamespacedSyncToUnsignedCommit(t *testing.T) {
-	SkipOnEnv(t, "GPG")
-	GivenWithNamespace(t, AppNamespace()).
+	fixture.SkipOnEnv(t, "GPG")
+	GivenWithNamespace(t, fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Project("gpg").
 		Path(guestbookPath).
@@ -234,9 +233,9 @@ func TestNamespacedSyncToUnsignedCommit(t *testing.T) {
 }
 
 func TestNamespacedSyncToSignedCommitWKK(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Project("gpg").
 		Path(guestbookPath).
@@ -252,9 +251,9 @@ func TestNamespacedSyncToSignedCommitWKK(t *testing.T) {
 }
 
 func TestNamespacedSyncToSignedCommitKWKK(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Project("gpg").
 		Path(guestbookPath).
@@ -276,23 +275,23 @@ func TestNamespacedAppCreation(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
-			assert.Equal(t, Name(), app.Name)
-			assert.Equal(t, AppNamespace(), app.Namespace)
-			assert.Equal(t, RepoURL(RepoURLTypeFile), app.Spec.GetSource().RepoURL)
+			assert.Equal(t, fixture.Name(), app.Name)
+			assert.Equal(t, fixture.AppNamespace(), app.Namespace)
+			assert.Equal(t, fixture.RepoURL(fixture.RepoURLTypeFile), app.Spec.GetSource().RepoURL)
 			assert.Equal(t, guestbookPath, app.Spec.GetSource().Path)
-			assert.Equal(t, DeploymentNamespace(), app.Spec.Destination.Namespace)
+			assert.Equal(t, fixture.DeploymentNamespace(), app.Spec.Destination.Namespace)
 			assert.Equal(t, KubernetesInternalAPIServerAddr, app.Spec.Destination.Server)
 		}).
-		Expect(NamespacedEvent(AppNamespace(), EventReasonResourceCreated, "create")).
+		Expect(NamespacedEvent(fixture.AppNamespace(), EventReasonResourceCreated, "create")).
 		And(func(app *Application) {
 			// app should be listed
-			output, err := RunCli("app", "list")
+			output, err := fixture.RunCli("app", "list")
 			require.NoError(t, err)
 			assert.Contains(t, output, ctx.AppQualifiedName())
 		}).
@@ -305,7 +304,7 @@ func TestNamespacedAppCreation(t *testing.T) {
 		When().
 		// ensure that update replaces spec and merge labels and annotations
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Patch(context.Background(),
 				ctx.GetName(), types.MergePatchType, []byte(`{"metadata": {"labels": { "test": "label" }, "annotations": { "test": "annotation" }}}`), metav1.PatchOptions{}))
 		}).
 		CreateApp("--upsert").
@@ -323,7 +322,7 @@ func TestNamespacedAppCreationWithoutForceUpdate(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		DestName("in-cluster").
 		When().
 		CreateApp().
@@ -331,16 +330,16 @@ func TestNamespacedAppCreationWithoutForceUpdate(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
 			assert.Equal(t, ctx.AppName(), app.Name)
-			assert.Equal(t, AppNamespace(), app.Namespace)
-			assert.Equal(t, RepoURL(RepoURLTypeFile), app.Spec.GetSource().RepoURL)
+			assert.Equal(t, fixture.AppNamespace(), app.Namespace)
+			assert.Equal(t, fixture.RepoURL(fixture.RepoURLTypeFile), app.Spec.GetSource().RepoURL)
 			assert.Equal(t, guestbookPath, app.Spec.GetSource().Path)
-			assert.Equal(t, DeploymentNamespace(), app.Spec.Destination.Namespace)
+			assert.Equal(t, fixture.DeploymentNamespace(), app.Spec.Destination.Namespace)
 			assert.Equal(t, "in-cluster", app.Spec.Destination.Name)
 		}).
-		Expect(NamespacedEvent(AppNamespace(), EventReasonResourceCreated, "create")).
+		Expect(NamespacedEvent(fixture.AppNamespace(), EventReasonResourceCreated, "create")).
 		And(func(_ *Application) {
 			// app should be listed
-			output, err := RunCli("app", "list")
+			output, err := fixture.RunCli("app", "list")
 			require.NoError(t, err)
 			assert.Contains(t, output, ctx.AppQualifiedName())
 		}).
@@ -357,7 +356,7 @@ func TestNamespacedDeleteAppResource(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
@@ -365,7 +364,7 @@ func TestNamespacedDeleteAppResource(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(_ *Application) {
 			// app should be listed
-			if _, err := RunCli("app", "delete-resource", ctx.AppQualifiedName(), "--kind", "Service", "--resource-name", "guestbook-ui"); err != nil {
+			if _, err := fixture.RunCli("app", "delete-resource", ctx.AppQualifiedName(), "--kind", "Service", "--resource-name", "guestbook-ui"); err != nil {
 				require.NoError(t, err)
 			}
 		}).
@@ -375,11 +374,11 @@ func TestNamespacedDeleteAppResource(t *testing.T) {
 
 // demonstrate that we cannot use a standard sync when an immutable field is changed, we must use "force"
 func TestNamespacedImmutableChange(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
 		Path("secrets").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		PatchFile("secrets.yaml", `[{"op": "add", "path": "/data/new-field", "value": "dGVzdA=="}, {"op": "add", "path": "/immutable", "value": true}]`).
@@ -400,7 +399,7 @@ func TestNamespacedImmutableChange(t *testing.T) {
 		Expect(ResourceResultMatches(ResourceResult{
 			Kind:      "Secret",
 			Version:   "v1",
-			Namespace: DeploymentNamespace(),
+			Namespace: fixture.DeploymentNamespace(),
 			Name:      "test-secret",
 			SyncPhase: "Sync",
 			Status:    "SyncFailed",
@@ -422,7 +421,7 @@ func TestNamespacedInvalidAppProject(t *testing.T) {
 	Given(t).
 		SetTrackingMethod("annotation").
 		Path(guestbookPath).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		Project("does-not-exist").
 		When().
 		IgnoreErrors().
@@ -438,7 +437,7 @@ func TestNamespacedAppDeletion(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Then().
@@ -447,9 +446,9 @@ func TestNamespacedAppDeletion(t *testing.T) {
 		Delete(true).
 		Then().
 		Expect(DoesNotExist()).
-		Expect(NamespacedEvent(AppNamespace(), EventReasonResourceDeleted, "delete"))
+		Expect(NamespacedEvent(fixture.AppNamespace(), EventReasonResourceDeleted, "delete"))
 
-	output, err := RunCli("app", "list")
+	output, err := fixture.RunCli("app", "list")
 	require.NoError(t, err)
 	assert.NotContains(t, output, ctx.AppQualifiedName())
 }
@@ -459,14 +458,14 @@ func TestNamespacedAppLabels(t *testing.T) {
 	ctx.
 		Path("config-map").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp("-l", "foo=bar").
 		Then().
 		And(func(app *Application) {
-			assert.Contains(t, FailOnErr(RunCli("app", "list")), ctx.AppQualifiedName())
-			assert.Contains(t, FailOnErr(RunCli("app", "list", "-l", "foo=bar")), ctx.AppQualifiedName())
-			assert.NotContains(t, FailOnErr(RunCli("app", "list", "-l", "foo=rubbish")), ctx.AppQualifiedName())
+			assert.Contains(t, FailOnErr(fixture.RunCli("app", "list")), ctx.AppQualifiedName())
+			assert.Contains(t, FailOnErr(fixture.RunCli("app", "list", "-l", "foo=bar")), ctx.AppQualifiedName())
+			assert.NotContains(t, FailOnErr(fixture.RunCli("app", "list", "-l", "foo=rubbish")), ctx.AppQualifiedName())
 		}).
 		Given().
 		// remove both name and replace labels means nothing will sync
@@ -487,7 +486,7 @@ func TestNamespacedTrackAppStateAndSyncApp(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
@@ -495,9 +494,9 @@ func TestNamespacedTrackAppStateAndSyncApp(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
-		Expect(Success(fmt.Sprintf("Service     %s  guestbook-ui  Synced ", DeploymentNamespace()))).
-		Expect(Success(fmt.Sprintf("apps   Deployment  %s  guestbook-ui  Synced", DeploymentNamespace()))).
-		Expect(NamespacedEvent(AppNamespace(), EventReasonResourceUpdated, "sync")).
+		Expect(Success(fmt.Sprintf("Service     %s  guestbook-ui  Synced ", fixture.DeploymentNamespace()))).
+		Expect(Success(fmt.Sprintf("apps   Deployment  %s  guestbook-ui  Synced", fixture.DeploymentNamespace()))).
+		Expect(NamespacedEvent(fixture.AppNamespace(), EventReasonResourceUpdated, "sync")).
 		And(func(app *Application) {
 			assert.NotNil(t, app.Status.OperationState.SyncResult)
 		})
@@ -508,7 +507,7 @@ func TestNamespacedAppRollbackSuccessful(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
@@ -532,14 +531,14 @@ func TestNamespacedAppRollbackSuccessful(t *testing.T) {
 			}}
 			patch, _, err := diff.CreateTwoWayMergePatch(app, appWithHistory, &Application{})
 			require.NoError(t, err)
-			app, err = AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			app, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Patch(context.Background(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 			require.NoError(t, err)
 
 			// sync app and make sure it reaches InSync state
-			_, err = RunCli("app", "rollback", app.QualifiedName(), "1")
+			_, err = fixture.RunCli("app", "rollback", app.QualifiedName(), "1")
 			require.NoError(t, err)
 		}).
-		Expect(NamespacedEvent(AppNamespace(), EventReasonOperationStarted, "rollback")).
+		Expect(NamespacedEvent(fixture.AppNamespace(), EventReasonOperationStarted, "rollback")).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
 			assert.Equal(t, SyncStatusCodeSynced, app.Status.Sync.Status)
@@ -554,7 +553,7 @@ func TestNamespacedComparisonFailsIfClusterNotAdded(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		DestServer("https://not-registered-cluster/api").
 		When().
 		IgnoreErrors().
@@ -567,7 +566,7 @@ func TestNamespacedCannotSetInvalidPath(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		IgnoreErrors().
@@ -581,14 +580,14 @@ func TestNamespacedManipulateApplicationResources(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			manifests, err := RunCli("app", "manifests", ctx.AppQualifiedName(), "--source", "live")
+			manifests, err := fixture.RunCli("app", "manifests", ctx.AppQualifiedName(), "--source", "live")
 			require.NoError(t, err)
 			resources, err := kube.SplitYAML([]byte(manifests))
 			require.NoError(t, err)
@@ -604,13 +603,13 @@ func TestNamespacedManipulateApplicationResources(t *testing.T) {
 
 			deployment := resources[index]
 
-			closer, client, err := ArgoCDClientset.NewApplicationClient()
+			closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 			require.NoError(t, err)
 			defer io.Close(closer)
 
 			_, err = client.DeleteResource(context.Background(), &applicationpkg.ApplicationResourceDeleteRequest{
 				Name:         &app.Name,
-				AppNamespace: ptr.To(AppNamespace()),
+				AppNamespace: ptr.To(fixture.AppNamespace()),
 				Group:        ptr.To(deployment.GroupVersionKind().Group),
 				Kind:         ptr.To(deployment.GroupVersionKind().Kind),
 				Version:      ptr.To(deployment.GroupVersionKind().Version),
@@ -623,14 +622,14 @@ func TestNamespacedManipulateApplicationResources(t *testing.T) {
 }
 
 func TestNamespacedAppWithSecrets(t *testing.T) {
-	closer, client, err := ArgoCDClientset.NewApplicationClient()
+	closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 	require.NoError(t, err)
 	defer io.Close(closer)
 
 	ctx := Given(t)
 	ctx.
 		Path("secrets").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		When().
 		CreateApp().
@@ -640,7 +639,7 @@ func TestNamespacedAppWithSecrets(t *testing.T) {
 		And(func(app *Application) {
 			res := FailOnErr(client.GetResource(context.Background(), &applicationpkg.ApplicationResourceRequest{
 				Namespace:    &app.Spec.Destination.Namespace,
-				AppNamespace: ptr.To(AppNamespace()),
+				AppNamespace: ptr.To(fixture.AppNamespace()),
 				Kind:         ptr.To(kube.SecretKind),
 				Group:        ptr.To(""),
 				Name:         &app.Name,
@@ -651,7 +650,7 @@ func TestNamespacedAppWithSecrets(t *testing.T) {
 
 			manifests, err := client.GetManifests(context.Background(), &applicationpkg.ApplicationManifestQuery{
 				Name:         &app.Name,
-				AppNamespace: ptr.To(AppNamespace()),
+				AppNamespace: ptr.To(fixture.AppNamespace()),
 			})
 			errors.CheckError(err)
 
@@ -659,19 +658,19 @@ func TestNamespacedAppWithSecrets(t *testing.T) {
 				assetSecretDataHidden(t, manifest)
 			}
 
-			diffOutput := FailOnErr(RunCli("app", "diff", ctx.AppQualifiedName())).(string)
+			diffOutput := FailOnErr(fixture.RunCli("app", "diff", ctx.AppQualifiedName())).(string)
 			assert.Empty(t, diffOutput)
 
 			// make sure resource update error does not print secret details
-			_, err = RunCli("app", "patch-resource", ctx.AppQualifiedName(), "--resource-name", "test-secret",
+			_, err = fixture.RunCli("app", "patch-resource", ctx.AppQualifiedName(), "--resource-name", "test-secret",
 				"--kind", "Secret", "--patch", `{"op": "add", "path": "/data", "value": "hello"}'`,
 				"--patch-type", "application/json-patch+json")
-			require.ErrorContains(t, err, fmt.Sprintf("failed to patch Secret %s/test-secret", DeploymentNamespace()))
+			require.ErrorContains(t, err, fmt.Sprintf("failed to patch Secret %s/test-secret", fixture.DeploymentNamespace()))
 			assert.NotContains(t, err.Error(), "username")
 			assert.NotContains(t, err.Error(), "password")
 
 			// patch secret and make sure app is out of sync and diff detects the change
-			FailOnErr(KubeClientset.CoreV1().Secrets(DeploymentNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.KubeClientset.CoreV1().Secrets(fixture.DeploymentNamespace()).Patch(context.Background(),
 				"test-secret", types.JSONPatchType, []byte(`[
 	{"op": "remove", "path": "/data/username"},
 	{"op": "add", "path": "/stringData", "value": {"password": "foo"}}
@@ -682,20 +681,20 @@ func TestNamespacedAppWithSecrets(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", ctx.AppQualifiedName())
+			diffOutput, err := fixture.RunCli("app", "diff", ctx.AppQualifiedName())
 			require.Error(t, err)
 			assert.Contains(t, diffOutput, "username: ++++++++")
 			assert.Contains(t, diffOutput, "password: ++++++++++++")
 
 			// local diff should ignore secrets
-			diffOutput = FailOnErr(RunCli("app", "diff", ctx.AppQualifiedName(), "--local", "testdata/secrets")).(string)
+			diffOutput = FailOnErr(fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local", "testdata/secrets")).(string)
 			assert.Empty(t, diffOutput)
 
 			// ignore missing field and make sure diff shows no difference
 			app.Spec.IgnoreDifferences = []ResourceIgnoreDifferences{{
 				Kind: kube.SecretKind, JSONPointers: []string{"/data"},
 			}}
-			FailOnErr(client.UpdateSpec(context.Background(), &applicationpkg.ApplicationUpdateSpecRequest{Name: &app.Name, AppNamespace: ptr.To(AppNamespace()), Spec: &app.Spec}))
+			FailOnErr(client.UpdateSpec(context.Background(), &applicationpkg.ApplicationUpdateSpecRequest{Name: &app.Name, AppNamespace: ptr.To(fixture.AppNamespace()), Spec: &app.Spec}))
 		}).
 		When().
 		Refresh(RefreshTypeNormal).
@@ -703,7 +702,7 @@ func TestNamespacedAppWithSecrets(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			diffOutput := FailOnErr(RunCli("app", "diff", ctx.AppQualifiedName())).(string)
+			diffOutput := FailOnErr(fixture.RunCli("app", "diff", ctx.AppQualifiedName())).(string)
 			assert.Empty(t, diffOutput)
 		}).
 		// verify not committed secret also ignore during diffing
@@ -717,7 +716,7 @@ stringData:
   username: test-username`).
 		Then().
 		And(func(app *Application) {
-			diffOutput := FailOnErr(RunCli("app", "diff", ctx.AppQualifiedName(), "--local", "testdata/secrets")).(string)
+			diffOutput := FailOnErr(fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local", "testdata/secrets")).(string)
 			assert.Empty(t, diffOutput)
 		})
 }
@@ -727,7 +726,7 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
@@ -735,7 +734,7 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
 			// Patch deployment
-			_, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Patch(context.Background(),
+			_, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Patch(context.Background(),
 				"guestbook-ui", types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "test" }]`), metav1.PatchOptions{})
 			require.NoError(t, err)
 		}).
@@ -744,9 +743,9 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", ctx.AppQualifiedName(), "--local-repo-root", ".", "--local", "testdata/guestbook")
+			diffOutput, err := fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local-repo-root", ".", "--local", "testdata/guestbook")
 			require.Error(t, err)
-			assert.Contains(t, diffOutput, fmt.Sprintf("===== apps/Deployment %s/guestbook-ui ======", DeploymentNamespace()))
+			assert.Contains(t, diffOutput, fmt.Sprintf("===== apps/Deployment %s/guestbook-ui ======", fixture.DeploymentNamespace()))
 		}).
 		Given().
 		ResourceOverrides(map[string]ResourceOverride{"apps/Deployment": {
@@ -757,7 +756,7 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", ctx.AppQualifiedName(), "--local-repo-root", ".", "--local", "testdata/guestbook")
+			diffOutput, err := fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local-repo-root", ".", "--local", "testdata/guestbook")
 			require.NoError(t, err)
 			assert.Empty(t, diffOutput)
 		}).
@@ -775,7 +774,7 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 			}]`).
 		Sync().
 		And(func() {
-			output, err := RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
+			output, err := fixture.RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", fixture.DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
 			require.NoError(t, err)
 			assert.Contains(t, output, "serverside-applied")
 		}).
@@ -802,12 +801,12 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 			"value": { "syncOptions": ["RespectIgnoreDifferences=true"] }
 			}]`).
 		And(func() {
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, int32(3), *deployment.Spec.RevisionHistoryLimit)
 		}).
 		And(func() {
-			output, err := RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
+			output, err := fixture.RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", fixture.DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
 			require.NoError(t, err)
 			assert.Contains(t, output, "serverside-applied")
 		}).
@@ -816,13 +815,13 @@ func TestNamespacedResourceDiffing(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, int32(1), *deployment.Spec.RevisionHistoryLimit)
 		}).
 		When().Sync().Then().Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, int32(1), *deployment.Spec.RevisionHistoryLimit)
 		})
@@ -839,12 +838,12 @@ func TestNamespacedKnownTypesInCRDDiffing(t *testing.T) {
 	ctx.
 		Path("crd-creation").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().CreateApp().Sync().Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		When().
 		And(func() {
-			dummyResIf := DynamicClientset.Resource(dummiesGVR).Namespace(DeploymentNamespace())
+			dummyResIf := fixture.DynamicClientset.Resource(dummiesGVR).Namespace(fixture.DeploymentNamespace())
 			patchData := []byte(`{"spec":{"cpu": "2"}}`)
 			FailOnErr(dummyResIf.Patch(context.Background(), "dummy-crd-instance", types.MergePatchType, patchData, metav1.PatchOptions{}))
 		}).Refresh(RefreshTypeNormal).
@@ -852,7 +851,7 @@ func TestNamespacedKnownTypesInCRDDiffing(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		When().
 		And(func() {
-			CheckError(SetResourceOverrides(map[string]ResourceOverride{
+			CheckError(fixture.SetResourceOverrides(map[string]ResourceOverride{
 				"argoproj.io/Dummy": {
 					KnownTypeFields: []KnownTypeField{{
 						Field: "spec",
@@ -881,7 +880,7 @@ func testNSEdgeCasesApplicationResources(t *testing.T, appPath string, statusCod
 	expect := ctx.
 		Path(appPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
@@ -894,7 +893,7 @@ func testNSEdgeCasesApplicationResources(t *testing.T, appPath string, statusCod
 	expect.
 		Expect(HealthIs(statusCode)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", ctx.AppQualifiedName(), "--local-repo-root", ".", "--local", path.Join("testdata", appPath))
+			diffOutput, err := fixture.RunCli("app", "diff", ctx.AppQualifiedName(), "--local-repo-root", ".", "--local", path.Join("testdata", appPath))
 			assert.Empty(t, diffOutput)
 			require.NoError(t, err)
 		})
@@ -914,24 +913,24 @@ func TestNamespacedResourceAction(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		ResourceOverrides(map[string]ResourceOverride{"apps/Deployment": {Actions: actionsConfig}}).
 		When().
 		CreateApp().
 		Sync().
 		Then().
 		And(func(app *Application) {
-			closer, client, err := ArgoCDClientset.NewApplicationClient()
+			closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 			require.NoError(t, err)
 			defer io.Close(closer)
 
 			actions, err := client.ListResourceActions(context.Background(), &applicationpkg.ApplicationResourceRequest{
 				Name:         &app.Name,
-				AppNamespace: ptr.To(AppNamespace()),
+				AppNamespace: ptr.To(fixture.AppNamespace()),
 				Group:        ptr.To("apps"),
 				Kind:         ptr.To("Deployment"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("guestbook-ui"),
 			})
 			require.NoError(t, err)
@@ -942,14 +941,14 @@ func TestNamespacedResourceAction(t *testing.T) {
 				Group:        ptr.To("apps"),
 				Kind:         ptr.To("Deployment"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("guestbook-ui"),
 				Action:       ptr.To("sample"),
-				AppNamespace: ptr.To(AppNamespace()),
+				AppNamespace: ptr.To(fixture.AppNamespace()),
 			})
 			require.NoError(t, err)
 
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, "test", deployment.Labels["sample"])
@@ -961,17 +960,17 @@ func TestNamespacedSyncResourceByLabel(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, _ = RunCli("app", "sync", ctx.AppQualifiedName(), "--label", "app.kubernetes.io/instance="+app.Name)
+			_, _ = fixture.RunCli("app", "sync", ctx.AppQualifiedName(), "--label", "app.kubernetes.io/instance="+app.Name)
 		}).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			_, err := RunCli("app", "sync", ctx.AppQualifiedName(), "--label", "this-label=does-not-exist")
+			_, err := fixture.RunCli("app", "sync", ctx.AppQualifiedName(), "--label", "this-label=does-not-exist")
 			assert.ErrorContains(t, err, "level=fatal")
 		})
 }
@@ -981,13 +980,13 @@ func TestNamespacedLocalManifestSync(t *testing.T) {
 	ctx.
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
 		Then().
 		And(func(app *Application) {
-			res, _ := RunCli("app", "manifests", ctx.AppQualifiedName())
+			res, _ := fixture.RunCli("app", "manifests", ctx.AppQualifiedName())
 			assert.Contains(t, res, "containerPort: 80")
 			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.2")
 		}).
@@ -998,7 +997,7 @@ func TestNamespacedLocalManifestSync(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			res, _ := RunCli("app", "manifests", ctx.AppQualifiedName())
+			res, _ := fixture.RunCli("app", "manifests", ctx.AppQualifiedName())
 			assert.Contains(t, res, "containerPort: 81")
 			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.3")
 		}).
@@ -1009,7 +1008,7 @@ func TestNamespacedLocalManifestSync(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			res, _ := RunCli("app", "manifests", ctx.AppQualifiedName())
+			res, _ := fixture.RunCli("app", "manifests", ctx.AppQualifiedName())
 			assert.Contains(t, res, "containerPort: 80")
 			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.2")
 		})
@@ -1020,12 +1019,12 @@ func TestNamespacedLocalSync(t *testing.T) {
 		// we've got to use Helm as this uses kubeVersion
 		Path("helm").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Then().
 		And(func(app *Application) {
-			FailOnErr(RunCli("app", "sync", app.QualifiedName(), "--local", "testdata/helm"))
+			FailOnErr(fixture.RunCli("app", "sync", app.QualifiedName(), "--local", "testdata/helm"))
 		})
 }
 
@@ -1033,16 +1032,16 @@ func TestNamespacedNoLocalSyncWithAutosyncEnabled(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "set", app.QualifiedName(), "--sync-policy", "automated")
+			_, err := fixture.RunCli("app", "set", app.QualifiedName(), "--sync-policy", "automated")
 			require.NoError(t, err)
 
-			_, err = RunCli("app", "sync", app.QualifiedName(), "--local", guestbookPathLocal)
+			_, err = fixture.RunCli("app", "sync", app.QualifiedName(), "--local", guestbookPathLocal)
 			assert.ErrorContains(t, err, "Cannot use local sync")
 		})
 }
@@ -1051,17 +1050,17 @@ func TestNamespacedLocalSyncDryRunWithASEnabled(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "set", app.QualifiedName(), "--sync-policy", "automated")
+			_, err := fixture.RunCli("app", "set", app.QualifiedName(), "--sync-policy", "automated")
 			require.NoError(t, err)
 
 			appBefore := app.DeepCopy()
-			_, err = RunCli("app", "sync", app.QualifiedName(), "--dry-run", "--local-repo-root", ".", "--local", guestbookPathLocal)
+			_, err = fixture.RunCli("app", "sync", app.QualifiedName(), "--dry-run", "--local-repo-root", ".", "--local", guestbookPathLocal)
 			require.NoError(t, err)
 
 			appAfter := app.DeepCopy()
@@ -1073,7 +1072,7 @@ func TestNamespacedSyncAsync(t *testing.T) {
 	Given(t).
 		Path(guestbookPath).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		Async(true).
 		When().
 		CreateApp().
@@ -1095,18 +1094,18 @@ func assertNSResourceActions(t *testing.T, appName string, successful bool) {
 		}
 	}
 
-	closer, cdClient := ArgoCDClientset.NewApplicationClientOrDie()
+	closer, cdClient := fixture.ArgoCDClientset.NewApplicationClientOrDie()
 	defer io.Close(closer)
 
-	deploymentResource, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+	deploymentResource, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 	require.NoError(t, err)
 
 	logs, err := cdClient.PodLogs(context.Background(), &applicationpkg.ApplicationPodLogsQuery{
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
 		Name:         &appName,
-		AppNamespace: ptr.To(AppNamespace()),
-		Namespace:    ptr.To(DeploymentNamespace()),
+		AppNamespace: ptr.To(fixture.AppNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Container:    ptr.To(""),
 		SinceSeconds: ptr.To(int64(0)),
 		TailLines:    ptr.To(int64(0)),
@@ -1120,18 +1119,18 @@ func assertNSResourceActions(t *testing.T, appName string, successful bool) {
 
 	_, err = cdClient.ListResourceEvents(context.Background(), &applicationpkg.ApplicationResourceEventsQuery{
 		Name:              &appName,
-		AppNamespace:      ptr.To(AppNamespace()),
+		AppNamespace:      ptr.To(fixture.AppNamespace()),
 		ResourceName:      ptr.To("guestbook-ui"),
-		ResourceNamespace: ptr.To(DeploymentNamespace()),
+		ResourceNamespace: ptr.To(fixture.DeploymentNamespace()),
 		ResourceUID:       ptr.To(string(deploymentResource.UID)),
 	})
 	assertError(err, fmt.Sprintf("%s not found as part of application %s", "guestbook-ui", appName))
 
 	_, err = cdClient.GetResource(context.Background(), &applicationpkg.ApplicationResourceRequest{
 		Name:         &appName,
-		AppNamespace: ptr.To(AppNamespace()),
+		AppNamespace: ptr.To(fixture.AppNamespace()),
 		ResourceName: ptr.To("guestbook-ui"),
-		Namespace:    ptr.To(DeploymentNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Version:      ptr.To("v1"),
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
@@ -1140,9 +1139,9 @@ func assertNSResourceActions(t *testing.T, appName string, successful bool) {
 
 	_, err = cdClient.RunResourceAction(context.Background(), &applicationpkg.ResourceActionRunRequest{
 		Name:         &appName,
-		AppNamespace: ptr.To(AppNamespace()),
+		AppNamespace: ptr.To(fixture.AppNamespace()),
 		ResourceName: ptr.To("guestbook-ui"),
-		Namespace:    ptr.To(DeploymentNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Version:      ptr.To("v1"),
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
@@ -1152,9 +1151,9 @@ func assertNSResourceActions(t *testing.T, appName string, successful bool) {
 
 	_, err = cdClient.DeleteResource(context.Background(), &applicationpkg.ApplicationResourceDeleteRequest{
 		Name:         &appName,
-		AppNamespace: ptr.To(AppNamespace()),
+		AppNamespace: ptr.To(fixture.AppNamespace()),
 		ResourceName: ptr.To("guestbook-ui"),
-		Namespace:    ptr.To(DeploymentNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Version:      ptr.To("v1"),
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
@@ -1168,17 +1167,17 @@ func TestNamespacedPermissions(t *testing.T) {
 	projActions := projectFixture.
 		Given(t).
 		Name(projName).
-		SourceNamespaces([]string{AppNamespace()}).
+		SourceNamespaces([]string{fixture.AppNamespace()}).
 		When().
 		Create()
 
-	sourceError := fmt.Sprintf("application repo %s is not permitted in project 'argo-project'", RepoURL(RepoURLTypeFile))
-	destinationError := fmt.Sprintf("application destination server '%s' and namespace '%s' do not match any of the allowed destinations in project 'argo-project'", KubernetesInternalAPIServerAddr, DeploymentNamespace())
+	sourceError := fmt.Sprintf("application repo %s is not permitted in project 'argo-project'", fixture.RepoURL(fixture.RepoURLTypeFile))
+	destinationError := fmt.Sprintf("application destination server '%s' and namespace '%s' do not match any of the allowed destinations in project 'argo-project'", KubernetesInternalAPIServerAddr, fixture.DeploymentNamespace())
 
 	appCtx.
 		Path("guestbook-logs").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		Project(projName).
 		When().
 		IgnoreErrors().
@@ -1215,7 +1214,7 @@ func TestNamespacedPermissions(t *testing.T) {
 		Expect(Condition(ApplicationConditionInvalidSpecError, destinationError)).
 		Expect(Condition(ApplicationConditionInvalidSpecError, sourceError)).
 		And(func(app *Application) {
-			closer, cdClient := ArgoCDClientset.NewApplicationClientOrDie()
+			closer, cdClient := fixture.ArgoCDClientset.NewApplicationClientOrDie()
 			defer io.Close(closer)
 			tree, err := cdClient.ResourceTree(context.Background(), &applicationpkg.ResourcesQuery{ApplicationName: &app.Name, AppNamespace: &app.Namespace})
 			require.NoError(t, err)
@@ -1246,23 +1245,23 @@ func TestNamespacedPermissionWithScopedRepo(t *testing.T) {
 	projectFixture.
 		Given(t).
 		Name(projName).
-		SourceNamespaces([]string{AppNamespace()}).
+		SourceNamespaces([]string{fixture.AppNamespace()}).
 		Destination("*,*").
 		When().
 		Create()
 
 	repoFixture.GivenWithSameState(t).
 		When().
-		Path(RepoURL(RepoURLTypeFile)).
+		Path(fixture.RepoURL(fixture.RepoURLTypeFile)).
 		Project(projName).
 		Create()
 
 	GivenWithSameState(t).
 		Project(projName).
-		RepoURLType(RepoURLTypeFile).
+		RepoURLType(fixture.RepoURLTypeFile).
 		Path("two-nice-pods").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Prune=false"}}]`).
 		CreateApp().
@@ -1287,20 +1286,20 @@ func TestNamespacedPermissionDeniedWithScopedRepo(t *testing.T) {
 		Given(t).
 		Name(projName).
 		Destination("*,*").
-		SourceNamespaces([]string{AppNamespace()}).
+		SourceNamespaces([]string{fixture.AppNamespace()}).
 		When().
 		Create()
 
 	repoFixture.GivenWithSameState(t).
 		When().
-		Path(RepoURL(RepoURLTypeFile)).
+		Path(fixture.RepoURL(fixture.RepoURLTypeFile)).
 		Create()
 
 	GivenWithSameState(t).
 		Project(projName).
-		RepoURLType(RepoURLTypeFile).
+		RepoURLType(fixture.RepoURLTypeFile).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		Path("two-nice-pods").
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Prune=false"}}]`).
@@ -1315,7 +1314,7 @@ func TestNamespacedSyncOptionPruneFalse(t *testing.T) {
 	Given(t).
 		Path("two-nice-pods").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Prune=false"}}]`).
 		CreateApp().
@@ -1339,7 +1338,7 @@ func TestNamespacedSyncOptionValidateFalse(t *testing.T) {
 	Given(t).
 		Path("crd-validation").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Then().
@@ -1363,7 +1362,7 @@ func TestNamespacedCompareOptionIgnoreExtraneous(t *testing.T) {
 	Given(t).
 		Prune(false).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		Path("two-nice-pods").
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/compare-options": "IgnoreExtraneous"}}]`).
@@ -1397,9 +1396,9 @@ func TestNamespacedSelfManagedApps(t *testing.T) {
 	Given(t).
 		Path("self-managed-app").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
-		PatchFile("resources.yaml", fmt.Sprintf(`[{"op": "replace", "path": "/spec/source/repoURL", "value": "%s"}]`, RepoURL(RepoURLTypeFile))).
+		PatchFile("resources.yaml", fmt.Sprintf(`[{"op": "replace", "path": "/spec/source/repoURL", "value": "%s"}]`, fixture.RepoURL(fixture.RepoURLTypeFile))).
 		CreateApp().
 		Sync().
 		Then().
@@ -1411,7 +1410,7 @@ func TestNamespacedSelfManagedApps(t *testing.T) {
 
 			reconciledCount := 0
 			var lastReconciledAt *metav1.Time
-			for event := range ArgoCDClientset.WatchApplicationWithRetry(ctx, a.QualifiedName(), a.ResourceVersion) {
+			for event := range fixture.ArgoCDClientset.WatchApplicationWithRetry(ctx, a.QualifiedName(), a.ResourceVersion) {
 				reconciledAt := event.Application.Status.ReconciledAt
 				if reconciledAt == nil {
 					reconciledAt = &metav1.Time{}
@@ -1430,7 +1429,7 @@ func TestNamespacedExcludedResource(t *testing.T) {
 	Given(t).
 		ResourceOverrides(map[string]ResourceOverride{"apps/Deployment": {Actions: actionsConfig}}).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		Path(guestbookPath).
 		ResourceFilter(settings.ResourcesFilter{
 			ResourceExclusions: []settings.FilteredResource{{Kinds: []string{kube.DeploymentKind}}},
@@ -1447,7 +1446,7 @@ func TestNamespacedRevisionHistoryLimit(t *testing.T) {
 	Given(t).
 		Path("config-map").
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		When().
 		CreateApp().
 		Sync().
@@ -1469,16 +1468,16 @@ func TestNamespacedRevisionHistoryLimit(t *testing.T) {
 }
 
 func TestNamespacedOrphanedResource(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
 		ProjectSpec(AppProjectSpec{
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: &OrphanedResourcesMonitorSettings{Warn: ptr.To(true)},
-			SourceNamespaces:  []string{AppNamespace()},
+			SourceNamespaces:  []string{fixture.AppNamespace()},
 		}).
 		SetTrackingMethod("annotation").
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		Path(guestbookPath).
 		When().
 		CreateApp().
@@ -1488,7 +1487,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -1498,7 +1497,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 		Then().
 		Expect(Condition(ApplicationConditionOrphanedResourceWarning, "Application has 1 orphaned resources")).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.QualifiedName())
+			output, err := fixture.RunCli("app", "resources", app.QualifiedName())
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 		}).
@@ -1507,14 +1506,14 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: &OrphanedResourcesMonitorSettings{Warn: ptr.To(true), Ignore: []OrphanedResourceKey{{Group: "Test", Kind: "ConfigMap"}}},
-			SourceNamespaces:  []string{AppNamespace()},
+			SourceNamespaces:  []string{fixture.AppNamespace()},
 		}).
 		When().
 		Refresh(RefreshTypeNormal).
 		Then().
 		Expect(Condition(ApplicationConditionOrphanedResourceWarning, "Application has 1 orphaned resources")).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.QualifiedName())
+			output, err := fixture.RunCli("app", "resources", app.QualifiedName())
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 		}).
@@ -1523,7 +1522,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: &OrphanedResourcesMonitorSettings{Warn: ptr.To(true), Ignore: []OrphanedResourceKey{{Kind: "ConfigMap"}}},
-			SourceNamespaces:  []string{AppNamespace()},
+			SourceNamespaces:  []string{fixture.AppNamespace()},
 		}).
 		When().
 		Refresh(RefreshTypeNormal).
@@ -1531,7 +1530,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(NoConditions()).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.QualifiedName())
+			output, err := fixture.RunCli("app", "resources", app.QualifiedName())
 			require.NoError(t, err)
 			assert.NotContains(t, output, "orphaned-configmap")
 		}).
@@ -1540,7 +1539,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: &OrphanedResourcesMonitorSettings{Warn: ptr.To(true), Ignore: []OrphanedResourceKey{{Kind: "ConfigMap", Name: "orphaned-configmap"}}},
-			SourceNamespaces:  []string{AppNamespace()},
+			SourceNamespaces:  []string{fixture.AppNamespace()},
 		}).
 		When().
 		Refresh(RefreshTypeNormal).
@@ -1548,7 +1547,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(NoConditions()).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.QualifiedName())
+			output, err := fixture.RunCli("app", "resources", app.QualifiedName())
 			require.NoError(t, err)
 			assert.NotContains(t, output, "orphaned-configmap")
 		}).
@@ -1557,7 +1556,7 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: nil,
-			SourceNamespaces:  []string{AppNamespace()},
+			SourceNamespaces:  []string{fixture.AppNamespace()},
 		}).
 		When().
 		Refresh(RefreshTypeNormal).
@@ -1568,13 +1567,13 @@ func TestNamespacedOrphanedResource(t *testing.T) {
 
 func TestNamespacedNotPermittedResources(t *testing.T) {
 	ctx := Given(t)
-	ctx.SetAppNamespace(AppNamespace())
+	ctx.SetAppNamespace(fixture.AppNamespace())
 	pathType := networkingv1.PathTypePrefix
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sample-ingress",
 			Annotations: map[string]string{
-				common.AnnotationKeyAppInstance: fmt.Sprintf("%s_%s:networking/Ingress:%s/sample-ingress", AppNamespace(), ctx.AppName(), DeploymentNamespace()),
+				common.AnnotationKeyAppInstance: fmt.Sprintf("%s_%s:networking/Ingress:%s/sample-ingress", fixture.AppNamespace(), ctx.AppName(), fixture.DeploymentNamespace()),
 			},
 		},
 		Spec: networkingv1.IngressSpec{
@@ -1597,15 +1596,15 @@ func TestNamespacedNotPermittedResources(t *testing.T) {
 		},
 	}
 	defer func() {
-		log.Infof("Ingress 'sample-ingress' deleted from %s", TestNamespace())
-		CheckError(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Delete(context.Background(), "sample-ingress", metav1.DeleteOptions{}))
+		log.Infof("Ingress 'sample-ingress' deleted from %s", fixture.TestNamespace())
+		CheckError(fixture.KubeClientset.NetworkingV1().Ingresses(fixture.TestNamespace()).Delete(context.Background(), "sample-ingress", metav1.DeleteOptions{}))
 	}()
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "guestbook-ui",
 			Annotations: map[string]string{
-				common.AnnotationKeyAppInstance: fmt.Sprintf("%s_%s:Service:%s/guesbook-ui", TestNamespace(), ctx.AppQualifiedName(), DeploymentNamespace()),
+				common.AnnotationKeyAppInstance: fmt.Sprintf("%s_%s:Service:%s/guesbook-ui", fixture.TestNamespace(), ctx.AppQualifiedName(), fixture.DeploymentNamespace()),
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -1621,15 +1620,15 @@ func TestNamespacedNotPermittedResources(t *testing.T) {
 
 	ctx.ProjectSpec(AppProjectSpec{
 		SourceRepos:      []string{"*"},
-		Destinations:     []ApplicationDestination{{Namespace: DeploymentNamespace(), Server: "*"}},
-		SourceNamespaces: []string{AppNamespace()},
+		Destinations:     []ApplicationDestination{{Namespace: fixture.DeploymentNamespace(), Server: "*"}},
+		SourceNamespaces: []string{fixture.AppNamespace()},
 		NamespaceResourceBlacklist: []metav1.GroupKind{
 			{Group: "", Kind: "Service"},
 		},
 	}).
 		And(func() {
-			FailOnErr(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Create(context.Background(), ingress, metav1.CreateOptions{}))
-			FailOnErr(KubeClientset.CoreV1().Services(DeploymentNamespace()).Create(context.Background(), svc, metav1.CreateOptions{}))
+			FailOnErr(fixture.KubeClientset.NetworkingV1().Ingresses(fixture.TestNamespace()).Create(context.Background(), ingress, metav1.CreateOptions{}))
+			FailOnErr(fixture.KubeClientset.CoreV1().Services(fixture.DeploymentNamespace()).Create(context.Background(), svc, metav1.CreateOptions{}))
 		}).
 		Path(guestbookPath).
 		When().
@@ -1654,8 +1653,8 @@ func TestNamespacedNotPermittedResources(t *testing.T) {
 		Expect(DoesNotExist())
 
 	// Make sure prohibited resources are not deleted during application deletion
-	FailOnErr(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Get(context.Background(), "sample-ingress", metav1.GetOptions{}))
-	FailOnErr(KubeClientset.CoreV1().Services(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{}))
+	FailOnErr(fixture.KubeClientset.NetworkingV1().Ingresses(fixture.TestNamespace()).Get(context.Background(), "sample-ingress", metav1.GetOptions{}))
+	FailOnErr(fixture.KubeClientset.CoreV1().Services(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{}))
 }
 
 func TestNamespacedSyncWithInfos(t *testing.T) {
@@ -1664,14 +1663,14 @@ func TestNamespacedSyncWithInfos(t *testing.T) {
 	expectedInfo[1] = &Info{Name: "name2", Value: "val2"}
 
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path(guestbookPath).
 		When().
 		CreateApp().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "sync", app.QualifiedName(),
+			_, err := fixture.RunCli("app", "sync", app.QualifiedName(),
 				"--info", fmt.Sprintf("%s=%s", expectedInfo[0].Name, expectedInfo[0].Value),
 				"--info", fmt.Sprintf("%s=%s", expectedInfo[1].Name, expectedInfo[1].Value))
 			require.NoError(t, err)
@@ -1689,14 +1688,14 @@ func TestNamespacedSyncWithInfos(t *testing.T) {
 // Expect: no app.Status.Conditions
 func TestNamespacedCreateAppWithNoNameSpaceForGlobalResource(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path(globalWithNoNameSpace).
 		When().
 		CreateWithNoNameSpace().
 		Then().
 		And(func(app *Application) {
-			app, err := AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
+			app, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Empty(t, app.Status.Conditions)
 		})
@@ -1710,7 +1709,7 @@ func TestNamespacedCreateAppWithNoNameSpaceForGlobalResource(t *testing.T) {
 // Expect: app.Status.Conditions for deployment ans service which does not have namespace in manifest
 func TestNamespacedCreateAppWithNoNameSpaceWhenRequired(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path(guestbookPath).
 		When().
@@ -1718,7 +1717,7 @@ func TestNamespacedCreateAppWithNoNameSpaceWhenRequired(t *testing.T) {
 		Refresh(RefreshTypeNormal).
 		Then().
 		And(func(app *Application) {
-			updatedApp, err := AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
+			updatedApp, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Len(t, updatedApp.Status.Conditions, 2)
@@ -1736,7 +1735,7 @@ func TestNamespacedCreateAppWithNoNameSpaceWhenRequired(t *testing.T) {
 // Expect: app.Status.Conditions for deployment and service which does not have namespace in manifest
 func TestNamespacedCreateAppWithNoNameSpaceWhenRequired2(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path(guestbookWithNamespace).
 		When().
@@ -1744,7 +1743,7 @@ func TestNamespacedCreateAppWithNoNameSpaceWhenRequired2(t *testing.T) {
 		Refresh(RefreshTypeNormal).
 		Then().
 		And(func(app *Application) {
-			updatedApp, err := AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
+			updatedApp, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Len(t, updatedApp.Status.Conditions, 2)
@@ -1754,15 +1753,15 @@ func TestNamespacedCreateAppWithNoNameSpaceWhenRequired2(t *testing.T) {
 }
 
 func TestNamespacedListResource(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		ProjectSpec(AppProjectSpec{
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: &OrphanedResourcesMonitorSettings{Warn: ptr.To(true)},
-			SourceNamespaces:  []string{AppNamespace()},
+			SourceNamespaces:  []string{fixture.AppNamespace()},
 		}).
 		Path(guestbookPath).
 		When().
@@ -1773,7 +1772,7 @@ func TestNamespacedListResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -1783,19 +1782,19 @@ func TestNamespacedListResource(t *testing.T) {
 		Then().
 		Expect(Condition(ApplicationConditionOrphanedResourceWarning, "Application has 1 orphaned resources")).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.QualifiedName())
+			output, err := fixture.RunCli("app", "resources", app.QualifiedName())
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 			assert.Contains(t, output, "guestbook-ui")
 		}).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.QualifiedName(), "--orphaned=true")
+			output, err := fixture.RunCli("app", "resources", app.QualifiedName(), "--orphaned=true")
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 			assert.NotContains(t, output, "guestbook-ui")
 		}).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.QualifiedName(), "--orphaned=false")
+			output, err := fixture.RunCli("app", "resources", app.QualifiedName(), "--orphaned=false")
 			require.NoError(t, err)
 			assert.NotContains(t, output, "orphaned-configmap")
 			assert.Contains(t, output, "guestbook-ui")
@@ -1805,7 +1804,7 @@ func TestNamespacedListResource(t *testing.T) {
 			SourceRepos:       []string{"*"},
 			Destinations:      []ApplicationDestination{{Namespace: "*", Server: "*"}},
 			OrphanedResources: nil,
-			SourceNamespaces:  []string{AppNamespace()},
+			SourceNamespaces:  []string{fixture.AppNamespace()},
 		}).
 		When().
 		Refresh(RefreshTypeNormal).
@@ -1823,16 +1822,16 @@ func TestNamespacedListResource(t *testing.T) {
 //		application sync successful
 //		when application is deleted, --dest-namespace is not deleted
 func TestNamespacedNamespaceAutoCreation(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	updatedNamespace := getNewNamespace(t)
 	defer func() {
 		if !t.Skipped() {
-			_, err := Run("", "kubectl", "delete", "namespace", updatedNamespace)
+			_, err := fixture.Run("", "kubectl", "delete", "namespace", updatedNamespace)
 			require.NoError(t, err)
 		}
 	}()
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Timeout(30).
 		Path("guestbook").
@@ -1855,7 +1854,7 @@ func TestNamespacedNamespaceAutoCreation(t *testing.T) {
 		Expect(Success("")).
 		And(func(app *Application) {
 			// Verify delete app does not delete the namespace auto created
-			output, err := Run("", "kubectl", "get", "namespace", updatedNamespace)
+			output, err := fixture.Run("", "kubectl", "get", "namespace", updatedNamespace)
 			require.NoError(t, err)
 			assert.Contains(t, output, updatedNamespace)
 		})
@@ -1867,17 +1866,17 @@ func TestNamespacedNamespaceAutoCreation(t *testing.T) {
 //
 //	    Verify application --dest-namespace is created with managedNamespaceMetadata
 func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	updatedNamespace := getNewNamespace(t)
 	defer func() {
 		if !t.Skipped() {
-			_, err := Run("", "kubectl", "delete", "namespace", updatedNamespace)
+			_, err := fixture.Run("", "kubectl", "delete", "namespace", updatedNamespace)
 			require.NoError(t, err)
 		}
 	}()
 	ctx := Given(t)
 	ctx.
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Timeout(30).
 		Path("guestbook").
@@ -1916,7 +1915,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		Expect(ResourceSyncStatusWithNamespaceIs("Deployment", "guestbook-ui", updatedNamespace, SyncStatusCodeSynced)).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/spec/syncPolicy/managedNamespaceMetadata/labels", "value": {"new":"label"} }]`), metav1.PatchOptions{}))
 		}).
 		Sync().
@@ -1935,7 +1934,7 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 		})).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/spec/syncPolicy/managedNamespaceMetadata/annotations", "value": {"new":"custom-annotation"} }]`), metav1.PatchOptions{}))
 		}).
 		Sync().
@@ -1960,18 +1959,18 @@ func TestNamespacedNamespaceAutoCreationWithMetadata(t *testing.T) {
 //
 //	    Verify application namespace manifest takes precedence over managedNamespaceMetadata
 func TestNamespacedNamespaceAutoCreationWithMetadataAndNsManifest(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	namespace := "guestbook-ui-with-namespace-manifest"
 	defer func() {
 		if !t.Skipped() {
-			_, err := Run("", "kubectl", "delete", "namespace", namespace)
+			_, err := fixture.Run("", "kubectl", "delete", "namespace", namespace)
 			require.NoError(t, err)
 		}
 	}()
 
 	ctx := Given(t)
 	ctx.
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Timeout(30).
 		Path("guestbook-with-namespace-manifest").
@@ -2014,11 +2013,11 @@ func TestNamespacedNamespaceAutoCreationWithMetadataAndNsManifest(t *testing.T) 
 //
 //	    Verify application --dest-namespace is updated with managedNamespaceMetadata labels and annotations
 func TestNamespacedNamespaceAutoCreationWithPreexistingNs(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	updatedNamespace := getNewNamespace(t)
 	defer func() {
 		if !t.Skipped() {
-			_, err := Run("", "kubectl", "delete", "namespace", updatedNamespace)
+			_, err := fixture.Run("", "kubectl", "delete", "namespace", updatedNamespace)
 			require.NoError(t, err)
 		}
 	}()
@@ -2040,12 +2039,12 @@ metadata:
 	_, err = tmpFile.Write([]byte(s))
 	errors.CheckError(err)
 
-	_, err = Run("", "kubectl", "apply", "-f", tmpFile.Name())
+	_, err = fixture.Run("", "kubectl", "apply", "-f", tmpFile.Name())
 	require.NoError(t, err)
 
 	ctx := Given(t)
 	ctx.
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Timeout(30).
 		Path("guestbook").
@@ -2087,7 +2086,7 @@ metadata:
 		})).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "add", "path": "/spec/syncPolicy/managedNamespaceMetadata/annotations/something", "value": "hmm" }]`), metav1.PatchOptions{}))
 		}).
 		Sync().
@@ -2107,7 +2106,7 @@ metadata:
 		})).
 		When().
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(AppNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.AppNamespace()).Patch(context.Background(),
 				ctx.GetName(), types.JSONPatchType, []byte(`[{ "op": "remove", "path": "/spec/syncPolicy/managedNamespaceMetadata/annotations/something" }]`), metav1.PatchOptions{}))
 		}).
 		Sync().
@@ -2132,7 +2131,7 @@ metadata:
 
 func TestNamespacedFailedSyncWithRetry(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("hook").
 		When().
@@ -2149,15 +2148,15 @@ func TestNamespacedFailedSyncWithRetry(t *testing.T) {
 
 func TestNamespacedCreateDisableValidation(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("baddir").
 		When().
 		CreateApp("--validate=false").
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "create", app.QualifiedName(), "--upsert", "--validate=false", "--repo", RepoURL(RepoURLTypeFile),
-				"--path", "baddir2", "--project", app.Spec.Project, "--dest-server", KubernetesInternalAPIServerAddr, "--dest-namespace", DeploymentNamespace())
+			_, err := fixture.RunCli("app", "create", app.QualifiedName(), "--upsert", "--validate=false", "--repo", fixture.RepoURL(fixture.RepoURLTypeFile),
+				"--path", "baddir2", "--project", app.Spec.Project, "--dest-server", KubernetesInternalAPIServerAddr, "--dest-namespace", fixture.DeploymentNamespace())
 			require.NoError(t, err)
 		}).
 		When().
@@ -2181,7 +2180,7 @@ spec:
 
 	path := "helm-values"
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		When().
 		// app should be auto-synced once created
@@ -2228,11 +2227,11 @@ definitions:
     return obj
 `
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("crd-subresource").
 		And(func() {
-			CheckError(SetResourceOverrides(map[string]ResourceOverride{
+			CheckError(fixture.SetResourceOverrides(map[string]ResourceOverride{
 				"argoproj.io/StatusSubResource": {
 					Actions: actions,
 				},
@@ -2248,49 +2247,49 @@ definitions:
 		Then().
 		// tests resource actions on a CRD using status subresource
 		And(func(app *Application) {
-			_, err := RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "StatusSubResource", "update-both")
+			_, err := fixture.RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "StatusSubResource", "update-both")
 			require.NoError(t, err)
-			text := FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text := FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-both", text)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-both", text)
 
-			_, err = RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "StatusSubResource", "update-spec")
+			_, err = fixture.RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "StatusSubResource", "update-spec")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-spec", text)
 
-			_, err = RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "StatusSubResource", "update-status")
+			_, err = fixture.RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "StatusSubResource", "update-status")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-status", text)
 		}).
 		// tests resource actions on a CRD *not* using status subresource
 		And(func(app *Application) {
-			_, err := RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "NonStatusSubResource", "update-both")
+			_, err := fixture.RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "NonStatusSubResource", "update-both")
 			require.NoError(t, err)
-			text := FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text := FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-both", text)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-both", text)
 
-			_, err = RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "NonStatusSubResource", "update-spec")
+			_, err = fixture.RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "NonStatusSubResource", "update-spec")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-spec", text)
 
-			_, err = RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "NonStatusSubResource", "update-status")
+			_, err = fixture.RunCli("app", "actions", "run", app.QualifiedName(), "--kind", "NonStatusSubResource", "update-status")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-status", text)
 		})
 }
 
 func TestNamespacedAppLogs(t *testing.T) {
 	t.SkipNow() // Too flaky. https://github.com/argoproj/argo-cd/issues/13834
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("guestbook-logs").
 		When().
@@ -2299,17 +2298,17 @@ func TestNamespacedAppLogs(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", app.QualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", app.QualifiedName(), "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", app.QualifiedName(), "--kind", "Pod")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", app.QualifiedName(), "--kind", "Pod")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(5, "app", "logs", app.QualifiedName(), "--kind", "Service")
+			out, err := fixture.RunCliWithRetry(5, "app", "logs", app.QualifiedName(), "--kind", "Service")
 			require.NoError(t, err)
 			assert.NotContains(t, out, "Hi")
 		})
@@ -2317,10 +2316,10 @@ func TestNamespacedAppLogs(t *testing.T) {
 
 func TestNamespacedAppWaitOperationInProgress(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		And(func() {
-			CheckError(SetResourceOverrides(map[string]ResourceOverride{
+			CheckError(fixture.SetResourceOverrides(map[string]ResourceOverride{
 				"batch/Job": {
 					HealthLua: `return { status = 'Running' }`,
 				},
@@ -2340,14 +2339,14 @@ func TestNamespacedAppWaitOperationInProgress(t *testing.T) {
 		When().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "wait", app.QualifiedName(), "--suspended")
+			_, err := fixture.RunCli("app", "wait", app.QualifiedName(), "--suspended")
 			errors.CheckError(err)
 		})
 }
 
 func TestNamespacedSyncOptionReplace(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("config-map").
 		When().
@@ -2370,7 +2369,7 @@ func TestNamespacedSyncOptionReplace(t *testing.T) {
 
 func TestNamespacedSyncOptionReplaceFromCLI(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("config-map").
 		Replace().
@@ -2394,7 +2393,7 @@ func TestNamespacedSyncOptionReplaceFromCLI(t *testing.T) {
 func TestNamespacedDiscoverNewCommit(t *testing.T) {
 	var sha string
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("config-map").
 		When().
@@ -2426,7 +2425,7 @@ func TestNamespacedDiscoverNewCommit(t *testing.T) {
 
 func TestNamespacedDisableManifestGeneration(t *testing.T) {
 	Given(t).
-		SetAppNamespace(AppNamespace()).
+		SetAppNamespace(fixture.AppNamespace()).
 		SetTrackingMethod("annotation").
 		Path("guestbook").
 		When().
@@ -2438,7 +2437,7 @@ func TestNamespacedDisableManifestGeneration(t *testing.T) {
 		}).
 		When().
 		And(func() {
-			CheckError(SetEnableManifestGeneration(map[ApplicationSourceType]bool{
+			CheckError(fixture.SetEnableManifestGeneration(map[ApplicationSourceType]bool{
 				ApplicationSourceTypeKustomize: false,
 			}))
 		}).

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -30,14 +30,12 @@ import (
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	accountFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/account"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	projectFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/project"
 	repoFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/repos"
 	"github.com/argoproj/argo-cd/v2/test/e2e/testdata"
 	"github.com/argoproj/argo-cd/v2/util/argo"
-	. "github.com/argoproj/argo-cd/v2/util/argo"
 	. "github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/argo-cd/v2/util/settings"
@@ -59,7 +57,7 @@ func TestGetLogsAllowNoSwitch(t *testing.T) {
 }
 
 func TestGetLogsDenySwitchOn(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 
 	accountFixture.Given(t).
 		Name("test").
@@ -98,13 +96,13 @@ func TestGetLogsDenySwitchOn(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			_, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			_, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			assert.ErrorContains(t, err, "permission denied")
 		})
 }
 
 func TestGetLogsAllowSwitchOn(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 
 	accountFixture.Given(t).
 		Name("test").
@@ -148,24 +146,24 @@ func TestGetLogsAllowSwitchOn(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Pod")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Pod")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Service")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Service")
 			require.NoError(t, err)
 			assert.NotContains(t, out, "Hi")
 		})
 }
 
 func TestGetLogsAllowSwitchOff(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 
 	accountFixture.Given(t).
 		Name("test").
@@ -204,24 +202,24 @@ func TestGetLogsAllowSwitchOff(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Pod")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Pod")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Service")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Service")
 			require.NoError(t, err)
 			assert.NotContains(t, out, "Hi")
 		})
 }
 
 func TestSyncToUnsignedCommit(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Path(guestbookPath).
@@ -236,7 +234,7 @@ func TestSyncToUnsignedCommit(t *testing.T) {
 }
 
 func TestSyncToSignedCommitWithoutKnownKey(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Path(guestbookPath).
@@ -252,7 +250,7 @@ func TestSyncToSignedCommitWithoutKnownKey(t *testing.T) {
 }
 
 func TestSyncToSignedCommitWithKnownKey(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Path(guestbookPath).
@@ -270,7 +268,7 @@ func TestSyncToSignedCommitWithKnownKey(t *testing.T) {
 }
 
 func TestSyncToSignedBranchWithKnownKey(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Path(guestbookPath).
@@ -289,7 +287,7 @@ func TestSyncToSignedBranchWithKnownKey(t *testing.T) {
 }
 
 func TestSyncToSignedBranchWithUnknownKey(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Path(guestbookPath).
@@ -307,7 +305,7 @@ func TestSyncToSignedBranchWithUnknownKey(t *testing.T) {
 }
 
 func TestSyncToUnsignedBranch(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Revision("master").
@@ -325,7 +323,7 @@ func TestSyncToUnsignedBranch(t *testing.T) {
 }
 
 func TestSyncToSignedTagWithKnownKey(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Revision("signed-tag").
@@ -344,7 +342,7 @@ func TestSyncToSignedTagWithKnownKey(t *testing.T) {
 }
 
 func TestSyncToSignedTagWithUnknownKey(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Revision("signed-tag").
@@ -362,7 +360,7 @@ func TestSyncToSignedTagWithUnknownKey(t *testing.T) {
 }
 
 func TestSyncToUnsignedTag(t *testing.T) {
-	SkipOnEnv(t, "GPG")
+	fixture.SkipOnEnv(t, "GPG")
 	Given(t).
 		Project("gpg").
 		Revision("unsigned-tag").
@@ -389,18 +387,18 @@ func TestAppCreation(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
-			assert.Equal(t, Name(), app.Name)
-			assert.Equal(t, RepoURL(RepoURLTypeFile), app.Spec.GetSource().RepoURL)
+			assert.Equal(t, fixture.Name(), app.Name)
+			assert.Equal(t, fixture.RepoURL(fixture.RepoURLTypeFile), app.Spec.GetSource().RepoURL)
 			assert.Equal(t, guestbookPath, app.Spec.GetSource().Path)
-			assert.Equal(t, DeploymentNamespace(), app.Spec.Destination.Namespace)
+			assert.Equal(t, fixture.DeploymentNamespace(), app.Spec.Destination.Namespace)
 			assert.Equal(t, KubernetesInternalAPIServerAddr, app.Spec.Destination.Server)
 		}).
-		Expect(Event(EventReasonResourceCreated, "create")).
+		Expect(Event(argo.EventReasonResourceCreated, "create")).
 		And(func(_ *Application) {
 			// app should be listed
-			output, err := RunCli("app", "list")
+			output, err := fixture.RunCli("app", "list")
 			require.NoError(t, err)
-			assert.Contains(t, output, Name())
+			assert.Contains(t, output, fixture.Name())
 		}).
 		When().
 		// ensure that create is idempotent
@@ -411,7 +409,7 @@ func TestAppCreation(t *testing.T) {
 		When().
 		// ensure that update replaces spec and merge labels and annotations
 		And(func() {
-			FailOnErr(AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Patch(context.Background(),
 				ctx.GetName(), types.MergePatchType, []byte(`{"metadata": {"labels": { "test": "label" }, "annotations": { "test": "annotation" }}}`), metav1.PatchOptions{}))
 		}).
 		CreateApp("--upsert").
@@ -435,17 +433,17 @@ func TestAppCreationWithoutForceUpdate(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
 			assert.Equal(t, ctx.AppName(), app.Name)
-			assert.Equal(t, RepoURL(RepoURLTypeFile), app.Spec.GetSource().RepoURL)
+			assert.Equal(t, fixture.RepoURL(fixture.RepoURLTypeFile), app.Spec.GetSource().RepoURL)
 			assert.Equal(t, guestbookPath, app.Spec.GetSource().Path)
-			assert.Equal(t, DeploymentNamespace(), app.Spec.Destination.Namespace)
+			assert.Equal(t, fixture.DeploymentNamespace(), app.Spec.Destination.Namespace)
 			assert.Equal(t, "in-cluster", app.Spec.Destination.Name)
 		}).
-		Expect(Event(EventReasonResourceCreated, "create")).
+		Expect(Event(argo.EventReasonResourceCreated, "create")).
 		And(func(_ *Application) {
 			// app should be listed
-			output, err := RunCli("app", "list")
+			output, err := fixture.RunCli("app", "list")
 			require.NoError(t, err)
-			assert.Contains(t, output, Name())
+			assert.Contains(t, output, fixture.Name())
 		}).
 		When().
 		IgnoreErrors().
@@ -505,7 +503,7 @@ func TestDeleteAppResource(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(_ *Application) {
 			// app should be listed
-			if _, err := RunCli("app", "delete-resource", Name(), "--kind", "Service", "--resource-name", "guestbook-ui"); err != nil {
+			if _, err := fixture.RunCli("app", "delete-resource", fixture.Name(), "--kind", "Service", "--resource-name", "guestbook-ui"); err != nil {
 				require.NoError(t, err)
 			}
 		}).
@@ -532,7 +530,7 @@ func TestPatchHttp(t *testing.T) {
 
 // demonstrate that we cannot use a standard sync when an immutable field is changed, we must use "force"
 func TestImmutableChange(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
 		Path("secrets").
 		When().
@@ -555,7 +553,7 @@ func TestImmutableChange(t *testing.T) {
 		Expect(ResourceResultMatches(ResourceResult{
 			Kind:      "Secret",
 			Version:   "v1",
-			Namespace: DeploymentNamespace(),
+			Namespace: fixture.DeploymentNamespace(),
 			Name:      "test-secret",
 			SyncPhase: "Sync",
 			Status:    "SyncFailed",
@@ -597,11 +595,11 @@ func TestAppDeletion(t *testing.T) {
 		Delete(true).
 		Then().
 		Expect(DoesNotExist()).
-		Expect(Event(EventReasonResourceDeleted, "delete"))
+		Expect(Event(argo.EventReasonResourceDeleted, "delete"))
 
-	output, err := RunCli("app", "list")
+	output, err := fixture.RunCli("app", "list")
 	require.NoError(t, err)
-	assert.NotContains(t, output, Name())
+	assert.NotContains(t, output, fixture.Name())
 }
 
 func TestAppLabels(t *testing.T) {
@@ -611,9 +609,9 @@ func TestAppLabels(t *testing.T) {
 		CreateApp("-l", "foo=bar").
 		Then().
 		And(func(app *Application) {
-			assert.Contains(t, FailOnErr(RunCli("app", "list")), Name())
-			assert.Contains(t, FailOnErr(RunCli("app", "list", "-l", "foo=bar")), Name())
-			assert.NotContains(t, FailOnErr(RunCli("app", "list", "-l", "foo=rubbish")), Name())
+			assert.Contains(t, FailOnErr(fixture.RunCli("app", "list")), fixture.Name())
+			assert.Contains(t, FailOnErr(fixture.RunCli("app", "list", "-l", "foo=bar")), fixture.Name())
+			assert.NotContains(t, FailOnErr(fixture.RunCli("app", "list", "-l", "foo=rubbish")), fixture.Name())
 		}).
 		Given().
 		// remove both name and replace labels means nothing will sync
@@ -640,9 +638,9 @@ func TestTrackAppStateAndSyncApp(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
-		Expect(Success(fmt.Sprintf("Service     %s  guestbook-ui  Synced ", DeploymentNamespace()))).
-		Expect(Success(fmt.Sprintf("apps   Deployment  %s  guestbook-ui  Synced", DeploymentNamespace()))).
-		Expect(Event(EventReasonResourceUpdated, "sync")).
+		Expect(Success(fmt.Sprintf("Service     %s  guestbook-ui  Synced ", fixture.DeploymentNamespace()))).
+		Expect(Success(fmt.Sprintf("apps   Deployment  %s  guestbook-ui  Synced", fixture.DeploymentNamespace()))).
+		Expect(Event(argo.EventReasonResourceUpdated, "sync")).
 		And(func(app *Application) {
 			assert.NotNil(t, app.Status.OperationState.SyncResult)
 		})
@@ -674,14 +672,14 @@ func TestAppRollbackSuccessful(t *testing.T) {
 			}}
 			patch, _, err := diff.CreateTwoWayMergePatch(app, appWithHistory, &Application{})
 			require.NoError(t, err)
-			app, err = AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).Patch(context.Background(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			app, err = fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Patch(context.Background(), app.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 			require.NoError(t, err)
 
 			// sync app and make sure it reaches InSync state
-			_, err = RunCli("app", "rollback", app.Name, "1")
+			_, err = fixture.RunCli("app", "rollback", app.Name, "1")
 			require.NoError(t, err)
 		}).
-		Expect(Event(EventReasonOperationStarted, "rollback")).
+		Expect(Event(argo.EventReasonOperationStarted, "rollback")).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
 			assert.Equal(t, SyncStatusCodeSynced, app.Status.Sync.Status)
@@ -723,7 +721,7 @@ func TestManipulateApplicationResources(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			manifests, err := RunCli("app", "manifests", app.Name, "--source", "live")
+			manifests, err := fixture.RunCli("app", "manifests", app.Name, "--source", "live")
 			require.NoError(t, err)
 			resources, err := kube.SplitYAML([]byte(manifests))
 			require.NoError(t, err)
@@ -739,7 +737,7 @@ func TestManipulateApplicationResources(t *testing.T) {
 
 			deployment := resources[index]
 
-			closer, client, err := ArgoCDClientset.NewApplicationClient()
+			closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 			require.NoError(t, err)
 			defer io.Close(closer)
 
@@ -782,7 +780,7 @@ func assetSecretDataHidden(t *testing.T, manifest string) {
 }
 
 func TestAppWithSecrets(t *testing.T) {
-	closer, client, err := ArgoCDClientset.NewApplicationClient()
+	closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 	require.NoError(t, err)
 	defer io.Close(closer)
 
@@ -811,19 +809,19 @@ func TestAppWithSecrets(t *testing.T) {
 				assetSecretDataHidden(t, manifest)
 			}
 
-			diffOutput := FailOnErr(RunCli("app", "diff", app.Name)).(string)
+			diffOutput := FailOnErr(fixture.RunCli("app", "diff", app.Name)).(string)
 			assert.Empty(t, diffOutput)
 
 			// make sure resource update error does not print secret details
-			_, err = RunCli("app", "patch-resource", "test-app-with-secrets", "--resource-name", "test-secret",
+			_, err = fixture.RunCli("app", "patch-resource", "test-app-with-secrets", "--resource-name", "test-secret",
 				"--kind", "Secret", "--patch", `{"op": "add", "path": "/data", "value": "hello"}'`,
 				"--patch-type", "application/json-patch+json")
-			require.ErrorContains(t, err, fmt.Sprintf("failed to patch Secret %s/test-secret", DeploymentNamespace()))
+			require.ErrorContains(t, err, fmt.Sprintf("failed to patch Secret %s/test-secret", fixture.DeploymentNamespace()))
 			assert.NotContains(t, err.Error(), "username")
 			assert.NotContains(t, err.Error(), "password")
 
 			// patch secret and make sure app is out of sync and diff detects the change
-			FailOnErr(KubeClientset.CoreV1().Secrets(DeploymentNamespace()).Patch(context.Background(),
+			FailOnErr(fixture.KubeClientset.CoreV1().Secrets(fixture.DeploymentNamespace()).Patch(context.Background(),
 				"test-secret", types.JSONPatchType, []byte(`[
 	{"op": "remove", "path": "/data/username"},
 	{"op": "add", "path": "/stringData", "value": {"password": "foo"}}
@@ -834,13 +832,13 @@ func TestAppWithSecrets(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", app.Name)
+			diffOutput, err := fixture.RunCli("app", "diff", app.Name)
 			require.Error(t, err)
 			assert.Contains(t, diffOutput, "username: ++++++++")
 			assert.Contains(t, diffOutput, "password: ++++++++++++")
 
 			// local diff should ignore secrets
-			diffOutput = FailOnErr(RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")).(string)
+			diffOutput = FailOnErr(fixture.RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")).(string)
 			assert.Empty(t, diffOutput)
 
 			// ignore missing field and make sure diff shows no difference
@@ -855,7 +853,7 @@ func TestAppWithSecrets(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			diffOutput := FailOnErr(RunCli("app", "diff", app.Name)).(string)
+			diffOutput := FailOnErr(fixture.RunCli("app", "diff", app.Name)).(string)
 			assert.Empty(t, diffOutput)
 		}).
 		// verify not committed secret also ignore during diffing
@@ -869,7 +867,7 @@ stringData:
   username: test-username`).
 		Then().
 		And(func(app *Application) {
-			diffOutput := FailOnErr(RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")).(string)
+			diffOutput := FailOnErr(fixture.RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")).(string)
 			assert.Empty(t, diffOutput)
 		})
 }
@@ -884,7 +882,7 @@ func TestResourceDiffing(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
 			// Patch deployment
-			_, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Patch(context.Background(),
+			_, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Patch(context.Background(),
 				"guestbook-ui", types.JSONPatchType, []byte(`[{ "op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "test" }]`), metav1.PatchOptions{})
 			require.NoError(t, err)
 		}).
@@ -893,9 +891,9 @@ func TestResourceDiffing(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")
+			diffOutput, err := fixture.RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")
 			require.Error(t, err)
-			assert.Contains(t, diffOutput, fmt.Sprintf("===== apps/Deployment %s/guestbook-ui ======", DeploymentNamespace()))
+			assert.Contains(t, diffOutput, fmt.Sprintf("===== apps/Deployment %s/guestbook-ui ======", fixture.DeploymentNamespace()))
 		}).
 		Given().
 		ResourceOverrides(map[string]ResourceOverride{"apps/Deployment": {
@@ -906,7 +904,7 @@ func TestResourceDiffing(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")
+			diffOutput, err := fixture.RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")
 			require.NoError(t, err)
 			assert.Empty(t, diffOutput)
 		}).
@@ -924,7 +922,7 @@ func TestResourceDiffing(t *testing.T) {
 			}]`).
 		Sync().
 		And(func() {
-			output, err := RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
+			output, err := fixture.RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", fixture.DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
 			require.NoError(t, err)
 			assert.Contains(t, output, "serverside-applied")
 		}).
@@ -951,12 +949,12 @@ func TestResourceDiffing(t *testing.T) {
 			"value": { "syncOptions": ["RespectIgnoreDifferences=true"] }
 			}]`).
 		And(func() {
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, int32(3), *deployment.Spec.RevisionHistoryLimit)
 		}).
 		And(func() {
-			output, err := RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
+			output, err := fixture.RunWithStdin(testdata.SSARevisionHistoryDeployment, "", "kubectl", "apply", "-n", fixture.DeploymentNamespace(), "--server-side=true", "--field-manager=revision-history-manager", "--validate=false", "--force-conflicts", "-f", "-")
 			require.NoError(t, err)
 			assert.Contains(t, output, "serverside-applied")
 		}).
@@ -965,13 +963,13 @@ func TestResourceDiffing(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, int32(1), *deployment.Spec.RevisionHistoryLimit)
 		}).
 		When().Sync().Then().Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, int32(1), *deployment.Spec.RevisionHistoryLimit)
 		})
@@ -990,7 +988,7 @@ func TestKnownTypesInCRDDiffing(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		When().
 		And(func() {
-			dummyResIf := DynamicClientset.Resource(dummiesGVR).Namespace(DeploymentNamespace())
+			dummyResIf := fixture.DynamicClientset.Resource(dummiesGVR).Namespace(fixture.DeploymentNamespace())
 			patchData := []byte(`{"spec":{"cpu": "2"}}`)
 			FailOnErr(dummyResIf.Patch(context.Background(), "dummy-crd-instance", types.MergePatchType, patchData, metav1.PatchOptions{}))
 		}).Refresh(RefreshTypeNormal).
@@ -998,7 +996,7 @@ func TestKnownTypesInCRDDiffing(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeOutOfSync)).
 		When().
 		And(func() {
-			CheckError(SetResourceOverrides(map[string]ResourceOverride{
+			CheckError(fixture.SetResourceOverrides(map[string]ResourceOverride{
 				"argoproj.io/Dummy": {
 					KnownTypeFields: []KnownTypeField{{
 						Field: "spec",
@@ -1036,7 +1034,7 @@ func testEdgeCasesApplicationResources(t *testing.T, appPath string, statusCode 
 	expect.
 		Expect(HealthIs(statusCode)).
 		And(func(app *Application) {
-			diffOutput, err := RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")
+			diffOutput, err := fixture.RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")
 			assert.Empty(t, diffOutput)
 			require.NoError(t, err)
 		})
@@ -1058,7 +1056,7 @@ func TestOldStyleResourceAction(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			closer, client, err := ArgoCDClientset.NewApplicationClient()
+			closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 			require.NoError(t, err)
 			defer io.Close(closer)
 
@@ -1067,7 +1065,7 @@ func TestOldStyleResourceAction(t *testing.T) {
 				Group:        ptr.To("apps"),
 				Kind:         ptr.To("Deployment"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("guestbook-ui"),
 			})
 			require.NoError(t, err)
@@ -1078,13 +1076,13 @@ func TestOldStyleResourceAction(t *testing.T) {
 				Group:        ptr.To("apps"),
 				Kind:         ptr.To("Deployment"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("guestbook-ui"),
 				Action:       ptr.To("sample"),
 			})
 			require.NoError(t, err)
 
-			deployment, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deployment, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, "test", deployment.Labels["sample"])
@@ -1164,7 +1162,7 @@ func TestNewStyleResourceActionPermitted(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			closer, client, err := ArgoCDClientset.NewApplicationClient()
+			closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 			require.NoError(t, err)
 			defer io.Close(closer)
 
@@ -1173,7 +1171,7 @@ func TestNewStyleResourceActionPermitted(t *testing.T) {
 				Group:        ptr.To("batch"),
 				Kind:         ptr.To("CronJob"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("hello"),
 			})
 			require.NoError(t, err)
@@ -1184,13 +1182,13 @@ func TestNewStyleResourceActionPermitted(t *testing.T) {
 				Group:        ptr.To("batch"),
 				Kind:         ptr.To("CronJob"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("hello"),
 				Action:       ptr.To("sample"),
 			})
 			require.NoError(t, err)
 
-			_, err = KubeClientset.BatchV1().Jobs(DeploymentNamespace()).Get(context.Background(), "hello-123", metav1.GetOptions{})
+			_, err = fixture.KubeClientset.BatchV1().Jobs(fixture.DeploymentNamespace()).Get(context.Background(), "hello-123", metav1.GetOptions{})
 			require.NoError(t, err)
 		})
 }
@@ -1275,7 +1273,7 @@ func TestNewStyleResourceActionMixedOk(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			closer, client, err := ArgoCDClientset.NewApplicationClient()
+			closer, client, err := fixture.ArgoCDClientset.NewApplicationClient()
 			require.NoError(t, err)
 			defer io.Close(closer)
 
@@ -1284,7 +1282,7 @@ func TestNewStyleResourceActionMixedOk(t *testing.T) {
 				Group:        ptr.To("batch"),
 				Kind:         ptr.To("CronJob"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("hello"),
 			})
 			require.NoError(t, err)
@@ -1295,17 +1293,17 @@ func TestNewStyleResourceActionMixedOk(t *testing.T) {
 				Group:        ptr.To("batch"),
 				Kind:         ptr.To("CronJob"),
 				Version:      ptr.To("v1"),
-				Namespace:    ptr.To(DeploymentNamespace()),
+				Namespace:    ptr.To(fixture.DeploymentNamespace()),
 				ResourceName: ptr.To("hello"),
 				Action:       ptr.To("sample"),
 			})
 			require.NoError(t, err)
 
 			// Assert new Job was created
-			_, err = KubeClientset.BatchV1().Jobs(DeploymentNamespace()).Get(context.Background(), "hello-123", metav1.GetOptions{})
+			_, err = fixture.KubeClientset.BatchV1().Jobs(fixture.DeploymentNamespace()).Get(context.Background(), "hello-123", metav1.GetOptions{})
 			require.NoError(t, err)
 			// Assert the original CronJob was patched
-			cronJob, err := KubeClientset.BatchV1().CronJobs(DeploymentNamespace()).Get(context.Background(), "hello", metav1.GetOptions{})
+			cronJob, err := fixture.KubeClientset.BatchV1().CronJobs(fixture.DeploymentNamespace()).Get(context.Background(), "hello", metav1.GetOptions{})
 			assert.Equal(t, "aValue", cronJob.Labels["aKey"])
 			require.NoError(t, err)
 		})
@@ -1319,11 +1317,11 @@ func TestSyncResourceByLabel(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, _ = RunCli("app", "sync", app.Name, "--label", "app.kubernetes.io/instance="+app.Name)
+			_, _ = fixture.RunCli("app", "sync", app.Name, "--label", "app.kubernetes.io/instance="+app.Name)
 		}).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			_, err := RunCli("app", "sync", app.Name, "--label", "this-label=does-not-exist")
+			_, err := fixture.RunCli("app", "sync", app.Name, "--label", "this-label=does-not-exist")
 			assert.ErrorContains(t, err, "level=fatal")
 		})
 }
@@ -1336,11 +1334,11 @@ func TestSyncResourceByProject(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, _ = RunCli("app", "sync", app.Name, "--project", app.Spec.Project)
+			_, _ = fixture.RunCli("app", "sync", app.Name, "--project", app.Spec.Project)
 		}).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			_, err := RunCli("app", "sync", app.Name, "--project", "this-project-does-not-exist")
+			_, err := fixture.RunCli("app", "sync", app.Name, "--project", "this-project-does-not-exist")
 			assert.ErrorContains(t, err, "level=fatal")
 		})
 }
@@ -1353,7 +1351,7 @@ func TestLocalManifestSync(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			res, _ := RunCli("app", "manifests", app.Name)
+			res, _ := fixture.RunCli("app", "manifests", app.Name)
 			assert.Contains(t, res, "containerPort: 80")
 			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.2")
 		}).
@@ -1364,7 +1362,7 @@ func TestLocalManifestSync(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			res, _ := RunCli("app", "manifests", app.Name)
+			res, _ := fixture.RunCli("app", "manifests", app.Name)
 			assert.Contains(t, res, "containerPort: 81")
 			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.3")
 		}).
@@ -1375,7 +1373,7 @@ func TestLocalManifestSync(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			res, _ := RunCli("app", "manifests", app.Name)
+			res, _ := fixture.RunCli("app", "manifests", app.Name)
 			assert.Contains(t, res, "containerPort: 80")
 			assert.Contains(t, res, "image: quay.io/argoprojlabs/argocd-e2e-container:0.2")
 		})
@@ -1389,7 +1387,7 @@ func TestLocalSync(t *testing.T) {
 		CreateApp().
 		Then().
 		And(func(app *Application) {
-			FailOnErr(RunCli("app", "sync", app.Name, "--local", "testdata/helm"))
+			FailOnErr(fixture.RunCli("app", "sync", app.Name, "--local", "testdata/helm"))
 		})
 }
 
@@ -1401,10 +1399,10 @@ func TestNoLocalSyncWithAutosyncEnabled(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "set", app.Name, "--sync-policy", "automated")
+			_, err := fixture.RunCli("app", "set", app.Name, "--sync-policy", "automated")
 			require.NoError(t, err)
 
-			_, err = RunCli("app", "sync", app.Name, "--local", guestbookPathLocal)
+			_, err = fixture.RunCli("app", "sync", app.Name, "--local", guestbookPathLocal)
 			require.Error(t, err)
 		})
 }
@@ -1417,11 +1415,11 @@ func TestLocalSyncDryRunWithAutosyncEnabled(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "set", app.Name, "--sync-policy", "automated")
+			_, err := fixture.RunCli("app", "set", app.Name, "--sync-policy", "automated")
 			require.NoError(t, err)
 
 			appBefore := app.DeepCopy()
-			_, err = RunCli("app", "sync", app.Name, "--dry-run", "--local-repo-root", ".", "--local", guestbookPathLocal)
+			_, err = fixture.RunCli("app", "sync", app.Name, "--dry-run", "--local-repo-root", ".", "--local", guestbookPathLocal)
 			require.NoError(t, err)
 
 			appAfter := app.DeepCopy()
@@ -1453,17 +1451,17 @@ func assertResourceActions(t *testing.T, appName string, successful bool) {
 		}
 	}
 
-	closer, cdClient := ArgoCDClientset.NewApplicationClientOrDie()
+	closer, cdClient := fixture.ArgoCDClientset.NewApplicationClientOrDie()
 	defer io.Close(closer)
 
-	deploymentResource, err := KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+	deploymentResource, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 	require.NoError(t, err)
 
 	logs, err := cdClient.PodLogs(context.Background(), &applicationpkg.ApplicationPodLogsQuery{
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
 		Name:         &appName,
-		Namespace:    ptr.To(DeploymentNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Container:    ptr.To(""),
 		SinceSeconds: ptr.To(int64(0)),
 		TailLines:    ptr.To(int64(0)),
@@ -1478,7 +1476,7 @@ func assertResourceActions(t *testing.T, appName string, successful bool) {
 	_, err = cdClient.ListResourceEvents(context.Background(), &applicationpkg.ApplicationResourceEventsQuery{
 		Name:              &appName,
 		ResourceName:      ptr.To("guestbook-ui"),
-		ResourceNamespace: ptr.To(DeploymentNamespace()),
+		ResourceNamespace: ptr.To(fixture.DeploymentNamespace()),
 		ResourceUID:       ptr.To(string(deploymentResource.UID)),
 	})
 	assertError(err, fmt.Sprintf("%s not found as part of application %s", "guestbook-ui", appName))
@@ -1486,7 +1484,7 @@ func assertResourceActions(t *testing.T, appName string, successful bool) {
 	_, err = cdClient.GetResource(context.Background(), &applicationpkg.ApplicationResourceRequest{
 		Name:         &appName,
 		ResourceName: ptr.To("guestbook-ui"),
-		Namespace:    ptr.To(DeploymentNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Version:      ptr.To("v1"),
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
@@ -1496,7 +1494,7 @@ func assertResourceActions(t *testing.T, appName string, successful bool) {
 	_, err = cdClient.RunResourceAction(context.Background(), &applicationpkg.ResourceActionRunRequest{
 		Name:         &appName,
 		ResourceName: ptr.To("guestbook-ui"),
-		Namespace:    ptr.To(DeploymentNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Version:      ptr.To("v1"),
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
@@ -1507,7 +1505,7 @@ func assertResourceActions(t *testing.T, appName string, successful bool) {
 	_, err = cdClient.DeleteResource(context.Background(), &applicationpkg.ApplicationResourceDeleteRequest{
 		Name:         &appName,
 		ResourceName: ptr.To("guestbook-ui"),
-		Namespace:    ptr.To(DeploymentNamespace()),
+		Namespace:    ptr.To(fixture.DeploymentNamespace()),
 		Version:      ptr.To("v1"),
 		Group:        ptr.To("apps"),
 		Kind:         ptr.To("Deployment"),
@@ -1524,8 +1522,8 @@ func TestPermissions(t *testing.T) {
 		When().
 		Create()
 
-	sourceError := fmt.Sprintf("application repo %s is not permitted in project 'argo-project'", RepoURL(RepoURLTypeFile))
-	destinationError := fmt.Sprintf("application destination server '%s' and namespace '%s' do not match any of the allowed destinations in project 'argo-project'", KubernetesInternalAPIServerAddr, DeploymentNamespace())
+	sourceError := fmt.Sprintf("application repo %s is not permitted in project 'argo-project'", fixture.RepoURL(fixture.RepoURLTypeFile))
+	destinationError := fmt.Sprintf("application destination server '%s' and namespace '%s' do not match any of the allowed destinations in project 'argo-project'", KubernetesInternalAPIServerAddr, fixture.DeploymentNamespace())
 
 	appCtx.
 		Path("guestbook-logs").
@@ -1565,7 +1563,7 @@ func TestPermissions(t *testing.T) {
 		Expect(Condition(ApplicationConditionInvalidSpecError, destinationError)).
 		Expect(Condition(ApplicationConditionInvalidSpecError, sourceError)).
 		And(func(app *Application) {
-			closer, cdClient := ArgoCDClientset.NewApplicationClientOrDie()
+			closer, cdClient := fixture.ArgoCDClientset.NewApplicationClientOrDie()
 			defer io.Close(closer)
 			appName, appNs := argo.ParseFromQualifiedName(app.Name, "")
 			fmt.Printf("APP NAME: %s\n", appName)
@@ -1605,13 +1603,13 @@ func TestPermissionWithScopedRepo(t *testing.T) {
 
 	repoFixture.GivenWithSameState(t).
 		When().
-		Path(RepoURL(RepoURLTypeFile)).
+		Path(fixture.RepoURL(fixture.RepoURLTypeFile)).
 		Project(projName).
 		Create()
 
 	GivenWithSameState(t).
 		Project(projName).
-		RepoURLType(RepoURLTypeFile).
+		RepoURLType(fixture.RepoURLTypeFile).
 		Path("two-nice-pods").
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Prune=false"}}]`).
@@ -1642,12 +1640,12 @@ func TestPermissionDeniedWithScopedRepo(t *testing.T) {
 
 	repoFixture.GivenWithSameState(t).
 		When().
-		Path(RepoURL(RepoURLTypeFile)).
+		Path(fixture.RepoURL(fixture.RepoURLTypeFile)).
 		Create()
 
 	GivenWithSameState(t).
 		Project(projName).
-		RepoURLType(RepoURLTypeFile).
+		RepoURLType(fixture.RepoURLTypeFile).
 		Path("two-nice-pods").
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Prune=false"}}]`).
@@ -1668,13 +1666,13 @@ func TestPermissionDeniedWithNegatedNamespace(t *testing.T) {
 
 	repoFixture.GivenWithSameState(t).
 		When().
-		Path(RepoURL(RepoURLTypeFile)).
+		Path(fixture.RepoURL(fixture.RepoURLTypeFile)).
 		Project(projName).
 		Create()
 
 	GivenWithSameState(t).
 		Project(projName).
-		RepoURLType(RepoURLTypeFile).
+		RepoURLType(fixture.RepoURLTypeFile).
 		Path("two-nice-pods").
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Prune=false"}}]`).
@@ -1695,13 +1693,13 @@ func TestPermissionDeniedWithNegatedServer(t *testing.T) {
 
 	repoFixture.GivenWithSameState(t).
 		When().
-		Path(RepoURL(RepoURLTypeFile)).
+		Path(fixture.RepoURL(fixture.RepoURLTypeFile)).
 		Project(projName).
 		Create()
 
 	GivenWithSameState(t).
 		Project(projName).
-		RepoURLType(RepoURLTypeFile).
+		RepoURLType(fixture.RepoURLTypeFile).
 		Path("two-nice-pods").
 		When().
 		PatchFile("pod-1.yaml", `[{"op": "add", "path": "/metadata/annotations", "value": {"argocd.argoproj.io/sync-options": "Prune=false"}}]`).
@@ -1793,7 +1791,7 @@ func TestSourceNamespaceCanBeMigratedToManagedNamespaceWithoutBeingPrunedOrOutOf
 		Prune(true).
 		Path("guestbook-with-plain-namespace-manifest").
 		When().
-		PatchFile("guestbook-ui-namespace.yaml", fmt.Sprintf(`[{"op": "replace", "path": "/metadata/name", "value": "%s"}]`, DeploymentNamespace())).
+		PatchFile("guestbook-ui-namespace.yaml", fmt.Sprintf(`[{"op": "replace", "path": "/metadata/name", "value": "%s"}]`, fixture.DeploymentNamespace())).
 		CreateApp().
 		Sync().
 		Then().
@@ -1826,7 +1824,7 @@ func TestSelfManagedApps(t *testing.T) {
 	Given(t).
 		Path("self-managed-app").
 		When().
-		PatchFile("resources.yaml", fmt.Sprintf(`[{"op": "replace", "path": "/spec/source/repoURL", "value": "%s"}]`, RepoURL(RepoURLTypeFile))).
+		PatchFile("resources.yaml", fmt.Sprintf(`[{"op": "replace", "path": "/spec/source/repoURL", "value": "%s"}]`, fixture.RepoURL(fixture.RepoURLTypeFile))).
 		CreateApp().
 		Sync().
 		Then().
@@ -1838,7 +1836,7 @@ func TestSelfManagedApps(t *testing.T) {
 
 			reconciledCount := 0
 			var lastReconciledAt *metav1.Time
-			for event := range ArgoCDClientset.WatchApplicationWithRetry(ctx, a.Name, a.ResourceVersion) {
+			for event := range fixture.ArgoCDClientset.WatchApplicationWithRetry(ctx, a.Name, a.ResourceVersion) {
 				reconciledAt := event.Application.Status.ReconciledAt
 				if reconciledAt == nil {
 					reconciledAt = &metav1.Time{}
@@ -1892,7 +1890,7 @@ func TestRevisionHistoryLimit(t *testing.T) {
 }
 
 func TestOrphanedResource(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
 		ProjectSpec(AppProjectSpec{
 			SourceRepos:       []string{"*"},
@@ -1908,7 +1906,7 @@ func TestOrphanedResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -1918,7 +1916,7 @@ func TestOrphanedResource(t *testing.T) {
 		Then().
 		Expect(Condition(ApplicationConditionOrphanedResourceWarning, "Application has 1 orphaned resources")).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.Name)
+			output, err := fixture.RunCli("app", "resources", app.Name)
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 		}).
@@ -1933,7 +1931,7 @@ func TestOrphanedResource(t *testing.T) {
 		Then().
 		Expect(Condition(ApplicationConditionOrphanedResourceWarning, "Application has 1 orphaned resources")).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.Name)
+			output, err := fixture.RunCli("app", "resources", app.Name)
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 		}).
@@ -1949,7 +1947,7 @@ func TestOrphanedResource(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(NoConditions()).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.Name)
+			output, err := fixture.RunCli("app", "resources", app.Name)
 			require.NoError(t, err)
 			assert.NotContains(t, output, "orphaned-configmap")
 		}).
@@ -1965,7 +1963,7 @@ func TestOrphanedResource(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(NoConditions()).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.Name)
+			output, err := fixture.RunCli("app", "resources", app.Name)
 			require.NoError(t, err)
 			assert.NotContains(t, output, "orphaned-configmap")
 		}).
@@ -2013,8 +2011,8 @@ func TestNotPermittedResources(t *testing.T) {
 		},
 	}
 	defer func() {
-		log.Infof("Ingress 'sample-ingress' deleted from %s", TestNamespace())
-		CheckError(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Delete(context.Background(), "sample-ingress", metav1.DeleteOptions{}))
+		log.Infof("Ingress 'sample-ingress' deleted from %s", fixture.TestNamespace())
+		CheckError(fixture.KubeClientset.NetworkingV1().Ingresses(fixture.TestNamespace()).Delete(context.Background(), "sample-ingress", metav1.DeleteOptions{}))
 	}()
 
 	svc := &corev1.Service{
@@ -2037,14 +2035,14 @@ func TestNotPermittedResources(t *testing.T) {
 
 	ctx.ProjectSpec(AppProjectSpec{
 		SourceRepos:  []string{"*"},
-		Destinations: []ApplicationDestination{{Namespace: DeploymentNamespace(), Server: "*"}},
+		Destinations: []ApplicationDestination{{Namespace: fixture.DeploymentNamespace(), Server: "*"}},
 		NamespaceResourceBlacklist: []metav1.GroupKind{
 			{Group: "", Kind: "Service"},
 		},
 	}).
 		And(func() {
-			FailOnErr(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Create(context.Background(), ingress, metav1.CreateOptions{}))
-			FailOnErr(KubeClientset.CoreV1().Services(DeploymentNamespace()).Create(context.Background(), svc, metav1.CreateOptions{}))
+			FailOnErr(fixture.KubeClientset.NetworkingV1().Ingresses(fixture.TestNamespace()).Create(context.Background(), ingress, metav1.CreateOptions{}))
+			FailOnErr(fixture.KubeClientset.CoreV1().Services(fixture.DeploymentNamespace()).Create(context.Background(), svc, metav1.CreateOptions{}))
 		}).
 		Path(guestbookPath).
 		When().
@@ -2069,8 +2067,8 @@ func TestNotPermittedResources(t *testing.T) {
 		Expect(DoesNotExist())
 
 	// Make sure prohibited resources are not deleted during application deletion
-	FailOnErr(KubeClientset.NetworkingV1().Ingresses(TestNamespace()).Get(context.Background(), "sample-ingress", metav1.GetOptions{}))
-	FailOnErr(KubeClientset.CoreV1().Services(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{}))
+	FailOnErr(fixture.KubeClientset.NetworkingV1().Ingresses(fixture.TestNamespace()).Get(context.Background(), "sample-ingress", metav1.GetOptions{}))
+	FailOnErr(fixture.KubeClientset.CoreV1().Services(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{}))
 }
 
 func TestSyncWithInfos(t *testing.T) {
@@ -2084,7 +2082,7 @@ func TestSyncWithInfos(t *testing.T) {
 		CreateApp().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "sync", app.Name,
+			_, err := fixture.RunCli("app", "sync", app.Name,
 				"--info", fmt.Sprintf("%s=%s", expectedInfo[0].Name, expectedInfo[0].Value),
 				"--info", fmt.Sprintf("%s=%s", expectedInfo[1].Name, expectedInfo[1].Value))
 			require.NoError(t, err)
@@ -2107,7 +2105,7 @@ func TestCreateAppWithNoNameSpaceForGlobalResource(t *testing.T) {
 		CreateWithNoNameSpace().
 		Then().
 		And(func(app *Application) {
-			app, err := AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
+			app, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Empty(t, app.Status.Conditions)
 		})
@@ -2127,7 +2125,7 @@ func TestCreateAppWithNoNameSpaceWhenRequired(t *testing.T) {
 		Refresh(RefreshTypeNormal).
 		Then().
 		And(func(app *Application) {
-			updatedApp, err := AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
+			updatedApp, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Len(t, updatedApp.Status.Conditions, 2)
@@ -2151,7 +2149,7 @@ func TestCreateAppWithNoNameSpaceWhenRequired2(t *testing.T) {
 		Refresh(RefreshTypeNormal).
 		Then().
 		And(func(app *Application) {
-			updatedApp, err := AppClientset.ArgoprojV1alpha1().Applications(TestNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
+			updatedApp, err := fixture.AppClientset.ArgoprojV1alpha1().Applications(fixture.TestNamespace()).Get(context.Background(), app.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Len(t, updatedApp.Status.Conditions, 2)
@@ -2161,7 +2159,7 @@ func TestCreateAppWithNoNameSpaceWhenRequired2(t *testing.T) {
 }
 
 func TestListResource(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
 		ProjectSpec(AppProjectSpec{
 			SourceRepos:       []string{"*"},
@@ -2177,7 +2175,7 @@ func TestListResource(t *testing.T) {
 		Expect(NoConditions()).
 		When().
 		And(func() {
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "orphaned-configmap",
 				},
@@ -2187,19 +2185,19 @@ func TestListResource(t *testing.T) {
 		Then().
 		Expect(Condition(ApplicationConditionOrphanedResourceWarning, "Application has 1 orphaned resources")).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.Name)
+			output, err := fixture.RunCli("app", "resources", app.Name)
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 			assert.Contains(t, output, "guestbook-ui")
 		}).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.Name, "--orphaned=true")
+			output, err := fixture.RunCli("app", "resources", app.Name, "--orphaned=true")
 			require.NoError(t, err)
 			assert.Contains(t, output, "orphaned-configmap")
 			assert.NotContains(t, output, "guestbook-ui")
 		}).
 		And(func(app *Application) {
-			output, err := RunCli("app", "resources", app.Name, "--orphaned=false")
+			output, err := fixture.RunCli("app", "resources", app.Name, "--orphaned=false")
 			require.NoError(t, err)
 			assert.NotContains(t, output, "orphaned-configmap")
 			assert.Contains(t, output, "guestbook-ui")
@@ -2226,11 +2224,11 @@ func TestListResource(t *testing.T) {
 //	application sync successful
 //	when application is deleted, --dest-namespace is not deleted
 func TestNamespaceAutoCreation(t *testing.T) {
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	updatedNamespace := getNewNamespace(t)
 	defer func() {
 		if !t.Skipped() {
-			_, err := Run("", "kubectl", "delete", "namespace", updatedNamespace)
+			_, err := fixture.Run("", "kubectl", "delete", "namespace", updatedNamespace)
 			require.NoError(t, err)
 		}
 	}()
@@ -2242,7 +2240,7 @@ func TestNamespaceAutoCreation(t *testing.T) {
 		Then().
 		And(func(app *Application) {
 			// Make sure the namespace we are about to update to does not exist
-			_, err := Run("", "kubectl", "get", "namespace", updatedNamespace)
+			_, err := fixture.Run("", "kubectl", "get", "namespace", updatedNamespace)
 			assert.ErrorContains(t, err, "not found")
 		}).
 		When().
@@ -2260,7 +2258,7 @@ func TestNamespaceAutoCreation(t *testing.T) {
 		Expect(Success("")).
 		And(func(app *Application) {
 			// Verify delete app does not delete the namespace auto created
-			output, err := Run("", "kubectl", "get", "namespace", updatedNamespace)
+			output, err := fixture.Run("", "kubectl", "get", "namespace", updatedNamespace)
 			require.NoError(t, err)
 			assert.Contains(t, output, updatedNamespace)
 		})
@@ -2288,8 +2286,8 @@ func TestCreateDisableValidation(t *testing.T) {
 		CreateApp("--validate=false").
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "create", app.Name, "--upsert", "--validate=false", "--repo", RepoURL(RepoURLTypeFile),
-				"--path", "baddir2", "--project", app.Spec.Project, "--dest-server", KubernetesInternalAPIServerAddr, "--dest-namespace", DeploymentNamespace())
+			_, err := fixture.RunCli("app", "create", app.Name, "--upsert", "--validate=false", "--repo", fixture.RepoURL(fixture.RepoURLTypeFile),
+				"--path", "baddir2", "--project", app.Spec.Project, "--dest-server", KubernetesInternalAPIServerAddr, "--dest-namespace", fixture.DeploymentNamespace())
 			require.NoError(t, err)
 		}).
 		When().
@@ -2360,7 +2358,7 @@ definitions:
 	Given(t).
 		Path("crd-subresource").
 		And(func() {
-			CheckError(SetResourceOverrides(map[string]ResourceOverride{
+			CheckError(fixture.SetResourceOverrides(map[string]ResourceOverride{
 				"argoproj.io/StatusSubResource": {
 					Actions: actions,
 				},
@@ -2376,47 +2374,47 @@ definitions:
 		Then().
 		// tests resource actions on a CRD using status subresource
 		And(func(app *Application) {
-			_, err := RunCli("app", "actions", "run", app.Name, "--kind", "StatusSubResource", "update-both")
+			_, err := fixture.RunCli("app", "actions", "run", app.Name, "--kind", "StatusSubResource", "update-both")
 			require.NoError(t, err)
-			text := FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text := FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-both", text)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-both", text)
 
-			_, err = RunCli("app", "actions", "run", app.Name, "--kind", "StatusSubResource", "update-spec")
+			_, err = fixture.RunCli("app", "actions", "run", app.Name, "--kind", "StatusSubResource", "update-spec")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-spec", text)
 
-			_, err = RunCli("app", "actions", "run", app.Name, "--kind", "StatusSubResource", "update-status")
+			_, err = fixture.RunCli("app", "actions", "run", app.Name, "--kind", "StatusSubResource", "update-status")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "statussubresources", "status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-status", text)
 		}).
 		// tests resource actions on a CRD *not* using status subresource
 		And(func(app *Application) {
-			_, err := RunCli("app", "actions", "run", app.Name, "--kind", "NonStatusSubResource", "update-both")
+			_, err := fixture.RunCli("app", "actions", "run", app.Name, "--kind", "NonStatusSubResource", "update-both")
 			require.NoError(t, err)
-			text := FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text := FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-both", text)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-both", text)
 
-			_, err = RunCli("app", "actions", "run", app.Name, "--kind", "NonStatusSubResource", "update-spec")
+			_, err = fixture.RunCli("app", "actions", "run", app.Name, "--kind", "NonStatusSubResource", "update-spec")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.spec.foo}")).(string)
 			assert.Equal(t, "update-spec", text)
 
-			_, err = RunCli("app", "actions", "run", app.Name, "--kind", "NonStatusSubResource", "update-status")
+			_, err = fixture.RunCli("app", "actions", "run", app.Name, "--kind", "NonStatusSubResource", "update-status")
 			require.NoError(t, err)
-			text = FailOnErr(Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
+			text = FailOnErr(fixture.Run(".", "kubectl", "-n", app.Spec.Destination.Namespace, "get", "nonstatussubresources", "non-status-subresource", "-o", "jsonpath={.status.bar}")).(string)
 			assert.Equal(t, "update-status", text)
 		})
 }
 
 func TestAppLogs(t *testing.T) {
 	t.SkipNow() // Too flaky. https://github.com/argoproj/argo-cd/issues/13834
-	SkipOnEnv(t, "OPENSHIFT")
+	fixture.SkipOnEnv(t, "OPENSHIFT")
 	Given(t).
 		Path("guestbook-logs").
 		When().
@@ -2425,17 +2423,17 @@ func TestAppLogs(t *testing.T) {
 		Then().
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Deployment", "--group", "", "--name", "guestbook-ui")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Pod")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Pod")
 			require.NoError(t, err)
 			assert.Contains(t, out, "Hi")
 		}).
 		And(func(app *Application) {
-			out, err := RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Service")
+			out, err := fixture.RunCliWithRetry(appLogsRetryCount, "app", "logs", app.Name, "--kind", "Service")
 			require.NoError(t, err)
 			assert.NotContains(t, out, "Hi")
 		})
@@ -2445,7 +2443,7 @@ func TestAppWaitOperationInProgress(t *testing.T) {
 	ctx := Given(t)
 	ctx.
 		And(func() {
-			CheckError(SetResourceOverrides(map[string]ResourceOverride{
+			CheckError(fixture.SetResourceOverrides(map[string]ResourceOverride{
 				"batch/Job": {
 					HealthLua: `return { status = 'Running' }`,
 				},
@@ -2464,7 +2462,7 @@ func TestAppWaitOperationInProgress(t *testing.T) {
 		Expect(OperationPhaseIs(OperationRunning)).
 		When().
 		And(func() {
-			_, err := RunCli("app", "wait", ctx.AppName(), "--suspended")
+			_, err := fixture.RunCli("app", "wait", ctx.AppName(), "--suspended")
 			errors.CheckError(err)
 		})
 }
@@ -2554,7 +2552,7 @@ func TestDisableManifestGeneration(t *testing.T) {
 		}).
 		When().
 		And(func() {
-			CheckError(SetEnableManifestGeneration(map[ApplicationSourceType]bool{
+			CheckError(fixture.SetEnableManifestGeneration(map[ApplicationSourceType]bool{
 				ApplicationSourceTypeKustomize: false,
 			}))
 		}).
@@ -2587,11 +2585,11 @@ func TestSwitchTrackingMethod(t *testing.T) {
 		And(func() {
 			// Add resource with tracking annotation. This should put the
 			// application OutOfSync.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Annotations: map[string]string{
-						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/other-configmap", Name(), DeploymentNamespace()),
+						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/other-configmap", fixture.Name(), fixture.DeploymentNamespace()),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2603,7 +2601,7 @@ func TestSwitchTrackingMethod(t *testing.T) {
 		When().
 		And(func() {
 			// Delete resource to bring application back in sync
-			FailOnErr(nil, KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Delete(context.Background(), "other-configmap", metav1.DeleteOptions{}))
+			FailOnErr(nil, fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Delete(context.Background(), "other-configmap", metav1.DeleteOptions{}))
 		}).
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
@@ -2621,11 +2619,11 @@ func TestSwitchTrackingMethod(t *testing.T) {
 			// Add a resource with a tracking annotation. This should not
 			// affect the application, because we now use the tracking method
 			// "label".
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Annotations: map[string]string{
-						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/other-configmap", Name(), DeploymentNamespace()),
+						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/other-configmap", fixture.Name(), fixture.DeploymentNamespace()),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2638,11 +2636,11 @@ func TestSwitchTrackingMethod(t *testing.T) {
 		And(func() {
 			// Add a resource with the tracking label. The app should become
 			// OutOfSync.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "extra-configmap",
 					Labels: map[string]string{
-						common.LabelKeyAppInstance: Name(),
+						common.LabelKeyAppInstance: fixture.Name(),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2654,7 +2652,7 @@ func TestSwitchTrackingMethod(t *testing.T) {
 		When().
 		And(func() {
 			// Delete resource to bring application back in sync
-			FailOnErr(nil, KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Delete(context.Background(), "extra-configmap", metav1.DeleteOptions{}))
+			FailOnErr(nil, fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Delete(context.Background(), "extra-configmap", metav1.DeleteOptions{}))
 		}).
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
@@ -2679,11 +2677,11 @@ func TestSwitchTrackingLabel(t *testing.T) {
 		And(func() {
 			// Add extra resource that carries the default tracking label
 			// We expect the app to go out of sync.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Labels: map[string]string{
-						common.LabelKeyAppInstance: Name(),
+						common.LabelKeyAppInstance: fixture.Name(),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2695,7 +2693,7 @@ func TestSwitchTrackingLabel(t *testing.T) {
 		When().
 		And(func() {
 			// Delete resource to bring application back in sync
-			FailOnErr(nil, KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Delete(context.Background(), "other-configmap", metav1.DeleteOptions{}))
+			FailOnErr(nil, fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Delete(context.Background(), "other-configmap", metav1.DeleteOptions{}))
 		}).
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
@@ -2713,11 +2711,11 @@ func TestSwitchTrackingLabel(t *testing.T) {
 		And(func() {
 			// Create resource with the new tracking label, the application
 			// is expected to go out of sync
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Labels: map[string]string{
-						"argocd.tracking": Name(),
+						"argocd.tracking": fixture.Name(),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2729,7 +2727,7 @@ func TestSwitchTrackingLabel(t *testing.T) {
 		When().
 		And(func() {
 			// Delete resource to bring application back in sync
-			FailOnErr(nil, KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Delete(context.Background(), "other-configmap", metav1.DeleteOptions{}))
+			FailOnErr(nil, fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Delete(context.Background(), "other-configmap", metav1.DeleteOptions{}))
 		}).
 		Then().
 		Expect(OperationPhaseIs(OperationSucceeded)).
@@ -2740,11 +2738,11 @@ func TestSwitchTrackingLabel(t *testing.T) {
 			// Add extra resource that carries the default tracking label
 			// We expect the app to stay in sync, because the configured
 			// label is different.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Labels: map[string]string{
-						common.LabelKeyAppInstance: Name(),
+						common.LabelKeyAppInstance: fixture.Name(),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2758,7 +2756,7 @@ func TestSwitchTrackingLabel(t *testing.T) {
 func TestAnnotationTrackingExtraResources(t *testing.T) {
 	ctx := Given(t)
 
-	CheckError(SetTrackingMethod(string(argo.TrackingMethodAnnotation)))
+	CheckError(fixture.SetTrackingMethod(string(argo.TrackingMethodAnnotation)))
 	ctx.
 		Path("deployment").
 		When().
@@ -2773,11 +2771,11 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		And(func() {
 			// Add a resource with an annotation that is not referencing the
 			// resource.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "extra-configmap",
 					Annotations: map[string]string{
-						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:apps/Deployment:%s/guestbook-cm", Name(), DeploymentNamespace()),
+						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:apps/Deployment:%s/guestbook-cm", fixture.Name(), fixture.DeploymentNamespace()),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2791,18 +2789,18 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		Sync("--prune").
 		And(func() {
 			// The extra configmap must not be pruned, because it's not tracked
-			cm, err := KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Get(context.Background(), "extra-configmap", metav1.GetOptions{})
+			cm, err := fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Get(context.Background(), "extra-configmap", metav1.GetOptions{})
 			require.NoError(t, err)
 			require.Equal(t, "extra-configmap", cm.Name)
 		}).
 		And(func() {
 			// Add a resource with an annotation that is self-referencing the
 			// resource.
-			FailOnErr(KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
+			FailOnErr(fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(context.Background(), &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-configmap",
 					Annotations: map[string]string{
-						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/other-configmap", Name(), DeploymentNamespace()),
+						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/other-configmap", fixture.Name(), fixture.DeploymentNamespace()),
 					},
 				},
 			}, metav1.CreateOptions{}))
@@ -2816,7 +2814,7 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		Sync("--prune").
 		And(func() {
 			// The extra configmap must be pruned now, because it's tracked
-			cm, err := KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Get(context.Background(), "other-configmap", metav1.GetOptions{})
+			cm, err := fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Get(context.Background(), "other-configmap", metav1.GetOptions{})
 			require.Error(t, err)
 			require.Equal(t, "", cm.Name)
 		}).
@@ -2827,11 +2825,11 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		When().
 		And(func() {
 			// Add a cluster-scoped resource that is not referencing itself
-			FailOnErr(KubeClientset.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
+			FailOnErr(fixture.KubeClientset.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "e2e-test-clusterrole",
 					Annotations: map[string]string{
-						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:rbac.authorization.k8s.io/ClusterRole:%s/e2e-other-clusterrole", Name(), DeploymentNamespace()),
+						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:rbac.authorization.k8s.io/ClusterRole:%s/e2e-other-clusterrole", fixture.Name(), fixture.DeploymentNamespace()),
 					},
 					Labels: map[string]string{
 						fixture.TestingLabel: "true",
@@ -2847,11 +2845,11 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		When().
 		And(func() {
 			// Add a cluster-scoped resource that is referencing itself
-			FailOnErr(KubeClientset.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
+			FailOnErr(fixture.KubeClientset.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "e2e-other-clusterrole",
 					Annotations: map[string]string{
-						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:rbac.authorization.k8s.io/ClusterRole:%s/e2e-other-clusterrole", Name(), DeploymentNamespace()),
+						common.AnnotationKeyAppInstance: fmt.Sprintf("%s:rbac.authorization.k8s.io/ClusterRole:%s/e2e-other-clusterrole", fixture.Name(), fixture.DeploymentNamespace()),
 					},
 					Labels: map[string]string{
 						fixture.TestingLabel: "true",
@@ -2868,7 +2866,7 @@ func TestAnnotationTrackingExtraResources(t *testing.T) {
 		Sync("--prune").
 		And(func() {
 			// The extra configmap must be pruned now, because it's tracked and does not exist in git
-			cr, err := KubeClientset.RbacV1().ClusterRoles().Get(context.Background(), "e2e-other-clusterrole", metav1.GetOptions{})
+			cr, err := fixture.KubeClientset.RbacV1().ClusterRoles().Get(context.Background(), "e2e-other-clusterrole", metav1.GetOptions{})
 			require.Error(t, err)
 			require.Equal(t, "", cr.Name)
 		}).
@@ -2886,7 +2884,7 @@ func TestCreateConfigMapsAndWaitForUpdate(t *testing.T) {
 		Sync().
 		Then().
 		And(func(app *Application) {
-			_, err := RunCli("app", "set", app.Name, "--sync-policy", "automated")
+			_, err := fixture.RunCli("app", "set", app.Name, "--sync-policy", "automated")
 			require.NoError(t, err)
 		}).
 		When().
@@ -2915,10 +2913,10 @@ data:
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
-		Expect(ResourceHealthWithNamespaceIs("ConfigMap", "other-map", DeploymentNamespace(), health.HealthStatusHealthy)).
-		Expect(ResourceSyncStatusWithNamespaceIs("ConfigMap", "other-map", DeploymentNamespace(), SyncStatusCodeSynced)).
-		Expect(ResourceHealthWithNamespaceIs("ConfigMap", "yet-another-map", DeploymentNamespace(), health.HealthStatusHealthy)).
-		Expect(ResourceSyncStatusWithNamespaceIs("ConfigMap", "yet-another-map", DeploymentNamespace(), SyncStatusCodeSynced))
+		Expect(ResourceHealthWithNamespaceIs("ConfigMap", "other-map", fixture.DeploymentNamespace(), health.HealthStatusHealthy)).
+		Expect(ResourceSyncStatusWithNamespaceIs("ConfigMap", "other-map", fixture.DeploymentNamespace(), SyncStatusCodeSynced)).
+		Expect(ResourceHealthWithNamespaceIs("ConfigMap", "yet-another-map", fixture.DeploymentNamespace(), health.HealthStatusHealthy)).
+		Expect(ResourceSyncStatusWithNamespaceIs("ConfigMap", "yet-another-map", fixture.DeploymentNamespace(), SyncStatusCodeSynced))
 }
 
 func TestInstallationID(t *testing.T) {
@@ -2926,12 +2924,12 @@ func TestInstallationID(t *testing.T) {
 	ctx.
 		SetTrackingMethod(string(argo.TrackingMethodAnnotation)).
 		And(func() {
-			_, err := fixture.KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(
+			_, err := fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(
 				context.Background(), &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-configmap",
 						Annotations: map[string]string{
-							common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/test-configmap", ctx.AppName(), DeploymentNamespace()),
+							common.AnnotationKeyAppInstance: fmt.Sprintf("%s:/ConfigMap:%s/test-configmap", ctx.AppName(), fixture.DeploymentNamespace()),
 						},
 					},
 				}, metav1.CreateOptions{})
@@ -2957,11 +2955,11 @@ func TestInstallationID(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
 			require.Len(t, app.Status.Resources, 2)
-			svc, err := fixture.KubeClientset.CoreV1().Services(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			svc, err := fixture.KubeClientset.CoreV1().Services(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			require.Equal(t, "test", svc.Annotations[common.AnnotationInstallationID])
 
-			deploy, err := fixture.KubeClientset.AppsV1().Deployments(DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
+			deploy, err := fixture.KubeClientset.AppsV1().Deployments(fixture.DeploymentNamespace()).Get(context.Background(), "guestbook-ui", metav1.GetOptions{})
 			require.NoError(t, err)
 			require.Equal(t, "test", deploy.Annotations[common.AnnotationInstallationID])
 		})
@@ -2971,7 +2969,7 @@ func TestDeletionConfirmation(t *testing.T) {
 	ctx := Given(t)
 	ctx.
 		And(func() {
-			_, err := fixture.KubeClientset.CoreV1().ConfigMaps(DeploymentNamespace()).Create(
+			_, err := fixture.KubeClientset.CoreV1().ConfigMaps(fixture.DeploymentNamespace()).Create(
 				context.Background(), &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-configmap",

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 
 	"github.com/stretchr/testify/assert"
@@ -59,7 +58,7 @@ var ExpectedConditions = []v1alpha1.ApplicationSetCondition{
 func TestSimpleListGeneratorExternalNamespace(t *testing.T) {
 	externalNamespace := string(utils.ArgoCDExternalNamespace)
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -69,21 +68,21 @@ func TestSimpleListGeneratorExternalNamespace(t *testing.T) {
 			Namespace:  externalNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -98,14 +97,14 @@ func TestSimpleListGeneratorExternalNamespace(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -121,7 +120,7 @@ func TestSimpleListGeneratorExternalNamespace(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -131,7 +130,7 @@ func TestSimpleListGeneratorExternalNamespace(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -147,21 +146,21 @@ func TestSimpleListGeneratorExternalNamespace(t *testing.T) {
 			appset.Spec.Template.Labels = map[string]string{
 				"label-key": "label-value",
 			}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("simple-list-generator-external", ExpectedConditions)).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewMetadata}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewMetadata}))
 }
 
 func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 	externalNamespace := string(utils.ArgoCDExternalNamespace)
 	externalNamespace2 := string(utils.ArgoCDExternalNamespace2)
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -171,21 +170,21 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 			Namespace:  externalNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
 
-	expectedAppExternalNamespace2 := argov1alpha1.Application{
+	expectedAppExternalNamespace2 := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -195,22 +194,22 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 			Namespace:  externalNamespace2,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
 
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -225,14 +224,14 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -248,7 +247,7 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppExternalNamespace2})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppExternalNamespace2})).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace).
 		CreateNamespace(externalNamespace).Create(v1alpha1.ApplicationSet{
@@ -260,14 +259,14 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -283,11 +282,11 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace2).
 		Then().
-		Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppExternalNamespace2})).
+		Expect(ApplicationsExist([]v1alpha1.Application{expectedAppExternalNamespace2})).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace).
 		Then().
@@ -299,11 +298,11 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace2).
 		Then().
-		Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppExternalNamespace2})).
+		Expect(ApplicationsExist([]v1alpha1.Application{expectedAppExternalNamespace2})).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace).
 		Then().
@@ -321,30 +320,30 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 			appset.Spec.Template.Labels = map[string]string{
 				"label-key": "label-value",
 			}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("simple-list-generator-external", ExpectedConditions)).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace2).
 		Then().
-		Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppExternalNamespace2})).
+		Expect(ApplicationsExist([]v1alpha1.Application{expectedAppExternalNamespace2})).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace).
 		Then().
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 		When().
 		SwitchToExternalNamespace(utils.ArgoCDExternalNamespace2).
 		Then().
-		Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppExternalNamespace2})).
+		Expect(ApplicationsExist([]v1alpha1.Application{expectedAppExternalNamespace2})).
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppExternalNamespace2}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppExternalNamespace2}))
 }
 
 func TestSimpleListGenerator(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -354,21 +353,21 @@ func TestSimpleListGenerator(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -379,14 +378,14 @@ func TestSimpleListGenerator(t *testing.T) {
 		Spec: v1alpha1.ApplicationSetSpec{
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{url}}",
 						Namespace: "guestbook",
 					},
@@ -402,7 +401,7 @@ func TestSimpleListGenerator(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -412,7 +411,7 @@ func TestSimpleListGenerator(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -424,18 +423,18 @@ func TestSimpleListGenerator(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("simple-list-generator", ExpectedConditions)).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewMetadata}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewMetadata}))
 }
 
 func TestSimpleListGeneratorGoTemplate(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -445,21 +444,21 @@ func TestSimpleListGeneratorGoTemplate(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -471,14 +470,14 @@ func TestSimpleListGeneratorGoTemplate(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -494,7 +493,7 @@ func TestSimpleListGeneratorGoTemplate(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -504,7 +503,7 @@ func TestSimpleListGeneratorGoTemplate(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -516,18 +515,18 @@ func TestSimpleListGeneratorGoTemplate(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("simple-list-generator", ExpectedConditions)).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewMetadata}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewMetadata}))
 }
 
 func TestRenderHelmValuesObject(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -537,20 +536,20 @@ func TestRenderHelmValuesObject(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "helm-guestbook",
-				Helm: &argov1alpha1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValuesObject: &runtime.RawExtension{
 						// This will always be converted as yaml
 						Raw: []byte(`{"some":{"string":"Hello world"}}`),
 					},
 				},
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -567,19 +566,19 @@ func TestRenderHelmValuesObject(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "helm-guestbook",
-						Helm: &argov1alpha1.ApplicationSourceHelm{
+						Helm: &v1alpha1.ApplicationSourceHelm{
 							ValuesObject: &runtime.RawExtension{
 								Raw: []byte(`{"some":{"string":"{{.test}}"}}`),
 							},
 						},
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -595,14 +594,14 @@ func TestRenderHelmValuesObject(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedApp}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedApp}))
 }
 
 func TestTemplatePatch(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -615,19 +614,19 @@ func TestTemplatePatch(t *testing.T) {
 				"annotation-some-key": "annotation-some-value",
 			},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
-			SyncPolicy: &argov1alpha1.SyncPolicy{
-				SyncOptions: argov1alpha1.SyncOptions{"CreateNamespace=true"},
+			SyncPolicy: &v1alpha1.SyncPolicy{
+				SyncOptions: v1alpha1.SyncOptions{"CreateNamespace=true"},
 			},
 		},
 	}
@@ -652,8 +651,8 @@ func TestTemplatePatch(t *testing.T) {
 	}
 	`
 
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -665,14 +664,14 @@ func TestTemplatePatch(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -696,7 +695,7 @@ func TestTemplatePatch(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -706,7 +705,7 @@ func TestTemplatePatch(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -718,18 +717,18 @@ func TestTemplatePatch(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("patch-template", ExpectedConditions)).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewMetadata}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewMetadata}))
 }
 
 func TestUpdateHelmValuesObject(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -739,20 +738,20 @@ func TestUpdateHelmValuesObject(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "helm-guestbook",
-				Helm: &argov1alpha1.ApplicationSourceHelm{
+				Helm: &v1alpha1.ApplicationSourceHelm{
 					ValuesObject: &runtime.RawExtension{
 						// This will always be converted as yaml
 						Raw: []byte(`{"some":{"foo":"bar"}}`),
 					},
 				},
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -769,19 +768,19 @@ func TestUpdateHelmValuesObject(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "helm-guestbook",
-						Helm: &argov1alpha1.ApplicationSourceHelm{
+						Helm: &v1alpha1.ApplicationSourceHelm{
 							ValuesObject: &runtime.RawExtension{
 								Raw: []byte(`{"some":{"string":"{{.test}}"}}`),
 							},
 						},
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -801,20 +800,20 @@ func TestUpdateHelmValuesObject(t *testing.T) {
 		Expect(ApplicationSetHasConditions("test-values-object-patch", ExpectedConditions)).
 		When().
 		// Update the app spec with some knew ValuesObject to force a merge
-		Update(func(as *argov1alpha1.ApplicationSet) {
+		Update(func(as *v1alpha1.ApplicationSet) {
 			as.Spec.Template.Spec.Source.Helm.ValuesObject = &runtime.RawExtension{
 				Raw: []byte(`{"some":{"foo":"bar"}}`),
 			}
 		}).
 		Then().
-		Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+		Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 		When().
 		// Delete the ApplicationSet, and verify it deletes the Applications
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedApp}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedApp}))
 }
 
 func TestSyncPolicyCreateUpdate(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -824,21 +823,21 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 			Namespace:  utils.ArgoCDNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -853,14 +852,14 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 					Name:       "{{.cluster}}-guestbook-sync-policy-create-update",
 					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 				},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -876,7 +875,7 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -886,7 +885,7 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template
 		// Update as well the policy
@@ -904,18 +903,18 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 			appset.Spec.Template.Labels = map[string]string{
 				"label-key": "label-value",
 			}
-			applicationsSyncPolicy := argov1alpha1.ApplicationsSyncPolicyCreateUpdate
-			appset.Spec.SyncPolicy = &argov1alpha1.ApplicationSetSyncPolicy{
+			applicationsSyncPolicy := v1alpha1.ApplicationsSyncPolicyCreateUpdate
+			appset.Spec.SyncPolicy = &v1alpha1.ApplicationSetSyncPolicy{
 				ApplicationsSync: &applicationsSyncPolicy,
 			}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// Update the list and remove element
 		// As policy is create-update, app deletion must not be reflected
 		When().
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Generators = []v1alpha1.ApplicationSetGenerator{}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("sync-policy-create-update", ExpectedConditions)).
@@ -924,11 +923,11 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 		// As policy is create-update, AppSet controller will remove all generated applications's ownerReferences on delete AppSet
 		// So AppSet deletion will be reflected, but all the applications it generates will still exist
 		When().
-		Delete().Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata}))
+		Delete().Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata}))
 }
 
 func TestSyncPolicyCreateDelete(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -938,20 +937,20 @@ func TestSyncPolicyCreateDelete(t *testing.T) {
 			Namespace:  utils.ArgoCDNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
-	var expectedAppNewNamespace *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -963,14 +962,14 @@ func TestSyncPolicyCreateDelete(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster}}-guestbook-sync-policy-create-delete"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -986,7 +985,7 @@ func TestSyncPolicyCreateDelete(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -996,7 +995,7 @@ func TestSyncPolicyCreateDelete(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template
 		// Update as well the policy
@@ -1005,29 +1004,29 @@ func TestSyncPolicyCreateDelete(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-			applicationsSyncPolicy := argov1alpha1.ApplicationsSyncPolicyCreateDelete
-			appset.Spec.SyncPolicy = &argov1alpha1.ApplicationSetSyncPolicy{
+			applicationsSyncPolicy := v1alpha1.ApplicationsSyncPolicyCreateDelete
+			appset.Spec.SyncPolicy = &v1alpha1.ApplicationSetSyncPolicy{
 				ApplicationsSync: &applicationsSyncPolicy,
 			}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the list and remove element
 		// As policy is create-delete, app deletion must be reflected
 		When().
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Generators = []v1alpha1.ApplicationSetGenerator{}
-		}).Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("sync-policy-create-delete", ExpectedConditions)).
 
 		// Delete the ApplicationSet
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewNamespace}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewNamespace}))
 }
 
 func TestSyncPolicyCreateOnly(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -1037,20 +1036,20 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 			Namespace:  utils.ArgoCDNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
 		},
 	}
-	var expectedAppNewNamespace *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
 
 	Given(t).
 		// Create a ListGenerator-based ApplicationSet
@@ -1065,14 +1064,14 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 					Name:       "{{.cluster}}-guestbook-sync-policy-create-only",
 					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 				},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -1088,7 +1087,7 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -1098,7 +1097,7 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template
 		// Update as well the policy
@@ -1107,18 +1106,18 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-			applicationsSyncPolicy := argov1alpha1.ApplicationsSyncPolicyCreateOnly
-			appset.Spec.SyncPolicy = &argov1alpha1.ApplicationSetSyncPolicy{
+			applicationsSyncPolicy := v1alpha1.ApplicationsSyncPolicyCreateOnly
+			appset.Spec.SyncPolicy = &v1alpha1.ApplicationSetSyncPolicy{
 				ApplicationsSync: &applicationsSyncPolicy,
 			}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the list and remove element
 		// As policy is create-only, app deletion must not be reflected
 		When().
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Generators = []v1alpha1.ApplicationSetGenerator{}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// verify the ApplicationSet status conditions were set correctly
 		Expect(ApplicationSetHasConditions("sync-policy-create-only", ExpectedConditions)).
@@ -1127,12 +1126,12 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 		// As policy is create-update, AppSet controller will remove all generated applications's ownerReferences on delete AppSet
 		// So AppSet deletion will be reflected, but all the applications it generates will still exist
 		When().
-		Delete().Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace}))
+		Delete().Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace}))
 }
 
 func TestSimpleGitDirectoryGenerator(t *testing.T) {
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1142,14 +1141,14 @@ func TestSimpleGitDirectoryGenerator(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -1157,14 +1156,14 @@ func TestSimpleGitDirectoryGenerator(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("kustomize-guestbook"),
 		generateExpectedApp("helm-guestbook"),
 		generateExpectedApp("ksonnet-guestbook"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		When().
@@ -1176,14 +1175,14 @@ func TestSimpleGitDirectoryGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},
@@ -1241,8 +1240,8 @@ func TestSimpleGitDirectoryGenerator(t *testing.T) {
 }
 
 func TestSimpleGitDirectoryGeneratorGoTemplate(t *testing.T) {
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1252,14 +1251,14 @@ func TestSimpleGitDirectoryGeneratorGoTemplate(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -1267,14 +1266,14 @@ func TestSimpleGitDirectoryGeneratorGoTemplate(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("kustomize-guestbook"),
 		generateExpectedApp("helm-guestbook"),
 		generateExpectedApp("ksonnet-guestbook"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		When().
@@ -1287,14 +1286,14 @@ func TestSimpleGitDirectoryGeneratorGoTemplate(t *testing.T) {
 				GoTemplate: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{.path.path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{.path.basename}}",
 						},
@@ -1374,8 +1373,8 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 			Reason:  v1alpha1.ApplicationSetReasonApplicationParamsGenerationError,
 		},
 	}
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1385,14 +1384,14 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -1400,7 +1399,7 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("guestbook"),
 	}
 	project := "gpg"
@@ -1416,14 +1415,14 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: project,
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},
@@ -1473,8 +1472,8 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 			Reason:  v1alpha1.ApplicationSetReasonApplicationParamsGenerationError,
 		},
 	}
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1484,14 +1483,14 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -1499,7 +1498,7 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("guestbook"),
 	}
 
@@ -1521,20 +1520,20 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: project,
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},
 						// Automatically create resources
-						SyncPolicy: &argov1alpha1.SyncPolicy{
-							Automated: &argov1alpha1.SyncPolicyAutomated{},
+						SyncPolicy: &v1alpha1.SyncPolicy{
+							Automated: &v1alpha1.SyncPolicyAutomated{},
 						},
 					},
 				},
@@ -1560,8 +1559,8 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 }
 
 func TestSimpleGitFilesGenerator(t *testing.T) {
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1571,14 +1570,14 @@ func TestSimpleGitFilesGenerator(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           "guestbook",
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: "guestbook",
 				},
@@ -1586,13 +1585,13 @@ func TestSimpleGitFilesGenerator(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("engineering-dev-guestbook"),
 		generateExpectedApp("engineering-prod-guestbook"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		When().
@@ -1604,14 +1603,14 @@ func TestSimpleGitFilesGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{cluster.name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "guestbook",
 						},
@@ -1692,8 +1691,8 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 		},
 	}
 	project := "gpg"
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1703,14 +1702,14 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: project,
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           "guestbook",
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: "guestbook",
 				},
@@ -1718,7 +1717,7 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("engineering-dev-guestbook"),
 		generateExpectedApp("engineering-prod-guestbook"),
 	}
@@ -1734,14 +1733,14 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{cluster.name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: project,
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "guestbook",
 						},
@@ -1791,8 +1790,8 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 		},
 	}
 	project := "gpg"
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1802,14 +1801,14 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: project,
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           "guestbook",
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: "guestbook",
 				},
@@ -1819,7 +1818,7 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 
 	str, _ := rand.RandString(1)
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("engineering-dev-guestbook"),
 		generateExpectedApp("engineering-prod-guestbook"),
 	}
@@ -1838,14 +1837,14 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{cluster.name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: project,
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "guestbook",
 						},
@@ -1873,8 +1872,8 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 }
 
 func TestSimpleGitFilesGeneratorGoTemplate(t *testing.T) {
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -1884,14 +1883,14 @@ func TestSimpleGitFilesGeneratorGoTemplate(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           "guestbook",
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: "guestbook",
 				},
@@ -1899,13 +1898,13 @@ func TestSimpleGitFilesGeneratorGoTemplate(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("engineering-dev-guestbook"),
 		generateExpectedApp("engineering-prod-guestbook"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		When().
@@ -1918,14 +1917,14 @@ func TestSimpleGitFilesGeneratorGoTemplate(t *testing.T) {
 				GoTemplate: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster.name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "guestbook",
 						},
@@ -1994,21 +1993,21 @@ func TestSimpleGitFilesPreserveResourcesOnDeletion(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{cluster.name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: utils.ApplicationsResourcesNamespace,
 						},
 
 						// Automatically create resources
-						SyncPolicy: &argov1alpha1.SyncPolicy{
-							Automated: &argov1alpha1.SyncPolicyAutomated{},
+						SyncPolicy: &v1alpha1.SyncPolicy{
+							Automated: &v1alpha1.SyncPolicyAutomated{},
 						},
 					},
 				},
@@ -2055,21 +2054,21 @@ func TestSimpleGitFilesPreserveResourcesOnDeletionGoTemplate(t *testing.T) {
 				GoTemplate: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.cluster.name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: utils.ApplicationsResourcesNamespace,
 						},
 
 						// Automatically create resources
-						SyncPolicy: &argov1alpha1.SyncPolicy{
-							Automated: &argov1alpha1.SyncPolicyAutomated{},
+						SyncPolicy: &v1alpha1.SyncPolicy{
+							Automated: &v1alpha1.SyncPolicyAutomated{},
 						},
 					},
 				},
@@ -2314,7 +2313,7 @@ func TestSimpleSCMProviderGenerator(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2324,14 +2323,14 @@ func TestSimpleSCMProviderGenerator(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:argoproj/argo-cd.git",
 				TargetRevision: "master",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -2350,14 +2349,14 @@ func TestSimpleSCMProviderGenerator(t *testing.T) {
 		Spec: v1alpha1.ApplicationSetSpec{
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{ repository }}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "{{ url }}",
 						TargetRevision: "{{ branch }}",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook",
 					},
@@ -2379,7 +2378,7 @@ func TestSimpleSCMProviderGenerator(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp}))
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp}))
 }
 
 func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
@@ -2389,7 +2388,7 @@ func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2399,14 +2398,14 @@ func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:argoproj/argo-cd.git",
 				TargetRevision: "master",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -2426,14 +2425,14 @@ func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{ .repository }}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "{{ .url }}",
 						TargetRevision: "{{ .branch }}",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook",
 					},
@@ -2455,11 +2454,11 @@ func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp}))
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp}))
 }
 
 func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2469,14 +2468,14 @@ func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:argoproj/argo-cd.git",
 				TargetRevision: "master",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -2496,14 +2495,14 @@ func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
 			GoTemplate: true,
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{ .repository }}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "{{ .url }}",
 						TargetRevision: "{{ .branch }}",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook",
 					},
@@ -2525,7 +2524,7 @@ func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedApp})).
 		And(func() {
 			// app should be listed
 			output, err := fixture.RunCli("appset", "get", "scm-provider-generator-scm-provider-not-allowed")
@@ -2535,7 +2534,7 @@ func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
 }
 
 func TestCustomApplicationFinalizers(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2545,14 +2544,14 @@ func TestCustomApplicationFinalizers(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -2571,14 +2570,14 @@ func TestCustomApplicationFinalizers(t *testing.T) {
 					Name:       "{{cluster}}-guestbook",
 					Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
 				},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{url}}",
 						Namespace: "guestbook",
 					},
@@ -2594,15 +2593,15 @@ func TestCustomApplicationFinalizers(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedApp}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedApp}))
 }
 
 func TestCustomApplicationFinalizersGoTemplate(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2612,14 +2611,14 @@ func TestCustomApplicationFinalizersGoTemplate(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -2639,14 +2638,14 @@ func TestCustomApplicationFinalizersGoTemplate(t *testing.T) {
 					Name:       "{{.cluster}}-guestbook",
 					Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
 				},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 						TargetRevision: "HEAD",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "{{.url}}",
 						Namespace: "guestbook",
 					},
@@ -2662,11 +2661,11 @@ func TestCustomApplicationFinalizersGoTemplate(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedApp}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedApp}))
 }
 
 func githubPullMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
@@ -2716,7 +2715,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2726,14 +2725,14 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:argoproj/argo-cd.git",
 				TargetRevision: "master",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -2768,14 +2767,14 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 		Spec: v1alpha1.ApplicationSetSpec{
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{ repository }}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "{{ url }}",
 						TargetRevision: "{{ branch }}",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook",
 					},
@@ -2787,7 +2786,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 						Github: &v1alpha1.SCMProviderGeneratorGithub{
 							Organization: "argoproj",
 							API:          ts.URL,
-							TokenRef: &argov1alpha1.SecretRef{
+							TokenRef: &v1alpha1.SecretRef{
 								SecretName: secretName,
 								Key:        "hello",
 							},
@@ -2801,7 +2800,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 		When().And(func() {
 		err := utils.GetE2EFixtureK8sClient().KubeClientset.CoreV1().Secrets(fixture.TestNamespace()).Delete(context.Background(), secretName, metav1.DeleteOptions{})
 		assert.NoError(t, err)
@@ -2818,7 +2817,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2831,14 +2830,14 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 				common.LabelKeyAppInstance: "simple-scm-provider-generator-strict-ko",
 			},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:argoproj/argo-cd.git",
 				TargetRevision: "master",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
@@ -2874,14 +2873,14 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 		Spec: v1alpha1.ApplicationSetSpec{
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{ repository }}-guestbook"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "{{ url }}",
 						TargetRevision: "{{ branch }}",
 						Path:           "guestbook",
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook",
 					},
@@ -2893,7 +2892,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 						Github: &v1alpha1.SCMProviderGeneratorGithub{
 							Organization: "argoproj",
 							API:          ts.URL,
-							TokenRef: &argov1alpha1.SecretRef{
+							TokenRef: &v1alpha1.SecretRef{
 								SecretName: secretName,
 								Key:        "hello",
 							},
@@ -2907,7 +2906,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedApp})).
 		When().
 		And(func() {
 			// app should be listed
@@ -2927,7 +2926,7 @@ func TestSimplePullRequestGenerator(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -2937,17 +2936,17 @@ func TestSimplePullRequestGenerator(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:applicationset-test-org/argocd-example-apps.git",
 				TargetRevision: "824a5c987fdfb2b0629e9dbf5f31636c69ba4772",
 				Path:           "kustomize-guestbook",
-				Kustomize: &argov1alpha1.ApplicationSourceKustomize{
+				Kustomize: &v1alpha1.ApplicationSourceKustomize{
 					NamePrefix: "guestbook-1",
 				},
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook-pull-request",
 			},
@@ -2963,17 +2962,17 @@ func TestSimplePullRequestGenerator(t *testing.T) {
 		Spec: v1alpha1.ApplicationSetSpec{
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "guestbook-{{ number }}"},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "git@github.com:applicationset-test-org/argocd-example-apps.git",
 						TargetRevision: "{{ head_sha }}",
 						Path:           "kustomize-guestbook",
-						Kustomize: &argov1alpha1.ApplicationSourceKustomize{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
 							NamePrefix: "guestbook-{{ number }}",
 						},
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook-{{ branch }}",
 					},
@@ -2994,7 +2993,7 @@ func TestSimplePullRequestGenerator(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp}))
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp}))
 }
 
 func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
@@ -3005,7 +3004,7 @@ func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -3016,17 +3015,17 @@ func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			Labels:     map[string]string{"app": "preview"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:applicationset-test-org/argocd-example-apps.git",
 				TargetRevision: "824a5c987fdfb2b0629e9dbf5f31636c69ba4772",
 				Path:           "kustomize-guestbook",
-				Kustomize: &argov1alpha1.ApplicationSourceKustomize{
+				Kustomize: &v1alpha1.ApplicationSourceKustomize{
 					NamePrefix: "guestbook-1",
 				},
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook-pull-request",
 			},
@@ -3046,17 +3045,17 @@ func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
 					Name:   "guestbook-{{ .number }}",
 					Labels: map[string]string{"app": "{{index .labels 0}}"},
 				},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "git@github.com:applicationset-test-org/argocd-example-apps.git",
 						TargetRevision: "{{ .head_sha }}",
 						Path:           "kustomize-guestbook",
-						Kustomize: &argov1alpha1.ApplicationSourceKustomize{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
 							NamePrefix: "guestbook-{{ .number }}",
 						},
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook-{{ .branch }}",
 					},
@@ -3077,11 +3076,11 @@ func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp}))
+	}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp}))
 }
 
 func TestPullRequestGeneratorNotAllowedSCMProvider(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -3094,17 +3093,17 @@ func TestPullRequestGeneratorNotAllowedSCMProvider(t *testing.T) {
 				"app": "preview",
 			},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "git@github.com:applicationset-test-org/argocd-example-apps.git",
 				TargetRevision: "824a5c987fdfb2b0629e9dbf5f31636c69ba4772",
 				Path:           "kustomize-guestbook",
-				Kustomize: &argov1alpha1.ApplicationSourceKustomize{
+				Kustomize: &v1alpha1.ApplicationSourceKustomize{
 					NamePrefix: "guestbook-1",
 				},
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook-pull-request",
 			},
@@ -3124,17 +3123,17 @@ func TestPullRequestGeneratorNotAllowedSCMProvider(t *testing.T) {
 					Name:   "guestbook-{{ .number }}",
 					Labels: map[string]string{"app": "{{index .labels 0}}"},
 				},
-				Spec: argov1alpha1.ApplicationSpec{
+				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
-					Source: &argov1alpha1.ApplicationSource{
+					Source: &v1alpha1.ApplicationSource{
 						RepoURL:        "git@github.com:applicationset-test-org/argocd-example-apps.git",
 						TargetRevision: "{{ .head_sha }}",
 						Path:           "kustomize-guestbook",
-						Kustomize: &argov1alpha1.ApplicationSourceKustomize{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
 							NamePrefix: "guestbook-{{ .number }}",
 						},
 					},
-					Destination: argov1alpha1.ApplicationDestination{
+					Destination: v1alpha1.ApplicationDestination{
 						Server:    "https://kubernetes.default.svc",
 						Namespace: "guestbook-{{ .branch }}",
 					},
@@ -3155,7 +3154,7 @@ func TestPullRequestGeneratorNotAllowedSCMProvider(t *testing.T) {
 				},
 			},
 		},
-	}).Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedApp})).
+	}).Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedApp})).
 		And(func() {
 			// app should be listed
 			output, err := fixture.RunCli("appset", "get", "pull-request-generator-not-allowed-scm")
@@ -3166,8 +3165,8 @@ func TestPullRequestGeneratorNotAllowedSCMProvider(t *testing.T) {
 
 func TestGitGeneratorPrivateRepo(t *testing.T) {
 	FailOnErr(fixture.RunCli("repo", "add", fixture.RepoURL(fixture.RepoURLTypeHTTPS), "--username", fixture.GitUsername, "--password", fixture.GitPassword, "--insecure-skip-server-verification"))
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -3177,14 +3176,14 @@ func TestGitGeneratorPrivateRepo(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        fixture.RepoURL(fixture.RepoURLTypeHTTPS),
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -3192,11 +3191,11 @@ func TestGitGeneratorPrivateRepo(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("https-kustomize-base"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
 
 	Given(t).
 		When().
@@ -3208,14 +3207,14 @@ func TestGitGeneratorPrivateRepo(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        fixture.RepoURL(fixture.RepoURLTypeHTTPS),
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},
@@ -3242,8 +3241,8 @@ func TestGitGeneratorPrivateRepo(t *testing.T) {
 
 func TestGitGeneratorPrivateRepoGoTemplate(t *testing.T) {
 	FailOnErr(fixture.RunCli("repo", "add", fixture.RepoURL(fixture.RepoURLTypeHTTPS), "--username", fixture.GitUsername, "--password", fixture.GitPassword, "--insecure-skip-server-verification"))
-	generateExpectedApp := func(name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -3253,14 +3252,14 @@ func TestGitGeneratorPrivateRepoGoTemplate(t *testing.T) {
 				Namespace:  fixture.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        fixture.RepoURL(fixture.RepoURLTypeHTTPS),
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -3268,11 +3267,11 @@ func TestGitGeneratorPrivateRepoGoTemplate(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("https-kustomize-base"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
 
 	Given(t).
 		When().
@@ -3285,14 +3284,14 @@ func TestGitGeneratorPrivateRepoGoTemplate(t *testing.T) {
 				GoTemplate: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{.path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        fixture.RepoURL(fixture.RepoURLTypeHTTPS),
 							TargetRevision: "HEAD",
 							Path:           "{{.path.path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{.path.basename}}",
 						},

--- a/test/e2e/cluster_generator_test.go
+++ b/test/e2e/cluster_generator_test.go
@@ -4,22 +4,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets/utils"
-
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 )
 
 func TestSimpleClusterGeneratorExternalNamespace(t *testing.T) {
 	externalNamespace := string(utils.ArgoCDExternalNamespace)
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -29,22 +26,22 @@ func TestSimpleClusterGeneratorExternalNamespace(t *testing.T) {
 			Namespace:  externalNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "cluster1",
 				Namespace: "guestbook",
 			},
 		},
 	}
 
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ClusterGenerator-based ApplicationSet
@@ -59,14 +56,14 @@ func TestSimpleClusterGeneratorExternalNamespace(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{name}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -85,7 +82,7 @@ func TestSimpleClusterGeneratorExternalNamespace(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -95,7 +92,7 @@ func TestSimpleClusterGeneratorExternalNamespace(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -111,15 +108,15 @@ func TestSimpleClusterGeneratorExternalNamespace(t *testing.T) {
 			appset.Spec.Template.Labels = map[string]string{
 				"label-key": "label-value",
 			}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewNamespace}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewNamespace}))
 }
 
 func TestSimpleClusterGenerator(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -129,22 +126,22 @@ func TestSimpleClusterGenerator(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "cluster1",
 				Namespace: "guestbook",
 			},
 		},
 	}
 
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	Given(t).
 		// Create a ClusterGenerator-based ApplicationSet
@@ -157,14 +154,14 @@ func TestSimpleClusterGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{name}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -183,7 +180,7 @@ func TestSimpleClusterGenerator(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -193,7 +190,7 @@ func TestSimpleClusterGenerator(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -205,15 +202,15 @@ func TestSimpleClusterGenerator(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewNamespace}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewNamespace}))
 }
 
 func TestClusterGeneratorWithLocalCluster(t *testing.T) {
-	expectedAppTemplate := argov1alpha1.Application{
+	expectedAppTemplate := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -223,9 +220,9 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
@@ -236,27 +233,27 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		appsetDestination argov1alpha1.ApplicationDestination
-		appDestination    argov1alpha1.ApplicationDestination
+		appsetDestination v1alpha1.ApplicationDestination
+		appDestination    v1alpha1.ApplicationDestination
 	}{
 		{
 			name: "specify local cluster by server field",
-			appDestination: argov1alpha1.ApplicationDestination{
+			appDestination: v1alpha1.ApplicationDestination{
 				Server:    "https://kubernetes.default.svc",
 				Namespace: "guestbook",
 			},
-			appsetDestination: argov1alpha1.ApplicationDestination{
+			appsetDestination: v1alpha1.ApplicationDestination{
 				Server:    "{{server}}",
 				Namespace: "guestbook",
 			},
 		},
 		{
 			name: "specify local cluster by name field",
-			appDestination: argov1alpha1.ApplicationDestination{
+			appDestination: v1alpha1.ApplicationDestination{
 				Name:      "in-cluster",
 				Namespace: "guestbook",
 			},
-			appsetDestination: argov1alpha1.ApplicationDestination{
+			appsetDestination: v1alpha1.ApplicationDestination{
 				Name:      "{{name}}",
 				Namespace: "guestbook",
 			},
@@ -265,8 +262,8 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var expectedAppNewNamespace *argov1alpha1.Application
-			var expectedAppNewMetadata *argov1alpha1.Application
+			var expectedAppNewNamespace *v1alpha1.Application
+			var expectedAppNewMetadata *v1alpha1.Application
 
 			// Create the expected application from the template, and copy in the destination from the test case
 			expectedApp := *expectedAppTemplate.DeepCopy()
@@ -282,9 +279,9 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 					Spec: v1alpha1.ApplicationSetSpec{
 						Template: v1alpha1.ApplicationSetTemplate{
 							ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-							Spec: argov1alpha1.ApplicationSpec{
+							Spec: v1alpha1.ApplicationSpec{
 								Project: "default",
-								Source: &argov1alpha1.ApplicationSource{
+								Source: &v1alpha1.ApplicationSource{
 									RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 									TargetRevision: "HEAD",
 									Path:           "guestbook",
@@ -298,7 +295,7 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 							},
 						},
 					},
-				}).Then().ExpectWithDuration(ApplicationsExist([]argov1alpha1.Application{expectedApp}), 8*time.Minute).
+				}).Then().ExpectWithDuration(ApplicationsExist([]v1alpha1.Application{expectedApp}), 8*time.Minute).
 
 				// Update the ApplicationSet template namespace, and verify it updates the Applications
 				When().
@@ -308,7 +305,7 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 				}).
 				Update(func(appset *v1alpha1.ApplicationSet) {
 					appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-				}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+				}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 				// Update the metadata fields in the appset template, and make sure it propagates to the apps
 				When().
@@ -320,17 +317,17 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 				Update(func(appset *v1alpha1.ApplicationSet) {
 					appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 					appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-				}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+				}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 				// Delete the ApplicationSet, and verify it deletes the Applications
 				When().
-				Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewNamespace}))
+				Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewNamespace}))
 		})
 	}
 }
 
 func TestSimpleClusterGeneratorAddingCluster(t *testing.T) {
-	expectedAppTemplate := argov1alpha1.Application{
+	expectedAppTemplate := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -340,14 +337,14 @@ func TestSimpleClusterGeneratorAddingCluster(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "{{name}}",
 				Namespace: "guestbook",
 			},
@@ -373,14 +370,14 @@ func TestSimpleClusterGeneratorAddingCluster(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{name}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -399,20 +396,20 @@ func TestSimpleClusterGeneratorAddingCluster(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
 		CreateClusterSecret("my-secret2", "cluster2", "https://kubernetes.default.svc").
-		Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
+		Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster1, expectedAppCluster2}))
 }
 
 func TestSimpleClusterGeneratorDeletingCluster(t *testing.T) {
-	expectedAppTemplate := argov1alpha1.Application{
+	expectedAppTemplate := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -422,14 +419,14 @@ func TestSimpleClusterGeneratorDeletingCluster(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "{{name}}",
 				Namespace: "guestbook",
 			},
@@ -456,14 +453,14 @@ func TestSimpleClusterGeneratorDeletingCluster(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{name}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -482,21 +479,21 @@ func TestSimpleClusterGeneratorDeletingCluster(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
 		DeleteClusterSecret("my-secret2").
-		Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1})).
-		Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster2})).
+		Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1})).
+		Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster2})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster1}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster1}))
 }
 
 func TestClusterGeneratorWithFlatListMode(t *testing.T) {
-	expectedAppTemplate := argov1alpha1.Application{
+	expectedAppTemplate := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -506,32 +503,32 @@ func TestClusterGeneratorWithFlatListMode(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "helm-guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "cluster1",
 				Namespace: fixture.TestNamespace(),
 			},
-			SyncPolicy: &argov1alpha1.SyncPolicy{
-				Automated: &argov1alpha1.SyncPolicyAutomated{},
+			SyncPolicy: &v1alpha1.SyncPolicy{
+				Automated: &v1alpha1.SyncPolicyAutomated{},
 			},
 		},
 	}
 
 	expectedAppCluster1 := *expectedAppTemplate.DeepCopy()
-	expectedAppCluster1.Spec.Source.Helm = &argov1alpha1.ApplicationSourceHelm{
+	expectedAppCluster1.Spec.Source.Helm = &v1alpha1.ApplicationSourceHelm{
 		Values: `clusters:
   - name: cluster1
 `,
 	}
 
 	expectedAppCluster2 := *expectedAppTemplate.DeepCopy()
-	expectedAppCluster2.Spec.Source.Helm = &argov1alpha1.ApplicationSourceHelm{
+	expectedAppCluster2.Spec.Source.Helm = &v1alpha1.ApplicationSourceHelm{
 		Values: `clusters:
   - name: cluster1
   - name: cluster2
@@ -550,13 +547,13 @@ func TestClusterGeneratorWithFlatListMode(t *testing.T) {
 				GoTemplate: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "flat-clusters"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "helm-guestbook",
-							Helm: &argov1alpha1.ApplicationSourceHelm{
+							Helm: &v1alpha1.ApplicationSourceHelm{
 								Values: `clusters:
 {{- range .clusters }}
   - name: {{ .name }}
@@ -564,12 +561,12 @@ func TestClusterGeneratorWithFlatListMode(t *testing.T) {
 `,
 							},
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name:      "cluster1",
 							Namespace: fixture.TestNamespace(),
 						},
-						SyncPolicy: &argov1alpha1.SyncPolicy{
-							Automated: &argov1alpha1.SyncPolicyAutomated{},
+						SyncPolicy: &v1alpha1.SyncPolicy{
+							Automated: &v1alpha1.SyncPolicyAutomated{},
 						},
 					},
 				},
@@ -586,15 +583,15 @@ func TestClusterGeneratorWithFlatListMode(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
 		CreateClusterSecret("my-secret2", "cluster2", "https://kubernetes.default.svc").
 		Then().
-		Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster2})).
+		Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster2})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster2}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster2}))
 }

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	accountFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/account"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	clusterFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/cluster"
@@ -19,16 +18,16 @@ import (
 )
 
 func TestClusterList(t *testing.T) {
-	SkipIfAlreadyRun(t)
-	defer RecordTestRun(t)
+	fixture.SkipIfAlreadyRun(t)
+	defer fixture.RecordTestRun(t)
 
 	last := ""
 	expected := fmt.Sprintf(`SERVER                          NAME        VERSION  STATUS      MESSAGE  PROJECT
-https://kubernetes.default.svc  in-cluster  %v     Successful           `, GetVersions().ServerVersion)
+https://kubernetes.default.svc  in-cluster  %v     Successful           `, fixture.GetVersions().ServerVersion)
 
 	clusterFixture.
 		Given(t).
-		Project(ProjectName)
+		Project(fixture.ProjectName)
 
 	// We need an application targeting the cluster, otherwise the test will
 	// fail if run isolated.
@@ -59,7 +58,7 @@ https://kubernetes.default.svc  in-cluster  %v     Successful           `, GetVe
 func TestClusterAdd(t *testing.T) {
 	clusterFixture.
 		Given(t).
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
@@ -68,7 +67,7 @@ func TestClusterAdd(t *testing.T) {
 		Then().
 		AndCLIOutput(func(output string, err error) {
 			assert.Equal(t, fmt.Sprintf(`SERVER                          NAME              VERSION  STATUS      MESSAGE  PROJECT
-https://kubernetes.default.svc  test-cluster-add  %v     Successful           %s`, GetVersions().ServerVersion, ProjectName), output)
+https://kubernetes.default.svc  test-cluster-add  %v     Successful           %s`, fixture.GetVersions().ServerVersion, fixture.ProjectName), output)
 		})
 }
 
@@ -82,7 +81,7 @@ func TestClusterAddPermissionDenied(t *testing.T) {
 
 	clusterFixture.
 		GivenWithSameState(t).
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
@@ -104,18 +103,18 @@ func TestClusterAddAllowed(t *testing.T) {
 			{
 				Resource: "clusters",
 				Action:   "create",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 			{
 				Resource: "clusters",
 				Action:   "get",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 		}, "org-admin")
 
 	clusterFixture.
 		GivenWithSameState(t).
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
@@ -124,7 +123,7 @@ func TestClusterAddAllowed(t *testing.T) {
 		Then().
 		AndCLIOutput(func(output string, err error) {
 			assert.Equal(t, fmt.Sprintf(`SERVER                          NAME                      VERSION  STATUS      MESSAGE  PROJECT
-https://kubernetes.default.svc  test-cluster-add-allowed  %v     Successful           argo-project`, GetVersions().ServerVersion), output)
+https://kubernetes.default.svc  test-cluster-add-allowed  %v     Successful           argo-project`, fixture.GetVersions().ServerVersion), output)
 		})
 }
 
@@ -138,13 +137,13 @@ func TestClusterListDenied(t *testing.T) {
 			{
 				Resource: "clusters",
 				Action:   "create",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 		}, "org-admin")
 
 	clusterFixture.
 		GivenWithSameState(t).
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
@@ -157,11 +156,11 @@ func TestClusterListDenied(t *testing.T) {
 }
 
 func TestClusterSet(t *testing.T) {
-	EnsureCleanState(t)
-	defer RecordTestRun(t)
+	fixture.EnsureCleanState(t)
+	defer fixture.RecordTestRun(t)
 	clusterFixture.
 		GivenWithSameState(t).
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Name("in-cluster").
 		Namespaces([]string{"namespace-edit-1", "namespace-edit-2"}).
 		Server(KubernetesInternalAPIServerAddr).
@@ -176,14 +175,14 @@ func TestClusterSet(t *testing.T) {
 }
 
 func TestClusterGet(t *testing.T) {
-	SkipIfAlreadyRun(t)
-	EnsureCleanState(t)
-	defer RecordTestRun(t)
-	output := FailOnErr(RunCli("cluster", "get", "https://kubernetes.default.svc")).(string)
+	fixture.SkipIfAlreadyRun(t)
+	fixture.EnsureCleanState(t)
+	defer fixture.RecordTestRun(t)
+	output := FailOnErr(fixture.RunCli("cluster", "get", "https://kubernetes.default.svc")).(string)
 
 	assert.Contains(t, output, "name: in-cluster")
 	assert.Contains(t, output, "server: https://kubernetes.default.svc")
-	assert.Contains(t, output, fmt.Sprintf(`serverVersion: "%v"`, GetVersions().ServerVersion))
+	assert.Contains(t, output, fmt.Sprintf(`serverVersion: "%v"`, fixture.GetVersions().ServerVersion))
 	assert.Contains(t, output, `config:
   tlsClientConfig:
     insecure: false`)
@@ -192,34 +191,34 @@ func TestClusterGet(t *testing.T) {
 }
 
 func TestClusterNameInRestAPI(t *testing.T) {
-	EnsureCleanState(t)
+	fixture.EnsureCleanState(t)
 
 	var cluster Cluster
-	err := DoHttpJsonRequest("GET", "/api/v1/clusters/in-cluster?id.type=name", &cluster)
+	err := fixture.DoHttpJsonRequest("GET", "/api/v1/clusters/in-cluster?id.type=name", &cluster)
 	require.NoError(t, err)
 
 	assert.Equal(t, "in-cluster", cluster.Name)
 	assert.Contains(t, cluster.Server, "https://kubernetes.default.svc")
 
-	err = DoHttpJsonRequest("PUT",
+	err = fixture.DoHttpJsonRequest("PUT",
 		"/api/v1/clusters/in-cluster?id.type=name&updatedFields=labels", &cluster, []byte(`{"labels":{"test": "val"}}`)...)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"test": "val"}, cluster.Labels)
 }
 
 func TestClusterURLInRestAPI(t *testing.T) {
-	EnsureCleanState(t)
+	fixture.EnsureCleanState(t)
 
 	clusterURL := url.QueryEscape(KubernetesInternalAPIServerAddr)
 
 	var cluster Cluster
-	err := DoHttpJsonRequest("GET", "/api/v1/clusters/"+clusterURL, &cluster)
+	err := fixture.DoHttpJsonRequest("GET", "/api/v1/clusters/"+clusterURL, &cluster)
 	require.NoError(t, err)
 
 	assert.Equal(t, "in-cluster", cluster.Name)
 	assert.Contains(t, cluster.Server, "https://kubernetes.default.svc")
 
-	err = DoHttpJsonRequest("PUT",
+	err = fixture.DoHttpJsonRequest("PUT",
 		fmt.Sprintf("/api/v1/clusters/%s?&updatedFields=labels", clusterURL), &cluster, []byte(`{"labels":{"test": "val"}}`)...)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"test": "val"}, cluster.Labels)
@@ -235,19 +234,19 @@ func TestClusterDeleteDenied(t *testing.T) {
 			{
 				Resource: "clusters",
 				Action:   "create",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 			{
 				Resource: "clusters",
 				Action:   "get",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 		}, "org-admin")
 
 	// Attempt to remove cluster creds by name
 	clusterFixture.
 		GivenWithSameState(t).
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
@@ -261,7 +260,7 @@ func TestClusterDeleteDenied(t *testing.T) {
 	// Attempt to remove cluster creds by server
 	clusterFixture.
 		GivenWithSameState(t).
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().
@@ -283,24 +282,24 @@ func TestClusterDelete(t *testing.T) {
 			{
 				Resource: "clusters",
 				Action:   "create",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 			{
 				Resource: "clusters",
 				Action:   "get",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 			{
 				Resource: "clusters",
 				Action:   "delete",
-				Scope:    ProjectName + "/*",
+				Scope:    fixture.ProjectName + "/*",
 			},
 		}, "org-admin")
 
 	clstAction := clusterFixture.
 		GivenWithSameState(t).
 		Name("default").
-		Project(ProjectName).
+		Project(fixture.ProjectName).
 		Upsert(true).
 		Server(KubernetesInternalAPIServerAddr).
 		When().

--- a/test/e2e/clusterdecisiongenerator_e2e_test.go
+++ b/test/e2e/clusterdecisiongenerator_e2e_test.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets/utils"
 
@@ -20,7 +19,7 @@ var tenSec = int64(10)
 func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 	externalNamespace := string(utils.ArgoCDExternalNamespace)
 
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Application",
 			APIVersion: "argoproj.io/v1alpha1",
@@ -30,22 +29,22 @@ func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 			Namespace:  externalNamespace,
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "cluster1",
 				Namespace: "guestbook",
 			},
 		},
 	}
 
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	clusterList := []any{
 		map[string]any{
@@ -71,14 +70,14 @@ func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{clusterName}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -94,7 +93,7 @@ func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -104,7 +103,7 @@ func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -120,15 +119,15 @@ func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 			appset.Spec.Template.Labels = map[string]string{
 				"label-key": "label-value",
 			}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewNamespace}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewNamespace}))
 }
 
 func TestSimpleClusterDecisionResourceGenerator(t *testing.T) {
-	expectedApp := argov1alpha1.Application{
+	expectedApp := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -138,22 +137,22 @@ func TestSimpleClusterDecisionResourceGenerator(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "cluster1",
 				Namespace: "guestbook",
 			},
 		},
 	}
 
-	var expectedAppNewNamespace *argov1alpha1.Application
-	var expectedAppNewMetadata *argov1alpha1.Application
+	var expectedAppNewNamespace *v1alpha1.Application
+	var expectedAppNewMetadata *v1alpha1.Application
 
 	clusterList := []any{
 		map[string]any{
@@ -177,14 +176,14 @@ func TestSimpleClusterDecisionResourceGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{clusterName}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -200,7 +199,7 @@ func TestSimpleClusterDecisionResourceGenerator(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedApp})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedApp})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
@@ -210,7 +209,7 @@ func TestSimpleClusterDecisionResourceGenerator(t *testing.T) {
 		}).
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Spec.Destination.Namespace = "guestbook2"
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewNamespace})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewNamespace})).
 
 		// Update the metadata fields in the appset template, and make sure it propagates to the apps
 		When().
@@ -222,15 +221,15 @@ func TestSimpleClusterDecisionResourceGenerator(t *testing.T) {
 		Update(func(appset *v1alpha1.ApplicationSet) {
 			appset.Spec.Template.Annotations = map[string]string{"annotation-key": "annotation-value"}
 			appset.Spec.Template.Labels = map[string]string{"label-key": "label-value"}
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{*expectedAppNewMetadata})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{*expectedAppNewMetadata})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{*expectedAppNewNamespace}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{*expectedAppNewNamespace}))
 }
 
 func TestSimpleClusterDecisionResourceGeneratorAddingCluster(t *testing.T) {
-	expectedAppTemplate := argov1alpha1.Application{
+	expectedAppTemplate := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -240,14 +239,14 @@ func TestSimpleClusterDecisionResourceGeneratorAddingCluster(t *testing.T) {
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "{{clusterName}}",
 				Namespace: "guestbook",
 			},
@@ -288,14 +287,14 @@ func TestSimpleClusterDecisionResourceGeneratorAddingCluster(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{clusterName}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -312,20 +311,20 @@ func TestSimpleClusterDecisionResourceGeneratorAddingCluster(t *testing.T) {
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
 		CreateClusterSecret("my-secret2", "cluster2", "https://kubernetes.default.svc").
-		Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
+		Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster1, expectedAppCluster2}))
 }
 
 func TestSimpleClusterDecisionResourceGeneratorDeletingClusterSecret(t *testing.T) {
-	expectedAppTemplate := argov1alpha1.Application{
+	expectedAppTemplate := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -335,14 +334,14 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterSecret(t *testing.
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "{{name}}",
 				Namespace: "guestbook",
 			},
@@ -384,14 +383,14 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterSecret(t *testing.
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{clusterName}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -408,21 +407,21 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterSecret(t *testing.
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
 		DeleteClusterSecret("my-secret2").
-		Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1})).
-		Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster2})).
+		Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1})).
+		Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster2})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster1}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster1}))
 }
 
 func TestSimpleClusterDecisionResourceGeneratorDeletingClusterFromResource(t *testing.T) {
-	expectedAppTemplate := argov1alpha1.Application{
+	expectedAppTemplate := v1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       application.ApplicationKind,
 			APIVersion: "argoproj.io/v1alpha1",
@@ -432,14 +431,14 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterFromResource(t *te
 			Namespace:  fixture.TestNamespace(),
 			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 		},
-		Spec: argov1alpha1.ApplicationSpec{
+		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
-			Source: &argov1alpha1.ApplicationSource{
+			Source: &v1alpha1.ApplicationSource{
 				RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 				TargetRevision: "HEAD",
 				Path:           "guestbook",
 			},
-			Destination: argov1alpha1.ApplicationDestination{
+			Destination: v1alpha1.ApplicationDestination{
 				Name:      "{{name}}",
 				Namespace: "guestbook",
 			},
@@ -488,14 +487,14 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterFromResource(t *te
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-guestbook"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "guestbook",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name: "{{clusterName}}",
 							// Server:    "{{server}}",
 							Namespace: "guestbook",
@@ -512,15 +511,15 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterFromResource(t *te
 					},
 				},
 			},
-		}).Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
+		}).Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1, expectedAppCluster2})).
 
 		// Update the ApplicationSet template namespace, and verify it updates the Applications
 		When().
 		StatusUpdatePlacementDecision("my-placementdecision", clusterListSmall).
-		Then().Expect(ApplicationsExist([]argov1alpha1.Application{expectedAppCluster1})).
-		Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster2})).
+		Then().Expect(ApplicationsExist([]v1alpha1.Application{expectedAppCluster1})).
+		Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster2})).
 
 		// Delete the ApplicationSet, and verify it deletes the Applications
 		When().
-		Delete().Then().Expect(ApplicationsDoNotExist([]argov1alpha1.Application{expectedAppCluster1}))
+		Delete().Then().Expect(ApplicationsDoNotExist([]v1alpha1.Application{expectedAppCluster1}))
 }

--- a/test/e2e/custom_tool_test.go
+++ b/test/e2e/custom_tool_test.go
@@ -15,7 +15,6 @@ import (
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	. "github.com/argoproj/argo-cd/v2/util/errors"
 )
@@ -32,7 +31,7 @@ func TestCustomToolWithGitCreds(t *testing.T) {
 		CustomCACertAdded().
 		// add the private repo with credentials
 		HTTPSRepoURLAdded(true).
-		RepoURLType(RepoURLTypeHTTPS).
+		RepoURLType(fixture.RepoURLTypeHTTPS).
 		Path("cmp-gitcreds").
 		When().
 		CreateApp().
@@ -42,7 +41,7 @@ func TestCustomToolWithGitCreds(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitAskpass}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitAskpass}")
 			require.NoError(t, err)
 			assert.Equal(t, "argocd", output)
 		})
@@ -62,7 +61,7 @@ func TestCustomToolWithGitCredsTemplate(t *testing.T) {
 		HTTPSCredentialsUserPassAdded().
 		// add the private repo without credentials
 		HTTPSRepoURLAdded(false).
-		RepoURLType(RepoURLTypeHTTPS).
+		RepoURLType(fixture.RepoURLTypeHTTPS).
 		Path("cmp-gitcredstemplate").
 		When().
 		CreateApp().
@@ -72,17 +71,17 @@ func TestCustomToolWithGitCredsTemplate(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitAskpass}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitAskpass}")
 			require.NoError(t, err)
 			assert.Equal(t, "argocd", output)
 		}).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitUsername}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitUsername}")
 			require.NoError(t, err)
 			assert.Empty(t, output)
 		}).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitPassword}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.GitPassword}")
 			require.NoError(t, err)
 			assert.Empty(t, output)
 		})
@@ -112,12 +111,12 @@ func TestCustomToolWithSSHGitCreds(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", Name(), "-o", "jsonpath={.metadata.annotations.GitSSHCommand}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", fixture.Name(), "-o", "jsonpath={.metadata.annotations.GitSSHCommand}")
 			require.NoError(t, err)
 			assert.Regexp(t, `-i [^ ]+`, output, "test plugin expects $GIT_SSH_COMMAND to contain the option '-i <path to ssh private key>'")
 		}).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", Name(), "-o", "jsonpath={.metadata.annotations.GitSSHCredsFileSHA}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", fixture.Name(), "-o", "jsonpath={.metadata.annotations.GitSSHCredsFileSHA}")
 			require.NoError(t, err)
 			assert.Regexp(t, `\w+\s+[\/\w]+`, output, "git ssh credentials file should be able to be read, hashing the contents")
 		})
@@ -136,7 +135,7 @@ func TestCustomToolWithSSHGitCredsDisabled(t *testing.T) {
 		// add the private repo with ssh credentials
 		CustomSSHKnownHostsAdded().
 		SSHRepoURLAdded(true).
-		RepoURLType(RepoURLTypeSSH).
+		RepoURLType(fixture.RepoURLTypeSSH).
 		Path("cmp-gitsshcreds").
 		When().
 		IgnoreErrors().
@@ -173,27 +172,27 @@ func TestCustomToolWithEnv(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.Bar}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.Bar}")
 			require.NoError(t, err)
 			assert.Equal(t, "baz", output)
 		}).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.Foo}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.Foo}")
 			require.NoError(t, err)
 			assert.Equal(t, "bar", output)
 		}).
 		And(func(app *Application) {
-			expectedKubeVersion := GetVersions().ServerVersion.Format("%s.%s")
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeVersion}")
+			expectedKubeVersion := fixture.GetVersions().ServerVersion.Format("%s.%s")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeVersion}")
 			require.NoError(t, err)
 			assert.Equal(t, expectedKubeVersion, output)
 		}).
 		And(func(app *Application) {
-			expectedApiVersion := GetApiResources()
+			expectedApiVersion := fixture.GetApiResources()
 			expectedApiVersionSlice := strings.Split(expectedApiVersion, ",")
 			sort.Strings(expectedApiVersionSlice)
 
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeApiVersion}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeApiVersion}")
 			require.NoError(t, err)
 			outputSlice := strings.Split(output, ",")
 			sort.Strings(outputSlice)
@@ -224,16 +223,16 @@ func TestCustomToolSyncAndDiffLocal(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			FailOnErr(RunCli("app", "sync", ctx.AppName(), "--local", appPath, "--local-repo-root", testdataPath))
+			FailOnErr(fixture.RunCli("app", "sync", ctx.AppName(), "--local", appPath, "--local-repo-root", testdataPath))
 		}).
 		And(func(app *Application) {
-			FailOnErr(RunCli("app", "diff", ctx.AppName(), "--local", appPath, "--local-repo-root", testdataPath))
+			FailOnErr(fixture.RunCli("app", "diff", ctx.AppName(), "--local", appPath, "--local-repo-root", testdataPath))
 		})
 }
 
 func startCMPServer(t *testing.T, configFile string) {
 	t.Helper()
-	pluginSockFilePath := TmpDir + PluginSockFilePath
+	pluginSockFilePath := fixture.TmpDir + fixture.PluginSockFilePath
 	t.Setenv("ARGOCD_BINARY_NAME", "argocd-cmp-server")
 	// ARGOCD_PLUGINSOCKFILEPATH should be set as the same value as repo server env var
 	t.Setenv("ARGOCD_PLUGINSOCKFILEPATH", pluginSockFilePath)
@@ -242,7 +241,7 @@ func startCMPServer(t *testing.T, configFile string) {
 		err := os.Mkdir(pluginSockFilePath, 0o700)
 		require.NoError(t, err)
 	}
-	FailOnErr(RunWithStdin("", "", "../../dist/argocd", "--config-dir-path", configFile))
+	FailOnErr(fixture.RunWithStdin("", "", "../../dist/argocd", "--config-dir-path", configFile))
 }
 
 // Discover by fileName
@@ -322,22 +321,22 @@ func TestCMPDiscoverWithFindCommandWithEnv(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		And(func(app *Application) {
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.Bar}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.Bar}")
 			require.NoError(t, err)
 			assert.Equal(t, "baz", output)
 		}).
 		And(func(app *Application) {
-			expectedKubeVersion := GetVersions().ServerVersion.Format("%s.%s")
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeVersion}")
+			expectedKubeVersion := fixture.GetVersions().ServerVersion.Format("%s.%s")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeVersion}")
 			require.NoError(t, err)
 			assert.Equal(t, expectedKubeVersion, output)
 		}).
 		And(func(app *Application) {
-			expectedApiVersion := GetApiResources()
+			expectedApiVersion := fixture.GetApiResources()
 			expectedApiVersionSlice := strings.Split(expectedApiVersion, ",")
 			sort.Strings(expectedApiVersionSlice)
 
-			output, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeApiVersion}")
+			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeApiVersion}")
 			require.NoError(t, err)
 			outputSlice := strings.Split(output, ",")
 			sort.Strings(outputSlice)
@@ -364,7 +363,7 @@ func TestPruneResourceFromCMP(t *testing.T) {
 		Then().
 		Expect(DoesNotExist()).
 		AndAction(func() {
-			_, err := Run("", "kubectl", "-n", DeploymentNamespace(), "get", "deployment", "guestbook-ui")
+			_, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "deployment", "guestbook-ui")
 			require.Error(t, err)
 		})
 }
@@ -390,7 +389,7 @@ func TestPreserveFileModeForCMP(t *testing.T) {
 }
 
 func TestCMPWithSymlinkPartialFiles(t *testing.T) {
-	Given(t, WithTestData("testdata2")).
+	Given(t, fixture.WithTestData("testdata2")).
 		And(func() {
 			go startCMPServer(t, "./testdata2/cmp-symlink")
 			time.Sleep(100 * time.Millisecond)
@@ -407,7 +406,7 @@ func TestCMPWithSymlinkPartialFiles(t *testing.T) {
 }
 
 func TestCMPWithSymlinkFiles(t *testing.T) {
-	Given(t, WithTestData("testdata2")).
+	Given(t, fixture.WithTestData("testdata2")).
 		And(func() {
 			go startCMPServer(t, "./testdata2/cmp-symlink")
 			time.Sleep(100 * time.Millisecond)
@@ -424,7 +423,7 @@ func TestCMPWithSymlinkFiles(t *testing.T) {
 }
 
 func TestCMPWithSymlinkFolder(t *testing.T) {
-	Given(t, WithTestData("testdata2")).
+	Given(t, fixture.WithTestData("testdata2")).
 		And(func() {
 			go startCMPServer(t, "./testdata2/cmp-symlink")
 			time.Sleep(100 * time.Millisecond)

--- a/test/e2e/graceful_restart_test.go
+++ b/test/e2e/graceful_restart_test.go
@@ -11,13 +11,12 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/settings"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 )
 
 func checkHealth(t *testing.T, requireHealthy bool) {
 	t.Helper()
-	resp, err := DoHttpRequest("GET", "/healthz?full=true", "")
+	resp, err := fixture.DoHttpRequest("GET", "/healthz?full=true", "")
 	if requireHealthy {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -33,7 +32,7 @@ func checkHealth(t *testing.T, requireHealthy bool) {
 }
 
 func TestAPIServerGracefulRestart(t *testing.T) {
-	EnsureCleanState(t)
+	fixture.EnsureCleanState(t)
 
 	// Should be healthy.
 	checkHealth(t, true)
@@ -47,7 +46,7 @@ func TestAPIServerGracefulRestart(t *testing.T) {
 	}
 	// One final time, should be healthy, or restart is considered too slow for tests
 	checkHealth(t, true)
-	closer, settingsClient, err := ArgoCDClientset.NewSettingsClient()
+	closer, settingsClient, err := fixture.ArgoCDClientset.NewSettingsClient()
 	if closer != nil {
 		defer closer.Close()
 	}

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	projectFixture "github.com/argoproj/argo-cd/v2/test/e2e/fixture/project"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture/repos"
@@ -37,7 +36,7 @@ func TestHelmHooksAreCreated(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(HealthIs(health.HealthStatusHealthy)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
-		Expect(ResourceResultIs(ResourceResult{Version: "v1", Kind: "Pod", Namespace: DeploymentNamespace(), Name: "hook", Message: "pod/hook created", HookType: HookTypePreSync, HookPhase: OperationSucceeded, SyncPhase: SyncPhasePreSync}))
+		Expect(ResourceResultIs(ResourceResult{Version: "v1", Kind: "Pod", Namespace: fixture.DeploymentNamespace(), Name: "hook", Message: "pod/hook created", HookType: HookTypePreSync, HookPhase: OperationSucceeded, SyncPhase: SyncPhasePreSync}))
 }
 
 // make sure we treat Helm weights as a sync wave
@@ -96,11 +95,11 @@ func TestDeclarativeHelmInvalidValuesFile(t *testing.T) {
 }
 
 func TestHelmRepo(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	Given(t).
 		CustomCACertAdded().
 		HelmRepoAdded("custom-repo").
-		RepoURLType(RepoURLTypeHelm).
+		RepoURLType(fixture.RepoURLTypeHelm).
 		Chart("helm").
 		Revision("1.0.0").
 		When().
@@ -255,7 +254,7 @@ func TestHelmValuesLiteralFileRemote(t *testing.T) {
 }
 
 func TestHelmCrdHook(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	Given(t).
 		Path("helm-crd").
 		When().
@@ -328,7 +327,7 @@ func TestHelmSetEnv(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			assert.Equal(t, Name(), FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map", "-o", "jsonpath={.data.foo}")).(string))
+			assert.Equal(t, fixture.Name(), FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map", "-o", "jsonpath={.data.foo}")).(string))
 		})
 }
 
@@ -343,13 +342,13 @@ func TestHelmSetStringEnv(t *testing.T) {
 		Expect(OperationPhaseIs(OperationSucceeded)).
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			assert.Equal(t, Name(), FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map", "-o", "jsonpath={.data.foo}")).(string))
+			assert.Equal(t, fixture.Name(), FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map", "-o", "jsonpath={.data.foo}")).(string))
 		})
 }
 
 // make sure kube-version gets passed down to resources
 func TestKubeVersion(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	Given(t).
 		Path("helm-kube-version").
 		When().
@@ -358,10 +357,10 @@ func TestKubeVersion(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			kubeVersion := FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			kubeVersion := FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.kubeVersion}")).(string)
 			// Capabilities.KubeVersion defaults to 1.9.0, we assume here you are running a later version
-			assert.LessOrEqual(t, GetVersions().ServerVersion.Format("v%s.%s.0"), kubeVersion)
+			assert.LessOrEqual(t, fixture.GetVersions().ServerVersion.Format("v%s.%s.0"), kubeVersion)
 		}).
 		When().
 		// Make sure override works.
@@ -370,14 +369,14 @@ func TestKubeVersion(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			assert.Equal(t, "v999.999.999", FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			assert.Equal(t, "v999.999.999", FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.kubeVersion}")).(string))
 		})
 }
 
 // make sure api versions gets passed down to resources
 func TestApiVersions(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	Given(t).
 		Path("helm-api-versions").
 		When().
@@ -386,7 +385,7 @@ func TestApiVersions(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			apiVersions := FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			apiVersions := FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.apiVersions}")).(string)
 			// The v1 API shouldn't be going anywhere.
 			assert.Contains(t, apiVersions, "v1")
@@ -398,14 +397,14 @@ func TestApiVersions(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			apiVersions := FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			apiVersions := FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.apiVersions}")).(string)
 			assert.Contains(t, apiVersions, "v1/MyTestResource")
 		})
 }
 
 func TestHelmNamespaceOverride(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	Given(t).
 		Path("helm-namespace").
 		When().
@@ -421,7 +420,7 @@ func TestHelmNamespaceOverride(t *testing.T) {
 }
 
 func TestHelmValuesHiddenDirectory(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	Given(t).
 		Path(".hidden-helm").
 		When().
@@ -436,12 +435,12 @@ func TestHelmValuesHiddenDirectory(t *testing.T) {
 }
 
 func TestHelmWithDependencies(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	testHelmWithDependencies(t, "helm-with-dependencies", false)
 }
 
 func TestHelmWithMultipleDependencies(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 
 	Given(t).Path("helm-with-multiple-dependencies").
 		CustomCACertAdded().
@@ -457,7 +456,7 @@ func TestHelmWithMultipleDependencies(t *testing.T) {
 }
 
 func TestHelmDependenciesPermissionDenied(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 
 	projName := "argo-helm-project-denied"
 	projectFixture.
@@ -466,7 +465,7 @@ func TestHelmDependenciesPermissionDenied(t *testing.T) {
 		Destination("*,*").
 		When().
 		Create().
-		AddSource(RepoURL(RepoURLTypeFile))
+		AddSource(fixture.RepoURL(fixture.RepoURLTypeFile))
 
 	expectedErr := fmt.Sprintf("helm repos localhost:5000/myrepo are not permitted in project '%s'", projName)
 	GivenWithSameState(t).
@@ -496,7 +495,7 @@ func TestHelmDependenciesPermissionDenied(t *testing.T) {
 }
 
 func TestHelmWithDependenciesLegacyRepo(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	testHelmWithDependencies(t, "helm-with-dependencies", true)
 }
 
@@ -513,14 +512,14 @@ func testHelmWithDependencies(t *testing.T, chartPath string, legacyRepo bool) {
 				"-n", fixture.TestNamespace(),
 				"--from-file=certSecret="+repos.CertPath,
 				"--from-file=keySecret="+repos.CertKeyPath,
-				"--from-literal=username="+GitUsername,
-				"--from-literal=password="+GitPassword,
+				"--from-literal=username="+fixture.GitUsername,
+				"--from-literal=password="+fixture.GitPassword,
 			))
 			FailOnErr(fixture.KubeClientset.CoreV1().Secrets(fixture.TestNamespace()).Patch(context.Background(),
 				"helm-repo", types.MergePatchType, []byte(`{"metadata": { "labels": {"e2e.argoproj.io": "true"} }}`), metav1.PatchOptions{}))
 
 			CheckError(fixture.SetHelmRepos(settings.HelmRepoCredentials{
-				URL:            RepoURL(RepoURLTypeHelm),
+				URL:            fixture.RepoURL(fixture.RepoURLTypeHelm),
 				Name:           "custom-repo",
 				KeySecret:      &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "helm-repo"}, Key: "keySecret"},
 				CertSecret:     &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "helm-repo"}, Key: "certSecret"},
@@ -543,7 +542,7 @@ func testHelmWithDependencies(t *testing.T, chartPath string, legacyRepo bool) {
 }
 
 func TestHelm3CRD(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	Given(t).
 		Path("helm3-crd").
 		When().
@@ -555,12 +554,12 @@ func TestHelm3CRD(t *testing.T) {
 }
 
 func TestHelmRepoDiffLocal(t *testing.T) {
-	SkipOnEnv(t, "HELM")
+	fixture.SkipOnEnv(t, "HELM")
 	helmTmp := t.TempDir()
 	Given(t).
 		CustomCACertAdded().
 		HelmRepoAdded("custom-repo").
-		RepoURLType(RepoURLTypeHelm).
+		RepoURLType(fixture.RepoURLTypeHelm).
 		Chart("helm").
 		Revision("1.0.0").
 		When().
@@ -574,14 +573,14 @@ func TestHelmRepoDiffLocal(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
 			_ = os.Setenv("XDG_CONFIG_HOME", helmTmp)
-			FailOnErr(Run("", "helm", "repo", "add", "custom-repo", GetEnvWithDefault("ARGOCD_E2E_HELM_SERVICE", RepoURL(RepoURLTypeHelm)),
-				"--username", GitUsername,
-				"--password", GitPassword,
+			FailOnErr(fixture.Run("", "helm", "repo", "add", "custom-repo", fixture.GetEnvWithDefault("ARGOCD_E2E_HELM_SERVICE", fixture.RepoURL(fixture.RepoURLTypeHelm)),
+				"--username", fixture.GitUsername,
+				"--password", fixture.GitPassword,
 				"--cert-file", "../fixture/certs/argocd-test-client.crt",
 				"--key-file", "../fixture/certs/argocd-test-client.key",
 				"--ca-file", "../fixture/certs/argocd-test-ca.crt",
 			))
-			diffOutput := FailOnErr(RunCli("app", "diff", app.Name, "--local", "testdata/helm")).(string)
+			diffOutput := FailOnErr(fixture.RunCli("app", "diff", app.Name, "--local", "testdata/helm")).(string)
 			assert.Empty(t, diffOutput)
 		})
 }
@@ -590,7 +589,7 @@ func TestHelmOCIRegistry(t *testing.T) {
 	Given(t).
 		PushChartToOCIRegistry("helm-values", "helm-values", "1.0.0").
 		HelmOCIRepoAdded("myrepo").
-		RepoURLType(RepoURLTypeHelmOCI).
+		RepoURLType(fixture.RepoURLTypeHelmOCI).
 		Chart("helm-values").
 		Revision("1.0.0").
 		When().
@@ -625,7 +624,7 @@ func TestHelmOCIRegistryWithDependencies(t *testing.T) {
 		PushChartToOCIRegistry("helm-values", "helm-values", "1.0.0").
 		PushChartToOCIRegistry("helm-oci-with-dependencies", "helm-oci-with-dependencies", "1.0.0").
 		HelmOCIRepoAdded("myrepo").
-		RepoURLType(RepoURLTypeHelmOCI).
+		RepoURLType(fixture.RepoURLTypeHelmOCI).
 		Chart("helm-oci-with-dependencies").
 		Revision("1.0.0").
 		When().
@@ -660,7 +659,7 @@ func TestTemplatesHelmOCIWithDependencies(t *testing.T) {
 		PushChartToOCIRegistry("helm-values", "helm-values", "1.0.0").
 		PushChartToOCIRegistry("helm-oci-with-dependencies", "helm-oci-with-dependencies", "1.0.0").
 		HelmoOCICredentialsWithoutUserPassAdded().
-		RepoURLType(RepoURLTypeHelmOCI).
+		RepoURLType(fixture.RepoURLTypeHelmOCI).
 		Chart("helm-oci-with-dependencies").
 		Revision("1.0.0").
 		When().

--- a/test/e2e/kustomize_test.go
+++ b/test/e2e/kustomize_test.go
@@ -11,10 +11,8 @@ import (
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	"github.com/argoproj/argo-cd/v2/util/errors"
-	. "github.com/argoproj/argo-cd/v2/util/errors"
 )
 
 func TestKustomize2AppSource(t *testing.T) {
@@ -304,10 +302,10 @@ func TestKustomizeKubeVersion(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			kubeVersion := FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			kubeVersion := errors.FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.kubeVersion}")).(string)
 			// Capabilities.KubeVersion defaults to 1.9.0, we assume here you are running a later version
-			assert.LessOrEqual(t, GetVersions().ServerVersion.Format("v%s.%s.0"), kubeVersion)
+			assert.LessOrEqual(t, fixture.GetVersions().ServerVersion.Format("v%s.%s.0"), kubeVersion)
 		}).
 		When().
 		// Make sure override works.
@@ -316,7 +314,7 @@ func TestKustomizeKubeVersion(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			assert.Equal(t, "v999.999.999", FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			assert.Equal(t, "v999.999.999", errors.FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.kubeVersion}")).(string))
 		})
 }
@@ -336,7 +334,7 @@ func TestKustomizeApiVersions(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			apiVersions := FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			apiVersions := errors.FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.apiVersions}")).(string)
 			// The v1 API shouldn't be going anywhere.
 			assert.Contains(t, apiVersions, "v1")
@@ -348,7 +346,7 @@ func TestKustomizeApiVersions(t *testing.T) {
 		Then().
 		Expect(SyncStatusIs(SyncStatusCodeSynced)).
 		And(func(app *Application) {
-			apiVersions := FailOnErr(Run(".", "kubectl", "-n", DeploymentNamespace(), "get", "cm", "my-map",
+			apiVersions := errors.FailOnErr(fixture.Run(".", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", "my-map",
 				"-o", "jsonpath={.data.apiVersions}")).(string)
 			assert.Contains(t, apiVersions, "v1/MyTestResource")
 		})

--- a/test/e2e/matrix_e2e_test.go
+++ b/test/e2e/matrix_e2e_test.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets/utils"
 
@@ -16,8 +15,8 @@ import (
 )
 
 func TestListMatrixGenerator(t *testing.T) {
-	generateExpectedApp := func(cluster, name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(cluster, name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -27,14 +26,14 @@ func TestListMatrixGenerator(t *testing.T) {
 				Namespace:  utils.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -42,7 +41,7 @@ func TestListMatrixGenerator(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook"),
 		generateExpectedApp("cluster1", "helm-guestbook"),
 		generateExpectedApp("cluster1", "ksonnet-guestbook"),
@@ -52,8 +51,8 @@ func TestListMatrixGenerator(t *testing.T) {
 		generateExpectedApp("cluster2", "ksonnet-guestbook"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		// Create a ClusterGenerator-based ApplicationSet
@@ -65,14 +64,14 @@ func TestListMatrixGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{values.name}}-{{path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},
@@ -141,8 +140,8 @@ func TestListMatrixGenerator(t *testing.T) {
 }
 
 func TestClusterMatrixGenerator(t *testing.T) {
-	generateExpectedApp := func(cluster, name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(cluster, name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -152,14 +151,14 @@ func TestClusterMatrixGenerator(t *testing.T) {
 				Namespace:  utils.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Name:      cluster,
 					Namespace: name,
 				},
@@ -167,7 +166,7 @@ func TestClusterMatrixGenerator(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook"),
 		generateExpectedApp("cluster1", "helm-guestbook"),
 		generateExpectedApp("cluster1", "ksonnet-guestbook"),
@@ -177,8 +176,8 @@ func TestClusterMatrixGenerator(t *testing.T) {
 		generateExpectedApp("cluster2", "ksonnet-guestbook"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		// Create a ClusterGenerator-based ApplicationSet
@@ -192,14 +191,14 @@ func TestClusterMatrixGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-{{path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name:      "{{name}}",
 							Namespace: "{{path.basename}}",
 						},
@@ -269,8 +268,8 @@ func TestClusterMatrixGenerator(t *testing.T) {
 }
 
 func TestMatrixTerminalMatrixGeneratorSelector(t *testing.T) {
-	generateExpectedApp := func(cluster, name string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(cluster, name string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -280,14 +279,14 @@ func TestMatrixTerminalMatrixGeneratorSelector(t *testing.T) {
 				Namespace:  utils.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -295,12 +294,12 @@ func TestMatrixTerminalMatrixGeneratorSelector(t *testing.T) {
 		}
 	}
 
-	expectedApps1 := []argov1alpha1.Application{
+	expectedApps1 := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook"),
 		generateExpectedApp("cluster1", "helm-guestbook"),
 		generateExpectedApp("cluster1", "ksonnet-guestbook"),
 	}
-	expectedApps2 := []argov1alpha1.Application{
+	expectedApps2 := []v1alpha1.Application{
 		generateExpectedApp("cluster2", "kustomize-guestbook"),
 		generateExpectedApp("cluster2", "helm-guestbook"),
 		generateExpectedApp("cluster2", "ksonnet-guestbook"),
@@ -317,14 +316,14 @@ func TestMatrixTerminalMatrixGeneratorSelector(t *testing.T) {
 				ApplyNestedSelectors: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{values.name}}-{{path.basename}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},
@@ -421,8 +420,8 @@ func TestMatrixTerminalMatrixGeneratorSelector(t *testing.T) {
 }
 
 func TestMatrixTerminalMergeGeneratorSelector(t *testing.T) {
-	generateExpectedApp := func(name, nameSuffix string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name, nameSuffix string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -432,14 +431,14 @@ func TestMatrixTerminalMergeGeneratorSelector(t *testing.T) {
 				Namespace:  utils.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -447,10 +446,10 @@ func TestMatrixTerminalMergeGeneratorSelector(t *testing.T) {
 		}
 	}
 
-	expectedApps1 := []argov1alpha1.Application{
+	expectedApps1 := []v1alpha1.Application{
 		generateExpectedApp("kustomize-guestbook", "1"),
 	}
-	expectedApps2 := []argov1alpha1.Application{
+	expectedApps2 := []v1alpha1.Application{
 		generateExpectedApp("helm-guestbook", "2"),
 	}
 
@@ -465,14 +464,14 @@ func TestMatrixTerminalMergeGeneratorSelector(t *testing.T) {
 				ApplyNestedSelectors: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{path.basename}}-{{name-suffix}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},

--- a/test/e2e/merge_e2e_test.go
+++ b/test/e2e/merge_e2e_test.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	argov1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture/applicationsets/utils"
 
@@ -17,8 +16,8 @@ import (
 )
 
 func TestListMergeGenerator(t *testing.T) {
-	generateExpectedApp := func(name, nameSuffix string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name, nameSuffix string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -28,14 +27,14 @@ func TestListMergeGenerator(t *testing.T) {
 				Namespace:  utils.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -43,13 +42,13 @@ func TestListMergeGenerator(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("kustomize-guestbook", "1"),
 		generateExpectedApp("helm-guestbook", "2"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		// Create a ClusterGenerator-based ApplicationSet
@@ -61,14 +60,14 @@ func TestListMergeGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{path.basename}}-{{name-suffix}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},
@@ -138,8 +137,8 @@ func TestListMergeGenerator(t *testing.T) {
 }
 
 func TestClusterMergeGenerator(t *testing.T) {
-	generateExpectedApp := func(cluster, name, nameSuffix string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(cluster, name, nameSuffix string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -149,14 +148,14 @@ func TestClusterMergeGenerator(t *testing.T) {
 				Namespace:  utils.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Name:      cluster,
 					Namespace: name,
 				},
@@ -164,7 +163,7 @@ func TestClusterMergeGenerator(t *testing.T) {
 		}
 	}
 
-	expectedApps := []argov1alpha1.Application{
+	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook", "1"),
 		generateExpectedApp("cluster1", "helm-guestbook", "0"),
 		generateExpectedApp("cluster1", "ksonnet-guestbook", "0"),
@@ -174,8 +173,8 @@ func TestClusterMergeGenerator(t *testing.T) {
 		generateExpectedApp("cluster2", "ksonnet-guestbook", "0"),
 	}
 
-	var expectedAppsNewNamespace []argov1alpha1.Application
-	var expectedAppsNewMetadata []argov1alpha1.Application
+	var expectedAppsNewNamespace []v1alpha1.Application
+	var expectedAppsNewMetadata []v1alpha1.Application
 
 	Given(t).
 		// Create a ClusterGenerator-based ApplicationSet
@@ -189,14 +188,14 @@ func TestClusterMergeGenerator(t *testing.T) {
 			Spec: v1alpha1.ApplicationSetSpec{
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{name}}-{{path.basename}}-{{values.name-suffix}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Name:      "{{name}}",
 							Namespace: "{{path.basename}}",
 						},
@@ -284,8 +283,8 @@ func TestClusterMergeGenerator(t *testing.T) {
 }
 
 func TestMergeTerminalMergeGeneratorSelector(t *testing.T) {
-	generateExpectedApp := func(name, nameSuffix string) argov1alpha1.Application {
-		return argov1alpha1.Application{
+	generateExpectedApp := func(name, nameSuffix string) v1alpha1.Application {
+		return v1alpha1.Application{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       application.ApplicationKind,
 				APIVersion: "argoproj.io/v1alpha1",
@@ -295,14 +294,14 @@ func TestMergeTerminalMergeGeneratorSelector(t *testing.T) {
 				Namespace:  utils.TestNamespace(),
 				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
 			},
-			Spec: argov1alpha1.ApplicationSpec{
+			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
-				Source: &argov1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 					TargetRevision: "HEAD",
 					Path:           name,
 				},
-				Destination: argov1alpha1.ApplicationDestination{
+				Destination: v1alpha1.ApplicationDestination{
 					Server:    "https://kubernetes.default.svc",
 					Namespace: name,
 				},
@@ -310,10 +309,10 @@ func TestMergeTerminalMergeGeneratorSelector(t *testing.T) {
 		}
 	}
 
-	expectedApps1 := []argov1alpha1.Application{
+	expectedApps1 := []v1alpha1.Application{
 		generateExpectedApp("kustomize-guestbook", "1"),
 	}
-	expectedApps2 := []argov1alpha1.Application{
+	expectedApps2 := []v1alpha1.Application{
 		generateExpectedApp("helm-guestbook", "2"),
 	}
 
@@ -328,14 +327,14 @@ func TestMergeTerminalMergeGeneratorSelector(t *testing.T) {
 				ApplyNestedSelectors: true,
 				Template: v1alpha1.ApplicationSetTemplate{
 					ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{Name: "{{path.basename}}-{{name-suffix}}"},
-					Spec: argov1alpha1.ApplicationSpec{
+					Spec: v1alpha1.ApplicationSpec{
 						Project: "default",
-						Source: &argov1alpha1.ApplicationSource{
+						Source: &v1alpha1.ApplicationSource{
 							RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
 							TargetRevision: "HEAD",
 							Path:           "{{path}}",
 						},
-						Destination: argov1alpha1.ApplicationDestination{
+						Destination: v1alpha1.ApplicationDestination{
 							Server:    "https://kubernetes.default.svc",
 							Namespace: "{{path.basename}}",
 						},

--- a/test/e2e/selective_sync_test.go
+++ b/test/e2e/selective_sync_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/test/e2e/fixture"
-	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture"
 	. "github.com/argoproj/argo-cd/v2/test/e2e/fixture/app"
 	. "github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/rand"
@@ -55,14 +54,14 @@ func TestSelectiveSyncWithoutNamespace(t *testing.T) {
 	selectedResourceNamespace := getNewNamespace(t)
 	defer func() {
 		if !t.Skipped() {
-			FailOnErr(Run("", "kubectl", "delete", "namespace", selectedResourceNamespace))
+			FailOnErr(fixture.Run("", "kubectl", "delete", "namespace", selectedResourceNamespace))
 		}
 	}()
 	Given(t).
 		Prune(true).
 		Path("guestbook-with-namespace").
 		And(func() {
-			FailOnErr(Run("", "kubectl", "create", "namespace", selectedResourceNamespace))
+			FailOnErr(fixture.Run("", "kubectl", "create", "namespace", selectedResourceNamespace))
 		}).
 		SelectedResource("apps:Deployment:guestbook-ui").
 		When().
@@ -85,14 +84,14 @@ func TestSelectiveSyncWithNamespace(t *testing.T) {
 	selectedResourceNamespace := getNewNamespace(t)
 	defer func() {
 		if !t.Skipped() {
-			FailOnErr(Run("", "kubectl", "delete", "namespace", selectedResourceNamespace))
+			FailOnErr(fixture.Run("", "kubectl", "delete", "namespace", selectedResourceNamespace))
 		}
 	}()
 	Given(t).
 		Prune(true).
 		Path("guestbook-with-namespace").
 		And(func() {
-			FailOnErr(Run("", "kubectl", "create", "namespace", selectedResourceNamespace))
+			FailOnErr(fixture.Run("", "kubectl", "create", "namespace", selectedResourceNamespace))
 		}).
 		SelectedResource(fmt.Sprintf("apps:Deployment:%s/guestbook-ui", selectedResourceNamespace)).
 		When().

--- a/util/argo/resource_tracking.go
+++ b/util/argo/resource_tracking.go
@@ -11,7 +11,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/kube"
-	argokube "github.com/argoproj/argo-cd/v2/util/kube"
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
@@ -69,7 +68,7 @@ func (rt *resourceTracking) getAppInstanceValue(un *unstructured.Unstructured, i
 	if installationID != "" && un.GetAnnotations() == nil || un.GetAnnotations()[common.AnnotationInstallationID] != installationID {
 		return nil
 	}
-	appInstanceAnnotation, err := argokube.GetAppInstanceAnnotation(un, common.AnnotationKeyAppInstance)
+	appInstanceAnnotation, err := kube.GetAppInstanceAnnotation(un, common.AnnotationKeyAppInstance)
 	if err != nil {
 		return nil
 	}
@@ -91,7 +90,7 @@ func (rt *resourceTracking) GetAppName(un *unstructured.Unstructured, key string
 	}
 	switch trackingMethod {
 	case TrackingMethodLabel:
-		label, err := argokube.GetAppInstanceLabel(un, key)
+		label, err := kube.GetAppInstanceLabel(un, key)
 		if err != nil {
 			return ""
 		}
@@ -101,7 +100,7 @@ func (rt *resourceTracking) GetAppName(un *unstructured.Unstructured, key string
 	case TrackingMethodAnnotation:
 		return retrieveAppInstanceValue()
 	default:
-		label, err := argokube.GetAppInstanceLabel(un, key)
+		label, err := kube.GetAppInstanceLabel(un, key)
 		if err != nil {
 			return ""
 		}
@@ -145,19 +144,19 @@ func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, v
 	setAppInstanceAnnotation := func() error {
 		appInstanceValue := UnstructuredToAppInstanceValue(un, val, namespace)
 		if instanceID != "" {
-			if err := argokube.SetAppInstanceAnnotation(un, common.AnnotationInstallationID, instanceID); err != nil {
+			if err := kube.SetAppInstanceAnnotation(un, common.AnnotationInstallationID, instanceID); err != nil {
 				return err
 			}
 		} else {
-			if err := argokube.RemoveAnnotation(un, common.AnnotationInstallationID); err != nil {
+			if err := kube.RemoveAnnotation(un, common.AnnotationInstallationID); err != nil {
 				return err
 			}
 		}
-		return argokube.SetAppInstanceAnnotation(un, common.AnnotationKeyAppInstance, rt.BuildAppInstanceValue(appInstanceValue))
+		return kube.SetAppInstanceAnnotation(un, common.AnnotationKeyAppInstance, rt.BuildAppInstanceValue(appInstanceValue))
 	}
 	switch trackingMethod {
 	case TrackingMethodLabel:
-		err := argokube.SetAppInstanceLabel(un, key, val)
+		err := kube.SetAppInstanceLabel(un, key, val)
 		if err != nil {
 			return fmt.Errorf("failed to set app instance label: %w", err)
 		}
@@ -180,13 +179,13 @@ func (rt *resourceTracking) SetAppInstance(un *unstructured.Unstructured, key, v
 				val = val[:len(val)-1]
 			}
 		}
-		err = argokube.SetAppInstanceLabel(un, key, val)
+		err = kube.SetAppInstanceLabel(un, key, val)
 		if err != nil {
 			return fmt.Errorf("failed to set app instance label: %w", err)
 		}
 		return nil
 	default:
-		err := argokube.SetAppInstanceLabel(un, key, val)
+		err := kube.SetAppInstanceLabel(un, key, val)
 		if err != nil {
 			return fmt.Errorf("failed to set app instance label: %w", err)
 		}
@@ -241,21 +240,21 @@ func (rt *resourceTracking) Normalize(config, live *unstructured.Unstructured, l
 		return nil
 	}
 
-	annotation, err := argokube.GetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance)
+	annotation, err := kube.GetAppInstanceAnnotation(config, common.AnnotationKeyAppInstance)
 	if err != nil {
 		return err
 	}
-	err = argokube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
+	err = kube.SetAppInstanceAnnotation(live, common.AnnotationKeyAppInstance, annotation)
 	if err != nil {
 		return err
 	}
 
-	label, err = argokube.GetAppInstanceLabel(config, labelKey)
+	label, err = kube.GetAppInstanceLabel(config, labelKey)
 	if err != nil {
 		return fmt.Errorf("failed to get app instance label: %w", err)
 	}
 	if label == "" {
-		err = argokube.RemoveLabel(live, labelKey)
+		err = kube.RemoveLabel(live, labelKey)
 		if err != nil {
 			return fmt.Errorf("failed to remove app instance label: %w", err)
 		}

--- a/util/db/cluster_test.go
+++ b/util/db/cluster_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/common"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
@@ -97,7 +96,7 @@ func Test_secretToCluster_LastAppliedConfigurationDropped(t *testing.T) {
 }
 
 func TestClusterToSecret(t *testing.T) {
-	cluster := &appv1.Cluster{
+	cluster := &v1alpha1.Cluster{
 		Server:      "server",
 		Labels:      map[string]string{"test": "label"},
 		Annotations: map[string]string{"test": "annotation"},
@@ -119,7 +118,7 @@ func TestClusterToSecret(t *testing.T) {
 }
 
 func TestClusterToSecret_LastAppliedConfigurationRejected(t *testing.T) {
-	cluster := &appv1.Cluster{
+	cluster := &v1alpha1.Cluster{
 		Server:      "server",
 		Annotations: map[string]string{corev1.LastAppliedConfigAnnotation: "val2"},
 		Name:        "test",
@@ -247,8 +246,8 @@ func TestRejectCreationForInClusterWhenDisabled(t *testing.T) {
 	kubeclientset := fake.NewClientset(argoCDConfigMapWithInClusterServerAddressDisabled, argoCDSecret)
 	settingsManager := settings.NewSettingsManager(context.Background(), kubeclientset, fakeNamespace)
 	db := NewDB(fakeNamespace, settingsManager, kubeclientset)
-	_, err := db.CreateCluster(context.Background(), &appv1.Cluster{
-		Server: appv1.KubernetesInternalAPIServerAddr,
+	_, err := db.CreateCluster(context.Background(), &v1alpha1.Cluster{
+		Server: v1alpha1.KubernetesInternalAPIServerAddr,
 		Name:   "incluster-name",
 	})
 	require.Error(t, err)
@@ -339,7 +338,7 @@ func TestListClusters(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"server": []byte(appv1.KubernetesInternalAPIServerAddr),
+			"server": []byte(v1alpha1.KubernetesInternalAPIServerAddr),
 			"name":   []byte("in-cluster"),
 		},
 	}

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -11,8 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	appsv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/settings"
 )
 
@@ -41,24 +40,24 @@ const (
 
 // repositoryBackend defines the API for types that wish to provide interaction with repository storage
 type repositoryBackend interface {
-	CreateRepository(ctx context.Context, r *appsv1.Repository) (*appsv1.Repository, error)
-	GetRepository(ctx context.Context, repoURL, project string) (*appsv1.Repository, error)
-	ListRepositories(ctx context.Context, repoType *string) ([]*appsv1.Repository, error)
-	UpdateRepository(ctx context.Context, r *appsv1.Repository) (*appsv1.Repository, error)
+	CreateRepository(ctx context.Context, r *v1alpha1.Repository) (*v1alpha1.Repository, error)
+	GetRepository(ctx context.Context, repoURL, project string) (*v1alpha1.Repository, error)
+	ListRepositories(ctx context.Context, repoType *string) ([]*v1alpha1.Repository, error)
+	UpdateRepository(ctx context.Context, r *v1alpha1.Repository) (*v1alpha1.Repository, error)
 	DeleteRepository(ctx context.Context, repoURL, project string) error
 	RepositoryExists(ctx context.Context, repoURL, project string, allowFallback bool) (bool, error)
 
-	CreateRepoCreds(ctx context.Context, r *appsv1.RepoCreds) (*appsv1.RepoCreds, error)
-	GetRepoCreds(ctx context.Context, repoURL string) (*appsv1.RepoCreds, error)
+	CreateRepoCreds(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error)
+	GetRepoCreds(ctx context.Context, repoURL string) (*v1alpha1.RepoCreds, error)
 	ListRepoCreds(ctx context.Context) ([]string, error)
-	UpdateRepoCreds(ctx context.Context, r *appsv1.RepoCreds) (*appsv1.RepoCreds, error)
+	UpdateRepoCreds(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error)
 	DeleteRepoCreds(ctx context.Context, name string) error
 	RepoCredsExists(ctx context.Context, repoURL string) (bool, error)
 
-	GetAllHelmRepoCreds(ctx context.Context) ([]*appsv1.RepoCreds, error)
+	GetAllHelmRepoCreds(ctx context.Context) ([]*v1alpha1.RepoCreds, error)
 }
 
-func (db *db) CreateRepository(ctx context.Context, r *appsv1.Repository) (*appsv1.Repository, error) {
+func (db *db) CreateRepository(ctx context.Context, r *v1alpha1.Repository) (*v1alpha1.Repository, error) {
 	secretBackend := db.repoBackend()
 	legacyBackend := db.legacyRepoBackend()
 
@@ -78,7 +77,7 @@ func (db *db) CreateRepository(ctx context.Context, r *appsv1.Repository) (*apps
 	return secretBackend.CreateRepository(ctx, r)
 }
 
-func (db *db) CreateWriteRepository(ctx context.Context, r *appsv1.Repository) (*appsv1.Repository, error) {
+func (db *db) CreateWriteRepository(ctx context.Context, r *v1alpha1.Repository) (*v1alpha1.Repository, error) {
 	secretBackend := db.repoWriteBackend()
 	secretExists, err := secretBackend.RepositoryExists(ctx, r.Repo, r.Project, false)
 	if err != nil {
@@ -92,7 +91,7 @@ func (db *db) CreateWriteRepository(ctx context.Context, r *appsv1.Repository) (
 	return secretBackend.CreateRepository(ctx, r)
 }
 
-func (db *db) GetRepository(ctx context.Context, repoURL, project string) (*appsv1.Repository, error) {
+func (db *db) GetRepository(ctx context.Context, repoURL, project string) (*v1alpha1.Repository, error) {
 	repository, err := db.getRepository(ctx, repoURL, project)
 	if err != nil {
 		return repository, fmt.Errorf("unable to get repository %q: %w", repoURL, err)
@@ -105,7 +104,7 @@ func (db *db) GetRepository(ctx context.Context, repoURL, project string) (*apps
 	return repository, err
 }
 
-func (db *db) GetWriteRepository(ctx context.Context, repoURL, project string) (*appsv1.Repository, error) {
+func (db *db) GetWriteRepository(ctx context.Context, repoURL, project string) (*v1alpha1.Repository, error) {
 	repository, err := db.repoWriteBackend().GetRepository(ctx, repoURL, project)
 	if err != nil {
 		return repository, fmt.Errorf("unable to get write repository %q: %w", repoURL, err)
@@ -119,15 +118,15 @@ func (db *db) GetWriteRepository(ctx context.Context, repoURL, project string) (
 	return repository, err
 }
 
-func (db *db) GetProjectRepositories(ctx context.Context, project string) ([]*appsv1.Repository, error) {
+func (db *db) GetProjectRepositories(ctx context.Context, project string) ([]*v1alpha1.Repository, error) {
 	return db.getRepositories(settings.ByProjectRepoIndexer, project)
 }
 
-func (db *db) GetProjectWriteRepositories(ctx context.Context, project string) ([]*appsv1.Repository, error) {
+func (db *db) GetProjectWriteRepositories(ctx context.Context, project string) ([]*v1alpha1.Repository, error) {
 	return db.getRepositories(settings.ByProjectRepoWriteIndexer, project)
 }
 
-func (db *db) getRepositories(indexer, project string) ([]*appv1.Repository, error) {
+func (db *db) getRepositories(indexer, project string) ([]*v1alpha1.Repository, error) {
 	informer, err := db.settingsMgr.GetSecretsInformer()
 	if err != nil {
 		return nil, err
@@ -136,7 +135,7 @@ func (db *db) getRepositories(indexer, project string) ([]*appv1.Repository, err
 	if err != nil {
 		return nil, err
 	}
-	var res []*appv1.Repository
+	var res []*v1alpha1.Repository
 	for i := range secrets {
 		repo, err := secretToRepository(secrets[i].(*corev1.Secret))
 		if err != nil {
@@ -163,7 +162,7 @@ func (db *db) WriteRepositoryExists(ctx context.Context, repoURL, project string
 	return secretsBackend.RepositoryExists(ctx, repoURL, project, true)
 }
 
-func (db *db) getRepository(ctx context.Context, repoURL, project string) (*appsv1.Repository, error) {
+func (db *db) getRepository(ctx context.Context, repoURL, project string) (*v1alpha1.Repository, error) {
 	secretsBackend := db.repoBackend()
 	exists, err := secretsBackend.RepositoryExists(ctx, repoURL, project, true)
 	if err != nil {
@@ -188,22 +187,22 @@ func (db *db) getRepository(ctx context.Context, repoURL, project string) (*apps
 		return repository, nil
 	}
 
-	return &appsv1.Repository{Repo: repoURL}, nil
+	return &v1alpha1.Repository{Repo: repoURL}, nil
 }
 
-func (db *db) ListRepositories(ctx context.Context) ([]*appsv1.Repository, error) {
+func (db *db) ListRepositories(ctx context.Context) ([]*v1alpha1.Repository, error) {
 	return db.listRepositories(ctx, nil, false)
 }
 
-func (db *db) ListWriteRepositories(ctx context.Context) ([]*appsv1.Repository, error) {
+func (db *db) ListWriteRepositories(ctx context.Context) ([]*v1alpha1.Repository, error) {
 	return db.listRepositories(ctx, nil, true)
 }
 
-func (db *db) listRepositories(ctx context.Context, repoType *string, writeCreds bool) ([]*appsv1.Repository, error) {
+func (db *db) listRepositories(ctx context.Context, repoType *string, writeCreds bool) ([]*v1alpha1.Repository, error) {
 	// TODO It would be nice to check for duplicates between secret and legacy repositories and make it so that
 	// 	repositories from secrets overlay repositories from legacys.
 
-	var repositories []*appv1.Repository
+	var repositories []*v1alpha1.Repository
 	if writeCreds {
 		var err error
 		repositories, err = db.repoWriteBackend().ListRepositories(ctx, repoType)
@@ -231,7 +230,7 @@ func (db *db) listRepositories(ctx context.Context, repoType *string, writeCreds
 }
 
 // UpdateRepository updates a repository
-func (db *db) UpdateRepository(ctx context.Context, r *appsv1.Repository) (*appsv1.Repository, error) {
+func (db *db) UpdateRepository(ctx context.Context, r *v1alpha1.Repository) (*v1alpha1.Repository, error) {
 	secretsBackend := db.repoBackend()
 	exists, err := secretsBackend.RepositoryExists(ctx, r.Repo, r.Project, false)
 	if err != nil {
@@ -251,7 +250,7 @@ func (db *db) UpdateRepository(ctx context.Context, r *appsv1.Repository) (*apps
 	return nil, status.Errorf(codes.NotFound, "repo '%s' not found", r.Repo)
 }
 
-func (db *db) UpdateWriteRepository(ctx context.Context, r *appsv1.Repository) (*appsv1.Repository, error) {
+func (db *db) UpdateWriteRepository(ctx context.Context, r *v1alpha1.Repository) (*v1alpha1.Repository, error) {
 	secretBackend := db.repoWriteBackend()
 	exists, err := secretBackend.RepositoryExists(ctx, r.Repo, r.Project, false)
 	if err != nil {
@@ -327,7 +326,7 @@ func (db *db) ListWriteRepositoryCredentials(ctx context.Context) ([]string, err
 }
 
 // GetRepositoryCredentials retrieves a repository credential set
-func (db *db) GetRepositoryCredentials(ctx context.Context, repoURL string) (*appsv1.RepoCreds, error) {
+func (db *db) GetRepositoryCredentials(ctx context.Context, repoURL string) (*v1alpha1.RepoCreds, error) {
 	secretsBackend := db.repoBackend()
 	exists, err := secretsBackend.RepoCredsExists(ctx, repoURL)
 	if err != nil {
@@ -356,7 +355,7 @@ func (db *db) GetRepositoryCredentials(ctx context.Context, repoURL string) (*ap
 }
 
 // GetWriteRepositoryCredentials retrieves a repository write credential set
-func (db *db) GetWriteRepositoryCredentials(ctx context.Context, repoURL string) (*appsv1.RepoCreds, error) {
+func (db *db) GetWriteRepositoryCredentials(ctx context.Context, repoURL string) (*v1alpha1.RepoCreds, error) {
 	secretBackend := db.repoWriteBackend()
 	exists, err := secretBackend.RepoCredsExists(ctx, repoURL)
 	if err != nil {
@@ -381,7 +380,7 @@ func (db *db) GetWriteRepositoryCredentials(ctx context.Context, repoURL string)
 }
 
 // GetAllHelmRepositoryCredentials retrieves all repository credentials
-func (db *db) GetAllHelmRepositoryCredentials(ctx context.Context) ([]*appsv1.RepoCreds, error) {
+func (db *db) GetAllHelmRepositoryCredentials(ctx context.Context) ([]*v1alpha1.RepoCreds, error) {
 	// TODO It would be nice to check for duplicates between secret and legacy repositories and make it so that
 	// 	repositories from secrets overlay repositories from legacys.
 
@@ -399,7 +398,7 @@ func (db *db) GetAllHelmRepositoryCredentials(ctx context.Context) ([]*appsv1.Re
 }
 
 // CreateRepositoryCredentials creates a repository credential set
-func (db *db) CreateRepositoryCredentials(ctx context.Context, r *appsv1.RepoCreds) (*appsv1.RepoCreds, error) {
+func (db *db) CreateRepositoryCredentials(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error) {
 	legacyBackend := db.legacyRepoBackend()
 	secretBackend := db.repoBackend()
 
@@ -420,7 +419,7 @@ func (db *db) CreateRepositoryCredentials(ctx context.Context, r *appsv1.RepoCre
 }
 
 // CreateWriteRepositoryCredentials creates a repository write credential set
-func (db *db) CreateWriteRepositoryCredentials(ctx context.Context, r *appsv1.RepoCreds) (*appsv1.RepoCreds, error) {
+func (db *db) CreateWriteRepositoryCredentials(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error) {
 	secretBackend := db.repoWriteBackend()
 	secretExists, err := secretBackend.RepoCredsExists(ctx, r.URL)
 	if err != nil {
@@ -435,7 +434,7 @@ func (db *db) CreateWriteRepositoryCredentials(ctx context.Context, r *appsv1.Re
 }
 
 // UpdateRepositoryCredentials updates a repository credential set
-func (db *db) UpdateRepositoryCredentials(ctx context.Context, r *appsv1.RepoCreds) (*appsv1.RepoCreds, error) {
+func (db *db) UpdateRepositoryCredentials(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error) {
 	secretsBackend := db.repoBackend()
 	exists, err := secretsBackend.RepoCredsExists(ctx, r.URL)
 	if err != nil {
@@ -456,7 +455,7 @@ func (db *db) UpdateRepositoryCredentials(ctx context.Context, r *appsv1.RepoCre
 }
 
 // UpdateWriteRepositoryCredentials updates a repository write credential set
-func (db *db) UpdateWriteRepositoryCredentials(ctx context.Context, r *appsv1.RepoCreds) (*appsv1.RepoCreds, error) {
+func (db *db) UpdateWriteRepositoryCredentials(ctx context.Context, r *v1alpha1.RepoCreds) (*v1alpha1.RepoCreds, error) {
 	secretBackend := db.repoWriteBackend()
 	exists, err := secretBackend.RepoCredsExists(ctx, r.URL)
 	if err != nil {
@@ -505,7 +504,7 @@ func (db *db) DeleteWriteRepositoryCredentials(ctx context.Context, name string)
 	return status.Errorf(codes.NotFound, "write repository credentials '%s' not found", name)
 }
 
-func (db *db) enrichCredsToRepos(ctx context.Context, repositories []*appsv1.Repository) error {
+func (db *db) enrichCredsToRepos(ctx context.Context, repositories []*v1alpha1.Repository) error {
 	for _, repository := range repositories {
 		if err := db.enrichCredsToRepo(ctx, repository); err != nil {
 			return err
@@ -526,7 +525,7 @@ func (db *db) legacyRepoBackend() repositoryBackend {
 	return &legacyRepositoryBackend{db: db}
 }
 
-func (db *db) enrichCredsToRepo(ctx context.Context, repository *appsv1.Repository) error {
+func (db *db) enrichCredsToRepo(ctx context.Context, repository *v1alpha1.Repository) error {
 	if !repository.HasCredentials() {
 		creds, err := db.GetRepositoryCredentials(ctx, repository.Repo)
 		if err == nil {

--- a/util/localconfig/localconfig.go
+++ b/util/localconfig/localconfig.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/argoproj/argo-cd/v2/util/config"
-	configUtil "github.com/argoproj/argo-cd/v2/util/config"
 )
 
 // LocalConfig is a local Argo CD config file
@@ -80,7 +79,7 @@ func (u *User) Claims() (*jwt.RegisteredClaims, error) {
 // ReadLocalConfig loads up the local configuration file. Returns nil if config does not exist
 func ReadLocalConfig(path string) (*LocalConfig, error) {
 	var err error
-	var config LocalConfig
+	var localconfig LocalConfig
 
 	// check file permission only when argocd config exists
 	if fi, err := os.Stat(path); err == nil {
@@ -90,15 +89,15 @@ func ReadLocalConfig(path string) (*LocalConfig, error) {
 		}
 	}
 
-	err = configUtil.UnmarshalLocalFile(path, &config)
+	err = config.UnmarshalLocalFile(path, &localconfig)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
-	err = ValidateLocalConfig(config)
+	err = ValidateLocalConfig(localconfig)
 	if err != nil {
 		return nil, err
 	}
-	return &config, nil
+	return &localconfig, nil
 }
 
 func ValidateLocalConfig(config LocalConfig) error {
@@ -112,12 +111,12 @@ func ValidateLocalConfig(config LocalConfig) error {
 }
 
 // WriteLocalConfig writes a new local configuration file.
-func WriteLocalConfig(config LocalConfig, configPath string) error {
+func WriteLocalConfig(localconfig LocalConfig, configPath string) error {
 	err := os.MkdirAll(path.Dir(configPath), os.ModePerm)
 	if err != nil {
 		return err
 	}
-	return configUtil.MarshalLocalYAMLFile(configPath, config)
+	return config.MarshalLocalYAMLFile(configPath, localconfig)
 }
 
 func DeleteLocalConfig(configPath string) error {


### PR DESCRIPTION
#### Description 

[duplicated-imports](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports): It is possible to unintentionally import the same package twice. This rule looks for packages that are imported two or more times.
