### PR TITLE
chore: define apiextensionsv1 alias with importas

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,8 @@ linters-settings:
         pkg: k8s.io/api/rbac/v1
       - alias: apierrors
         pkg: k8s.io/apimachinery/pkg/api/errors
+      - alias: apiextensionsv1
+        pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
       - alias: metav1
         pkg: k8s.io/apimachinery/pkg/apis/meta/v1
       - alias: informersv1

--- a/hack/gen-crd-spec/main.go
+++ b/hack/gen-crd-spec/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application"
 
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
-	extensionsobj "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
@@ -22,7 +22,7 @@ var kindToCRDPath = map[string]string{
 	application.ApplicationSetFullName: "manifests/crds/applicationset-crd.yaml",
 }
 
-func getCustomResourceDefinitions() map[string]*extensionsobj.CustomResourceDefinition {
+func getCustomResourceDefinitions() map[string]*apiextensionsv1.CustomResourceDefinition {
 	crdYamlBytes, err := exec.Command(
 		"controller-gen",
 		"paths=./pkg/apis/application/...",
@@ -41,7 +41,7 @@ func getCustomResourceDefinitions() map[string]*extensionsobj.CustomResourceDefi
 
 	objs, err := kube.SplitYAML(crdYamlBytes)
 	checkErr(err)
-	crds := make(map[string]*extensionsobj.CustomResourceDefinition)
+	crds := make(map[string]*apiextensionsv1.CustomResourceDefinition)
 	for i := range objs {
 		un := objs[i]
 
@@ -80,14 +80,14 @@ func removeValidation(un *unstructured.Unstructured, path string) {
 	unstructured.RemoveNestedField(un.Object, schemaPath...)
 }
 
-func toCRD(un *unstructured.Unstructured, removeDesc bool) *extensionsobj.CustomResourceDefinition {
+func toCRD(un *unstructured.Unstructured, removeDesc bool) *apiextensionsv1.CustomResourceDefinition {
 	if removeDesc {
 		removeDescription(un.Object)
 	}
 	unBytes, err := json.Marshal(un)
 	checkErr(err)
 
-	var crd extensionsobj.CustomResourceDefinition
+	var crd apiextensionsv1.CustomResourceDefinition
 	err = json.Unmarshal(unBytes, &crd)
 	checkErr(err)
 
@@ -134,7 +134,7 @@ func main() {
 	}
 }
 
-func writeCRDintoFile(crd *extensionsobj.CustomResourceDefinition, path string) {
+func writeCRDintoFile(crd *apiextensionsv1.CustomResourceDefinition, path string) {
 	jsonBytes, err := json.Marshal(crd)
 	checkErr(err)
 


### PR DESCRIPTION
#### Description 

 define `apiextensionsv1` alias with importas `k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1`

This is to align with https://github.com/argoproj/gitops-engine/blob/master/.golangci.yaml#L49-L50

This is implicitly applied as only one file did not comply with this rule.