### PR TITLE
chore(metrics)!: remove deprecated metrics

### DIFF
--- a/controller/metrics/metrics_test.go
+++ b/controller/metrics/metrics_test.go
@@ -399,30 +399,6 @@ argocd_app_condition{condition="ExcludedResourceWarning",name="my-app-4",namespa
 	}
 }
 
-func TestLegacyMetrics(t *testing.T) {
-	t.Setenv(EnvVarLegacyControllerMetrics, "true")
-
-	expectedResponse := `
-# HELP argocd_app_created_time Creation time in unix timestamp for an application.
-# TYPE argocd_app_created_time gauge
-argocd_app_created_time{name="my-app",namespace="argocd",project="important-project"} -6.21355968e+10
-# HELP argocd_app_health_status The application current health status.
-# TYPE argocd_app_health_status gauge
-argocd_app_health_status{health_status="Degraded",name="my-app",namespace="argocd",project="important-project"} 0
-argocd_app_health_status{health_status="Healthy",name="my-app",namespace="argocd",project="important-project"} 1
-argocd_app_health_status{health_status="Missing",name="my-app",namespace="argocd",project="important-project"} 0
-argocd_app_health_status{health_status="Progressing",name="my-app",namespace="argocd",project="important-project"} 0
-argocd_app_health_status{health_status="Suspended",name="my-app",namespace="argocd",project="important-project"} 0
-argocd_app_health_status{health_status="Unknown",name="my-app",namespace="argocd",project="important-project"} 0
-# HELP argocd_app_sync_status The application current sync status.
-# TYPE argocd_app_sync_status gauge
-argocd_app_sync_status{name="my-app",namespace="argocd",project="important-project",sync_status="OutOfSync"} 0
-argocd_app_sync_status{name="my-app",namespace="argocd",project="important-project",sync_status="Synced"} 1
-argocd_app_sync_status{name="my-app",namespace="argocd",project="important-project",sync_status="Unknown"} 0
-`
-	testApp(t, []string{fakeApp}, expectedResponse)
-}
-
 func TestMetricsSyncCounter(t *testing.T) {
 	cancel, appLister := newFakeLister()
 	defer cancel()

--- a/docs/operator-manual/upgrading/2.14-3.0.md
+++ b/docs/operator-manual/upgrading/2.14-3.0.md
@@ -23,6 +23,22 @@ to `false` in the Argo CD ConfigMap `argocd-cm`.
 
 Read the [RBAC documentation](../rbac.md#fine-grained-permissions-for-updatedelete-action) for more detailed inforamtion.
 
+### Removal of `argocd_app_sync_status`, `argocd_app_health_status` and `argocd_app_created_time` Metrics
+
+The `argocd_app_sync_status`, `argocd_app_health_status` and `argocd_app_created_time`, deprecated and disabled by 
+default since 1.5.0, have been removed. The information previously provided by these metrics is now available as labels
+on the  `argocd_app_info` metric.
+
+#### Detection
+
+Starting with 1.5.0, these metrics are only available if `ARGOCD_LEGACY_CONTROLLER_METRICS` is explicitly set to `true`.
+If it is not set to true, you can safely upgrade with no changes.
+
+#### Migration
+
+If you are using these metrics, you will need to update your monitoring dashboards and alerts to use the new metric and
+labels before upgrading.
+
 ## Other changes
 
 ### Using `cluster.inClusterEnabled: "false"`


### PR DESCRIPTION
I just noticed these metrics have been disabled since 1.5, so probably makes sense to remove them in 3.0. 

Open as draft now to run tests. Still need to write docs.