### PR TITLE
fix(controller): wrong tracking annotation for malformed resources

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -416,6 +416,9 @@ func DeduplicateTargetObjects(
 func normalizeClusterScopeTracking(targetObjs []*unstructured.Unstructured, infoProvider kubeutil.ResourceInfoProvider, setAppInstance func(*unstructured.Unstructured) error) error {
 	for i := len(targetObjs) - 1; i >= 0; i-- {
 		targetObj := targetObjs[i]
+		if targetObj == nil {
+			continue
+		}
 		gvk := targetObj.GroupVersionKind()
 		if !kubeutil.IsNamespacedOrUnknown(infoProvider, gvk.GroupKind()) {
 			if targetObj.GetNamespace() != "" {

--- a/controller/state.go
+++ b/controller/state.go
@@ -410,6 +410,26 @@ func DeduplicateTargetObjects(
 	return result, conditions, nil
 }
 
+// normalizeClusterScopeTracking will set the app instance tracking metadata on malformed cluster-scoped resources where
+// metadata.namespace is not empty. The repo-server doesn't know which resources are cluster-scoped, so it may apply
+// an incorrect tracking annotation using the metadata.namespace. This function will correct that.
+func normalizeClusterScopeTracking(targetObjs []*unstructured.Unstructured, infoProvider kubeutil.ResourceInfoProvider, setAppInstance func(*unstructured.Unstructured) error) error {
+	for i := len(targetObjs) - 1; i >= 0; i-- {
+		targetObj := targetObjs[i]
+		gvk := targetObj.GroupVersionKind()
+		if !kubeutil.IsNamespacedOrUnknown(infoProvider, gvk.GroupKind()) {
+			if targetObj.GetNamespace() != "" {
+				targetObj.SetNamespace("")
+				err := setAppInstance(targetObj)
+				if err != nil {
+					return fmt.Errorf("failed to set app instance label on cluster-scoped resource %s/%s: %w", gvk.String(), targetObj.GetName(), err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // getComparisonSettings will return the system level settings related to the
 // diff/normalization process.
 func (m *appStateManager) getComparisonSettings() (string, map[string]v1alpha1.ResourceOverride, *settings.ResourcesFilter, string, error) {
@@ -591,12 +611,24 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 	if err != nil {
 		infoProvider = &resourceInfoProviderStub{}
 	}
+
+	trackingMethod := argo.GetTrackingMethod(m.settingsMgr)
+
+	err = normalizeClusterScopeTracking(targetObjs, infoProvider, func(u *unstructured.Unstructured) error {
+		return m.resourceTracking.SetAppInstance(u, appLabelKey, app.InstanceName(m.namespace), app.Spec.Destination.Namespace, trackingMethod, installationID)
+	})
+	if err != nil {
+		msg := "Failed to normalize cluster-scoped resource tracking: " + err.Error()
+		conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: msg, LastTransitionTime: &now})
+	}
+
 	targetObjs, dedupConditions, err := DeduplicateTargetObjects(app.Spec.Destination.Namespace, targetObjs, infoProvider)
 	if err != nil {
 		msg := "Failed to deduplicate target state: " + err.Error()
 		conditions = append(conditions, v1alpha1.ApplicationCondition{Type: v1alpha1.ApplicationConditionComparisonError, Message: msg, LastTransitionTime: &now})
 	}
 	conditions = append(conditions, dedupConditions...)
+
 	for i := len(targetObjs) - 1; i >= 0; i-- {
 		targetObj := targetObjs[i]
 		gvk := targetObj.GroupVersionKind()
@@ -647,8 +679,6 @@ func (m *appStateManager) CompareAppState(app *v1alpha1.Application, project *v1
 			delete(liveObjByKey, k)
 		}
 	}
-
-	trackingMethod := argo.GetTrackingMethod(m.settingsMgr)
 
 	for _, liveObj := range liveObjByKey {
 		if liveObj != nil {

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"encoding/json"
 	"errors"
-	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/rbac/v1"
 	"os"
 	"testing"
@@ -18,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -21,7 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1801,7 +1801,7 @@ func TestCompareAppStateRevisionUpdatedWithHelmSource(t *testing.T) {
 }
 
 func Test_normalizeClusterScopeTracking(t *testing.T) {
-	obj := kube.MustToUnstructured(&v1.ClusterRole{
+	obj := kube.MustToUnstructured(&rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",

--- a/controller/state_test.go
+++ b/controller/state_test.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"encoding/json"
 	"errors"
-	v1 "k8s.io/api/rbac/v1"
 	"os"
 	"testing"
 	"time"
@@ -22,6 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1005,6 +1005,9 @@ func TestKnownTypesInCRDDiffing(t *testing.T) {
 }
 
 func TestDuplicatedClusterResourcesAnnotationTracking(t *testing.T) {
+	// This test will fail if the controller fails to fix the tracking annotation for malformed cluster resources
+	// (i.e. resources where metadata.namespace is set). Before the bugfix, this test would fail with a diff in the
+	// tracking annotation.
 	Given(t).
 		SetTrackingMethod(string(argo.TrackingMethodAnnotation)).
 		Path("duplicated-resources").

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -1004,6 +1004,24 @@ func TestKnownTypesInCRDDiffing(t *testing.T) {
 		Expect(SyncStatusIs(SyncStatusCodeSynced))
 }
 
+func TestDuplicatedClusterResourcesAnnotationTracking(t *testing.T) {
+	Given(t).
+		SetTrackingMethod(string(argo.TrackingMethodAnnotation)).
+		Path("duplicated-resources").
+		When().
+		CreateApp().
+		Sync().
+		Then().
+		Expect(OperationPhaseIs(OperationSucceeded)).
+		Expect(SyncStatusIs(SyncStatusCodeSynced)).
+		Expect(HealthIs(health.HealthStatusHealthy)).
+		And(func(app *Application) {
+			diffOutput, err := fixture.RunCli("app", "diff", app.Name, "--local", "testdata", "--server-side-generate")
+			assert.Empty(t, diffOutput)
+			require.NoError(t, err)
+		})
+}
+
 func TestDuplicatedResources(t *testing.T) {
 	testEdgeCasesApplicationResources(t, "duplicated-resources", health.HealthStatusHealthy)
 }


### PR DESCRIPTION
If a cluster-scope resource erroneously has a metadata.namespace set, the repo-server may apply the wrong tracking annotation (because the repo-server doesn't know which resources are cluster-scoped and which are namespace-scoped).

This change has the app controller perform a follow-up normalization to fix the tracking annotation for any malformed resources.