### PR TITLE
fix(appset): update gitlab SCM provider to search on parent folder (#16253)

### DIFF
--- a/applicationset/services/scm_provider/gitlab.go
+++ b/applicationset/services/scm_provider/gitlab.go
@@ -131,37 +131,30 @@ func (g *GitlabProvider) RepoHasPath(_ context.Context, repo *Repository, path s
 	if err != nil {
 		return false, err
 	}
-	directories := []string{
-		path,
-		pathpkg.Dir(path),
+
+	options := gitlab.ListTreeOptions{
+		Path: gitlab.Ptr(pathpkg.Dir(path)), // search parent folder
+		Ref:  &repo.Branch,
 	}
-	for _, directory := range directories {
-		options := gitlab.ListTreeOptions{
-			Path: &directory,
-			Ref:  &repo.Branch,
+	for {
+		treeNode, resp, err := g.client.Repositories.ListTree(p.ID, &options)
+		if err != nil {
+			return false, err
 		}
-		for {
-			treeNode, resp, err := g.client.Repositories.ListTree(p.ID, &options)
-			if err != nil {
-				return false, err
+
+		// search for presence of the requested file in the parent folder
+		for i := range treeNode {
+			if treeNode[i].Path == path {
+				return true, nil
 			}
-			if path == directory {
-				if resp.TotalItems > 0 {
-					return true, nil
-				}
-			}
-			for i := range treeNode {
-				if treeNode[i].Path == path {
-					return true, nil
-				}
-			}
-			if resp.NextPage == 0 {
-				// no future pages
-				break
-			}
-			options.Page = resp.NextPage
 		}
+		if resp.NextPage == 0 {
+			// no future pages
+			break
+		}
+		options.Page = resp.NextPage
 	}
+
 	return false, nil
 }
 

--- a/applicationset/services/scm_provider/gitlab_test.go
+++ b/applicationset/services/scm_provider/gitlab_test.go
@@ -1040,6 +1040,8 @@ func gitlabMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 			if err != nil {
 				t.Fail()
 			}
+		case "/api/v4/projects/27084533/repository/tree?path=argocd/filepath.yaml&ref=master":
+			w.WriteHeader(http.StatusNotFound)
 		case "/api/v4/projects/27084533/repository/branches/foo":
 			w.WriteHeader(http.StatusNotFound)
 		default:
@@ -1192,6 +1194,11 @@ func TestGitlabHasPath(t *testing.T) {
 		{
 			name:   "file does not exist",
 			path:   "argocd/notathing.yaml",
+			exists: false,
+		},
+		{
+			name:   "send a file path",
+			path:   "argocd/filepath.yaml",
 			exists: false,
 		},
 	}

--- a/applicationset/services/scm_provider/gitlab_test.go
+++ b/applicationset/services/scm_provider/gitlab_test.go
@@ -1040,6 +1040,10 @@ func gitlabMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 			if err != nil {
 				t.Fail()
 			}
+		// Recent versions of the Gitlab API (v17.7+) return 404 not only when a file doesn't exist, but also
+		// when a path is to a file instead of a directory. Our code should not hit this path, because
+		// we should only send requests for parent directories. But we leave this handler in place
+		// to prevent regressions.
 		case "/api/v4/projects/27084533/repository/tree?path=argocd/filepath.yaml&ref=master":
 			w.WriteHeader(http.StatusNotFound)
 		case "/api/v4/projects/27084533/repository/branches/foo":


### PR DESCRIPTION
Fixes [#16253]

This PR solves the ISsue with Gitlab 17.7 (probably others) where using the `ListTree` API request and specifying a path to a file returns a 404. 
This is a change in the API and prevent usage of files in the Gitlab SCM `PathExist`.

This PR changes the way we do the search, by looking for all individual entries in the parent folder, whatever we're looking for a file or a folder.

## Pros
- we only query the API once
- we solve the 404 bug

## Cons
- in case there's a ton of entities (folders and files) in the parent folder and we only care for a folder, we have to iterate over all the entities until we find the right one. This is already the case when looking for a file, so it's not a real behaviour change.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
