### PR TITLE
chore(golangci): remove std-error-handling preset from linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,7 +40,6 @@ linters:
       - comments
       - common-false-positives
       - legacy
-      - std-error-handling
 
     warn-unused: true
 


### PR DESCRIPTION
#### Description

remove std-error-handling preset from linters