### PR TITLE
feat(redis-client): Support for ConnMaxIdleTime option for redis client

### DIFF
--- a/docs/operator-manual/argocd-cmd-params-cm.yaml
+++ b/docs/operator-manual/argocd-cmd-params-cm.yaml
@@ -18,6 +18,8 @@ data:
   redis.compression: gzip
   # Redis database
   redis.db:
+  # Redis clients connection maximum idle time (default 30 minutes)
+  redis.connection-max-idle-time: "5m"
 
   # Enables the alpha "manifest hydrator" feature. (default "false")
   hydrator.enabled: "false"

--- a/docs/operator-manual/server-commands/argocd-application-controller.md
+++ b/docs/operator-manual/server-commands/argocd-application-controller.md
@@ -61,6 +61,7 @@ argocd-application-controller [flags]
       --redis-client-certificate string                           Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                                   Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                                     Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-connection-max-idle-time duration                   Redis client connection max idle time (default 30m0s)
       --redis-insecure-skip-tls-verify                            Skip Redis server certificate validation.
       --redis-use-tls                                             Use TLS when connecting to Redis. 
       --redisdb int                                               Redis database.

--- a/docs/operator-manual/server-commands/argocd-repo-server.md
+++ b/docs/operator-manual/server-commands/argocd-repo-server.md
@@ -42,6 +42,7 @@ argocd-repo-server [flags]
       --redis-client-certificate string                Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
       --redis-client-key string                        Path to Redis client key (e.g. /etc/certs/redis/client.crt).
       --redis-compress string                          Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-connection-max-idle-time duration        Redis client connection max idle time (default 30m0s)
       --redis-insecure-skip-tls-verify                 Skip Redis server certificate validation.
       --redis-use-tls                                  Use TLS when connecting to Redis. 
       --redisdb int                                    Redis database.

