### PR TITLE
chore: enable redundant-import-alias from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,12 +60,18 @@ linters-settings:
     alias:
       - alias: jwtgo 
         pkg: github.com/golang-jwt/jwt/v5
+      - alias: appsv1
+        pkg: k8s.io/api/apps/v1
       - alias: corev1
         pkg: k8s.io/api/core/v1
+      - alias: rbacv1
+        pkg: k8s.io/api/rbac/v1
       - alias: apierrors 
         pkg: k8s.io/apimachinery/pkg/api/errors
       - alias: metav1 
         pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      - alias: informersv1
+        pkg: k8s.io/client-go/informers/core/v1
       - alias: stderrors
         pkg: errors
   perfsprint:
@@ -106,19 +112,24 @@ linters-settings:
         disabled: true
       # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
       - name: errorf
+        disabled: false
       # incrementing an integer variable by 1 is recommended to be done using the `++` operator
       - name: increment-decrement
+        disabled: false
       # highlights redundant else-blocks that can be eliminated from the code
       - name: indent-error-flow
         disabled: true
       # This rule suggests a shorter way of writing ranges that do not use the second value.
       - name: range
+        disabled: false
       # receiver names in a method should reflect the struct name (p for Person, for example)
       - name: receiver-naming
         disabled: true
       # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
       - name: redefines-builtin-id
         disabled: true
+      - name: redundant-import-alias
+        disabled: false
       # redundant else-blocks that can be eliminated from the code.
       - name: superfluous-else
         disabled: true
@@ -130,13 +141,16 @@ linters-settings:
         disabled: true
       # spots and proposes to remove unreachable code. also helps to spot errors
       - name: unreachable-code
+        disabled: false
       # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
       - name: unused-parameter
         disabled: true
       # Since Go 1.18, interface{} has an alias: any. This rule proposes to replace instances of interface{} with any.
       - name: use-any
+        disabled: false
       # report when a variable declaration can be simplified
       - name: var-declaration
+        disabled: false
       # warns when initialism, variable or package naming conventions are not followed.
       - name: var-naming
         disabled: true

--- a/applicationset/metrics/metrics_test.go
+++ b/applicationset/metrics/metrics_test.go
@@ -7,23 +7,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/argo-cd/v2/applicationset/utils"
-	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	prometheus "github.com/prometheus/client_golang/prometheus"
-
-	metricsutil "github.com/argoproj/argo-cd/v2/util/metrics"
-
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
 	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-cd/v2/applicationset/utils"
+	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	metricsutil "github.com/argoproj/argo-cd/v2/util/metrics"
 )
 
 var (

--- a/applicationset/services/pull_request/azure_devops.go
+++ b/applicationset/services/pull_request/azure_devops.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
-	core "github.com/microsoft/azure-devops-go-api/azuredevops/core"
-	git "github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/core"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
 )
 
 const AZURE_DEVOPS_DEFAULT_URL = "https://dev.azure.com"

--- a/applicationset/services/pull_request/azure_devops_test.go
+++ b/applicationset/services/pull_request/azure_devops_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/core"
-	git "github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/cmd/argocd/commands/admin/notifications.go
+++ b/cmd/argocd/commands/admin/notifications.go
@@ -11,7 +11,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/argoproj/argo-cd/v2/util/env"
 	service "github.com/argoproj/argo-cd/v2/util/notification/argocd"
-	settings "github.com/argoproj/argo-cd/v2/util/notification/settings"
+	"github.com/argoproj/argo-cd/v2/util/notification/settings"
 	"github.com/argoproj/argo-cd/v2/util/tls"
 
 	"github.com/argoproj/notifications-engine/pkg/cmd"

