### PR TITLE
fix(ci): all version bump changes go in the PR

### DIFF
--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           mkdir -p ~/go/src/github.com/argoproj
           ln -s ../argo-cd ~/go/src/github.com/argoproj/argo-cd
+          ls ~/go/src/github.com/argoproj/argo-cd
       - name: Add ~/go/bin to PATH
         run: |
           echo "/home/runner/go/bin" >> $GITHUB_PATH

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -63,7 +63,10 @@ jobs:
         run: |
           set -x
           export GOPATH=$(go env GOPATH)
+          git add .
           make codegen-local
+          git diff
+          git add .
         working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 
       - name: Create pull request

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -70,7 +70,8 @@ jobs:
 
       - name: Copy changes back
         run: |
-          cp -a /home/runner/go/src/github.com/argoproj/argo-cd/. ../argo-cd
+          # Copy the contents back, but skip the .git directory
+          rsync -a --exclude=.git /home/runner/go/src/github.com/argoproj/argo-cd/ ../argo-cd
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -65,10 +65,7 @@ jobs:
         run: |
           set -x
           export GOPATH=$(go env GOPATH)
-          git add .
           make codegen-local
-          git diff
-          git add .
         working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 
       - name: Create pull request

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Create symlink in GOPATH
         run: |
           mkdir -p ~/go/src/github.com/argoproj
-          ln -s ~/go/src/github.com/argoproj/argo-cd ../argo-cd
+          ln -s ../argo-cd ~/go/src/github.com/argoproj/argo-cd
       - name: Add ~/go/bin to PATH
         run: |
           echo "/home/runner/go/bin" >> $GITHUB_PATH

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -68,6 +68,10 @@ jobs:
           make codegen-local
         working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 
+      - name: Copy changes back
+        run: |
+          cp -a /home/runner/go/src/github.com/argoproj/argo-cd/. ../argo-cd
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f  # v7.0.5
         with:
@@ -81,5 +85,3 @@ jobs:
             - [ ] Add an upgrade guide to the docs for this version
           branch: bump-major-version
           branch-suffix: random
-          signoff: true
-        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           mkdir -p ~/go/src/github.com/argoproj
           ln -s ../argo-cd ~/go/src/github.com/argoproj/argo-cd
+          ls ../argo-cd/*
           ls ~/go/src/github.com/argoproj/argo-cd/*
       - name: Add ~/go/bin to PATH
         run: |

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -86,3 +86,4 @@ jobs:
             - [ ] Add an upgrade guide to the docs for this version
           branch: bump-major-version
           branch-suffix: random
+          signoff: true

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -26,20 +26,20 @@ jobs:
           CURRENT_VERSION=$(grep 'module github.com/argoproj/argo-cd' go.mod | awk '{print $2}' | sed 's/.*\/v//')
           echo "TARGET_VERSION=$((CURRENT_VERSION + 1))" >> $GITHUB_OUTPUT
 
+      - name: Copy source code to GOPATH
+        run: |
+          mkdir -p ~/go/src/github.com/argoproj
+          cp -a ../argo-cd ~/go/src/github.com/argoproj
+
       - name: Run script to bump the version
         run: |
           hack/bump-major-version.sh
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd
 
       - name: Setup Golang
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ env.GOLANG_VERSION }}
-      - name: Create symlink in GOPATH
-        run: |
-          mkdir -p ~/go/src/github.com/argoproj
-          ln -s ../argo-cd ~/go/src/github.com/argoproj/argo-cd
-          ls ../argo-cd/*
-          ls ~/go/src/github.com/argoproj/argo-cd/*
       - name: Add ~/go/bin to PATH
         run: |
           echo "/home/runner/go/bin" >> $GITHUB_PATH

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -82,3 +82,4 @@ jobs:
           branch: bump-major-version
           branch-suffix: random
           signoff: true
+        working-directory: /home/runner/go/src/github.com/argoproj/argo-cd

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir -p ~/go/src/github.com/argoproj
           ln -s ../argo-cd ~/go/src/github.com/argoproj/argo-cd
-          ls ~/go/src/github.com/argoproj/argo-cd
+          ls ~/go/src/github.com/argoproj/argo-cd/*
       - name: Add ~/go/bin to PATH
         run: |
           echo "/home/runner/go/bin" >> $GITHUB_PATH

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -36,6 +36,7 @@ jobs:
           go-version: ${{ env.GOLANG_VERSION }}
       - name: Create symlink in GOPATH
         run: |
+          mkdir -p ~/go/src/github.com/argoproj
           ln -s ~/go/src/github.com/argoproj/argo-cd ../argo-cd
       - name: Add ~/go/bin to PATH
         run: |

--- a/.github/workflows/bump-major-version.yaml
+++ b/.github/workflows/bump-major-version.yaml
@@ -36,8 +36,7 @@ jobs:
           go-version: ${{ env.GOLANG_VERSION }}
       - name: Create symlink in GOPATH
         run: |
-          mkdir -p ~/go/src/github.com/argoproj
-          cp -a ../argo-cd ~/go/src/github.com/argoproj
+          ln -s ~/go/src/github.com/argoproj/argo-cd ../argo-cd
       - name: Add ~/go/bin to PATH
         run: |
           echo "/home/runner/go/bin" >> $GITHUB_PATH


### PR DESCRIPTION
We have to run codegen in the go path, but we have to open the PR from the github actions workspace. Go figure.