### PR TITLE
fix: generator interpolation didn't take into account nested matrix generators (fixes #22051)

### DIFF
--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -1892,7 +1892,7 @@ func TestRequeueGeneratorFails(t *testing.T) {
 	generatorMock := mocks.Generator{}
 	generatorMock.On("GetTemplate", &generator).
 		Return(&v1alpha1.ApplicationSetTemplate{})
-	generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything).
+	generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything, mock.Anything).
 		Return([]map[string]any{}, errors.New("Simulated error generating params that could be related to an external service/API call"))
 
 	metrics := appsetmetrics.NewFakeAppsetMetrics()

--- a/applicationset/controllers/template/template_test.go
+++ b/applicationset/controllers/template/template_test.go
@@ -91,7 +91,7 @@ func TestGenerateApplications(t *testing.T) {
 				List: &v1alpha1.ListGenerator{},
 			}
 
-			generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything).
+			generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything, mock.Anything).
 				Return(cc.params, cc.generateParamsError)
 
 			generatorMock.On("GetTemplate", &generator).
@@ -205,7 +205,7 @@ func TestMergeTemplateApplications(t *testing.T) {
 				List: &v1alpha1.ListGenerator{},
 			}
 
-			generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything).
+			generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything, mock.Anything).
 				Return(cc.params, nil)
 
 			generatorMock.On("GetTemplate", &generator).
@@ -317,7 +317,7 @@ func TestGenerateAppsUsingPullRequestGenerator(t *testing.T) {
 				PullRequest: &v1alpha1.PullRequestGenerator{},
 			}
 
-			generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything).
+			generatorMock.On("GenerateParams", &generator, mock.AnythingOfType("*v1alpha1.ApplicationSet"), mock.Anything, mock.Anything).
 				Return(cases.params, nil)
 
 			generatorMock.On("GetTemplate", &generator).

--- a/applicationset/generators/cluster.go
+++ b/applicationset/generators/cluster.go
@@ -56,7 +56,7 @@ func (g *ClusterGenerator) GetTemplate(appSetGenerator *argoappsetv1alpha1.Appli
 	return &appSetGenerator.Clusters.Template
 }
 
