### PR TITLE
fix: Allow ClusterAPI MachinePool scaling to be considered Healthy

### DIFF
--- a/resource_customizations/cluster.x-k8s.io/MachinePool/health.lua
+++ b/resource_customizations/cluster.x-k8s.io/MachinePool/health.lua
@@ -6,7 +6,7 @@ function getStatusBasedOnPhase(obj, hs)
     -- https://github.com/kubernetes-sigs/cluster-api/blob/release-1.8/exp/api/v1beta1/machinepool_types.go#L139-L182
     if obj.status ~= nil and obj.status.phase ~= nil then
         hs.message = "MachinePool is " .. obj.status.phase
-        if obj.status.phase == "Running" then
+        if obj.status.phase == "Running" or obj.status.phase == "Scaling" then
             hs.status = "Healthy"
         end
         if obj.status.phase == "Failed" or obj.status.phase == "Unknown"  then

--- a/resource_customizations/cluster.x-k8s.io/MachinePool/health_test.yaml
+++ b/resource_customizations/cluster.x-k8s.io/MachinePool/health_test.yaml
@@ -4,6 +4,10 @@ tests:
     message: 'MachinePool is Running'
   inputPath: testdata/healthy_provisioned.yaml
 - healthStatus:
+    status: Healthy
+    message: 'MachinePool is Scaling'
+  inputPath: testdata/scaling_provisioned.yaml
+- healthStatus:
     status: Progressing
     message: 'MachinePool is Provisioning: Not Ready (WaitingForInfrastructure), Not InfrastructureReady (WaitingForInfrastructure)'
   inputPath: testdata/progressing_provisioning.yaml

--- a/resource_customizations/cluster.x-k8s.io/MachinePool/testdata/scaling_provisioned.yaml
+++ b/resource_customizations/cluster.x-k8s.io/MachinePool/testdata/scaling_provisioned.yaml
@@ -1,0 +1,58 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  labels:
+    argocd.argoproj.io/instance: foo
+    cluster.x-k8s.io/cluster-name: foo
+  name: foo-pool
+  namespace: default
+spec:
+  clusterName: foo
+  replicas: 3
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: foo
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: AWSManagedMachinePool
+        name: foo-pool
+        namespace: default
+      version: v1.30.0
+status:
+  availableReplicas: 2
+  bootstrapReady: true
+  conditions:
+    - lastTransitionTime: '2024-08-19T20:33:02Z'
+      status: 'True'
+      type: Ready
+    - lastTransitionTime: '2024-08-19T20:18:31Z'
+      status: 'True'
+      type: BootstrapReady
+    - lastTransitionTime: '2024-08-19T20:33:02Z'
+      status: 'True'
+      type: InfrastructureReady
+    - lastTransitionTime: '2024-08-19T20:18:31Z'
+      status: 'True'
+      type: ReplicasReady
+  infrastructureReady: true
+  nodeRefs:
+    - apiVersion: v1
+      kind: Node
+      name: ip-18-232-50-123-ec2.internal
+      uid: e4b3a44f-1c2d-4fd3-bb9e-3b0e08787a5a
+    - apiVersion: v1
+      kind: Node
+      name: ip-52-23-45-67-ec2.internal
+      uid: 2b9dabe5-3a1d-429a-985b-5e7ffb9649c6
+    - apiVersion: v1
+      kind: Node
+      name: ip-34-207-89-12-ec2.internal
+      uid: 6f94031a-d3e4-48f7-bc94-22bb9b687f5e
+  observedGeneration: 2
+  phase: Scaling
+  readyReplicas: 2
+  unavailableReplicas: 1
+  replicas: 3


### PR DESCRIPTION
This allows the ClusterAPI MachinePool health checks to be considered Healthy when the MachinePool(s) are in a scaling state. It is very common for a MachinePool to be scaling up or down during normal operations of a cluster outside of the Argo CD sync so I wouldn't think it would be considered that the sync is in a Progressing state.

I would propose that this should be cherrypicked back to 2.13 (where it was introduced) & 2.14 instead of waiting for 3.0.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates? no
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [na] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).
