### PR TITLE
chore: enable var-naming from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -140,7 +140,11 @@ linters-settings:
       - name: useless-break
       - name: var-declaration
       - name: var-naming
-        disabled: true
+        arguments:
+          - ["ID"]
+          - ["VM"]
+          - - skipPackageNameChecks: true
+              upperCaseConst: true
   testifylint:
     enable-all: true
     disable:

--- a/applicationset/generators/duck_type_test.go
+++ b/applicationset/generators/duck_type_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	resourceApiVersion = "mallard.io/v1"
+	resourceAPIVersion = "mallard.io/v1"
 	resourceKind       = "ducks"
 	resourceName       = "quak"
 )
@@ -79,7 +79,7 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 
 	duckType := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resourceApiVersion,
+			"apiVersion": resourceAPIVersion,
 			"kind":       "Duck",
 			"metadata": map[string]any{
 				"name":      resourceName,
@@ -101,7 +101,7 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 
 	duckTypeProdOnly := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resourceApiVersion,
+			"apiVersion": resourceAPIVersion,
 			"kind":       "Duck",
 			"metadata": map[string]any{
 				"name":      resourceName,
@@ -120,7 +120,7 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 
 	duckTypeEmpty := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resourceApiVersion,
+			"apiVersion": resourceAPIVersion,
 			"kind":       "Duck",
 			"metadata": map[string]any{
 				"name":      resourceName,
@@ -137,7 +137,7 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 			Namespace: "namespace",
 		},
 		Data: map[string]string{
-			"apiVersion":    resourceApiVersion,
+			"apiVersion":    resourceAPIVersion,
 			"kind":          resourceKind,
 			"statusListKey": "decisions",
 			"matchKey":      "clusterName",
@@ -375,7 +375,7 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 
 	duckType := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resourceApiVersion,
+			"apiVersion": resourceAPIVersion,
 			"kind":       "Duck",
 			"metadata": map[string]any{
 				"name":      resourceName,
@@ -397,7 +397,7 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 
 	duckTypeProdOnly := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resourceApiVersion,
+			"apiVersion": resourceAPIVersion,
 			"kind":       "Duck",
 			"metadata": map[string]any{
 				"name":      resourceName,
@@ -416,7 +416,7 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 
 	duckTypeEmpty := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resourceApiVersion,
+			"apiVersion": resourceAPIVersion,
 			"kind":       "Duck",
 			"metadata": map[string]any{
 				"name":      resourceName,
@@ -433,7 +433,7 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 			Namespace: "namespace",
 		},
 		Data: map[string]string{
-			"apiVersion":    resourceApiVersion,
+			"apiVersion":    resourceAPIVersion,
 			"kind":          resourceKind,
 			"statusListKey": "decisions",
 			"matchKey":      "clusterName",

--- a/applicationset/generators/merge.go
+++ b/applicationset/generators/merge.go
@@ -122,11 +122,11 @@ func getParamSetsByMergeKey(mergeKeys []string, paramSets []map[string]any) (map
 		for mergeKey := range deDuplicatedMergeKeys {
 			paramSetKey[mergeKey] = paramSet[mergeKey]
 		}
-		paramSetKeyJson, err := json.Marshal(paramSetKey)
+		paramSetKeyJSON, err := json.Marshal(paramSetKey)
 		if err != nil {
 			return nil, fmt.Errorf("error marshalling param set key json: %w", err)
 		}
-		paramSetKeyString := string(paramSetKeyJson)
+		paramSetKeyString := string(paramSetKeyJSON)
 		if _, exists := paramSetsByMergeKey[paramSetKeyString]; exists {
 			return nil, fmt.Errorf("%w. Duplicate key was %s", ErrNonUniqueParamSets, paramSetKeyString)
 		}

--- a/applicationset/generators/merge_test.go
+++ b/applicationset/generators/merge_test.go
@@ -39,12 +39,12 @@ func getTerminalListGeneratorMultiple(jsons []string) argoprojiov1alpha1.Applica
 func listOfMapsToSet(maps []map[string]any) (map[string]bool, error) {
 	set := make(map[string]bool, len(maps))
 	for _, paramMap := range maps {
-		paramMapAsJson, err := json.Marshal(paramMap)
+		paramMapAsJSON, err := json.Marshal(paramMap)
 		if err != nil {
 			return nil, err
 		}
 
-		set[string(paramMapAsJson)] = false
+		set[string(paramMapAsJSON)] = false
 	}
 	return set, nil
 }

--- a/applicationset/generators/plugin.go
+++ b/applicationset/generators/plugin.go
@@ -193,8 +193,8 @@ func (g *PluginGenerator) getConfigMap(ctx context.Context, configMapRef string)
 		return nil, err
 	}
 
-	baseUrl, ok := cm.Data["baseUrl"]
-	if !ok || baseUrl == "" {
+	baseURL, ok := cm.Data["baseUrl"]
+	if !ok || baseURL == "" {
 		return nil, errors.New("baseUrl not found in ConfigMap")
 	}
 

--- a/applicationset/generators/plugin_test.go
+++ b/applicationset/generators/plugin_test.go
@@ -691,11 +691,11 @@ func TestPluginGenerateParams(t *testing.T) {
 				require.EqualError(t, err, testCase.expectedError.Error())
 			} else {
 				require.NoError(t, err)
-				expectedJson, err := json.Marshal(testCase.expected)
+				expectedJSON, err := json.Marshal(testCase.expected)
 				require.NoError(t, err)
-				gotJson, err := json.Marshal(got)
+				gotJSON, err := json.Marshal(got)
 				require.NoError(t, err)
-				assert.JSONEq(t, string(expectedJson), string(gotJson))
+				assert.JSONEq(t, string(expectedJSON), string(gotJSON))
 			}
 		})
 	}

--- a/applicationset/generators/scm_utils.go
+++ b/applicationset/generators/scm_utils.go
@@ -1,5 +1,5 @@
 package generators
 
-type SCMGeneratorWithCustomApiUrl interface {
+type SCMGeneratorWithCustomApiUrl interface { //nolint:revive //FIXME(var-naming)
 	CustomApiUrl() string
 }

--- a/applicationset/services/pull_request/azure_devops.go
+++ b/applicationset/services/pull_request/azure_devops.go
@@ -42,13 +42,13 @@ var (
 )
 
 func NewAzureDevOpsService(token, url, organization, project, repo string, labels []string) (PullRequestService, error) {
-	organizationUrl := buildURL(url, organization)
+	organizationURL := buildURL(url, organization)
 
 	var connection *azuredevops.Connection
 	if token == "" {
-		connection = azuredevops.NewAnonymousConnection(organizationUrl)
+		connection = azuredevops.NewAnonymousConnection(organizationURL)
 	} else {
-		connection = azuredevops.NewPatConnection(organizationUrl, token)
+		connection = azuredevops.NewPatConnection(organizationURL, token)
 	}
 
 	return &AzureDevOpsService{

--- a/applicationset/services/pull_request/azure_devops_test.go
+++ b/applicationset/services/pull_request/azure_devops_test.go
@@ -61,20 +61,20 @@ func (m *AzureClientFactoryMock) GetClient(ctx context.Context) (git.Client, err
 func TestListPullRequest(t *testing.T) {
 	teamProject := "myorg_project"
 	repoName := "myorg_project_repo"
-	pr_id := 123
-	pr_title := "feat(123)"
-	pr_head_sha := "cd4973d9d14a08ffe6b641a89a68891d6aac8056"
+	prID := 123
+	prTitle := "feat(123)"
+	prHeadSha := "cd4973d9d14a08ffe6b641a89a68891d6aac8056"
 	ctx := context.Background()
 	uniqueName := "testName"
 
 	pullRequestMock := []git.GitPullRequest{
 		{
-			PullRequestId: createIntPtr(pr_id),
-			Title:         createStringPtr(pr_title),
+			PullRequestId: createIntPtr(prID),
+			Title:         createStringPtr(prTitle),
 			SourceRefName: createStringPtr("refs/heads/feature-branch"),
 			TargetRefName: createStringPtr("refs/heads/main"),
 			LastMergeSourceCommit: &git.GitCommitRef{
-				CommitId: createStringPtr(pr_head_sha),
+				CommitId: createStringPtr(prHeadSha),
 			},
 			Labels: &[]core.WebApiTagDefinition{},
 			Repository: &git.GitRepository{
@@ -108,9 +108,9 @@ func TestListPullRequest(t *testing.T) {
 	assert.Len(t, list, 1)
 	assert.Equal(t, "feature-branch", list[0].Branch)
 	assert.Equal(t, "main", list[0].TargetBranch)
-	assert.Equal(t, pr_head_sha, list[0].HeadSHA)
+	assert.Equal(t, prHeadSha, list[0].HeadSHA)
 	assert.Equal(t, "feat(123)", list[0].Title)
-	assert.Equal(t, pr_id, list[0].Number)
+	assert.Equal(t, prID, list[0].Number)
 	assert.Equal(t, uniqueName, list[0].Author)
 }
 

--- a/applicationset/services/pull_request/bitbucket_cloud.go
+++ b/applicationset/services/pull_request/bitbucket_cloud.go
@@ -52,7 +52,7 @@ type PullRequestResponse struct {
 
 var _ PullRequestService = (*BitbucketCloudService)(nil)
 
-func parseUrl(uri string) (*url.URL, error) {
+func parseURL(uri string) (*url.URL, error) {
 	if uri == "" {
 		uri = "https://api.bitbucket.org/2.0"
 	}
@@ -65,10 +65,10 @@ func parseUrl(uri string) (*url.URL, error) {
 	return url, nil
 }
 
-func NewBitbucketCloudServiceBasicAuth(baseUrl, username, password, owner, repositorySlug string) (PullRequestService, error) {
-	url, err := parseUrl(baseUrl)
+func NewBitbucketCloudServiceBasicAuth(baseURL, username, password, owner, repositorySlug string) (PullRequestService, error) {
+	url, err := parseURL(baseURL)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing base url of %s for %s/%s: %w", baseUrl, owner, repositorySlug, err)
+		return nil, fmt.Errorf("error parsing base url of %s for %s/%s: %w", baseURL, owner, repositorySlug, err)
 	}
 
 	bitbucketClient := bitbucket.NewBasicAuth(username, password)
@@ -81,10 +81,10 @@ func NewBitbucketCloudServiceBasicAuth(baseUrl, username, password, owner, repos
 	}, nil
 }
 
-func NewBitbucketCloudServiceBearerToken(baseUrl, bearerToken, owner, repositorySlug string) (PullRequestService, error) {
-	url, err := parseUrl(baseUrl)
+func NewBitbucketCloudServiceBearerToken(baseURL, bearerToken, owner, repositorySlug string) (PullRequestService, error) {
+	url, err := parseURL(baseURL)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing base url of %s for %s/%s: %w", baseUrl, owner, repositorySlug, err)
+		return nil, fmt.Errorf("error parsing base url of %s for %s/%s: %w", baseURL, owner, repositorySlug, err)
 	}
 
 	bitbucketClient := bitbucket.NewOAuthbearerToken(bearerToken)
@@ -97,9 +97,9 @@ func NewBitbucketCloudServiceBearerToken(baseUrl, bearerToken, owner, repository
 	}, nil
 }
 
-func NewBitbucketCloudServiceNoAuth(baseUrl, owner, repositorySlug string) (PullRequestService, error) {
+func NewBitbucketCloudServiceNoAuth(baseURL, owner, repositorySlug string) (PullRequestService, error) {
 	// There is currently no method to explicitly not require auth
-	return NewBitbucketCloudServiceBearerToken(baseUrl, "", owner, repositorySlug)
+	return NewBitbucketCloudServiceBearerToken(baseURL, "", owner, repositorySlug)
 }
 
 func (b *BitbucketCloudService) List(_ context.Context) ([]*PullRequest, error) {

--- a/applicationset/services/pull_request/bitbucket_cloud_test.go
+++ b/applicationset/services/pull_request/bitbucket_cloud_test.go
@@ -54,11 +54,11 @@ func defaultHandlerCloud(t *testing.T) func(http.ResponseWriter, *http.Request) 
 }
 
 func TestParseUrlEmptyUrl(t *testing.T) {
-	url, err := parseUrl("")
-	bitbucketUrl, _ := url.Parse("https://api.bitbucket.org/2.0")
+	url, err := parseURL("")
+	bitbucketURL, _ := url.Parse("https://api.bitbucket.org/2.0")
 
 	require.NoError(t, err)
-	assert.Equal(t, bitbucketUrl, url)
+	assert.Equal(t, bitbucketURL, url)
 }
 
 func TestInvalidBaseUrlBasicAuthCloud(t *testing.T) {

--- a/applicationset/services/scm_provider/aws_codecommit.go
+++ b/applicationset/services/scm_provider/aws_codecommit.go
@@ -26,8 +26,8 @@ import (
 
 const (
 	resourceTypeCodeCommitRepository = "codecommit:repository"
-	prefixGitUrlHttps                = "https://git-codecommit."
-	prefixGitUrlHttpsFIPS            = "https://git-codecommit-fips."
+	prefixGitURLHTTPS                = "https://git-codecommit."
+	prefixGitURLHTTPSFIPS            = "https://git-codecommit-fips."
 )
 
 // AWSCodeCommitClient is a lean facade to the codecommitiface.CodeCommitAPI
@@ -315,16 +315,16 @@ func getCodeCommitRepoName(repoArn string) (string, error) {
 // getCodeCommitFIPSEndpoint transforms provided https:// codecommit URL to a FIPS-compliant endpoint.
 // note that the specified region must support FIPS, otherwise the returned URL won't be reachable
 // see: https://docs.aws.amazon.com/codecommit/latest/userguide/regions.html#regions-git
-func getCodeCommitFIPSEndpoint(repoUrl string) (string, error) {
-	if strings.HasPrefix(repoUrl, prefixGitUrlHttpsFIPS) {
-		log.Debugf("provided repoUrl %s is already a fips endpoint", repoUrl)
-		return repoUrl, nil
+func getCodeCommitFIPSEndpoint(repoURL string) (string, error) {
+	if strings.HasPrefix(repoURL, prefixGitURLHTTPSFIPS) {
+		log.Debugf("provided repoUrl %s is already a fips endpoint", repoURL)
+		return repoURL, nil
 	}
-	if !strings.HasPrefix(repoUrl, prefixGitUrlHttps) {
-		return "", fmt.Errorf("the provided https endpoint isn't recognized, cannot be transformed to FIPS endpoint: %s", repoUrl)
+	if !strings.HasPrefix(repoURL, prefixGitURLHTTPS) {
+		return "", fmt.Errorf("the provided https endpoint isn't recognized, cannot be transformed to FIPS endpoint: %s", repoURL)
 	}
 	// we already have the prefix, so we guarantee to replace exactly the prefix only.
-	return strings.Replace(repoUrl, prefixGitUrlHttps, prefixGitUrlHttpsFIPS, 1), nil
+	return strings.Replace(repoURL, prefixGitURLHTTPS, prefixGitURLHTTPSFIPS, 1), nil
 }
 
 func hasAwsError(err error, codes ...string) bool {

--- a/applicationset/services/scm_provider/aws_codecommit_test.go
+++ b/applicationset/services/scm_provider/aws_codecommit_test.go
@@ -23,7 +23,7 @@ type awsCodeCommitTestRepository struct {
 	arn                      string
 	accountId                string
 	defaultBranch            string
-	expectedCloneUrl         string
+	expectedCloneURL         string
 	getRepositoryError       error
 	getRepositoryNilMetadata bool
 	valid                    bool
@@ -49,7 +49,7 @@ func TestAWSCodeCommitListRepos(t *testing.T) {
 					id:               "8235624d-d248-4df9-a983-2558b01dbe83",
 					arn:              "arn:aws:codecommit:us-east-1:111111111111:repo1",
 					defaultBranch:    "main",
-					expectedCloneUrl: "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/repo1",
+					expectedCloneURL: "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/repo1",
 					valid:            true,
 				},
 			},
@@ -74,7 +74,7 @@ func TestAWSCodeCommitListRepos(t *testing.T) {
 					id:               "8235624d-d248-4df9-a983-2558b01dbe83",
 					arn:              "arn:aws:codecommit:us-east-1:111111111111:repo1",
 					defaultBranch:    "main",
-					expectedCloneUrl: "https://git-codecommit-fips.us-east-1.amazonaws.com/v1/repos/repo1",
+					expectedCloneURL: "https://git-codecommit-fips.us-east-1.amazonaws.com/v1/repos/repo1",
 					valid:            true,
 				},
 			},
@@ -96,7 +96,7 @@ func TestAWSCodeCommitListRepos(t *testing.T) {
 					id:               "8235624d-d248-4df9-a983-2558b01dbe83",
 					arn:              "arn:aws:codecommit:us-east-1:111111111111:repo1",
 					defaultBranch:    "main",
-					expectedCloneUrl: "ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/repo1",
+					expectedCloneURL: "ssh://git-codecommit.us-east-1.amazonaws.com/v1/repos/repo1",
 					valid:            true,
 				},
 				{
@@ -226,7 +226,7 @@ func TestAWSCodeCommitListRepos(t *testing.T) {
 					assert.Equal(t, originRepo.name, repo.Repository)
 					assert.Equal(t, originRepo.id, repo.RepositoryId)
 					assert.Equal(t, originRepo.defaultBranch, repo.Branch)
-					assert.Equal(t, originRepo.expectedCloneUrl, repo.URL)
+					assert.Equal(t, originRepo.expectedCloneURL, repo.URL)
 					assert.Empty(t, repo.SHA, "SHA is always empty")
 				}
 			}
@@ -382,7 +382,7 @@ func TestAWSCodeCommitGetBranches(t *testing.T) {
 	id := "1a64adc4-2fb5-4abd-afe7-127984ba83c0"
 	defaultBranch := "main"
 	organization := "111111111111"
-	cloneUrl := "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/repo1"
+	cloneURL := "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/repo1"
 
 	testCases := []struct {
 		name               string
@@ -445,7 +445,7 @@ func TestAWSCodeCommitGetBranches(t *testing.T) {
 			actual, err := provider.GetBranches(ctx, &Repository{
 				Organization: organization,
 				Repository:   name,
-				URL:          cloneUrl,
+				URL:          cloneURL,
 				RepositoryId: id,
 			})
 			if testCase.expectOverallError {
@@ -454,7 +454,7 @@ func TestAWSCodeCommitGetBranches(t *testing.T) {
 				assertCopiedProperties := func(repo *Repository) {
 					assert.Equal(t, id, repo.RepositoryId)
 					assert.Equal(t, name, repo.Repository)
-					assert.Equal(t, cloneUrl, repo.URL)
+					assert.Equal(t, cloneURL, repo.URL)
 					assert.Equal(t, organization, repo.Organization)
 					assert.Empty(t, repo.SHA)
 				}

--- a/applicationset/services/scm_provider/azure_devops.go
+++ b/applicationset/services/scm_provider/azure_devops.go
@@ -107,7 +107,7 @@ func (g *AzureDevOpsProvider) RepoHasPath(ctx context.Context, repo *Repository,
 	}
 
 	var repoId string
-	if uuid, isUuid := repo.RepositoryId.(uuid.UUID); isUuid { // most likely an UUID, but do type-safe check anyway. Do %v fallback if not expected type.
+	if uuid, isUUID := repo.RepositoryId.(uuid.UUID); isUUID { // most likely an UUID, but do type-safe check anyway. Do %v fallback if not expected type.
 		repoId = uuid.String()
 	} else {
 		repoId = fmt.Sprintf("%v", repo.RepositoryId)

--- a/applicationset/services/scm_provider/azure_devops_test.go
+++ b/applicationset/services/scm_provider/azure_devops_test.go
@@ -272,7 +272,7 @@ func TestAzureDevOpsGetBranchesDefultBranchOnly(t *testing.T) {
 	testCases := []struct {
 		name                string
 		expectedBranch      *azureGit.GitBranchStats
-		getBranchesApiError error
+		getBranchesAPIError error
 		clientError         error
 	}{
 		{
@@ -281,7 +281,7 @@ func TestAzureDevOpsGetBranchesDefultBranchOnly(t *testing.T) {
 		},
 		{
 			name:                "GetBranches AllBranches false when request fails returns error and empty result",
-			getBranchesApiError: errors.New("Remote Azure Devops GetBranches error"),
+			getBranchesAPIError: errors.New("Remote Azure Devops GetBranches error"),
 		},
 		{
 			name:        "GetBranches AllBranches false when Azure DevOps client fails returns error",
@@ -300,7 +300,7 @@ func TestAzureDevOpsGetBranchesDefultBranchOnly(t *testing.T) {
 			clientFactoryMock := &AzureClientFactoryMock{mock: &mock.Mock{}}
 			clientFactoryMock.mock.On("GetClient", mock.Anything).Return(&gitClientMock, testCase.clientError)
 
-			gitClientMock.On("GetBranch", ctx, azureGit.GetBranchArgs{RepositoryId: &repoName, Project: &teamProject, Name: &defaultBranch}).Return(testCase.expectedBranch, testCase.getBranchesApiError)
+			gitClientMock.On("GetBranch", ctx, azureGit.GetBranchArgs{RepositoryId: &repoName, Project: &teamProject, Name: &defaultBranch}).Return(testCase.expectedBranch, testCase.getBranchesAPIError)
 
 			repo := &Repository{Organization: organization, Repository: repoName, RepositoryId: uuid, Branch: defaultBranch}
 
@@ -314,9 +314,9 @@ func TestAzureDevOpsGetBranchesDefultBranchOnly(t *testing.T) {
 				return
 			}
 
-			if testCase.getBranchesApiError != nil {
+			if testCase.getBranchesAPIError != nil {
 				assert.Empty(t, branches)
-				require.ErrorContains(t, err, testCase.getBranchesApiError.Error())
+				require.ErrorContains(t, err, testCase.getBranchesAPIError.Error())
 			} else {
 				if testCase.expectedBranch != nil {
 					assert.NotEmpty(t, branches)
@@ -341,7 +341,7 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 	testCases := []struct {
 		name                       string
 		expectedBranches           *[]azureGit.GitBranchStats
-		getBranchesApiError        error
+		getBranchesAPIError        error
 		clientError                error
 		allBranches                bool
 		expectedProcessingErrorMsg string
@@ -353,7 +353,7 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 		},
 		{
 			name:                "GetBranches when Azure DevOps request fails returns error and empty result",
-			getBranchesApiError: errors.New("Remote Azure Devops GetBranches error"),
+			getBranchesAPIError: errors.New("Remote Azure Devops GetBranches error"),
 			allBranches:         true,
 		},
 		{
@@ -384,7 +384,7 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 			clientFactoryMock := &AzureClientFactoryMock{mock: &mock.Mock{}}
 			clientFactoryMock.mock.On("GetClient", mock.Anything).Return(&gitClientMock, testCase.clientError)
 
-			gitClientMock.On("GetBranches", ctx, azureGit.GetBranchesArgs{RepositoryId: &repoName, Project: &teamProject}).Return(testCase.expectedBranches, testCase.getBranchesApiError)
+			gitClientMock.On("GetBranches", ctx, azureGit.GetBranchesArgs{RepositoryId: &repoName, Project: &teamProject}).Return(testCase.expectedBranches, testCase.getBranchesAPIError)
 
 			repo := &Repository{Organization: organization, Repository: repoName, RepositoryId: uuid}
 
@@ -403,9 +403,9 @@ func TestAzureDevopsGetBranches(t *testing.T) {
 				return
 			}
 
-			if testCase.getBranchesApiError != nil {
+			if testCase.getBranchesAPIError != nil {
 				assert.Empty(t, branches)
-				require.ErrorContains(t, err, testCase.getBranchesApiError.Error())
+				require.ErrorContains(t, err, testCase.getBranchesAPIError.Error())
 			} else {
 				if len(*testCase.expectedBranches) > 0 {
 					assert.NotEmpty(t, branches)

--- a/applicationset/services/scm_provider/bitbucket_cloud.go
+++ b/applicationset/services/scm_provider/bitbucket_cloud.go
@@ -101,7 +101,7 @@ func (g *BitBucketCloudProvider) ListRepos(_ context.Context, cloneProtocol stri
 		return nil, fmt.Errorf("error listing repositories for %s: %w", g.owner, err)
 	}
 	for _, bitBucketRepo := range accountReposResp.Items {
-		cloneUrl, err := findCloneURL(cloneProtocol, &bitBucketRepo)
+		cloneURL, err := findCloneURL(cloneProtocol, &bitBucketRepo)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching clone url for repo %s: %w", bitBucketRepo.Slug, err)
 		}
@@ -109,7 +109,7 @@ func (g *BitBucketCloudProvider) ListRepos(_ context.Context, cloneProtocol stri
 			Organization: g.owner,
 			Repository:   bitBucketRepo.Slug,
 			Branch:       bitBucketRepo.Mainbranch.Name,
-			URL:          *cloneUrl,
+			URL:          *cloneURL,
 			Labels:       []string{},
 			RepositoryId: bitBucketRepo.Uuid,
 		})

--- a/applicationset/utils/createOrUpdate.go
+++ b/applicationset/utils/createOrUpdate.go
@@ -163,12 +163,12 @@ func applyIgnoreDifferences(applicationSetIgnoreDifferences argov1alpha1.Applica
 	if len(result.Lives) != 1 {
 		return fmt.Errorf("expected 1 normalized application, got %d", len(result.Lives))
 	}
-	foundJsonNormalized, err := json.Marshal(result.Lives[0].Object)
+	foundJSONNormalized, err := json.Marshal(result.Lives[0].Object)
 	if err != nil {
 		return fmt.Errorf("failed to marshal normalized app to json: %w", err)
 	}
 	foundNormalized := &argov1alpha1.Application{}
-	err = json.Unmarshal(foundJsonNormalized, &foundNormalized)
+	err = json.Unmarshal(foundJSONNormalized, &foundNormalized)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal normalized app to json: %w", err)
 	}
@@ -176,12 +176,12 @@ func applyIgnoreDifferences(applicationSetIgnoreDifferences argov1alpha1.Applica
 		return fmt.Errorf("expected 1 normalized application, got %d", len(result.Targets))
 	}
 	foundNormalized.DeepCopyInto(found)
-	generatedJsonNormalized, err := json.Marshal(result.Targets[0].Object)
+	generatedJSONNormalized, err := json.Marshal(result.Targets[0].Object)
 	if err != nil {
 		return fmt.Errorf("failed to marshal normalized app to json: %w", err)
 	}
 	generatedAppNormalized := &argov1alpha1.Application{}
-	err = json.Unmarshal(generatedJsonNormalized, &generatedAppNormalized)
+	err = json.Unmarshal(generatedJSONNormalized, &generatedAppNormalized)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal normalized app json to structured app: %w", err)
 	}

--- a/applicationset/utils/utils.go
+++ b/applicationset/utils/utils.go
@@ -139,11 +139,11 @@ func (r *Render) deeplyReplace(copy, original reflect.Value, replaceMap map[stri
 			} else if currentType == "Raw.k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1" || currentType == "Raw.k8s.io/apimachinery/pkg/runtime" {
 				var unmarshaled any
 				originalBytes := original.Field(i).Bytes()
-				convertedToJson, err := ConvertYAMLToJSON(string(originalBytes))
+				convertedToJSON, err := ConvertYAMLToJSON(string(originalBytes))
 				if err != nil {
-					return fmt.Errorf("error while converting template to json %q: %w", convertedToJson, err)
+					return fmt.Errorf("error while converting template to json %q: %w", convertedToJSON, err)
 				}
-				err = json.Unmarshal([]byte(convertedToJson), &unmarshaled)
+				err = json.Unmarshal([]byte(convertedToJSON), &unmarshaled)
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal JSON field: %w", err)
 				}
@@ -489,7 +489,7 @@ func SlugifyName(args ...any) string {
 	return urlSlug
 }
 
-func getTlsConfigWithCACert(scmRootCAPath string, caCerts []byte) *tls.Config {
+func getTLSConfigWithCACert(scmRootCAPath string, caCerts []byte) *tls.Config {
 	tlsConfig := &tls.Config{}
 
 	if scmRootCAPath != "" {
@@ -518,8 +518,8 @@ func getTlsConfigWithCACert(scmRootCAPath string, caCerts []byte) *tls.Config {
 	return tlsConfig
 }
 
-func GetTlsConfig(scmRootCAPath string, insecure bool, caCerts []byte) *tls.Config {
-	tlsConfig := getTlsConfigWithCACert(scmRootCAPath, caCerts)
+func GetTlsConfig(scmRootCAPath string, insecure bool, caCerts []byte) *tls.Config { //nolint:revive //FIXME(var-naming)
+	tlsConfig := getTLSConfigWithCACert(scmRootCAPath, caCerts)
 
 	if insecure {
 		tlsConfig.InsecureSkipVerify = true

--- a/applicationset/utils/utils_test.go
+++ b/applicationset/utils/utils_test.go
@@ -1331,42 +1331,42 @@ WkBKOclmOV2xlTVuPw==
 		scmRootCAPath           string
 		insecure                bool
 		caCerts                 []byte
-		validateCertInTlsConfig bool
+		validateCertInTLSConfig bool
 	}{
 		{
 			name:                    "Insecure mode configured, SCM Root CA Path not set",
 			scmRootCAPath:           "",
 			insecure:                true,
 			caCerts:                 nil,
-			validateCertInTlsConfig: false,
+			validateCertInTLSConfig: false,
 		},
 		{
 			name:                    "SCM Root CA Path set, Insecure mode set to false",
 			scmRootCAPath:           rootCAPath,
 			insecure:                false,
 			caCerts:                 nil,
-			validateCertInTlsConfig: true,
+			validateCertInTLSConfig: true,
 		},
 		{
 			name:                    "SCM Root CA Path set, Insecure mode set to true",
 			scmRootCAPath:           rootCAPath,
 			insecure:                true,
 			caCerts:                 nil,
-			validateCertInTlsConfig: true,
+			validateCertInTLSConfig: true,
 		},
 		{
 			name:                    "Cert passed, Insecure mode set to false",
 			scmRootCAPath:           "",
 			insecure:                false,
 			caCerts:                 []byte(certFromCM),
-			validateCertInTlsConfig: true,
+			validateCertInTLSConfig: true,
 		},
 		{
 			name:                    "SCM Root CA Path set, cert passed, Insecure mode set to false",
 			scmRootCAPath:           rootCAPath,
 			insecure:                false,
 			caCerts:                 []byte(certFromCM),
-			validateCertInTlsConfig: true,
+			validateCertInTLSConfig: true,
 		},
 	}
 
@@ -1384,7 +1384,7 @@ WkBKOclmOV2xlTVuPw==
 				assert.True(t, ok)
 			}
 			assert.NotNil(t, tlsConfig)
-			if testCase.validateCertInTlsConfig {
+			if testCase.validateCertInTLSConfig {
 				assert.True(t, tlsConfig.RootCAs.Equal(certPool))
 			}
 		})

--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -179,7 +179,7 @@ func NewCommand() *cobra.Command {
 				tlsConfig.Certificates = pool
 			}
 
-			dexTlsConfig := &dex.DexTLSConfig{
+			dexTLSConfig := &dex.DexTLSConfig{
 				DisableTLS:       dexServerPlaintext,
 				StrictValidation: dexServerStrictTLS,
 			}
@@ -191,14 +191,14 @@ func NewCommand() *cobra.Command {
 				if err != nil {
 					log.Fatalf("%v", err)
 				}
-				dexTlsConfig.RootCAs = pool
+				dexTLSConfig.RootCAs = pool
 				cert, err := tls.LoadX509Cert(
 					env.StringFromEnv(common.EnvAppConfigPath, common.DefaultAppConfigPath) + "/dex/tls/tls.crt",
 				)
 				if err != nil {
 					log.Fatalf("%v", err)
 				}
-				dexTlsConfig.Certificate = cert.Raw
+				dexTLSConfig.Certificate = cert.Raw
 			}
 
 			repoclientset := apiclient.NewRepoServerClientset(repoServerAddress, repoServerTimeoutSeconds, tlsConfig)
@@ -229,7 +229,7 @@ func NewCommand() *cobra.Command {
 				AppClientset:            appClientSet,
 				RepoClientset:           repoclientset,
 				DexServerAddr:           dexServerAddress,
-				DexTLSConfig:            dexTlsConfig,
+				DexTLSConfig:            dexTLSConfig,
 				DisableAuth:             disableAuth,
 				ContentTypes:            contentTypesList,
 				EnableGZip:              enableGZip,

--- a/cmd/argocd/commands/admin/cluster.go
+++ b/cmd/argocd/commands/admin/cluster.go
@@ -545,7 +545,7 @@ argocd admin cluster kubeconfig https://cluster-api-url:6443 /path/to/output/kub
 				c.HelpFunc()(c, args)
 				os.Exit(1)
 			}
-			serverUrl := args[0]
+			serverURL := args[0]
 			output := args[1]
 			conf, err := clientConfig.ClientConfig()
 			errors.CheckError(err)
@@ -554,7 +554,7 @@ argocd admin cluster kubeconfig https://cluster-api-url:6443 /path/to/output/kub
 			kubeclientset, err := kubernetes.NewForConfig(conf)
 			errors.CheckError(err)
 
-			cluster, err := db.NewDB(namespace, settings.NewSettingsManager(ctx, kubeclientset, namespace), kubeclientset).GetCluster(ctx, serverUrl)
+			cluster, err := db.NewDB(namespace, settings.NewSettingsManager(ctx, kubeclientset, namespace), kubeclientset).GetCluster(ctx, serverURL)
 			errors.CheckError(err)
 			rawConfig, err := cluster.RawRestConfig()
 			errors.CheckError(err)

--- a/cmd/argocd/commands/admin/project_allowlist.go
+++ b/cmd/argocd/commands/admin/project_allowlist.go
@@ -136,17 +136,17 @@ func generateProjectAllowList(serverResources []*metav1.APIResourceList, cluster
 			continue
 		}
 
-		ruleApiGroup := rule.APIGroups[0]
+		ruleAPIGroup := rule.APIGroups[0]
 		for _, ruleResource := range rule.Resources {
 			for _, apiResourcesList := range serverResources {
 				gv, err := schema.ParseGroupVersion(apiResourcesList.GroupVersion)
 				if err != nil {
 					gv = schema.GroupVersion{}
 				}
-				if ruleApiGroup == gv.Group {
+				if ruleAPIGroup == gv.Group {
 					for _, apiResource := range apiResourcesList.APIResources {
 						if apiResource.Name == ruleResource {
-							resourceList = append(resourceList, metav1.GroupKind{Group: ruleApiGroup, Kind: apiResource.Kind})
+							resourceList = append(resourceList, metav1.GroupKind{Group: ruleAPIGroup, Kind: apiResource.Kind})
 						}
 					}
 				}

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -276,7 +276,7 @@ func hasAppChanged(appReq, appRes *argoappv1.Application, upsert bool) bool {
 }
 
 func parentChildDetails(ctx context.Context, appIf application.ApplicationServiceClient, appName string, appNs string) (map[string]argoappv1.ResourceNode, map[string][]string, map[string]struct{}) {
-	mapUidToNode := make(map[string]argoappv1.ResourceNode)
+	mapUIDToNode := make(map[string]argoappv1.ResourceNode)
 	mapParentToChild := make(map[string][]string)
 	parentNode := make(map[string]struct{})
 
@@ -284,7 +284,7 @@ func parentChildDetails(ctx context.Context, appIf application.ApplicationServic
 	errors.CheckError(err)
 
 	for _, node := range resourceTree.Nodes {
-		mapUidToNode[node.UID] = node
+		mapUIDToNode[node.UID] = node
 
 		if len(node.ParentRefs) > 0 {
 			_, ok := mapParentToChild[node.ParentRefs[0].UID]
@@ -297,7 +297,7 @@ func parentChildDetails(ctx context.Context, appIf application.ApplicationServic
 			parentNode[node.UID] = struct{}{}
 		}
 	}
-	return mapUidToNode, mapParentToChild, parentNode
+	return mapUIDToNode, mapParentToChild, parentNode
 }
 
 func printHeader(ctx context.Context, acdClient argocdclient.Client, app *argoappv1.Application, windows *argoappv1.SyncWindows, showOperation bool, showParams bool, sourcePosition int) {
@@ -444,17 +444,17 @@ func NewApplicationGetCommand(clientOpts *argocdclient.ClientOptions) *cobra.Com
 				}
 			case "tree":
 				printHeader(ctx, acdClient, app, windows, showOperation, showParams, sourcePosition)
-				mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appName, appNs)
-				if len(mapUidToNode) > 0 {
+				mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appName, appNs)
+				if len(mapUIDToNode) > 0 {
 					fmt.Println()
-					printTreeView(mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
+					printTreeView(mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
 				}
 			case "tree=detailed":
 				printHeader(ctx, acdClient, app, windows, showOperation, showParams, sourcePosition)
-				mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appName, appNs)
-				if len(mapUidToNode) > 0 {
+				mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appName, appNs)
+				if len(mapUIDToNode) > 0 {
 					fmt.Println()
-					printTreeViewDetailed(mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
+					printTreeViewDetailed(mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
 				}
 			default:
 				errors.CheckError(fmt.Errorf("unknown output format: %s", output))
@@ -2500,14 +2500,14 @@ func checkResourceStatus(watch watchOpts, healthStatus string, syncStatus string
 // constructs the necessary data structures to print the app as a tree.
 func resourceParentChild(ctx context.Context, acdClient argocdclient.Client, appName string, appNs string) (map[string]argoappv1.ResourceNode, map[string][]string, map[string]struct{}, map[string]*resourceState) {
 	_, appIf := acdClient.NewApplicationClientOrDie()
-	mapUidToNode, mapParentToChild, parentNode := parentChildDetails(ctx, appIf, appName, appNs)
+	mapUIDToNode, mapParentToChild, parentNode := parentChildDetails(ctx, appIf, appName, appNs)
 	app, err := appIf.Get(ctx, &application.ApplicationQuery{Name: ptr.To(appName), AppNamespace: ptr.To(appNs)})
 	errors.CheckError(err)
 	mapNodeNameToResourceState := make(map[string]*resourceState)
 	for _, res := range getResourceStates(app, nil) {
 		mapNodeNameToResourceState[res.Kind+"/"+res.Name] = res
 	}
-	return mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState
+	return mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState
 }
 
 const waitFormatString = "%s\t%5s\t%10s\t%10s\t%20s\t%8s\t%7s\t%10s\t%s\n"
@@ -2565,16 +2565,17 @@ func waitOnApplicationStatus(ctx context.Context, acdClient argocdclient.Client,
 				_ = w.Flush()
 			}
 		case "tree":
-			mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appRealName, appNs)
-			if len(mapUidToNode) > 0 {
+			mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appRealName, appNs)
+			if len(mapUIDToNode) > 0 {
 				fmt.Println()
-				printTreeView(mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
+				printTreeView(mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
 			}
 		case "tree=detailed":
-			mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appRealName, appNs)
-			if len(mapUidToNode) > 0 {
+
+			mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState := resourceParentChild(ctx, acdClient, appRealName, appNs)
+			if len(mapUIDToNode) > 0 {
 				fmt.Println()
-				printTreeViewDetailed(mapUidToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
+				printTreeViewDetailed(mapUIDToNode, mapParentToChild, parentNode, mapNodeNameToResourceState)
 			}
 		default:
 			errors.CheckError(fmt.Errorf("unknown output format: %s", output))
@@ -2741,7 +2742,7 @@ func setParameterOverrides(app *argoappv1.Application, parameters []string, sour
 }
 
 // Print list of history ID's for an application.
-func printApplicationHistoryIds(revHistory []argoappv1.RevisionHistory) {
+func printApplicationHistoryIDs(revHistory []argoappv1.RevisionHistory) {
 	for _, depInfo := range revHistory {
 		fmt.Println(depInfo.ID)
 	}
@@ -2749,7 +2750,7 @@ func printApplicationHistoryIds(revHistory []argoappv1.RevisionHistory) {
 
 // Print a history table for an application.
 func printApplicationHistoryTable(revHistory []argoappv1.RevisionHistory) {
-	MAX_ALLOWED_REVISIONS := 7
+	maxAllowedRevisions := 7
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	type history struct {
 		id       int64
@@ -2762,8 +2763,8 @@ func printApplicationHistoryTable(revHistory []argoappv1.RevisionHistory) {
 		if depInfo.Sources != nil {
 			for i, sourceInfo := range depInfo.Sources {
 				rev := sourceInfo.TargetRevision
-				if len(depInfo.Revisions) == len(depInfo.Sources) && len(depInfo.Revisions[i]) >= MAX_ALLOWED_REVISIONS {
-					rev = fmt.Sprintf("%s (%s)", rev, depInfo.Revisions[i][0:MAX_ALLOWED_REVISIONS])
+				if len(depInfo.Revisions) == len(depInfo.Sources) && len(depInfo.Revisions[i]) >= maxAllowedRevisions {
+					rev = fmt.Sprintf("%s (%s)", rev, depInfo.Revisions[i][0:maxAllowedRevisions])
 				}
 				if _, ok := varHistory[sourceInfo.RepoURL]; !ok {
 					varHistoryKeys = append(varHistoryKeys, sourceInfo.RepoURL)
@@ -2776,8 +2777,8 @@ func printApplicationHistoryTable(revHistory []argoappv1.RevisionHistory) {
 			}
 		} else {
 			rev := depInfo.Source.TargetRevision
-			if len(depInfo.Revision) >= MAX_ALLOWED_REVISIONS {
-				rev = fmt.Sprintf("%s (%s)", rev, depInfo.Revision[0:MAX_ALLOWED_REVISIONS])
+			if len(depInfo.Revision) >= maxAllowedRevisions {
+				rev = fmt.Sprintf("%s (%s)", rev, depInfo.Revision[0:maxAllowedRevisions])
 			}
 			if _, ok := varHistory[depInfo.Source.RepoURL]; !ok {
 				varHistoryKeys = append(varHistoryKeys, depInfo.Source.RepoURL)
@@ -2829,7 +2830,7 @@ func NewApplicationHistoryCommand(clientOpts *argocdclient.ClientOptions) *cobra
 			errors.CheckError(err)
 
 			if output == "id" {
-				printApplicationHistoryIds(app.Status.History)
+				printApplicationHistoryIDs(app.Status.History)
 			} else {
 				printApplicationHistoryTable(app.Status.History)
 			}

--- a/cmd/argocd/commands/app_resources.go
+++ b/cmd/argocd/commands/app_resources.go
@@ -164,12 +164,12 @@ func NewApplicationDeleteResourceCommand(clientOpts *argocdclient.ClientOptions)
 }
 
 func parentChildInfo(nodes []v1alpha1.ResourceNode) (map[string]v1alpha1.ResourceNode, map[string][]string, map[string]struct{}) {
-	mapUidToNode := make(map[string]v1alpha1.ResourceNode)
+	mapUIDToNode := make(map[string]v1alpha1.ResourceNode)
 	mapParentToChild := make(map[string][]string)
 	parentNode := make(map[string]struct{})
 
 	for _, node := range nodes {
-		mapUidToNode[node.UID] = node
+		mapUIDToNode[node.UID] = node
 
 		if len(node.ParentRefs) > 0 {
 			_, ok := mapParentToChild[node.ParentRefs[0].UID]
@@ -182,7 +182,7 @@ func parentChildInfo(nodes []v1alpha1.ResourceNode) (map[string]v1alpha1.Resourc
 			parentNode[node.UID] = struct{}{}
 		}
 	}
-	return mapUidToNode, mapParentToChild, parentNode
+	return mapUIDToNode, mapParentToChild, parentNode
 }
 
 func printDetailedTreeViewAppResourcesNotOrphaned(nodeMapping map[string]v1alpha1.ResourceNode, parentChildMapping map[string][]string, parentNodes map[string]struct{}, w *tabwriter.Writer) {
@@ -216,25 +216,25 @@ func printResources(listAll bool, orphaned bool, appResourceTree *v1alpha1.Appli
 		fmt.Fprintf(w, "GROUP\tKIND\tNAMESPACE\tNAME\tORPHANED\tAGE\tHEALTH\tREASON\n")
 
 		if !orphaned || listAll {
-			mapUidToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.Nodes)
-			printDetailedTreeViewAppResourcesNotOrphaned(mapUidToNode, mapParentToChild, parentNode, w)
+			mapUIDToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.Nodes)
+			printDetailedTreeViewAppResourcesNotOrphaned(mapUIDToNode, mapParentToChild, parentNode, w)
 		}
 
 		if orphaned || listAll {
-			mapUidToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.OrphanedNodes)
-			printDetailedTreeViewAppResourcesOrphaned(mapUidToNode, mapParentToChild, parentNode, w)
+			mapUIDToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.OrphanedNodes)
+			printDetailedTreeViewAppResourcesOrphaned(mapUIDToNode, mapParentToChild, parentNode, w)
 		}
 	case "tree":
 		fmt.Fprintf(w, "GROUP\tKIND\tNAMESPACE\tNAME\tORPHANED\n")
 
 		if !orphaned || listAll {
-			mapUidToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.Nodes)
-			printTreeViewAppResourcesNotOrphaned(mapUidToNode, mapParentToChild, parentNode, w)
+			mapUIDToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.Nodes)
+			printTreeViewAppResourcesNotOrphaned(mapUIDToNode, mapParentToChild, parentNode, w)
 		}
 
 		if orphaned || listAll {
-			mapUidToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.OrphanedNodes)
-			printTreeViewAppResourcesOrphaned(mapUidToNode, mapParentToChild, parentNode, w)
+			mapUIDToNode, mapParentToChild, parentNode := parentChildInfo(appResourceTree.OrphanedNodes)
+			printTreeViewAppResourcesOrphaned(mapUIDToNode, mapParentToChild, parentNode, w)
 		}
 	default:
 		headers := []any{"GROUP", "KIND", "NAMESPACE", "NAME", "ORPHANED"}

--- a/cmd/argocd/commands/applicationset.go
+++ b/cmd/argocd/commands/applicationset.go
@@ -135,8 +135,8 @@ func NewApplicationSetCreateCommand(clientOpts *argocdclient.ClientOptions) *cob
 				os.Exit(1)
 			}
 			argocdClient := headless.NewClientOrDie(clientOpts, c)
-			fileUrl := args[0]
-			appsets, err := cmdutil.ConstructApplicationSet(fileUrl)
+			fileURL := args[0]
+			appsets, err := cmdutil.ConstructApplicationSet(fileURL)
 			errors.CheckError(err)
 
 			if len(appsets) == 0 {
@@ -228,8 +228,8 @@ func NewApplicationSetGenerateCommand(clientOpts *argocdclient.ClientOptions) *c
 				os.Exit(1)
 			}
 			argocdClient := headless.NewClientOrDie(clientOpts, c)
-			fileUrl := args[0]
-			appsets, err := cmdutil.ConstructApplicationSet(fileUrl)
+			fileURL := args[0]
+			appsets, err := cmdutil.ConstructApplicationSet(fileURL)
 			errors.CheckError(err)
 
 			if len(appsets) != 1 {

--- a/cmd/argocd/commands/common_test.go
+++ b/cmd/argocd/commands/common_test.go
@@ -16,7 +16,7 @@ baz: foo
 foo: bar
 `
 
-const expectJsonSingle = `{
+const expectJSONSingle = `{
   "bar": "",
   "baz": "foo",
   "foo": "bar"
@@ -33,7 +33,7 @@ two:
   foo: bar
 `
 
-const expectJsonList = `{
+const expectJSONList = `{
   "one": {
     "bar": "",
     "baz": "foo",
@@ -88,7 +88,7 @@ func Test_PrintResource(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
-	assert.JSONEq(t, expectJsonSingle, str)
+	assert.JSONEq(t, expectJSONSingle, str)
 
 	err = PrintResource(testResource, "unknown")
 	require.Error(t, err)
@@ -123,7 +123,7 @@ func Test_PrintResourceList(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
-	assert.JSONEq(t, expectJsonList, str)
+	assert.JSONEq(t, expectJSONList, str)
 
 	str, err = captureOutput(func() error {
 		err := PrintResourceList(testResource2, "yaml", true)
@@ -137,7 +137,7 @@ func Test_PrintResourceList(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
-	assert.JSONEq(t, expectJsonSingle, str)
+	assert.JSONEq(t, expectJSONSingle, str)
 
 	err = PrintResourceList(testResource, "unknown", false)
 	require.Error(t, err)

--- a/cmd/argocd/commands/tree.go
+++ b/cmd/argocd/commands/tree.go
@@ -36,7 +36,7 @@ func treeViewAppGet(prefix string, uidToNodeMap map[string]v1alpha1.ResourceNode
 		_, _ = fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\n", printPrefix(prefix), parent.Kind+"/"+parent.Name, "", healthStatus, "")
 	}
 	chs := parentToChildMap[parent.UID]
-	for i, childUid := range chs {
+	for i, childUID := range chs {
 		var p string
 		switch i {
 		case len(chs) - 1:
@@ -44,7 +44,7 @@ func treeViewAppGet(prefix string, uidToNodeMap map[string]v1alpha1.ResourceNode
 		default:
 			p = prefix + firstElemPrefix
 		}
-		treeViewAppGet(p, uidToNodeMap, parentToChildMap, uidToNodeMap[childUid], mapNodeNameToResourceState, w)
+		treeViewAppGet(p, uidToNodeMap, parentToChildMap, uidToNodeMap[childUID], mapNodeNameToResourceState, w)
 	}
 }
 

--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -55,7 +55,7 @@ type AppOptions struct {
 	helmSkipTests                   bool
 	helmNamespace                   string
 	helmKubeVersion                 string
-	helmApiVersions                 []string
+	helmApiVersions                 []string //nolint:revive //FIXME(var-naming)
 	project                         string
 	syncPolicy                      string
 	syncOptions                     []string
@@ -81,7 +81,7 @@ type AppOptions struct {
 	kustomizeForceCommonAnnotations bool
 	kustomizeNamespace              string
 	kustomizeKubeVersion            string
-	kustomizeApiVersions            []string
+	kustomizeApiVersions            []string //nolint:revive //FIXME(var-naming)
 	ignoreMissingComponents         bool
 	pluginEnvs                      []string
 	Validate                        bool
@@ -630,7 +630,7 @@ func constructAppsBaseOnName(appName string, labels, annotations, args []string,
 	}, nil
 }
 
-func constructAppsFromFileUrl(fileURL, appName string, labels, annotations, args []string, appOpts AppOptions, flags *pflag.FlagSet) ([]*argoappv1.Application, error) {
+func constructAppsFromFileURL(fileURL, appName string, labels, annotations, args []string, appOpts AppOptions, flags *pflag.FlagSet) ([]*argoappv1.Application, error) {
 	apps := make([]*argoappv1.Application, 0)
 	// read uri
 	err := readAppsFromURI(fileURL, &apps)
@@ -664,7 +664,7 @@ func ConstructApps(fileURL, appName string, labels, annotations, args []string, 
 	if fileURL == "-" {
 		return constructAppsFromStdin()
 	} else if fileURL != "" {
-		return constructAppsFromFileUrl(fileURL, appName, labels, annotations, args, appOpts, flags)
+		return constructAppsFromFileURL(fileURL, appName, labels, annotations, args, appOpts, flags)
 	}
 
 	return constructAppsBaseOnName(appName, labels, annotations, args, appOpts, flags)

--- a/cmd/util/applicationset.go
+++ b/cmd/util/applicationset.go
@@ -13,12 +13,12 @@ import (
 
 func ConstructApplicationSet(fileURL string) ([]*argoprojiov1alpha1.ApplicationSet, error) {
 	if fileURL != "" {
-		return constructAppsetFromFileUrl(fileURL)
+		return constructAppsetFromFileURL(fileURL)
 	}
 	return nil, nil
 }
 
-func constructAppsetFromFileUrl(fileURL string) ([]*argoprojiov1alpha1.ApplicationSet, error) {
+func constructAppsetFromFileURL(fileURL string) ([]*argoprojiov1alpha1.ApplicationSet, error) {
 	appset := make([]*argoprojiov1alpha1.ApplicationSet, 0)
 	// read uri
 	err := readAppsetFromURI(fileURL, &appset)

--- a/cmd/util/cluster.go
+++ b/cmd/util/cluster.go
@@ -169,7 +169,7 @@ type ClusterOptions struct {
 	ExecProviderInstallHint string
 	ClusterEndpoint         string
 	DisableCompression      bool
-	ProxyUrl                string
+	ProxyUrl                string //nolint:revive //FIXME(var-naming)
 }
 
 // InClusterEndpoint returns true if ArgoCD should reference the in-cluster

--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -10,11 +10,11 @@ import (
 type RepoOptions struct {
 	Repo                           appsv1.Repository
 	Upsert                         bool
-	SshPrivateKeyPath              string
+	SshPrivateKeyPath              string //nolint:revive //FIXME(var-naming)
 	InsecureIgnoreHostKey          bool
 	InsecureSkipServerVerification bool
-	TlsClientCertPath              string
-	TlsClientCertKeyPath           string
+	TlsClientCertPath              string //nolint:revive //FIXME(var-naming)
+	TlsClientCertKeyPath           string //nolint:revive //FIXME(var-naming)
 	EnableLfs                      bool
 	EnableOci                      bool
 	GithubAppId                    int64
@@ -24,7 +24,7 @@ type RepoOptions struct {
 	Proxy                          string
 	NoProxy                        string
 	GCPServiceAccountKeyPath       string
-	ForceHttpBasicAuth             bool
+	ForceHttpBasicAuth             bool //nolint:revive //FIXME(var-naming)
 	UseAzureWorkloadIdentity       bool
 }
 

--- a/commitserver/commit/hydratorhelper.go
+++ b/commitserver/commit/hydratorhelper.go
@@ -17,7 +17,7 @@ import (
 
 // WriteForPaths writes the manifests, hydrator.metadata, and README.md files for each path in the provided paths. It
 // also writes a root-level hydrator.metadata file containing the repo URL and dry SHA.
-func WriteForPaths(rootPath string, repoUrl string, drySha string, paths []*apiclient.PathDetails) error {
+func WriteForPaths(rootPath string, repoUrl string, drySha string, paths []*apiclient.PathDetails) error { //nolint:revive //FIXME(var-naming)
 	// Write the top-level readme.
 	err := writeMetadata(rootPath, hydratorMetadataFile{DrySHA: drySha, RepoURL: repoUrl})
 	if err != nil {
@@ -64,13 +64,13 @@ func WriteForPaths(rootPath string, repoUrl string, drySha string, paths []*apic
 
 // writeMetadata writes the metadata to the hydrator.metadata file.
 func writeMetadata(dirPath string, metadata hydratorMetadataFile) error {
-	hydratorMetadataJson, err := json.MarshalIndent(metadata, "", "  ")
+	hydratorMetadataJSON, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal hydrator metadata: %w", err)
 	}
 	// No need to use SecureJoin here, as the path is already sanitized.
 	hydratorMetadataPath := path.Join(dirPath, "hydrator.metadata")
-	err = os.WriteFile(hydratorMetadataPath, hydratorMetadataJson, os.ModePerm)
+	err = os.WriteFile(hydratorMetadataPath, hydratorMetadataJSON, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to write hydrator metadata: %w", err)
 	}

--- a/commitserver/commit/hydratorhelper_test.go
+++ b/commitserver/commit/hydratorhelper_test.go
@@ -16,7 +16,7 @@ import (
 func TestWriteForPaths(t *testing.T) {
 	dir := t.TempDir()
 
-	repoUrl := "https://github.com/example/repo"
+	repoURL := "https://github.com/example/repo"
 	drySha := "abc123"
 	paths := []*apiclient.PathDetails{
 		{
@@ -35,7 +35,7 @@ func TestWriteForPaths(t *testing.T) {
 		},
 	}
 
-	err := WriteForPaths(dir, repoUrl, drySha, paths)
+	err := WriteForPaths(dir, repoURL, drySha, paths)
 	require.NoError(t, err)
 
 	// Check if the top-level hydrator.metadata exists and contains the repo URL and dry SHA
@@ -46,7 +46,7 @@ func TestWriteForPaths(t *testing.T) {
 	var topMetadata hydratorMetadataFile
 	err = json.Unmarshal(topMetadataBytes, &topMetadata)
 	require.NoError(t, err)
-	assert.Equal(t, repoUrl, topMetadata.RepoURL)
+	assert.Equal(t, repoURL, topMetadata.RepoURL)
 	assert.Equal(t, drySha, topMetadata.DrySHA)
 
 	for _, p := range paths {
@@ -64,13 +64,13 @@ func TestWriteForPaths(t *testing.T) {
 		var readMetadata hydratorMetadataFile
 		err = json.Unmarshal(metadataBytes, &readMetadata)
 		require.NoError(t, err)
-		assert.Equal(t, repoUrl, readMetadata.RepoURL)
+		assert.Equal(t, repoURL, readMetadata.RepoURL)
 
 		// Check if each path contains a README.md file and contains the repo URL
 		readmePath := path.Join(fullHydratePath, "README.md")
 		readmeBytes, err := os.ReadFile(readmePath)
 		require.NoError(t, err)
-		assert.Contains(t, string(readmeBytes), repoUrl)
+		assert.Contains(t, string(readmeBytes), repoURL)
 
 		// Check if each path contains a manifest.yaml file and contains the word Pod
 		manifestPath := path.Join(fullHydratePath, "manifest.yaml")

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -343,11 +343,11 @@ func getAppRecursive(r *clustercache.Resource, ns map[kube.ResourceKey]*clusterc
 	for _, ownerRef := range r.OwnerRefs {
 		gv := ownerRefGV(ownerRef)
 		if parent, ok := ns[kube.NewResourceKey(gv.Group, ownerRef.Kind, r.Ref.Namespace, ownerRef.Name)]; ok {
-			visited_branch := make(map[kube.ResourceKey]bool, len(visited))
+			visitedBranch := make(map[kube.ResourceKey]bool, len(visited))
 			for k, v := range visited {
-				visited_branch[k] = v
+				visitedBranch[k] = v
 			}
-			app, ok := getAppRecursive(parent, ns, visited_branch)
+			app, ok := getAppRecursive(parent, ns, visitedBranch)
 			if app != "" || !ok {
 				return app, ok
 			}

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -536,12 +536,12 @@ func Test_getAppRecursive(t *testing.T) {
 
 func TestSkipResourceUpdate(t *testing.T) {
 	var (
-		hash1_x = "x"
-		hash2_y = "y"
-		hash3_x = "x"
+		hash1X = "x"
+		hash2Y = "y"
+		hash3X = "x"
 	)
 	info := &ResourceInfo{
-		manifestHash: hash1_x,
+		manifestHash: hash1X,
 		Health: &health.HealthStatus{
 			Status:  health.HealthStatusHealthy,
 			Message: "default",
@@ -561,51 +561,51 @@ func TestSkipResourceUpdate(t *testing.T) {
 	})
 	t.Run("Same hash", func(t *testing.T) {
 		assert.True(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 		}, &ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 		}))
 	})
 	t.Run("Same hash value", func(t *testing.T) {
 		assert.True(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 		}, &ResourceInfo{
-			manifestHash: hash3_x,
+			manifestHash: hash3X,
 		}))
 	})
 	t.Run("Different hash value", func(t *testing.T) {
 		assert.False(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 		}, &ResourceInfo{
-			manifestHash: hash2_y,
+			manifestHash: hash2Y,
 		}))
 	})
 	t.Run("Same hash, empty health", func(t *testing.T) {
 		assert.True(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 			Health:       &health.HealthStatus{},
 		}, &ResourceInfo{
-			manifestHash: hash3_x,
+			manifestHash: hash3X,
 			Health:       &health.HealthStatus{},
 		}))
 	})
 	t.Run("Same hash, old health", func(t *testing.T) {
 		assert.False(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 			Health: &health.HealthStatus{
 				Status: health.HealthStatusHealthy,
 			},
 		}, &ResourceInfo{
-			manifestHash: hash3_x,
+			manifestHash: hash3X,
 			Health:       nil,
 		}))
 	})
 	t.Run("Same hash, new health", func(t *testing.T) {
 		assert.False(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 			Health:       &health.HealthStatus{},
 		}, &ResourceInfo{
-			manifestHash: hash3_x,
+			manifestHash: hash3X,
 			Health: &health.HealthStatus{
 				Status: health.HealthStatusHealthy,
 			},
@@ -613,13 +613,13 @@ func TestSkipResourceUpdate(t *testing.T) {
 	})
 	t.Run("Same hash, same health", func(t *testing.T) {
 		assert.True(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 			Health: &health.HealthStatus{
 				Status:  health.HealthStatusHealthy,
 				Message: "same",
 			},
 		}, &ResourceInfo{
-			manifestHash: hash3_x,
+			manifestHash: hash3X,
 			Health: &health.HealthStatus{
 				Status:  health.HealthStatusHealthy,
 				Message: "same",
@@ -628,13 +628,13 @@ func TestSkipResourceUpdate(t *testing.T) {
 	})
 	t.Run("Same hash, different health status", func(t *testing.T) {
 		assert.False(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 			Health: &health.HealthStatus{
 				Status:  health.HealthStatusHealthy,
 				Message: "same",
 			},
 		}, &ResourceInfo{
-			manifestHash: hash3_x,
+			manifestHash: hash3X,
 			Health: &health.HealthStatus{
 				Status:  health.HealthStatusDegraded,
 				Message: "same",
@@ -643,13 +643,13 @@ func TestSkipResourceUpdate(t *testing.T) {
 	})
 	t.Run("Same hash, different health message", func(t *testing.T) {
 		assert.True(t, skipResourceUpdate(&ResourceInfo{
-			manifestHash: hash1_x,
+			manifestHash: hash1X,
 			Health: &health.HealthStatus{
 				Status:  health.HealthStatusHealthy,
 				Message: "same",
 			},
 		}, &ResourceInfo{
-			manifestHash: hash3_x,
+			manifestHash: hash3X,
 			Health: &health.HealthStatus{
 				Status:  health.HealthStatusHealthy,
 				Message: "different",

--- a/controller/cache/info_test.go
+++ b/controller/cache/info_test.go
@@ -157,7 +157,7 @@ var (
       ingress:
       - ip: 107.178.210.11`)
 
-	testIngressWithoutTls = strToUnstructured(`
+	testIngressWithoutTLS = strToUnstructured(`
   apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
@@ -1052,7 +1052,7 @@ func TestGetIngressInfoWildCardPath(t *testing.T) {
 
 func TestGetIngressInfoWithoutTls(t *testing.T) {
 	info := &ResourceInfo{}
-	populateNodeInfo(testIngressWithoutTls, info, []string{})
+	populateNodeInfo(testIngressWithoutTLS, info, []string{})
 	assert.Empty(t, info.Info)
 	sort.Slice(info.NetworkingInfo.TargetRefs, func(i, j int) bool {
 		return strings.Compare(info.NetworkingInfo.TargetRefs[j].Name, info.NetworkingInfo.TargetRefs[i].Name) < 0

--- a/controller/hydrator/hydrator.go
+++ b/controller/hydrator/hydrator.go
@@ -269,11 +269,11 @@ func (h *Hydrator) hydrate(logCtx *log.Entry, apps []*appv1.Application) (string
 		// Set up a ManifestsRequest
 		manifestDetails := make([]*commitclient.HydratedManifestDetails, len(objs))
 		for i, obj := range objs {
-			objJson, err := json.Marshal(obj)
+			objJSON, err := json.Marshal(obj)
 			if err != nil {
 				return "", "", fmt.Errorf("failed to marshal object: %w", err)
 			}
-			manifestDetails[i] = &commitclient.HydratedManifestDetails{ManifestJSON: string(objJson)}
+			manifestDetails[i] = &commitclient.HydratedManifestDetails{ManifestJSON: string(objJSON)}
 		}
 
 		paths = append(paths, &commitclient.PathDetails{

--- a/controller/sync_test.go
+++ b/controller/sync_test.go
@@ -464,7 +464,7 @@ func TestNormalizeTargetResourcesWithList(t *testing.T) {
 	type fixture struct {
 		comparisonResult *comparisonResult
 	}
-	setupHttpProxy := func(t *testing.T, ignores []v1alpha1.ResourceIgnoreDifferences) *fixture {
+	setupHTTPProxy := func(t *testing.T, ignores []v1alpha1.ResourceIgnoreDifferences) *fixture {
 		t.Helper()
 		dc, err := diff.NewDiffConfigBuilder().
 			WithDiffSettings(ignores, nil, true, normalizers.IgnoreNormalizerOpts{}).
@@ -494,7 +494,7 @@ func TestNormalizeTargetResourcesWithList(t *testing.T) {
 				// JSONPointers: []string{"/spec/routes"},
 			},
 		}
-		f := setupHttpProxy(t, ignores)
+		f := setupHTTPProxy(t, ignores)
 		target := test.YamlToUnstructured(testdata.TargetHTTPProxy)
 		f.comparisonResult.reconciliationResult.Target = []*unstructured.Unstructured{target}
 
@@ -531,7 +531,7 @@ func TestNormalizeTargetResourcesWithList(t *testing.T) {
 				JQPathExpressions: []string{".spec.template.spec.containers[].env[] | select(.name == \"SOME_ENV_VAR\")"},
 			},
 		}
-		f := setupHttpProxy(t, ignores)
+		f := setupHTTPProxy(t, ignores)
 		live := test.YamlToUnstructured(testdata.LiveDeploymentEnvVarsYaml)
 		target := test.YamlToUnstructured(testdata.TargetDeploymentEnvVarsYaml)
 		f.comparisonResult.reconciliationResult.Live = []*unstructured.Unstructured{live}
@@ -583,7 +583,7 @@ func TestNormalizeTargetResourcesWithList(t *testing.T) {
 				JQPathExpressions: []string{".spec.template.spec.containers[].image"},
 			},
 		}
-		f := setupHttpProxy(t, ignores)
+		f := setupHTTPProxy(t, ignores)
 		live := test.YamlToUnstructured(testdata.MinimalImageReplicaDeploymentYaml)
 		target := test.YamlToUnstructured(testdata.AdditionalImageReplicaDeploymentYaml)
 		f.comparisonResult.reconciliationResult.Live = []*unstructured.Unstructured{live}

--- a/hack/gen-resources/generators/cluster_generator.go
+++ b/hack/gen-resources/generators/cluster_generator.go
@@ -146,7 +146,7 @@ func (cg *ClusterGenerator) installVCluster(opts *util.GenerateOpts, namespace s
 	return nil
 }
 
-func (cg *ClusterGenerator) getClusterServerUri(namespace string, releaseSuffix string) (string, error) {
+func (cg *ClusterGenerator) getClusterServerURI(namespace string, releaseSuffix string) (string, error) {
 	pod, err := cg.clientSet.CoreV1().Pods(namespace).Get(context.TODO(), POD_PREFIX+"-"+releaseSuffix+"-0", metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -156,10 +156,10 @@ func (cg *ClusterGenerator) getClusterServerUri(namespace string, releaseSuffix 
 	return "https://" + pod.Status.PodIP + ":8443", nil
 }
 
-func (cg *ClusterGenerator) retrieveClusterUri(namespace, releaseSuffix string) string {
+func (cg *ClusterGenerator) retrieveClusterURI(namespace, releaseSuffix string) string {
 	for i := 0; i < 10; i++ {
 		log.Print("Attempting to get cluster uri")
-		uri, err := cg.getClusterServerUri(namespace, releaseSuffix)
+		uri, err := cg.getClusterServerURI(namespace, releaseSuffix)
 		if err != nil {
 			log.Printf("Failed to get cluster uri due to %s", err.Error())
 			time.Sleep(10 * time.Second)
@@ -203,7 +203,7 @@ func (cg *ClusterGenerator) generate(i int, opts *util.GenerateOpts) error {
 
 	log.Print("Get cluster server uri")
 
-	uri := cg.retrieveClusterUri(namespace, releaseSuffix)
+	uri := cg.retrieveClusterURI(namespace, releaseSuffix)
 	log.Printf("Cluster server uri is %s", uri)
 
 	log.Print("Create cluster")

--- a/hack/gen-resources/generators/repo_generator.go
+++ b/hack/gen-resources/generators/repo_generator.go
@@ -19,7 +19,7 @@ import (
 
 type Repo struct {
 	Id  int    `json:"id"`
-	Url string `json:"html_url"`
+	Url string `json:"html_url"` //nolint:revive //FIXME(var-naming)
 }
 
 type RepoGenerator struct {

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -119,7 +119,7 @@ type ClientOptions struct {
 	PortForward          bool
 	PortForwardNamespace string
 	Headers              []string
-	HttpRetryMax         int
+	HttpRetryMax         int //nolint:revive //FIXME(var-naming)
 	KubeOverrides        *clientcmd.ConfigOverrides
 	AppControllerName    string
 	ServerName           string

--- a/pkg/apis/application/v1alpha1/applicationset_types.go
+++ b/pkg/apis/application/v1alpha1/applicationset_types.go
@@ -448,7 +448,7 @@ type SCMProviderGenerator struct {
 	// If you add a new SCM provider, update CustomApiUrl below.
 }
 
-func (g *SCMProviderGenerator) CustomApiUrl() string {
+func (g *SCMProviderGenerator) CustomApiUrl() string { //nolint:revive //FIXME(var-naming)
 	switch {
 	case g.Github != nil:
 		return g.Github.API
@@ -615,7 +615,7 @@ type PullRequestGenerator struct {
 	// If you add a new SCM provider, update CustomApiUrl below.
 }
 
-func (p *PullRequestGenerator) CustomApiUrl() string {
+func (p *PullRequestGenerator) CustomApiUrl() string { //nolint:revive //FIXME(var-naming)
 	if p.Github != nil {
 		return p.Github.API
 	}

--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -46,7 +46,7 @@ type RepoCreds struct {
 	// Proxy specifies the HTTP/HTTPS proxy used to access repos at the repo server
 	Proxy string `json:"proxy,omitempty" protobuf:"bytes,19,opt,name=proxy"`
 	// ForceHttpBasicAuth specifies whether Argo CD should attempt to force basic auth for HTTP connections
-	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty" protobuf:"bytes,20,opt,name=forceHttpBasicAuth"`
+	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty" protobuf:"bytes,20,opt,name=forceHttpBasicAuth"` //nolint:revive //FIXME(var-naming)
 	// NoProxy specifies a list of targets where the proxy isn't used, applies only in cases where the proxy is applied
 	NoProxy string `json:"noProxy,omitempty" protobuf:"bytes,23,opt,name=noProxy"`
 	// UseAzureWorkloadIdentity specifies whether to use Azure Workload Identity for authentication
@@ -99,7 +99,7 @@ type Repository struct {
 	// GCPServiceAccountKey specifies the service account key in JSON format to be used for getting credentials to Google Cloud Source repos
 	GCPServiceAccountKey string `json:"gcpServiceAccountKey,omitempty" protobuf:"bytes,21,opt,name=gcpServiceAccountKey"`
 	// ForceHttpBasicAuth specifies whether Argo CD should attempt to force basic auth for HTTP connections
-	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty" protobuf:"bytes,22,opt,name=forceHttpBasicAuth"`
+	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty" protobuf:"bytes,22,opt,name=forceHttpBasicAuth"` //nolint:revive //FIXME(var-naming)
 	// NoProxy specifies a list of targets where the proxy isn't used, applies only in cases where the proxy is applied
 	NoProxy string `json:"noProxy,omitempty" protobuf:"bytes,23,opt,name=noProxy"`
 	// UseAzureWorkloadIdentity specifies whether to use Azure Workload Identity for authentication

--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -928,7 +928,7 @@ type ApplicationSourcePluginParameter struct {
 	// Name is the name identifying a parameter.
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	// String_ is the value of a string type parameter.
-	String_ *string `json:"string,omitempty" protobuf:"bytes,5,opt,name=string"`
+	String_ *string `json:"string,omitempty" protobuf:"bytes,5,opt,name=string"` //nolint:revive //FIXME(var-naming)
 	// Map is the value of a map type parameter.
 	*OptionalMap `json:",omitempty" protobuf:"bytes,3,rep,name=map"`
 	// Array is the value of an array type parameter.
@@ -2136,7 +2136,7 @@ func (c *ClusterInfo) GetKubeVersion() string {
 	return c.ServerVersion
 }
 
-func (c *ClusterInfo) GetApiVersions() []string {
+func (c *ClusterInfo) GetApiVersions() []string { //nolint:revive //FIXME(var-naming)
 	return c.APIVersions
 }
 
@@ -2212,7 +2212,7 @@ type ClusterConfig struct {
 	DisableCompression bool `json:"disableCompression,omitempty" protobuf:"bytes,7,opt,name=disableCompression"`
 
 	// ProxyURL is the URL to the proxy to be used for all requests send to the server
-	ProxyUrl string `json:"proxyUrl,omitempty" protobuf:"bytes,8,opt,name=proxyUrl"`
+	ProxyUrl string `json:"proxyUrl,omitempty" protobuf:"bytes,8,opt,name=proxyUrl"` //nolint:revive //FIXME(var-naming)
 }
 
 // TLSClientConfig contains settings to enable transport layer security
@@ -3340,7 +3340,7 @@ func SetK8SConfigDefaults(config *rest.Config) error {
 }
 
 // ParseProxyUrl returns a parsed url and verifies that schema is correct
-func ParseProxyUrl(proxyUrl string) (*url.URL, error) {
+func ParseProxyUrl(proxyUrl string) (*url.URL, error) { //nolint:revive //FIXME(var-naming)
 	u, err := url.Parse(proxyUrl)
 	if err != nil {
 		return nil, err

--- a/pkg/apis/application/v1alpha1/types_test.go
+++ b/pkg/apis/application/v1alpha1/types_test.go
@@ -3946,9 +3946,9 @@ func TestApplicationSourcePluginParameters_Environ_string(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, environ, 2)
 	assert.Contains(t, environ, "PARAM_VERSION=1.2.3")
-	paramsJson, err := json.Marshal(params)
+	paramsJSON, err := json.Marshal(params)
 	require.NoError(t, err)
-	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJson))
+	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJSON))
 }
 
 func TestApplicationSourcePluginParameters_Environ_array(t *testing.T) {
@@ -3963,9 +3963,9 @@ func TestApplicationSourcePluginParameters_Environ_array(t *testing.T) {
 	assert.Len(t, environ, 3)
 	assert.Contains(t, environ, "PARAM_DEPENDENCIES_0=redis")
 	assert.Contains(t, environ, "PARAM_DEPENDENCIES_1=minio")
-	paramsJson, err := json.Marshal(params)
+	paramsJSON, err := json.Marshal(params)
 	require.NoError(t, err)
-	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJson))
+	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJSON))
 }
 
 func TestApplicationSourcePluginParameters_Environ_map(t *testing.T) {
@@ -3985,9 +3985,9 @@ func TestApplicationSourcePluginParameters_Environ_map(t *testing.T) {
 	assert.Len(t, environ, 3)
 	assert.Contains(t, environ, "PARAM_HELM_PARAMETERS_IMAGE_REPO=quay.io/argoproj/argo-cd")
 	assert.Contains(t, environ, "PARAM_HELM_PARAMETERS_IMAGE_TAG=v2.4.0")
-	paramsJson, err := json.Marshal(params)
+	paramsJSON, err := json.Marshal(params)
 	require.NoError(t, err)
-	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJson))
+	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJSON))
 }
 
 func TestApplicationSourcePluginParameters_Environ_all(t *testing.T) {
@@ -4016,9 +4016,9 @@ func TestApplicationSourcePluginParameters_Environ_all(t *testing.T) {
 	assert.Contains(t, environ, "PARAM_SOME_NAME_1=minio")
 	assert.Contains(t, environ, "PARAM_SOME_NAME_IMAGE_REPO=quay.io/argoproj/argo-cd")
 	assert.Contains(t, environ, "PARAM_SOME_NAME_IMAGE_TAG=v2.4.0")
-	paramsJson, err := json.Marshal(params)
+	paramsJSON, err := json.Marshal(params)
 	require.NoError(t, err)
-	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJson))
+	assert.Contains(t, environ, fmt.Sprintf("ARGOCD_APP_PARAMETERS=%s", paramsJSON))
 }
 
 func getApplicationSpec() *ApplicationSpec {

--- a/reposerver/cache/cache.go
+++ b/reposerver/cache/cache.go
@@ -145,15 +145,15 @@ func listApps(repoURL, revision string) string {
 	return fmt.Sprintf("ldir|%s|%s", repoURL, revision)
 }
 
-func (c *Cache) ListApps(repoUrl, revision string) (map[string]string, error) {
+func (c *Cache) ListApps(repoURL, revision string) (map[string]string, error) {
 	res := make(map[string]string)
-	err := c.cache.GetItem(listApps(repoUrl, revision), &res)
+	err := c.cache.GetItem(listApps(repoURL, revision), &res)
 	return res, err
 }
 
-func (c *Cache) SetApps(repoUrl, revision string, apps map[string]string) error {
+func (c *Cache) SetApps(repoURL, revision string, apps map[string]string) error {
 	return c.cache.SetItem(
-		listApps(repoUrl, revision),
+		listApps(repoURL, revision),
 		apps,
 		&cacheutil.CacheActionOpts{
 			Expiration: c.repoCacheExpiration,

--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -968,9 +968,9 @@ func getHelmRepos(appPath string, repositories []*v1alpha1.Repository, helmRepoC
 		return nil, fmt.Errorf("error retrieving helm dependency repos: %w", err)
 	}
 	reposByName := make(map[string]*v1alpha1.Repository)
-	reposByUrl := make(map[string]*v1alpha1.Repository)
+	reposByURL := make(map[string]*v1alpha1.Repository)
 	for _, repo := range repositories {
-		reposByUrl[repo.Repo] = repo
+		reposByURL[repo.Repo] = repo
 		if repo.Name != "" {
 			reposByName[repo.Name] = repo
 		}
@@ -979,7 +979,7 @@ func getHelmRepos(appPath string, repositories []*v1alpha1.Repository, helmRepoC
 	repos := make([]helm.HelmRepository, 0)
 	for _, dep := range dependencies {
 		// find matching repo credentials by URL or name
-		repo, ok := reposByUrl[dep.Repo]
+		repo, ok := reposByURL[dep.Repo]
 		if !ok && dep.Name != "" {
 			repo, ok = reposByName[dep.Name]
 		}
@@ -1681,7 +1681,7 @@ func findManifests(logCtx *log.Entry, appPath string, repoRoot string, env *v1al
 			if !discovery.IsManifestGenerationEnabled(v1alpha1.ApplicationSourceTypeDirectory, enabledManifestGeneration) {
 				continue
 			}
-			vm, err := makeJsonnetVm(appPath, repoRoot, directory.Jsonnet, env)
+			vm, err := makeJsonnetVM(appPath, repoRoot, directory.Jsonnet, env)
 			if err != nil {
 				return nil, err
 			}
@@ -1704,7 +1704,7 @@ func findManifests(logCtx *log.Entry, appPath string, repoRoot string, env *v1al
 				objs = append(objs, &jsonObj)
 			}
 		} else {
-			err := getObjsFromYAMLOrJson(logCtx, manifestPath, manifestFileInfo.Name(), &objs)
+			err := getObjsFromYAMLOrJSON(logCtx, manifestPath, manifestFileInfo.Name(), &objs)
 			if err != nil {
 				return nil, err
 			}
@@ -1713,8 +1713,8 @@ func findManifests(logCtx *log.Entry, appPath string, repoRoot string, env *v1al
 	return objs, nil
 }
 
-// getObjsFromYAMLOrJson unmarshals the given yaml or json file and appends it to the given list of objects.
-func getObjsFromYAMLOrJson(logCtx *log.Entry, manifestPath string, filename string, objs *[]*unstructured.Unstructured) error {
+// getObjsFromYAMLOrJSON unmarshals the given yaml or json file and appends it to the given list of objects.
+func getObjsFromYAMLOrJSON(logCtx *log.Entry, manifestPath string, filename string, objs *[]*unstructured.Unstructured) error {
 	reader, err := utfutil.OpenFile(manifestPath, utfutil.UTF8)
 	if err != nil {
 		return status.Errorf(codes.FailedPrecondition, "Failed to open %q", manifestPath)
@@ -1902,7 +1902,7 @@ func getPotentiallyValidManifests(logCtx *log.Entry, appPath string, repoRoot st
 	return potentiallyValidManifests, nil
 }
 
-func makeJsonnetVm(appPath string, repoRoot string, sourceJsonnet v1alpha1.ApplicationSourceJsonnet, env *v1alpha1.Env) (*jsonnet.VM, error) {
+func makeJsonnetVM(appPath string, repoRoot string, sourceJsonnet v1alpha1.ApplicationSourceJsonnet, env *v1alpha1.Env) (*jsonnet.VM, error) {
 	vm := jsonnet.MakeVM()
 	for i, j := range sourceJsonnet.TLAs {
 		sourceJsonnet.TLAs[i].Value = env.Envsubst(j.Value)

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -3101,8 +3101,8 @@ func Test_walkHelmValueFilesInPath(t *testing.T) {
 	t.Run("unrelated root", func(t *testing.T) {
 		var files []string
 		root := "./testdata/values-files"
-		unrelated_root := "/different/root/path"
-		err := filepath.Walk(root, walkHelmValueFilesInPath(unrelated_root, &files))
+		unrelatedRoot := "/different/root/path"
+		err := filepath.Walk(root, walkHelmValueFilesInPath(unrelatedRoot, &files))
 		require.Error(t, err)
 	})
 }
@@ -3990,8 +3990,8 @@ func TestGetRefs_CacheUnlockedOnUpdateFailed(t *testing.T) {
 	})
 	cacheMocks := newCacheMocks()
 	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
-	repoUrl := "file://" + dir
-	client, err := git.NewClient(repoUrl, git.NopCreds{}, true, false, "", "", git.WithCache(cacheMocks.cache, true))
+	repoURL := "file://" + dir
+	client, err := git.NewClient(repoURL, git.NopCreds{}, true, false, "", "", git.WithCache(cacheMocks.cache, true))
 	require.NoError(t, err)
 	refs, err := client.LsRefs()
 	require.NoError(t, err)
@@ -3999,7 +3999,7 @@ func TestGetRefs_CacheUnlockedOnUpdateFailed(t *testing.T) {
 	assert.NotEmpty(t, refs.Branches, "Expected branches to be populated")
 	assert.NotEmpty(t, refs.Branches[0])
 	var output [][2]string
-	err = cacheMocks.cacheutilCache.GetItem(fmt.Sprintf("git-refs|%s|%s", repoUrl, common.CacheVersion), &output)
+	err = cacheMocks.cacheutilCache.GetItem(fmt.Sprintf("git-refs|%s|%s", repoURL, common.CacheVersion), &output)
 	require.Error(t, err, "Should be a cache miss")
 	assert.Empty(t, output, "Expected cache to be empty for key")
 	cacheMocks.mockCache.AssertNumberOfCalls(t, "UnlockGitReferences", 0)
@@ -4019,10 +4019,10 @@ func TestGetRefs_CacheLockTryLockGitRefCacheError(t *testing.T) {
 	})
 	cacheMocks := newCacheMocks()
 	t.Cleanup(cacheMocks.mockCache.StopRedisCallback)
-	repoUrl := "file://" + dir
+	repoURL := "file://" + dir
 	// buf := bytes.Buffer{}
 	// log.SetOutput(&buf)
-	client, err := git.NewClient(repoUrl, git.NopCreds{}, true, false, "", "", git.WithCache(cacheMocks.cache, true))
+	client, err := git.NewClient(repoURL, git.NopCreds{}, true, false, "", "", git.WithCache(cacheMocks.cache, true))
 	require.NoError(t, err)
 	refs, err := client.LsRefs()
 	require.NoError(t, err)
@@ -4048,8 +4048,8 @@ func TestGetRevisionChartDetails(t *testing.T) {
 	t.Run("Test GetRevisionChartDetails", func(t *testing.T) {
 		root := t.TempDir()
 		service := newService(t, root)
-		repoUrl := "file://" + root
-		err := service.cache.SetRevisionChartDetails(repoUrl, "my-chart", "1.1.0", &v1alpha1.ChartDetails{
+		repoURL := "file://" + root
+		err := service.cache.SetRevisionChartDetails(repoURL, "my-chart", "1.1.0", &v1alpha1.ChartDetails{
 			Description: "test-description",
 			Home:        "test-home",
 			Maintainers: []string{"test-maintainer"},

--- a/reposerver/repository/types.go
+++ b/reposerver/repository/types.go
@@ -10,5 +10,5 @@ type Chart struct {
 type Maintainer struct {
 	Name  string `yaml:"name,omitempty"`
 	Email string `yaml:"email,omitempty"`
-	Url   string `yaml:"url,omitempty"`
+	Url   string `yaml:"url,omitempty"` //nolint:revive //FIXME(var-naming)
 }

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -148,7 +148,7 @@ func (s *Server) CanI(ctx context.Context, r *account.CanIRequest) (*account.Can
 	return &account.CanIResponse{Value: "no"}, nil
 }
 
-func toApiAccount(name string, a settings.Account) *account.Account {
+func toAPIAccount(name string, a settings.Account) *account.Account {
 	var capabilities []string
 	for _, c := range a.Capabilities {
 		capabilities = append(capabilities, string(c))
@@ -190,7 +190,7 @@ func (s *Server) ListAccounts(ctx context.Context, _ *account.ListAccountRequest
 	}
 	for name, a := range accounts {
 		if err := s.ensureHasAccountPermission(ctx, rbacpolicy.ActionGet, name); err == nil {
-			resp.Items = append(resp.Items, toApiAccount(name, a))
+			resp.Items = append(resp.Items, toAPIAccount(name, a))
 		}
 	}
 	sort.Slice(resp.Items, func(i, j int) bool {
@@ -208,7 +208,7 @@ func (s *Server) GetAccount(ctx context.Context, r *account.GetAccountRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to get account %s: %w", r.Name, err)
 	}
-	return toApiAccount(r.Name, *a), nil
+	return toAPIAccount(r.Name, *a), nil
 }
 
 // CreateToken creates a token

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -2257,12 +2257,12 @@ func (s *Server) resolveRevision(ctx context.Context, app *v1alpha1.Application,
 
 	ambiguousRevision := getAmbiguousRevision(app, syncReq, sourceIndex)
 
-	repoUrl := app.Spec.GetSource().RepoURL
+	repoURL := app.Spec.GetSource().RepoURL
 	if app.Spec.HasMultipleSources() {
-		repoUrl = app.Spec.Sources[sourceIndex].RepoURL
+		repoURL = app.Spec.Sources[sourceIndex].RepoURL
 	}
 
-	repo, err := s.db.GetRepository(ctx, repoUrl, app.Spec.Project)
+	repo, err := s.db.GetRepository(ctx, repoURL, app.Spec.Project)
 	if err != nil {
 		return "", "", fmt.Errorf("error getting repository by URL: %w", err)
 	}

--- a/server/project/project.go
+++ b/server/project/project.go
@@ -374,8 +374,8 @@ func (s *Server) Update(ctx context.Context, q *project.ProjectUpdateRequest) (*
 		}
 	}
 
-	for _, repoUrl := range difference(q.Project.Spec.SourceRepos, oldProj.Spec.SourceRepos) {
-		if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceRepositories, rbacpolicy.ActionUpdate, repoUrl); err != nil {
+	for _, repoURL := range difference(q.Project.Spec.SourceRepos, oldProj.Spec.SourceRepos) {
+		if err := s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceRepositories, rbacpolicy.ActionUpdate, repoURL); err != nil {
 			return nil, err
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1406,8 +1406,8 @@ func TestIsMainJsBundle(t *testing.T) {
 		testCaseCopy := testCase
 		t.Run(testCaseCopy.name, func(t *testing.T) {
 			t.Parallel()
-			testUrl, _ := url.Parse(testCaseCopy.url)
-			isMainJsBundle := isMainJsBundle(testUrl)
+			testURL, _ := url.Parse(testCaseCopy.url)
+			isMainJsBundle := isMainJsBundle(testURL)
 			assert.Equal(t, testCaseCopy.isMainJsBundle, isMainJsBundle)
 		})
 	}

--- a/test/e2e/custom_tool_test.go
+++ b/test/e2e/custom_tool_test.go
@@ -188,16 +188,16 @@ func TestCustomToolWithEnv(t *testing.T) {
 			assert.Equal(t, expectedKubeVersion, output)
 		}).
 		And(func(_ *Application) {
-			expectedApiVersion := fixture.GetApiResources()
-			expectedApiVersionSlice := strings.Split(expectedApiVersion, ",")
-			sort.Strings(expectedApiVersionSlice)
+			expectedAPIVersion := fixture.GetApiResources()
+			expectedAPIVersionSlice := strings.Split(expectedAPIVersion, ",")
+			sort.Strings(expectedAPIVersionSlice)
 
 			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeApiVersion}")
 			require.NoError(t, err)
 			outputSlice := strings.Split(output, ",")
 			sort.Strings(outputSlice)
 
-			assert.EqualValues(t, expectedApiVersionSlice, outputSlice)
+			assert.EqualValues(t, expectedAPIVersionSlice, outputSlice)
 		})
 }
 
@@ -332,16 +332,16 @@ func TestCMPDiscoverWithFindCommandWithEnv(t *testing.T) {
 			assert.Equal(t, expectedKubeVersion, output)
 		}).
 		And(func(_ *Application) {
-			expectedApiVersion := fixture.GetApiResources()
-			expectedApiVersionSlice := strings.Split(expectedApiVersion, ",")
-			sort.Strings(expectedApiVersionSlice)
+			expectedAPIVersion := fixture.GetApiResources()
+			expectedAPIVersionSlice := strings.Split(expectedAPIVersion, ",")
+			sort.Strings(expectedAPIVersionSlice)
 
 			output, err := fixture.Run("", "kubectl", "-n", fixture.DeploymentNamespace(), "get", "cm", ctx.AppName(), "-o", "jsonpath={.metadata.annotations.KubeApiVersion}")
 			require.NoError(t, err)
 			outputSlice := strings.Split(output, ",")
 			sort.Strings(outputSlice)
 
-			assert.EqualValues(t, expectedApiVersionSlice, outputSlice)
+			assert.EqualValues(t, expectedAPIVersionSlice, outputSlice)
 		})
 }
 

--- a/test/e2e/fixture/app/actions.go
+++ b/test/e2e/fixture/app/actions.go
@@ -333,7 +333,7 @@ func (a *Actions) PatchApp(patch string) *Actions {
 	return a
 }
 
-func (a *Actions) PatchAppHttp(patch string) *Actions {
+func (a *Actions) PatchAppHttp(patch string) *Actions { //nolint:revive //FIXME(var-naming)
 	a.context.t.Helper()
 	var application Application
 	patchType := "merge"

--- a/test/e2e/fixture/applicationsets/utils/fixture.go
+++ b/test/e2e/fixture/applicationsets/utils/fixture.go
@@ -363,7 +363,7 @@ func init() {
 }
 
 // PrettyPrintJson is a utility function for debugging purposes
-func PrettyPrintJson(obj any) string {
+func PrettyPrintJson(obj any) string { //nolint:revive //FIXME(var-naming)
 	bytes, err := json.MarshalIndent(obj, "", "    ")
 	if err != nil {
 		return err.Error()
@@ -372,7 +372,7 @@ func PrettyPrintJson(obj any) string {
 }
 
 // returns dns friends string which is no longer than 63 characters and has specified postfix at the end
-func DnsFriendly(str string, postfix string) string {
+func DnsFriendly(str string, postfix string) string { //nolint:revive //FIXME(var-naming)
 	matchFirstCap := regexp.MustCompile("(.)([A-Z][a-z]+)")
 	matchAllCap := regexp.MustCompile("([a-z0-9])([A-Z])")
 

--- a/test/e2e/fixture/fixture.go
+++ b/test/e2e/fixture/fixture.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	defaultApiServer        = "localhost:8080"
+	defaultAPIServer        = "localhost:8080"
 	defaultAdminPassword    = "password"
 	defaultAdminUsername    = "admin"
 	DefaultTestUserPassword = "password"
@@ -180,7 +180,7 @@ func init() {
 	DynamicClientset = dynamic.NewForConfigOrDie(config)
 	KubeConfig = config
 
-	apiServerAddress = GetEnvWithDefault(apiclient.EnvArgoCDServer, defaultApiServer)
+	apiServerAddress = GetEnvWithDefault(apiclient.EnvArgoCDServer, defaultAPIServer)
 	adminUsername = GetEnvWithDefault(EnvAdminUsername, defaultAdminUsername)
 	AdminPassword = GetEnvWithDefault(EnvAdminPassword, defaultAdminPassword)
 
@@ -1303,7 +1303,7 @@ func RecordTestRun(t *testing.T) {
 	}
 }
 
-func GetApiServerAddress() string {
+func GetApiServerAddress() string { //nolint:revive //FIXME(var-naming)
 	return apiServerAddress
 }
 

--- a/test/e2e/fixture/http.go
+++ b/test/e2e/fixture/http.go
@@ -12,22 +12,22 @@ import (
 )
 
 // DoHttpRequest executes a http request against the Argo CD API server
-func DoHttpRequest(method string, path string, host string, data ...byte) (*http.Response, error) {
-	reqUrl, err := url.Parse(path)
+func DoHttpRequest(method string, path string, host string, data ...byte) (*http.Response, error) { //nolint:revive //FIXME(var-naming)
+	reqURL, err := url.Parse(path)
 	if err != nil {
 		return nil, err
 	}
-	reqUrl.Scheme = "http"
+	reqURL.Scheme = "http"
 	if host != "" {
-		reqUrl.Host = host
+		reqURL.Host = host
 	} else {
-		reqUrl.Host = apiServerAddress
+		reqURL.Host = apiServerAddress
 	}
 	var body io.Reader
 	if data != nil {
 		body = bytes.NewReader(data)
 	}
-	req, err := http.NewRequest(method, reqUrl.String(), body)
+	req, err := http.NewRequest(method, reqURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func DoHttpRequest(method string, path string, host string, data ...byte) (*http
 }
 
 // DoHttpJsonRequest executes a http request against the Argo CD API server and unmarshals the response body as JSON
-func DoHttpJsonRequest(method string, path string, result any, data ...byte) error {
+func DoHttpJsonRequest(method string, path string, result any, data ...byte) error { //nolint:revive //FIXME(var-naming)
 	resp, err := DoHttpRequest(method, path, "", data...)
 	if err != nil {
 		return err

--- a/test/e2e/fixture/util.go
+++ b/test/e2e/fixture/util.go
@@ -16,7 +16,7 @@ var (
 )
 
 // returns dns friends string which is no longer than 63 characters and has specified postfix at the end
-func DnsFriendly(str string, postfix string) string {
+func DnsFriendly(str string, postfix string) string { //nolint:revive //FIXME(var-naming)
 	str = matchFirstCap.ReplaceAllString(str, "${1}-${2}")
 	str = matchAllCap.ReplaceAllString(str, "${1}-${2}")
 	str = strings.ToLower(str)

--- a/test/e2e/fixture/versions.go
+++ b/test/e2e/fixture/versions.go
@@ -36,7 +36,7 @@ func GetVersions() *Versions {
 	return version
 }
 
-func GetApiResources() string {
+func GetApiResources() string { //nolint:revive //FIXME(var-naming)
 	kubectl := kubeutil.NewKubectl()
 	resources := errors.FailOnErr(kubectl.GetAPIResources(KubeConfig, false, cache.NewNoopSettings())).([]kube.APIResourceInfo)
 	return strings.Join(argo.APIResourcesToStrings(resources, true), ",")

--- a/test/e2e/repo_management_test.go
+++ b/test/e2e/repo_management_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestAddRemovePublicRepo(t *testing.T) {
 	app.Given(t).And(func() {
-		repoUrl := fixture.RepoURL(fixture.RepoURLTypeFile)
-		_, err := fixture.RunCli("repo", "add", repoUrl)
+		repoURL := fixture.RepoURL(fixture.RepoURLTypeFile)
+		_, err := fixture.RunCli("repo", "add", repoURL)
 		require.NoError(t, err)
 
 		conn, repoClient, err := fixture.ArgoCDClientset.NewRepoClient()
@@ -31,21 +31,21 @@ func TestAddRemovePublicRepo(t *testing.T) {
 		require.NoError(t, err)
 		exists := false
 		for i := range repo.Items {
-			if repo.Items[i].Repo == repoUrl {
+			if repo.Items[i].Repo == repoURL {
 				exists = true
 				break
 			}
 		}
 		assert.True(t, exists)
 
-		_, err = fixture.RunCli("repo", "rm", repoUrl)
+		_, err = fixture.RunCli("repo", "rm", repoURL)
 		require.NoError(t, err)
 
 		repo, err = repoClient.ListRepositories(context.Background(), &repositorypkg.RepoQuery{})
 		require.NoError(t, err)
 		exists = false
 		for i := range repo.Items {
-			if repo.Items[i].Repo == repoUrl {
+			if repo.Items[i].Repo == repoURL {
 				exists = true
 				break
 			}
@@ -59,10 +59,10 @@ func TestGetRepoWithInheritedCreds(t *testing.T) {
 		// create repo credentials
 		FailOnErr(fixture.RunCli("repocreds", "add", fixture.RepoURL(fixture.RepoURLTypeHTTPSOrg), "--github-app-id", fixture.GithubAppID, "--github-app-installation-id", fixture.GithubAppInstallationID, "--github-app-private-key-path", repos.CertKeyPath))
 
-		repoUrl := fixture.RepoURL(fixture.RepoURLTypeHTTPS)
+		repoURL := fixture.RepoURL(fixture.RepoURLTypeHTTPS)
 
 		// Hack: First we need to create repo with valid credentials
-		FailOnErr(fixture.RunCli("repo", "add", repoUrl, "--username", fixture.GitUsername, "--password", fixture.GitPassword, "--insecure-skip-server-verification"))
+		FailOnErr(fixture.RunCli("repo", "add", repoURL, "--username", fixture.GitUsername, "--password", fixture.GitPassword, "--insecure-skip-server-verification"))
 
 		// Then, we remove username/password so that the repo inherits the credentials from our repocreds
 		conn, repoClient, err := fixture.ArgoCDClientset.NewRepoClient()
@@ -71,31 +71,31 @@ func TestGetRepoWithInheritedCreds(t *testing.T) {
 
 		_, err = repoClient.UpdateRepository(context.Background(), &repositorypkg.RepoUpdateRequest{
 			Repo: &v1alpha1.Repository{
-				Repo: repoUrl,
+				Repo: repoURL,
 			},
 		})
 		require.NoError(t, err)
 
 		// CLI output should indicate that repo has inherited credentials
-		out, err := fixture.RunCli("repo", "get", repoUrl)
+		out, err := fixture.RunCli("repo", "get", repoURL)
 		require.NoError(t, err)
 		assert.Contains(t, out, "inherited")
 
-		_, err = fixture.RunCli("repo", "rm", repoUrl)
+		_, err = fixture.RunCli("repo", "rm", repoURL)
 		require.NoError(t, err)
 	})
 }
 
 func TestUpsertExistingRepo(t *testing.T) {
 	app.Given(t).And(func() {
-		repoUrl := fixture.RepoURL(fixture.RepoURLTypeFile)
-		_, err := fixture.RunCli("repo", "add", repoUrl)
+		repoURL := fixture.RepoURL(fixture.RepoURLTypeFile)
+		_, err := fixture.RunCli("repo", "add", repoURL)
 		require.NoError(t, err)
 
-		_, err = fixture.RunCli("repo", "add", repoUrl, "--username", fixture.GitUsername, "--password", fixture.GitPassword)
+		_, err = fixture.RunCli("repo", "add", repoURL, "--username", fixture.GitUsername, "--password", fixture.GitPassword)
 		require.Error(t, err)
 
-		_, err = fixture.RunCli("repo", "add", repoUrl, "--upsert", "--username", fixture.GitUsername, "--password", fixture.GitPassword)
+		_, err = fixture.RunCli("repo", "add", repoURL, "--upsert", "--username", fixture.GitUsername, "--password", fixture.GitPassword)
 		require.NoError(t, err)
 	})
 }

--- a/util/argo/argo.go
+++ b/util/argo/argo.go
@@ -66,8 +66,8 @@ func AugmentSyncMsg(res common.ResourceSyncResult, apiResourceInfoGetter func() 
 // getAPIResourceInfo gets Kubernetes API resource info for the given group and kind. If there's a matching resource
 // group _and_ kind, it will return the resource info. If there's a matching kind but no matching group, it will
 // return the first resource info that matches the kind. If there's no matching kind, it will return nil.
-func getAPIResourceInfo(group, kind string, getApiResourceInfo func() ([]kube.APIResourceInfo, error)) (*kube.APIResourceInfo, error) {
-	apiResources, err := getApiResourceInfo()
+func getAPIResourceInfo(group, kind string, getAPIResourceInfo func() ([]kube.APIResourceInfo, error)) (*kube.APIResourceInfo, error) {
+	apiResources, err := getAPIResourceInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API resource info: %w", err)
 	}

--- a/util/argo/normalizers/diff_normalizer.go
+++ b/util/argo/normalizers/diff_normalizer.go
@@ -70,8 +70,8 @@ type jqNormalizerPatch struct {
 }
 
 func (np *jqNormalizerPatch) Apply(data []byte) ([]byte, error) {
-	dataJson := make(map[string]any)
-	err := json.Unmarshal(data, &dataJson)
+	dataJSON := make(map[string]any)
+	err := json.Unmarshal(data, &dataJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (np *jqNormalizerPatch) Apply(data []byte) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), np.jqExecutionTimeout)
 	defer cancel()
 
-	iter := np.code.RunWithContext(ctx, dataJson)
+	iter := np.code.RunWithContext(ctx, dataJSON)
 	first, ok := iter.Next()
 	if !ok {
 		return nil, errors.New("JQ patch did not return any data")

--- a/util/cert/cert_test.go
+++ b/util/cert/cert_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	Test_Cert1CN            = "CN=foo.example.com,OU=SpecOps,O=Capone\\, Inc,L=Chicago,ST=IL,C=US"
-	Test_Cert2CN            = "CN=bar.example.com,OU=Testsuite,O=Testing Corp,L=Hanover,ST=Lower Saxony,C=DE"
-	Test_TLSValidSingleCert = `
+	TestCert1CN            = "CN=foo.example.com,OU=SpecOps,O=Capone\\, Inc,L=Chicago,ST=IL,C=US"
+	TestCert2CN            = "CN=bar.example.com,OU=Testsuite,O=Testing Corp,L=Hanover,ST=Lower Saxony,C=DE"
+	TestTLSValidSingleCert = `
 -----BEGIN CERTIFICATE-----
 MIIFvTCCA6WgAwIBAgIUGrTmW3qc39zqnE08e3qNDhUkeWswDQYJKoZIhvcNAQEL
 BQAwbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAklMMRAwDgYDVQQHDAdDaGljYWdv
@@ -51,7 +51,7 @@ xO7Tr5lAo74vNUkF2EHNaI28/RGnJPm2TIxZqy4rNH6L
 `
 )
 
-const Test_TLSInvalidPEMData = `
+const TestTLSInvalidPEMData = `
 MIIF1zCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
 BQAwezELMAkGA1UEBhMCREUxFTATBgNVBAgMDExvd2VyIFNheG9ueTEQMA4GA1UE
 BwwHSGFub3ZlcjEVMBMGA1UECgwMVGVzdGluZyBDb3JwMRIwEAYDVQQLDAlUZXN0
@@ -68,7 +68,7 @@ YilqCPFX+az09EqqK/iHXnkdZ/Z2fCuU+9M/Zhrnlwlygl3RuVBI6xhm/ZsXtL2E
 Gxa61lNy6pyx5+hSxHEFEJshXLtioRd702VdLKxEOuYSXKeJDs1x9o6cJ75S6hko
 `
 
-const Test_TLSInvalidSingleCert = `
+const TestTLSInvalidSingleCert = `
 -----BEGIN CERTIFICATE-----
 MIIF1zCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
 BQAwezELMAkGA1UEBhMCREUxFTATBgNVBAgMDExvd2VyIFNheG9ueTEQMA4GA1UE
@@ -105,7 +105,7 @@ XWyb96wrUlv+E8I=
 -----END CERTIFICATE-----
 `
 
-const Test_TLSValidMultiCert = `
+const TestTLSValidMultiCert = `
 -----BEGIN CERTIFICATE-----
 MIIFvTCCA6WgAwIBAgIUGrTmW3qc39zqnE08e3qNDhUkeWswDQYJKoZIhvcNAQEL
 BQAwbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAklMMRAwDgYDVQQHDAdDaGljYWdv
@@ -176,7 +176,7 @@ XWyb96wrUlv+E8I=
 `
 
 // Taken from hack/ssh_known_hosts
-const Test_ValidSSHKnownHostsData = `
+const TestValidSSHKnownHostsData = `
 # BitBucket
 bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=
 # GitHub
@@ -190,7 +190,7 @@ ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4Nak
 vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
 `
 
-const Test_InvalidSSHKnownHostsData = `
+const TestInvalidSSHKnownHostsData = `
 bitbucket.org AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=
 # GitHub
 github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
@@ -203,20 +203,20 @@ ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4Nak
 vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
 `
 
-func Test_TLSCertificate_ValidPEM_ValidCert(t *testing.T) {
+func TestTLSCertificateValidPEMValidCert(t *testing.T) {
 	// Valid PEM data, single certificate, expect array of length 1
-	certificates, err := ParseTLSCertificatesFromData(Test_TLSValidSingleCert)
+	certificates, err := ParseTLSCertificatesFromData(TestTLSValidSingleCert)
 	require.NoError(t, err)
 	assert.Len(t, certificates, 1)
 	// Expect good decode
 	x509Cert, err := DecodePEMCertificateToX509(certificates[0])
 	require.NoError(t, err)
-	assert.Equal(t, Test_Cert1CN, x509Cert.Subject.String())
+	assert.Equal(t, TestCert1CN, x509Cert.Subject.String())
 }
 
-func Test_TLSCertificate_ValidPEM_InvalidCert(t *testing.T) {
+func TestTLSCertificateValidPEMInvalidCert(t *testing.T) {
 	// Valid PEM data, but invalid certificate
-	certificates, err := ParseTLSCertificatesFromData(Test_TLSInvalidSingleCert)
+	certificates, err := ParseTLSCertificatesFromData(TestTLSInvalidSingleCert)
 	require.NoError(t, err)
 	assert.Len(t, certificates, 1)
 	// Expect bad decode
@@ -224,28 +224,28 @@ func Test_TLSCertificate_ValidPEM_InvalidCert(t *testing.T) {
 	require.Error(t, err)
 }
 
-func Test_TLSCertificate_InvalidPEM(t *testing.T) {
+func TestTLSCertificateInvalidPEM(t *testing.T) {
 	// Invalid PEM data, expect array of length 0
-	certificates, err := ParseTLSCertificatesFromData(Test_TLSInvalidPEMData)
+	certificates, err := ParseTLSCertificatesFromData(TestTLSInvalidPEMData)
 	require.NoError(t, err)
 	assert.Empty(t, certificates)
 }
 
-func Test_TLSCertificate_ValidPEM_ValidCert_Multi(t *testing.T) {
+func TestTLSCertificateValidPEMValidCertMulti(t *testing.T) {
 	// Valid PEM data, two certificates, expect array of length 2
-	certificates, err := ParseTLSCertificatesFromData(Test_TLSValidMultiCert)
+	certificates, err := ParseTLSCertificatesFromData(TestTLSValidMultiCert)
 	require.NoError(t, err)
 	assert.Len(t, certificates, 2)
 	// Expect good decode
 	x509Cert, err := DecodePEMCertificateToX509(certificates[0])
 	require.NoError(t, err)
-	assert.Equal(t, Test_Cert1CN, x509Cert.Subject.String())
+	assert.Equal(t, TestCert1CN, x509Cert.Subject.String())
 	x509Cert, err = DecodePEMCertificateToX509(certificates[1])
 	require.NoError(t, err)
-	assert.Equal(t, Test_Cert2CN, x509Cert.Subject.String())
+	assert.Equal(t, TestCert2CN, x509Cert.Subject.String())
 }
 
-func Test_TLSCertificate_ValidPEM_ValidCert_FromFile(t *testing.T) {
+func TestTLSCertificateValidPEMValidCertFromFile(t *testing.T) {
 	// Valid PEM data, single certificate from file, expect array of length 1
 	certificates, err := ParseTLSCertificatesFromPath("../../test/certificates/cert1.pem")
 	require.NoError(t, err)
@@ -253,48 +253,48 @@ func Test_TLSCertificate_ValidPEM_ValidCert_FromFile(t *testing.T) {
 	// Expect good decode
 	x509Cert, err := DecodePEMCertificateToX509(certificates[0])
 	require.NoError(t, err)
-	assert.Equal(t, Test_Cert1CN, x509Cert.Subject.String())
+	assert.Equal(t, TestCert1CN, x509Cert.Subject.String())
 }
 
-func Test_TLSCertPool(t *testing.T) {
-	certificates, err := ParseTLSCertificatesFromData(Test_TLSValidMultiCert)
+func TestTLSCertPool(t *testing.T) {
+	certificates, err := ParseTLSCertificatesFromData(TestTLSValidMultiCert)
 	require.NoError(t, err)
 	assert.Len(t, certificates, 2)
 	certPool := GetCertPoolFromPEMData(certificates)
 	assert.NotNil(t, certPool)
 }
 
-func Test_TLSCertificate_CertFromNonExistingFile(t *testing.T) {
+func TestTLSCertificateCertFromNonExistingFile(t *testing.T) {
 	// Non-existing file, expect err
 	_, err := ParseTLSCertificatesFromPath("../../test/certificates/cert_nonexisting.pem")
 	require.Error(t, err)
 }
 
-func Test_SSHKnownHostsData_ParseData(t *testing.T) {
+func TestSSHKnownHostsDataParseData(t *testing.T) {
 	// Expect valid data with 7 known host entries
-	entries, err := ParseSSHKnownHostsFromData(Test_ValidSSHKnownHostsData)
+	entries, err := ParseSSHKnownHostsFromData(TestValidSSHKnownHostsData)
 	require.NoError(t, err)
 	assert.Len(t, entries, 7)
 }
 
-func Test_SSHKnownHostsData_ParseFile(t *testing.T) {
+func TestSSHKnownHostsDataParseFile(t *testing.T) {
 	// Expect valid data with 7 known host entries
 	entries, err := ParseSSHKnownHostsFromPath("../../test/certificates/ssh_known_hosts")
 	require.NoError(t, err)
 	assert.Len(t, entries, 7)
 }
 
-func Test_SSHKnownHostsData_ParseNonExistingFile(t *testing.T) {
+func TestSSHKnownHostsDataParseNonExistingFile(t *testing.T) {
 	// Expect valid data with 7 known host entries
 	entries, err := ParseSSHKnownHostsFromPath("../../test/certificates/ssh_known_hosts_invalid")
 	require.Error(t, err)
 	assert.Nil(t, entries)
 }
 
-func Test_SSHKnownHostsData_Tokenize(t *testing.T) {
+func TestSSHKnownHostsDataTokenize(t *testing.T) {
 	// All entries should parse to valid SSH public keys
 	// All entries should be tokenizable, and tokens should be feedable to decoder
-	entries, err := ParseSSHKnownHostsFromData(Test_ValidSSHKnownHostsData)
+	entries, err := ParseSSHKnownHostsFromData(TestValidSSHKnownHostsData)
 	require.NoError(t, err)
 	for _, entry := range entries {
 		hosts, _, err := KnownHostsLineToPublicKey(entry)
@@ -308,7 +308,7 @@ func Test_SSHKnownHostsData_Tokenize(t *testing.T) {
 	}
 }
 
-func Test_MatchHostName(t *testing.T) {
+func TestMatchHostName(t *testing.T) {
 	matchHostName := "foo.example.com"
 	assert.True(t, MatchHostName(matchHostName, "*"))
 	assert.True(t, MatchHostName(matchHostName, "*.example.com"))
@@ -321,7 +321,7 @@ func Test_MatchHostName(t *testing.T) {
 	assert.False(t, MatchHostName(matchHostName, "foo.otherexample.*"))
 }
 
-func Test_SSHFingerprintSHA256(t *testing.T) {
+func TestSSHFingerprintSHA256(t *testing.T) {
 	// actual SHA256 fingerprints for keys defined above
 	fingerprints := [...]string{
 		"46OSHA1Rmj8E8ERTC6xkNcmGOw9oFxYr0WF6zWW8l1E",
@@ -332,7 +332,7 @@ func Test_SSHFingerprintSHA256(t *testing.T) {
 		"ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og",
 		"ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og",
 	}
-	entries, err := ParseSSHKnownHostsFromData(Test_ValidSSHKnownHostsData)
+	entries, err := ParseSSHKnownHostsFromData(TestValidSSHKnownHostsData)
 	require.NoError(t, err)
 	assert.Len(t, entries, 7)
 	for idx, entry := range entries {
@@ -343,7 +343,7 @@ func Test_SSHFingerprintSHA256(t *testing.T) {
 	}
 }
 
-func Test_SSHFingerPrintSHA256FromString(t *testing.T) {
+func TestSSHFingerPrintSHA256FromString(t *testing.T) {
 	// actual SHA256 fingerprints for keys defined above
 	fingerprints := [...]string{
 		"46OSHA1Rmj8E8ERTC6xkNcmGOw9oFxYr0WF6zWW8l1E",
@@ -354,7 +354,7 @@ func Test_SSHFingerPrintSHA256FromString(t *testing.T) {
 		"ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og",
 		"ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og",
 	}
-	entries, err := ParseSSHKnownHostsFromData(Test_ValidSSHKnownHostsData)
+	entries, err := ParseSSHKnownHostsFromData(TestValidSSHKnownHostsData)
 	require.NoError(t, err)
 	assert.Len(t, entries, 7)
 	for idx, entry := range entries {
@@ -363,7 +363,7 @@ func Test_SSHFingerPrintSHA256FromString(t *testing.T) {
 	}
 }
 
-func Test_ServerNameWithoutPort(t *testing.T) {
+func TestServerNameWithoutPort(t *testing.T) {
 	hostNames := map[string]string{
 		"localhost":            "localhost",
 		"localhost:9443":       "localhost",
@@ -378,7 +378,7 @@ func Test_ServerNameWithoutPort(t *testing.T) {
 	}
 }
 
-func Test_ValidHostnames(t *testing.T) {
+func TestValidHostnames(t *testing.T) {
 	hostNames := map[string]bool{
 		"localhost":                          true,
 		"localhost.localdomain":              true,
@@ -404,7 +404,7 @@ func Test_ValidHostnames(t *testing.T) {
 	}
 }
 
-func Test_ValidFQDNs(t *testing.T) {
+func TestValidFQDNs(t *testing.T) {
 	hostNames := map[string]bool{
 		"localhost":                          false,
 		"localhost.localdomain":              false,
@@ -426,7 +426,7 @@ func Test_ValidFQDNs(t *testing.T) {
 	}
 }
 
-func Test_EscapeBracketPattern(t *testing.T) {
+func TestEscapeBracketPattern(t *testing.T) {
 	// input: expected output
 	patternList := map[string]string{
 		"foo.bar":         "foo.bar",

--- a/util/db/certificate_test.go
+++ b/util/db/certificate_test.go
@@ -16,16 +16,16 @@ import (
 )
 
 const (
-	Test_Cert1CN = "CN=foo.example.com,OU=SpecOps,O=Capone\\, Inc,L=Chicago,ST=IL,C=US"
-	Test_Cert2CN = "CN=bar.example.com,OU=Testsuite,O=Testing Corp,L=Hanover,ST=Lower Saxony,C=DE"
+	TestCert1CN = "CN=foo.example.com,OU=SpecOps,O=Capone\\, Inc,L=Chicago,ST=IL,C=US"
+	TestCert2CN = "CN=bar.example.com,OU=Testsuite,O=Testing Corp,L=Hanover,ST=Lower Saxony,C=DE"
 )
 
-var Test_TLS_Subjects = []string{
+var TestTLSSubjects = []string{
 	"CN=foo.example.com,OU=SpecOps,O=Capone\\, Inc,L=Chicago,ST=IL,C=US",
 	"CN=bar.example.com,OU=Testsuite,O=Testing Corp,L=Hanover,ST=Lower Saxony,C=DE",
 }
 
-const Test_TLSValidSingleCert = `
+const TestTLSValidSingleCert = `
 -----BEGIN CERTIFICATE-----
 MIIFvTCCA6WgAwIBAgIUGrTmW3qc39zqnE08e3qNDhUkeWswDQYJKoZIhvcNAQEL
 BQAwbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAklMMRAwDgYDVQQHDAdDaGljYWdv
@@ -61,7 +61,7 @@ xO7Tr5lAo74vNUkF2EHNaI28/RGnJPm2TIxZqy4rNH6L
 -----END CERTIFICATE-----
 `
 
-const Test_TLSInvalidPEMData = `
+const TestTLSInvalidPEMData = `
 MIIF1zCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
 BQAwezELMAkGA1UEBhMCREUxFTATBgNVBAgMDExvd2VyIFNheG9ueTEQMA4GA1UE
 BwwHSGFub3ZlcjEVMBMGA1UECgwMVGVzdGluZyBDb3JwMRIwEAYDVQQLDAlUZXN0
@@ -78,7 +78,7 @@ YilqCPFX+az09EqqK/iHXnkdZ/Z2fCuU+9M/Zhrnlwlygl3RuVBI6xhm/ZsXtL2E
 Gxa61lNy6pyx5+hSxHEFEJshXLtioRd702VdLKxEOuYSXKeJDs1x9o6cJ75S6hko
 `
 
-const Test_TLSInvalidSingleCert = `
+const TestTLSInvalidSingleCert = `
 -----BEGIN CERTIFICATE-----
 MIIF1zCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
 BQAwezELMAkGA1UEBhMCREUxFTATBgNVBAgMDExvd2VyIFNheG9ueTEQMA4GA1UE
@@ -115,7 +115,7 @@ XWyb96wrUlv+E8I=
 -----END CERTIFICATE-----
 `
 
-const Test_TLSValidMultiCert = `
+const TestTLSValidMultiCert = `
 -----BEGIN CERTIFICATE-----
 MIIFvTCCA6WgAwIBAgIUGrTmW3qc39zqnE08e3qNDhUkeWswDQYJKoZIhvcNAQEL
 BQAwbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAklMMRAwDgYDVQQHDAdDaGljYWdv
@@ -186,7 +186,7 @@ XWyb96wrUlv+E8I=
 `
 
 // Taken from hack/ssh_known_hosts
-const Test_ValidSSHKnownHostsData = `
+const TestValidSSHKnownHostsData = `
 # BitBucket
 bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=
 # GitHub
@@ -200,7 +200,7 @@ ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4Nak
 vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
 `
 
-const Test_InvalidSSHKnownHostsData = `
+const TestInvalidSSHKnownHostsData = `
 bitbucket.org AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=
 # GitHub
 github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
@@ -213,7 +213,7 @@ ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4Nak
 vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
 `
 
-var Test_SSH_Hostname_Entries = []string{
+var TestSSHHostnameEntries = []string{
 	"bitbucket.org",
 	"github.com",
 	"gitlab.com",
@@ -223,7 +223,7 @@ var Test_SSH_Hostname_Entries = []string{
 	"vs-ssh.visualstudio.com",
 }
 
-var Test_SSH_Subtypes = []string{
+var TestSSHSubtypes = []string{
 	"ssh-rsa",
 	"ssh-rsa",
 	"ecdsa-sha2-nistp256",
@@ -233,15 +233,15 @@ var Test_SSH_Subtypes = []string{
 	"ssh-rsa",
 }
 
-var Test_TLS_Hostnames = []string{
+var TestTLSHostnames = []string{
 	"test.example.com",
 	"test.example.com",
 	"github.com",
 }
 
 const (
-	Test_NumSSHKnownHostsExpected   = 7
-	Test_NumTLSCertificatesExpected = 3
+	TestNumSSHKnownHostsExpected   = 7
+	TestNumTLSCertificatesExpected = 3
 )
 
 func getCertClientset() *fake.Clientset {
@@ -265,7 +265,7 @@ func getCertClientset() *fake.Clientset {
 			},
 		},
 		Data: map[string]string{
-			"ssh_known_hosts": Test_ValidSSHKnownHostsData,
+			"ssh_known_hosts": TestValidSSHKnownHostsData,
 		},
 	}
 
@@ -278,15 +278,15 @@ func getCertClientset() *fake.Clientset {
 			},
 		},
 		Data: map[string]string{
-			"test.example.com": Test_TLSValidMultiCert,
-			"gitlab.com":       Test_TLSValidSingleCert,
+			"test.example.com": TestTLSValidMultiCert,
+			"gitlab.com":       TestTLSValidSingleCert,
 		},
 	}
 
 	return fake.NewClientset([]runtime.Object{&cm, &sshCM, &tlsCM}...)
 }
 
-func Test_ListCertificate(t *testing.T) {
+func TestListCertificate(t *testing.T) {
 	clientset := getCertClientset()
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
 	assert.NotNil(t, db)
@@ -299,10 +299,10 @@ func Test_ListCertificate(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, certList)
-	assert.Len(t, certList.Items, Test_NumSSHKnownHostsExpected)
+	assert.Len(t, certList.Items, TestNumSSHKnownHostsExpected)
 	for idx, entry := range certList.Items {
-		assert.Equal(t, entry.ServerName, Test_SSH_Hostname_Entries[idx])
-		assert.Equal(t, entry.CertSubType, Test_SSH_Subtypes[idx])
+		assert.Equal(t, entry.ServerName, TestSSHHostnameEntries[idx])
+		assert.Equal(t, entry.CertSubType, TestSSHSubtypes[idx])
 	}
 
 	// List all TLS certificates from configuration.
@@ -313,7 +313,7 @@ func Test_ListCertificate(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, certList)
-	assert.Len(t, certList.Items, Test_NumTLSCertificatesExpected)
+	assert.Len(t, certList.Items, TestNumTLSCertificatesExpected)
 
 	// List all certificates using selector
 	// Expected: List of 10 entries
@@ -323,14 +323,14 @@ func Test_ListCertificate(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, certList)
-	assert.Len(t, certList.Items, Test_NumTLSCertificatesExpected+Test_NumSSHKnownHostsExpected)
+	assert.Len(t, certList.Items, TestNumTLSCertificatesExpected+TestNumSSHKnownHostsExpected)
 
 	// List all certificates using nil selector
 	// Expected: List of 10 entries
 	certList, err = db.ListRepoCertificates(context.Background(), nil)
 	require.NoError(t, err)
 	assert.NotNil(t, certList)
-	assert.Len(t, certList.Items, Test_NumTLSCertificatesExpected+Test_NumSSHKnownHostsExpected)
+	assert.Len(t, certList.Items, TestNumTLSCertificatesExpected+TestNumSSHKnownHostsExpected)
 
 	// List all certificates matching a host name pattern
 	// Expected: List of 4 entries, all with servername gitlab.com
@@ -357,7 +357,7 @@ func Test_ListCertificate(t *testing.T) {
 	assert.Equal(t, "https", certList.Items[0].CertType)
 }
 
-func Test_CreateSSHKnownHostEntries(t *testing.T) {
+func TestCreateSSHKnownHostEntries(t *testing.T) {
 	clientset := getCertClientset()
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
 	assert.NotNil(t, db)
@@ -486,7 +486,7 @@ func Test_CreateSSHKnownHostEntries(t *testing.T) {
 	assert.Nil(t, certList)
 }
 
-func Test_CreateTLSCertificates(t *testing.T) {
+func TestCreateTLSCertificates(t *testing.T) {
 	clientset := getCertClientset()
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
 	assert.NotNil(t, db)
@@ -498,7 +498,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "foo.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSValidSingleCert),
+				CertData:   []byte(TestTLSValidSingleCert),
 			},
 		},
 	}, false)
@@ -513,7 +513,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "foo..example",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSValidSingleCert),
+				CertData:   []byte(TestTLSValidSingleCert),
 			},
 		},
 	}, false)
@@ -537,7 +537,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "bar.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSValidMultiCert),
+				CertData:   []byte(TestTLSValidMultiCert),
 			},
 		},
 	}, false)
@@ -562,7 +562,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "foo.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSValidSingleCert),
+				CertData:   []byte(TestTLSValidSingleCert),
 			},
 		},
 	}, false)
@@ -577,7 +577,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "foo.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSValidMultiCert),
+				CertData:   []byte(TestTLSValidMultiCert),
 			},
 		},
 	}, false)
@@ -591,7 +591,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "foo.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSValidMultiCert),
+				CertData:   []byte(TestTLSValidMultiCert),
 			},
 		},
 	}, true)
@@ -620,7 +620,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "baz.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSInvalidPEMData),
+				CertData:   []byte(TestTLSInvalidPEMData),
 			},
 		},
 	}, false)
@@ -634,7 +634,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "baz.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSInvalidSingleCert),
+				CertData:   []byte(TestTLSInvalidSingleCert),
 			},
 		},
 	}, false)
@@ -648,7 +648,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "baz.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSInvalidPEMData),
+				CertData:   []byte(TestTLSInvalidPEMData),
 			},
 		},
 	}, true)
@@ -662,7 +662,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 			{
 				ServerName: "baz.example.com",
 				CertType:   "https",
-				CertData:   []byte(Test_TLSInvalidSingleCert),
+				CertData:   []byte(TestTLSInvalidSingleCert),
 			},
 		},
 	}, true)
@@ -670,7 +670,7 @@ func Test_CreateTLSCertificates(t *testing.T) {
 	assert.Nil(t, certList)
 }
 
-func Test_RemoveSSHKnownHosts(t *testing.T) {
+func TestRemoveSSHKnownHosts(t *testing.T) {
 	clientset := getCertClientset()
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
 	assert.NotNil(t, db)
@@ -734,7 +734,7 @@ func Test_RemoveSSHKnownHosts(t *testing.T) {
 	assert.Empty(t, certList.Items)
 }
 
-func Test_RemoveTLSCertificates(t *testing.T) {
+func TestRemoveTLSCertificates(t *testing.T) {
 	clientset := getCertClientset()
 	db := NewDB(testNamespace, settings.NewSettingsManager(context.Background(), clientset, testNamespace), clientset)
 	assert.NotNil(t, db)

--- a/util/db/repository_secrets.go
+++ b/util/db/repository_secrets.go
@@ -526,13 +526,13 @@ func (s *secretsRepositoryBackend) getRepositoryCredentialIndex(repoCredentials 
 	max, idx := 0, -1
 	repoURL = git.NormalizeGitURL(repoURL)
 	for i, cred := range repoCredentials {
-		credUrl := git.NormalizeGitURL(string(cred.Data["url"]))
-		if strings.HasPrefix(repoURL, credUrl) {
-			if len(credUrl) == max {
+		credURL := git.NormalizeGitURL(string(cred.Data["url"]))
+		if strings.HasPrefix(repoURL, credURL) {
+			if len(credURL) == max {
 				log.Warnf("Found multiple credentials for repoURL: %s", repoURL)
 			}
-			if len(credUrl) > max {
-				max = len(credUrl)
+			if len(credURL) > max {
+				max = len(credURL)
 				idx = i
 			}
 		}

--- a/util/db/repository_test.go
+++ b/util/db/repository_test.go
@@ -227,62 +227,62 @@ func TestDb_GetRepositoryCredentials(t *testing.T) {
 
 func TestRepoURLToSecretName(t *testing.T) {
 	tables := []struct {
-		repoUrl    string
+		repoURL    string
 		secretName string
 		project    string
 	}{{
-		repoUrl:    "git://git@github.com:argoproj/ARGO-cd.git",
+		repoURL:    "git://git@github.com:argoproj/ARGO-cd.git",
 		secretName: "repo-83273445",
 		project:    "",
 	}, {
-		repoUrl:    "git://git@github.com:argoproj/ARGO-cd.git",
+		repoURL:    "git://git@github.com:argoproj/ARGO-cd.git",
 		secretName: "repo-2733415816",
 		project:    "foobar",
 	}, {
-		repoUrl:    "https://github.com/argoproj/ARGO-cd",
+		repoURL:    "https://github.com/argoproj/ARGO-cd",
 		secretName: "repo-1890113693",
 		project:    "",
 	}, {
-		repoUrl:    "https://github.com/argoproj/ARGO-cd",
+		repoURL:    "https://github.com/argoproj/ARGO-cd",
 		secretName: "repo-4161185408",
 		project:    "foobar",
 	}, {
-		repoUrl:    "https://github.com/argoproj/argo-cd",
+		repoURL:    "https://github.com/argoproj/argo-cd",
 		secretName: "repo-42374749",
 		project:    "",
 	}, {
-		repoUrl:    "https://github.com/argoproj/argo-cd",
+		repoURL:    "https://github.com/argoproj/argo-cd",
 		secretName: "repo-1894545728",
 		project:    "foobar",
 	}, {
-		repoUrl:    "https://github.com/argoproj/argo-cd.git",
+		repoURL:    "https://github.com/argoproj/argo-cd.git",
 		secretName: "repo-821842295",
 		project:    "",
 	}, {
-		repoUrl:    "https://github.com/argoproj/argo-cd.git",
+		repoURL:    "https://github.com/argoproj/argo-cd.git",
 		secretName: "repo-1474166686",
 		project:    "foobar",
 	}, {
-		repoUrl:    "https://github.com/argoproj/argo_cd.git",
+		repoURL:    "https://github.com/argoproj/argo_cd.git",
 		secretName: "repo-1049844989",
 		project:    "",
 	}, {
-		repoUrl:    "https://github.com/argoproj/argo_cd.git",
+		repoURL:    "https://github.com/argoproj/argo_cd.git",
 		secretName: "repo-3916272608",
 		project:    "foobar",
 	}, {
-		repoUrl:    "ssh://git@github.com/argoproj/argo-cd.git",
+		repoURL:    "ssh://git@github.com/argoproj/argo-cd.git",
 		secretName: "repo-3569564120",
 		project:    "",
 	}, {
-		repoUrl:    "ssh://git@github.com/argoproj/argo-cd.git",
+		repoURL:    "ssh://git@github.com/argoproj/argo-cd.git",
 		secretName: "repo-754834421",
 		project:    "foobar",
 	}}
 
 	for _, v := range tables {
-		sn := RepoURLToSecretName(repoSecretPrefix, v.repoUrl, v.project)
-		assert.Equal(t, sn, v.secretName, "Expected secret name %q for repo %q; instead, got %q", v.secretName, v.repoUrl, sn)
+		sn := RepoURLToSecretName(repoSecretPrefix, v.repoURL, v.project)
+		assert.Equal(t, sn, v.secretName, "Expected secret name %q for repo %q; instead, got %q", v.secretName, v.repoURL, sn)
 	}
 }
 

--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTls bool) ([]byte, error) {
+func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTLS bool) ([]byte, error) {
 	if !argocdSettings.IsDexConfigured() {
 		return nil, nil
 	}
@@ -30,7 +30,7 @@ func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTls b
 	dexCfg["storage"] = map[string]any{
 		"type": "memory",
 	}
-	if disableTls {
+	if disableTLS {
 		dexCfg["web"] = map[string]any{
 			"http": "0.0.0.0:5556",
 		}

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -425,12 +425,12 @@ func (m *nativeGitClient) LsFiles(path string, enableNewGitFileGlobbing bool) ([
 		if err != nil {
 			return nil, err
 		}
-		all_files, err := doublestar.FilepathGlob(path)
+		allFiles, err := doublestar.FilepathGlob(path)
 		if err != nil {
 			return nil, err
 		}
 		var files []string
-		for _, file := range all_files {
+		for _, file := range allFiles {
 			link, err := filepath.EvalSymlinks(file)
 			if err != nil {
 				return nil, err

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -579,7 +579,7 @@ func Test_nativeGitClient_CheckoutOrOrphan(t *testing.T) {
 		// make origin git repository
 		tempDir, err := _createEmptyGitRepo()
 		require.NoError(t, err)
-		originGitRepoUrl := "file://" + tempDir
+		originGitRepoURL := "file://" + tempDir
 		err = runCmd(tempDir, "git", "commit", "-m", "Second commit", "--allow-empty")
 		require.NoError(t, err)
 
@@ -592,7 +592,7 @@ func Test_nativeGitClient_CheckoutOrOrphan(t *testing.T) {
 		tempDir, err = os.MkdirTemp("", "")
 		require.NoError(t, err)
 
-		client, err := NewClientExt(originGitRepoUrl, tempDir, NopCreds{}, true, false, "", "")
+		client, err := NewClientExt(originGitRepoURL, tempDir, NopCreds{}, true, false, "", "")
 		require.NoError(t, err)
 
 		err = client.Init()

--- a/util/git/creds.go
+++ b/util/git/creds.go
@@ -354,8 +354,8 @@ func (c SSHCreds) Environ() (io.Closer, []string, error) {
 			parsedProxyURL.Port()))
 		if parsedProxyURL.User != nil {
 			proxyEnv = append(proxyEnv, "SOCKS5_USER="+parsedProxyURL.User.Username())
-			if socks5_passwd, isPasswdSet := parsedProxyURL.User.Password(); isPasswdSet {
-				proxyEnv = append(proxyEnv, "SOCKS5_PASSWD="+socks5_passwd)
+			if socks5Passwd, isPasswdSet := parsedProxyURL.User.Password(); isPasswdSet {
+				proxyEnv = append(proxyEnv, "SOCKS5_PASSWD="+socks5Passwd)
 			}
 		}
 	}
@@ -498,13 +498,13 @@ func (g GitHubAppCreds) getAccessToken() (string, error) {
 // getAppTransport creates a new GitHub transport for the app
 func (g GitHubAppCreds) getAppTransport() (*ghinstallation.AppsTransport, error) {
 	// GitHub API url
-	baseUrl := "https://api.github.com"
+	baseURL := "https://api.github.com"
 	if g.baseURL != "" {
-		baseUrl = strings.TrimSuffix(g.baseURL, "/")
+		baseURL = strings.TrimSuffix(g.baseURL, "/")
 	}
 
 	// Create a new GitHub transport
-	c := GetRepoHTTPClient(baseUrl, g.insecure, g, g.proxy, g.noProxy)
+	c := GetRepoHTTPClient(baseURL, g.insecure, g, g.proxy, g.noProxy)
 	itr, err := ghinstallation.NewAppsTransport(c.Transport,
 		g.appID,
 		[]byte(g.privateKey),
@@ -513,7 +513,7 @@ func (g GitHubAppCreds) getAppTransport() (*ghinstallation.AppsTransport, error)
 		return nil, fmt.Errorf("failed to initialize GitHub installation transport: %w", err)
 	}
 
-	itr.BaseURL = baseUrl
+	itr.BaseURL = baseURL
 
 	return itr, nil
 }
@@ -537,13 +537,13 @@ func (g GitHubAppCreds) getInstallationTransport() (*ghinstallation.Transport, e
 	}
 
 	// GitHub API url
-	baseUrl := "https://api.github.com"
+	baseURL := "https://api.github.com"
 	if g.baseURL != "" {
-		baseUrl = strings.TrimSuffix(g.baseURL, "/")
+		baseURL = strings.TrimSuffix(g.baseURL, "/")
 	}
 
 	// Create a new GitHub transport
-	c := GetRepoHTTPClient(baseUrl, g.insecure, g, g.proxy, g.noProxy)
+	c := GetRepoHTTPClient(baseURL, g.insecure, g, g.proxy, g.noProxy)
 	itr, err := ghinstallation.New(c.Transport,
 		g.appID,
 		g.appInstallId,
@@ -553,7 +553,7 @@ func (g GitHubAppCreds) getInstallationTransport() (*ghinstallation.Transport, e
 		return nil, fmt.Errorf("failed to initialize GitHub installation transport: %w", err)
 	}
 
-	itr.BaseURL = baseUrl
+	itr.BaseURL = baseURL
 
 	// Add transport to cache
 	githubAppTokenCache.Set(key, itr, time.Minute*60)

--- a/util/helm/client_test.go
+++ b/util/helm/client_test.go
@@ -294,20 +294,20 @@ func TestGetTagsFromURLPrivateRepoAuthentication(t *testing.T) {
 
 func TestGetTagsFromURLPrivateRepoWithAzureWorkloadIdentityAuthentication(t *testing.T) {
 	expectedAuthorization := "Basic MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwOmFjY2Vzc1Rva2Vu" // base64(00000000-0000-0000-0000-000000000000:accessToken)
-	mockUrl := ""
-	serverUrl := func() string {
-		return mockUrl
+	mockServerURL := ""
+	mockedServerURL := func() string {
+		return mockServerURL
 	}
 
 	workloadIdentityMock := new(mocks.TokenProvider)
 	workloadIdentityMock.On("GetToken", "https://management.core.windows.net/.default").Return("accessToken", nil)
 
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("called %s", r.URL.Path)
 
 		switch r.URL.Path {
 		case "/v2/":
-			w.Header().Set("Www-Authenticate", fmt.Sprintf(`Bearer realm="%s",service="%s"`, serverUrl(), serverUrl()[8:]))
+			w.Header().Set("Www-Authenticate", fmt.Sprintf(`Bearer realm="%s",service="%s"`, mockedServerURL(), mockedServerURL()[8:]))
 			w.WriteHeader(http.StatusUnauthorized)
 
 		case "/oauth2/exchange":
@@ -340,10 +340,10 @@ func TestGetTagsFromURLPrivateRepoWithAzureWorkloadIdentityAuthentication(t *tes
 			require.NoError(t, json.NewEncoder(w).Encode(responseTags))
 		}
 	}))
-	mockUrl = server.URL
-	t.Cleanup(server.Close)
+	mockServerURL = mockServer.URL
+	t.Cleanup(mockServer.Close)
 
-	serverURL, err := url.Parse(server.URL)
+	serverURL, err := url.Parse(mockServer.URL)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -352,11 +352,11 @@ func TestGetTagsFromURLPrivateRepoWithAzureWorkloadIdentityAuthentication(t *tes
 	}{
 		{
 			name:    "should login correctly when the repo path is in the server root with http scheme",
-			repoURL: server.URL,
+			repoURL: mockServer.URL,
 		},
 		{
 			name:    "should login correctly when the repo path is not in the server root with http scheme",
-			repoURL: server.URL + "/my-repo",
+			repoURL: mockServer.URL + "/my-repo",
 		},
 		{
 			name:    "should login correctly when the repo path is in the server root without http scheme",
@@ -371,7 +371,7 @@ func TestGetTagsFromURLPrivateRepoWithAzureWorkloadIdentityAuthentication(t *tes
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			client := NewClient(testCase.repoURL, AzureWorkloadIdentityCreds{
-				repoUrl:            server.URL[8:],
+				repoURL:            mockServer.URL[8:],
 				InsecureSkipVerify: true,
 				tokenProvider:      workloadIdentityMock,
 			}, true, "", "")

--- a/util/helm/creds.go
+++ b/util/helm/creds.go
@@ -77,7 +77,7 @@ func (creds HelmCreds) GetInsecureSkipVerify() bool {
 var _ Creds = AzureWorkloadIdentityCreds{}
 
 type AzureWorkloadIdentityCreds struct {
-	repoUrl            string
+	repoURL            string
 	CAPath             string
 	CertData           []byte
 	KeyData            []byte
@@ -109,9 +109,9 @@ func (creds AzureWorkloadIdentityCreds) GetInsecureSkipVerify() bool {
 	return creds.InsecureSkipVerify
 }
 
-func NewAzureWorkloadIdentityCreds(repoUrl string, caPath string, certData []byte, keyData []byte, insecureSkipVerify bool, tokenProvider workloadidentity.TokenProvider) AzureWorkloadIdentityCreds {
+func NewAzureWorkloadIdentityCreds(repoURL string, caPath string, certData []byte, keyData []byte, insecureSkipVerify bool, tokenProvider workloadidentity.TokenProvider) AzureWorkloadIdentityCreds {
 	return AzureWorkloadIdentityCreds{
-		repoUrl:            repoUrl,
+		repoURL:            repoURL,
 		CAPath:             caPath,
 		CertData:           certData,
 		KeyData:            keyData,
@@ -121,7 +121,7 @@ func NewAzureWorkloadIdentityCreds(repoUrl string, caPath string, certData []byt
 }
 
 func (creds AzureWorkloadIdentityCreds) GetAccessToken() (string, error) {
-	registryHost := strings.Split(creds.repoUrl, "/")[0]
+	registryHost := strings.Split(creds.repoURL, "/")[0]
 
 	// Compute hash as key for refresh token in the cache
 	key, err := argoutils.GenerateCacheKey("accesstoken-%s", registryHost)
@@ -161,9 +161,9 @@ func (creds AzureWorkloadIdentityCreds) getAccessTokenAfterChallenge(tokenParams
 		return "", fmt.Errorf("failed to get Azure access token: %w", err)
 	}
 
-	parsedUrl, _ := url.Parse(realm)
-	parsedUrl.Path = "/oauth2/exchange"
-	refreshTokenUrl := parsedUrl.String()
+	parsedURL, _ := url.Parse(realm)
+	parsedURL.Path = "/oauth2/exchange"
+	refreshTokenURL := parsedURL.String()
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -179,7 +179,7 @@ func (creds AzureWorkloadIdentityCreds) getAccessTokenAfterChallenge(tokenParams
 	formValues.Add("service", service)
 	formValues.Add("access_token", armAccessToken)
 
-	resp, err := client.PostForm(refreshTokenUrl, formValues)
+	resp, err := client.PostForm(refreshTokenURL, formValues)
 	if err != nil {
 		return "", fmt.Errorf("unable to connect to registry '%w'", err)
 	}
@@ -209,7 +209,7 @@ func (creds AzureWorkloadIdentityCreds) getAccessTokenAfterChallenge(tokenParams
 }
 
 func (creds AzureWorkloadIdentityCreds) challengeAzureContainerRegistry(azureContainerRegistry string) (map[string]string, error) {
-	requestUrl := fmt.Sprintf("https://%s/v2/", azureContainerRegistry)
+	requestURL := fmt.Sprintf("https://%s/v2/", azureContainerRegistry)
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -220,7 +220,7 @@ func (creds AzureWorkloadIdentityCreds) challengeAzureContainerRegistry(azureCon
 		},
 	}
 
-	req, err := http.NewRequest(http.MethodGet, requestUrl, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/util/helm/creds_test.go
+++ b/util/helm/creds_test.go
@@ -56,16 +56,16 @@ func TestGetPasswordShouldReturnTokenFromCacheIfPresent(t *testing.T) {
 }
 
 func TestGetPasswordShouldGenerateTokenIfNotPresentInCache(t *testing.T) {
-	mockUrl := ""
-	serverUrl := func() string {
-		return mockUrl
+	mockServerURL := ""
+	mockedServerURL := func() string {
+		return mockServerURL
 	}
 
 	// Mock the server to return a successful response
 	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v2/":
-			w.Header().Set("Www-Authenticate", fmt.Sprintf(`Bearer realm="%s",service="%s"`, serverUrl(), serverUrl()[8:]))
+			w.Header().Set("Www-Authenticate", fmt.Sprintf(`Bearer realm="%s",service="%s"`, mockedServerURL(), mockedServerURL()[8:]))
 			w.WriteHeader(http.StatusUnauthorized)
 
 		case "/oauth2/exchange":
@@ -75,7 +75,7 @@ func TestGetPasswordShouldGenerateTokenIfNotPresentInCache(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}))
-	mockUrl = mockServer.URL
+	mockServerURL = mockServer.URL
 	defer mockServer.Close()
 
 	workloadIdentityMock := new(mocks.TokenProvider)
@@ -100,7 +100,7 @@ func TestChallengeAzureContainerRegistry(t *testing.T) {
 	workloadIdentityMock := new(mocks.TokenProvider)
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
-	tokenParams, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
+	tokenParams, err := creds.challengeAzureContainerRegistry(creds.repoURL)
 	require.NoError(t, err)
 
 	expectedParams := map[string]string{
@@ -122,7 +122,7 @@ func TestChallengeAzureContainerRegistryNoChallenge(t *testing.T) {
 	workloadIdentityMock := new(mocks.TokenProvider)
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
-	_, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
+	_, err := creds.challengeAzureContainerRegistry(creds.repoURL)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "did not issue a challenge")
 }
@@ -140,7 +140,7 @@ func TestChallengeAzureContainerRegistryNonBearer(t *testing.T) {
 	workloadIdentityMock := new(mocks.TokenProvider)
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
-	_, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
+	_, err := creds.challengeAzureContainerRegistry(creds.repoURL)
 	assert.ErrorContains(t, err, "does not allow 'Bearer' authentication")
 }
 
@@ -157,7 +157,7 @@ func TestChallengeAzureContainerRegistryNoService(t *testing.T) {
 	workloadIdentityMock := new(mocks.TokenProvider)
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
-	_, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
+	_, err := creds.challengeAzureContainerRegistry(creds.repoURL)
 	assert.ErrorContains(t, err, "service parameter not found in challenge")
 }
 
@@ -174,7 +174,7 @@ func TestChallengeAzureContainerRegistryNoRealm(t *testing.T) {
 	workloadIdentityMock := new(mocks.TokenProvider)
 	creds := NewAzureWorkloadIdentityCreds(mockServer.URL[8:], "", nil, nil, true, workloadIdentityMock)
 
-	_, err := creds.challengeAzureContainerRegistry(creds.repoUrl)
+	_, err := creds.challengeAzureContainerRegistry(creds.repoURL)
 	assert.ErrorContains(t, err, "realm parameter not found in challenge")
 }
 

--- a/util/io/path/resolved.go
+++ b/util/io/path/resolved.go
@@ -110,7 +110,7 @@ func ResolveFileOrDirectoryPath(appPath, repoRoot, dir string) (ResolvedFileOrDi
 //
 // isRemote will be set to true if valueFile is an URL using an allowed
 // protocol scheme, or to false if it resolved to a local file.
-func ResolveValueFilePathOrUrl(appPath, repoRoot, valueFile string, allowedURLSchemes []string) (resolvedPath ResolvedFilePath, isRemote bool, err error) {
+func ResolveValueFilePathOrUrl(appPath, repoRoot, valueFile string, allowedURLSchemes []string) (resolvedPath ResolvedFilePath, isRemote bool, err error) { //nolint:revive //FIXME(var-naming)
 	// A value file can be specified as an URL to a remote resource.
 	// We only allow certain URL schemes for remote value files.
 	url, err := url.Parse(valueFile)

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	JsonFormat = "json"
+	JsonFormat = "json" //nolint:revive //FIXME(var-naming)
 	TextFormat = "text"
 )
 

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -38,7 +38,7 @@ metadata:
   resourceVersion: "123"
 `
 
-const ec2AWSCrossplaneObjJson = `
+const ec2AWSCrossplaneObjJSON = `
 apiVersion: ec2.aws.crossplane.io/v1alpha1
 kind: Instance
 metadata:
@@ -90,7 +90,7 @@ func TestExecuteNewHealthStatusFunction(t *testing.T) {
 }
 
 func TestExecuteWildcardHealthStatusFunction(t *testing.T) {
-	testObj := StrToUnstructured(ec2AWSCrossplaneObjJson)
+	testObj := StrToUnstructured(ec2AWSCrossplaneObjJSON)
 	vm := VM{}
 	status, err := vm.ExecuteHealthLua(testObj, newWildcardHealthStatusFunction)
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestGetHealthScriptWithGroupWildcardOverride(t *testing.T) {
 }
 
 func TestGetHealthScriptWithGroupAndKindWildcardOverride(t *testing.T) {
-	testObj := StrToUnstructured(ec2AWSCrossplaneObjJson)
+	testObj := StrToUnstructured(ec2AWSCrossplaneObjJSON)
 	vm := VM{
 		ResourceOverrides: map[string]appv1.ResourceOverride{
 			"*.aws.crossplane.io/*": {
@@ -847,7 +847,7 @@ return hs`
 	})
 
 	t.Run("Get resource health for wildcard override", func(t *testing.T) {
-		testObj := StrToUnstructured(ec2AWSCrossplaneObjJson)
+		testObj := StrToUnstructured(ec2AWSCrossplaneObjJSON)
 		overrides := getWildcardHealthOverride
 		status, err := overrides.GetResourceHealth(testObj)
 		require.NoError(t, err)
@@ -858,7 +858,7 @@ return hs`
 	})
 
 	t.Run("Get resource health for wildcard override with non-empty health.lua", func(t *testing.T) {
-		testObj := StrToUnstructured(ec2AWSCrossplaneObjJson)
+		testObj := StrToUnstructured(ec2AWSCrossplaneObjJSON)
 		overrides := getMultipleWildcardHealthOverrides
 		status, err := overrides.GetResourceHealth(testObj)
 		require.NoError(t, err)
@@ -867,7 +867,7 @@ return hs`
 	})
 
 	t.Run("Get resource health for */* override with empty health.lua", func(t *testing.T) {
-		testObj := StrToUnstructured(ec2AWSCrossplaneObjJson)
+		testObj := StrToUnstructured(ec2AWSCrossplaneObjJSON)
 		overrides := getBaseWildcardHealthOverrides
 		status, err := overrides.GetResourceHealth(testObj)
 		require.NoError(t, err)

--- a/util/oidc/oidc.go
+++ b/util/oidc/oidc.go
@@ -107,7 +107,7 @@ func GetScopesOrDefault(scopes []string) []string {
 
 // NewClientApp will register the Argo CD client app (either via Dex or external OIDC) and return an
 // object which has HTTP handlers for handling the HTTP responses for login and callback
-func NewClientApp(settings *settings.ArgoCDSettings, dexServerAddr string, dexTlsConfig *dex.DexTLSConfig, baseHRef string, cacheClient cache.CacheClient) (*ClientApp, error) {
+func NewClientApp(settings *settings.ArgoCDSettings, dexServerAddr string, dexTLSConfig *dex.DexTLSConfig, baseHRef string, cacheClient cache.CacheClient) (*ClientApp, error) {
 	redirectURL, err := settings.RedirectURL()
 	if err != nil {
 		return nil, err
@@ -148,8 +148,8 @@ func NewClientApp(settings *settings.ArgoCDSettings, dexServerAddr string, dexTl
 	}
 
 	if settings.DexConfig != "" && settings.OIDCConfigRAW == "" {
-		transport.TLSClientConfig = dex.TLSConfig(dexTlsConfig)
-		addrWithProto := dex.DexServerAddressWithProtocol(dexServerAddr, dexTlsConfig)
+		transport.TLSClientConfig = dex.TLSConfig(dexTLSConfig)
+		addrWithProto := dex.DexServerAddressWithProtocol(dexServerAddr, dexTLSConfig)
 		a.client.Transport = dex.NewDexRewriteURLRoundTripper(addrWithProto, a.client.Transport)
 	} else {
 		transport.TLSClientConfig = settings.OIDCTLSConfig()
@@ -233,11 +233,11 @@ func (a *ClientApp) verifyAppState(r *http.Request, w http.ResponseWriter, state
 	if len(parts) == 2 && parts[1] != "" {
 		if !isValidRedirectURL(parts[1],
 			append([]string{a.settings.URL, a.baseHRef}, a.settings.AdditionalURLs...)) {
-			sanitizedUrl := parts[1]
-			if len(sanitizedUrl) > 100 {
-				sanitizedUrl = sanitizedUrl[:100]
+			sanitizedURL := parts[1]
+			if len(sanitizedURL) > 100 {
+				sanitizedURL = sanitizedURL[:100]
 			}
-			log.Warnf("Failed to verify app state - got invalid redirectURL %q", sanitizedUrl)
+			log.Warnf("Failed to verify app state - got invalid redirectURL %q", sanitizedURL)
 			return "", fmt.Errorf("failed to verify app state: %w", InvalidRedirectURLError)
 		}
 		redirectURL = parts[1]

--- a/util/oidc/oidc_test.go
+++ b/util/oidc/oidc_test.go
@@ -433,10 +433,10 @@ requestedScopes: ["oidc"]`, oidcTestServer.URL),
 
 	app.HandleLogin(w, req)
 
-	redirectUrl, err := w.Result().Location()
+	redirectURL, err := w.Result().Location()
 	require.NoError(t, err)
 
-	state := redirectUrl.Query()["state"]
+	state := redirectURL.Query()["state"]
 
 	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://argocd.example.com/auth/callback?state=%s&code=abc", state), nil)
 	for _, cookie := range w.Result().Cookies() {

--- a/util/session/sessionmanager.go
+++ b/util/session/sessionmanager.go
@@ -112,7 +112,7 @@ func getLoginFailureWindow() time.Duration {
 }
 
 // NewSessionManager creates a new session manager from Argo CD settings
-func NewSessionManager(settingsMgr *settings.SettingsManager, projectsLister v1alpha1.AppProjectNamespaceLister, dexServerAddr string, dexTlsConfig *dex.DexTLSConfig, storage UserStateStorage) *SessionManager {
+func NewSessionManager(settingsMgr *settings.SettingsManager, projectsLister v1alpha1.AppProjectNamespaceLister, dexServerAddr string, dexTLSConfig *dex.DexTLSConfig, storage UserStateStorage) *SessionManager {
 	s := SessionManager{
 		settingsMgr:                   settingsMgr,
 		storage:                       storage,
@@ -140,8 +140,8 @@ func NewSessionManager(settingsMgr *settings.SettingsManager, projectsLister v1a
 	}
 
 	if settings.DexConfig != "" {
-		transport.TLSClientConfig = dex.TLSConfig(dexTlsConfig)
-		addrWithProto := dex.DexServerAddressWithProtocol(dexServerAddr, dexTlsConfig)
+		transport.TLSClientConfig = dex.TLSConfig(dexTLSConfig)
+		addrWithProto := dex.DexServerAddressWithProtocol(dexServerAddr, dexTLSConfig)
 		s.client.Transport = dex.NewDexRewriteURLRoundTripper(addrWithProto, s.client.Transport)
 	} else {
 		transport.TLSClientConfig = settings.OIDCTLSConfig()

--- a/util/settings/accounts.go
+++ b/util/settings/accounts.go
@@ -38,7 +38,7 @@ const (
 	// AccountCapabilityLogin represents capability to create UI session tokens.
 	AccountCapabilityLogin AccountCapability = "login"
 	// AccountCapabilityLogin represents capability to generate API auth tokens.
-	AccountCapabilityApiKey AccountCapability = "apiKey"
+	AccountCapabilityApiKey AccountCapability = "apiKey" //nolint:revive //FIXME(var-naming)
 )
 
 // Token holds the information about the generated auth token.

--- a/util/settings/filtered_resource.go
+++ b/util/settings/filtered_resource.go
@@ -9,8 +9,8 @@ type FilteredResource struct {
 }
 
 func (r FilteredResource) matchGroup(apiGroup string) bool {
-	for _, excludedApiGroup := range r.APIGroups {
-		if glob.Match(excludedApiGroup, apiGroup) {
+	for _, excludedAPIGroup := range r.APIGroups {
+		if glob.Match(excludedAPIGroup, apiGroup) {
 			return true
 		}
 	}

--- a/util/settings/settings.go
+++ b/util/settings/settings.go
@@ -55,7 +55,7 @@ type ArgoCDSettings struct {
 	// Indicates if status badge is enabled or not.
 	StatusBadgeEnabled bool `json:"statusBadgeEnable"`
 	// Indicates if status badge custom root URL should be used.
-	StatusBadgeRootUrl string `json:"statusBadgeRootUrl,omitempty"`
+	StatusBadgeRootUrl string `json:"statusBadgeRootUrl,omitempty"` //nolint:revive //FIXME(var-naming)
 	// DexConfig contains portions of a dex config yaml
 	DexConfig string `json:"dexConfig,omitempty"`
 	// OIDCConfigRAW holds OIDC configuration as a raw string
@@ -90,15 +90,15 @@ type ArgoCDSettings struct {
 	// Specifies token expiration duration
 	UserSessionDuration time.Duration `json:"userSessionDuration,omitempty"`
 	// UiCssURL local or remote path to user-defined CSS to customize ArgoCD UI
-	UiCssURL string `json:"uiCssURL,omitempty"`
+	UiCssURL string `json:"uiCssURL,omitempty"` //nolint:revive //FIXME(var-naming)
 	// Content of UI Banner
-	UiBannerContent string `json:"uiBannerContent,omitempty"`
+	UiBannerContent string `json:"uiBannerContent,omitempty"` //nolint:revive //FIXME(var-naming)
 	// URL for UI Banner
-	UiBannerURL string `json:"uiBannerURL,omitempty"`
+	UiBannerURL string `json:"uiBannerURL,omitempty"` //nolint:revive //FIXME(var-naming)
 	// Make Banner permanent and not closeable
-	UiBannerPermanent bool `json:"uiBannerPermanent,omitempty"`
+	UiBannerPermanent bool `json:"uiBannerPermanent,omitempty"` //nolint:revive //FIXME(var-naming)
 	// Position of UI Banner
-	UiBannerPosition string `json:"uiBannerPosition,omitempty"`
+	UiBannerPosition string `json:"uiBannerPosition,omitempty"` //nolint:revive //FIXME(var-naming)
 	// PasswordPattern for password regular expression
 	PasswordPattern string `json:"passwordPattern,omitempty"`
 	// BinaryUrls contains the URLs for downloading argocd binaries
@@ -355,7 +355,7 @@ type Repository struct {
 	// GCPServiceAccountKey specifies the service account key in JSON format to be used for getting credentials to Google Cloud Source repos
 	GCPServiceAccountKey *corev1.SecretKeySelector `json:"gcpServiceAccountKey,omitempty"`
 	// ForceHttpBasicAuth determines whether Argo CD should force use of basic auth for HTTP connected repositories
-	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty"`
+	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty"` //nolint:revive //FIXME(var-naming)
 	// UseAzureWorkloadIdentity specifies whether to use Azure Workload Identity for authentication
 	UseAzureWorkloadIdentity bool `json:"useAzureWorkloadIdentity,omitempty"`
 }
@@ -389,7 +389,7 @@ type RepositoryCredentials struct {
 	// GCPServiceAccountKey specifies the service account key in JSON format to be used for getting credentials to Google Cloud Source repos
 	GCPServiceAccountKey *corev1.SecretKeySelector `json:"gcpServiceAccountKey,omitempty"`
 	// ForceHttpBasicAuth determines whether Argo CD should force use of basic auth for HTTP connected repositories
-	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty"`
+	ForceHttpBasicAuth bool `json:"forceHttpBasicAuth,omitempty"` //nolint:revive //FIXME(var-naming)
 	// UseAzureWorkloadIdentity specifies whether to use Azure Workload Identity for authentication
 	UseAzureWorkloadIdentity bool `json:"useAzureWorkloadIdentity,omitempty"`
 }
@@ -433,8 +433,8 @@ const (
 	settingsOIDCConfigKey = "oidc.config"
 	// statusBadgeEnabledKey holds the key which enables of disables status badge feature
 	statusBadgeEnabledKey = "statusbadge.enabled"
-	// statusBadgeRootUrlKey holds the key for the root badge URL override
-	statusBadgeRootUrlKey = "statusbadge.url"
+	// statusBadgeRootURLKey holds the key for the root badge URL override
+	statusBadgeRootURLKey = "statusbadge.url"
 	// settingsWebhookGitHubSecret is the key for the GitHub shared webhook secret
 	settingsWebhookGitHubSecretKey = "webhook.github.secret"
 	// settingsWebhookGitLabSecret is the key for the GitLab shared webhook secret
@@ -485,16 +485,16 @@ const (
 	userSessionDurationKey = "users.session.duration"
 	// diffOptions is the key where diff options are configured
 	resourceCompareOptionsKey = "resource.compareoptions"
-	// settingUiCssURLKey designates the key for user-defined CSS URL for UI customization
-	settingUiCssURLKey = "ui.cssurl"
-	// settingUiBannerContentKey designates the key for content of user-defined info banner for UI
-	settingUiBannerContentKey = "ui.bannercontent"
-	// settingUiBannerURLKey designates the key for the link for user-defined info banner for UI
-	settingUiBannerURLKey = "ui.bannerurl"
-	// settingUiBannerPermanentKey designates the key for whether the banner is permanent and not closeable
-	settingUiBannerPermanentKey = "ui.bannerpermanent"
-	// settingUiBannerPositionKey designates the key for the position of the banner
-	settingUiBannerPositionKey = "ui.bannerposition"
+	// settingUICSSURLKey designates the key for user-defined CSS URL for UI customization
+	settingUICSSURLKey = "ui.cssurl"
+	// settingUIBannerContentKey designates the key for content of user-defined info banner for UI
+	settingUIBannerContentKey = "ui.bannercontent"
+	// settingUIBannerURLKey designates the key for the link for user-defined info banner for UI
+	settingUIBannerURLKey = "ui.bannerurl"
+	// settingUIBannerPermanentKey designates the key for whether the banner is permanent and not closeable
+	settingUIBannerPermanentKey = "ui.bannerpermanent"
+	// settingUIBannerPositionKey designates the key for the position of the banner
+	settingUIBannerPositionKey = "ui.bannerposition"
 	// settingsBinaryUrlsKey designates the key for the argocd binary URLs
 	settingsBinaryUrlsKey = "help.download"
 	// globalProjectsKey designates the key for global project settings
@@ -1418,19 +1418,19 @@ func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *corev1.Conf
 	settings.OIDCConfigRAW = argoCDCM.Data[settingsOIDCConfigKey]
 	settings.KustomizeBuildOptions = argoCDCM.Data[kustomizeBuildOptionsKey]
 	settings.StatusBadgeEnabled = argoCDCM.Data[statusBadgeEnabledKey] == "true"
-	settings.StatusBadgeRootUrl = argoCDCM.Data[statusBadgeRootUrlKey]
+	settings.StatusBadgeRootUrl = argoCDCM.Data[statusBadgeRootURLKey]
 	settings.AnonymousUserEnabled = argoCDCM.Data[anonymousUserEnabledKey] == "true"
-	settings.UiCssURL = argoCDCM.Data[settingUiCssURLKey]
-	settings.UiBannerContent = argoCDCM.Data[settingUiBannerContentKey]
-	settings.UiBannerPermanent = argoCDCM.Data[settingUiBannerPermanentKey] == "true"
-	settings.UiBannerPosition = argoCDCM.Data[settingUiBannerPositionKey]
+	settings.UiCssURL = argoCDCM.Data[settingUICSSURLKey]
+	settings.UiBannerContent = argoCDCM.Data[settingUIBannerContentKey]
+	settings.UiBannerPermanent = argoCDCM.Data[settingUIBannerPermanentKey] == "true"
+	settings.UiBannerPosition = argoCDCM.Data[settingUIBannerPositionKey]
 	settings.ServerRBACLogEnforceEnable = argoCDCM.Data[settingsServerRBACLogEnforceEnableKey] == "true"
 	settings.BinaryUrls = getDownloadBinaryUrlsFromConfigMap(argoCDCM)
 	if err := validateExternalURL(argoCDCM.Data[settingURLKey]); err != nil {
 		log.Warnf("Failed to validate URL in configmap: %v", err)
 	}
 	settings.URL = argoCDCM.Data[settingURLKey]
-	if err := validateExternalURL(argoCDCM.Data[settingUiBannerURLKey]); err != nil {
+	if err := validateExternalURL(argoCDCM.Data[settingUIBannerURLKey]); err != nil {
 		log.Warnf("Failed to validate UI banner URL in configmap: %v", err)
 	}
 	if argoCDCM.Data[settingAdditionalUrlsKey] != "" {
@@ -1443,7 +1443,7 @@ func updateSettingsFromConfigMap(settings *ArgoCDSettings, argoCDCM *corev1.Conf
 			log.Warnf("Failed to validate external URL in configmap: %v", err)
 		}
 	}
-	settings.UiBannerURL = argoCDCM.Data[settingUiBannerURLKey]
+	settings.UiBannerURL = argoCDCM.Data[settingUIBannerURLKey]
 	settings.UserSessionDuration = time.Hour * 24
 	if userSessionDurationStr, ok := argoCDCM.Data[userSessionDurationKey]; ok {
 		if val, err := timeutil.ParseDuration(userSessionDurationStr); err != nil {
@@ -1605,17 +1605,17 @@ func (mgr *SettingsManager) SaveSettings(settings *ArgoCDSettings) error {
 			delete(argoCDCM.Data, settingsOIDCConfigKey)
 		}
 		if settings.UiCssURL != "" {
-			argoCDCM.Data[settingUiCssURLKey] = settings.UiCssURL
+			argoCDCM.Data[settingUICSSURLKey] = settings.UiCssURL
 		}
 		if settings.UiBannerContent != "" {
-			argoCDCM.Data[settingUiBannerContentKey] = settings.UiBannerContent
+			argoCDCM.Data[settingUIBannerContentKey] = settings.UiBannerContent
 		} else {
-			delete(argoCDCM.Data, settingUiBannerContentKey)
+			delete(argoCDCM.Data, settingUIBannerContentKey)
 		}
 		if settings.UiBannerURL != "" {
-			argoCDCM.Data[settingUiBannerURLKey] = settings.UiBannerURL
+			argoCDCM.Data[settingUIBannerURLKey] = settings.UiBannerURL
 		} else {
-			delete(argoCDCM.Data, settingUiBannerURLKey)
+			delete(argoCDCM.Data, settingUIBannerURLKey)
 		}
 		return nil
 	})

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -300,7 +300,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 	}
 
 	for _, webURL := range webURLs {
-		repoRegexp, err := getWebUrlRegex(webURL)
+		repoRegexp, err := getWebURLRegex(webURL)
 		if err != nil {
 			log.Warnf("Failed to get repoRegexp: %s", err)
 			continue
@@ -329,9 +329,9 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 	}
 }
 
-// getWebUrlRegex compiles a regex that will match any targetRevision referring to the same repo as the given webURL.
+// getWebURLRegex compiles a regex that will match any targetRevision referring to the same repo as the given webURL.
 // webURL is expected to be a URL from an SCM webhook payload pointing to the web page for the repo.
-func getWebUrlRegex(webURL string) (*regexp.Regexp, error) {
+func getWebURLRegex(webURL string) (*regexp.Regexp, error) {
 	urlObj, err := url.Parse(webURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse repoURL '%s'", webURL)

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -325,10 +325,10 @@ func TestBitbucketServerRepositoryReferenceChangedEvent(t *testing.T) {
 	close(h.queue)
 	h.Wait()
 	assert.Equal(t, http.StatusOK, w.Code)
-	expectedLogResultSsh := "Received push event repo: ssh://git@bitbucketserver:7999/myproject/test-repo.git, revision: master, touchedHead: true"
-	assert.Equal(t, expectedLogResultSsh, hook.AllEntries()[len(hook.AllEntries())-2].Message)
-	expectedLogResultHttps := "Received push event repo: https://bitbucketserver/scm/myproject/test-repo.git, revision: master, touchedHead: true"
-	assert.Equal(t, expectedLogResultHttps, hook.LastEntry().Message)
+	expectedLogResultSSH := "Received push event repo: ssh://git@bitbucketserver:7999/myproject/test-repo.git, revision: master, touchedHead: true"
+	assert.Equal(t, expectedLogResultSSH, hook.AllEntries()[len(hook.AllEntries())-2].Message)
+	expectedLogResultHTTPS := "Received push event repo: https://bitbucketserver/scm/myproject/test-repo.git, revision: master, touchedHead: true"
+	assert.Equal(t, expectedLogResultHTTPS, hook.LastEntry().Message)
 	hook.Reset()
 }
 
@@ -632,7 +632,7 @@ func Test_getWebUrlRegex(t *testing.T) {
 		testCopy := testCase
 		t.Run(testCopy.name, func(t *testing.T) {
 			t.Parallel()
-			regexp, err := getWebUrlRegex(testCopy.webURL)
+			regexp, err := getWebURLRegex(testCopy.webURL)
 			require.NoError(t, err)
 			assert.Equal(t, regexp.MatchString(testCopy.repo), testCopy.shouldMatch, "sourceRevisionHasChanged()")
 		})

--- a/util/workloadidentity/workloadidentity.go
+++ b/util/workloadidentity/workloadidentity.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	EmptyGuid = "00000000-0000-0000-0000-000000000000"
+	EmptyGuid = "00000000-0000-0000-0000-000000000000" //nolint:revive //FIXME(var-naming)
 )
 
 type TokenProvider interface {


### PR DESCRIPTION
#### Description 

[var-naming](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming): This rule warns when initialism, variable or package naming conventions are not followed.

The breaking changingissues has been excluded with `//nolint:revive //FIXME(var-naming)` so the rule can be applied to all new developpements and le the time to decide on how to address the existing issues.