### PR TITLE
fix: Disable ESO refresh/push custom actions when they would do nothing

### DIFF
--- a/resource_customizations/external-secrets.io/ExternalSecret/actions/discovery.lua
+++ b/resource_customizations/external-secrets.io/ExternalSecret/actions/discovery.lua
@@ -1,3 +1,15 @@
 local actions = {}
-actions["refresh"] = {["disabled"] = false}
+
+local disable_refresh = false
+local time_units = {"ns", "us", "µs", "ms", "s", "m", "h"}
+local digits = obj.spec.refreshInterval
+for _, time_unit in ipairs(time_units) do
+  digits, _ = digits:gsub(time_unit, "")
+  if tonumber(digits) == 0 then
+    disable_refresh = true
+    break
+  end
+end
+
+actions["refresh"] = {["disabled"] = disable_refresh}
 return actions

--- a/resource_customizations/external-secrets.io/PushSecret/actions/discovery.lua
+++ b/resource_customizations/external-secrets.io/PushSecret/actions/discovery.lua
@@ -1,3 +1,15 @@
-actions = {}
-actions["push"] = {["disabled"] = false}
+local actions = {}
+
+local disable_push = false
+local time_units = {"ns", "us", "µs", "ms", "s", "m", "h"}
+local digits = obj.spec.refreshInterval
+for _, time_unit in ipairs(time_units) do
+  digits, _ = digits:gsub(time_unit, "")
+  if tonumber(digits) == 0 then
+    disable_push = true
+    break
+  end
+end
+
+actions["push"] = {["disabled"] = disable_push}
 return actions


### PR DESCRIPTION
When `spec.refreshInterval` is `0s` for either `ExternalSecret` or `PushSecret`, adding the annotation to it will not trigger a forced refresh/push, so the custom action are misleading as it would seem like something happens, but nothing actually does.

Related ESO issue: https://github.com/external-secrets/external-secrets/issues/4447

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
