### PR TITLE
fix: Add proxy registry key by dest server + name

### DIFF
--- a/docs/developer-guide/extensions/proxy-extensions.md
+++ b/docs/developer-guide/extensions/proxy-extensions.md
@@ -184,12 +184,11 @@ the argocd-secret with key 'some.argocd.secret.key'.
 If provided, and multiple services are configured, will have to match
 the application destination name or server to have requests properly
 forwarded to this service URL. If there are multiple backends for the
-same extension this field is required. In this case at least one of
-the two will be required: name or server. It is better to provide both
-values to avoid problems with applications unable to send requests to
-the proper backend service. If only one backend service is
-configured, this field is ignored, and all requests are forwarded to
-the configured one.
+same extension this field is required. In this case, it is necessary
+to provide both values to avoid problems with applications unable to
+send requests to the proper backend service. If only one backend
+service is configured, this field is ignored, and all requests are
+forwarded to the configured one.
 
 #### `extensions.backend.services.cluster.name` (*string*)
 (optional)

--- a/server/extension/extension.go
+++ b/server/extension/extension.go
@@ -642,6 +642,14 @@ func appendProxy(registry ProxyRegistry,
 		}
 		registry[key] = proxy
 	}
+	if service.Cluster.Name != "" && service.Cluster.Server != "" {
+		key := proxyKey(extName, service.Cluster.Name, service.Cluster.Server)
+		if _, exist := registry[key]; exist {
+			return fmt.Errorf("duplicated proxy configuration found for extension key %q", key)
+		}
+		registry[key] = proxy
+	}
+
 	return nil
 }
 

--- a/server/extension/extension_test.go
+++ b/server/extension/extension_test.go
@@ -486,11 +486,13 @@ func TestCallExtension(t *testing.T) {
 
 		response1 := "response backend 1"
 		cluster1Name := "cluster1"
+		cluster1URL := "url1"
 		beSrv1 := startBackendTestSrv(response1)
 		defer beSrv1.Close()
 
 		response2 := "response backend 2"
-		cluster2URL := "cluster2"
+		cluster2Name := "cluster2"
+		cluster2URL := "url2"
 		beSrv2 := startBackendTestSrv(response2)
 		defer beSrv2.Close()
 
@@ -498,7 +500,7 @@ func TestCallExtension(t *testing.T) {
 		f.appGetterMock.On("Get", "ns2", "app2").Return(getApp("", cluster2URL, defaultProjectName), nil)
 
 		withRbac(f, true, true)
-		withExtensionConfig(getExtensionConfigWith2Backends(extName, beSrv1.URL, cluster1Name, beSrv2.URL, cluster2URL), f)
+		withExtensionConfig(getExtensionConfigWith2Backends(extName, beSrv1.URL, cluster1Name, cluster1URL, beSrv2.URL, cluster2Name, cluster2URL), f)
 		withProject(getProjectWithDestinations("project-name", []string{cluster1Name}, []string{cluster2URL}), f)
 		withMetrics(f)
 		withUser(f, "some-user", []string{"group1", "group2"})
@@ -678,7 +680,7 @@ func TestCallExtension(t *testing.T) {
 		f.appGetterMock.On("Get", "ns1", "app1").Return(getApp(maliciousName, destinationServer, defaultProjectName), nil)
 
 		withRbac(f, true, true)
-		withExtensionConfig(getExtensionConfigWith2Backends(extName, "url1", "clusterName", "url2", "clusterURL"), f)
+		withExtensionConfig(getExtensionConfigWith2Backends(extName, "url1", "cluster1Name", "cluster1URL", "url2", "cluster2Name", "cluster2URL"), f)
 		withProject(getProjectWithDestinations("project-name", nil, []string{"srv1", destinationServer}), f)
 		withMetrics(f)
 		withUser(f, "some-user", []string{"group1", "group2"})
@@ -745,7 +747,7 @@ extensions:
 	return fmt.Sprintf(cfg, name, url)
 }
 
-func getExtensionConfigWith2Backends(name, url1, clusName, url2, clusURL string) string {
+func getExtensionConfigWith2Backends(name, url1, clus1Name, clus1URL, url2, clus2Name, clus2URL string) string {
 	cfg := `
 extensions:
 - name: %s
@@ -757,11 +759,13 @@ extensions:
         value: '$extension.auth.header'
       cluster:
         name: %s
+        server: %s
     - url: %s
       headers:
       - name: Authorization
         value: '$extension.auth.header2'
       cluster:
+        name: %s
         server: %s
     - url: http://test.com
       cluster:
@@ -770,10 +774,7 @@ extensions:
       cluster:
         name: cl2
 `
-	// second extension is configured with the cluster url rather
-	// than the cluster name so we can validate that both use-cases
-	// are working
-	return fmt.Sprintf(cfg, name, url1, clusName, url2, clusURL)
+	return fmt.Sprintf(cfg, name, url1, clus1Name, clus1URL, url2, clus2Name, clus2URL)
 }
 
 func getExtensionConfigString() string {

--- a/server/extension/extension_test.go
+++ b/server/extension/extension_test.go
@@ -360,7 +360,8 @@ func TestCallExtension(t *testing.T) {
 
 		settings := &settings.ArgoCDSettings{
 			ExtensionConfig: map[string]string{
-				"": configYaml,
+				"ephemeral": "services:\n- url: http://some-server.com",
+				"":          configYaml,
 			},
 			Secrets: secrets,
 		}
@@ -762,6 +763,12 @@ extensions:
         value: '$extension.auth.header2'
       cluster:
         server: %s
+    - url: http://test.com
+      cluster:
+        name: cl1
+    - url: http://test2.com
+      cluster:
+        name: cl2
 `
 	// second extension is configured with the cluster url rather
 	// than the cluster name so we can validate that both use-cases


### PR DESCRIPTION
Regression: 
Argo CD Proxy registry was broken for cases when multiple services were configured for one extension.
The proxy extension lookup was working as expected in Argo CD 2.13.1 and broken on 2.13.3.
Adding a new key in the registry containing the destination name + server addresses the problem.
I wasn't able to confirm 100% but I suspect that this bug was introduced by the following PR: https://github.com/argoproj/argo-cd/pull/21063

This fix needs to be cherry-picked in 2.13 and 2.14 branches

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
