### PR TITLE
fix: incorrect decoding of lua output when patch creates empty map (lua array)

### DIFF
--- a/util/lua/lua.go
+++ b/util/lua/lua.go
@@ -258,7 +258,7 @@ func cleanReturnedObj(newObj, obj map[string]any) map[string]any {
 				switch oldValue := oldValueInterface.(type) {
 				case map[string]any:
 					if len(newValue) == 0 {
-						mapToReturn[key] = oldValue
+						mapToReturn[key] = make(map[string]any)
 					}
 				case []any:
 					newArray := cleanReturnedArray(newValue, oldValue)


### PR DESCRIPTION
Fixes the decoding from a Lua scripts returned object

Previously, if a non-empty map was patched to be empty then the patch was actually reverted by setting it to the previous value here: https://github.com/argoproj/argo-cd/blob/75cb7fc42de2b6aa4e58c899a28a3a07d88cf671/util/lua/lua.go#L258-L262

If the new value is empty, then I believe it should just be set to an empty map.

Closes https://github.com/argoproj/argo-cd/issues/22270

---

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
