### PR TITLE
fix(ui): parameter tab null ref w/ hydrator (#22097)

### DIFF
--- a/ui/src/app/applications/components/application-parameters/application-parameters.tsx
+++ b/ui/src/app/applications/components/application-parameters/application-parameters.tsx
@@ -1092,7 +1092,7 @@ async function getSourceFromAppSources(aSource: models.ApplicationSource, name: 
 
 // Delete when source field is removed
 async function getSingleSource(app: models.Application) {
-    if (app.spec.source) {
+    if (app.spec.source || app.spec.sourceHydrator) {
         const repoDetail = await services.repos.appDetails(getAppDefaultSource(app), app.metadata.name, app.spec.project, 0, 0).catch(() => ({
             type: 'Directory' as models.AppSourceType,
             path: getAppDefaultSource(app).path


### PR DESCRIPTION
This is a very lazy fix. It doesn't address how the parameters tab should adapt to the hydrator or what should happen when you try to edit parameters. It just keeps the page from crashing.

Fixes #22097