### PR TITLE
chore(health): report progressing status for AppSets

### DIFF
--- a/resource_customizations/argoproj.io/ApplicationSet/health.lua
+++ b/resource_customizations/argoproj.io/ApplicationSet/health.lua
@@ -17,8 +17,6 @@ if obj.status ~= nil then
   end
 end
 
--- Conditions were introduced in ApplicationSet v0.3. To give v0.2 users a good experience, we default to "Healthy".
--- Once v0.3 is more generally adopted, we'll default to "Progressing" instead.
-hs.status = "Healthy"
-hs.message = ""
+hs.status = "Progressing"
+hs.message = "Waiting for the status to be reported"
 return hs

--- a/resource_customizations/argoproj.io/ApplicationSet/health_test.yaml
+++ b/resource_customizations/argoproj.io/ApplicationSet/health_test.yaml
@@ -8,6 +8,6 @@ tests:
       message: "found less than two generators, Merge requires two or more"
     inputPath: testdata/errorApplicationSetWithStatusMessage.yaml
   - healthStatus:
-      status: Healthy
-      message: ""
+      status: Progressing
+      message: "Waiting for the status to be reported"
     inputPath: testdata/noStatusApplicationSet.yaml


### PR DESCRIPTION
We've shipped the AppSet controller with Argo CD for a long time. Running v0.2 of AppSet with Argo CD 3.0 would be a far, far edge case. I don't think we even need an upgrade note for this.