### PR TITLE
chore(ci): run codegen as part of version bump job

### DIFF
--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -63,6 +63,7 @@ jobs:
         run: |
           set -x
           export GOPATH=$(go env GOPATH)
+          git status
           make codegen-local
         working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -30,6 +30,43 @@ jobs:
         run: |
           hack/bump-major-version.sh
 
+      - name: Setup Golang
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+      - name: Create symlink in GOPATH
+        run: |
+          mkdir -p ~/go/src/github.com/argoproj
+          cp -a ../argo-cd ~/go/src/github.com/argoproj
+      - name: Add ~/go/bin to PATH
+        run: |
+          echo "/home/runner/go/bin" >> $GITHUB_PATH
+      - name: Add /usr/local/bin to PATH
+        run: |
+          echo "/usr/local/bin" >> $GITHUB_PATH
+      - name: Download & vendor dependencies
+        run: |
+          # We need to vendor go modules for codegen yet
+          go mod download
+          go mod vendor -v
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
+      - name: Install toolchain for codegen
+        run: |
+          make install-codegen-tools-local
+          make install-go-tools-local
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
+        # We install kustomize in the dist directory
+      - name: Add dist to PATH
+        run: |
+          echo "/home/runner/work/argo-cd/argo-cd/dist" >> $GITHUB_PATH
+      - name: Run codegen
+        run: |
+          set -x
+          export GOPATH=$(go env GOPATH)
+          git checkout -- go.mod go.sum
+          make codegen-local
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -64,6 +64,8 @@ jobs:
           set -x
           export GOPATH=$(go env GOPATH)
           git status
+          ls .
+          cat reposerver/repository/repository.proto
           make codegen-local
         working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -63,7 +63,6 @@ jobs:
         run: |
           set -x
           export GOPATH=$(go env GOPATH)
-          git checkout -- go.mod go.sum
           make codegen-local
         working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -63,9 +63,6 @@ jobs:
         run: |
           set -x
           export GOPATH=$(go env GOPATH)
-          git status
-          ls .
-          cat reposerver/repository/repository.proto
           make codegen-local
         working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 

--- a/hack/bump-major-version.sh
+++ b/hack/bump-major-version.sh
@@ -11,22 +11,22 @@ echo "Upgrading from v${CURRENT_VERSION} to v$((CURRENT_VERSION + 1))..."
 
 for file in .golangci.yaml .goreleaser.yaml .mockery.yaml Makefile Procfile; do
   echo "Incrementing the major version in $file..."
-  sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" "$file" && rm "$file.bak"
+  sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" "$file" && echo "  Updated $file" && rm "$file.bak"
 done
 
 for file in hack/generate-proto.sh hack/update-codegen.sh hack/update-openapi.sh; do
   echo "Incrementing the major version in $file..."
-  sed -i.bak "s/v${CURRENT_VERSION}/v$((CURRENT_VERSION + 1))/g" "$file" && rm "$file.bak"
+  sed -i.bak "s/v${CURRENT_VERSION}/v$((CURRENT_VERSION + 1))/g" "$file" && echo "  Update $file" && rm "$file.bak"
 done
 
 echo "Incrementing the major version in proto files..."
-find . -name '*.proto' -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec rm {}.bak \;
-find . -name '*.proto' -exec sed -i.bak "s/github\.com.\argoproj\.argo_cd\.v${CURRENT_VERSION}/github\.com.\argoproj\.argo_cd\.v$((CURRENT_VERSION + 1))/g" {} \; -exec rm {}.bak \;
+find . -name '*.proto' -not -path "./vendor/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
+find . -name '*.proto' -not -path "./vendor/*" -exec sed -i.bak "s/github\.com.\argoproj\.argo_cd\.v${CURRENT_VERSION}/github\.com.\argoproj\.argo_cd\.v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
 
 echo "Incrementing the major version in go files..."
-find . -name '*.go' -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec rm {}.bak \;
+find . -name '*.go' -not -path "./vendor/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
 
 echo "Incrementing the major version in go.mod..."
-sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" go.mod && rm go.mod.bak
+sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" go.mod && echo "  Updated go.mod" && rm go.mod.bak
 
 echo 'Finished! Now run `make codegen-local && make lint-local && make test-local` to ensure everything is working as expected.'

--- a/hack/bump-major-version.sh
+++ b/hack/bump-major-version.sh
@@ -21,7 +21,7 @@ done
 
 echo "Incrementing the major version in proto files..."
 find . -name '*.proto' -not -path "./vendor/*" -not -path "./dist/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
-find . -name '*.proto' -not -path "./vendor/*" -not -path "./dist/*" -exec sed -i.bak "s/github\.com.\argoproj\.argo_cd\.v${CURRENT_VERSION}/github\.com.\argoproj\.argo_cd\.v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
+find . -name '*.proto' -not -path "./vendor/*" -not -path "./dist/*" -exec sed -i.bak "s/github\.com\.argoproj\.argo_cd\.v${CURRENT_VERSION}/github\.com\.argoproj\.argo_cd\.v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
 
 echo "Incrementing the major version in go files..."
 find . -name '*.go' -not -path "./vendor/*" -not -path "./dist/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;

--- a/hack/bump-major-version.sh
+++ b/hack/bump-major-version.sh
@@ -20,11 +20,11 @@ for file in hack/generate-proto.sh hack/update-codegen.sh hack/update-openapi.sh
 done
 
 echo "Incrementing the major version in proto files..."
-find . -name '*.proto' -not -path "./vendor/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
-find . -name '*.proto' -not -path "./vendor/*" -exec sed -i.bak "s/github\.com.\argoproj\.argo_cd\.v${CURRENT_VERSION}/github\.com.\argoproj\.argo_cd\.v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
+find . -name '*.proto' -not -path "./vendor/*" -not -path "./dist/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
+find . -name '*.proto' -not -path "./vendor/*" -not -path "./dist/*" -exec sed -i.bak "s/github\.com.\argoproj\.argo_cd\.v${CURRENT_VERSION}/github\.com.\argoproj\.argo_cd\.v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
 
 echo "Incrementing the major version in go files..."
-find . -name '*.go' -not -path "./vendor/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
+find . -name '*.go' -not -path "./vendor/*" -not -path "./dist/*" -exec sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" {} \; -exec echo "  Updated" {} \; -exec rm {}.bak \;
 
 echo "Incrementing the major version in go.mod..."
 sed -i.bak "s/github\.com\/argoproj\/argo-cd\/v${CURRENT_VERSION}/github\.com\/argoproj\/argo-cd\/v$((CURRENT_VERSION + 1))/g" go.mod && echo "  Updated go.mod" && rm go.mod.bak


### PR DESCRIPTION
The generated PR will fail on codegen if we don't run codegen before pushing the PR.

This also fixes a typo which caused some proto file changes to be missed when using GNU sed.