### PR TITLE
fix: do not fail on manifest-like yaml files - fixes #21934

### DIFF
--- a/docs/user-guide/directory.md
+++ b/docs/user-guide/directory.md
@@ -130,3 +130,28 @@ spec:
       exclude: '{config.json,env-usw2/*}'
       include: '*.yaml'
 ```
+
+### Skipping File Rendering
+
+In some cases, repositories may contain YAML files that resemble Kubernetes manifests because they include fields like `apiVersion`, `kind`, and `metadata`, but are not intended to be rendered or applied as actual Kubernetes resources. Examples include Helm `values.yaml` files or configuration snippets used by CI/CD pipelines.
+
+To prevent Argo CD from attempting to parse these files as manifests (which could result in errors), you can explicitly mark them to be skipped using a special comment directive:
+
+```yaml
+# +argocd:skip-file-rendering
+```
+
+When this comment is present anywhere in the file, Argo CD will ignore the file during manifest processing. This allows for safe coexistence of Kubernetes-like files that are not actual manifests.
+
+#### Example
+
+```yaml
+# +argocd:skip-file-rendering
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+data:
+  not-actually: a-manifest
+```
+

--- a/reposerver/repository/repository_test.go
+++ b/reposerver/repository/repository_test.go
@@ -681,6 +681,17 @@ func TestInvalidManifestsInDir(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSkippedInvalidManifestsInDir(t *testing.T) {
+	service := newService(t, ".")
+
+	src := v1alpha1.ApplicationSource{Path: "./testdata/invalid-manifests-skipped", Directory: &v1alpha1.ApplicationSourceDirectory{Recurse: true}}
+
+	q := apiclient.ManifestRequest{Repo: &v1alpha1.Repository{}, ApplicationSource: &src}
+
+	_, err := service.GenerateManifest(t.Context(), &q)
+	require.NoError(t, err)
+}
+
 func TestInvalidMetadata(t *testing.T) {
 	service := newService(t, ".")
 
@@ -2815,6 +2826,13 @@ func Test_findManifests(t *testing.T) {
 		manifests, err := findManifests(logCtx, "./testdata/invalid-manifests", "./testdata/invalid-manifests", nil, noRecurse, nil, resource.MustParse("0"))
 		assert.Empty(t, manifests)
 		require.Error(t, err)
+	})
+
+	t.Run("invalid manifest containing '+argocd:skip-file-rendering' doesn't throw an error", func(t *testing.T) {
+		require.DirExists(t, "./testdata/invalid-manifests-skipped")
+		manifests, err := findManifests(logCtx, "./testdata/invalid-manifests-skipped", "./testdata/invalid-manifests-skipped", nil, noRecurse, nil, resource.MustParse("0"))
+		assert.Empty(t, manifests)
+		require.NoError(t, err)
 	})
 
 	t.Run("irrelevant YAML gets skipped, relevant YAML gets parsed", func(t *testing.T) {

--- a/reposerver/repository/testdata/invalid-manifests-skipped/bad.yaml
+++ b/reposerver/repository/testdata/invalid-manifests-skipped/bad.yaml
@@ -1,0 +1,16 @@
+# +argocd:skip-file-rendering
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "stuff.fullname" . }}-init
+  labels:
+    app: {{ template "stuff.name" . }}
+    chart: {{ template "stuff.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- $files := .Files }}
+    {{-  range tuple "init/init.sh" }}
+    {{ . }}: |-
+    {{ $files.Get . }}
+    {{ end }}


### PR DESCRIPTION
# Description 
Fixes https://github.com/argoproj/argo-cd/issues/21934

Repositories may contain YAML files that resemble valid k8s manifests, as they include `apiVersion`, `metadata`, and `kind`, but are not necessarily valid k8s manifests.  An example highlighted in [this GitHub issue](https://github.com/argoproj/argo-cd/issues/21934)  involves a Helm values file that could be mistaken for a manifest.

Currently, these manifest-like YAMLs cause an error in the form of `Failed to unmarshal "{filename}": <nil>` that stops the Application from continuing. 

This PR replaces the error with a warning  without stopping execution. The rationale being that manifest-like files are allowed to exist but a warning is issued to provide information on true positives (manifest that are malformed).

# Alternative
A potential downside of this change is that invalid manifests (true positives) will only trigger a warning rather than causing a failure. An alternative approach to address this could be to introduce an annotation or comment, such as `# ArgoCD: IgnoreNotAManifest`, which can be added to non-manifest YAML files. This would allow those manifests to be ignored if their unmarshalling fails.

# Testing
https://github.com/argoproj/argo-cd/issues/21934 contains a fairly simple way to reproduce the problem. Using this PR's branch should allow the Application to proceed while logging the warning.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [X] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [X] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