-func (g *ClusterGenerator) GenerateParams(appSetGenerator *argoappsetv1alpha1.ApplicationSetGenerator, appSet *argoappsetv1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *ClusterGenerator) GenerateParams(appSetGenerator *argoappsetv1alpha1.ApplicationSetGenerator, appSet *argoappsetv1alpha1.ApplicationSet, _ map[string]any, _ client.Client) ([]map[string]any, error) {
 	logCtx := log.WithField("applicationset", appSet.GetName()).WithField("namespace", appSet.GetNamespace())
 	if appSetGenerator == nil {
 		return nil, EmptyAppSetGeneratorError

--- a/applicationset/generators/cluster_test.go
+++ b/applicationset/generators/cluster_test.go
@@ -330,7 +330,7 @@ func TestGenerateParams(t *testing.T) {
 					Values:   testCase.values,
 					FlatList: testCase.isFlatMode,
 				},
-			}, &applicationSetInfo, nil)
+			}, &applicationSetInfo, nil, nil)
 
 			if testCase.expectedError != nil {
 				require.EqualError(t, err, testCase.expectedError.Error())
@@ -870,7 +870,7 @@ func TestGenerateParamsGoTemplate(t *testing.T) {
 					Values:   testCase.values,
 					FlatList: testCase.isFlatMode,
 				},
-			}, &applicationSetInfo, nil)
+			}, &applicationSetInfo, nil, nil)
 
 			if testCase.expectedError != nil {
 				require.EqualError(t, err, testCase.expectedError.Error())

--- a/applicationset/generators/duck_type.go
+++ b/applicationset/generators/duck_type.go
@@ -60,7 +60,7 @@ func (g *DuckTypeGenerator) GetTemplate(appSetGenerator *argoprojiov1alpha1.Appl
 	return &appSetGenerator.ClusterDecisionResource.Template
 }
 
-func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *DuckTypeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ map[string]any, _ client.Client) ([]map[string]any, error) {
 	if appSetGenerator == nil {
 		return nil, EmptyAppSetGeneratorError
 	}

--- a/applicationset/generators/duck_type_test.go
+++ b/applicationset/generators/duck_type_test.go
@@ -308,7 +308,7 @@ func TestGenerateParamsForDuckType(t *testing.T) {
 					LabelSelector: testCase.labelSelector,
 					Values:        testCase.values,
 				},
-			}, &applicationSetInfo, nil)
+			}, &applicationSetInfo, nil, nil)
 
 			if testCase.expectedError != nil {
 				require.EqualError(t, err, testCase.expectedError.Error())
@@ -606,7 +606,7 @@ func TestGenerateParamsForDuckTypeGoTemplate(t *testing.T) {
 					LabelSelector: testCase.labelSelector,
 					Values:        testCase.values,
 				},
-			}, &applicationSetInfo, nil)
+			}, &applicationSetInfo, nil, nil)
 
 			if testCase.expectedError != nil {
 				require.EqualError(t, err, testCase.expectedError.Error())

--- a/applicationset/generators/generator_spec_processor.go
+++ b/applicationset/generators/generator_spec_processor.go
@@ -53,7 +53,8 @@ func Transform(requestedGenerator argoprojiov1alpha1.ApplicationSetGenerator, al
 			continue
 		}
 		var params []map[string]any
-		if len(genParams) != 0 {
+		_, isMatrix := g.(*MatrixGenerator)
+		if len(genParams) != 0 && !isMatrix {
 			tempInterpolatedGenerator, err := InterpolateGenerator(&requestedGenerator, genParams, appSet.Spec.GoTemplate, appSet.Spec.GoTemplateOptions)
 			interpolatedGenerator = &tempInterpolatedGenerator
 			if err != nil {
@@ -65,7 +66,7 @@ func Transform(requestedGenerator argoprojiov1alpha1.ApplicationSetGenerator, al
 				continue
 			}
 		}
-		params, err = g.GenerateParams(interpolatedGenerator, appSet, client)
+		params, err = g.GenerateParams(interpolatedGenerator, appSet, genParams, client)
 		if err != nil {
 			log.WithError(err).WithField("generator", g).
 				Error("error generating params")

--- a/applicationset/generators/git.go
+++ b/applicationset/generators/git.go
@@ -51,7 +51,7 @@ func (g *GitGenerator) GetRequeueAfter(appSetGenerator *argoprojiov1alpha1.Appli
 	return getDefaultRequeueAfter()
 }
 
-func (g *GitGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, client client.Client) ([]map[string]any, error) {
+func (g *GitGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ map[string]any, client client.Client) ([]map[string]any, error) {
 	if appSetGenerator == nil {
 		return nil, EmptyAppSetGeneratorError
 	}

--- a/applicationset/generators/git_test.go
+++ b/applicationset/generators/git_test.go
@@ -348,7 +348,7 @@ func TestGitGenerateParamsFromDirectories(t *testing.T) {
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
-			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, client)
+			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, client)
 
 			if testCaseCopy.expectedError != nil {
 				require.EqualError(t, err, testCaseCopy.expectedError.Error())
@@ -649,7 +649,7 @@ func TestGitGenerateParamsFromDirectoriesGoTemplate(t *testing.T) {
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
-			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, client)
+			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, client)
 
 			if testCaseCopy.expectedError != nil {
 				require.EqualError(t, err, testCaseCopy.expectedError.Error())
@@ -1013,7 +1013,7 @@ cluster:
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
-			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, client)
+			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, client)
 			fmt.Println(got, err)
 
 			if testCaseCopy.expectedError != nil {
@@ -1369,7 +1369,7 @@ cluster:
 
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&appProject).Build()
 
-			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, client)
+			got, err := gitGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, client)
 			fmt.Println(got, err)
 
 			if testCaseCopy.expectedError != nil {
@@ -1565,7 +1565,7 @@ func TestGitGenerator_GenerateParams(t *testing.T) {
 
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&testCase.appProject).Build()
 
-		got, err := gitGenerator.GenerateParams(&testCase.appset.Spec.Generators[0], &testCase.appset, client)
+		got, err := gitGenerator.GenerateParams(&testCase.appset.Spec.Generators[0], &testCase.appset, nil, client)
 
 		if testCase.expectedError != nil {
 			require.EqualError(t, err, testCase.expectedError.Error())

--- a/applicationset/generators/interface.go
+++ b/applicationset/generators/interface.go
@@ -15,7 +15,7 @@ type Generator interface {
 	// GenerateParams interprets the ApplicationSet and generates all relevant parameters for the application template.
 	// The expected / desired list of parameters is returned, it then will be render and reconciled
 	// against the current state of the Applications in the cluster.
-	GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, client client.Client) ([]map[string]any, error)
+	GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, params map[string]any, client client.Client) ([]map[string]any, error)
 
 	// GetRequeueAfter is the generator can controller the next reconciled loop
 	// In case there is more then one generator the time will be the minimum of the times.

--- a/applicationset/generators/list.go
+++ b/applicationset/generators/list.go
@@ -29,7 +29,7 @@ func (g *ListGenerator) GetTemplate(appSetGenerator *argoprojiov1alpha1.Applicat
 	return &appSetGenerator.List.Template
 }
 
-func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *ListGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ map[string]any, _ client.Client) ([]map[string]any, error) {
 	if appSetGenerator == nil {
 		return nil, EmptyAppSetGeneratorError
 	}

--- a/applicationset/generators/list_test.go
+++ b/applicationset/generators/list_test.go
@@ -39,7 +39,7 @@ func TestGenerateListParams(t *testing.T) {
 			List: &argoprojiov1alpha1.ListGenerator{
 				Elements: testCase.elements,
 			},
-		}, &applicationSetInfo, nil)
+		}, &applicationSetInfo, nil, nil)
 
 		require.NoError(t, err)
 		assert.ElementsMatch(t, testCase.expected, got)
