### PR TITLE
chore: clean-up golangci-lint configuration 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,24 +1,19 @@
-version: "2"
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/argoproj/argo-cd/v3
+
 issues:
   max-issues-per-linter: 0
+
   max-same-issues: 0
+
 linters:
-  exclusions:
-    rules:
-      - linters:
-          - unparam
-        path: (.+)_test\.go
-      - path: (.+)\.go$
-        text: SA5011
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
   enable:
     - errorlint
     - gocritic
@@ -27,12 +22,28 @@ linters:
     - misspell
     - perfsprint
     - revive
+    - staticcheck
     - testifylint
     - thelper
     - unparam
     - usestdlibvars
     - usetesting
     - whitespace
+
+  exclusions:
+    rules:
+      - linters:
+          - unparam
+        path: (.+)_test\.go
+
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+
+    warn-unused: true
+
   settings:
     gocritic:
       disabled-checks:
@@ -41,41 +52,55 @@ linters:
         - exitAfterDefer
         - mapKey
         - typeSwitchVar
+
     gomodguard:
       blocked:
         modules:
           - github.com/golang-jwt/jwt/v4:
               recommendations:
                 - github.com/golang-jwt/jwt/v5
+
           - github.com/imdario/mergo:
               recommendations:
                 - dario.cat/mergo
               reason: '`github.com/imdario/mergo` has been renamed.'
+
           - github.com/pkg/errors:
               recommendations:
                 - errors
+
     importas:
       alias:
         - pkg: github.com/golang-jwt/jwt/v5
           alias: jwtgo
+
         - pkg: k8s.io/api/apps/v1
           alias: appsv1
+
         - pkg: k8s.io/api/core/v1
           alias: corev1
+
         - pkg: k8s.io/api/rbac/v1
           alias: rbacv1
+
         - pkg: k8s.io/apimachinery/pkg/api/errors
           alias: apierrors
+
         - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
           alias: apiextensionsv1
+
         - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
           alias: metav1
+
         - pkg: k8s.io/client-go/informers/core/v1
           alias: informersv1
+
         - pkg: errors
           alias: stderrors
+
     nolintlint:
       require-specific: true
+
     perfsprint:
       # Optimizes even if it requires an int or uint type cast.
       int-conversion: true
@@ -87,80 +112,115 @@ linters:
       sprintf1: true
       # Optimizes into strings concatenation.
       strconcat: true
+
     revive:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
       rules:
         - name: bool-literal-in-expr
+
         - name: blank-imports
           disabled: true
+
         - name: context-as-argument
           arguments:
             - allowTypesBefore: '*testing.T,testing.TB'
+
         - name: context-keys-type
           disabled: true
+
         - name: dot-imports
           disabled: true
+
         - name: duplicated-imports
+
         - name: early-return
           arguments:
             - preserveScope
+
         - name: empty-block
           disabled: true
+
         - name: error-naming
           disabled: true
+
         - name: error-return
+
         - name: error-strings
           disabled: true
+
         - name: errorf
+
         - name: identical-branches
+
         - name: if-return
+
         - name: increment-decrement
+
         - name: indent-error-flow
           arguments:
             - preserveScope
+
         - name: modifies-parameter
+
         - name: optimize-operands-order
+
         - name: range
+
         - name: receiver-naming
+
         - name: redefines-builtin-id
           disabled: true
+
         - name: redundant-import-alias
+
         - name: superfluous-else
           arguments:
             - preserveScope
+
         - name: time-equal
+
         - name: time-naming
           disabled: true
+
         - name: unexported-return
           disabled: true
+
         - name: unnecessary-stmt
+
         - name: unreachable-code
+
         - name: unused-parameter
+
         - name: use-any
+
         - name: useless-break
+
         - name: var-declaration
+
         - name: var-naming
           arguments:
             - - ID
             - - VM
             - - skipPackageNameChecks: true
                 upperCaseConst: true
+
+    staticcheck:
+      checks:
+        - all
+        - -SA5011
+        - -ST1003
+        - -ST1016
+
     testifylint:
       enable-all: true
+
       disable:
         - go-require
+
     usetesting:
       os-mkdir-temp: false
-formatters:
-  enable:
-    - gofumpt
-    - goimports
-  settings:
-    goimports:
-      local-prefixes:
-        - github.com/argoproj/argo-cd/v3
-  exclusions:
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+
+output:
+  show-stats: false
+
+version: "2"


### PR DESCRIPTION
#### Description

* sort fields alphabetically
* move SA5011 exclusion to staticcheck linter settings
* log a warning if an exclusion rule is unused.