### PR TITLE
feat(webhook): Fixed manifest-generate-paths annotation support for monorepos in BitBucket

### DIFF
--- a/docs/operator-manual/webhook.md
+++ b/docs/operator-manual/webhook.md
@@ -32,9 +32,6 @@ To prevent DDoS attacks with unauthenticated webhook events (the `/api/webhook` 
 
 ![Add Webhook](../assets/azure-devops-webhook-config.png "Add Webhook")
 
-
-
-
 Azure DevOps optionally supports securing the webhook using basic authentication. To use it, specify the username and password in the webhook configuration and configure the same username/password in `argocd-secret` Kubernetes secret in
 `webhook.azuredevops.username` and `webhook.azuredevops.password` keys.
 

--- a/docs/operator-manual/webhook.md
+++ b/docs/operator-manual/webhook.md
@@ -32,6 +32,9 @@ To prevent DDoS attacks with unauthenticated webhook events (the `/api/webhook` 
 
 ![Add Webhook](../assets/azure-devops-webhook-config.png "Add Webhook")
 
+
+
+
 Azure DevOps optionally supports securing the webhook using basic authentication. To use it, specify the username and password in the webhook configuration and configure the same username/password in `argocd-secret` Kubernetes secret in
 `webhook.azuredevops.username` and `webhook.azuredevops.password` keys.
 
@@ -109,3 +112,17 @@ Syntax: `$<k8s_secret_name>:<a_key_in_that_k8s_secret>`
 > NOTE: Secret must have label `app.kubernetes.io/part-of: argocd`
 
 For more information refer to the corresponding section in the [User Management Documentation](user-management/index.md#alternative).
+
+## Special handling for BitBucket Cloud
+BitBucket does not include the list of changed files in the webhook request body.
+This prevents the [Manifest Paths Annotation](high_availability.md#manifest-paths-annotation) feature from working with repositories hosted on BitBucket Cloud.
+BitBucket provides the `diffstat` API to determine the list of changed files between two commits.
+To address the missing changed files list in the webhook, the Argo CD webhook handler makes an API callback to the originating server.
+To prevent Server-side request forgery (SSRF) attacks, Argo CD server supports the callback mechanism only for encrypted webhook requests.
+The incoming webhook must include `X-Hook-UUID` request header. The corresponding UUID must be provided as `webhook.bitbucket.uuid` in `argocd-secret` for verification.
+The callback mechanism supports both public and private repositories on BitBucket Cloud.
+For public repositories, the Argo CD webhook handler uses a no-auth client for the API callback.
+For private repositories, the Argo CD webhook handler searches for a valid repository OAuth token for the HTTP/HTTPS URL.
+The webhook handler uses this OAuth token to make the API request to the originating server.
+If the Argo CD webhook handler cannot find a matching repository credential, the list of changed files would remain empty.
+If errors occur during the callback, the list of changed files will be empty.

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/improbable-eng/grpc-web v0.15.1-0.20230209220825-1d9bbb09a099
 	github.com/itchyny/gojq v0.12.17
+	github.com/jarcoal/httpmock v1.3.1
 	github.com/jeremywohl/flatten v1.0.2-0.20211013061545-07e4a09fb8e4
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/ktrysmt/go-bitbucket v0.9.81

--- a/go.sum
+++ b/go.sum
@@ -499,6 +499,8 @@ github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
 github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJGxm9/mAERQg=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jaytaylor/html2text v0.0.0-20190408195923-01ec452cbe43/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
@@ -583,6 +585,8 @@ github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-zglob v0.0.6 h1:mP8RnmCgho4oaUYDIDn6GNxYk+qJGUs8fJLn+twYj2A=
 github.com/mattn/go-zglob v0.0.6/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.1-0.20241014080628-3045bdf43455 h1:7rDE4oHmFDgf+4fqnT5vztz7Bmcos1tr17VisCXgs/o=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.1-0.20241014080628-3045bdf43455/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -10,6 +10,9 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
+
+	bb "github.com/ktrysmt/go-bitbucket"
 
 	"github.com/go-playground/webhooks/v6/azuredevops"
 	"github.com/go-playground/webhooks/v6/bitbucket"
@@ -29,6 +32,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/app/path"
 	"github.com/argoproj/argo-cd/v3/util/argo"
 	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/git"
 	"github.com/argoproj/argo-cd/v3/util/glob"
 	"github.com/argoproj/argo-cd/v3/util/settings"
 )
@@ -61,6 +65,7 @@ type ArgoCDWebhookHandler struct {
 	bitbucketserver        *bitbucketserver.Webhook
 	azuredevops            *azuredevops.Webhook
 	gogs                   *gogs.Webhook
+	settings               *settings.ArgoCDSettings
 	settingsSrc            settingsSource
 	queue                  chan any
 	maxWebhookPayloadSizeB int64
@@ -105,6 +110,7 @@ func NewHandler(namespace string, applicationNamespaces []string, webhookParalle
 		settingsSrc:            settingsSrc,
 		repoCache:              repoCache,
 		serverCache:            serverCache,
+		settings:               set,
 		db:                     argoDB,
 		queue:                  make(chan any, payloadQueueSize),
 		maxWebhookPayloadSizeB: maxWebhookPayloadSizeB,
@@ -137,8 +143,8 @@ func ParseRevision(ref string) string {
 }
 
 // affectedRevisionInfo examines a payload from a webhook event, and extracts the repo web URL,
-// the revision, and whether or not this affected origin/HEAD (the default branch of the repository)
-func affectedRevisionInfo(payloadIf any) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
+// the revision, and whether, or not this affected origin/HEAD (the default branch of the repository)
+func (a *ArgoCDWebhookHandler) affectedRevisionInfo(payloadIf any) (webURLs []string, revision string, change changeInfo, touchedHead bool, changedFiles []string) {
 	switch payload := payloadIf.(type) {
 	case azuredevops.GitPushEvent:
 		// See: https://learn.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops#git.push
@@ -189,15 +195,54 @@ func affectedRevisionInfo(payloadIf any) (webURLs []string, revision string, cha
 		// See: https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push
 		// NOTE: this is untested
 		webURLs = append(webURLs, payload.Repository.Links.HTML.Href)
-		// TODO: bitbucket includes multiple changes as part of a single event.
-		// We only pick the first but need to consider how to handle multiple
-		for _, change := range payload.Push.Changes {
-			revision = change.New.Name
+		for _, changes := range payload.Push.Changes {
+			revision = changes.New.Name
+			change.shaBefore = changes.Old.Target.Hash
+			change.shaAfter = changes.New.Target.Hash
 			break
 		}
 		// Not actually sure how to check if the incoming change affected HEAD just by examining the
 		// payload alone. To be safe, we just return true and let the controller check for himself.
 		touchedHead = true
+
+		// Get DiffSet only for authenticated webhooks.
+		// when WebhookBitbucketUUID is set in argocd-secret, then the payload must be signed and
+		// signature is validated before payload is parsed.
+		if len(a.settings.WebhookBitbucketUUID) > 0 {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			argoRepo, err := a.lookupRepository(ctx, webURLs[0])
+			if err != nil {
+				log.Warnf("error trying to find a matching repo for URL %s: %v", payload.Repository.Links.HTML.Href, err)
+				break
+			}
+			if argoRepo == nil {
+				// it could be a public repository with no repo creds stored.
+				// initialize with empty bearer token to use the no auth bitbucket client.
+				log.Debugf("no bitbucket repository configured for URL %s, initializing with empty bearer token", webURLs[0])
+				argoRepo = &v1alpha1.Repository{BearerToken: "", Repo: webURLs[0]}
+			}
+			apiBaseURL := strings.ReplaceAll(payload.Repository.Links.Self.Href, "/repositories/"+payload.Repository.FullName, "")
+			bbClient, err := newBitbucketClient(ctx, argoRepo, apiBaseURL)
+			if err != nil {
+				log.Warnf("error creating Bitbucket client for repo %s: %v", payload.Repository.Name, err)
+				break
+			}
+			log.Debugf("created bitbucket client with base URL '%s'", apiBaseURL)
+			owner := strings.ReplaceAll(payload.Repository.FullName, "/"+payload.Repository.Name, "")
+			spec := change.shaBefore + ".." + change.shaAfter
+			diffStatChangedFiles, err := fetchDiffStatFromBitbucket(ctx, bbClient, owner, payload.Repository.Name, spec)
+			if err != nil {
+				log.Warnf("error fetching changed files using bitbucket diffstat api: %v", err)
+			}
+			changedFiles = append(changedFiles, diffStatChangedFiles...)
+			touchedHead, err = isHeadTouched(ctx, bbClient, owner, payload.Repository.Name, revision)
+			if err != nil {
+				log.Warnf("error fetching bitbucket repo details: %v", err)
+				// To be safe, we just return true and let the controller check for himself.
+				touchedHead = true
+			}
+		}
 
 	// Bitbucket does not include a list of changed files anywhere in it's payload
 	// so we cannot update changedFiles for this type of payload
@@ -251,7 +296,7 @@ type changeInfo struct {
 
 // HandleEvent handles webhook events for repo push events
 func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
-	webURLs, revision, change, touchedHead, changedFiles := affectedRevisionInfo(payload)
+	webURLs, revision, change, touchedHead, changedFiles := a.affectedRevisionInfo(payload)
 	// NOTE: the webURL does not include the .git extension
 	if len(webURLs) == 0 {
 		log.Info("Ignoring webhook event")
@@ -405,6 +450,23 @@ func (a *ArgoCDWebhookHandler) storePreviouslyCachedManifests(app *v1alpha1.Appl
 	return nil
 }
 
+// lookupRepository returns a repository with its credentials for a given URL. If there are no matching repository secret found,
+// then nil repository is returned.
+func (a *ArgoCDWebhookHandler) lookupRepository(ctx context.Context, repoURL string) (*v1alpha1.Repository, error) {
+	repositories, err := a.db.ListRepositories(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error listing repositories: %w", err)
+	}
+	var repository *v1alpha1.Repository
+	for _, repo := range repositories {
+		if git.SameURL(repo.Repo, repoURL) {
+			log.Debugf("found a matching repository for URL %s", repoURL)
+			return repo, nil
+		}
+	}
+	return repository, nil
+}
+
 func sourceRevisionHasChanged(source v1alpha1.ApplicationSource, revision string, touchedHead bool) bool {
 	targetRev := ParseRevision(source.TargetRevision)
 	if targetRev == "HEAD" || targetRev == "" { // revision is head
@@ -428,6 +490,76 @@ func sourceUsesURL(source v1alpha1.ApplicationSource, webURL string, repoRegexp 
 
 	log.Debugf("%s uses repoURL %s", source.RepoURL, webURL)
 	return true
+}
+
+// newBitbucketClient creates a new bitbucket client for the given repository and uses the provided apiURL to connect
+// to the bitbucket server. If the repository uses basic auth, then a basic auth client is created or if bearer token
+// is provided, then oauth based client is created.
+func newBitbucketClient(_ context.Context, repository *v1alpha1.Repository, apiBaseURL string) (*bb.Client, error) {
+	var bbClient *bb.Client
+	if repository.Username != "" && repository.Password != "" {
+		log.Debugf("fetched user/password for repository URL '%s', initializing basic auth client", repository.Repo)
+		if repository.Username == "x-token-auth" {
+			bbClient = bb.NewOAuthbearerToken(repository.Password)
+		} else {
+			bbClient = bb.NewBasicAuth(repository.Username, repository.Password)
+		}
+	} else {
+		if repository.BearerToken != "" {
+			log.Debugf("fetched bearer token for repository URL '%s', initializing bearer token auth based client", repository.Repo)
+		} else {
+			log.Debugf("no credentials available for repository URL '%s', initializing no auth client", repository.Repo)
+		}
+		bbClient = bb.NewOAuthbearerToken(repository.BearerToken)
+	}
+	// parse and set the target URL of the Bitbucket server in the client
+	repoBaseURL, err := url.Parse(apiBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse bitbucket api base URL '%s'", apiBaseURL)
+	}
+	bbClient.SetApiBaseURL(*repoBaseURL)
+	return bbClient, nil
+}
+
+// fetchDiffStatFromBitbucket gets the list of files changed between two commits, by making a diffstat api callback to the
+// bitbucket server from where the webhook orignated.
+func fetchDiffStatFromBitbucket(_ context.Context, bbClient *bb.Client, owner, repoSlug, spec string) ([]string, error) {
+	// Getting the files changed from diff API:
+	// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-diffstat-spec-get
+
+	// invoke the diffstat api call to get the list of changed files between two commit shas
+	log.Debugf("invoking diffstat call with parameters: [Owner:%s, RepoSlug:%s, Spec:%s]", owner, repoSlug, spec)
+	diffStatResp, err := bbClient.Repositories.Diff.GetDiffStat(&bb.DiffStatOptions{
+		Owner:    owner,
+		RepoSlug: repoSlug,
+		Spec:     spec,
+		Renames:  true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting the diffstat: %w", err)
+	}
+	changedFiles := make([]string, len(diffStatResp.DiffStats))
+	for i, value := range diffStatResp.DiffStats {
+		changedFilePath := value.New["path"]
+		if changedFilePath != nil {
+			changedFiles[i] = changedFilePath.(string)
+		}
+	}
+	log.Debugf("changed files for spec %s: %v", spec, changedFiles)
+	return changedFiles, nil
+}
+
+// isHeadTouched returns true if the repository's main branch is modified, false otherwise
+func isHeadTouched(ctx context.Context, bbClient *bb.Client, owner, repoSlug, revision string) (bool, error) {
+	bbRepoOptions := &bb.RepositoryOptions{
+		Owner:    owner,
+		RepoSlug: repoSlug,
+	}
+	bbRepo, err := bbClient.Repositories.Repository.Get(bbRepoOptions.WithContext(ctx))
+	if err != nil {
+		return false, err
+	}
+	return bbRepo.Mainbranch.Name == revision, nil
 }
 
 func (a *ArgoCDWebhookHandler) Handler(w http.ResponseWriter, r *http.Request) {

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -2,15 +2,21 @@ package webhook
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"text/template"
 	"time"
 
+	bb "github.com/ktrysmt/go-bitbucket"
+	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-playground/webhooks/v6/bitbucket"
@@ -18,14 +24,14 @@ import (
 	"github.com/go-playground/webhooks/v6/github"
 	"github.com/go-playground/webhooks/v6/gitlab"
 	gogsclient "github.com/gogits/go-gogs-client"
+	"github.com/jarcoal/httpmock"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubetesting "k8s.io/client-go/testing"
 
-	"github.com/argoproj/argo-cd/v3/util/cache/appstate"
-
-	"github.com/argoproj/argo-cd/v3/util/db/mocks"
-
 	servercache "github.com/argoproj/argo-cd/v3/server/cache"
+	"github.com/argoproj/argo-cd/v3/util/cache/appstate"
+	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/db/mocks"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +71,34 @@ func NewMockHandler(reactor *reactorDef, applicationNamespaces []string, objects
 }
 
 func NewMockHandlerWithPayloadLimit(reactor *reactorDef, applicationNamespaces []string, maxPayloadSize int64, objects ...runtime.Object) *ArgoCDWebhookHandler {
+	return newMockHandler(reactor, applicationNamespaces, maxPayloadSize, &mocks.ArgoDB{}, &settings.ArgoCDSettings{}, objects...)
+}
+
+func NewMockHandlerForBitbucketCallback(reactor *reactorDef, applicationNamespaces []string, objects ...runtime.Object) *ArgoCDWebhookHandler {
+	mockDB := mocks.ArgoDB{}
+	mockDB.On("ListRepositories", mock.Anything).Return(
+		[]*v1alpha1.Repository{
+			{
+				Repo:     "https://bitbucket.org/test/argocd-examples-pub.git",
+				Username: "test",
+				Password: "test",
+			},
+			{
+				Repo:     "https://bitbucket.org/test-owner/test-repo.git",
+				Username: "test",
+				Password: "test",
+			},
+			{
+				Repo:          "git@bitbucket.org:test/argocd-examples-pub.git",
+				SSHPrivateKey: "test-ssh-key",
+			},
+		}, nil)
+	argoSettings := settings.ArgoCDSettings{WebhookBitbucketUUID: "abcd-efgh-ijkl-mnop"}
+	defaultMaxPayloadSize := int64(50) * 1024 * 1024
+	return newMockHandler(reactor, applicationNamespaces, defaultMaxPayloadSize, &mockDB, &argoSettings, objects...)
+}
+
+func newMockHandler(reactor *reactorDef, applicationNamespaces []string, maxPayloadSize int64, argoDB db.ArgoDB, argoSettings *settings.ArgoCDSettings, objects ...runtime.Object) *ArgoCDWebhookHandler {
 	appClientset := appclientset.NewSimpleClientset(objects...)
 	if reactor != nil {
 		defaultReactor := appClientset.ReactionChain[0]
@@ -76,12 +110,12 @@ func NewMockHandlerWithPayloadLimit(reactor *reactorDef, applicationNamespaces [
 	}
 	cacheClient := cacheutil.NewCache(cacheutil.NewInMemoryCache(1 * time.Hour))
 
-	return NewHandler("argocd", applicationNamespaces, 10, appClientset, &settings.ArgoCDSettings{}, &fakeSettingsSrc{}, cache.NewCache(
+	return NewHandler("argocd", applicationNamespaces, 10, appClientset, argoSettings, &fakeSettingsSrc{}, cache.NewCache(
 		cacheClient,
 		1*time.Minute,
 		1*time.Minute,
 		10*time.Second,
-	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute, time.Minute), &mocks.ArgoDB{}, maxPayloadSize)
+	), servercache.NewCache(appstate.NewCache(cacheClient, time.Minute), time.Minute, time.Minute, time.Minute), argoDB, maxPayloadSize)
 }
 
 func TestGitHubCommitEvent(t *testing.T) {
@@ -596,9 +630,11 @@ func Test_affectedRevisionInfo_appRevisionHasChanged(t *testing.T) {
 		testCopy := testCase
 		t.Run(testCopy.name, func(t *testing.T) {
 			t.Parallel()
-			_, revisionFromHook, _, _, _ := affectedRevisionInfo(testCopy.hookPayload)
-			got := sourceRevisionHasChanged(sourceWithRevision(testCopy.targetRevision), revisionFromHook, false)
-			assert.Equal(t, got, testCopy.hasChanged, "sourceRevisionHasChanged()")
+			h := NewMockHandler(nil, []string{})
+			_, revisionFromHook, _, _, _ := h.affectedRevisionInfo(testCopy.hookPayload)
+			if got := sourceRevisionHasChanged(sourceWithRevision(testCopy.targetRevision), revisionFromHook, false); got != testCopy.hasChanged {
+				t.Errorf("sourceRevisionHasChanged() = %v, want %v", got, testCopy.hasChanged)
+			}
 		})
 	}
 }
@@ -643,7 +679,9 @@ func Test_GetWebURLRegex(t *testing.T) {
 			t.Parallel()
 			regexp, err := GetWebURLRegex(testCopy.webURL)
 			require.NoError(t, err)
-			assert.Equal(t, regexp.MatchString(testCopy.repo), testCopy.shouldMatch, "sourceRevisionHasChanged()")
+			if matches := regexp.MatchString(testCopy.repo); matches != testCopy.shouldMatch {
+				t.Errorf("sourceRevisionHasChanged() = %v, want %v", matches, testCopy.shouldMatch)
+			}
 		})
 	}
 
@@ -678,7 +716,9 @@ func Test_GetAPIURLRegex(t *testing.T) {
 			t.Parallel()
 			regexp, err := GetAPIURLRegex(testCopy.apiURL)
 			require.NoError(t, err)
-			assert.Equal(t, regexp.MatchString(testCopy.repo), testCopy.shouldMatch, "sourceRevisionHasChanged()")
+			if matches := regexp.MatchString(testCopy.repo); matches != testCopy.shouldMatch {
+				t.Errorf("sourceRevisionHasChanged() = %v, want %v", matches, testCopy.shouldMatch)
+			}
 		})
 	}
 
@@ -705,4 +745,365 @@ func TestGitHubCommitEventMaxPayloadSize(t *testing.T) {
 	expectedLogResult := "Webhook processing failed: The payload is either too large or corrupted. Please check the payload size (must be under 0 MB) and ensure it is valid JSON"
 	assert.Equal(t, expectedLogResult, hook.LastEntry().Message)
 	hook.Reset()
+}
+
+func Test_affectedRevisionInfo_bitbucket_changed_files(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET",
+		"https://api.bitbucket.org/2.0/repositories/test-owner/test-repo/diffstat/abcdef..ghijkl",
+		getDiffstatResponderFn())
+	httpmock.RegisterResponder("GET",
+		"https://api.bitbucket.org/2.0/repositories/test-owner/test-repo",
+		getRepositoryResponderFn())
+	const payloadTemplateString = `
+{
+  "push":{
+    "changes":[
+      {"new":{"name":"{{.branch}}", "target": {"hash": "{{.newHash}}"}}, "old": {"name":"{{.branch}}", "target": {"hash": "{{.oldHash}}"}}}
+    ]
+  },
+  "repository":{
+    "type": "repository", 
+    "full_name": "{{.owner}}/{{.repo}}",
+    "name": "{{.repo}}", 
+    "scm": "git", 
+    "links": {
+      "self": {"href": "https://api.bitbucket.org/2.0/repositories/{{.owner}}/{{.repo}}"},
+      "html": {"href": "https://bitbucket.org/{{.owner}}/{{.repo}}"}
+    }
+  }
+}`
+	tmpl, err := template.New("test").Parse(payloadTemplateString)
+	if err != nil {
+		panic(err)
+	}
+
+	bitbucketPushPayload := func(branchName, owner, repo string) bitbucket.RepoPushPayload {
+		// The payload's "push.changes[0].new.name" member seems to only have the branch name (based on the example payload).
+		// https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#EventPayloads-Push
+		var pl bitbucket.RepoPushPayload
+		var doc bytes.Buffer
+		err = tmpl.Execute(&doc, map[string]string{
+			"branch":  branchName,
+			"owner":   owner,
+			"repo":    repo,
+			"oldHash": "abcdef",
+			"newHash": "ghijkl",
+		})
+		if err != nil {
+			require.NoError(t, err)
+		}
+		_ = json.Unmarshal(doc.Bytes(), &pl)
+		return pl
+	}
+
+	tests := []struct {
+		name                 string
+		hasChanged           bool
+		revision             string
+		hookPayload          bitbucket.RepoPushPayload
+		expectedTouchHead    bool
+		expectedChangedFiles []string
+		expectedChangeInfo   changeInfo
+	}{
+		{
+			"bitbucket branch name containing 'refs/heads/'",
+			false,
+			"release-0.0",
+			bitbucketPushPayload("release-0.0", "test-owner", "test-repo"),
+			false,
+			[]string{"guestbook/guestbook-ui-deployment.yaml"},
+			changeInfo{
+				shaBefore: "abcdef",
+				shaAfter:  "ghijkl",
+			},
+		},
+		{
+			"bitbucket branch name containing 'main'",
+			false,
+			"main",
+			bitbucketPushPayload("main", "test-owner", "test-repo"),
+			true,
+			[]string{"guestbook/guestbook-ui-deployment.yaml"},
+			changeInfo{
+				shaBefore: "abcdef",
+				shaAfter:  "ghijkl",
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := NewMockHandlerForBitbucketCallback(nil, []string{})
+			_, revisionFromHook, change, touchHead, changedFiles := h.affectedRevisionInfo(testCase.hookPayload)
+			require.Equal(t, testCase.revision, revisionFromHook)
+			require.Equal(t, testCase.expectedTouchHead, touchHead)
+			require.Equal(t, testCase.expectedChangedFiles, changedFiles)
+			require.Equal(t, testCase.expectedChangeInfo, change)
+		})
+	}
+}
+
+func TestLookupRepository(t *testing.T) {
+	mockCtx, cancel := context.WithDeadline(t.Context(), time.Now().Add(10*time.Second))
+	defer cancel()
+	h := NewMockHandlerForBitbucketCallback(nil, []string{})
+	data := []string{
+		"https://bitbucket.org/test/argocd-examples-pub.git",
+		"https://bitbucket.org/test/argocd-examples-pub",
+		"https://BITBUCKET.org/test/argocd-examples-pub",
+		"https://BITBUCKET.org/test/argocd-examples-pub.git",
+		"\thttps://bitbucket.org/test/argocd-examples-pub\n",
+		"\thttps://bitbucket.org/test/argocd-examples-pub.git\n",
+		"git@BITBUCKET.org:test/argocd-examples-pub",
+		"git@BITBUCKET.org:test/argocd-examples-pub.git",
+		"git@bitbucket.org:test/argocd-examples-pub",
+		"git@bitbucket.org:test/argocd-examples-pub.git",
+	}
+	for _, url := range data {
+		repository, err := h.lookupRepository(mockCtx, url)
+		require.NoError(t, err)
+		require.NotNil(t, repository)
+		require.Contains(t, strings.ToLower(repository.Repo), strings.Trim(strings.ToLower(url), "\t\n"))
+		require.True(t, repository.Username == "test" || repository.SSHPrivateKey == "test-ssh-key")
+	}
+	// when no matching repository is found, then it should return nil error and nil repository
+	repository, err := h.lookupRepository(t.Context(), "https://bitbucket.org/test/argocd-examples-not-found.git")
+	require.NoError(t, err)
+	require.Nil(t, repository)
+}
+
+func TestCreateBitbucketClient(t *testing.T) {
+	tests := []struct {
+		name         string
+		apiURL       string
+		repository   *v1alpha1.Repository
+		expectedAuth string
+		expectedErr  error
+	}{
+		{
+			"client creation with username and password",
+			"https://api.bitbucket.org/2.0/",
+			&v1alpha1.Repository{
+				Repo:     "https://bitbucket.org/test",
+				Username: "test",
+				Password: "test",
+			},
+			"user:\"test\", password:\"test\"",
+			nil,
+		},
+		{
+			"client creation for user x-token-auth and token in password",
+			"https://api.bitbucket.org/2.0/",
+			&v1alpha1.Repository{
+				Repo:     "https://bitbucket.org/test",
+				Username: "x-token-auth",
+				Password: "test-token",
+			},
+			"bearerToken:\"test-token\"",
+			nil,
+		},
+		{
+			"client creation with oauth bearer token",
+			"https://api.bitbucket.org/2.0/",
+			&v1alpha1.Repository{
+				Repo:        "https://bitbucket.org/test",
+				BearerToken: "test-token",
+			},
+			"bearerToken:\"test-token\"",
+			nil,
+		},
+		{
+			"client creation with no auth",
+			"https://api.bitbucket.org/2.0/",
+			&v1alpha1.Repository{
+				Repo: "https://bitbucket.org/test",
+			},
+			"bearerToken:\"\"",
+			nil,
+		},
+		{
+			"client creation with invalid api URL",
+			"api.bitbucket.org%%/2.0/",
+			&v1alpha1.Repository{},
+			"",
+			errors.New("failed to parse bitbucket api base URL 'api.bitbucket.org%%/2.0/'"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := newBitbucketClient(t.Context(), tt.repository, tt.apiURL)
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+				require.NotNil(t, client)
+				require.Equal(t, tt.apiURL, client.GetApiBaseURL())
+				require.Contains(t, fmt.Sprintf("%#v", *client.Auth), tt.expectedAuth)
+			} else {
+				require.Error(t, err)
+				require.Nil(t, client)
+				require.Equal(t, tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestFetchDiffStatBitbucketClient(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET",
+		"https://api.bitbucket.org/2.0/repositories/test-owner/test-repo/diffstat/abcdef..ghijkl",
+		getDiffstatResponderFn())
+	client := bb.NewOAuthbearerToken("")
+	tt := []struct {
+		name                string
+		owner               string
+		repo                string
+		spec                string
+		expectedLen         int
+		expectedFileChanged string
+		expectedErrString   string
+	}{
+		{
+			name:                "valid repo and spec",
+			owner:               "test-owner",
+			repo:                "test-repo",
+			spec:                "abcdef..ghijkl",
+			expectedLen:         1,
+			expectedFileChanged: "guestbook/guestbook-ui-deployment.yaml",
+		},
+		{
+			name:              "invalid spec",
+			owner:             "test-owner",
+			repo:              "test-repo",
+			spec:              "abcdef..",
+			expectedErrString: "error getting the diffstat",
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			changedFiles, err := fetchDiffStatFromBitbucket(t.Context(), client, test.owner, test.repo, test.spec)
+			if test.expectedErrString == "" {
+				require.NoError(t, err)
+				require.NotNil(t, changedFiles)
+				require.Len(t, changedFiles, test.expectedLen)
+				require.Equal(t, test.expectedFileChanged, changedFiles[0])
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErrString)
+			}
+		})
+	}
+}
+
+func TestIsHeadTouched(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET",
+		"https://api.bitbucket.org/2.0/repositories/test-owner/test-repo",
+		getRepositoryResponderFn())
+	client := bb.NewOAuthbearerToken("")
+	tt := []struct {
+		name              string
+		owner             string
+		repo              string
+		revision          string
+		expectedErrString string
+		expectedTouchHead bool
+	}{
+		{
+			name:              "valid repo with main branch in revision",
+			owner:             "test-owner",
+			repo:              "test-repo",
+			revision:          "main",
+			expectedErrString: "",
+			expectedTouchHead: true,
+		},
+		{
+			name:              "valid repo with main branch in revision",
+			owner:             "test-owner",
+			repo:              "test-repo",
+			revision:          "release-0.0",
+			expectedErrString: "",
+			expectedTouchHead: false,
+		},
+		{
+			name:              "valid repo with main branch in revision",
+			owner:             "test-owner",
+			repo:              "unknown-repo",
+			revision:          "master",
+			expectedErrString: "Get \"https://api.bitbucket.org/2.0/repositories/test-owner/unknown-repo\"",
+			expectedTouchHead: false,
+		},
+	}
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			touchedHead, err := isHeadTouched(t.Context(), client, test.owner, test.repo, test.revision)
+			if test.expectedErrString == "" {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedTouchHead, touchedHead)
+			} else {
+				require.Error(t, err)
+				require.False(t, touchedHead)
+			}
+		})
+	}
+}
+
+// getRepositoryResponderFn return a httpmock responder function to mock a get repository api call to bitbucket server
+func getRepositoryResponderFn() func(req *http.Request) (*http.Response, error) {
+	return func(_ *http.Request) (*http.Response, error) {
+		// sample response: https://api.bitbucket.org/2.0/repositories/anandjoseph/argocd-examples-pub
+		repository := &bb.Repository{
+			Type:        "repository",
+			Full_name:   "test-owner/test-repo",
+			Name:        "test-repo",
+			Is_private:  false,
+			Fork_policy: "allow_forks",
+			Mainbranch: bb.RepositoryBranch{
+				Name: "main",
+				Type: "branch",
+			},
+		}
+		resp, err := httpmock.NewJsonResponse(200, repository)
+		if err != nil {
+			return httpmock.NewStringResponse(500, ""), nil
+		}
+		return resp, nil
+	}
+}
+
+// getDiffstatResponderFn return a httpmock responder function to mock a diffstat api call to bitbucket server
+func getDiffstatResponderFn() func(req *http.Request) (*http.Response, error) {
+	return func(_ *http.Request) (*http.Response, error) {
+		// sample response : https://api.bitbucket.org/2.0/repositories/anandjoseph/argocd-examples-pub/diffstat/3a53cee247fc820fbae0a9cf463a6f4a18369f90..3d0965f36fcc07e88130b2d5c917a37c2876c484
+		diffStatRes := &bb.DiffStatRes{
+			Page:    1,
+			Size:    1,
+			Pagelen: 500,
+			DiffStats: []*bb.DiffStat{
+				{
+					Type:         "diffstat",
+					Status:       "added",
+					LinedAdded:   20,
+					LinesRemoved: 0,
+					New: map[string]any{
+						"path":         "guestbook/guestbook-ui-deployment.yaml",
+						"type":         "commit_file",
+						"escaped_path": "guestbook/guestbook-ui-deployment.yaml",
+						"links": map[string]any{
+							"self": map[string]any{
+								"href": "https://bitbucket.org/guestbook/guestbook-ui-deployment.yaml",
+							},
+						},
+					},
+				},
+			},
+		}
+		resp, err := httpmock.NewJsonResponse(200, diffStatRes)
+		if err != nil {
+			return httpmock.NewStringResponse(500, ""), nil
+		}
+		return resp, nil
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/18968

This PR addresses adds improvements for https://github.com/argoproj/argo-cd/pull/20993

### PR Summary:
This PR addresses an issue with the argocd.argoproj.io/manifest-generate-paths [Manifest Paths Annotation](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#manifest-paths-annotation) in Argo CD when used with Bitbucket repositories.

### Key Changes:
Prevents spurious refreshes in cases where multiple Applications are using the same Git monorepo stored in Bitbucket.
Ensures that the manifest-generate-paths annotation is handled correctly, refreshing the app only when the files changed match with the paths in manifest-generate-paths .

### Steps to Verify this feature:
1. Disable the periodic polling of the git repositories by the following command to ensure that all refreshes happen only via webhook notifications.
```
kubectl patch cm argocd-cm -n argocd -p '{"data": {"timeout.reconciliation": "0"}}'
```
2. Set the debug logs in Argo CD Server component using the following command to verify changed files are being calculated correctly.
```
kubectl patch cm argocd-cmd-params-cm -n argocd -p '{"data": {"server.log.level": "debug"}}'
```
3. Restart the `argocd-server` deployment to ensure that the log level configuration change is picked up by the application.
```
kubectl scale deploy argocd-server -n argocd --replicas=0
kubectl scale deploy argocd-server -n argocd --replicas=1
```
4. Create a webhook for the private repository using the steps provided in https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/

5. Create a Repository webhook token in BitBucket for the private repository and add the repository secret as follows
Detailed steps provided in this link : https://support.atlassian.com/bitbucket-cloud/docs/create-a-repository-access-token/
```
argocd login <server_hostname> --username admin --password $(kubectl get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d) --insecure
export WEBHOOK_TOKEN=<token_from_bb_console>
argocd repo add https://bitbucket.org/anandjoseph/argocd-sample-pvt.git --username x-token-auth --password $(echo $WEBHOOK_TOKEN)
```
6. Create a webhook in BitBucket, update the webhook UUID in secret
```
export WEBHOOK_UUID=<uuid_from_bb_console>
kubectl patch secret argocd-secret -n argocd -p '{"stringData": {"webhook.bitbucket.uuid": "$WEBHOOK_UUID"}}'
```
7. Check the logs and see if you find some debug logs as below
```
{"level":"debug","msg":"https://bitbucket.org/anandjoseph/argocd-sample-pvt.git has credentials","time":"2025-05-18T07:53:49Z"}
{"level":"debug","msg":"quay.io/rh-ee-anjoseph has credentials","time":"2025-05-18T07:53:49Z"}
{"level":"debug","msg":"found a matching repository for URL https://bitbucket.org/anandjoseph/argocd-sample-pvt","time":"2025-05-18T07:53:49Z"}
{"level":"debug","msg":"fetched user/password for repository URL 'https://bitbucket.org/anandjoseph/argocd-sample-pvt.git', initializing basic auth client","time":"2025-05-18T07:53:49Z"}
{"level":"debug","msg":"created bitbucket client with base URL 'https://api.bitbucket.org/2.0'","time":"2025-05-18T07:53:49Z"}
{"level":"debug","msg":"invoking diffstat call with parameters: [Owner:anandjoseph, RepoSlug:argocd-sample-pvt, Spec:..397e8a657cc47a32b8c4e150cb731a0f9d3cb751]","time":"2025-05-18T07:53:49Z"}
{"level":"debug","msg":"changed files for spec ..397e8a657cc47a32b8c4e150cb731a0f9d3cb751: [guestbook/guestbook-ui-deployment.yaml]","time":"2025-05-18T07:53:50Z"}
{"level":"info","msg":"Received push event repo: https://bitbucket.org/anandjoseph/argocd-sample-pvt, revision: change_version_28, touchedHead: false","time":"2025-05-18T07:53:51Z"}
```



<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
