### PR TITLE
chore: enable indent-error-flow from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -120,9 +120,11 @@ linters-settings:
       # incrementing an integer variable by 1 is recommended to be done using the `++` operator
       - name: increment-decrement
         disabled: false
-      # highlights redundant else-blocks that can be eliminated from the code
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
       - name: indent-error-flow
-        disabled: true
+        disabled: false
+        arguments:
+          - "preserveScope"
       # This rule suggests a shorter way of writing ranges that do not use the second value.
       - name: range
         disabled: false
@@ -132,12 +134,15 @@ linters-settings:
       # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
       - name: redefines-builtin-id
         disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
       - name: redundant-import-alias
         disabled: false
       # redundant else-blocks that can be eliminated from the code.
       - name: superfluous-else
         disabled: false
-      # prevent confusing name for variables when using `time` package
+        arguments:
+          - "preserveScope"
+       # prevent confusing name for variables when using `time` package
       - name: time-naming
         disabled: true
       # warns when an exported function or method returns a value of an un-exported type.

--- a/applicationset/generators/matrix.go
+++ b/applicationset/generators/matrix.go
@@ -169,9 +169,8 @@ func (m *MatrixGenerator) GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.Ap
 
 	if found {
 		return res
-	} else {
-		return NoRequeueAfter
 	}
+	return NoRequeueAfter
 }
 
 func getMatrixGenerator(r argoprojiov1alpha1.ApplicationSetNestedGenerator) (*argoprojiov1alpha1.MatrixGenerator, error) {

--- a/applicationset/generators/merge.go
+++ b/applicationset/generators/merge.go
@@ -224,9 +224,8 @@ func (m *MergeGenerator) GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.App
 
 	if found {
 		return res
-	} else {
-		return NoRequeueAfter
 	}
+	return NoRequeueAfter
 }
 
 func getMergeGenerator(r argoprojiov1alpha1.ApplicationSetNestedGenerator) (*argoprojiov1alpha1.MergeGenerator, error) {

--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -176,9 +176,8 @@ func (g *PullRequestGenerator) selectServiceProvider(ctx context.Context, genera
 				return nil, fmt.Errorf("error fetching Secret token: %w", err)
 			}
 			return pullrequest.NewBitbucketServiceBasicAuth(ctx, providerConfig.BasicAuth.Username, password, providerConfig.API, providerConfig.Project, providerConfig.Repo, g.scmRootCAPath, providerConfig.Insecure, caCerts)
-		} else {
-			return pullrequest.NewBitbucketServiceNoAuth(ctx, providerConfig.API, providerConfig.Project, providerConfig.Repo, g.scmRootCAPath, providerConfig.Insecure, caCerts)
 		}
+		return pullrequest.NewBitbucketServiceNoAuth(ctx, providerConfig.API, providerConfig.Project, providerConfig.Repo, g.scmRootCAPath, providerConfig.Insecure, caCerts)
 	}
 	if generatorConfig.Bitbucket != nil {
 		providerConfig := generatorConfig.Bitbucket
@@ -194,9 +193,8 @@ func (g *PullRequestGenerator) selectServiceProvider(ctx context.Context, genera
 				return nil, fmt.Errorf("error fetching Secret token: %w", err)
 			}
 			return pullrequest.NewBitbucketCloudServiceBasicAuth(providerConfig.API, providerConfig.BasicAuth.Username, password, providerConfig.Owner, providerConfig.Repo)
-		} else {
-			return pullrequest.NewBitbucketCloudServiceNoAuth(providerConfig.API, providerConfig.Owner, providerConfig.Repo)
 		}
