### PR TITLE
docs: Document askpass socket sharing between reposerver and cmp sidecar

### DIFF
--- a/docs/operator-manual/config-management-plugins.md
+++ b/docs/operator-manual/config-management-plugins.md
@@ -519,6 +519,10 @@ call from the config management sidecar container to the reposerver to retrieve 
 Utilizing `ASKPASS` means that credentials are not proactively shared, but rather only provided when an operation requires
 them.
 
+`ASKPASS` requires a socket to be shared between the config management plugin and the reposerver. To mitigate path traversal
+attacks, it's recommended to use a dedicated volume to share the socket, and mount it in the reposerver and sidecar.
+To change the socket path, you must set the `ARGOCD_ASK_PASS_SOCK` environment variable for both containers.
+
 To allow the plugin to access the reposerver git credentials, you can set `provideGitCreds` to `true` in the plugin spec:
 
 !!! warning


### PR DESCRIPTION
With the introduction of the `provideGitCreds` flag, it's now possible to share the git credentials with the cmp sidecar, but the documentation was lacking on how to make this work exactly.

I've opened a discussion (https://github.com/argoproj/argo-cd/discussions/22053) how to make it work, and this documents my findings.

This PR documents how to use the `ARGOCD_ASK_PASS_SOCK` env var, to change the sockets location, and recommends to use a dedicated volume/emptyDir to share the socket between the reposerver and sidecar, to avoid sharing the whole `/tmp` directory.


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or **(c) this does not need to be in the release notes.**
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

