### PR TITLE
fix(ci): get correct previous version, fail workflow if not

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,8 @@ jobs:
       - name: Set GORELEASER_PREVIOUS_TAG # Workaround, GoReleaser uses 'git-describe' to determine a previous tag. Our tags are created in release branches.
         run: |
           set -xue
-          echo "GORELEASER_PREVIOUS_TAG=$(go run hack/get-previous-release/get-previous-version-for-release-notes.go ${{ github.ref_name }})" >> $GITHUB_ENV
+          GORELEASER_PREVIOUS_TAG=$(go run hack/get-previous-release/get-previous-version-for-release-notes.go ${{ github.ref_name }}) || exit 1
+          echo "GORELEASER_PREVIOUS_TAG=$GORELEASER_PREVIOUS_TAG" >> $GITHUB_ENV
 
       - name: Set environment variables for ldflags
         id: set_ldflag

--- a/hack/get-previous-release/get-previous-version-for-release-notes_test.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes_test.go
@@ -76,6 +76,11 @@ func TestFindPreviousTagRules(t *testing.T) {
 		{"Rule 3: 1 release candidate", "v2.14.0-rc1", "v2.13.0-rc3", false},
 		// Rule 4: If we're releasing a non-1 release candidate, get the most recent rc tag on the current minor release series.
 		{"Rule 4: non-1 release candidate", "v2.13.0-rc4", "v2.13.0-rc3", false},
+		// Rule 5: If we're releasing a major version RC, get the most recent tag on the previous major release series.
+		{"Rule 5: major version RC", "v3.0.0-rc1", "v2.13.0-rc3", false},
+		// Rule 6: If we're releasing a major version, get the most recent tag on the previous major release series,
+		//         even if it's an RC.
+		{"Rule 6: major version", "v3.0.0", "v2.13.0-rc3", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixed the workflow to fail if the previous version script failed.

Fixed the go code to correctly handle a major version upgrade. The code got simpler, because the previous version was written by copilot, and these changes were written by me. It's still hard to read, but the tests pass, so I think we're good.