### PR TITLE
docs: fix tmp path and document Rancher caveat

### DIFF
--- a/docs/developer-guide/test-e2e.md
+++ b/docs/developer-guide/test-e2e.md
@@ -3,8 +3,19 @@
 The test [directory](https://github.com/argoproj/argo-cd/tree/master/test) contains E2E tests and test applications. The tests assume that Argo CD services are installed into `argocd-e2e` namespace or cluster in current context. A throw-away
 namespace `argocd-e2e***` is created prior to the execution of the tests. The throw-away namespace is used as a target namespace for test applications.
 
-The [/test/e2e/testdata](https://github.com/argoproj/argo-cd/tree/master/test/e2e/testdata) directory contains various Argo CD applications. Before test execution, the directory is copied into `/tmp/argocd-e2e***` temp directory and used in tests as a
-Git repository via file url: `file:///tmp/argocd-e2e***`.
+The [/test/e2e/testdata](https://github.com/argoproj/argo-cd/tree/master/test/e2e/testdata) directory contains various Argo CD applications. Before test execution, the directory is copied into `/tmp/argo-e2e***` temp directory and used in tests as a
+Git repository via file url: `file:///tmp/argo-e2e***`.
+
+!!! note "Rancher Desktop Volume Sharing"
+    The e2e git server runs in a container. If you are using Rancher Desktop, you will need to enable volume sharing for
+    the e2e container to access the testdata directory. To do this, add the following to 
+    `~/Library/Application\ Support/rancher-desktop/lima/_config/override.yaml` and restart Rancher Desktop:
+
+    ```yaml
+    mounts:
+    - location: /private/tmp
+      writable: true
+    ```
 
 ## Running Tests Locally
 
@@ -31,7 +42,7 @@ If you have changed the port for `argocd-server`, be sure to also set `ARGOCD_SE
 Some effort has been made to balance test isolation with speed. Tests are isolated as follows as each test gets:
 
 * A random 5 character ID.
-* A unique Git repository containing the `testdata` in `/tmp/argocd-e2e/${id}`.
+* A unique Git repository containing the `testdata` in `/tmp/argo-e2e/${id}`.
 * A namespace `argocd-e2e-ns-${id}`.
 * A primary name for the app `argocd-e2e-${id}`.
 


### PR DESCRIPTION
Changed `/tmp/argocd-e2e` to `/tmp/argo-e2e` (the docs were just wrong) and added docs for how to make e2e tests work for Rancher Desktop.