@@ -76,7 +76,7 @@ func TestGenerateListParamsGoTemplate(t *testing.T) {
 			List: &argoprojiov1alpha1.ListGenerator{
 				Elements: testCase.elements,
 			},
-		}, &applicationSetInfo, nil)
+		}, &applicationSetInfo, nil, nil)
 
 		require.NoError(t, err)
 		assert.ElementsMatch(t, testCase.expected, got)

--- a/applicationset/generators/merge.go
+++ b/applicationset/generators/merge.go
@@ -50,7 +50,7 @@ func (m *MergeGenerator) getParamSetsForAllGenerators(generators []argoprojiov1a
 }
 
 // GenerateParams gets the params produced by the MergeGenerator.
-func (m *MergeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, client client.Client) ([]map[string]any, error) {
+func (m *MergeGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, appSet *argoprojiov1alpha1.ApplicationSet, _ map[string]any, client client.Client) ([]map[string]any, error) {
 	if appSetGenerator.Merge == nil {
 		return nil, EmptyAppSetGeneratorError
 	}

--- a/applicationset/generators/merge_test.go
+++ b/applicationset/generators/merge_test.go
@@ -178,7 +178,7 @@ func TestMergeGenerate(t *testing.T) {
 					MergeKeys:  testCaseCopy.mergeKeys,
 					Template:   argoprojiov1alpha1.ApplicationSetTemplate{},
 				},
-			}, appSet, nil)
+			}, appSet, nil, nil)
 
 			if testCaseCopy.expectedErr != nil {
 				require.EqualError(t, err, testCaseCopy.expectedErr.Error())

--- a/applicationset/generators/mocks/Generator.go
+++ b/applicationset/generators/mocks/Generator.go
@@ -17,9 +17,9 @@ type Generator struct {
 	mock.Mock
 }
 
-// GenerateParams provides a mock function with given fields: appSetGenerator, applicationSetInfo, _a2
-func (_m *Generator) GenerateParams(appSetGenerator *v1alpha1.ApplicationSetGenerator, applicationSetInfo *v1alpha1.ApplicationSet, _a2 client.Client) ([]map[string]interface{}, error) {
-	ret := _m.Called(appSetGenerator, applicationSetInfo, _a2)
+// GenerateParams provides a mock function with given fields: appSetGenerator, applicationSetInfo, params, _a3
+func (_m *Generator) GenerateParams(appSetGenerator *v1alpha1.ApplicationSetGenerator, applicationSetInfo *v1alpha1.ApplicationSet, params map[string]interface{}, _a3 client.Client) ([]map[string]interface{}, error) {
+	ret := _m.Called(appSetGenerator, applicationSetInfo, params, _a3)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateParams")
@@ -27,19 +27,19 @@ func (_m *Generator) GenerateParams(appSetGenerator *v1alpha1.ApplicationSetGene
 
 	var r0 []map[string]interface{}
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*v1alpha1.ApplicationSetGenerator, *v1alpha1.ApplicationSet, client.Client) ([]map[string]interface{}, error)); ok {
-		return rf(appSetGenerator, applicationSetInfo, _a2)
+	if rf, ok := ret.Get(0).(func(*v1alpha1.ApplicationSetGenerator, *v1alpha1.ApplicationSet, map[string]interface{}, client.Client) ([]map[string]interface{}, error)); ok {
+		return rf(appSetGenerator, applicationSetInfo, params, _a3)
 	}
-	if rf, ok := ret.Get(0).(func(*v1alpha1.ApplicationSetGenerator, *v1alpha1.ApplicationSet, client.Client) []map[string]interface{}); ok {
-		r0 = rf(appSetGenerator, applicationSetInfo, _a2)
+	if rf, ok := ret.Get(0).(func(*v1alpha1.ApplicationSetGenerator, *v1alpha1.ApplicationSet, map[string]interface{}, client.Client) []map[string]interface{}); ok {
+		r0 = rf(appSetGenerator, applicationSetInfo, params, _a3)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]map[string]interface{})
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*v1alpha1.ApplicationSetGenerator, *v1alpha1.ApplicationSet, client.Client) error); ok {
-		r1 = rf(appSetGenerator, applicationSetInfo, _a2)
+	if rf, ok := ret.Get(1).(func(*v1alpha1.ApplicationSetGenerator, *v1alpha1.ApplicationSet, map[string]interface{}, client.Client) error); ok {
+		r1 = rf(appSetGenerator, applicationSetInfo, params, _a3)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/applicationset/generators/plugin.go
+++ b/applicationset/generators/plugin.go
@@ -56,7 +56,7 @@ func (g *PluginGenerator) GetTemplate(appSetGenerator *argoprojiov1alpha1.Applic
 	return &appSetGenerator.Plugin.Template
 }
 
-func (g *PluginGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *PluginGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, _ map[string]any, _ client.Client) ([]map[string]any, error) {
 	if appSetGenerator == nil {
 		return nil, EmptyAppSetGeneratorError
 	}

--- a/applicationset/generators/plugin_test.go
+++ b/applicationset/generators/plugin_test.go
@@ -681,7 +681,7 @@ func TestPluginGenerateParams(t *testing.T) {
 				},
 			}
 
-			got, err := pluginGenerator.GenerateParams(&generatorConfig, &applicationSetInfo, nil)
+			got, err := pluginGenerator.GenerateParams(&generatorConfig, &applicationSetInfo, nil, nil)
 			if err != nil {
 				fmt.Println(err)
 			}

--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -51,7 +51,7 @@ func (g *PullRequestGenerator) GetTemplate(appSetGenerator *argoprojiov1alpha1.A
 	return &appSetGenerator.PullRequest.Template
 }
 
-func (g *PullRequestGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *PullRequestGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, _ map[string]any, _ client.Client) ([]map[string]any, error) {
 	if appSetGenerator == nil {
 		return nil, EmptyAppSetGeneratorError
 	}

--- a/applicationset/generators/pull_request_test.go
+++ b/applicationset/generators/pull_request_test.go
@@ -222,7 +222,7 @@ func TestPullRequestGithubGenerateParams(t *testing.T) {
 			PullRequest: &argoprojiov1alpha1.PullRequestGenerator{},
 		}
 
-		got, gotErr := gen.GenerateParams(&generatorConfig, &c.applicationSet, nil)
+		got, gotErr := gen.GenerateParams(&generatorConfig, &c.applicationSet, nil, nil)
 		if c.expectedErr != nil {
 			require.EqualError(t, gotErr, c.expectedErr.Error())
 		} else {
@@ -296,7 +296,7 @@ func TestAllowedSCMProviderPullRequest(t *testing.T) {
 				},
 			}
 
-			_, err := pullRequestGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil)
+			_, err := pullRequestGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, nil)
 
 			require.Error(t, err, "Must return an error")
 			var expectedError ErrDisallowedSCMProvider
@@ -323,6 +323,6 @@ func TestSCMProviderDisabled_PRGenerator(t *testing.T) {
 		},
 	}
 
-	_, err := generator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil)
+	_, err := generator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, nil)
 	assert.ErrorIs(t, err, ErrSCMProvidersDisabled)
 }

