### PR TITLE
chore(repo-server): simplify Kustomize/Helm version detection

### DIFF
--- a/server/version/version.go
+++ b/server/version/version.go
@@ -39,7 +39,7 @@ func (s *Server) Version(ctx context.Context, _ *empty.Empty) (*version.VersionM
 	}
 
 	if s.kustomizeVersion == "" {
-		kustomizeVersion, err := kustomize.Version(true)
+		kustomizeVersion, err := kustomize.Version()
 		if err == nil {
 			s.kustomizeVersion = kustomizeVersion
 		} else {
@@ -47,7 +47,7 @@ func (s *Server) Version(ctx context.Context, _ *empty.Empty) (*version.VersionM
 		}
 	}
 	if s.helmVersion == "" {
-		helmVersion, err := helm.Version(true)
+		helmVersion, err := helm.Version()
 		if err == nil {
 			s.helmVersion = helmVersion
 		} else {

--- a/util/helm/helm.go
+++ b/util/helm/helm.go
@@ -114,15 +114,9 @@ func (h *helm) Dispose() {
 	h.cmd.Close()
 }
 
-func Version(shortForm bool) (string, error) {
-	executable := "helm"
-	cmdArgs := []string{"version", "--client"}
-	if shortForm {
-		cmdArgs = append(cmdArgs, "--short")
-	}
-	cmd := exec.Command(executable, cmdArgs...)
+func Version() (string, error) {
+	cmd := exec.Command("helm", "version", "--client", "--short")
 	// example version output:
-	// long: "version.BuildInfo{Version:\"v3.3.1\", GitCommit:\"249e5215cde0c3fa72e27eb7a30e8d55c9696144\", GitTreeState:\"clean\", GoVersion:\"go1.14.7\"}"
 	// short: "v3.3.1+g249e521"
 	version, err := executil.RunWithRedactor(cmd, redactor)
 	if err != nil {

--- a/util/helm/helm_test.go
+++ b/util/helm/helm_test.go
@@ -175,7 +175,7 @@ func TestHelmArgCleaner(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	ver, err := Version(false)
+	ver, err := Version()
 	require.NoError(t, err)
 	assert.NotEmpty(t, ver)
 }

--- a/util/kustomize/kustomize.go
+++ b/util/kustomize/kustomize.go
@@ -397,7 +397,7 @@ var (
 
 // getSemver returns parsed kustomize version
 func getSemver() (*semver.Version, error) {
-	verStr, err := Version(true)
+	verStr, err := Version()
 	if err != nil {
 		return nil, err
 	}
@@ -428,33 +428,25 @@ func getSemverSafe() *semver.Version {
 	return semVer
 }
 
-func Version(shortForm bool) (string, error) {
-	executable := "kustomize"
-	cmdArgs := []string{"version"}
-	if shortForm {
-		cmdArgs = append(cmdArgs, "--short")
-	}
-	cmd := exec.Command(executable, cmdArgs...)
+func Version() (string, error) {
+	cmd := exec.Command("kustomize", "version", "--short")
 	// example version output:
-	// long: "{Version:kustomize/v3.8.1 GitCommit:0b359d0ef0272e6545eda0e99aacd63aef99c4d0 BuildDate:2020-07-16T00:58:46Z GoOs:linux GoArch:amd64}"
 	// short: "{kustomize/v3.8.1  2020-07-16T00:58:46Z  }"
 	version, err := executil.Run(cmd)
 	if err != nil {
 		return "", fmt.Errorf("could not get kustomize version: %w", err)
 	}
 	version = strings.TrimSpace(version)
-	if shortForm {
-		// trim the curly braces
-		version = strings.TrimPrefix(version, "{")
-		version = strings.TrimSuffix(version, "}")
-		version = strings.TrimSpace(version)
+	// trim the curly braces
+	version = strings.TrimPrefix(version, "{")
+	version = strings.TrimSuffix(version, "}")
+	version = strings.TrimSpace(version)
 
-		// remove double space in middle
-		version = strings.ReplaceAll(version, "  ", " ")
+	// remove double space in middle
+	version = strings.ReplaceAll(version, "  ", " ")
 
-		// remove extra 'kustomize/' before version
-		version = strings.TrimPrefix(version, "kustomize/")
-	}
+	// remove extra 'kustomize/' before version
+	version = strings.TrimPrefix(version, "kustomize/")
 	return version, nil
 }
 

--- a/util/kustomize/kustomize_test.go
+++ b/util/kustomize/kustomize_test.go
@@ -170,7 +170,7 @@ func TestParseKustomizeBuildHelmOptions(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	ver, err := Version(false)
+	ver, err := Version()
 	require.NoError(t, err)
 	assert.NotEmpty(t, ver)
 }


### PR DESCRIPTION
There are no non-test code paths that request the long form of the Helm or Kustomize versions. Remove the unused function params.