### PR TITLE
fix(actions): don't run empty Lua scripts (#22084)

### DIFF
--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -395,7 +395,6 @@ func (vm VM) GetResourceActionDiscovery(obj *unstructured.Unstructured) ([]strin
 	// Fetch predefined Lua scripts
 	discoveryKey := key + "/actions/"
 	discoveryScript, err := vm.getPredefinedLuaScripts(discoveryKey, actionDiscoveryScriptFile)
-
 	if err != nil {
 		var doesNotExistErr *ScriptDoesNotExistError
 		if errors.As(err, &doesNotExistErr) {

--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -396,9 +396,12 @@ func (vm VM) GetResourceActionDiscovery(obj *unstructured.Unstructured) ([]strin
 	discoveryKey := key + "/actions/"
 	discoveryScript, err := vm.getPredefinedLuaScripts(discoveryKey, actionDiscoveryScriptFile)
 
-	// Ignore the error if the script does not exist.
-	var doesNotExistErr *ScriptDoesNotExistError
-	if err != nil && !errors.As(err, &doesNotExistErr) {
+	if err != nil {
+		var doesNotExistErr *ScriptDoesNotExistError
+		if errors.As(err, &doesNotExistErr) {
+			// No worries, just return what we have.
+			return discoveryScripts, nil
+		}
 		return nil, fmt.Errorf("error while fetching predefined lua scripts: %w", err)
 	}
 

--- a/util/lua/lua_test.go
+++ b/util/lua/lua_test.go
@@ -325,7 +325,7 @@ func TestGetResourceActionDiscoveryNoPredefined(t *testing.T) {
 	vm := VM{}
 	discoveryLua, err := vm.GetResourceActionDiscovery(testObj)
 	require.NoError(t, err)
-	assert.Equal(t, "", discoveryLua[0])
+	assert.Empty(t, discoveryLua)
 }
 
 func TestGetResourceActionDiscoveryWithOverride(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/22084

The code currently appends an empty Lua script to the slice of actions scripts when a script isn't found. The end result of that is that we run an empty Lua script and get an error about the output of the script being `nil`. This fix just skips appending the empty script when a script isn't found.