### PR TITLE
fix: ensure enable-oci is always propagated with repo-creds

### DIFF
--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -192,6 +192,10 @@ func (repo *Repository) CopyCredentialsFrom(source *RepoCreds) {
 		if repo.NoProxy == "" {
 			repo.NoProxy = source.NoProxy
 		}
+		if repo.Type == "" {
+			repo.Type = source.Type
+		}
+		repo.EnableOCI = source.EnableOCI
 		repo.ForceHttpBasicAuth = source.ForceHttpBasicAuth
 	}
 }

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -1314,6 +1314,8 @@ func TestRepository_CopyCredentialsFrom(t *testing.T) {
 		{"SourceTLSClientCertData", &Repository{}, &RepoCreds{TLSClientCertData: "foo"}, Repository{TLSClientCertData: "foo"}},
 		{"SourceTLSClientCertKey", &Repository{}, &RepoCreds{TLSClientCertKey: "foo"}, Repository{TLSClientCertKey: "foo"}},
 		{"SourceContainsProxy", &Repository{}, &RepoCreds{Proxy: "http://proxy.argoproj.io:3128", NoProxy: ".example.com"}, Repository{Proxy: "http://proxy.argoproj.io:3128", NoProxy: ".example.com"}},
+		{"SourceType", &Repository{}, &RepoCreds{Type: "helm"}, Repository{Type: "helm"}},
+		{"SourceEnableOCI", &Repository{}, &RepoCreds{EnableOCI: true}, Repository{EnableOCI: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ui/src/app/settings/components/repos-list/repos-list.tsx
+++ b/ui/src/app/settings/components/repos-list/repos-list.tsx
@@ -86,6 +86,7 @@ interface NewSSHRepoCredsParams {
 
 interface NewHTTPSRepoCredsParams {
     url: string;
+    type: string;
     username: string;
     password: string;
     tlsClientCertData: string;
@@ -906,7 +907,8 @@ export class ReposList extends React.Component<
     // Connect a new repository or create a repository credentials for HTTPS repositories
     private async connectHTTPSRepo(params: NewHTTPSRepoParams) {
         if (this.credsTemplate) {
-            this.createHTTPSCreds({
+            await this.createHTTPSCreds({
+                type: params.type,
                 url: params.url,
                 username: params.username,
                 password: params.password,

--- a/ui/src/app/shared/services/repocreds-service.ts
+++ b/ui/src/app/shared/services/repocreds-service.ts
@@ -7,8 +7,10 @@ export interface HTTPSCreds {
     password: string;
     tlsClientCertData: string;
     tlsClientCertKey: string;
+    type: string;
     proxy: string;
     noProxy: string;
+    enableOCI: boolean;
 }
 
 export interface SSHCreds {


### PR DESCRIPTION
It seems like `EnableOCI` is not always propagated when using repository credential templates. Add a conversion in `*Repository.CopyCredentialsFrom` to ensure that's the case.

For completeness, we also add a conversion for `repo.Type` and also make it explicit in `HTTPSCreds` that these fields are used.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
