### PR TITLE
chore!: add 60s default jitter

### DIFF
--- a/cmd/argocd-application-controller/commands/argocd_application_controller.go
+++ b/cmd/argocd-application-controller/commands/argocd_application_controller.go
@@ -44,9 +44,13 @@ const (
 	// CLIName is the name of the CLI
 	cliName = common.ApplicationController
 	// Default time in seconds for application resync period
-	defaultAppResyncPeriod = 180
+	defaultAppResyncPeriod = 120
+	// Default time in seconds for application resync period jitter
+	defaultAppResyncPeriodJitter = 60
 	// Default time in seconds for application hard resync period
 	defaultAppHardResyncPeriod = 0
+	// Default time in seconds for ignoring consecutive errors when comminicating with repo-server
+	defaultRepoErrorGracePeriod = defaultAppResyncPeriod + defaultAppResyncPeriodJitter
 )
 
 func NewCommand() *cobra.Command {
@@ -252,8 +256,8 @@ func NewCommand() *cobra.Command {
 	clientConfig = cli.AddKubectlFlagsToCmd(&command)
 	command.Flags().Int64Var(&appResyncPeriod, "app-resync", int64(env.ParseDurationFromEnv("ARGOCD_RECONCILIATION_TIMEOUT", defaultAppResyncPeriod*time.Second, 0, math.MaxInt64).Seconds()), "Time period in seconds for application resync.")
 	command.Flags().Int64Var(&appHardResyncPeriod, "app-hard-resync", int64(env.ParseDurationFromEnv("ARGOCD_HARD_RECONCILIATION_TIMEOUT", defaultAppHardResyncPeriod*time.Second, 0, math.MaxInt64).Seconds()), "Time period in seconds for application hard resync.")
-	command.Flags().Int64Var(&appResyncJitter, "app-resync-jitter", int64(env.ParseDurationFromEnv("ARGOCD_RECONCILIATION_JITTER", 0*time.Second, 0, math.MaxInt64).Seconds()), "Maximum time period in seconds to add as a delay jitter for application resync.")
-	command.Flags().Int64Var(&repoErrorGracePeriod, "repo-error-grace-period-seconds", int64(env.ParseDurationFromEnv("ARGOCD_REPO_ERROR_GRACE_PERIOD_SECONDS", defaultAppResyncPeriod*time.Second, 0, math.MaxInt64).Seconds()), "Grace period in seconds for ignoring consecutive errors while communicating with repo server.")
+	command.Flags().Int64Var(&appResyncJitter, "app-resync-jitter", int64(env.ParseDurationFromEnv("ARGOCD_RECONCILIATION_JITTER", defaultAppResyncPeriodJitter*time.Second, 0, math.MaxInt64).Seconds()), "Maximum time period in seconds to add as a delay jitter for application resync.")
+	command.Flags().Int64Var(&repoErrorGracePeriod, "repo-error-grace-period-seconds", int64(env.ParseDurationFromEnv("ARGOCD_REPO_ERROR_GRACE_PERIOD_SECONDS", defaultRepoErrorGracePeriod*time.Second, 0, math.MaxInt64).Seconds()), "Grace period in seconds for ignoring consecutive errors while communicating with repo server.")
 	command.Flags().StringVar(&repoServerAddress, "repo-server", env.StringFromEnv("ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER", common.DefaultRepoServerAddr), "Repo server address.")
 	command.Flags().IntVar(&repoServerTimeoutSeconds, "repo-server-timeout-seconds", env.ParseNumFromEnv("ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_TIMEOUT_SECONDS", 60, 0, math.MaxInt64), "Repo server RPC call timeout seconds.")
 	command.Flags().StringVar(&commitServerAddress, "commit-server", env.StringFromEnv("ARGOCD_APPLICATION_CONTROLLER_COMMIT_SERVER", common.DefaultCommitServerAddr), "Commit server address.")

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -147,7 +147,7 @@ See [#1482](https://github.com/argoproj/argo-cd/issues/1482).
 
 ## How often does Argo CD check for changes to my Git or Helm repository ?
 
-The default polling interval is 3 minutes (180 seconds) with a configurable jitter.
+The default maximum polling interval is 3 minutes (120 seconds + 60 seconds jitter).
 You can change the setting by updating the `timeout.reconciliation` value and the `timeout.reconciliation.jitter` in the [argocd-cm](https://github.com/argoproj/argo-cd/blob/2d6ce088acd4fb29271ffb6f6023dbb27594d59b/docs/operator-manual/argocd-cm.yaml#L279-L282) config map. If there are any Git changes, Argo CD will only update applications with the [auto-sync setting](user-guide/auto_sync.md) enabled. If you set it to `0` then Argo CD will stop polling Git repositories automatically and you can only use alternative methods such as [webhooks](operator-manual/webhook.md) and/or manual syncs for deploying applications.
 
 

--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -326,17 +326,18 @@ data:
   # at the bottom of the page. Change the value as needed.
   # ui.bannerposition: "bottom"
 
-  # Application reconciliation timeout is the max amount of time required to discover if a new manifests version got
-  # published to the repository. Reconciliation by timeout is disabled if timeout is set to 0. Three minutes by default.
+  # Application reconciliation timeout is the amount of time spent before Argo tries to discover if a new manifests version got
+  # published to the repository. Reconciliation by timeout is disabled if timeout is set to 0. Two minutes by default with additional jitter.
   # > Note: The argocd-repo-server deployment and the argocd-application-controller statefulset (or deployment, if
   # configured) must be manually restarted after changing the setting.
-  timeout.reconciliation: 180s
+  timeout.reconciliation: 120s
+
   # With a large number of applications, the periodic refresh for each application can cause a spike in the refresh queue
   # and can cause a spike in the repo-server component. To avoid this, you can set a jitter to the sync timeout, which will
   # spread out the refreshes and give time to the repo-server to catch up. The jitter is the maximum duration that can be
   # added to the sync timeout. So, if the sync timeout is 3 minutes and the jitter is 1 minute, then the actual timeout will
-  # be between 3 and 4 minutes. Disabled when the value is 0, defaults to 0.
-  timeout.reconciliation.jitter: "0"
+  # be between 3 and 4 minutes. Disabled when the value is 0, defaults to 1 minute.
+  timeout.reconciliation.jitter: 60s
 
   # cluster.inClusterEnabled indicates whether to allow in-cluster server address. This is enabled by default.
   cluster.inClusterEnabled: "true"

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -16,8 +16,8 @@ argocd-application-controller [flags]
 
 ```
       --app-hard-resync int                                       Time period in seconds for application hard resync.
-      --app-resync int                                            Time period in seconds for application resync. (default 180)
-      --app-resync-jitter int                                     Maximum time period in seconds to add as a delay jitter for application resync.
+      --app-resync int                                            Time period in seconds for application resync. (default 120)
+      --app-resync-jitter int                                     Maximum time period in seconds to add as a delay jitter for application resync. (default 60)
       --app-state-cache-expiration duration                       Cache expiration for app state (default 1h0m0s)
       --application-namespaces strings                            List of additional namespaces that applications are allowed to be reconciled from
       --as string                                                 Username to impersonate for the operation

--- a/docs/user-guide/auto_sync.md
+++ b/docs/user-guide/auto_sync.md
@@ -96,4 +96,4 @@ which is controlled by `--self-heal-timeout-seconds` flag of `argocd-application
   and parameters had failed.
 
 * Rollback cannot be performed against an application with automated sync enabled.
-* The automatic sync interval is determined by [the `timeout.reconciliation` value in the `argocd-cm` ConfigMap](../faq.md#how-often-does-argo-cd-check-for-changes-to-my-git-or-helm-repository), which defaults to `180s` (3 minutes).
+* The automatic sync interval is determined by [the `timeout.reconciliation` value in the `argocd-cm` ConfigMap](../faq.md#how-often-does-argo-cd-check-for-changes-to-my-git-or-helm-repository), which defaults to `120s` with added jitter of `60s` for a maximum period of 3 minutes.

--- a/docs/user-guide/ci_automation.md
+++ b/docs/user-guide/ci_automation.md
@@ -52,4 +52,4 @@ argocd app wait guestbook
 
 If [automated synchronization](auto_sync.md) is configured for the application, this step is
 unnecessary. The controller will automatically detect the new config (fast tracked using a
-[webhook](../operator-manual/webhook.md), or polled every 3 minutes), and automatically sync the new manifests.
+[webhook](../operator-manual/webhook.md), or polled at least every 3 minutes by default), and automatically sync the new manifests.


### PR DESCRIPTION
Not documenting in the 2.14 -> 3.0 migration guide because the maximum default is the same (at least every 3 minutes). 