### PR TITLE
feat(ui): Added theme profile to log-viewer

### DIFF
--- a/ui/src/app/applications/components/pod-logs-viewer/dark-mode-toggle-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/dark-mode-toggle-button.tsx
@@ -5,38 +5,34 @@ import {ToggleButton} from '../../../shared/components/toggle-button';
 // DarkModeToggleButton is a component that renders a toggle button that toggles dark mode.
 // Added a logviewer theme profile
 
-interface LogViewerTheme {
-    light: boolean;
-    dark: boolean;
-}
-
 export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
     React.useEffect(() => {
-        const profiles = prefs.appDetails.LogViewerTheme as LogViewerTheme;
-        const currentTheme = prefs.theme;
-
-        if (!profiles) {
+        // Only run when theme changes or LogViewerTheme is not initialized
+        const profile = prefs.appDetails.UseDarkModeInLogViewerForAppTheme;
+        
+        if (!profile) {
+            // First time initialization
             services.viewPreferences.updatePreferences({
                 ...prefs,
                 appDetails: {
                     ...prefs.appDetails,
-                    LogViewerTheme: {
-                        light: false,
-                        dark: true
-                    },
-                    darkMode: currentTheme === 'dark'
+                    UseDarkModeInLogViewerForAppTheme: {
+                        light: prefs.appDetails.darkMode,  
+                        dark: prefs.appDetails.darkMode    
+                    }
                 }
             });
             return;
         }
 
-        const profilePreference = currentTheme === 'dark' ? profiles.dark : profiles.light;
-        if (prefs.appDetails.darkMode !== profilePreference) {
+        // Update darkMode based on saved preference for current theme
+        const currentThemeDarkMode = profile[prefs.theme as keyof typeof profile];
+        if (prefs.appDetails.darkMode !==currentThemeDarkMode) {
             services.viewPreferences.updatePreferences({
                 ...prefs,
                 appDetails: {
                     ...prefs.appDetails,
-                    darkMode: profilePreference
+                    darkMode: currentThemeDarkMode
                 }
             });
         }
@@ -44,10 +40,9 @@ export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
 
     const handleToggle = () => {
         const newDarkMode = !prefs.appDetails.darkMode;
-        const currentTheme = prefs.theme;
-        const profiles = (prefs.appDetails.LogViewerTheme as LogViewerTheme) || {
-            light: false,
-            dark: true
+        const currentProfile = prefs.appDetails.UseDarkModeInLogViewerForAppTheme || {
+            light: prefs.appDetails.darkMode,
+            dark: prefs.appDetails.darkMode
         };
 
         services.viewPreferences.updatePreferences({
@@ -55,13 +50,20 @@ export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
             appDetails: {
                 ...prefs.appDetails,
                 darkMode: newDarkMode,
-                LogViewerTheme: {
-                    ...profiles,
-                    [currentTheme]: newDarkMode
+                UseDarkModeInLogViewerForAppTheme: {
+                    ...currentProfile,
+                    [prefs.theme]: newDarkMode
                 }
             }
         });
     };
 
-    return <ToggleButton title='Dark Mode' onToggle={handleToggle} toggled={prefs.appDetails.darkMode} icon='moon' />;
+    return (
+        <ToggleButton
+            title='Dark Mode'
+            onToggle={handleToggle}
+            toggled={prefs.appDetails.darkMode}
+            icon='moon'
+        />
+    );
 };

--- a/ui/src/app/applications/components/pod-logs-viewer/dark-mode-toggle-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/dark-mode-toggle-button.tsx
@@ -3,17 +3,65 @@ import * as React from 'react';
 import {ToggleButton} from '../../../shared/components/toggle-button';
 
 // DarkModeToggleButton is a component that renders a toggle button that toggles dark mode.
-export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => (
-    <ToggleButton
-        title='Dark Mode'
-        onToggle={() => {
-            const inverted = prefs.appDetails.darkMode;
+// Added a logviewer theme profile
+
+interface LogViewerTheme {
+    light: boolean;
+    dark: boolean;
+}
+
+export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
+    React.useEffect(() => {
+        const profiles = prefs.appDetails.LogViewerTheme as LogViewerTheme;
+        const currentTheme = prefs.theme;
+
+        if (!profiles) {
             services.viewPreferences.updatePreferences({
                 ...prefs,
-                appDetails: {...prefs.appDetails, darkMode: !inverted}
+                appDetails: {
+                    ...prefs.appDetails,
+                    LogViewerTheme: {
+                        light: false,
+                        dark: true
+                    },
+                    darkMode: currentTheme === 'dark'
+                }
             });
-        }}
-        toggled={prefs.appDetails.darkMode}
-        icon='moon'
-    />
-);
+            return;
+        }
+
+        const profilePreference = currentTheme === 'dark' ? profiles.dark : profiles.light;
+        if (prefs.appDetails.darkMode !== profilePreference) {
+            services.viewPreferences.updatePreferences({
+                ...prefs,
+                appDetails: {
+                    ...prefs.appDetails,
+                    darkMode: profilePreference
+                }
+            });
+        }
+    }, [prefs.theme]);
+
+    const handleToggle = () => {
+        const newDarkMode = !prefs.appDetails.darkMode;
+        const currentTheme = prefs.theme;
+        const profiles = (prefs.appDetails.LogViewerTheme as LogViewerTheme) || {
+            light: false,
+            dark: true
+        };
+
+        services.viewPreferences.updatePreferences({
+            ...prefs,
+            appDetails: {
+                ...prefs.appDetails,
+                darkMode: newDarkMode,
+                LogViewerTheme: {
+                    ...profiles,
+                    [currentTheme]: newDarkMode
+                }
+            }
+        });
+    };
+
+    return <ToggleButton title='Dark Mode' onToggle={handleToggle} toggled={prefs.appDetails.darkMode} icon='moon' />;
+};

--- a/ui/src/app/applications/components/pod-logs-viewer/dark-mode-toggle-button.tsx
+++ b/ui/src/app/applications/components/pod-logs-viewer/dark-mode-toggle-button.tsx
@@ -9,7 +9,7 @@ export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
     React.useEffect(() => {
         // Only run when theme changes or LogViewerTheme is not initialized
         const profile = prefs.appDetails.UseDarkModeInLogViewerForAppTheme;
-        
+
         if (!profile) {
             // First time initialization
             services.viewPreferences.updatePreferences({
@@ -17,8 +17,8 @@ export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
                 appDetails: {
                     ...prefs.appDetails,
                     UseDarkModeInLogViewerForAppTheme: {
-                        light: prefs.appDetails.darkMode,  
-                        dark: prefs.appDetails.darkMode    
+                        light: prefs.appDetails.darkMode,
+                        dark: prefs.appDetails.darkMode
                     }
                 }
             });
@@ -27,7 +27,7 @@ export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
 
         // Update darkMode based on saved preference for current theme
         const currentThemeDarkMode = profile[prefs.theme as keyof typeof profile];
-        if (prefs.appDetails.darkMode !==currentThemeDarkMode) {
+        if (prefs.appDetails.darkMode !== currentThemeDarkMode) {
             services.viewPreferences.updatePreferences({
                 ...prefs,
                 appDetails: {
@@ -58,12 +58,5 @@ export const DarkModeToggleButton = ({prefs}: {prefs: ViewPreferences}) => {
         });
     };
 
-    return (
-        <ToggleButton
-            title='Dark Mode'
-            onToggle={handleToggle}
-            toggled={prefs.appDetails.darkMode}
-            icon='moon'
-        />
-    );
+    return <ToggleButton title='Dark Mode' onToggle={handleToggle} toggled={prefs.appDetails.darkMode} icon='moon' />;
 };

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -31,6 +31,7 @@ export interface AppDetailsPreferences {
     zoom: number;
     podGroupCount: number;
     userHelpTipMsgs: UserMessages[];
+    LogViewerTheme?: {light: boolean; dark: boolean};
 }
 
 export interface PodViewPreferences {

--- a/ui/src/app/shared/services/view-preferences-service.ts
+++ b/ui/src/app/shared/services/view-preferences-service.ts
@@ -31,7 +31,7 @@ export interface AppDetailsPreferences {
     zoom: number;
     podGroupCount: number;
     userHelpTipMsgs: UserMessages[];
-    LogViewerTheme?: {light: boolean; dark: boolean};
+    UseDarkModeInLogViewerForAppTheme?: {light: boolean; dark: boolean};
 }
 
 export interface PodViewPreferences {


### PR DESCRIPTION
Closes #21426

The log viewer will now  be set using the preferred theme. 
By default, it adopts the global theme as the log viewer profile unless the user has already set a specific preference for that mode


https://github.com/user-attachments/assets/7d246054-01c9-4aa3-924a-641749c32597

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
