### PR TITLE
chore: allow to set CGO flags in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ CURRENT_DIR=$(shell pwd)
 DIST_DIR=${CURRENT_DIR}/dist
 CLI_NAME=argocd
 BIN_NAME=argocd
-CGO_FLAG=0
+
+# When using OSX/Darwin, you might need to enable CGO for local builds
+CGO_FLAG?=0
 
 GEN_RESOURCES_CLI_NAME=argocd-resources-gen
 


### PR DESCRIPTION
Mitigate https://github.com/argoproj/argo-cd/issues/22427

We can use `make mod-vendor-local && CGO_FLAG=1 STATIC_BUILD=false make cli-local`