### PR TITLE
fix: make argocd login respect the context name

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -112,6 +112,8 @@ argocd login cd.argoproj.io --core`,
 				ServerName:           globalClientOpts.ServerName,
 			}
 
+			ctxName = globalClientOpts.Context
+
 			if ctxName == "" {
 				ctxName = server
 				if globalClientOpts.GRPCWebRootPath != "" {
@@ -167,9 +169,6 @@ argocd login cd.argoproj.io --core`,
 				AuthToken:    tokenString,
 				RefreshToken: refreshToken,
 			})
-			if ctxName == "" {
-				ctxName = server
-			}
 			localCfg.CurrentContext = ctxName
 			localCfg.UpsertContext(localconfig.ContextRef{
 				Name:   ctxName,


### PR DESCRIPTION
The argocd CLI login command does not respect the --argocd-context flag to name the context and always uses the name of the server. This makes it respect the flag and use the supplied context name. Removed check against empty ctxName which is done higher up already.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