--- a/docs/operator-manual/server-commands/argocd-server.md
+++ b/docs/operator-manual/server-commands/argocd-server.md
@@ -25,96 +25,98 @@ argocd-server [flags]
 ### Options
 
 ```
-      --address string                                  Listen on given address (default "0.0.0.0")
-      --api-content-types string                        Semicolon separated list of allowed content types for non GET api requests. Any content type is allowed if empty. (default "application/json")
-      --app-state-cache-expiration duration             Cache expiration for app state (default 1h0m0s)
-      --application-namespaces strings                  List of additional namespaces where application resources can be managed in
-      --appset-allowed-scm-providers strings            The list of allowed custom SCM provider API URLs. This restriction does not apply to SCM or PR generators which do not accept a custom API URL. (Default: Empty = all)
-      --appset-enable-new-git-file-globbing             Enable new globbing in Git files generator.
-      --appset-enable-scm-providers                     Enable retrieving information from SCM providers, used by the SCM and PR generators (Default: true) (default true)
-      --appset-scm-root-ca-path string                  Provide Root CA Path for self-signed TLS Certificates
-      --as string                                       Username to impersonate for the operation
-      --as-group stringArray                            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --as-uid string                                   UID to impersonate for the operation
-      --basehref string                                 Value for base href in index.html. Used if Argo CD is running behind reverse proxy under subpath different from / (default "/")
-      --certificate-authority string                    Path to a cert file for the certificate authority
-      --client-certificate string                       Path to a client certificate file for TLS
-      --client-key string                               Path to a client key file for TLS
-      --cluster string                                  The name of the kubeconfig cluster to use
-      --connection-status-cache-expiration duration     Cache expiration for cluster/repo connection status (default 1h0m0s)
-      --content-security-policy value                   Set Content-Security-Policy header in HTTP responses to value. To disable, set to "". (default "frame-ancestors 'self';")
-      --context string                                  The name of the kubeconfig context to use
-      --default-cache-expiration duration               Cache expiration default (default 24h0m0s)
-      --dex-server string                               Dex server address (default "argocd-dex-server:5556")
-      --dex-server-plaintext                            Use a plaintext client (non-TLS) to connect to dex server
-      --dex-server-strict-tls                           Perform strict validation of TLS certificates when connecting to dex server
-      --disable-auth                                    Disable client authentication
-      --disable-compression                             If true, opt-out of response compression for all requests to the server
-      --enable-gzip                                     Enable GZIP compression (default true)
-      --enable-k8s-event none                           Enable ArgoCD to use k8s event. For disabling all events, set the value as none. (e.g --enable-k8s-event=none), For enabling specific events, set the value as `event reason`. (e.g --enable-k8s-event=StatusRefreshed,ResourceCreated) (default [all])
-      --enable-proxy-extension                          Enable Proxy Extension feature
-      --gloglevel int                                   Set the glog logging level
-  -h, --help                                            help for argocd-server
-      --hydrator-enabled                                Feature flag to enable Hydrator. Default ("false")
-      --insecure                                        Run server without TLS
-      --insecure-skip-tls-verify                        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                               Path to a kube config. Only required if out-of-cluster
-      --logformat string                                Set the logging format. One of: json|text (default "json")
-      --login-attempts-expiration duration              Cache expiration for failed login attempts (default 24h0m0s)
-      --loglevel string                                 Set the logging level. One of: debug|info|warn|error (default "info")
-      --metrics-address string                          Listen for metrics on given address (default "0.0.0.0")
-      --metrics-port int                                Start metrics on given port (default 8083)
-  -n, --namespace string                                If present, the namespace scope for this CLI request
-      --oidc-cache-expiration duration                  Cache expiration for OIDC state (default 3m0s)
-      --otlp-address string                             OpenTelemetry collector address to send traces to
-      --otlp-attrs strings                              List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)
-      --otlp-headers stringToString                     List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2) (default [])
-      --otlp-insecure                                   OpenTelemetry collector insecure mode (default true)
-      --password string                                 Password for basic authentication to the API server
-      --port int                                        Listen on given port (default 8080)
-      --proxy-url string                                If provided, this URL will be used to connect via proxy
-      --redis string                                    Redis server hostname and port (e.g. argocd-redis:6379). 
-      --redis-ca-certificate string                     Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
-      --redis-client-certificate string                 Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
-      --redis-client-key string                         Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                           Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
-      --redis-insecure-skip-tls-verify                  Skip Redis server certificate validation.
-      --redis-use-tls                                   Use TLS when connecting to Redis. 
-      --redisdb int                                     Redis database.
-      --repo-cache-expiration duration                  Cache expiration for repo state, incl. app lists, app details, manifest generation, revision meta-data (default 24h0m0s)
-      --repo-server string                              Repo server address (default "argocd-repo-server:8081")
-      --repo-server-default-cache-expiration duration   Cache expiration default (default 24h0m0s)
-      --repo-server-plaintext                           Use a plaintext client (non-TLS) to connect to repository server
-      --repo-server-redis string                        Redis server hostname and port (e.g. argocd-redis:6379). 
-      --repo-server-redis-ca-certificate string         Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
-      --repo-server-redis-client-certificate string     Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
-      --repo-server-redis-client-key string             Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --repo-server-redis-compress string               Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
-      --repo-server-redis-insecure-skip-tls-verify      Skip Redis server certificate validation.
-      --repo-server-redis-use-tls                       Use TLS when connecting to Redis. 
-      --repo-server-redisdb int                         Redis database.
-      --repo-server-sentinel stringArray                Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
-      --repo-server-sentinelmaster string               Redis sentinel master group name. (default "master")
-      --repo-server-strict-tls                          Perform strict validation of TLS certificates when connecting to repo server
-      --repo-server-timeout-seconds int                 Repo server RPC call timeout seconds. (default 60)
-      --request-timeout string                          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --revision-cache-expiration duration              Cache expiration for cached revision (default 3m0s)
-      --revision-cache-lock-timeout duration            Cache TTL for locks to prevent duplicate requests on revisions, set to 0 to disable (default 10s)
-      --rootpath string                                 Used if Argo CD is running behind reverse proxy under subpath different from /
-      --sentinel stringArray                            Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
-      --sentinelmaster string                           Redis sentinel master group name. (default "master")
-      --server string                                   The address and port of the Kubernetes API server
-      --staticassets string                             Directory path that contains additional static assets (default "/shared/app")
-      --sync-with-replace-allowed                       Whether to allow users to select replace for syncs from UI/CLI (default true)
-      --tls-server-name string                          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --tlsciphers string                               The list of acceptable ciphers to be used when establishing TLS connections. Use 'list' to list available ciphers. (default "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
-      --tlsmaxversion string                            The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.3")
-      --tlsminversion string                            The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.2")
-      --token string                                    Bearer token for authentication to the API server
-      --user string                                     The name of the kubeconfig user to use
-      --username string                                 Username for basic authentication to the API server
-      --webhook-parallelism-limit int                   Number of webhook requests processed concurrently (default 50)
-      --x-frame-options value                           Set X-Frame-Options header in HTTP responses to value. To disable, set to "". (default "sameorigin")
+      --address string                                        Listen on given address (default "0.0.0.0")
+      --api-content-types string                              Semicolon separated list of allowed content types for non GET api requests. Any content type is allowed if empty. (default "application/json")
+      --app-state-cache-expiration duration                   Cache expiration for app state (default 1h0m0s)
+      --application-namespaces strings                        List of additional namespaces where application resources can be managed in
+      --appset-allowed-scm-providers strings                  The list of allowed custom SCM provider API URLs. This restriction does not apply to SCM or PR generators which do not accept a custom API URL. (Default: Empty = all)
+      --appset-enable-new-git-file-globbing                   Enable new globbing in Git files generator.
+      --appset-enable-scm-providers                           Enable retrieving information from SCM providers, used by the SCM and PR generators (Default: true) (default true)
+      --appset-scm-root-ca-path string                        Provide Root CA Path for self-signed TLS Certificates
+      --as string                                             Username to impersonate for the operation
+      --as-group stringArray                                  Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                                         UID to impersonate for the operation
+      --basehref string                                       Value for base href in index.html. Used if Argo CD is running behind reverse proxy under subpath different from / (default "/")
+      --certificate-authority string                          Path to a cert file for the certificate authority
+      --client-certificate string                             Path to a client certificate file for TLS
+      --client-key string                                     Path to a client key file for TLS
+      --cluster string                                        The name of the kubeconfig cluster to use
+      --connection-status-cache-expiration duration           Cache expiration for cluster/repo connection status (default 1h0m0s)
+      --content-security-policy value                         Set Content-Security-Policy header in HTTP responses to value. To disable, set to "". (default "frame-ancestors 'self';")
+      --context string                                        The name of the kubeconfig context to use
+      --default-cache-expiration duration                     Cache expiration default (default 24h0m0s)
+      --dex-server string                                     Dex server address (default "argocd-dex-server:5556")
+      --dex-server-plaintext                                  Use a plaintext client (non-TLS) to connect to dex server
+      --dex-server-strict-tls                                 Perform strict validation of TLS certificates when connecting to dex server
+      --disable-auth                                          Disable client authentication
+      --disable-compression                                   If true, opt-out of response compression for all requests to the server
+      --enable-gzip                                           Enable GZIP compression (default true)
+      --enable-k8s-event none                                 Enable ArgoCD to use k8s event. For disabling all events, set the value as none. (e.g --enable-k8s-event=none), For enabling specific events, set the value as `event reason`. (e.g --enable-k8s-event=StatusRefreshed,ResourceCreated) (default [all])
+      --enable-proxy-extension                                Enable Proxy Extension feature
+      --gloglevel int                                         Set the glog logging level
+  -h, --help                                                  help for argocd-server
+      --hydrator-enabled                                      Feature flag to enable Hydrator. Default ("false")
+      --insecure                                              Run server without TLS
+      --insecure-skip-tls-verify                              If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                                     Path to a kube config. Only required if out-of-cluster
+      --logformat string                                      Set the logging format. One of: json|text (default "json")
+      --login-attempts-expiration duration                    Cache expiration for failed login attempts (default 24h0m0s)
+      --loglevel string                                       Set the logging level. One of: debug|info|warn|error (default "info")
+      --metrics-address string                                Listen for metrics on given address (default "0.0.0.0")
+      --metrics-port int                                      Start metrics on given port (default 8083)
+  -n, --namespace string                                      If present, the namespace scope for this CLI request
+      --oidc-cache-expiration duration                        Cache expiration for OIDC state (default 3m0s)
+      --otlp-address string                                   OpenTelemetry collector address to send traces to
+      --otlp-attrs strings                                    List of OpenTelemetry collector extra attrs when send traces, each attribute is separated by a colon(e.g. key:value)
+      --otlp-headers stringToString                           List of OpenTelemetry collector extra headers sent with traces, headers are comma-separated key-value pairs(e.g. key1=value1,key2=value2) (default [])
+      --otlp-insecure                                         OpenTelemetry collector insecure mode (default true)
+      --password string                                       Password for basic authentication to the API server
+      --port int                                              Listen on given port (default 8080)
+      --proxy-url string                                      If provided, this URL will be used to connect via proxy
+      --redis string                                          Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string                           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string                       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string                               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress string                                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-connection-max-idle-time duration               Redis client connection max idle time (default 30m0s)
+      --redis-insecure-skip-tls-verify                        Skip Redis server certificate validation.
+      --redis-use-tls                                         Use TLS when connecting to Redis. 
+      --redisdb int                                           Redis database.
+      --repo-cache-expiration duration                        Cache expiration for repo state, incl. app lists, app details, manifest generation, revision meta-data (default 24h0m0s)
+      --repo-server string                                    Repo server address (default "argocd-repo-server:8081")
+      --repo-server-default-cache-expiration duration         Cache expiration default (default 24h0m0s)
+      --repo-server-plaintext                                 Use a plaintext client (non-TLS) to connect to repository server
+      --repo-server-redis string                              Redis server hostname and port (e.g. argocd-redis:6379). 
+      --repo-server-redis-ca-certificate string               Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --repo-server-redis-client-certificate string           Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --repo-server-redis-client-key string                   Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --repo-server-redis-compress string                     Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --repo-server-redis-connection-max-idle-time duration   Redis client connection max idle time (default 30m0s)
+      --repo-server-redis-insecure-skip-tls-verify            Skip Redis server certificate validation.
+      --repo-server-redis-use-tls                             Use TLS when connecting to Redis. 
+      --repo-server-redisdb int                               Redis database.
+      --repo-server-sentinel stringArray                      Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
+      --repo-server-sentinelmaster string                     Redis sentinel master group name. (default "master")
+      --repo-server-strict-tls                                Perform strict validation of TLS certificates when connecting to repo server
+      --repo-server-timeout-seconds int                       Repo server RPC call timeout seconds. (default 60)
+      --request-timeout string                                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --revision-cache-expiration duration                    Cache expiration for cached revision (default 3m0s)
+      --revision-cache-lock-timeout duration                  Cache TTL for locks to prevent duplicate requests on revisions, set to 0 to disable (default 10s)
+      --rootpath string                                       Used if Argo CD is running behind reverse proxy under subpath different from /
+      --sentinel stringArray                                  Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
+      --sentinelmaster string                                 Redis sentinel master group name. (default "master")
+      --server string                                         The address and port of the Kubernetes API server
+      --staticassets string                                   Directory path that contains additional static assets (default "/shared/app")
+      --sync-with-replace-allowed                             Whether to allow users to select replace for syncs from UI/CLI (default true)
+      --tls-server-name string                                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --tlsciphers string                                     The list of acceptable ciphers to be used when establishing TLS connections. Use 'list' to list available ciphers. (default "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+      --tlsmaxversion string                                  The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.3")
+      --tlsminversion string                                  The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2|1.3) (default "1.2")
+      --token string                                          Bearer token for authentication to the API server
+      --user string                                           The name of the kubeconfig user to use
+      --username string                                       Username for basic authentication to the API server
+      --webhook-parallelism-limit int                         Number of webhook requests processed concurrently (default 50)
+      --x-frame-options value                                 Set X-Frame-Options header in HTTP responses to value. To disable, set to "". (default "sameorigin")
 ```
 
 ### SEE ALSO