+		return pullrequest.NewBitbucketCloudServiceNoAuth(providerConfig.API, providerConfig.Owner, providerConfig.Repo)
 	}
 	if generatorConfig.AzureDevOps != nil {
 		providerConfig := generatorConfig.AzureDevOps

--- a/cmd/argocd-dex/commands/argocd_dex.go
+++ b/cmd/argocd-dex/commands/argocd_dex.go
@@ -242,9 +242,8 @@ func redactor(dirtyString string) string {
 	iterateStringFields(config, func(name string, val string) string {
 		if name == "clientSecret" || name == "secret" || name == "bindPW" {
 			return "********"
-		} else {
-			return val
 		}
+		return val
 	})
 	data, err := yaml.Marshal(config)
 	errors.CheckError(err)

--- a/cmd/argocd/commands/admin/settings_rbac.go
+++ b/cmd/argocd/commands/admin/settings_rbac.go
@@ -463,9 +463,8 @@ func checkPolicy(subject, action, resource, subResource, builtinPolicy, userPoli
 func resolveRBACResourceName(name string) string {
 	if res, ok := resourceMap[name]; ok {
 		return res
-	} else {
-		return name
 	}
+	return name
 }
 
 // validateRBACResourceAction checks whether a given resource is a valid RBAC resource.

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -599,22 +599,21 @@ func modifyResourcesList(list *[]metav1.GroupKind, add bool, listDesc string, gr
 		fmt.Printf("Group '%s' and kind '%s' is added to %s resources\n", group, kind, listDesc)
 		*list = append(*list, metav1.GroupKind{Group: group, Kind: kind})
 		return true
-	} else {
-		index := -1
-		for i, item := range *list {
-			if item.Group == group && item.Kind == kind {
-				index = i
-				break
-			}
-		}
-		if index == -1 {
-			fmt.Printf("Group '%s' and kind '%s' not in %s resources\n", group, kind, listDesc)
-			return false
-		}
-		*list = append((*list)[:index], (*list)[index+1:]...)
-		fmt.Printf("Group '%s' and kind '%s' is removed from %s resources\n", group, kind, listDesc)
-		return true
 	}
+	index := -1
+	for i, item := range *list {
+		if item.Group == group && item.Kind == kind {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		fmt.Printf("Group '%s' and kind '%s' not in %s resources\n", group, kind, listDesc)
+		return false
+	}
+	*list = append((*list)[:index], (*list)[index+1:]...)
+	fmt.Printf("Group '%s' and kind '%s' is removed from %s resources\n", group, kind, listDesc)
+	return true
 }
 
 func modifyResourceListCmd(cmdUse, cmdDesc, examples string, clientOpts *argocdclient.ClientOptions, allow bool, namespacedList bool) *cobra.Command {
@@ -1111,12 +1110,11 @@ func NewProjectAddDestinationServiceAccountCommand(clientOpts *argocdclient.Clie
 				Namespace:             namespace,
 				DefaultServiceAccount: fmt.Sprintf("%s:%s", serviceAccountNamespace, serviceAccount),
 			}
-		} else {
-			return v1alpha1.ApplicationDestinationServiceAccount{
-				Server:                destination,
-				Namespace:             namespace,
-				DefaultServiceAccount: serviceAccount,
-			}
+		}
+		return v1alpha1.ApplicationDestinationServiceAccount{
+			Server:                destination,
+			Namespace:             namespace,
+			DefaultServiceAccount: serviceAccount,
 		}
 	}
 

--- a/common/common.go
+++ b/common/common.go
@@ -354,20 +354,20 @@ const (
 
 // GetGnuPGHomePath retrieves the path to use for GnuPG home directory, which is either taken from GNUPGHOME environment or a default value
 func GetGnuPGHomePath() string {
-	if gnuPgHome := os.Getenv(EnvGnuPGHome); gnuPgHome == "" {
+	gnuPgHome := os.Getenv(EnvGnuPGHome)
+	if gnuPgHome == "" {
 		return DefaultGnuPgHomePath
-	} else {
-		return gnuPgHome
 	}
+	return gnuPgHome
 }
 
 // GetPluginSockFilePath retrieves the path of plugin sock file, which is either taken from PluginSockFilePath environment or a default value
 func GetPluginSockFilePath() string {
-	if pluginSockFilePath := os.Getenv(EnvPluginSockFilePath); pluginSockFilePath == "" {
+	pluginSockFilePath := os.Getenv(EnvPluginSockFilePath)
+	if pluginSockFilePath == "" {
 		return DefaultPluginSockFilePath
-	} else {
-		return pluginSockFilePath
 	}
+	return pluginSockFilePath
 }
 
 // GetCMPChunkSize will return the env var EnvCMPChunkSize value if defined or DefaultCMPChunkSize otherwise.

--- a/controller/state.go
+++ b/controller/state.go
@@ -488,16 +488,15 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 				},
 				healthStatus: &v1alpha1.HealthStatus{Status: health.HealthStatusUnknown, LastTransitionTime: &now},
 			}, nil
-		} else {
-			return &comparisonResult{
-				syncStatus: &v1alpha1.SyncStatus{
-					ComparedTo: app.Spec.BuildComparedToStatus(),
-					Status:     v1alpha1.SyncStatusCodeUnknown,
-					Revision:   revisions[0],
-				},
-				healthStatus: &v1alpha1.HealthStatus{Status: health.HealthStatusUnknown, LastTransitionTime: &now},
-			}, nil
 		}
+		return &comparisonResult{
+			syncStatus: &v1alpha1.SyncStatus{
+				ComparedTo: app.Spec.BuildComparedToStatus(),
+				Status:     v1alpha1.SyncStatusCodeUnknown,
+				Revision:   revisions[0],
+			},
+			healthStatus: &v1alpha1.HealthStatus{Status: health.HealthStatusUnknown, LastTransitionTime: &now},
+		}, nil
 	}
 
 	// When signature keys are defined in the project spec, we need to verify the signature on the Git revision

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -626,10 +626,9 @@ func deriveServiceAccountToImpersonate(project *v1alpha1.AppProject, application
 			} else if strings.Contains(item.DefaultServiceAccount, ":") {
 				// service account is specified along with its namespace.
 				return "system:serviceaccount:" + item.DefaultServiceAccount, nil
-			} else {
-				// service account needs to be prefixed with a namespace
-				return fmt.Sprintf("system:serviceaccount:%s:%s", serviceAccountNamespace, item.DefaultServiceAccount), nil
 			}
+			// service account needs to be prefixed with a namespace
+			return fmt.Sprintf("system:serviceaccount:%s:%s", serviceAccountNamespace, item.DefaultServiceAccount), nil
 		}
 	}
 	// if there is no match found in the AppProject.Spec.DestinationServiceAccounts, use the default service account of the destination namespace.

--- a/pkg/apiclient/grpcproxy.go
+++ b/pkg/apiclient/grpcproxy.go
@@ -169,9 +169,8 @@ func (c *client) startGRPCProxy() (*grpc.Server, net.Listener, error) {
 						return err
 					} else if read < length {
 						return io.ErrUnexpectedEOF
-					} else {
-						return nil
 					}
