### PR TITLE
fix(ui): prevent parameter editor from resetting when props update (fixes #14351)

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -270,7 +270,7 @@ export const ApplicationParameters = (props: {
         } else {
             // For single source field, details page where we have to do the load to retrieve repo details
             return (
-                <DataLoader input={app} load={application => getSingleSource(application)}>
+                <DataLoader noLoaderOnInputChange={true} input={app} load={application => getSingleSource(application)}>
                     {(details: models.RepoAppDetails) => {
                         attributes = [];
                         const attr = gatherDetails(

--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -269,6 +269,7 @@ export const ApplicationParameters = (props: {
             );
         } else {
             // For single source field, details page where we have to do the load to retrieve repo details
+            // Input changes frequently due to updates higher in the tree, do not show loading state when reloading
             return (
                 <DataLoader noLoaderOnInputChange={true} input={app} load={application => getSingleSource(application)}>
                     {(details: models.RepoAppDetails) => {


### PR DESCRIPTION
Fixes #14351 

**Explanation**
The UI is continually making calls to `appdetails` and `syncwindows` when viewing an Application or its settings.

When this happens it updates the input passed to the `<DataLoader />` inside the `application-parameters` component, which causes it to re-run its `load` function. Without setting `noLoaderOnInputChange` to `true`, this causes the component to render `loading...` momentarily every time the input prop changes,  before switching back to what was there before once the load function completes. 

Because the component has an "edit" mode, this can be problematic as the switch to "loading..." and back causes the component to reset to its base state, losing the change the user might be in the middle of making. I believe this is what is being described in the referenced issue, and our users have the same problem. 

The PR simply sets `noLoaderOnInputChange` to true, as seems to be done in a handful of other UI components elsewhere in the app. From testing locally this appears to fix the issue*.

>*Note: To get my local environment to work at all I had to add the option chaining operator `?.` to all instances of `sourceHydrator.currentOperation` for some reason - I don't know if this is an issue with my local env or if it's a problem in the master branch but that change is not included in this PR.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. (N/A)
* [x] Does this PR require documentation updates? (No)
* [x] I've updated documentation as required by this PR. (N/A)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
  - Doesn't seem necessary
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. (N/A)
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] ~Optional. My organization is added to USERS.md.~
*  Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity). (?)
   - I'm not sure - we use 2.11.2 but can upgrade - ideally this would at least be cherry-picked into a stable version so we can roll it out soon.
<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->

