### PR TITLE
docs: various wording fixes for 3.0 migration guide

### DIFF
--- a/docs/operator-manual/upgrading/2.14-3.0.md
+++ b/docs/operator-manual/upgrading/2.14-3.0.md
@@ -1,22 +1,21 @@
 # v2.14 to 3.0
 
-Argo CD 3.0 is meant to be a low-risk upgrade, containing some minor breaking changes. For each change, the next
+Argo CD 3.0 is meant to be a low-risk upgrade containing only minor breaking changes. For each change, the next
 section will describe how to quickly determine if you are impacted, how to remediate the breaking change, and (if
-applicable) how to opt out of the change.
+applicable) restore Argo CD 2.x default behavior.
 
 Once 3.0 is released, no more 2.x minor versions will be released. We will continue to cut patch releases for the two
-most recent minor versions (so 2.14 until 3.2 is released, and 2.13 until 3.1 is released).
+most recent minor versions (so 2.14 until 3.2 is released and 2.13 until 3.1 is released).
 
 ## Breaking Changes
 
 ### Fine-Grained RBAC for application `update` and `delete` sub-resources
 
-The default behavior of fine-grained policies have changed so they do not apply to sub-resources anymore.
-Prior to v3, when `update` or `delete` actions were allowed on an application, it gave the permission to
-update and delete the application itself and any of its sub-resources.
+The default behavior of fine-grained policies have changed so they no longer apply to sub-resources.
+Prior to v3, policies granting `update` or `delete` to an application also applied to any of its sub-resources.
 
-Starting with v3, the `update` or `delete` actions only apply on the application. New policies must be defined
-to allow the `update/*` or `delete/*` actions on the application to give permissions on sub-resources.
+Starting with v3, the `update` or `delete` actions only apply to the application itself. New policies must be defined
+to allow the `update/*` or `delete/*` actions on an Application's managed resources.
 
 The v2 behavior can be preserved by setting the config value `server.rbac.disableApplicationFineGrainedRBACInheritance`
 to `false` in the Argo CD ConfigMap `argocd-cm`.
@@ -52,14 +51,14 @@ For users without a default policy, add this policy to `policy.csv`: `p, role:gl
 
 ##### Recommended remediation (per-policy change)
 Explicitly add a `logs, get` policy to every role that has a policy for `applications, get` or for `applications, *`.   
-This is the recommended way for maintaining the principle of least-privilege.       
-Similarly to the way you currently manage the access to Applications, the access to logs can be either granted on a Project scope level (Project resource) or on the `argocd-rbac-cm` ConfigMap level.      
+This is the recommended way to maintain the principle of least privilege.       
+Similar to the way access to Applications are currently managed, access to logs can be either granted on a Project scope level (Project resource) or on the `argocd-rbac-cm` ConfigMap level.      
 See this [example](../upgrading/2.3-2.4.md#example-1) for more details.   
 
 ### Default `resource.exclusions` configurations
 
 Argo CD manifest now contains a default configuration for `resource.exclusions` in the `argocd-cm` to exclude resources that
-are known to be created by controller and not usually managed in Git. The exclusions contains high volume and high churn objects
+are known to be created by controllers and not usually managed in Git. The exclusions contain high volume and high churn objects
 which we exclude for performance reasons, reducing connections and load to the K8s API servers of managed clusters.
 
 The excluded Kinds are:
@@ -247,7 +246,7 @@ kubectl get cm argocd-cm -n argocd -o jsonpath='{.data.application\.resourceTrac
 #### Remediation
 
 For most users, it is safe to upgrade to Argo CD 3.0 and use annotation-based tracking. Labels will be replaced with
-annotations on the next sync. Applications will not be marked as out-of-sync if the labels are not present on the
+annotations on the next sync. Applications will not be marked as out-of-sync if labels are not present on the
 resources.
 
 !!! warning "Potential for orphaned resources"
@@ -271,7 +270,7 @@ For cluster-scoped resources, the namespace is set to the value in the Applicati
 
 !!! warning
 
-    Manually constructing and applying tracking labels and annotations is not an officially-supported feature, and Argo
+    Manually constructing and applying tracking labels and annotations is not an officially supported feature, and Argo
     CD's behavior may change in the future. It is recommended to manage resources with Argo CD via GitOps.
 
 #### Opting Out
@@ -394,8 +393,8 @@ spec:
 
 By default, the existing system-level `ignoreDifferences` customizations will be added to ignore resource updates as well.
 
-Logically, if a field is configured to be ignore for the difference, there is no reason to gnerate the diff for the application
-whenever that field changes.
+Logically, if differences to a field are configured to be ignored, there is no reason to generate the diff for the application
+when that field changes.
 
 To disable this behavior and preserve the v2 default, the `ignoreDifferencesOnResourceUpdates` can be set to false:
 


### PR DESCRIPTION
Noticed some wording issues on the migration doc while preparing the 3.0 RC blogpost. 

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
