### PR TITLE
chore: use testify instead of native testing

### DIFF
--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -169,11 +169,12 @@ foo:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params, err := (*GitGenerator)(nil).generateParamsFromGitFile(tt.args.filePath, tt.args.fileContent, tt.args.values, tt.args.useGoTemplate, tt.args.goTemplateOptions, tt.args.pathParamPrefix)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GitGenerator.generateParamsFromGitFile() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				assert.Error(t, err, "GitGenerator.generateParamsFromGitFile()")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, params)
 			}
-			assert.Equal(t, tt.want, params)
 		})
 	}
 }

--- a/applicationset/generators/pull_request_test.go
+++ b/applicationset/generators/pull_request_test.go
@@ -224,7 +224,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 
 		got, gotErr := gen.GenerateParams(&generatorConfig, &c.applicationSet, nil)
 		if c.expectedErr != nil {
-			assert.Equal(t, c.expectedErr.Error(), gotErr.Error())
+			require.EqualError(t, gotErr, c.expectedErr.Error())
 		} else {
 			require.NoError(t, gotErr)
 		}

--- a/commitserver/commit/credentialtypehelper_test.go
+++ b/commitserver/commit/credentialtypehelper_test.go
@@ -3,6 +3,8 @@ package commit
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 )
 
@@ -54,9 +56,7 @@ func TestRepository_GetCredentialType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getCredentialType(tt.repo); got != tt.want {
-				t.Errorf("Repository.GetCredentialType() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, getCredentialType(tt.repo), "Repository.GetCredentialType()")
 		})
 	}
 }