+					return nil
 				}
 
 				if err := stream.SendMsg(data); err != nil {

--- a/pkg/apis/application/v1alpha1/app_project_types.go
+++ b/pkg/apis/application/v1alpha1/app_project_types.go
@@ -152,10 +152,9 @@ func (proj AppProject) RemoveJWTToken(roleIndex int, issuedAt int64, id string) 
 	if err1 == nil || err2 == nil {
 		// If we find this token from either places, we can say there are no error
 		return nil
-	} else {
-		// If we could not locate this taken from either places, we can return any of the errors
-		return err2
 	}
+	// If we could not locate this taken from either places, we can return any of the errors
+	return err2
 }
 
 // TODO: document this method

--- a/pkg/apis/application/v1alpha1/applicationset_types.go
+++ b/pkg/apis/application/v1alpha1/applicationset_types.go
@@ -960,7 +960,6 @@ func (status *ApplicationSetStatus) SetApplicationStatus(newStatus ApplicationSe
 func (a *ApplicationSet) QualifiedName() string {
 	if a.Namespace == "" {
 		return a.Name
-	} else {
-		return a.Namespace + "/" + a.Name
 	}
+	return a.Namespace + "/" + a.Name
 }

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -167,9 +167,8 @@ func (e Env) Envsubst(s string) string {
 		// allow escaping $ with $$
 		if s == "$" {
 			return "$"
-		} else {
-			return valByEnv[s]
 		}
+		return valByEnv[s]
 	})
 }
 
@@ -678,14 +677,13 @@ type KustomizeReplicas []KustomizeReplica
 // If parsing error occurs, returns 0 and error.
 func (kr KustomizeReplica) GetIntCount() (int, error) {
 	if kr.Count.Type == intstr.String {
-		if count, err := strconv.Atoi(kr.Count.StrVal); err != nil {
+		count, err := strconv.Atoi(kr.Count.StrVal)
+		if err != nil {
 			return 0, fmt.Errorf("expected integer value for count. Received: %s", kr.Count.StrVal)
-		} else {
-			return count, nil
 		}
-	} else {
-		return kr.Count.IntValue(), nil
+		return count, nil
 	}
+	return kr.Count.IntValue(), nil
 }
 
 // NewKustomizeReplica parses a string in format name=count into a KustomizeReplica object and returns it
@@ -815,9 +813,8 @@ func NewJsonnetVar(s string, code bool) JsonnetVar {
 	parts := strings.SplitN(s, "=", 2)
 	if len(parts) == 2 {
 		return JsonnetVar{Name: parts[0], Value: parts[1], Code: code}
-	} else {
-		return JsonnetVar{Name: s, Code: code}
 	}
+	return JsonnetVar{Name: s, Code: code}
 }
 
 // ApplicationSourceJsonnet holds options specific to applications of type Jsonnet
@@ -1528,9 +1525,8 @@ func (m *SyncStrategy) Force() bool {
 		return m.Apply.Force
 	} else if m.Hook != nil {
 		return m.Hook.Force
-	} else {
-		return false
 	}
+	return false
 }
 
 // SyncStrategyApply uses `kubectl apply` to perform the apply
