### PR TITLE
fix: 21634 Check for semver constraint matching in application webhook handler

### DIFF
--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -466,8 +466,15 @@ func TestAppRevisionHasChanged(t *testing.T) {
 		{"dev target revision, dev, did not touch head", getSource("dev"), "dev", false, true},
 		{"refs/heads/dev target revision, master, touched head", getSource("refs/heads/dev"), "master", true, false},
 		{"refs/heads/dev target revision, dev, did not touch head", getSource("refs/heads/dev"), "dev", false, true},
+		{"refs/tags/dev target revision, dev, did not touch head", getSource("refs/tags/dev"), "dev", false, true},
 		{"env/test target revision, env/test, did not touch head", getSource("env/test"), "env/test", false, true},
 		{"refs/heads/env/test target revision, env/test, did not touch head", getSource("refs/heads/env/test"), "env/test", false, true},
+		{"refs/tags/env/test target revision, env/test, did not touch head", getSource("refs/tags/env/test"), "env/test", false, true},
+		{"three/part/rev target revision, rev, did not touch head", getSource("three/part/rev"), "rev", false, false},
+		{"1.* target revision (matching), 1.1.0, did not touch head", getSource("1.*"), "1.1.0", false, true},
+		{"refs/tags/1.* target revision (matching), 1.1.0, did not touch head", getSource("refs/tags/1.*"), "1.1.0", false, true},
+		{"1.* target revision (not matching), 2.0.0, did not touch head", getSource("1.*"), "2.0.0", false, false},
+		{"1.* target revision, dev (not semver), did not touch head", getSource("1.*"), "dev", false, false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION

The `sourceRevisionHasChanged` method, rather than doing a simple equality check, now checks if the revision supplied by the webhook matches the target revision's semver constraint, if the latter is a constraint.

Fixes https://github.com/argoproj/argo-cd/issues/21634

This change ought to be possible to cherry-pick back as far as 2.12 (support for semver constraints for Git revisions isn't present in 2.11).

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
