### PR TITLE
fix(controller): always set health.status.lastTransitionTime (#22665)

### DIFF
--- a/controller/health.go
+++ b/controller/health.go
@@ -80,15 +80,15 @@ func setApplicationHealth(resources []managedResource, statuses []appv1.Resource
 			appHealth.Status = healthStatus.Status
 		}
 	}
+	// if the status didn't change, don't update the timestamp
+	if app.Status.Health.Status == appHealth.Status && app.Status.Health.LastTransitionTime != nil {
+		appHealth.LastTransitionTime = app.Status.Health.LastTransitionTime
+	} else {
+		now := metav1.Now()
+		appHealth.LastTransitionTime = &now
+	}
 	if persistResourceHealth {
 		app.Status.ResourceHealthSource = appv1.ResourceHealthLocationInline
-		// if the status didn't change, don't update the timestamp
-		if app.Status.Health.Status == appHealth.Status && app.Status.Health.LastTransitionTime != nil {
-			appHealth.LastTransitionTime = app.Status.Health.LastTransitionTime
-		} else {
-			now := metav1.Now()
-			appHealth.LastTransitionTime = &now
-		}
 	} else {
 		app.Status.ResourceHealthSource = appv1.ResourceHealthLocationAppTree
 	}

--- a/controller/health_test.go
+++ b/controller/health_test.go
@@ -109,6 +109,7 @@ func TestSetApplicationHealth_ResourceHealthNotPersisted(t *testing.T) {
 	healthStatus, err := setApplicationHealth(resources, resourceStatuses, lua.ResourceHealthOverrides{}, app, false)
 	require.NoError(t, err)
 	assert.Equal(t, health.HealthStatusDegraded, healthStatus.Status)
+	assert.NotNil(t, healthStatus.LastTransitionTime)
 
 	assert.Nil(t, resourceStatuses[0].Health)
 }

--- a/docs/operator-manual/upgrading/2.14-3.0.md
+++ b/docs/operator-manual/upgrading/2.14-3.0.md
@@ -319,6 +319,7 @@ Example of a status field in the Application CR persisting health:
 status:
   health:
     status: Healthy
+    lastTransitionTime: "2025-01-01T00:00:00Z"
   resources:
     - group: apps
       health:
@@ -338,6 +339,7 @@ Example of a status field in the Application CR _not_ persisting health:
 status:
   health:
     status: Healthy
+    lastTransitionTime: "2025-01-01T00:00:00Z"
   resourceHealthSource: appTree
   resources:
     - group: apps


### PR DESCRIPTION
Fixes #22665

I think the lastTransitionTime was erroneously gated behind persistResourceHealth when persistResourceHealth was disabled by default for 3.0.

Resource-specific health shouldn't be persisted by default, but app-level health should be. lastTransitionTime is only updated when the app health is updated.