### PR TITLE
fix(appset): reverted Gitlab SCM HasPath search and consider 404 errors as file not found (#16253)

### DIFF
--- a/applicationset/services/scm_provider/gitlab.go
+++ b/applicationset/services/scm_provider/gitlab.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	pathpkg "path"
 
 	"github.com/hashicorp/go-retryablehttp"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -133,51 +132,28 @@ func (g *GitlabProvider) RepoHasPath(_ context.Context, repo *Repository, path s
 		return false, fmt.Errorf("error getting Project Info: %w", err)
 	}
 
-	// first check the provided path
-	// if it's a directory, check for it's presence
-	// if it's a file, we'll get a first error then we check the parent folder
-	directories := []string{
-		path,
-		pathpkg.Dir(path),
-	}
-
-	for _, directory := range directories {
-		options := gitlab.ListTreeOptions{
-			Path: &directory,
-			Ref:  &repo.Branch,
-		}
-
-		for {
-			treeNode, resp, err := g.client.Repositories.ListTree(p.ID, &options)
+	// search if the path is a file and existe in the repo
+	fileOptions := gitlab.GetFileOptions{Ref: &repo.Branch}
+	_, _, err = g.client.RepositoryFiles.GetFile(p.ID, path, &fileOptions)
+	if err != nil {
+		if errors.Is(err, gitlab.ErrNotFound) {
+			// no file found, check for a directory
+			options := gitlab.ListTreeOptions{
+				Path: &path,
+				Ref:  &repo.Branch,
+			}
+			_, _, err := g.client.Repositories.ListTree(p.ID, &options)
 			if err != nil {
 				if errors.Is(err, gitlab.ErrNotFound) {
-					break // no directory here, checking for files in the parent folder
+					return false, nil // no file or directory found
 				}
-				return false, fmt.Errorf("error listing Project files %s(%s) on branch %s: %w", path, pathpkg.Dir(path), repo.Branch, err)
+				return false, err
 			}
-
-			if path == directory {
-				// we found the requested directory
-				if resp.TotalItems > 0 {
-					return true, nil
-				}
-			}
-
-			// search for presence of the requested file in the parent folder
-			for i := range treeNode {
-				if treeNode[i].Path == path {
-					return true, nil
-				}
-			}
-			if resp.NextPage == 0 {
-				// no future pages
-				break
-			}
-			options.Page = resp.NextPage
+			return true, nil // directory found
 		}
+		return false, err
 	}
-
-	return false, nil
+	return true, nil // file found
 }
 
 func (g *GitlabProvider) listBranches(_ context.Context, repo *Repository) ([]gitlab.Branch, error) {

--- a/applicationset/services/scm_provider/gitlab.go
+++ b/applicationset/services/scm_provider/gitlab.go
@@ -132,7 +132,7 @@ func (g *GitlabProvider) RepoHasPath(_ context.Context, repo *Repository, path s
 		return false, fmt.Errorf("error getting Project Info: %w", err)
 	}
 
-	// search if the path is a file and existe in the repo
+	// search if the path is a file and exists in the repo
 	fileOptions := gitlab.GetFileOptions{Ref: &repo.Branch}
 	_, _, err = g.client.RepositoryFiles.GetFile(p.ID, path, &fileOptions)
 	if err != nil {

--- a/applicationset/services/scm_provider/gitlab_test.go
+++ b/applicationset/services/scm_provider/gitlab_test.go
@@ -1044,7 +1044,15 @@ func gitlabMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 		// when a path is to a file instead of a directory. Our code should not hit this path, because
 		// we should only send requests for parent directories. But we leave this handler in place
 		// to prevent regressions.
-		case "/api/v4/projects/27084533/repository/tree?path=argocd/filepath.yaml&ref=master":
+		case "/api/v4/projects/27084533/repository/tree?path=argocd/notathing.yaml&ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/tree?path=notathing&ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/tree?path=notathing/notathing.yaml&ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/tree?path=notathing/notathing/notathing.yaml&ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/tree?path=notathing/notathing&ref=master":
 			w.WriteHeader(http.StatusNotFound)
 		case "/api/v4/projects/27084533/repository/branches/foo":
 			w.WriteHeader(http.StatusNotFound)
@@ -1201,8 +1209,13 @@ func TestGitlabHasPath(t *testing.T) {
 			exists: false,
 		},
 		{
-			name:   "send a file path",
-			path:   "argocd/filepath.yaml",
+			name:   "search noexistent file in noexistent directory",
+			path:   "notathing/notathing.yaml",
+			exists: false,
+		},
+		{
+			name:   "search noexistent file in nested noexistent directory",
+			path:   "notathing/notathing/notathing.yaml",
 			exists: false,
 		},
 	}

--- a/applicationset/services/scm_provider/gitlab_test.go
+++ b/applicationset/services/scm_provider/gitlab_test.go
@@ -20,6 +20,7 @@ func gitlabMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		fmt.Println(r.RequestURI)
 		switch r.RequestURI {
 		case "/api/v4":
 			fmt.Println("here1")
@@ -1040,19 +1041,31 @@ func gitlabMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 			if err != nil {
 				t.Fail()
 			}
-		// Recent versions of the Gitlab API (v17.7+) return 404 not only when a file doesn't exist, but also
-		// when a path is to a file instead of a directory. Our code should not hit this path, because
-		// we should only send requests for parent directories. But we leave this handler in place
-		// to prevent regressions.
-		case "/api/v4/projects/27084533/repository/tree?path=argocd/notathing.yaml&ref=master":
+			// Recent versions of the Gitlab API (v17.7+) listTree return 404 not only when a file doesn't exist, but also
+			// when a path is to a file instead of a directory. Code was refactored to explicitely search for file then
+			// search for directory, catching 404 errors as "file not found".
+		case "/api/v4/projects/27084533/repository/files/argocd?ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/files/argocd%2Finstall%2Eyaml?ref=master":
+			_, err := io.WriteString(w, `{"file_name":"install.yaml","file_path":"argocd/install.yaml","size":0,"encoding":"base64","content_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","ref":"main","blob_id":"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391","commit_id":"6d4c0f9d34534ccc73aa3f3180b25e2aebe630eb","last_commit_id":"b50eb63f9c0e09bfdb070db26fd32c7210291f52","execute_filemode":false,"content":""}`)
+			if err != nil {
+				t.Fail()
+			}
+		case "/api/v4/projects/27084533/repository/files/notathing?ref=master":
 			w.WriteHeader(http.StatusNotFound)
 		case "/api/v4/projects/27084533/repository/tree?path=notathing&ref=master":
 			w.WriteHeader(http.StatusNotFound)
-		case "/api/v4/projects/27084533/repository/tree?path=notathing/notathing.yaml&ref=master":
+		case "/api/v4/projects/27084533/repository/files/argocd%2Fnotathing%2Eyaml?ref=master":
 			w.WriteHeader(http.StatusNotFound)
-		case "/api/v4/projects/27084533/repository/tree?path=notathing/notathing/notathing.yaml&ref=master":
+		case "/api/v4/projects/27084533/repository/tree?path=argocd%2Fnotathing.yaml&ref=master":
 			w.WriteHeader(http.StatusNotFound)
-		case "/api/v4/projects/27084533/repository/tree?path=notathing/notathing&ref=master":
+		case "/api/v4/projects/27084533/repository/files/notathing%2Fnotathing%2Eyaml?ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/tree?path=notathing%2Fnotathing.yaml&ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/files/notathing%2Fnotathing%2Fnotathing%2Eyaml?ref=master":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v4/projects/27084533/repository/tree?path=notathing%2Fnotathing%2Fnotathing.yaml&ref=master":
 			w.WriteHeader(http.StatusNotFound)
 		case "/api/v4/projects/27084533/repository/branches/foo":
 			w.WriteHeader(http.StatusNotFound)
@@ -1209,12 +1222,12 @@ func TestGitlabHasPath(t *testing.T) {
 			exists: false,
 		},
 		{
-			name:   "search noexistent file in noexistent directory",
+			name:   "noexistent file in noexistent directory",
 			path:   "notathing/notathing.yaml",
 			exists: false,
 		},
 		{
-			name:   "search noexistent file in nested noexistent directory",
+			name:   "noexistent file in nested noexistent directory",
 			path:   "notathing/notathing/notathing.yaml",
 			exists: false,
 		},

--- a/applicationset/services/scm_provider/gitlab_test.go
+++ b/applicationset/services/scm_provider/gitlab_test.go
@@ -1042,7 +1042,7 @@ func gitlabMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request) {
 				t.Fail()
 			}
 			// Recent versions of the Gitlab API (v17.7+) listTree return 404 not only when a file doesn't exist, but also
-			// when a path is to a file instead of a directory. Code was refactored to explicitely search for file then
+			// when a path is to a file instead of a directory. Code was refactored to explicitly search for file then
 			// search for directory, catching 404 errors as "file not found".
 		case "/api/v4/projects/27084533/repository/files/argocd?ref=master":
 			w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Fixes [https://github.com/argoproj/argo-cd/issues/16253]

Previous patch in https://github.com/argoproj/argo-cd/pull/21491 was not covering the case where both the file and nested subfolder were non-existent.

This patch uses two Gitlab API to:

- search for the path as a file (`RepositoryFiles.GetFile`)
- if not found, search the path as a directory (`Repositories.ListTree`)
- else return false
  
More tests are added to cover all possible cases.

This patch has already been tested by some users experiencing the new Gitlab behaviour and confirmed it solved the issue.

## Other possibilities

- go back to old version and consider 404 as a `false` (="file not found") instead of an error
 
- search in the root (`.`) and set `recursive=true` to grab the list of all the items in the repo. Then we manually search for each component of the path. 
This will cover all use-cases, BUT will have a massive impact on really large mono-repos with a lot of files. 

Right now I think we should stick with the Gitlab behaviour: the `listTree` API returns a `404 file not found` when searching for a non-existent folder, but this is not an error.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
