### PR TITLE
fix: resolve the failing e2e appset tests for ksonnet applications

### DIFF
--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -1159,7 +1159,6 @@ func TestSimpleGitDirectoryGenerator(t *testing.T) {
 	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("kustomize-guestbook"),
 		generateExpectedApp("helm-guestbook"),
-		generateExpectedApp("ksonnet-guestbook"),
 	}
 
 	var expectedAppsNewNamespace []v1alpha1.Application
@@ -1269,7 +1268,6 @@ func TestSimpleGitDirectoryGeneratorGoTemplate(t *testing.T) {
 	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("kustomize-guestbook"),
 		generateExpectedApp("helm-guestbook"),
-		generateExpectedApp("ksonnet-guestbook"),
 	}
 
 	var expectedAppsNewNamespace []v1alpha1.Application

--- a/test/e2e/matrix_e2e_test.go
+++ b/test/e2e/matrix_e2e_test.go
@@ -44,11 +44,9 @@ func TestListMatrixGenerator(t *testing.T) {
 	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook"),
 		generateExpectedApp("cluster1", "helm-guestbook"),
-		generateExpectedApp("cluster1", "ksonnet-guestbook"),
 
 		generateExpectedApp("cluster2", "kustomize-guestbook"),
 		generateExpectedApp("cluster2", "helm-guestbook"),
-		generateExpectedApp("cluster2", "ksonnet-guestbook"),
 	}
 
 	var expectedAppsNewNamespace []v1alpha1.Application
@@ -169,11 +167,9 @@ func TestClusterMatrixGenerator(t *testing.T) {
 	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook"),
 		generateExpectedApp("cluster1", "helm-guestbook"),
-		generateExpectedApp("cluster1", "ksonnet-guestbook"),
 
 		generateExpectedApp("cluster2", "kustomize-guestbook"),
 		generateExpectedApp("cluster2", "helm-guestbook"),
-		generateExpectedApp("cluster2", "ksonnet-guestbook"),
 	}
 
 	var expectedAppsNewNamespace []v1alpha1.Application
@@ -297,12 +293,10 @@ func TestMatrixTerminalMatrixGeneratorSelector(t *testing.T) {
 	expectedApps1 := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook"),
 		generateExpectedApp("cluster1", "helm-guestbook"),
-		generateExpectedApp("cluster1", "ksonnet-guestbook"),
 	}
 	expectedApps2 := []v1alpha1.Application{
 		generateExpectedApp("cluster2", "kustomize-guestbook"),
 		generateExpectedApp("cluster2", "helm-guestbook"),
-		generateExpectedApp("cluster2", "ksonnet-guestbook"),
 	}
 
 	Given(t).

--- a/test/e2e/merge_e2e_test.go
+++ b/test/e2e/merge_e2e_test.go
@@ -166,11 +166,9 @@ func TestClusterMergeGenerator(t *testing.T) {
 	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("cluster1", "kustomize-guestbook", "1"),
 		generateExpectedApp("cluster1", "helm-guestbook", "0"),
-		generateExpectedApp("cluster1", "ksonnet-guestbook", "0"),
 
 		generateExpectedApp("cluster2", "kustomize-guestbook", "0"),
 		generateExpectedApp("cluster2", "helm-guestbook", "2"),
-		generateExpectedApp("cluster2", "ksonnet-guestbook", "0"),
 	}
 
 	var expectedAppsNewNamespace []v1alpha1.Application


### PR DESCRIPTION
ksonnet apps were deleted from the argocd-examples-repo:
https://github.com/argoproj/argocd-example-apps/commit/ce918f91b3e5460da698c51a55644787e65e1ac1

So now ksonnet-related e2e tests are failing.
Removed ksonnet apps from the e2e tests.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
