### PR TITLE
chore(ci): address goreleaser deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,11 +45,11 @@ builds:
 
 archives:
   - id: argocd-archive
-    builds:
+    ids:
     - argocd-cli
     name_template: |-
       {{ .ProjectName }}-{{ .Os }}-{{ .Arch }}
-    format: binary
+    formats: [binary]
 
 checksum:
   name_template: 'cli_checksums.txt'
@@ -92,7 +92,7 @@ release:
 
 
 snapshot: #### To be removed for PR
-  name_template: "2.6.0"
+  version_template: "2.6.0"
 
 changelog:
   use:


### PR DESCRIPTION
Addresses these deprecations, noticed in the 3.0.0 release pipeline run.

> 
>   • setting defaults
>     • DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
>     • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
>     • DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info