### PR TITLE
fix(#22617): Filter Pull Requests Server-Side with GitHub GraphQL API in Pull Request GitHub Service

### DIFF
--- a/applicationset/services/pull_request/github_app.go
+++ b/applicationset/services/pull_request/github_app.go
@@ -10,14 +10,14 @@ import (
 
 func NewGithubAppService(g github_app_auth.Authentication, url, owner, repo string, labels []string, optionalHTTPClient ...*http.Client) (PullRequestService, error) {
 	httpClient := appsetutils.GetOptionalHTTPClient(optionalHTTPClient...)
-	client, err := github_app.Client(g, url, httpClient)
+	v4Client, err := github_app.V4Client(g, url, httpClient)
 	if err != nil {
 		return nil, err
 	}
 	return &GithubService{
-		client: client,
-		owner:  owner,
-		repo:   repo,
-		labels: labels,
+		v4Client: v4Client,
+		owner:    owner,
+		repo:     repo,
+		labels:   labels,
 	}, nil
 }

--- a/applicationset/services/pull_request/github_test.go
+++ b/applicationset/services/pull_request/github_test.go
@@ -5,84 +5,34 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func toPtr(s string) *string {
-	return &s
-}
-
-func TestContainLabels(t *testing.T) {
-	cases := []struct {
-		Name       string
-		Labels     []string
-		PullLabels []*github.Label
-		Expect     bool
-	}{
-		{
-			Name:   "Match labels",
-			Labels: []string{"label1", "label2"},
-			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
-			},
-			Expect: true,
-		},
-		{
-			Name:   "Not match labels",
-			Labels: []string{"label1", "label4"},
-			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
-			},
-			Expect: false,
-		},
-		{
-			Name:   "No specify",
-			Labels: []string{},
-			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
-			},
-			Expect: true,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.Name, func(t *testing.T) {
-			got := containLabels(c.Labels, c.PullLabels)
-			require.Equal(t, got, c.Expect)
-		})
-	}
-}
-
 func TestGetGitHubPRLabelNames(t *testing.T) {
-	Tests := []struct {
+	tests := []struct {
 		Name           string
-		PullLabels     []*github.Label
+		PullLabels     []githubLabel
 		ExpectedResult []string
 	}{
 		{
 			Name: "PR has labels",
-			PullLabels: []*github.Label{
-				{Name: toPtr("label1")},
-				{Name: toPtr("label2")},
-				{Name: toPtr("label3")},
+			PullLabels: []githubLabel{
+				{Name: githubv4.String("label1")},
+				{Name: githubv4.String("label2")},
+				{Name: githubv4.String("label3")},
 			},
 			ExpectedResult: []string{"label1", "label2", "label3"},
 		},
 		{
 			Name:           "PR does not have labels",
-			PullLabels:     []*github.Label{},
+			PullLabels:     []githubLabel{},
 			ExpectedResult: nil,
 		},
 	}
-	for _, test := range Tests {
+
+	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			labels := getGithubPRLabelNames(test.PullLabels)
 			require.Equal(t, test.ExpectedResult, labels)
@@ -95,12 +45,9 @@ func TestGitHubListReturnsRepositoryNotFoundError(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	path := "/repos/nonexistent/nonexistent/pulls"
-
-	mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
-		// Return 404 status to simulate repository not found
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"message": "404 Project Not Found"}`))
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, _ *http.Request) {
+		// Return error message to simulate repository not found
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Could not resolve to a Repository with the name 'nonexistent/nonexistent'."}]}`))
 	})
 
 	svc, err := NewGithubService("", server.URL, "nonexistent", "nonexistent", []string{}, nil)

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/r3labs/diff/v3 v3.0.2
 	github.com/redis/go-redis/v9 v9.8.0
 	github.com/robfig/cron/v3 v3.0.2-0.20210106135023-bc59245fe10e
+	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	github.com/sirupsen/logrus v1.9.3
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/soheilhy/cmux v0.1.5
@@ -247,6 +248,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/slack-go/slack v0.16.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -819,6 +819,10 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 h1:cYCy18SHPKRkvclm+pWm1Lk4YrREb4IOIb/YdFO0p2M=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -1694,29 +1694,36 @@ func githubPullMockHandler(t *testing.T) func(http.ResponseWriter, *http.Request
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.RequestURI {
-		case "/api/v3/repos/applicationset-test-org/argocd-example-apps/pulls?per_page=100":
-			_, err := io.WriteString(w, `[
-  {
-    "number": 1,
-    "title": "title1",
-    "labels": [
-      {
-        "name": "preview"
+		case "/graphql":
+			_, err := io.WriteString(w, `{
+  "data": {
+    "search": {
+      "nodes": [
+        {
+          "number": 1,
+          "title": "title1",
+          "headRefName": "pull-request",
+          "baseRefName": "master",
+          "headRefOid": "824a5c987fdfb2b0629e9dbf5f31636c69ba4772",
+          "labels": {
+            "nodes": [
+              {
+                "name": "preview"
+              }
+            ]
+          },
+          "author": {
+            "login": "testName"
+          }
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "cursor1",
+        "hasNextPage": false
       }
-    ],
-	"base": {
-		"ref": "master",
-		"sha": "7a4a5c987fdfb2b0629e9dbf5f31636c69ba4775"
-	},
-    "head": {
-      "ref": "pull-request",
-      "sha": "824a5c987fdfb2b0629e9dbf5f31636c69ba4772"
-    },
-	"user": {
-	  "login": "testName"
-	}
+    }
   }
-]`)
+}`)
 			if err != nil {
 				t.Fail()
 			}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-cd/issues/22617

### Description

Repositories with large pull request volume might have thousands of open PRs at any one time. This currently would require 10s of round trips in order to list all pull requests which is noticeably slow to the developer who is waiting for ArgoCD to create their application when using the `ApplicationSet` pull request generator.

This uses the GraphQL API instead of the REST API for listing pull requests in the pull request `GithubService` which allows for filtering by labels on the server side.

When the `GithubService.List` function is run a repo with over 4000 open PRs...

On this branch with GraphQL search query:
```
github_test.go:82: List function took 808.005791ms
```

On `master`:
```
github_test.go:102: List function took 1m4.252771416s
```

### Notes

- [`open` is the default `state` when listing pull requests with the GitHub REST API](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests), so including `is:open` in our search query will keep that the same.
- This introduces a potential limit on the number of labels that are returned per PR. For backwards compatibility, I've set this to `100` which [appears to be the artificial limit for the number of labels](https://stackoverflow.com/questions/68109675/is-there-a-maximum-number-of-labels-that-can-be-created-in-a-github-repo/77738289#77738289) that can be added to a PR.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
