### PR TITLE
chore: embed trivial rand string function

### DIFF
--- a/test/e2e/applicationset_git_generator_test.go
+++ b/test/e2e/applicationset_git_generator_test.go
@@ -2,12 +2,14 @@ package e2e
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/argoproj/pkg/rand"
 	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,6 +21,16 @@ import (
 	. "github.com/argoproj/argo-cd/v3/test/e2e/fixture/applicationsets"
 	"github.com/argoproj/argo-cd/v3/test/e2e/fixture/applicationsets/utils"
 )
+
+func randStr(t *testing.T) string {
+	t.Helper()
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		require.NoError(t, err)
+		return ""
+	}
+	return hex.EncodeToString(bytes)
+}
 
 func TestSimpleGitDirectoryGenerator(t *testing.T) {
 	generateExpectedApp := func(name string) v1alpha1.Application {
@@ -393,13 +405,11 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 
 	project := "gpg"
 
-	str, _ := rand.RandString(1)
-
 	Given(t).
 		Project(project).
 		Path(guestbookPath).
 		When().
-		AddSignedFile("test.yaml", str).IgnoreErrors().
+		AddSignedFile("test.yaml", randStr(t)).IgnoreErrors().
 		IgnoreErrors().
 		// Create a GitGenerator-based ApplicationSet
 		Create(v1alpha1.ApplicationSet{
@@ -705,8 +715,6 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 		}
 	}
 
-	str, _ := rand.RandString(1)
-
 	expectedApps := []v1alpha1.Application{
 		generateExpectedApp("engineering-dev-guestbook"),
 		generateExpectedApp("engineering-prod-guestbook"),
@@ -716,7 +724,7 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 		Project(project).
 		Path(guestbookPath).
 		When().
-		AddSignedFile("test.yaml", str).IgnoreErrors().
+		AddSignedFile("test.yaml", randStr(t)).IgnoreErrors().
 		IgnoreErrors().
 		// Create a GitGenerator-based ApplicationSet
 		Create(v1alpha1.ApplicationSet{


### PR DESCRIPTION
Relying on an external package for a trivial function introduces maintenance cost. This PR embeds the function where needed.

https://github.com/argoproj/argo-cd/issues/22175