### PR TITLE
chore(ci): improve previous-version script readability, fix bug

### DIFF
--- a/hack/get-previous-release/get-previous-version-for-release-notes.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes.go
@@ -93,14 +93,10 @@ func getMostRecentTag(tags []string) string {
 }
 
 func findPreviousTag(proposedTag string, tags []string) (string, error) {
-	proposedPatch, proposedRC, err := extractPatchAndRC(proposedTag)
-	if err != nil {
-		return "", err
-	}
-
 	tags = removeInvalidTags(tags)
 	tags = removeNewerOrEqualTags(proposedTag, tags)
 
+	proposedPatch, proposedRC, _ := extractPatchAndRC(proposedTag) // Ignore the error, we already filtered out invalid tags.
 	if proposedRC == "0" && proposedPatch == "0" {
 		// If we're cutting the first patch of a new minor release series, don't consider tags in the same minor release
 		// series. We want to compare to the latest tag in the previous minor release series.

--- a/hack/get-previous-release/get-previous-version-for-release-notes.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes.go
@@ -61,10 +61,10 @@ func removeInvalidTags(tags []string) []string {
 	return validTags
 }
 
-func removeNewerTags(proposedTag string, tags []string) []string {
+func removeNewerOrEqualTags(proposedTag string, tags []string) []string {
 	var validTags []string
 	for _, tag := range tags {
-		if semver.Compare(tag, proposedTag) <= 0 {
+		if semver.Compare(tag, proposedTag) < 0 {
 			validTags = append(validTags, tag)
 		}
 	}
@@ -99,7 +99,7 @@ func findPreviousTag(proposedTag string, tags []string) (string, error) {
 	}
 
 	tags = removeInvalidTags(tags)
-	tags = removeNewerTags(proposedTag, tags)
+	tags = removeNewerOrEqualTags(proposedTag, tags)
 
 	if proposedRC == "0" && proposedPatch == "0" {
 		// If we're cutting the first patch of a new minor release series, don't consider tags in the same minor release

--- a/hack/get-previous-release/get-previous-version-for-release-notes.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes.go
@@ -103,7 +103,7 @@ func findPreviousTag(proposedTag string, tags []string) (string, error) {
 
 	if proposedRC == "0" && proposedPatch == "0" {
 		// If we're cutting the first patch of a new minor release series, don't consider tags in the same minor release
-		// series.
+		// series. We want to compare to the latest tag in the previous minor release series.
 		tags = removeTagsFromSameMinorSeries(proposedTag, tags)
 	}
 

--- a/hack/get-previous-release/get-previous-version-for-release-notes.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes.go
@@ -51,50 +51,63 @@ func extractPatchAndRC(tag string) (string, string, error) {
 	return patch, rc, nil
 }
 
-func findPreviousTag(proposedTag string, tags []string) (string, error) {
-	var previousTag string
-	proposedMinor := semver.MajorMinor(proposedTag)
+func removeInvalidTags(tags []string) []string {
+	var validTags []string
+	for _, tag := range tags {
+		if _, _, err := extractPatchAndRC(tag); err == nil {
+			validTags = append(validTags, tag)
+		}
+	}
+	return validTags
+}
 
+func removeNewerTags(proposedTag string, tags []string) []string {
+	var validTags []string
+	for _, tag := range tags {
+		if semver.Compare(tag, proposedTag) <= 0 {
+			validTags = append(validTags, tag)
+		}
+	}
+	return validTags
+}
+
+func removeTagsFromSameMinorSeries(proposedTag string, tags []string) []string {
+	var validTags []string
+	proposedMinor := semver.MajorMinor(proposedTag)
+	for _, tag := range tags {
+		if semver.MajorMinor(tag) != proposedMinor {
+			validTags = append(validTags, tag)
+		}
+	}
+	return validTags
+}
+
+func getMostRecentTag(tags []string) string {
+	var mostRecentTag string
+	for _, tag := range tags {
+		if mostRecentTag == "" || semver.Compare(tag, mostRecentTag) > 0 {
+			mostRecentTag = tag
+		}
+	}
+	return mostRecentTag
+}
+
+func findPreviousTag(proposedTag string, tags []string) (string, error) {
 	proposedPatch, proposedRC, err := extractPatchAndRC(proposedTag)
 	if err != nil {
 		return "", err
 	}
 
-	for _, tag := range tags {
-		// If this tag is newer than the proposed tag, skip it.
-		if semver.Compare(tag, proposedTag) > 0 {
-			continue
-		}
+	tags = removeInvalidTags(tags)
+	tags = removeNewerTags(proposedTag, tags)
 
-		// If this tag is older than a tag we've already decided is a candidate, skip it.
-		if semver.Compare(tag, previousTag) <= 0 {
-			continue
-		}
-		tagPatch, tagRC, err := extractPatchAndRC(tag)
-		if err != nil {
-			continue
-		}
-
-		// If it's a non-RC release...
-		if proposedRC == "0" {
-			if proposedPatch == "0" {
-				// ...and we're cutting the first patch of a new minor release series, don't consider tags in the same
-				// minor release series.
-				if semver.MajorMinor(tag) != proposedMinor {
-					previousTag = tag
-				}
-			} else {
-
-				previousTag = tag
-			}
-		} else {
-			if tagRC != "0" && tagPatch == proposedPatch {
-				previousTag = tag
-			} else if tagRC == "0" {
-				previousTag = tag
-			}
-		}
+	if proposedRC == "0" && proposedPatch == "0" {
+		// If we're cutting the first patch of a new minor release series, don't consider tags in the same minor release
+		// series.
+		tags = removeTagsFromSameMinorSeries(proposedTag, tags)
 	}
+
+	previousTag := getMostRecentTag(tags)
 	if previousTag == "" {
 		return "", fmt.Errorf("no matching tag found for tags: " + strings.Join(tags, ", "))
 	}

--- a/hack/get-previous-release/get-previous-version-for-release-notes_test.go
+++ b/hack/get-previous-release/get-previous-version-for-release-notes_test.go
@@ -81,6 +81,8 @@ func TestFindPreviousTagRules(t *testing.T) {
 		// Rule 6: If we're releasing a major version, get the most recent tag on the previous major release series,
 		//         even if it's an RC.
 		{"Rule 6: major version", "v3.0.0", "v2.13.0-rc3", false},
+		// Rule 7: If the proposed tag already exists, don't return it.
+		{"Rule 7: proposed tag already exists", "v2.12.5", "v2.12.4", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The old code was Copilot-generated and very difficult to read. This is hopefully better.

I also fixed a bug where, if a tag already exists, the script just returns that tag.