### PR TITLE
fix: Check placement exists before length check (#22060)

### DIFF
--- a/resource_customizations/policy.open-cluster-management.io/Policy/health.lua
+++ b/resource_customizations/policy.open-cluster-management.io/Policy/health.lua
@@ -1,4 +1,5 @@
 hs = {}
+
 if obj.status == nil then
   hs.status = "Progressing"
   hs.message = "Waiting for the status to be reported"
@@ -7,7 +8,7 @@ end
 
 -- A policy will not have a compliant field but will have a placement key set if
 -- it is not being applied to any clusters
-if obj.status.compliant == nil and #obj.status.placement > 0 and obj.status.status == nil then
+if obj.status.compliant == nil and obj.status.status == nil and obj.status.placement ~= nil and #obj.status.placement > 0 then
   hs.status = "Healthy"
   hs.message = "No clusters match this policy"
   return hs
@@ -24,6 +25,8 @@ if obj.status.compliant == "Compliant" then
 else
   hs.status = "Degraded"
 end
+
+-- Collect NonCompliant clusters for the policy
 noncompliants = {}
 if obj.status.status ~= nil then
   -- "root" policy
@@ -50,4 +53,5 @@ elseif obj.status.details ~= nil then
     hs.message = "NonCompliant templates: " .. table.concat(noncompliants, ", ")
   end
 end
+
 return hs

--- a/resource_customizations/policy.open-cluster-management.io/Policy/health_test.yaml
+++ b/resource_customizations/policy.open-cluster-management.io/Policy/health_test.yaml
@@ -20,6 +20,10 @@ tests:
       message: Waiting for the status to be reported
     inputPath: testdata/progressing_no_status.yaml
   - healthStatus:
+      status: Progressing
+      message: Waiting for the status to be reported
+    inputPath: testdata/progressing_nil_status.yaml
+  - healthStatus:
       status: Healthy
       message: No clusters match this policy
     inputPath: testdata/healthy_with_placement_empty_compliant.yaml

--- a/resource_customizations/policy.open-cluster-management.io/Policy/testdata/progressing_nil_status.yaml
+++ b/resource_customizations/policy.open-cluster-management.io/Policy/testdata/progressing_nil_status.yaml
@@ -49,4 +49,3 @@ spec:
         remediationAction: enforce
         severity: medium
   remediationAction: enforce
-status: {}


### PR DESCRIPTION
Adds a missing `nil` check to `status.placement` for Policy. The original PR was delivered to v2.14, so a backport there would be ideal.

Followup to:
- #21297 

Closes #22060

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
