### PR TITLE
feat(hydrator): handle sourceHydrator fields from webhook (#19397)

### DIFF
--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -313,7 +313,7 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 					if path.AppFilesHaveChanged(refreshPaths, changedFiles) {
 						namespacedAppInterface := a.appClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace)
 						log.Infof("webhook trigger refresh app to hydrate '%s'", app.ObjectMeta.Name)
-						_, err = argo.RefreshApp(namespacedAppInterface, app.ObjectMeta.Name, v1alpha1.RefreshTypeNormal)
+						_, err = argo.RefreshApp(namespacedAppInterface, app.ObjectMeta.Name, v1alpha1.RefreshTypeNormal, true)
 						if err != nil {
 							log.Warnf("Failed to hydrate app '%s' for controller reprocessing: %v", app.ObjectMeta.Name, err)
 							continue

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -306,6 +306,22 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 			continue
 		}
 		for _, app := range filteredApps {
+			if app.Spec.SourceHydrator != nil {
+				drySource := app.Spec.SourceHydrator.GetDrySource()
+				if sourceRevisionHasChanged(drySource, revision, touchedHead) && sourceUsesURL(drySource, webURL, repoRegexp) {
+					refreshPaths := path.GetAppRefreshPaths(&app)
+					if path.AppFilesHaveChanged(refreshPaths, changedFiles) {
+						namespacedAppInterface := a.appClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace)
+						log.Infof("webhook trigger refresh app to hydrate '%s'", app.ObjectMeta.Name)
+						_, err = argo.RefreshApp(namespacedAppInterface, app.ObjectMeta.Name, v1alpha1.RefreshTypeNormal)
+						if err != nil {
+							log.Warnf("Failed to hydrate app '%s' for controller reprocessing: %v", app.ObjectMeta.Name, err)
+							continue
+						}
+					}
+				}
+			}
+
 			for _, source := range app.Spec.GetSources() {
 				if sourceRevisionHasChanged(source, revision, touchedHead) && sourceUsesURL(source, webURL, repoRegexp) {
 					refreshPaths := path.GetAppRefreshPaths(&app)

--- a/util/webhook/webhook_test.go
+++ b/util/webhook/webhook_test.go
@@ -276,6 +276,72 @@ func TestGitHubCommitEvent_AppsInOtherNamespaces(t *testing.T) {
 	hook.Reset()
 }
 
+// TestGitHubCommitEvent_Hydrate makes sure that a webhook will hydrate an app when dry source changed.
+func TestGitHubCommitEvent_Hydrate(t *testing.T) {
+	hook := test.NewGlobal()
+	var patched bool
+	reaction := func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(kubetesting.PatchAction)
+		assert.Equal(t, "app-to-hydrate", patchAction.GetName())
+		patched = true
+		return true, nil, nil
+	}
+	h := NewMockHandler(&reactorDef{"patch", "applications", reaction}, []string{}, &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-to-hydrate",
+			Namespace: "argocd",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			SourceHydrator: &v1alpha1.SourceHydrator{
+				DrySource: v1alpha1.DrySource{
+					RepoURL:        "https://github.com/jessesuen/test-repo",
+					TargetRevision: "HEAD",
+					Path:           ".",
+				},
+				SyncSource: v1alpha1.SyncSource{
+					TargetBranch: "environments/dev",
+					Path:         ".",
+				},
+				HydrateTo: nil,
+			},
+		},
+	}, &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-to-ignore",
+		},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: v1alpha1.ApplicationSources{
+				{
+					RepoURL: "https://github.com/some/unrelated-repo",
+					Path:    ".",
+				},
+			},
+		},
+	},
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhook", nil)
+	req.Header.Set("X-GitHub-Event", "push")
+	eventJSON, err := os.ReadFile("testdata/github-commit-event.json")
+	require.NoError(t, err)
+	req.Body = io.NopCloser(bytes.NewReader(eventJSON))
+	w := httptest.NewRecorder()
+	h.Handler(w, req)
+	close(h.queue)
+	h.Wait()
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, patched)
+
+	logMessages := make([]string, 0, len(hook.Entries))
+	for _, entry := range hook.Entries {
+		logMessages = append(logMessages, entry.Message)
+	}
+
+	assert.Contains(t, logMessages, "webhook trigger refresh app to hydrate 'app-to-hydrate'")
+	assert.NotContains(t, logMessages, "webhook trigger refresh app to hydrate 'app-to-ignore'")
+
+	hook.Reset()
+}
+
 func TestGitHubTagEvent(t *testing.T) {
 	hook := test.NewGlobal()
 	h := NewMockHandler(nil, []string{})


### PR DESCRIPTION
Cherry-pick of https://github.com/argoproj/argo-cd/pull/19397, but I had to update it slightly to add the new hydrate flag.

It seems like this was approved and merged into the `hydrator` branch but never brought back into `master`, I'm not sure if this was intentional or not but there does not seem to be an equivalent feature on `master` currently.

Current behavior: webhooks only look at the `syncSource` revision to determine if it needs to trigger a refresh. This means that an update to the dry sources does not trigger a refresh and does not rehydrate.

Expected behavior: webhooks should look at both the `drySource` to trigger a rehydration and at the `syncSource` to trigger a sync.

I've retested it on my side and it works great.

Resolves https://github.com/argoproj/argo-cd/issues/19070

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
