### PR TITLE
fix: login return_url doesn't work with custom server paths

### DIFF
--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -235,7 +235,7 @@ export class App extends React.Component<
     }
 
     public getChildContext() {
-        return {history, apis: {popup: this.popupManager, notifications: this.notificationsManager, navigation: this.navigationManager}};
+        return {history, apis: {popup: this.popupManager, notifications: this.notificationsManager, navigation: this.navigationManager, baseHref: base}};
     }
 
     private async subscribeUnauthorized() {

--- a/ui/src/app/login/components/login.tsx
+++ b/ui/src/app/login/components/login.tsx
@@ -135,7 +135,12 @@ export class Login extends React.Component<RouteComponentProps<{}>, State> {
             this.setState({loginInProgress: false});
             if (returnURL) {
                 const url = new URL(returnURL);
-                this.appContext.apis.navigation.goto(url.pathname + url.search);
+                let redirectURL = url.pathname + url.search;
+                // return url already contains baseHref, so we need to remove it
+                if (this.appContext.apis.baseHref != '/' && redirectURL.startsWith(this.appContext.apis.baseHref)) {
+                    redirectURL = redirectURL.substring(this.appContext.apis.baseHref.length);
+                }
+                this.appContext.apis.navigation.goto(redirectURL);
             } else {
                 this.appContext.apis.navigation.goto('/applications');
             }


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/21432

Login page redirects to return URL history API. The history API automatically appends base path, so it has to be removed from the return URL before redirect

https://github.com/user-attachments/assets/d0de14a3-df1e-41f3-990a-16bff36dbd78

