### PR TITLE
docs: Improve doc on project roles

### DIFF
--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -135,20 +135,20 @@ metadata:
 spec:
   ...
   roles:
-  - name: admin 
-    description: some-role 
+  - name: admin
+    description: Some role description
     groups:
     - some-user
     policies:
-    - p, proj:sample-test-project:some-role, applications, *, *, allow
+    - p, proj:sample-test-project:admin, applications, *, sample-test-project/*, allow
   ...
 ```
 
 Argo CD will use the policies defined in the AppProject roles while authorizing users actions. To determine which role a given users is associated with, it will dynamically create groups based on the role name in runtime. The project definition above will generate the following Casbin RBAC rules:
 
 ```
-    p, proj:sample-test-project:some-role, applications, *, *, allow
-    g, some-user, proj:sample-test-project:some-role
+    p, proj:sample-test-project:admin, applications, *, sample-test-project/*, allow
+    g, some-user, proj:sample-test-project:admin
 ```
 
 _Note 1_: It is very important that policy roles follow the pattern `proj:<project-name>:<role-name>` or they won't be effective during the Argo CD authorization process.


### PR DESCRIPTION
Use role name instead of role description within policies. Also scope the role policy to that project only.