### PR TITLE
fix: On deployed trigger must consider race between last transition time and sync finished time (#9070)

### DIFF
--- a/notifications_catalog/install.yaml
+++ b/notifications_catalog/install.yaml
@@ -491,7 +491,7 @@ data:
       send:
       - app-deployed
       when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded']
-        and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Before(time.Parse(app.status.operationState.finishedAt))
+        and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Add(1 * time.Minute).Before(time.Parse(app.status.operationState.finishedAt))
   trigger.on-health-degraded: |
     - description: Application has degraded
       oncePer: app.status.operationState?.syncResult?.revision

--- a/notifications_catalog/install.yaml
+++ b/notifications_catalog/install.yaml
@@ -491,8 +491,8 @@ data:
       send:
       - app-deployed
       when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded']
-        and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Add(1 *
-        time.Minute).Before(time.Parse(app.status.operationState.finishedAt))
+        and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Add(1
+        * time.Minute).Before(time.Parse(app.status.operationState.finishedAt))
   trigger.on-health-degraded: |
     - description: Application has degraded
       oncePer: app.status.operationState?.syncResult?.revision

--- a/notifications_catalog/install.yaml
+++ b/notifications_catalog/install.yaml
@@ -491,7 +491,8 @@ data:
       send:
       - app-deployed
       when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded']
-        and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Add(1 * time.Minute).Before(time.Parse(app.status.operationState.finishedAt))
+        and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Add(1 *
+        time.Minute).Before(time.Parse(app.status.operationState.finishedAt))
   trigger.on-health-degraded: |
     - description: Application has degraded
       oncePer: app.status.operationState?.syncResult?.revision

--- a/notifications_catalog/triggers/on-deployed.yaml
+++ b/notifications_catalog/triggers/on-deployed.yaml
@@ -1,4 +1,4 @@
-- when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Before(time.Parse(app.status.operationState.finishedAt))
+- when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Add(1 * time.Minute).Before(time.Parse(app.status.operationState.finishedAt))
   description: Application is synced and healthy. Triggered once per commit.
   send: [app-deployed]
   oncePer: app.status.operationState?.syncResult?.revision


### PR DESCRIPTION
Fixes #9070

There are cases during legitimate sync/deploy, when the last transition time is like 1 second before the operation finished time. In theory, the gap can be a bit bigger if there are more sync waves that don't do any updates. So giving some more gap of 1 minute.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
