### PR TITLE
fix: sync result getting updated incorrectly for dry run

### DIFF
--- a/controller/sync.go
+++ b/controller/sync.go
@@ -453,7 +453,7 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 
 	if !syncOp.DryRun && len(syncOp.Resources) == 0 && state.Phase.Successful() {
 		err := m.persistRevisionHistory(app, compareResult.syncStatus.Revision, source, compareResult.syncStatus.Revisions, compareResult.syncStatus.ComparedTo.Sources, isMultiSourceRevision, state.StartedAt, state.Operation.InitiatedBy)
-		if err != nil && !syncOp.DryRun {
+		if err != nil {
 			state.Phase = common.OperationError
 			state.Message = fmt.Sprintf("failed to record sync to history: %v", err)
 		}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -141,21 +141,21 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 		}
 	}
 
-	if state.SyncResult != nil {
-		syncRes = state.SyncResult
-		revision = state.SyncResult.Revision
-		revisions = append(revisions, state.SyncResult.Revisions...)
-	} else {
-		syncRes = &v1alpha1.SyncOperationResult{}
-		// status.operationState.syncResult.source. must be set properly since auto-sync relies
-		// on this information to decide if it should sync (if source is different than the last
-		// sync attempt)
-		if isMultiSourceRevision {
-			syncRes.Sources = sources
+	if !syncOp.DryRun {
+		if state.SyncResult != nil {
+			syncRes = state.SyncResult
+			revision = state.SyncResult.Revision
+			revisions = append(revisions, state.SyncResult.Revisions...)
 		} else {
-			syncRes.Source = source
-		}
-		if !syncOp.DryRun {
+			syncRes = &v1alpha1.SyncOperationResult{}
+			// status.operationState.syncResult.source. must be set properly since auto-sync relies
+			// on this information to decide if it should sync (if source is different than the last
+			// sync attempt)
+			if isMultiSourceRevision {
+				syncRes.Sources = sources
+			} else {
+				syncRes.Source = source
+			}
 			state.SyncResult = syncRes
 		}
 	}


### PR DESCRIPTION
This PR fixes the bug where application's sync state is incorrectly getting updated on a dry run operation.
Fixes issue https://github.com/argoproj/argo-cd/issues/21899
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
