### PR TITLE
docs: fix broken link in notifications overview

### DIFF
--- a/docs/operator-manual/notifications/index.md
+++ b/docs/operator-manual/notifications/index.md
@@ -112,4 +112,4 @@ metadata:
     When the same notification service and trigger are defined in controller level configuration and application level configuration,
     both notifications will be sent according to its own configuration.
 
-[Defining and using secrets within notification templates](templates.md/#defining-and-using-secrets-within-notification-templates) function is not available when flag `--self-service-notification-enable` is on.
+[Defining and using secrets within notification templates](templates/#defining-and-using-secrets-within-notification-templates) function is not available when flag `--self-service-notification-enable` is on.


### PR DESCRIPTION
Just a small fix in the hyperlink.

![image](https://github.com/user-attachments/assets/93789a8f-899e-4193-be90-850b75bd4f9c)
