### PR TITLE
fix(ci): use pinned Helm version for init-release (#22164)

### DIFF
--- a/hack/installers/install-codegen-tools.sh
+++ b/hack/installers/install-codegen-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-KUSTOMIZE_VERSION=5.4.3 "$(dirname $0)/../install.sh" kustomize protoc
+KUSTOMIZE_VERSION=5.4.3 "$(dirname $0)/../install.sh" helm kustomize protoc

--- a/manifests/ha/base/redis-ha/generate.sh
+++ b/manifests/ha/base/redis-ha/generate.sh
@@ -5,6 +5,7 @@ helm dependency update ./chart
 AUTOGENMSG="# This is an auto-generated file. DO NOT EDIT"
 echo "${AUTOGENMSG}" > ./chart/upstream.yaml
 
+helm version
 helm template argocd ./chart \
   --namespace argocd \
   --values ./chart/values.yaml \


### PR DESCRIPTION
Fixes #22164

The "Init Release" workflow currently runs `make codegen-local` to make sure manifests are up to date before opening the version bump PR.

Unfortunately, the script currently uses a floating Helm version, probably whatever is on the GHA runner.

This change pins the version by ensuring we run the helm install script before running codegen. It also prints the Helm version before running `helm template` in the redis-ha generate script, so that we can confirm the version being used. 

I've confirmed the behavior [before](https://github.com/crenshaw-dev/argo-cd/actions/runs/13657168107/job/38179418229) and [after](https://github.com/crenshaw-dev/argo-cd/actions/runs/13657342519/job/38179768297) in my fork (search for "helm version" - the version run should match the pinned version, i.e. 3.16.3).