--- a/controller/sharding/sharding_test.go
+++ b/controller/sharding/sharding_test.go
@@ -391,12 +391,8 @@ func TestGetShardByIndexModuloReplicasCountDistributionFunction(t *testing.T) {
 	shardForCluster1 := distributionFunction(&cluster1)
 	shardForCluster2 := distributionFunction(&cluster2)
 
-	if shardForCluster1 != expectedShardForCluster1 {
-		t.Errorf("Expected shard for cluster1 to be %d but got %d", expectedShardForCluster1, shardForCluster1)
-	}
-	if shardForCluster2 != expectedShardForCluster2 {
-		t.Errorf("Expected shard for cluster2 to be %d but got %d", expectedShardForCluster2, shardForCluster2)
-	}
+	assert.Equal(t, expectedShardForCluster1, shardForCluster1, "Expected shard for cluster1 to be %d but got %d", expectedShardForCluster1, shardForCluster1)
+	assert.Equal(t, expectedShardForCluster2, shardForCluster2, "Expected shard for cluster2 to be %d but got %d", expectedShardForCluster2, shardForCluster2)
 }
 
 func TestInferShard(t *testing.T) {
@@ -975,11 +971,7 @@ func TestGetClusterSharding(t *testing.T) {
 			}
 
 			if tc.expectedErr != nil {
-				if err != nil {
-					assert.Equal(t, tc.expectedErr.Error(), err.Error())
-				} else {
-					t.Errorf("Expected error %v but got nil", tc.expectedErr)
-				}
+				assert.EqualError(t, err, tc.expectedErr.Error())
 			} else {
 				require.NoError(t, err)
 			}

--- a/controller/sort_delete_test.go
+++ b/controller/sort_delete_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
 	. "github.com/argoproj/gitops-engine/pkg/utils/testing"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -22,9 +24,8 @@ func TestFilterObjectsForDeletion(t *testing.T) {
 	for _, tt := range tests {
 		in := sliceOfObjectsWithSyncWaves(tt.input)
 		need := sliceOfObjectsWithSyncWaves(tt.want)
-		if got := FilterObjectsForDeletion(in); !reflect.DeepEqual(got, need) {
-			t.Errorf("Received unexpected objects for deletion = %v, want %v", got, need)
-		}
+		got := FilterObjectsForDeletion(in)
+		assert.True(t, reflect.DeepEqual(got, need), "Received unexpected objects for deletion")
 	}
 }
 

--- a/notification_controller/controller/controller_test.go
+++ b/notification_controller/controller/controller_test.go
@@ -166,8 +166,7 @@ func TestInitTimeout(t *testing.T) {
 	err = nc.Init(ctx)
 
 	// Expect an error & add assertion for the error message
-	require.Error(t, err)
-	assert.Equal(t, "Timed out waiting for caches to sync", err.Error())
+	assert.EqualError(t, err, "Timed out waiting for caches to sync")
 }
 
 func TestCheckAppNotInAdditionalNamespaces(t *testing.T) {

--- a/pkg/apis/application/v1alpha1/applicationset_types_test.go
+++ b/pkg/apis/application/v1alpha1/applicationset_types_test.go
@@ -165,7 +165,7 @@ func TestApplicationSetSetConditions(t *testing.T) {
 
 func assertAppSetConditions(t *testing.T, expected []ApplicationSetCondition, actual []ApplicationSetCondition) {
 	t.Helper()
-	assert.Equal(t, len(expected), len(actual))
+	assert.Len(t, actual, len(expected))
 	for i := range expected {
 		assert.Equal(t, expected[i].Type, actual[i].Type)
 		assert.Equal(t, expected[i].Message, actual[i].Message)

--- a/pkg/apis/application/v1alpha1/repository_types_test.go
+++ b/pkg/apis/application/v1alpha1/repository_types_test.go
@@ -3,6 +3,8 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/helm"
 )
@@ -13,9 +15,7 @@ func TestGetGitCredsShouldReturnAzureWorkloadIdentityCredsIfSpecified(t *testing
 	creds := repository.GetGitCreds(git.NoopCredsStore{})
 
 	_, ok := creds.(git.AzureWorkloadIdentityCreds)
-	if !ok {
-		t.Fatalf("expected AzureWorkloadIdentityCreds but got %T", creds)
-	}
+	require.Truef(t, ok, "expected AzureWorkloadIdentityCreds but got %T", creds)
 }
 
 func TestGetHelmCredsShouldReturnAzureWorkloadIdentityCredsIfSpecified(t *testing.T) {
@@ -24,9 +24,7 @@ func TestGetHelmCredsShouldReturnAzureWorkloadIdentityCredsIfSpecified(t *testin
 	creds := repository.GetHelmCreds()
 
 	_, ok := creds.(helm.AzureWorkloadIdentityCreds)
-	if !ok {
-		t.Fatalf("expected AzureWorkloadIdentityCreds but got %T", creds)
-	}
+	require.Truef(t, ok, "expected AzureWorkloadIdentityCreds but got %T", creds)
 }
 
 func TestGetHelmCredsShouldReturnHelmCredsIfAzureWorkloadIdentityNotSpecified(t *testing.T) {
@@ -35,7 +33,5 @@ func TestGetHelmCredsShouldReturnHelmCredsIfAzureWorkloadIdentityNotSpecified(t 
 	creds := repository.GetHelmCreds()
 
 	_, ok := creds.(helm.HelmCreds)
-	if !ok {
-		t.Fatalf("expected HelmCreds but got %T", creds)
-	}
+	require.Truef(t, ok, "expected HelmCreds but got %T", creds)
 }

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3314,7 +3314,7 @@ func TestSetConditions(t *testing.T) {
 // to match positions.
 func assertConditions(t *testing.T, expected []ApplicationCondition, actual []ApplicationCondition) {
 	t.Helper()
-	assert.Equal(t, len(expected), len(actual))
+	assert.Len(t, actual, len(expected))
 	for i := range expected {
 		assert.Equal(t, expected[i].Type, actual[i].Type)
 		assert.Equal(t, expected[i].Message, actual[i].Message)

--- a/reposerver/cache/cache_test.go
+++ b/reposerver/cache/cache_test.go
@@ -317,7 +317,7 @@ func TestCachedManifestResponse_ShallowCopyExpectedFields(t *testing.T) {
 		"numberOfConsecutiveFailures", "numberOfCachedResponsesReturned",
 	}
 
-	assert.Equal(t, len(jsonMap), len(expectedFields))
+	assert.Len(t, jsonMap, len(expectedFields))
 
 	// If this test failed, you probably also forgot to update CachedManifestResponse.shallowCopy(), so
 	// go do that first :)

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -707,11 +707,12 @@ func TestListCluster(t *testing.T) {
 			t.Parallel()
 
 			got, err := s.List(context.Background(), tt.q)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Server.List() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				assert.Error(t, err, "Server.List()")
+			} else {
+				require.NoError(t, err)
+				assert.Truef(t, reflect.DeepEqual(got, tt.want), "Server.List() = %v, want %v", got, tt.want)
 			}
-			assert.Truef(t, reflect.DeepEqual(got, tt.want), "Server.List() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/test/e2e/app_multiple_sources_test.go
+++ b/test/e2e/app_multiple_sources_test.go
@@ -286,12 +286,10 @@ func TestMultiSourceApptErrorWhenSourceNameAndSourcePosition(t *testing.T) {
 		Expect(Event(EventReasonResourceCreated, "create")).
 		And(func(_ *Application) {
 			_, err := RunCli("app", "get", Name(), "--source-name", sources[1].Name, "--source-position", "1")
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Only one of source-position and source-name can be specified.")
+			assert.ErrorContains(t, err, "Only one of source-position and source-name can be specified.")
 		}).
 		And(func(_ *Application) {
 			_, err := RunCli("app", "manifests", Name(), "--revisions", "0.0.2", "--source-names", sources[0].Name, "--revisions", "0.0.2", "--source-positions", "1")
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Only one of source-positions and source-names can be specified.")
+			assert.ErrorContains(t, err, "Only one of source-positions and source-names can be specified.")
 		})
 }

--- a/test/e2e/scoped_repository_test.go
+++ b/test/e2e/scoped_repository_test.go
@@ -189,7 +189,7 @@ func TestDeleteRepository(t *testing.T) {
 		Delete().
 		Then().
 		And(func(_ *Repository, err error) {
-			assert.Equal(t, "repo not found", err.Error())
+			assert.EqualError(t, err, "repo not found")
 		})
 }
 

--- a/util/app/path/path_test.go
+++ b/util/app/path/path_test.go
@@ -179,9 +179,7 @@ func Test_AppFilesHaveChanged(t *testing.T) {
 		t.Run(ttc.name, func(t *testing.T) {
 			t.Parallel()
 			refreshPaths := GetAppRefreshPaths(ttc.app)
-			if got := AppFilesHaveChanged(refreshPaths, ttc.files); got != ttc.changeExpected {
-				t.Errorf("AppFilesHaveChanged() = %v, want %v", got, ttc.changeExpected)
-			}
+			assert.Equal(t, ttc.changeExpected, AppFilesHaveChanged(refreshPaths, ttc.files), "AppFilesHaveChanged()")
 		})
 	}
 }
@@ -206,9 +204,7 @@ func Test_GetAppRefreshPaths(t *testing.T) {
 		ttc := tt
 		t.Run(ttc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := GetAppRefreshPaths(ttc.app); !assert.ElementsMatch(t, ttc.expectedPaths, got) {
-				t.Errorf("GetAppRefreshPath() = %v, want %v", got, ttc.expectedPaths)
-			}
+			assert.ElementsMatch(t, ttc.expectedPaths, GetAppRefreshPaths(ttc.app), "GetAppRefreshPath()")
 		})
 	}
 }

--- a/util/argo/argo_test.go
+++ b/util/argo/argo_test.go
@@ -260,9 +260,8 @@ func TestContainsSyncResource(t *testing.T) {
 	}
 
 	for _, table := range tables {
-		if out := ContainsSyncResource(table.u.GetName(), table.u.GetNamespace(), table.u.GroupVersionKind(), table.rr); out != table.expected {
-			t.Errorf("Expected %t for slice %+v contains resource %+v; instead got %t", table.expected, table.rr, table.u, out)
-		}
+		out := ContainsSyncResource(table.u.GetName(), table.u.GetNamespace(), table.u.GroupVersionKind(), table.rr)
+		assert.Equal(t, table.expected, out, "Expected %t for slice %+v contains resource %+v; instead got %t", table.expected, table.rr, table.u, out)
 	}
 }
 
@@ -965,7 +964,7 @@ func TestGetDestinationCluster(t *testing.T) {
 		}
 
 		_, err := GetDestinationCluster(context.Background(), dest, nil)
-		assert.Equal(t, "application destination can't have both name and server defined: minikube https://127.0.0.1:6443", err.Error())
+		assert.EqualError(t, err, "application destination can't have both name and server defined: minikube https://127.0.0.1:6443")
 	})
 
 	t.Run("GetClusterServersByName fails", func(t *testing.T) {
@@ -989,7 +988,7 @@ func TestGetDestinationCluster(t *testing.T) {
 		db.On("GetClusterServersByName", context.Background(), "minikube").Return(nil, nil)
 
 		_, err := GetDestinationCluster(context.Background(), dest, db)
-		assert.Equal(t, "there are no clusters with this name: minikube", err.Error())
+		assert.EqualError(t, err, "there are no clusters with this name: minikube")
 	})
 
 	t.Run("Validate too many clusters with the same name", func(t *testing.T) {
@@ -1001,7 +1000,7 @@ func TestGetDestinationCluster(t *testing.T) {
 		db.On("GetClusterServersByName", context.Background(), "dind").Return([]string{"https://127.0.0.1:2443", "https://127.0.0.1:8443"}, nil)
 
 		_, err := GetDestinationCluster(context.Background(), dest, db)
-		assert.Equal(t, "there are 2 clusters with the same name: [https://127.0.0.1:2443 https://127.0.0.1:8443]", err.Error())
+		assert.EqualError(t, err, "there are 2 clusters with the same name: [https://127.0.0.1:2443 https://127.0.0.1:8443]")
 	})
 }
 
@@ -1590,8 +1589,7 @@ func TestAugmentSyncMsg(t *testing.T) {
 			tt.res.Message = tt.msg
 			msg, err := AugmentSyncMsg(tt.res, tt.mockFn)
 			if tt.errMsg != "" {
-				require.Error(t, err)
-				assert.Equal(t, tt.errMsg, err.Error())
+				assert.EqualError(t, err, tt.errMsg)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedMessage, msg)
@@ -1701,7 +1699,7 @@ func TestGetAppEventLabels(t *testing.T) {
 			argoDB := db.NewDB("default", settingsMgr, kubeClient)
 
 			eventLabels := GetAppEventLabels(ctx, &app, applisters.NewAppProjectLister(informer.GetIndexer()), test.FakeArgoCDNamespace, settingsMgr, argoDB)
-			assert.Equal(t, len(tt.expectedEventLabels), len(eventLabels))
+			assert.Len(t, eventLabels, len(tt.expectedEventLabels))
 			for ek, ev := range tt.expectedEventLabels {
 				v, found := eventLabels[ek]
 				assert.True(t, found)

--- a/util/claims/claims_test.go
+++ b/util/claims/claims_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetUserIdentifier(t *testing.T) {
@@ -147,12 +148,11 @@ func TestMapClaimsToArgoClaims(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := MapClaimsToArgoClaims(tt.claims)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MapClaimsToArgoClaims() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MapClaimsToArgoClaims() = %v, want %v", got, tt.want)
+			if tt.wantErr {
+				assert.Error(t, err, "MapClaimsToArgoClaims()")
+			} else {
+				require.NoError(t, err, "MapClaimsToArgoClaims()")
+				assert.Truef(t, reflect.DeepEqual(got, tt.want), "MapClaimsToArgoClaims() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/util/clusterauth/clusterauth_test.go
+++ b/util/clusterauth/clusterauth_test.go
@@ -291,9 +291,7 @@ func Test_getOrCreateServiceAccountTokenSecret_NoSecretForSA(t *testing.T) {
 
 	obj, err := cs.Tracker().Get(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"},
 		ns.Name, ArgoCDManagerServiceAccount)
-	if err != nil {
-		t.Errorf("ServiceAccount %s not found but was expected to be found: %s", ArgoCDManagerServiceAccount, err.Error())
-	}
+	require.NoError(t, err, "ServiceAccount %s not found but was expected to be found", ArgoCDManagerServiceAccount)
 
 	sa := obj.(*corev1.ServiceAccount)
 	assert.Len(t, sa.Secrets, 1)
@@ -342,9 +340,7 @@ func Test_getOrCreateServiceAccountTokenSecret_SAHasSecret(t *testing.T) {
 
 	obj, err := cs.Tracker().Get(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"},
 		ns.Name, ArgoCDManagerServiceAccount)
-	if err != nil {
-		t.Errorf("ServiceAccount %s not found but was expected to be found: %s", ArgoCDManagerServiceAccount, err.Error())
-	}
+	require.NoError(t, err, "ServiceAccount %s not found but was expected to be found", ArgoCDManagerServiceAccount)
 
 	sa := obj.(*corev1.ServiceAccount)
 	assert.Len(t, sa.Secrets, 1)

--- a/util/config/reader_test.go
+++ b/util/config/reader_test.go
@@ -37,9 +37,7 @@ func TestUnmarshalLocalFile(t *testing.T) {
 		Field2 int
 	}
 	err = UnmarshalLocalFile(file.Name(), &testStruct)
-	if err != nil {
-		t.Errorf("Could not unmarshal test data: %s", err)
-	}
+	require.NoError(t, err, "Could not unmarshal test data")
 
 	if testStruct.Field1 != field1 || testStruct.Field2 != field2 {
 		t.Errorf("Test data did not match! Expected {%s %d} but got: %v", field1, field2, testStruct)
@@ -58,9 +56,7 @@ func TestUnmarshal(t *testing.T) {
 		Field2 int
 	}
 	err := Unmarshal([]byte(sentinel), &testStruct)
-	if err != nil {
-		t.Errorf("Could not unmarshal test data: %s", err)
-	}
+	require.NoError(t, err, "Could not unmarshal test data")
 
 	if testStruct.Field1 != field1 || testStruct.Field2 != field2 {
 		t.Errorf("Test data did not match! Expected {%s %d} but got: %v", field1, field2, testStruct)
@@ -101,18 +97,14 @@ func TestUnmarshalRemoteFile(t *testing.T) {
 	t.Logf("Listening at address: %s", address)
 
 	data, err := ReadRemoteFile("http://" + address)
-	if string(data) != sentinel {
-		t.Errorf("Test data did not match (err = %v)! Expected %q and received %q", err, sentinel, string(data))
-	}
+	assert.Equal(t, string(data), sentinel, "Test data did not match (err = %v)! Expected %q and received %q", err, sentinel, string(data))
 
 	var testStruct struct {
 		Field1 string
 		Field2 int
 	}
 	err = UnmarshalRemoteFile("http://"+address, &testStruct)
-	if err != nil {
-		t.Errorf("Could not unmarshal test data: %s", err)
-	}
+	require.NoError(t, err, "Could not unmarshal test data")
 
 	if testStruct.Field1 != field1 || testStruct.Field2 != field2 {
 		t.Errorf("Test data did not match! Expected {%s %d} but got: %v", field1, field2, testStruct)

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -281,9 +281,8 @@ func TestRepoURLToSecretName(t *testing.T) {
 	}}
 
 	for _, v := range tables {
-		if sn := RepoURLToSecretName(repoSecretPrefix, v.repoUrl, v.project); sn != v.secretName {
-			t.Errorf("Expected secret name %q for repo %q; instead, got %q", v.secretName, v.repoUrl, sn)
-		}
+		sn := RepoURLToSecretName(repoSecretPrefix, v.repoUrl, v.project)
+		assert.Equal(t, sn, v.secretName, "Expected secret name %q for repo %q; instead, got %q", v.secretName, v.repoUrl, sn)
 	}
 }
 
@@ -296,9 +295,8 @@ func Test_CredsURLToSecretName(t *testing.T) {
 	}
 
 	for k, v := range tables {
-		if sn := RepoURLToSecretName(credSecretPrefix, k, ""); sn != v {
-			t.Errorf("Expected secret name %q for repo %q; instead, got %q", v, k, sn)
-		}
+		sn := RepoURLToSecretName(credSecretPrefix, k, "")
+		assert.Equal(t, sn, v, "Expected secret name %q for repo %q; instead, got %q", v, k, sn)
 	}
 }
 

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -849,7 +849,5 @@ func Test_newAuth_AzureWorkloadIdentity(t *testing.T) {
 	auth, err := newAuth("", creds)
 	require.NoError(t, err)
 	_, ok := auth.(*githttp.TokenAuth)
-	if !ok {
-		t.Fatalf("expected TokenAuth but got %T", auth)
-	}
+	require.Truef(t, ok, "expected TokenAuth but got %T", auth)
 }

--- a/util/git/creds_test.go
+++ b/util/git/creds_test.go
@@ -435,7 +435,5 @@ func TestGetHelmCredsShouldReturnHelmCredsIfAzureWorkloadIdentityNotSpecified(t 
 	var creds Creds = NewAzureWorkloadIdentityCreds(NoopCredsStore{}, new(mocks.TokenProvider))
 
 	_, ok := creds.(AzureWorkloadIdentityCreds)
-	if !ok {
-		t.Fatalf("expected HelmCreds but got %T", creds)
-	}
+	require.Truef(t, ok, "expected HelmCreds but got %T", creds)
 }

--- a/util/grpc/sanitizer_test.go
+++ b/util/grpc/sanitizer_test.go
@@ -47,5 +47,5 @@ func TestErrorSanitizerUnaryServerInterceptor(t *testing.T) {
 		return nil, status.Error(codes.Internal, "error at /my-random/path/sub-dir: something went wrong")
 	})
 
-	assert.Equal(t, "rpc error: code = Internal desc = error at ./sub-dir: something went wrong", err.Error())
+	assert.EqualError(t, err, "rpc error: code = Internal desc = error at ./sub-dir: something went wrong")
 }

--- a/util/helm/creds_test.go
+++ b/util/helm/creds_test.go
@@ -141,8 +141,7 @@ func TestChallengeAzureContainerRegistryNonBearer(t *testing.T) {
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
 	_, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not allow 'Bearer' authentication")
+	assert.ErrorContains(t, err, "does not allow 'Bearer' authentication")
 }
 
 func TestChallengeAzureContainerRegistryNoService(t *testing.T) {
@@ -159,8 +158,7 @@ func TestChallengeAzureContainerRegistryNoService(t *testing.T) {
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
 	_, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "service parameter not found in challenge")
+	assert.ErrorContains(t, err, "service parameter not found in challenge")
 }
 
 func TestChallengeAzureContainerRegistryNoRealm(t *testing.T) {
@@ -177,8 +175,7 @@ func TestChallengeAzureContainerRegistryNoRealm(t *testing.T) {
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
 	_, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "realm parameter not found in challenge")
+	assert.ErrorContains(t, err, "realm parameter not found in challenge")
 }
 
 func TestGetAccessTokenAfterChallenge_Success(t *testing.T) {
@@ -228,8 +225,7 @@ func TestGetAccessTokenAfterChallenge_Failure(t *testing.T) {
 	}
 
 	refreshToken, err := creds.getAccessTokenAfterChallenge(tokenParams)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get refresh token")
+	require.ErrorContains(t, err, "failed to get refresh token")
 	assert.Empty(t, refreshToken)
 }
 
@@ -254,7 +250,6 @@ func TestGetAccessTokenAfterChallenge_MalformedResponse(t *testing.T) {
 	}
 
 	refreshToken, err := creds.getAccessTokenAfterChallenge(tokenParams)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to unmarshal response body")
+	require.ErrorContains(t, err, "failed to unmarshal response body")
 	assert.Empty(t, refreshToken)
 }

--- a/util/io/files/tar_test.go
+++ b/util/io/files/tar_test.go
@@ -113,10 +113,7 @@ func TestUntgz(t *testing.T) {
 	}
 	deleteTmpDir := func(t *testing.T, dirname string) {
 		t.Helper()
-		err := os.RemoveAll(dirname)
-		if err != nil {
-			t.Errorf("error removing tmpDir: %s", err)
-		}
+		assert.NoError(t, os.RemoveAll(dirname), "error removing tmpDir")
 	}
 	createTgz := func(t *testing.T, fromDir, destDir string) *os.File {
 		t.Helper()

--- a/util/kube/kube_test.go
+++ b/util/kube/kube_test.go
@@ -192,8 +192,7 @@ func TestSetAppInstanceAnnotationWithInvalidData(t *testing.T) {
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	require.NoError(t, err)
 	err = SetAppInstanceAnnotation(&obj, common.LabelKeyAppInstance, "my-app")
-	require.Error(t, err)
-	assert.Equal(t, "failed to get annotations from target object /v1, Kind=Service /my-service: .metadata.annotations accessor error: contains non-string value in the map under key \"invalid-annotation\": <nil> is of the type <nil>, expected string", err.Error())
+	assert.EqualError(t, err, "failed to get annotations from target object /v1, Kind=Service /my-service: .metadata.annotations accessor error: contains non-string value in the map under key \"invalid-annotation\": <nil> is of the type <nil>, expected string")
 }
 
 func TestGetAppInstanceAnnotation(t *testing.T) {
@@ -218,8 +217,7 @@ func TestGetAppInstanceAnnotationWithInvalidData(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = GetAppInstanceAnnotation(&obj, "valid-annotation")
-	require.Error(t, err)
-	assert.Equal(t, "failed to get annotations from target object /v1, Kind=Service /my-service: .metadata.annotations accessor error: contains non-string value in the map under key \"invalid-annotation\": <nil> is of the type <nil>, expected string", err.Error())
+	assert.EqualError(t, err, "failed to get annotations from target object /v1, Kind=Service /my-service: .metadata.annotations accessor error: contains non-string value in the map under key \"invalid-annotation\": <nil> is of the type <nil>, expected string")
 }
 
 func TestGetAppInstanceLabel(t *testing.T) {
@@ -242,8 +240,7 @@ func TestGetAppInstanceLabelWithInvalidData(t *testing.T) {
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	require.NoError(t, err)
 	_, err = GetAppInstanceLabel(&obj, "valid-label")
-	require.Error(t, err)
-	assert.Equal(t, "failed to get labels for /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string", err.Error())
+	assert.EqualError(t, err, "failed to get labels for /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string")
 }
 
 func TestRemoveLabel(t *testing.T) {
@@ -268,6 +265,5 @@ func TestRemoveLabelWithInvalidData(t *testing.T) {
 	require.NoError(t, err)
 
 	err = RemoveLabel(&obj, "valid-label")
-	require.Error(t, err)
-	assert.Equal(t, "failed to get labels for /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string", err.Error())
+	assert.EqualError(t, err, "failed to get labels for /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string")
 }

--- a/util/lua/custom_actions_test.go
+++ b/util/lua/custom_actions_test.go
@@ -220,9 +220,7 @@ func getExpectedObjectList(t *testing.T, path string) *unstructured.Unstructured
 		// Append each map in objList to the Items field of the new object
 		for i, obj := range objList {
 			unstructuredObj, ok := obj["unstructuredObj"].(map[string]any)
-			if !ok {
-				t.Error("Wrong type of unstructuredObj")
-			}
+			assert.True(t, ok, "Wrong type of unstructuredObj")
 			unstructuredList.Items[i] = unstructured.Unstructured{Object: unstructuredObj}
 		}
 	} else {

--- a/util/password/password_test.go
+++ b/util/password/password_test.go
@@ -2,6 +2,9 @@ package password
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testPasswordHasher(t *testing.T, h PasswordHasher) {
@@ -12,12 +15,8 @@ func testPasswordHasher(t *testing.T, h PasswordHasher) {
 		pollution       = "extradata12345"
 	)
 	hashedPassword, _ := h.HashPassword(defaultPassword)
-	if !h.VerifyPassword(defaultPassword, hashedPassword) {
-		t.Errorf("Password %q should have validated against hash %q", defaultPassword, hashedPassword)
-	}
-	if h.VerifyPassword(defaultPassword, pollution+hashedPassword) {
-		t.Errorf("Password %q should NOT have validated against hash %q", defaultPassword, pollution+hashedPassword)
-	}
+	assert.True(t, h.VerifyPassword(defaultPassword, hashedPassword), "Password %q should have validated against hash %q", defaultPassword, hashedPassword)
+	assert.False(t, h.VerifyPassword(defaultPassword, pollution+hashedPassword), "Password %q should NOT have validated against hash %q", defaultPassword, pollution+hashedPassword)
 }
 
 func TestBcryptPasswordHasher(t *testing.T) {
@@ -43,27 +42,15 @@ func TestPasswordHashing(t *testing.T) {
 
 	hashedPassword, _ := hashPasswordWithHashers(defaultPassword, hashers)
 	valid, stale := verifyPasswordWithHashers(defaultPassword, hashedPassword, hashers)
-	if !valid {
-		t.Errorf("Password %q should have validated against hash %q", defaultPassword, hashedPassword)
-	}
-	if stale {
-		t.Errorf("Password %q should not have been marked stale against hash %q", defaultPassword, hashedPassword)
-	}
+	assert.True(t, valid, "Password %q should have validated against hash %q", defaultPassword, hashedPassword)
+	assert.False(t, stale, "Password %q should not have been marked stale against hash %q", defaultPassword, hashedPassword)
 	valid, stale = verifyPasswordWithHashers(defaultPassword, defaultPassword, hashers)
-	if !valid {
-		t.Errorf("Password %q should have validated against itself with dummy hasher", defaultPassword)
-	}
-	if !stale {
-		t.Errorf("Password %q should have been acknowledged stale against itself with dummy hasher", defaultPassword)
-	}
+	assert.True(t, valid, "Password %q should have validated against itself with dummy hasher", defaultPassword)
+	assert.True(t, stale, "Password %q should have been acknowledged stale against itself with dummy hasher", defaultPassword)
 
 	hashedPassword, err := hashPasswordWithHashers(blankPassword, hashers)
-	if err == nil {
-		t.Errorf("Blank password should have produced error, rather than hash %q", hashedPassword)
-	}
+	require.Error(t, err, "Blank password should have produced error, rather than hash %q", hashedPassword)
 
 	valid, _ = verifyPasswordWithHashers(blankPassword, "", hashers)
-	if valid {
-		t.Errorf("Blank password should have failed verification")
-	}
+	assert.False(t, valid, "Blank password should have failed verification")
 }

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -355,39 +355,27 @@ func TestEnforceErrorMessage(t *testing.T) {
 	err := enf.syncUpdate(fakeConfigMap(), noOpUpdate)
 	require.NoError(t, err)
 
-	err = enf.EnforceErr("admin", "applications", "get", "foo/bar")
-	require.Error(t, err)
-	assert.Equal(t, "rpc error: code = PermissionDenied desc = permission denied: applications, get, foo/bar", err.Error())
+	require.EqualError(t, enf.EnforceErr("admin", "applications", "get", "foo/bar"), "rpc error: code = PermissionDenied desc = permission denied: applications, get, foo/bar")
 
-	err = enf.EnforceErr()
-	require.Error(t, err)
-	assert.Equal(t, "rpc error: code = PermissionDenied desc = permission denied", err.Error())
+	require.EqualError(t, enf.EnforceErr(), "rpc error: code = PermissionDenied desc = permission denied")
 
 	//nolint:staticcheck
 	ctx := context.WithValue(context.Background(), "claims", &jwt.RegisteredClaims{Subject: "proj:default:admin"})
-	err = enf.EnforceErr(ctx.Value("claims"), "project")
-	require.Error(t, err)
-	assert.Equal(t, "rpc error: code = PermissionDenied desc = permission denied: project, sub: proj:default:admin", err.Error())
+	require.EqualError(t, enf.EnforceErr(ctx.Value("claims"), "project"), "rpc error: code = PermissionDenied desc = permission denied: project, sub: proj:default:admin")
 
 	iat := time.Unix(int64(1593035962), 0).Format(time.RFC3339)
 	exp := "rpc error: code = PermissionDenied desc = permission denied: project, sub: proj:default:admin, iat: " + iat
 	//nolint:staticcheck
 	ctx = context.WithValue(context.Background(), "claims", &jwt.RegisteredClaims{Subject: "proj:default:admin", IssuedAt: jwt.NewNumericDate(time.Unix(int64(1593035962), 0))})
-	err = enf.EnforceErr(ctx.Value("claims"), "project")
-	require.Error(t, err)
-	assert.Equal(t, exp, err.Error())
+	require.EqualError(t, enf.EnforceErr(ctx.Value("claims"), "project"), exp)
 
 	//nolint:staticcheck
 	ctx = context.WithValue(context.Background(), "claims", &jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now())})
-	err = enf.EnforceErr(ctx.Value("claims"), "project")
-	require.Error(t, err)
-	assert.Equal(t, "rpc error: code = PermissionDenied desc = permission denied: project", err.Error())
+	require.EqualError(t, enf.EnforceErr(ctx.Value("claims"), "project"), "rpc error: code = PermissionDenied desc = permission denied: project")
 
 	//nolint:staticcheck
 	ctx = context.WithValue(context.Background(), "claims", &jwt.RegisteredClaims{Subject: "proj:default:admin", IssuedAt: nil})
-	err = enf.EnforceErr(ctx.Value("claims"), "project")
-	require.Error(t, err)
-	assert.Equal(t, "rpc error: code = PermissionDenied desc = permission denied: project, sub: proj:default:admin", err.Error())
+	assert.EqualError(t, enf.EnforceErr(ctx.Value("claims"), "project"), "rpc error: code = PermissionDenied desc = permission denied: project, sub: proj:default:admin")
 }
 
 func TestDefaultGlobMatchMode(t *testing.T) {

--- a/util/resource/revision_test.go
+++ b/util/resource/revision_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/argoproj/gitops-engine/pkg/utils/testing"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/argoproj/argo-cd/v3/test"
@@ -28,9 +29,7 @@ func TestGetRevision(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetRevision(tt.args.obj); got != tt.want {
-				t.Errorf("GetRevision() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, GetRevision(tt.args.obj), "GetRevision()")
 		})
 	}
 }

--- a/util/session/sessionmanager_test.go
+++ b/util/session/sessionmanager_test.go
@@ -92,9 +92,7 @@ func TestSessionManager_AdminToken(t *testing.T) {
 	mgr := newSessionManager(settingsMgr, getProjLister(), NewUserStateStorage(redisClient))
 
 	token, err := mgr.Create("admin:login", 0, "123")
-	if err != nil {
-		t.Errorf("Could not create token: %v", err)
-	}
+	require.NoError(t, err, "Could not create token")
 
 	claims, newToken, err := mgr.Parse(token)
 	require.NoError(t, err)
@@ -152,8 +150,7 @@ func TestSessionManager_AdminToken_Revoked(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, err = mgr.Parse(token)
-	require.Error(t, err)
-	assert.Equal(t, "token is revoked, please re-login", err.Error())
+	assert.EqualError(t, err, "token is revoked, please re-login")
 }
 
 func TestSessionManager_AdminToken_Deactivated(t *testing.T) {
@@ -161,9 +158,7 @@ func TestSessionManager_AdminToken_Deactivated(t *testing.T) {
 	mgr := newSessionManager(settingsMgr, getProjLister(), NewUserStateStorage(nil))
 
 	token, err := mgr.Create("admin:login", 0, "abc")
-	if err != nil {
-		t.Errorf("Could not create token: %v", err)
-	}
+	require.NoError(t, err, "Could not create token")
 
 	_, _, err = mgr.Parse(token)
 	assert.ErrorContains(t, err, "account admin is disabled")
@@ -174,9 +169,7 @@ func TestSessionManager_AdminToken_LoginCapabilityDisabled(t *testing.T) {
 	mgr := newSessionManager(settingsMgr, getProjLister(), NewUserStateStorage(nil))
 
 	token, err := mgr.Create("admin", 0, "abc")
-	if err != nil {
-		t.Errorf("Could not create token: %v", err)
-	}
+	require.NoError(t, err, "Could not create token")
 
 	_, _, err = mgr.Parse(token)
 	assert.ErrorContains(t, err, "account admin does not have 'apiKey' capability")

--- a/util/settings/settings_test.go
+++ b/util/settings/settings_test.go
@@ -800,10 +800,10 @@ func TestSettingsManager_GetEventLabelKeys(t *testing.T) {
 			}
 
 			inKeys := settingsManager.GetIncludeEventLabelKeys()
-			assert.Equal(t, len(tt.expectedKeys), len(inKeys))
+			assert.Len(t, inKeys, len(tt.expectedKeys))
 
 			exKeys := settingsManager.GetExcludeEventLabelKeys()
-			assert.Equal(t, len(tt.expectedKeys), len(exKeys))
+			assert.Len(t, exKeys, len(tt.expectedKeys))
 
 			for i := range tt.expectedKeys {
 				assert.Equal(t, tt.expectedKeys[i], inKeys[i])
@@ -1894,7 +1894,7 @@ func TestSettingsManager_GetHideSecretAnnotations(t *testing.T) {
 				resourceSensitiveAnnotationsKey: tt.input,
 			})
 			keys := settingsManager.GetSensitiveAnnotations()
-			assert.Equal(t, len(tt.output), len(keys))
+			assert.Len(t, keys, len(tt.output))
 			assert.Equal(t, tt.output, keys)
 		})
 	}

--- a/util/text/text_test.go
+++ b/util/text/text_test.go
@@ -23,9 +23,7 @@ func TestTrunc(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Trunc(tt.args.message, tt.args.n); got != tt.want {
-				t.Errorf("Trunc() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, Trunc(tt.args.message, tt.args.n), "Trunc()")
 		})
 	}
 }

--- a/util/tls/tls_test.go
+++ b/util/tls/tls_test.go
@@ -116,9 +116,7 @@ func TestEncodeX509KeyPairString(t *testing.T) {
 	certChain := decodePem(chain)
 	cert, _ := EncodeX509KeyPairString(certChain)
 
-	if strings.TrimSpace(chain) != strings.TrimSpace(cert) {
-		t.Errorf("Incorrect, got: %s, want: %s", cert, chain)
-	}
+	assert.Equal(t, strings.TrimSpace(chain), strings.TrimSpace(cert))
 }
 
 func TestGetTLSVersionByString(t *testing.T) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -15,9 +16,7 @@ import (
 func TestMakeSignature(t *testing.T) {
 	for size := 1; size <= 64; size++ {
 		s, err := util.MakeSignature(size)
-		if err != nil {
-			t.Errorf("Could not generate signature of size %d: %v", size, err)
-		}
+		require.NoError(t, err, "Could not generate signature of size %d: %v", size, err)
 		t.Logf("Generated token: %v", s)
 	}
 }
@@ -116,17 +115,11 @@ func TestGenerateCacheKey(t *testing.T) {
 		t.Run(fmt.Sprintf("format=%s args=%v", tc.format, tc.args), func(t *testing.T) {
 			key, err := util.GenerateCacheKey(tc.format, tc.args...)
 			if tc.shouldErr {
-				if err == nil {
-					t.Fatalf("expected error but got none")
-				}
+				require.Errorf(t, err, "expected error but got none")
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if key != tc.expected {
-				t.Fatalf("expected %s but got %s", tc.expected, key)
-			}
+			require.NoErrorf(t, err, "unexpected error: %v", err)
+			require.Equalf(t, tc.expected, key, "expected %s but got %s", tc.expected, key)
 		})
 	}
 }

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -597,9 +597,8 @@ func Test_affectedRevisionInfo_appRevisionHasChanged(t *testing.T) {
 		t.Run(testCopy.name, func(t *testing.T) {
 			t.Parallel()
 			_, revisionFromHook, _, _, _ := affectedRevisionInfo(testCopy.hookPayload)
-			if got := sourceRevisionHasChanged(sourceWithRevision(testCopy.targetRevision), revisionFromHook, false); got != testCopy.hasChanged {
-				t.Errorf("sourceRevisionHasChanged() = %v, want %v", got, testCopy.hasChanged)
-			}
+			got := sourceRevisionHasChanged(sourceWithRevision(testCopy.targetRevision), revisionFromHook, false)
+			assert.Equal(t, got, testCopy.hasChanged, "sourceRevisionHasChanged()")
 		})
 	}
 }
@@ -635,9 +634,7 @@ func Test_getWebUrlRegex(t *testing.T) {
 			t.Parallel()
 			regexp, err := getWebUrlRegex(testCopy.webURL)
 			require.NoError(t, err)
-			if matches := regexp.MatchString(testCopy.repo); matches != testCopy.shouldMatch {
-				t.Errorf("sourceRevisionHasChanged() = %v, want %v", matches, testCopy.shouldMatch)
-			}
+			assert.Equal(t, regexp.MatchString(testCopy.repo), testCopy.shouldMatch, "sourceRevisionHasChanged()")
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Uses testify instead of testing when possible.
It also applies testifylint in the process which explains the changes of `assert.Equal(t, len(actual), len(expected))` to `assert.Len(t, actual ,len(expected))`

