### PR TITLE
fix: return cluster URL in error message, not full cluster object

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -723,7 +723,7 @@ func (c *liveStateCache) GetManagedLiveObjs(destCluster *appv1.Cluster, a *appv1
 func (c *liveStateCache) GetVersionsInfo(server *appv1.Cluster) (string, []kube.APIResourceInfo, error) {
 	clusterInfo, err := c.getSyncedCluster(server)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to get cluster info for %q: %w", server, err)
+		return "", nil, fmt.Errorf("failed to get cluster info for %q: %w", server.Server, err)
 	}
 	return clusterInfo.GetServerVersion(), clusterInfo.GetAPIResources(), nil
 }

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -731,3 +731,17 @@ func TestShouldHashManifest(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetVersionsInfo_error_redacted(t *testing.T) {
+	c := liveStateCache{}
+	cluster := &appv1.Cluster{
+		Server: "https://localhost:1234",
+		Config: appv1.ClusterConfig{
+			Username: "admin",
+			Password: "password",
+		},
+	}
+	_, _, err := c.GetVersionsInfo(cluster)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "password")
+}


### PR DESCRIPTION
We should return the URL in an error message, but not the whole cluster object.

I introduced the problematic code here: https://github.com/argoproj/argo-cd/pull/21189/files#diff-9d84a09335b303bfb7f7b6dc9eed32b026c4c57778842c48aba95369b91ef126R724

The problematic code is only in the master branch and hasn't been released.