--- a/applicationset/generators/scm_provider.go
+++ b/applicationset/generators/scm_provider.go
@@ -116,7 +116,7 @@ func ScmProviderAllowed(applicationSetInfo *argoprojiov1alpha1.ApplicationSet, g
 	return NewErrDisallowedSCMProvider(url, allowedScmProviders)
 }
 
-func (g *SCMProviderGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *SCMProviderGenerator) GenerateParams(appSetGenerator *argoprojiov1alpha1.ApplicationSetGenerator, applicationSetInfo *argoprojiov1alpha1.ApplicationSet, _ map[string]any, _ client.Client) ([]map[string]any, error) {
 	if appSetGenerator == nil {
 		return nil, EmptyAppSetGeneratorError
 	}

--- a/applicationset/generators/scm_provider_test.go
+++ b/applicationset/generators/scm_provider_test.go
@@ -120,7 +120,7 @@ func TestSCMProviderGenerateParams(t *testing.T) {
 				},
 			}
 
-			got, err := scmGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil)
+			got, err := scmGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, nil)
 
 			if testCaseCopy.expectedError != nil {
 				assert.EqualError(t, err, testCaseCopy.expectedError.Error())
@@ -209,7 +209,7 @@ func TestAllowedSCMProvider(t *testing.T) {
 				},
 			}
 
