### PR TITLE
feat: add `ARGOCD_APP_PROJECT_NAME` to the build environment (#15185)

### DIFF
--- a/docs/user-guide/build-environment.md
+++ b/docs/user-guide/build-environment.md
@@ -6,6 +6,7 @@
 |-------------------------------------|-------------------------------------------------------------------------|
 | `ARGOCD_APP_NAME`                   | The name of the application.                                            |
 | `ARGOCD_APP_NAMESPACE`              | The destination namespace of the application.                           |
+| `ARGOCD_APP_PROJECT_NAME`           | The name of the project the application belongs to.                     |
 | `ARGOCD_APP_REVISION`               | The resolved revision, e.g. `f913b6cbf58aa5ae5ca1f8a2b149477aebcbd9d8`. |
 | `ARGOCD_APP_REVISION_SHORT`         | The resolved short revision, e.g. `f913b6c`.                            |
 | `ARGOCD_APP_REVISION_SHORT_8`       | The resolved short revision with length 8, e.g. `f913b6cb`.             |

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -1529,6 +1529,7 @@ func newEnv(q *apiclient.ManifestRequest, revision string) *v1alpha1.Env {
 	return &v1alpha1.Env{
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAME", Value: q.AppName},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAMESPACE", Value: q.Namespace},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_PROJECT_NAME", Value: q.ProjectName},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION", Value: revision},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT", Value: shortRevision},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT_8", Value: shortRevision8},

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -1811,6 +1811,7 @@ func Test_newEnv(t *testing.T) {
 	assert.Equal(t, &v1alpha1.Env{
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAME", Value: "my-app-name"},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_NAMESPACE", Value: "my-namespace"},
+		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_PROJECT_NAME", Value: "my-project-name"},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION", Value: "my-revision"},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT", Value: "my-revi"},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_REVISION_SHORT_8", Value: "my-revis"},
@@ -1818,9 +1819,10 @@ func Test_newEnv(t *testing.T) {
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_PATH", Value: "my-path"},
 		&v1alpha1.EnvEntry{Name: "ARGOCD_APP_SOURCE_TARGET_REVISION", Value: "my-target-revision"},
 	}, newEnv(&apiclient.ManifestRequest{
-		AppName:   "my-app-name",
-		Namespace: "my-namespace",
-		Repo:      &v1alpha1.Repository{Repo: "https://github.com/my-org/my-repo"},
+		AppName:     "my-app-name",
+		Namespace:   "my-namespace",
+		ProjectName: "my-project-name",
+		Repo:        &v1alpha1.Repository{Repo: "https://github.com/my-org/my-repo"},
 		ApplicationSource: &v1alpha1.ApplicationSource{
 			Path:           "my-path",
 			TargetRevision: "my-target-revision",


### PR DESCRIPTION
Fixes #15185
Closes #15186

I am submitting this since #15186 is stale. The content is mostly the same, just with the docs updated slightly. The linked issue and PR contain more details, but I'll also provide a summary here.

Currently, the application's project name is not exposed to the build environment. This means that CMPs are not aware of the project the calling application belongs to. This PR adds a new environment variable to the build environment, `ARGOCD_APP_PROJECT_NAME`, to expose this value.

For my use case, I would like to provide a shared location for the CMP container that applications can use for caching, but I would like this location to not be shared between projects. Knowing the application's project name would allow me to segregate the cache in this way.

The original issue also has a good example use case:

> we want to install the Argo Vault Plugin with different Vault Credentials for each AppProject, for this the CMP must be aware of the AppProject name.