### PR TITLE
feat: use log format config for klog (#5715)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ const (
 )
 
 func init() {
-	// Make sure klog and gRPC uses the configured log level and format.
+	// Make sure klog uses the configured log level and format.
 	klog.SetLogger(log.NewLogrusLogger(log.NewWithCurrentConfig()))
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,13 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/klog/v2"
-
-	"github.com/argoproj/argo-cd/v3/util/log"
-
-	"github.com/argoproj/argo-cd/v3/cmd/util"
-
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	appcontroller "github.com/argoproj/argo-cd/v3/cmd/argocd-application-controller/commands"
 	applicationset "github.com/argoproj/argo-cd/v3/cmd/argocd-applicationset-controller/commands"
@@ -23,6 +18,8 @@ import (
 	reposerver "github.com/argoproj/argo-cd/v3/cmd/argocd-repo-server/commands"
 	apiserver "github.com/argoproj/argo-cd/v3/cmd/argocd-server/commands"
 	cli "github.com/argoproj/argo-cd/v3/cmd/argocd/commands"
+	"github.com/argoproj/argo-cd/v3/cmd/util"
+	"github.com/argoproj/argo-cd/v3/util/log"
 )
 
 const (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"k8s.io/klog/v2"
+
+	"github.com/argoproj/argo-cd/v3/util/log"
+
 	"github.com/argoproj/argo-cd/v3/cmd/util"
 
 	"github.com/spf13/cobra"
@@ -27,6 +31,9 @@ const (
 
 func main() {
 	var command *cobra.Command
+
+	// Make sure klog uses the configured log level and format.
+	klog.SetLogger(log.NewLogrusLogger(log.NewWithCurrentConfig()))
 
 	binaryName := filepath.Base(os.Args[0])
 	if val := os.Getenv(binaryNameEnv); val != "" {
@@ -66,6 +73,8 @@ func main() {
 		isCLI = true
 	}
 	util.SetAutoMaxProcs(isCLI)
+
+	klog.Error("test")
 
 	if err := command.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,11 +29,13 @@ const (
 	binaryNameEnv = "ARGOCD_BINARY_NAME"
 )
 
+func init() {
+	// Make sure klog and gRPC uses the configured log level and format.
+	klog.SetLogger(log.NewLogrusLogger(log.NewWithCurrentConfig()))
+}
+
 func main() {
 	var command *cobra.Command
-
-	// Make sure klog uses the configured log level and format.
-	klog.SetLogger(log.NewLogrusLogger(log.NewWithCurrentConfig()))
 
 	binaryName := filepath.Base(os.Args[0])
 	if val := os.Getenv(binaryNameEnv); val != "" {
@@ -73,8 +75,6 @@ func main() {
 		isCLI = true
 	}
 	util.SetAutoMaxProcs(isCLI)
-
-	klog.Error("test")
 
 	if err := command.Execute(); err != nil {
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/bmatcuk/doublestar/v4 v4.7.1
-	github.com/bombsimon/logrusr/v2 v2.0.1
+	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.13.0
 	github.com/casbin/casbin/v2 v2.103.0
 	github.com/casbin/govaluate v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
 github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
-github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
+github.com/bombsimon/logrusr/v4 v4.1.0 h1:uZNPbwusB0eUXlO8hIUwStE6Lr5bLN6IgYgG+75kuh4=
+github.com/bombsimon/logrusr/v4 v4.1.0/go.mod h1:pjfHC5e59CvjTBIU3V3sGhFWFAnsnhOR03TRc6im0l8=
 github.com/bradleyfalzon/ghinstallation/v2 v2.13.0 h1:5FhjW93/YLQJDmPdeyMPw7IjAPzqsr+0jHPfrPz0sZI=
 github.com/bradleyfalzon/ghinstallation/v2 v2.13.0/go.mod h1:EJ6fgedVEHa2kUyBTTvslJCXJafS/mhJNNKEOCspZXQ=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -311,7 +311,6 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -881,7 +880,6 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.2/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
@@ -1198,7 +1196,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210608053332-aa57babbf139/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	adapter "github.com/bombsimon/logrusr/v2"
+	adapter "github.com/bombsimon/logrusr/v4"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 
@@ -18,7 +18,7 @@ const (
 )
 
 func NewLogrusLogger(fieldLogger logrus.FieldLogger) logr.Logger {
-	return adapter.New(fieldLogger, adapter.WithFormatter(func(val any) string {
+	return adapter.New(fieldLogger, adapter.WithFormatter(func(val any) any {
 		return fmt.Sprintf("%v", val)
 	}))
 }


### PR DESCRIPTION
Fixes #5715

Modeled on https://github.com/argoproj/argo-rollouts/pull/2701/files

Took the opportunity to upgrade the adapter package.

Test:

```
> dist/argocd version
ERRO[0000] test                                          error="<nil>"
argocd: v2.14.0+2d0f48b.dirty
  BuildDate: 2025-01-10T21:56:48Z
  GitCommit: 2d0f48b67638f25f147f9e13ba6239fc047a40e4
  GitTreeState: dirty
  GoVersion: go1.22.5
  Compiler: gc
  Platform: darwin/arm64
FATA[0001] oauth2: "invalid_request" "Refresh token is invalid or has already been claimed by another client." 
> ARGOCD_LOG_FORMAT=json dist/argocd version
{"error":null,"level":"error","msg":"test","time":"2025-01-10T16:57:20-05:00"}
argocd: v2.14.0+2d0f48b.dirty
  BuildDate: 2025-01-10T21:56:48Z
  GitCommit: 2d0f48b67638f25f147f9e13ba6239fc047a40e4
  GitTreeState: dirty
  GoVersion: go1.22.5
  Compiler: gc
  Platform: darwin/arm64
FATA[0001] oauth2: "invalid_request" "Refresh token is invalid or has already been claimed by another client." 
```