-			_, err := scmGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil)
+			_, err := scmGenerator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, nil)
 
 			require.Error(t, err, "Must return an error")
 			var expectedError ErrDisallowedSCMProvider
@@ -236,6 +236,6 @@ func TestSCMProviderDisabled_SCMGenerator(t *testing.T) {
 		},
 	}
 
-	_, err := generator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil)
+	_, err := generator.GenerateParams(&applicationSetInfo.Spec.Generators[0], &applicationSetInfo, nil, nil)
 	assert.ErrorIs(t, err, ErrSCMProvidersDisabled)
 }

--- a/applicationset/webhook/webhook.go
+++ b/applicationset/webhook/webhook.go
@@ -507,7 +507,7 @@ func (h *WebhookHandler) shouldRefreshMatrixGenerator(gen *v1alpha1.MatrixGenera
 	relGenerators := generators.GetRelevantGenerators(requestedGenerator0, h.generators)
 	params := []map[string]any{}
 	for _, g := range relGenerators {
-		p, err := g.GenerateParams(requestedGenerator0, appSet, h.client)
+		p, err := g.GenerateParams(requestedGenerator0, appSet, nil, h.client)
 		if err != nil {
 			log.Error(err)
 			return false

--- a/applicationset/webhook/webhook_test.go
+++ b/applicationset/webhook/webhook_test.go
@@ -38,7 +38,7 @@ func (g *generatorMock) GetTemplate(_ *v1alpha1.ApplicationSetGenerator) *v1alph
 	return &v1alpha1.ApplicationSetTemplate{}
 }
 
-func (g *generatorMock) GenerateParams(_ *v1alpha1.ApplicationSetGenerator, _ *v1alpha1.ApplicationSet, _ client.Client) ([]map[string]any, error) {
+func (g *generatorMock) GenerateParams(_ *v1alpha1.ApplicationSetGenerator, _ *v1alpha1.ApplicationSet, _ map[string]any, _ client.Client) ([]map[string]any, error) {
 	return []map[string]any{}, nil
 }
 

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -3397,7 +3397,7 @@ func Test_DeepCopyInformers(t *testing.T) {
 
 	s := newTestAppServer(t, ro...)
 
-	appList, err := s.appclientset.ArgoprojV1alpha1().Applications(namespace).List(context.Background(), metav1.ListOptions{})
+	appList, err := s.appclientset.ArgoprojV1alpha1().Applications(namespace).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, appls, appList.Items)
 	sAppList := appList.Items
@@ -3411,12 +3411,12 @@ func Test_DeepCopyInformers(t *testing.T) {
 	for i := range appls {
 		assert.NotSame(t, &appls[i], &sAppList[i])
 		assert.NotSame(t, &appls[i].Spec, &sAppList[i].Spec)
-		a, err := s.appclientset.ArgoprojV1alpha1().Applications(namespace).Get(context.Background(), sAppList[i].Name, metav1.GetOptions{})
+		a, err := s.appclientset.ArgoprojV1alpha1().Applications(namespace).Get(t.Context(), sAppList[i].Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotSame(t, a, &sAppList[i])
 	}
 
-	appSetList, err := s.appclientset.ArgoprojV1alpha1().ApplicationSets(namespace).List(context.Background(), metav1.ListOptions{})
+	appSetList, err := s.appclientset.ArgoprojV1alpha1().ApplicationSets(namespace).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, appSets, appSetList.Items)
 	sAppSetList := appSetList.Items
@@ -3429,13 +3429,13 @@ func Test_DeepCopyInformers(t *testing.T) {
 	for i := range appSets {
 		assert.NotSame(t, &appSets[i], &sAppSetList[i])
 		assert.NotSame(t, &appSets[i].Spec, &sAppSetList[i].Spec)
-		a, err := s.appclientset.ArgoprojV1alpha1().ApplicationSets(namespace).Get(context.Background(),
+		a, err := s.appclientset.ArgoprojV1alpha1().ApplicationSets(namespace).Get(t.Context(),
 			sAppSetList[i].Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotSame(t, a, &sAppSetList[i])
 	}
 
-	projList, err := s.appclientset.ArgoprojV1alpha1().AppProjects("deep-copy-ns").List(context.Background(), metav1.ListOptions{})
+	projList, err := s.appclientset.ArgoprojV1alpha1().AppProjects("deep-copy-ns").List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, appProjects, projList.Items)
 	spList := projList.Items
@@ -3448,7 +3448,7 @@ func Test_DeepCopyInformers(t *testing.T) {
 	for i := range appProjects {
 		assert.NotSame(t, &appProjects[i], &spList[i])
 		assert.NotSame(t, &appProjects[i].Spec, &spList[i].Spec)
-		p, err := s.appclientset.ArgoprojV1alpha1().AppProjects("deep-copy-ns").Get(context.Background(),
+		p, err := s.appclientset.ArgoprojV1alpha1().AppProjects("deep-copy-ns").Get(t.Context(),
 			spList[i].Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotSame(t, p, &spList[i])

--- a/server/application/deepinformer_test.go
+++ b/server/application/deepinformer_test.go
@@ -1,7 +1,6 @@
 package application
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -41,7 +40,7 @@ func Test_deepCopyAppProjectClient_Get(t *testing.T) {
 			fields: fields{
 				AppProjectInterface: func() clientset.AppProjectInterface {
 					appProject := mocks.AppProjectInterface{}
-					appProject.On("Get", context.Background(), "appproject2", metav1.GetOptions{}).Return(nil, errors.New("error"))
+					appProject.On("Get", t.Context(), "appproject2", metav1.GetOptions{}).Return(nil, errors.New("error"))
 					return &appProject
 				}(),
 			},
@@ -57,7 +56,7 @@ func Test_deepCopyAppProjectClient_Get(t *testing.T) {
 			d := &deepCopyAppProjectClient{
 				AppProjectInterface: tt.fields.AppProjectInterface,
 			}
-			got, err := d.Get(context.Background(), tt.args.name, metav1.GetOptions{})
+			got, err := d.Get(t.Context(), tt.args.name, metav1.GetOptions{})
 			if !tt.wantErr(t, err, fmt.Sprintf("Get(%v)", tt.args.name)) {
 				return
 			}
@@ -86,7 +85,7 @@ func Test_deepCopyAppProjectClient_List(t *testing.T) {
 		{name: "Error listing app project", fields: fields{
 			AppProjectInterface: func() clientset.AppProjectInterface {
 				appProject := mocks.AppProjectInterface{}
-				appProject.On("List", context.Background(), metav1.ListOptions{}).Return(nil, errors.New("error"))
+				appProject.On("List", t.Context(), metav1.ListOptions{}).Return(nil, errors.New("error"))
 				return &appProject
 			}(),
 		}, want: nil, wantErr: assert.Error},
@@ -96,7 +95,7 @@ func Test_deepCopyAppProjectClient_List(t *testing.T) {
 			d := &deepCopyAppProjectClient{
 				AppProjectInterface: tt.fields.AppProjectInterface,
 			}
-			got, err := d.List(context.Background(), metav1.ListOptions{})
+			got, err := d.List(t.Context(), metav1.ListOptions{})
 			if !tt.wantErr(t, err, "List") {
 				return
 			}


### PR DESCRIPTION
Fixes #22051 

The issue occurs due to the following root causes:

When a matrix generator is noticed, the interpolation logic interpolates the second generator with the first generator parameters - even if the second generator is another matrix (and in that case it doesn't recursively interpolates, as expected).  For example:
```
Matrix:
  List
  - item
  Matrix:
  - List - defines `.someValue`
  - List - uses {{ .someValue }}
```
The current logic would go through the outer matrix, notice the List and Matrix generators, and try to interpolate the second generator with the first one (i.e., will expect `.someValue` to exist from the outer List generator, even if it was defined in the inner first List generator). To resolve this, the interpolation logic now checks if the generator is a matrix, and if so, it wouldn't interpolate but wait for a deeper level in the matrix to handle the interpolation (this is done with the `!isMatrix` check before calling `InterpolateGenerator`).

The second root cause is that the `GenerateParams` method doesn't currently have context of params from an outer matrix generator when called recursively. To resolve this, I've added a `params` parameter to this method.


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