--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -21,7 +21,7 @@ import (
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
-	v1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/argo"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"

--- a/controller/appcontroller_test.go
+++ b/controller/appcontroller_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1696,7 +1696,7 @@ func TestUpdateReconciledAt(t *testing.T) {
 }
 
 func TestUpdateHealthStatusTransitionTime(t *testing.T) {
-	deployment := kube.MustToUnstructured(&v1.Deployment{
+	deployment := kube.MustToUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -1798,7 +1798,7 @@ apps/Deployment:
 
 func TestUpdateHealthStatusProgression(t *testing.T) {
 	app := newFakeAppWithHealthAndTime(health.HealthStatusDegraded, testTimestamp)
-	deployment := kube.MustToUnstructured(&v1.Deployment{
+	deployment := kube.MustToUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -1807,7 +1807,7 @@ func TestUpdateHealthStatusProgression(t *testing.T) {
 			Name:      "demo",
 			Namespace: "default",
 		},
-		Status: v1.DeploymentStatus{
+		Status: appsv1.DeploymentStatus{
 			ObservedGeneration: 0,
 		},
 	})

--- a/controller/sharding/sharding.go
+++ b/controller/sharding/sharding.go
@@ -8,12 +8,12 @@ import (
 	"hash/fnv"
 	"math"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
-	slices "golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -16,7 +16,7 @@ import (
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -684,7 +684,7 @@ func TestCompareAppStateWithManifestGeneratePath(t *testing.T) {
 
 func TestSetHealth(t *testing.T) {
 	app := newFakeApp()
-	deployment := kube.MustToUnstructured(&v1.Deployment{
+	deployment := kube.MustToUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -721,7 +721,7 @@ func TestSetHealth(t *testing.T) {
 func TestPreserveStatusTimestamp(t *testing.T) {
 	timestamp := metav1.Now()
 	app := newFakeAppWithHealthAndTime(health.HealthStatusHealthy, timestamp)
-	deployment := kube.MustToUnstructured(&v1.Deployment{
+	deployment := kube.MustToUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -758,7 +758,7 @@ func TestPreserveStatusTimestamp(t *testing.T) {
 func TestSetHealthSelfReferencedApp(t *testing.T) {
 	app := newFakeApp()
 	unstructuredApp := kube.MustToUnstructured(app)
-	deployment := kube.MustToUnstructured(&v1.Deployment{
+	deployment := kube.MustToUnstructured(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",

--- a/pkg/apis/application/v1alpha1/values.go
+++ b/pkg/apis/application/v1alpha1/values.go
@@ -3,10 +3,10 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-	reflect "reflect"
+	"reflect"
 	"strings"
 
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 )
 

--- a/reposerver/apiclient/mocks/Clientset.go
+++ b/reposerver/apiclient/mocks/Clientset.go
@@ -1,9 +1,8 @@
 package mocks
 
 import (
-	apiclient "github.com/argoproj/argo-cd/v2/reposerver/apiclient"
-
-	io "github.com/argoproj/argo-cd/v2/util/io"
+	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
+	"github.com/argoproj/argo-cd/v2/util/io"
 )
 
 type Clientset struct {

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
@@ -1113,7 +1113,7 @@ func TestGenerateHelmWithValues(t *testing.T) {
 		require.NoError(t, err)
 
 		if obj.GetKind() == "Deployment" && obj.GetName() == "test-redis-slave" {
-			var dep v1.Deployment
+			var dep appsv1.Deployment
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &dep)
 			require.NoError(t, err)
 			assert.Equal(t, int32(2), *dep.Spec.Replicas)
@@ -1175,7 +1175,7 @@ func TestGenerateHelmWithEnvVars(t *testing.T) {
 		require.NoError(t, err)
 
 		if obj.GetKind() == "Deployment" && obj.GetName() == "production-redis-slave" {
-			var dep v1.Deployment
+			var dep appsv1.Deployment
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &dep)
 			require.NoError(t, err)
 			assert.Equal(t, int32(3), *dep.Spec.Replicas)

--- a/server/badge/badge.go
+++ b/server/badge/badge.go
@@ -10,7 +10,7 @@ import (
 
 	healthutil "github.com/argoproj/gitops-engine/pkg/health"
 	"k8s.io/apimachinery/pkg/api/errors"
-	validation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"

--- a/test/e2e/fixture/admin/utils/backup.go
+++ b/test/e2e/fixture/admin/utils/backup.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	kube "github.com/argoproj/gitops-engine/pkg/utils/kube"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )

--- a/test/e2e/fixture/applicationsets/actions.go
+++ b/test/e2e/fixture/applicationsets/actions.go
@@ -11,7 +11,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -242,9 +242,9 @@ func (a *Actions) CreatePlacementRoleAndRoleBinding() *Actions {
 
 	var err error
 
-	_, err = fixtureClient.KubeClientset.RbacV1().Roles(fixture.TestNamespace()).Create(context.Background(), &v1.Role{
+	_, err = fixtureClient.KubeClientset.RbacV1().Roles(fixture.TestNamespace()).Create(context.Background(), &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{Name: "placement-role", Namespace: fixture.TestNamespace()},
-		Rules: []v1.PolicyRule{
+		Rules: []rbacv1.PolicyRule{
 			{
 				Verbs:     []string{"get", "list", "watch"},
 				APIGroups: []string{"cluster.open-cluster-management.io"},
@@ -258,16 +258,16 @@ func (a *Actions) CreatePlacementRoleAndRoleBinding() *Actions {
 
 	if err == nil {
 		_, err = fixtureClient.KubeClientset.RbacV1().RoleBindings(fixture.TestNamespace()).Create(context.Background(),
-			&v1.RoleBinding{
+			&rbacv1.RoleBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: "placement-role-binding", Namespace: fixture.TestNamespace()},
-				Subjects: []v1.Subject{
+				Subjects: []rbacv1.Subject{
 					{
 						Name:      "argocd-applicationset-controller",
 						Namespace: fixture.TestNamespace(),
 						Kind:      "ServiceAccount",
 					},
 				},
-				RoleRef: v1.RoleRef{
+				RoleRef: rbacv1.RoleRef{
 					Kind:     "Role",
 					APIGroup: "rbac.authorization.k8s.io",
 					Name:     "placement-role",

--- a/test/e2e/sync_with_impersonate_test.go
+++ b/test/e2e/sync_with_impersonate_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	rbac "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -78,7 +78,7 @@ func TestSyncWithImpersonateWithSyncServiceAccount(t *testing.T) {
 			require.NoError(t, err)
 			err = createTestAppProject(projectName, fixture.TestNamespace(), destinationServiceAccounts)
 			require.NoError(t, err)
-			err = createTestRole(roleName, fixture.DeploymentNamespace(), []rbac.PolicyRule{
+			err = createTestRole(roleName, fixture.DeploymentNamespace(), []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"apps", ""},
 					Resources: []string{"deployments"},
@@ -132,7 +132,7 @@ func TestSyncWithMissingServiceAccount(t *testing.T) {
 			require.NoError(t, err)
 			err = createTestAppProject(projectName, fixture.TestNamespace(), destinationServiceAccounts)
 			require.NoError(t, err)
-			err = createTestRole(roleName, fixture.DeploymentNamespace(), []rbac.PolicyRule{
+			err = createTestRole(roleName, fixture.DeploymentNamespace(), []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"apps", ""},
 					Resources: []string{"deployments"},
@@ -182,7 +182,7 @@ func TestSyncWithValidSAButDisallowedDestination(t *testing.T) {
 			require.NoError(t, err)
 			err = createTestAppProject(projectName, fixture.TestNamespace(), destinationServiceAccounts)
 			require.NoError(t, err)
-			err = createTestRole(roleName, fixture.DeploymentNamespace(), []rbac.PolicyRule{
+			err = createTestRole(roleName, fixture.DeploymentNamespace(), []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"apps", ""},
 					Resources: []string{"deployments"},
@@ -251,8 +251,8 @@ func createTestAppProject(name, namespace string, destinationServiceAccounts []v
 }
 
 // createTestRole creates a test Role resource.
-func createTestRole(roleName, namespace string, rules []rbac.PolicyRule) error {
-	role := &rbac.Role{
+func createTestRole(roleName, namespace string, rules []rbacv1.PolicyRule) error {
+	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,
 			Namespace: namespace,
@@ -266,18 +266,18 @@ func createTestRole(roleName, namespace string, rules []rbac.PolicyRule) error {
 
 // createTestRoleBinding creates a test RoleBinding resource.
 func createTestRoleBinding(roleName, serviceAccountName, namespace string) error {
-	roleBinding := &rbac.RoleBinding{
+	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: roleName + "-binding",
 		},
-		Subjects: []rbac.Subject{
+		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      serviceAccountName,
 				Namespace: namespace,
 			},
 		},
-		RoleRef: rbac.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			Kind:     "Role",
 			Name:     roleName,
 			APIGroup: "rbac.authorization.k8s.io",

--- a/util/db/db_test.go
+++ b/util/db/db_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	appv1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -817,12 +817,12 @@ func TestGetApplicationControllerReplicas(t *testing.T) {
 	assert.Equal(t, int(expectedReplicas), replicas)
 
 	expectedReplicas = int32(3)
-	clientset = getClientset(nil, &appv1.Deployment{
+	clientset = getClientset(nil, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ApplicationController,
 			Namespace: testNamespace,
 		},
-		Spec: appv1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: &expectedReplicas,
 		},
 	})

--- a/util/db/secrets.go
+++ b/util/db/secrets.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	informerv1 "k8s.io/client-go/informers/core/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/argoproj/argo-cd/v2/common"
@@ -143,7 +143,7 @@ func (db *db) watchSecrets(ctx context.Context,
 	}
 
 	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
-	clusterSecretInformer := informerv1.NewFilteredSecretInformer(db.kubeclientset, db.ns, 3*time.Minute, indexers, secretListOptions)
+	clusterSecretInformer := informersv1.NewFilteredSecretInformer(db.kubeclientset, db.ns, 3*time.Minute, indexers, secretListOptions)
 	_, err := clusterSecretInformer.AddEventHandler(secretEventHandler)
 	if err != nil {
 		log.Error(err)

--- a/util/notification/k8s/informers.go
+++ b/util/notification/k8s/informers.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/client-go/informers/core/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
@@ -14,13 +14,13 @@ const (
 )
 
 func NewSecretInformer(clientset kubernetes.Interface, namespace string, secretName string) cache.SharedIndexInformer {
-	return corev1.NewFilteredSecretInformer(clientset, namespace, settingsResyncDuration, cache.Indexers{}, func(options *metav1.ListOptions) {
+	return informersv1.NewFilteredSecretInformer(clientset, namespace, settingsResyncDuration, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.FieldSelector = "metadata.name=" + secretName
 	})
 }
 
 func NewConfigMapInformer(clientset kubernetes.Interface, namespace string, configMapName string) cache.SharedIndexInformer {
-	return corev1.NewFilteredConfigMapInformer(clientset, namespace, settingsResyncDuration, cache.Indexers{}, func(options *metav1.ListOptions) {
+	return informersv1.NewFilteredConfigMapInformer(clientset, namespace, settingsResyncDuration, cache.Indexers{}, func(options *metav1.ListOptions) {
 		options.FieldSelector = "metadata.name=" + configMapName
 	})
 }

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -27,7 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	v1 "k8s.io/client-go/informers/core/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
@@ -341,7 +341,7 @@ func (e *Enforcer) newInformer() cache.SharedIndexInformer {
 		options.FieldSelector = cmFieldSelector.String()
 	}
 	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
-	return v1.NewFilteredConfigMapInformer(e.clientset, e.namespace, defaultRBACSyncPeriod, indexers, tweakConfigMap)
+	return informersv1.NewFilteredConfigMapInformer(e.clientset, e.namespace, defaultRBACSyncPeriod, indexers, tweakConfigMap)
 }
 
 // RunPolicyLoader runs the policy loader which watches policy updates from the configmap and reloads them

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	v1 "k8s.io/client-go/informers/core/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -1407,8 +1407,8 @@ func (mgr *SettingsManager) initialize(ctx context.Context) error {
 		ByProjectRepoIndexer:      byProjectIndexerFunc(common.LabelValueSecretTypeRepository),
 		ByProjectRepoWriteIndexer: byProjectIndexerFunc(common.LabelValueSecretTypeRepositoryWrite),
 	}
-	cmInformer := v1.NewFilteredConfigMapInformer(mgr.clientset, mgr.namespace, 3*time.Minute, indexers, tweakConfigMap)
-	secretsInformer := v1.NewSecretInformer(mgr.clientset, mgr.namespace, 3*time.Minute, indexers)
+	cmInformer := informersv1.NewFilteredConfigMapInformer(mgr.clientset, mgr.namespace, 3*time.Minute, indexers, tweakConfigMap)
+	secretsInformer := informersv1.NewSecretInformer(mgr.clientset, mgr.namespace, 3*time.Minute, indexers)
 	_, err := cmInformer.AddEventHandler(eventHandler)
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
#### Description 

[redundant-import-alias](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias): This rule warns on redundant import aliases. This happens when the alias used on the import statement matches the imported package name.