--- a/docs/user-guide/commands/argocd_admin_cluster_shards.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_shards.md
@@ -11,43 +11,44 @@ argocd admin cluster shards [flags]
 ### Options
 
 ```
-      --app-state-cache-expiration duration   Cache expiration for app state (default 1h0m0s)
-      --as string                             Username to impersonate for the operation
-      --as-group stringArray                  Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --as-uid string                         UID to impersonate for the operation
-      --certificate-authority string          Path to a cert file for the certificate authority
-      --client-certificate string             Path to a client certificate file for TLS
-      --client-key string                     Path to a client key file for TLS
-      --cluster string                        The name of the kubeconfig cluster to use
-      --context string                        The name of the kubeconfig context to use
-      --default-cache-expiration duration     Cache expiration default (default 24h0m0s)
-      --disable-compression                   If true, opt-out of response compression for all requests to the server
-  -h, --help                                  help for shards
-      --insecure-skip-tls-verify              If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                     Path to a kube config. Only required if out-of-cluster
-  -n, --namespace string                      If present, the namespace scope for this CLI request
-      --password string                       Password for basic authentication to the API server
-      --port-forward-redis                    Automatically port-forward ha proxy redis from current namespace? (default true)
-      --proxy-url string                      If provided, this URL will be used to connect via proxy
-      --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
-      --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
-      --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
-      --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
-      --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
-      --redis-use-tls                         Use TLS when connecting to Redis. 
-      --redisdb int                           Redis database.
-      --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified
-      --request-timeout string                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --sentinel stringArray                  Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
-      --sentinelmaster string                 Redis sentinel master group name. (default "master")
-      --server string                         The address and port of the Kubernetes API server
-      --shard int                             Cluster shard filter (default -1)
-      --sharding-method string                Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
-      --tls-server-name string                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                          Bearer token for authentication to the API server
-      --user string                           The name of the kubeconfig user to use
-      --username string                       Username for basic authentication to the API server
+      --app-state-cache-expiration duration       Cache expiration for app state (default 1h0m0s)
+      --as string                                 Username to impersonate for the operation
+      --as-group stringArray                      Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                             UID to impersonate for the operation
+      --certificate-authority string              Path to a cert file for the certificate authority
+      --client-certificate string                 Path to a client certificate file for TLS
+      --client-key string                         Path to a client key file for TLS
+      --cluster string                            The name of the kubeconfig cluster to use
+      --context string                            The name of the kubeconfig context to use
+      --default-cache-expiration duration         Cache expiration default (default 24h0m0s)
+      --disable-compression                       If true, opt-out of response compression for all requests to the server
+  -h, --help                                      help for shards
+      --insecure-skip-tls-verify                  If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                         Path to a kube config. Only required if out-of-cluster
+  -n, --namespace string                          If present, the namespace scope for this CLI request
+      --password string                           Password for basic authentication to the API server
+      --port-forward-redis                        Automatically port-forward ha proxy redis from current namespace? (default true)
+      --proxy-url string                          If provided, this URL will be used to connect via proxy
+      --redis string                              Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string               Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string           Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string                   Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress string                     Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-connection-max-idle-time duration   Redis client connection max idle time (default 30m0s)
+      --redis-insecure-skip-tls-verify            Skip Redis server certificate validation.
+      --redis-use-tls                             Use TLS when connecting to Redis. 
+      --redisdb int                               Redis database.
+      --replicas int                              Application controller replicas count. Inferred from number of running controller pods if not specified
+      --request-timeout string                    The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --sentinel stringArray                      Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
+      --sentinelmaster string                     Redis sentinel master group name. (default "master")
+      --server string                             The address and port of the Kubernetes API server
+      --shard int                                 Cluster shard filter (default -1)
+      --sharding-method string                    Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
+      --tls-server-name string                    If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                              Bearer token for authentication to the API server
+      --user string                               The name of the kubeconfig user to use
+      --username string                           Username for basic authentication to the API server
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_admin_cluster_stats.md
+++ b/docs/user-guide/commands/argocd_admin_cluster_stats.md
@@ -25,43 +25,44 @@ argocd admin cluster stats target-cluster
 ### Options
 
 ```
