### PR TITLE
fix(ci): use pinned Helm version for init-release (#22164)

### DIFF
--- a/hack/installers/install-codegen-tools.sh
+++ b/hack/installers/install-codegen-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux -o pipefail
 
-KUSTOMIZE_VERSION=4.5.7 "$(dirname $0)/../install.sh" kustomize protoc
+KUSTOMIZE_VERSION=4.5.7 "$(dirname $0)/../install.sh" helm kustomize protoc

--- a/manifests/ha/base/redis-ha/generate.sh
+++ b/manifests/ha/base/redis-ha/generate.sh
@@ -5,6 +5,7 @@ helm dependency update ./chart
 AUTOGENMSG="# This is an auto-generated file. DO NOT EDIT"
 echo "${AUTOGENMSG}" > ./chart/upstream.yaml
 
+helm version
 helm template argocd ./chart \
   --namespace argocd \
   --values ./chart/values.yaml \


### PR DESCRIPTION
To avoid new helm behavior that affects security context config.