### PR TITLE
docs: document bearerToken in repo example doc

### DIFF
--- a/docs/operator-manual/argocd-repositories.yaml
+++ b/docs/operator-manual/argocd-repositories.yaml
@@ -12,6 +12,7 @@ stringData:
   url: https://github.com/argoproj/argocd-example-apps
   password: my-password
   username: my-username
+  bearerToken: my-token
   project: my-project
   insecure: "true" # Ignore validity of server's TLS certificate. Defaults to "false"
   forceHttpBasicAuth: "true" # Skip auth method negotiation and force usage of HTTP basic auth. Defaults to "false"


### PR DESCRIPTION
Documenting [this feature](https://github.com/argoproj/argo-cd/pull/21462) in one additional place.