### PR TITLE
fix(ci): handle major versions in compatibility table generator

### DIFF
--- a/hack/update-supported-versions.sh
+++ b/hack/update-supported-versions.sh
@@ -7,8 +7,9 @@ argocd_minor_version=$(git rev-parse --abbrev-ref HEAD | sed 's/release-//')
 argocd_major_version_num=$(echo "$argocd_minor_version" | sed -E 's/\.[0-9]+//')
 argocd_minor_version_num=$(echo "$argocd_minor_version" | sed -E 's/[0-9]+\.//')
 
-for n in 0 1 2; do
-  minor_version_num=$((argocd_minor_version_num - n))
+minor_version_decrement=0
+for _ in {1..3}; do
+  minor_version_num=$((argocd_minor_version_num - minor_version_decrement))
   minor_version="${argocd_major_version_num}.${minor_version_num}"
   git checkout "release-$minor_version" > /dev/null || exit 1
 
@@ -19,9 +20,22 @@ for n in 0 1 2; do
     jq --arg minor_version "$minor_version" --raw-input --slurp --raw-output \
     'split("\n")[:-1] | map(sub("\\.[0-9]+$"; "")) | join(", ") | "| \($minor_version) | \(.) |"')
   out+="$line\n"
+
+  minor_version_decrement=$((minor_version_decrement + 1))
+
+  # If we're at minor version 0, there's no further version back in this series. Instead, move to the latest version in
+  # the previous major release series.
+  if [ "$argocd_minor_version_num" -eq 0 ]; then
+    argocd_major_version_num=$((argocd_major_version_num - 1))
+    # Get the latest minor version in the previous series.
+    argocd_minor_version_num=$(git branch -l "release-$argocd_major_version_num.*" | sort -V | tail -n 1 | sed -E 's/release-[0-9]+\.//')
+
+    # Don't decrement the minor version, since we're switching to the previous major release series. We want the latest
+    # minor version in that series.
+    minor_version_decrement=0
+  fi
 done
 
 git checkout "release-$argocd_minor_version"
-
 
 printf "$out" > docs/operator-manual/tested-kubernetes-versions.md


### PR DESCRIPTION
Fixes this: https://github.com/argoproj/argo-cd/actions/runs/13901754319