### PR TITLE
fix: Apply deletion permission checks when syncing with replace (#14161)

### DIFF
--- a/assets/builtin-policy.csv
+++ b/assets/builtin-policy.csv
@@ -1,4 +1,5 @@
-# Built-in policy which defines two roles: role:readonly and role:admin,
+# Built-in policy which defines several roles: role:readonly, role:applicationsyncer,
+# role:applicationdeleter, role:deploymentdeleter, role:resourcesdeleter and role:admin, 
 # and additionally assigns the admin user to the role:admin role.
 # There are two policy formats:
 # 1. Applications, applicationsets, logs, and exec (which belong to a project):
@@ -15,6 +16,14 @@ p, role:readonly, projects, get, *, allow
 p, role:readonly, accounts, get, *, allow
 p, role:readonly, gpgkeys, get, *, allow
 p, role:readonly, logs, get, */*, allow
+
+p, role:applicationsyncer, applications, sync, */*, allow
+
+p, role:applicationdeleter, applications, delete, */*, allow
+
+p, role:deploymentdeleter, applications, delete/*/Deployment/*, */*, allow
+
+p, role:resourcesdeleter, applications, delete/*, */*, allow
 
 p, role:admin, applications, create, */*, allow
 p, role:admin, applications, update, */*, allow
@@ -49,4 +58,8 @@ p, role:admin, gpgkeys, delete, *, allow
 p, role:admin, exec, create, */*, allow
 
 g, role:admin, role:readonly
+g, role:applicationsyncer, role:readonly
+g, role:applicationdeleter, role:applicationsyncer
+g, role:deploymentdeleter, role:applicationsyncer
+g, role:resourcesdeleter, role:applicationsyncer
 g, admin, role:admin

--- a/docs/operator-manual/rbac.md
+++ b/docs/operator-manual/rbac.md
@@ -174,6 +174,21 @@ p, example-user, applications, update/*, default/prod-app, deny
     p, example-user, applications, delete/*/Pod/*, default/prod-app, deny
     ```
 
+!!! note
+
+    The deletion permissions are generally necessary to do a sync with replace, since that deletes and recreates the objects.
+    However, the checks are not done when replace option is specified via application/resource annotations. This would be hard to
+    implement, but also may offer a bit of extra protection by PR reviews for example. This is also a way to avoid giving users
+    too broad delete permissions if only specific resources need to be synced with replace. Here are examples of how you can configure
+    deletion options necessary for various syncs replace:
+
+    ```csv
+    p, example-user-whole-app-sync-with-replace, applications, delete/*, */*, allow
+    p, example-user-deployment-sync-with-replace, applications, delete/*/Deployment/*, */*, allow
+    ```
+
+    We don't have to grant a permission to delete a whole application.
+
 #### The `action` action
 
 The `action` action corresponds to either built-in resource customizations defined

--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -186,6 +186,9 @@ If the `Replace=true` sync option is set the Argo CD will use `kubectl replace` 
       During the sync process, the resources will be synchronized using the 'kubectl replace/create' command.
       This sync option has the potential to be destructive and might lead to resources having to be recreated, which could cause an outage for your application.
 
+!!! warning
+      Using these annotations would bypass the RBAC checks for resources deletion which are normally applied when syncing with replace.
+
 This can also be configured at individual resource level.
 ```yaml
 metadata:


### PR DESCRIPTION
Closes #14161

Sync with replace can be quite dangerous, but we currently allow it if the sync is allowed. Since sync with replace deletes resources and recreates them, it's reasonable to check deletion permissions for application and/or specific resources.

Let's cherry-pick this to 2.13.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