@@ -2762,9 +2758,8 @@ func (w *SyncWindows) CanSync(isManual bool) (bool, error) {
 	if hasActiveDeny {
 		if isManual && manualEnabled {
 			return true, nil
-		} else {
-			return false, nil
 		}
+		return false, nil
 	}
 
 	if active.hasAllow() {
@@ -2778,9 +2773,8 @@ func (w *SyncWindows) CanSync(isManual bool) (bool, error) {
 	if inactiveAllows.HasWindows() {
 		if isManual && inactiveAllows.manualEnabled() {
 			return true, nil
-		} else {
-			return false, nil
 		}
+		return false, nil
 	}
 
 	return true, nil
@@ -3554,9 +3548,8 @@ func (app *Application) InstanceName(defaultNs string) string {
 func (app *Application) QualifiedName() string {
 	if app.Namespace == "" {
 		return app.Name
-	} else {
-		return app.Namespace + "/" + app.Name
 	}
+	return app.Namespace + "/" + app.Name
 }
 
 // RBACName returns the full qualified RBAC resource name for the application

--- a/reposerver/repository/lock.go
+++ b/reposerver/repository/lock.go
@@ -68,11 +68,10 @@ func (r *repositoryLock) Lock(path string, revision string, allowConcurrent bool
 			state.processCount++
 			state.cond.L.Unlock()
 			return closer, nil
-		} else {
-			state.cond.Wait()
-			// wait when all in-flight processes of this revision complete and try again
-			state.cond.L.Unlock()
 		}
+		state.cond.Wait()
+		// wait when all in-flight processes of this revision complete and try again
+		state.cond.L.Unlock()
 	}
 }
 

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -143,9 +143,8 @@ func (s *Server) CanI(ctx context.Context, r *account.CanIRequest) (*account.Can
 	ok := s.enf.Enforce(ctx.Value("claims"), r.Resource, r.Action, r.Subresource)
 	if ok {
 		return &account.CanIResponse{Value: "yes"}, nil
-	} else {
-		return &account.CanIResponse{Value: "no"}, nil
 	}
+	return &account.CanIResponse{Value: "no"}, nil
 }
 
 func toApiAccount(name string, a settings.Account) *account.Account {

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1689,12 +1689,12 @@ func (s *Server) PodLogs(q *application.ApplicationPodLogsQuery, ws application.
 	}
 	var untilTime *metav1.Time
 	if q.GetUntilTime() != "" {
-		if val, err := time.Parse(time.RFC3339Nano, q.GetUntilTime()); err != nil {
+		val, err := time.Parse(time.RFC3339Nano, q.GetUntilTime())
+		if err != nil {
 			return fmt.Errorf("invalid untilTime parameter value: %w", err)
-		} else {
-			untilTimeVal := metav1.NewTime(val)
-			untilTime = &untilTimeVal
 		}
+		untilTimeVal := metav1.NewTime(val)
+		untilTime = &untilTimeVal
 	}
 
 	literal := ""
@@ -1796,36 +1796,34 @@ func (s *Server) PodLogs(q *application.ApplicationPodLogsQuery, ws application.
 			if entry.err != nil {
 				done <- entry.err
 				return
-			} else {
-				if q.Filter != nil {
-					lineContainsFilter := strings.Contains(entry.line, literal)
-					if (inverse && lineContainsFilter) || (!inverse && !lineContainsFilter) {
-						continue
-					}
+			}
+			if q.Filter != nil {
+				lineContainsFilter := strings.Contains(entry.line, literal)
+				if (inverse && lineContainsFilter) || (!inverse && !lineContainsFilter) {
+					continue
 				}
-				ts := metav1.NewTime(entry.timeStamp)
-				if untilTime != nil && entry.timeStamp.After(untilTime.Time) {
-					done <- ws.Send(&application.LogEntry{
-						Last:         ptr.To(true),
-						PodName:      &entry.podName,
-						Content:      &entry.line,
-						TimeStampStr: ptr.To(entry.timeStamp.Format(time.RFC3339Nano)),
-						TimeStamp:    &ts,
-					})
-					return
-				} else {
-					sentCount++
-					if err := ws.Send(&application.LogEntry{
-						PodName:      &entry.podName,
-						Content:      &entry.line,
-						TimeStampStr: ptr.To(entry.timeStamp.Format(time.RFC3339Nano)),
-						TimeStamp:    &ts,
-						Last:         ptr.To(false),
-					}); err != nil {
-						done <- err
-						break
-					}
-				}
+			}
+			ts := metav1.NewTime(entry.timeStamp)
+			if untilTime != nil && entry.timeStamp.After(untilTime.Time) {
+				done <- ws.Send(&application.LogEntry{
+					Last:         ptr.To(true),
+					PodName:      &entry.podName,
+					Content:      &entry.line,
+					TimeStampStr: ptr.To(entry.timeStamp.Format(time.RFC3339Nano)),
+					TimeStamp:    &ts,
+				})
+				return
+			}
+			sentCount++
+			if err := ws.Send(&application.LogEntry{
+				PodName:      &entry.podName,
+				Content:      &entry.line,
+				TimeStampStr: ptr.To(entry.timeStamp.Format(time.RFC3339Nano)),
+				TimeStamp:    &ts,
+				Last:         ptr.To(false),
+			}); err != nil {
+				done <- err
+				break
 			}
 		}
 		now := time.Now()
@@ -2036,19 +2034,18 @@ func (s *Server) resolveSourceRevisions(ctx context.Context, a *v1alpha1.Applica
 			displayRevisions[index] = displayRevision
 		}
 		return "", "", sourceRevisions, displayRevisions, nil
-	} else {
-		source := a.Spec.GetSource()
-		if a.Spec.SyncPolicy != nil && a.Spec.SyncPolicy.Automated != nil && !syncReq.GetDryRun() {
-			if syncReq.GetRevision() != "" && syncReq.GetRevision() != text.FirstNonEmpty(source.TargetRevision, "HEAD") {
-				return "", "", nil, nil, status.Errorf(codes.FailedPrecondition, "Cannot sync to %s: auto-sync currently set to %s", syncReq.GetRevision(), source.TargetRevision)
-			}
-		}
-		revision, displayRevision, err := s.resolveRevision(ctx, a, syncReq, -1)
-		if err != nil {
-			return "", "", nil, nil, status.Error(codes.FailedPrecondition, err.Error())
-		}
-		return revision, displayRevision, nil, nil, nil
 	}
+	source := a.Spec.GetSource()
+	if a.Spec.SyncPolicy != nil && a.Spec.SyncPolicy.Automated != nil && !syncReq.GetDryRun() {
+		if syncReq.GetRevision() != "" && syncReq.GetRevision() != text.FirstNonEmpty(source.TargetRevision, "HEAD") {
+			return "", "", nil, nil, status.Errorf(codes.FailedPrecondition, "Cannot sync to %s: auto-sync currently set to %s", syncReq.GetRevision(), source.TargetRevision)
+		}
+	}
+	revision, displayRevision, err := s.resolveRevision(ctx, a, syncReq, -1)
+	if err != nil {
+		return "", "", nil, nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	return revision, displayRevision, nil, nil, nil
 }
 
 func (s *Server) Rollback(ctx context.Context, rollbackReq *application.ApplicationRollbackRequest) (*v1alpha1.Application, error) {
@@ -2701,9 +2698,8 @@ func getPropagationPolicyFinalizer(policy string) string {
 func (s *Server) appNamespaceOrDefault(appNs string) string {
 	if appNs == "" {
 		return s.ns
-	} else {
-		return appNs
 	}
+	return appNs
 }
 
 func (s *Server) isNamespaceEnabled(namespace string) bool {

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2262,10 +2262,9 @@ func createAppServerWithMaxLodLogs(t *testing.T, podNumber int, maxPodLogsToRend
 		formatInt := strconv.FormatInt(maxPodLogsToRender[0], 10)
 		appServer := newTestAppServerWithEnforcerConfigure(t, f, map[string]string{"server.maxPodLogsToRender": formatInt}, runtimeObjects...)
 		return appServer, adminCtx
-	} else {
-		appServer := newTestAppServer(t, runtimeObjects...)
-		return appServer, adminCtx
 	}
+	appServer := newTestAppServer(t, runtimeObjects...)
+	return appServer, adminCtx
 }
 
 // refreshAnnotationRemover runs an infinite loop until it detects and removes refresh annotation or given context is done

--- a/server/applicationset/applicationset.go
+++ b/server/applicationset/applicationset.go
@@ -508,9 +508,8 @@ func (s *Server) logAppSetEvent(a *v1alpha1.ApplicationSet, ctx context.Context,
 func (s *Server) appsetNamespaceOrDefault(appNs string) string {
 	if appNs == "" {
 		return s.ns
-	} else {
-		return appNs
 	}
+	return appNs
 }
 
 func (s *Server) isNamespaceEnabled(namespace string) bool {

--- a/server/server.go
+++ b/server/server.go
@@ -1500,10 +1500,9 @@ func (server *ArgoCDServer) Authenticate(ctx context.Context) (context.Context, 
 		}
 		if !argoCDSettings.AnonymousUserEnabled {
 			return ctx, claimsErr
-		} else {
-			// nolint:staticcheck
-			ctx = context.WithValue(ctx, "claims", "")
 		}
+		// nolint:staticcheck
+		ctx = context.WithValue(ctx, "claims", "")
 	}
 
 	return ctx, nil

--- a/test/e2e/fixture/app/context.go
+++ b/test/e2e/fixture/app/context.go
@@ -98,17 +98,15 @@ func (c *Context) AppName() string {
 func (c *Context) AppQualifiedName() string {
 	if c.appNamespace != "" {
 		return c.appNamespace + "/" + c.AppName()
-	} else {
-		return c.AppName()
 	}
+	return c.AppName()
 }
 
 func (c *Context) AppNamespace() string {
 	if c.appNamespace != "" {
 		return c.appNamespace
-	} else {
-		return fixture.TestNamespace()
 	}
+	return fixture.TestNamespace()
 }
 
 func (c *Context) SetAppNamespace(namespace string) *Context {

--- a/test/e2e/fixture/app/expectation.go
+++ b/test/e2e/fixture/app/expectation.go
@@ -53,9 +53,8 @@ func OperationMessageContains(text string) Expectation {
 func simple(success bool, message string) (state, string) {
 	if success {
 		return succeeded, message
-	} else {
-		return pending, message
 	}
+	return pending, message
 }
 
 func SyncStatusIs(expected SyncStatusCode) Expectation {
@@ -176,9 +175,8 @@ func ResourceResultNumbering(num int) Expectation {
 			return pending, fmt.Sprintf("not enough results yet, want %d, got %d", num, actualNum)
 		} else if actualNum == num {
 			return succeeded, fmt.Sprintf("right number of results, want %d, got %d", num, actualNum)
-		} else {
-			return failed, fmt.Sprintf("too many results, want %d, got %d", num, actualNum)
 		}
+		return failed, fmt.Sprintf("too many results, want %d, got %d", num, actualNum)
 	}
 }
 

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -220,9 +220,8 @@ func init() {
 	if err != nil {
 		if stderrors.Is(err, os.ErrNotExist) {
 			return
-		} else {
-			panic(fmt.Sprintf("Could not read record file %s: %v", rf, err))
 		}
+		panic(fmt.Sprintf("Could not read record file %s: %v", rf, err))
 	}
 	defer func() {
 		err := f.Close()
@@ -1220,9 +1219,8 @@ func RestartAPIServer() {
 func LocalOrRemotePath(base string) string {
 	if IsRemote() {
 		return base + "/remote"
-	} else {
-		return base + "/local"
 	}
+	return base + "/local"
 }
 
 // SkipOnEnv allows to skip a test when a given environment variable is set.

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -1158,9 +1158,8 @@ func ParseInstanceName(appName string, defaultNs string) (string, string) {
 func AppInstanceName(appName, appNs, defaultNs string) string {
 	if appNs == "" || appNs == defaultNs {
 		return appName
-	} else {
-		return appNs + "_" + appName
 	}
+	return appNs + "_" + appName
 }
 
 // InstanceNameFromQualified returns the value to be used for app

--- a/util/argo/normalizers/knowntypes_normalizer_test.go
+++ b/util/argo/normalizers/knowntypes_normalizer_test.go
@@ -61,11 +61,11 @@ func nestedSliceMap(obj map[string]any, i int, path ...string) (map[string]any, 
 	if len(items) < i {
 		return nil, fmt.Errorf("field %s has less than %d items", strings.Join(path, "."), i)
 	}
-	if item, ok := items[i].(map[string]any); !ok {
+	item, ok := items[i].(map[string]any)
+	if !ok {
 		return nil, fmt.Errorf("field %s[%d] is not map", strings.Join(path, "."), i)
-	} else {
-		return item, nil
 	}
+	return item, nil
 }
 
 func TestNormalize_MapField(t *testing.T) {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -280,9 +280,8 @@ func (c *Cache) SetItem(key string, item any, opts *CacheActionOpts) error {
 	client := c.GetClient()
 	if opts.Delete {
 		return client.Delete(fullKey)
-	} else {
-		return client.Set(&Item{Key: fullKey, Object: item, CacheActionOpts: *opts})
 	}
+	return client.Set(&Item{Key: fullKey, Object: item, CacheActionOpts: *opts})
 }
 
 func (c *Cache) GetItem(key string, item any) error {

--- a/util/cache/redis.go
+++ b/util/cache/redis.go
@@ -91,11 +91,11 @@ func (r *redisCache) unmarshal(data []byte, obj any) error {
 	buf := bytes.NewReader(data)
 	var reader io.Reader = buf
 	if r.redisCompressionType == RedisCompressionGZip {
-		if gzipReader, err := gzip.NewReader(buf); err != nil {
+		gzipReader, err := gzip.NewReader(buf)
+		if err != nil {
 			return err
-		} else {
-			reader = gzipReader
 		}
+		reader = gzipReader
 	}
 	if err := json.NewDecoder(reader).Decode(obj); err != nil {
 		return fmt.Errorf("failed to decode cached data: %w", err)

--- a/util/cert/cert.go
+++ b/util/cert/cert.go
@@ -80,9 +80,8 @@ var validFQDNRegexp = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{
 func IsValidHostname(hostname string, fqdn bool) bool {
 	if !fqdn {
 		return validHostNameRegexp.Match([]byte(hostname)) || validIPv6Regexp.Match([]byte(hostname))
-	} else {
-		return validFQDNRegexp.Match([]byte(hostname))
 	}
+	return validFQDNRegexp.Match([]byte(hostname))
 }
 
 // Get the configured path to where TLS certificates are stored on the local
@@ -91,9 +90,8 @@ func IsValidHostname(hostname string, fqdn bool) bool {
 func GetTLSCertificateDataPath() string {
 	if envPath := os.Getenv(common.EnvVarTLSDataPath); envPath != "" {
 		return envPath
-	} else {
-		return common.DefaultPathTLSConfig
 	}
+	return common.DefaultPathTLSConfig
 }
 
 // Get the configured path to where SSH certificates are stored on the local
@@ -102,9 +100,8 @@ func GetTLSCertificateDataPath() string {
 func GetSSHKnownHostsDataPath() string {
 	if envPath := os.Getenv(common.EnvVarSSHDataPath); envPath != "" {
 		return filepath.Join(envPath, common.DefaultSSHKnownHostsName)
-	} else {
-		return filepath.Join(common.DefaultPathSSHConfig, common.DefaultSSHKnownHostsName)
 	}
+	return filepath.Join(common.DefaultPathSSHConfig, common.DefaultSSHKnownHostsName)
 }
 
 // Decode a certificate in PEM format to X509 data structure
@@ -326,9 +323,8 @@ func GetCertificateForConnect(serverName string) ([]string, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 
 	if len(certificates) == 0 {

--- a/util/db/certificate.go
+++ b/util/db/certificate.go
@@ -204,16 +204,15 @@ func (db *db) CreateRepoCertificate(ctx context.Context, certificates *appsv1.Re
 				if entry.Host == certificate.ServerName && entry.SubType == certificate.CertSubType {
 					if !upsert && entry.Data != string(certificate.CertData) {
 						return nil, fmt.Errorf("Key for '%s' (subtype: '%s') already exist and upsert was not specified.", entry.Host, entry.SubType)
-					} else {
-						// Do not add an entry on upsert, but remember if we actual did an
-						// upsert.
-						newEntry = false
-						if entry.Data != string(certificate.CertData) {
-							entry.Data = string(certificate.CertData)
-							upserted = true
-						}
-						break
 					}
+					// Do not add an entry on upsert, but remember if we actual did an
+					// upsert.
+					newEntry = false
+					if entry.Data != string(certificate.CertData) {
+						entry.Data = string(certificate.CertData)
+						upserted = true
+					}
+					break
 				}
 			}
 

--- a/util/db/gpgkeys.go
+++ b/util/db/gpgkeys.go
@@ -51,9 +51,8 @@ func validatePGPKey(keyData string) (*appsv1.GnuPGPublicKey, error) {
 	if retKey != nil {
 		retKey.KeyData = keyData
 		return retKey, nil
-	} else {
-		return nil, errors.New("Could not find the GPG key")
 	}
+	return nil, errors.New("Could not find the GPG key")
 }
 
 // ListConfiguredGPGPublicKeys returns a list of all configured GPG public keys from the ConfigMap

--- a/util/db/repository_legacy.go
+++ b/util/db/repository_legacy.go
@@ -341,11 +341,10 @@ func (l *legacyRepositoryBackend) upsertSecret(name string, data map[string][]by
 				return l.db.kubeclientset.CoreV1().Secrets(l.db.ns).Delete(context.Background(), name, metav1.DeleteOptions{})
 			}
 			return nil
-		} else {
-			_, err = l.db.kubeclientset.CoreV1().Secrets(l.db.ns).Update(context.Background(), secret, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
+		}
+		_, err = l.db.kubeclientset.CoreV1().Secrets(l.db.ns).Update(context.Background(), secret, metav1.UpdateOptions{})
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/util/dex/dex.go
+++ b/util/dex/dex.go
@@ -129,11 +129,9 @@ func (s DexRewriteURLRoundTripper) RoundTrip(r *http.Request) (*http.Response, e
 func DexServerAddressWithProtocol(orig string, tlsConfig *DexTLSConfig) string {
 	if strings.Contains(orig, "://") {
 		return orig
-	} else {
-		if tlsConfig == nil || tlsConfig.DisableTLS {
-			return "http://" + orig
-		} else {
-			return "https://" + orig
-		}
 	}
+	if tlsConfig == nil || tlsConfig.DisableTLS {
+		return "http://" + orig
+	}
+	return "https://" + orig
 }

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -381,9 +381,8 @@ func (m *nativeGitClient) IsRevisionPresent(revision string) bool {
 	out, err := m.runCmdOutput(cmd, runOpts{SkipErrorLogging: true})
 	if out == "commit" && err == nil {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 // Fetch fetches latest updates from origin
@@ -438,16 +437,15 @@ func (m *nativeGitClient) LsFiles(path string, enableNewGitFileGlobbing bool) ([
 			}
 		}
 		return files, nil
-	} else {
-		// This is the old and default way
-		out, err := m.runCmd("ls-files", "--full-name", "-z", "--", path)
-		if err != nil {
-			return nil, err
-		}
-		// remove last element, which is blank regardless of whether we're using nullbyte or newline
-		ss := strings.Split(out, "\000")
-		return ss[:len(ss)-1], nil
 	}
+	// This is the old and default way
+	out, err := m.runCmd("ls-files", "--full-name", "-z", "--", path)
+	if err != nil {
+		return nil, err
+	}
+	// remove last element, which is blank regardless of whether we're using nullbyte or newline
+	ss := strings.Split(out, "\000")
+	return ss[:len(ss)-1], nil
 }
 
 // LsLargeFiles lists all files that have references to LFS storage
@@ -795,9 +793,8 @@ func (m *nativeGitClient) IsAnnotatedTag(revision string) bool {
 	out, err := m.runCmdOutput(cmd, runOpts{SkipErrorLogging: true})
 	if out != "" && err == nil {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 // ChangedFiles returns a list of files changed between two revisions

--- a/util/gpg/gpg.go
+++ b/util/gpg/gpg.go
@@ -66,11 +66,7 @@ type PGPKeyID string
 
 func isHexString(s string) bool {
 	_, err := hex.DecodeString(s)
-	if err != nil {
-		return false
-	} else {
-		return true
-	}
+	return err == nil
 }
 
 // KeyID get the actual correct (short) key ID from either a fingerprint or the key ID. Returns the empty string if k seems not to be a PGP key ID.
@@ -88,18 +84,16 @@ func KeyID(k string) string {
 func IsLongKeyID(k string) bool {
 	if len(k) == 40 && isHexString(k) {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 // IsShortKeyID returns true if the string represents a short key ID
 func IsShortKeyID(k string) bool {
 	if len(k) == 16 && isHexString(k) {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 // Result of a git commit verification
@@ -186,9 +180,8 @@ func removeKeyRing(path string) error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("refusing to remove directory %s: it's not initialized by Argo CD", path)
-		} else {
-			return err
 		}
+		return err
 	}
 	rd, err := os.Open(path)
 	if err != nil {
@@ -679,10 +672,9 @@ func ParseGitCommitVerification(signature string) PGPVerifyResult {
 	} else if linesParsed >= MaxVerificationLinesToParse {
 		// Too many output lines, return error
 		return unknownResult("Too many lines of gpg verify-commit output, abort.")
-	} else {
-		// No data found, return error
-		return unknownResult("Could not parse output of verify-commit, no verification data found.")
 	}
+	// No data found, return error
+	return unknownResult("Could not parse output of verify-commit, no verification data found.")
 }
 
 // SyncKeyRingFromDirectory will sync the GPG keyring with files in a directory. This is a one-way sync,

--- a/util/helm/client.go
+++ b/util/helm/client.go
@@ -113,9 +113,8 @@ func fileExist(filePath string) (bool, error) {
 	if _, err := os.Stat(filePath); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
-		} else {
-			return false, fmt.Errorf("error checking file existence for %s: %w", filePath, err)
 		}
+		return false, fmt.Errorf("error checking file existence for %s: %w", filePath, err)
 	}
 	return true, nil
 }

--- a/util/io/path/resolved.go
+++ b/util/io/path/resolved.go
@@ -119,9 +119,8 @@ func ResolveValueFilePathOrUrl(appPath, repoRoot, valueFile string, allowedURLSc
 		if url.Scheme != "" {
 			if isURLSchemeAllowed(url.Scheme, allowedURLSchemes) {
 				return ResolvedFilePath(valueFile), true, nil
-			} else {
-				return "", false, fmt.Errorf("the URL scheme '%s' is not allowed", url.Scheme)
 			}
+			return "", false, fmt.Errorf("the URL scheme '%s' is not allowed", url.Scheme)
 		}
 	}
 

--- a/util/lua/custom_actions_test.go
+++ b/util/lua/custom_actions_test.go
@@ -166,9 +166,8 @@ func TestLuaResourceActionsScript(t *testing.T) {
 						// TODO: maybe this should use a normalizer function instead of hard-coding the resource specifics here
 						if (result.GetKind() == "Job" && sourceObj.GetKind() == "CronJob") || (result.GetKind() == "Workflow" && (sourceObj.GetKind() == "CronWorkflow" || sourceObj.GetKind() == "WorkflowTemplate")) {
 							return u.GroupVersionKind() == result.GroupVersionKind() && strings.HasPrefix(u.GetName(), sourceObj.GetName()) && u.GetNamespace() == result.GetNamespace()
-						} else {
-							return u.GroupVersionKind() == result.GroupVersionKind() && u.GetName() == result.GetName() && u.GetNamespace() == result.GetNamespace()
 						}
+						return u.GroupVersionKind() == result.GroupVersionKind() && u.GetName() == result.GetName() && u.GetNamespace() == result.GetNamespace()
 					})
 
 					assert.NotNil(t, expectedObj)

--- a/util/lua/oslib_safe.go
+++ b/util/lua/oslib_safe.go
@@ -162,22 +162,21 @@ func (fs *flagScanner) Next() (byte, bool) {
 			fs.AppendString(fs.end)
 		}
 		return c, true
-	} else {
-		c = fs.str[fs.Pos]
-		if c == fs.flag {
-			if fs.Pos < (fs.Length-1) && fs.str[fs.Pos+1] == fs.flag {
-				fs.HasFlag = false
-				fs.AppendChar(fs.flag)
-				fs.Pos += 2
-				return fs.Next()
-			} else if fs.Pos != fs.Length-1 {
-				if fs.HasFlag {
-					fs.AppendString(fs.end)
-				}
-				fs.AppendString(fs.start)
-				fs.ChangeFlag = true
-				fs.HasFlag = true
+	}
+	c = fs.str[fs.Pos]
+	if c == fs.flag {
+		if fs.Pos < (fs.Length-1) && fs.str[fs.Pos+1] == fs.flag {
+			fs.HasFlag = false
+			fs.AppendChar(fs.flag)
+			fs.Pos += 2
+			return fs.Next()
+		} else if fs.Pos != fs.Length-1 {
+			if fs.HasFlag {
+				fs.AppendString(fs.end)
 			}
+			fs.AppendString(fs.start)
+			fs.ChangeFlag = true
+			fs.HasFlag = true
 		}
 	}
 	fs.Pos++

--- a/util/security/rbac.go
+++ b/util/security/rbac.go
@@ -8,7 +8,6 @@ import (
 func RBACName(defaultNS string, project string, namespace string, name string) string {
 	if defaultNS != "" && namespace != defaultNS && namespace != "" {
 		return fmt.Sprintf("%s/%s/%s", project, namespace, name)
-	} else {
-		return fmt.Sprintf("%s/%s", project, name)
 	}
+	return fmt.Sprintf("%s/%s", project, name)
 }

--- a/util/settings/accounts.go
+++ b/util/settings/accounts.go
@@ -296,11 +296,11 @@ func parseAccounts(secret *corev1.Secret, cm *corev1.ConfigMap) (map[string]Acco
 			account.PasswordHash = string(passwordHash)
 		}
 		if passwordMtime, ok := secret.Data[fmt.Sprintf("%s.%s.%s", accountsKeyPrefix, name, accountPasswordMtimeSuffix)]; ok {
-			if mTime, err := time.Parse(time.RFC3339, string(passwordMtime)); err != nil {
+			mTime, err := time.Parse(time.RFC3339, string(passwordMtime))
+			if err != nil {
 				return nil, err
-			} else {
-				account.PasswordMtime = &mTime
 			}
+			account.PasswordMtime = &mTime
 		}
 		if tokensStr, ok := secret.Data[fmt.Sprintf("%s.%s.%s", accountsKeyPrefix, name, accountTokensSuffix)]; ok {
 			account.Tokens = make([]Token, 0)

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -345,14 +345,13 @@ func LoadX509CertPool(paths ...string) (*x509.CertPool, error) {
 			}
 			// ...but everything else is considered an error
 			return nil, fmt.Errorf("could not load TLS certificate: %w", err)
-		} else {
-			f, err := os.ReadFile(path)
-			if err != nil {
-				return nil, fmt.Errorf("failure to load TLS certificates from %s: %w", path, err)
-			}
-			if ok := pool.AppendCertsFromPEM(f); !ok {
-				return nil, fmt.Errorf("invalid cert data in %s", path)
-			}
+		}
+		f, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failure to load TLS certificates from %s: %w", path, err)
+		}
+		if ok := pool.AppendCertsFromPEM(f); !ok {
+			return nil, fmt.Errorf("invalid cert data in %s", path)
 		}
 	}
 	return pool, nil


### PR DESCRIPTION
#### Description 

[indent-error-flow](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow): To improve the readability of code, it is recommended to reduce the indentation as much as possible. This rule highlights redundant else-blocks that can be eliminated from the code.

NB:  superfluous-else use it's default arguments