-      --app-state-cache-expiration duration   Cache expiration for app state (default 1h0m0s)
-      --as string                             Username to impersonate for the operation
-      --as-group stringArray                  Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --as-uid string                         UID to impersonate for the operation
-      --certificate-authority string          Path to a cert file for the certificate authority
-      --client-certificate string             Path to a client certificate file for TLS
-      --client-key string                     Path to a client key file for TLS
-      --cluster string                        The name of the kubeconfig cluster to use
-      --context string                        The name of the kubeconfig context to use
-      --default-cache-expiration duration     Cache expiration default (default 24h0m0s)
-      --disable-compression                   If true, opt-out of response compression for all requests to the server
-  -h, --help                                  help for stats
-      --insecure-skip-tls-verify              If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                     Path to a kube config. Only required if out-of-cluster
-  -n, --namespace string                      If present, the namespace scope for this CLI request
-      --password string                       Password for basic authentication to the API server
-      --port-forward-redis                    Automatically port-forward ha proxy redis from current namespace? (default true)
-      --proxy-url string                      If provided, this URL will be used to connect via proxy
-      --redis string                          Redis server hostname and port (e.g. argocd-redis:6379). 
-      --redis-ca-certificate string           Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
-      --redis-client-certificate string       Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
-      --redis-client-key string               Path to Redis client key (e.g. /etc/certs/redis/client.crt).
-      --redis-compress string                 Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
-      --redis-insecure-skip-tls-verify        Skip Redis server certificate validation.
-      --redis-use-tls                         Use TLS when connecting to Redis. 
-      --redisdb int                           Redis database.
-      --replicas int                          Application controller replicas count. Inferred from number of running controller pods if not specified
-      --request-timeout string                The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-      --sentinel stringArray                  Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
-      --sentinelmaster string                 Redis sentinel master group name. (default "master")
-      --server string                         The address and port of the Kubernetes API server
-      --shard int                             Cluster shard filter (default -1)
-      --sharding-method string                Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
-      --tls-server-name string                If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
-      --token string                          Bearer token for authentication to the API server
-      --user string                           The name of the kubeconfig user to use
-      --username string                       Username for basic authentication to the API server
+      --app-state-cache-expiration duration       Cache expiration for app state (default 1h0m0s)
+      --as string                                 Username to impersonate for the operation
+      --as-group stringArray                      Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                             UID to impersonate for the operation
+      --certificate-authority string              Path to a cert file for the certificate authority
+      --client-certificate string                 Path to a client certificate file for TLS
+      --client-key string                         Path to a client key file for TLS
+      --cluster string                            The name of the kubeconfig cluster to use
+      --context string                            The name of the kubeconfig context to use
+      --default-cache-expiration duration         Cache expiration default (default 24h0m0s)
+      --disable-compression                       If true, opt-out of response compression for all requests to the server
+  -h, --help                                      help for stats
+      --insecure-skip-tls-verify                  If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                         Path to a kube config. Only required if out-of-cluster
+  -n, --namespace string                          If present, the namespace scope for this CLI request
+      --password string                           Password for basic authentication to the API server
+      --port-forward-redis                        Automatically port-forward ha proxy redis from current namespace? (default true)
+      --proxy-url string                          If provided, this URL will be used to connect via proxy
+      --redis string                              Redis server hostname and port (e.g. argocd-redis:6379). 
+      --redis-ca-certificate string               Path to Redis server CA certificate (e.g. /etc/certs/redis/ca.crt). If not specified, system trusted CAs will be used for server certificate validation.
+      --redis-client-certificate string           Path to Redis client certificate (e.g. /etc/certs/redis/client.crt).
+      --redis-client-key string                   Path to Redis client key (e.g. /etc/certs/redis/client.crt).
+      --redis-compress string                     Enable compression for data sent to Redis with the required compression algorithm. (possible values: gzip, none) (default "gzip")
+      --redis-connection-max-idle-time duration   Redis client connection max idle time (default 30m0s)
+      --redis-insecure-skip-tls-verify            Skip Redis server certificate validation.
+      --redis-use-tls                             Use TLS when connecting to Redis. 
+      --redisdb int                               Redis database.
+      --replicas int                              Application controller replicas count. Inferred from number of running controller pods if not specified
+      --request-timeout string                    The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --sentinel stringArray                      Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379). 
+      --sentinelmaster string                     Redis sentinel master group name. (default "master")
+      --server string                             The address and port of the Kubernetes API server
+      --shard int                                 Cluster shard filter (default -1)
+      --sharding-method string                    Sharding method. Defaults: legacy. Supported sharding methods are : [legacy, round-robin, consistent-hashing]  (default "legacy")
+      --tls-server-name string                    If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --token string                              Bearer token for authentication to the API server
+      --user string                               The name of the kubeconfig user to use
+      --username string                           Username for basic authentication to the API server
 ```
 
 ### Options inherited from parent commands

--- a/manifests/base/application-controller-deployment/argocd-application-controller-deployment.yaml
+++ b/manifests/base/application-controller-deployment/argocd-application-controller-deployment.yaml
@@ -169,6 +169,12 @@ spec:
               name: argocd-cmd-params-cm
               key: redis.db
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: redis.connection-max-idle-time
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:

--- a/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
+++ b/manifests/base/application-controller/argocd-application-controller-statefulset.yaml
@@ -172,6 +172,12 @@ spec:
               name: argocd-cmd-params-cm
               key: redis.db
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-cmd-params-cm
+              key: redis.connection-max-idle-time
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:

--- a/manifests/base/repo-server/argocd-repo-server-deployment.yaml
+++ b/manifests/base/repo-server/argocd-repo-server-deployment.yaml
@@ -119,6 +119,12 @@ spec:
                   name: argocd-cmd-params-cm
                   key: redis.db
                   optional: true
+          - name: REDIS_CONN_MAX_IDLE_TIME
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: redis.connection-max-idle-time
+                optional: true
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
                 configMapKeyRef:

--- a/manifests/base/server/argocd-server-deployment.yaml
+++ b/manifests/base/server/argocd-server-deployment.yaml
@@ -190,6 +190,12 @@ spec:
                   name: argocd-cmd-params-cm
                   key: redis.db
                   optional: true
+            - name: REDIS_CONN_MAX_IDLE_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: argocd-cmd-params-cm
+                  key: redis.connection-max-idle-time
+                  optional: true
             - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
               valueFrom:
                 configMapKeyRef:

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -25094,6 +25094,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -25502,6 +25508,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -24906,6 +24906,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -25314,6 +25320,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/ha/install-with-hydrator.yaml
+++ b/manifests/ha/install-with-hydrator.yaml
@@ -26728,6 +26728,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -27154,6 +27160,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -27546,6 +27558,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -26542,6 +26542,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -26968,6 +26974,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -27360,6 +27372,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/ha/namespace-install-with-hydrator.yaml
+++ b/manifests/ha/namespace-install-with-hydrator.yaml
@@ -2563,6 +2563,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -2989,6 +2995,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -3381,6 +3393,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/ha/namespace-install.yaml
+++ b/manifests/ha/namespace-install.yaml
@@ -2377,6 +2377,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -2803,6 +2809,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -3195,6 +3207,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -25775,6 +25775,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -26199,6 +26205,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -26591,6 +26603,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -25587,6 +25587,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -26011,6 +26017,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -26403,6 +26415,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1610,6 +1610,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -2034,6 +2040,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -2426,6 +2438,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1422,6 +1422,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -1846,6 +1852,12 @@ spec:
               key: redis.db
               name: argocd-cmd-params-cm
               optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
+              name: argocd-cmd-params-cm
+              optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
           valueFrom:
             configMapKeyRef:
@@ -2238,6 +2250,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: redis.db
+              name: argocd-cmd-params-cm
+              optional: true
+        - name: REDIS_CONN_MAX_IDLE_TIME
+          valueFrom:
+            configMapKeyRef:
+              key: redis.connection-max-idle-time
               name: argocd-cmd-params-cm
               optional: true
         - name: ARGOCD_DEFAULT_CACHE_EXPIRATION

--- a/util/webhook/webhook.go
+++ b/util/webhook/webhook.go
@@ -357,11 +357,11 @@ func (a *ArgoCDWebhookHandler) HandleEvent(payload any) {
 				if sourceRevisionHasChanged(drySource, revision, touchedHead) && sourceUsesURL(drySource, webURL, repoRegexp) {
 					refreshPaths := path.GetAppRefreshPaths(&app)
 					if path.AppFilesHaveChanged(refreshPaths, changedFiles) {
-						namespacedAppInterface := a.appClientset.ArgoprojV1alpha1().Applications(app.ObjectMeta.Namespace)
-						log.Infof("webhook trigger refresh app to hydrate '%s'", app.ObjectMeta.Name)
-						_, err = argo.RefreshApp(namespacedAppInterface, app.ObjectMeta.Name, v1alpha1.RefreshTypeNormal, true)
+						namespacedAppInterface := a.appClientset.ArgoprojV1alpha1().Applications(app.Namespace)
+						log.Infof("webhook trigger refresh app to hydrate '%s'", app.Name)
+						_, err = argo.RefreshApp(namespacedAppInterface, app.Name, v1alpha1.RefreshTypeNormal, true)
 						if err != nil {
-							log.Warnf("Failed to hydrate app '%s' for controller reprocessing: %v", app.ObjectMeta.Name, err)
+							log.Warnf("Failed to hydrate app '%s' for controller reprocessing: %v", app.Name, err)
 							continue
 						}
 					}


### PR DESCRIPTION
Fixes #22489 

The default value is aligned with the redis client one:

![image](https://github.com/user-attachments/assets/4ddc7e08-8a35-4e6a-afed-610f68658b8d)


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
