### PR TITLE
docs: Removed IgnoreExtraneous since it is now in the new compare-options doc

### DIFF
--- a/docs/user-guide/sync-options.md
+++ b/docs/user-guide/sync-options.md
@@ -16,11 +16,6 @@ metadata:
     argocd.argoproj.io/sync-options: Prune=false
 ```
 
-In the UI, the pod will simply appear as out-of-sync:
-
-![sync option no prune](../assets/sync-option-no-prune.png)
-
-
 The sync-status panel shows that pruning was skipped, and why:
 
 ![sync option no prune](../assets/sync-option-no-prune-sync-status.png)


### PR DESCRIPTION
The graphic for `IgnoreExtraneous` is still in the [Sync Options doc](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#no-prune-resources), which is no longer needed since `IgnoreExtraneous` has been moved to [the Compare Options doc](https://argo-cd.readthedocs.io/en/stable/user-guide/compare-options/#ignoring-resources-that-are-extraneous).