### PR TITLE
fix(bug): Fix setting retryLimit to 0 implicitly uses retryLimit as 5

### DIFF
--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -179,7 +179,7 @@ func AddAppFlags(command *cobra.Command, opts *AppOptions) {
 	command.Flags().StringArrayVar(&opts.kustomizeApiVersions, "kustomize-api-versions", nil, "api-versions (in format [group/]version/kind) to use when running helm template (Can be repeated to set several values: --helm-api-versions traefik.io/v1alpha1/TLSOption --helm-api-versions v1/Service). If not set, use the api-versions from the destination cluster. Only applicable when Helm is enabled for Kustomize builds")
 	command.Flags().StringVar(&opts.directoryExclude, "directory-exclude", "", "Set glob expression used to exclude files from application source path")
 	command.Flags().StringVar(&opts.directoryInclude, "directory-include", "", "Set glob expression used to include files from application source path")
-	command.Flags().Int64Var(&opts.retryLimit, "sync-retry-limit", 5, "Max number of allowed sync retries")
+	command.Flags().Int64Var(&opts.retryLimit, "sync-retry-limit", 5, "Max number of allowed sync retries (Setting to 0 means disabling retries)")
 	command.Flags().DurationVar(&opts.retryBackoffDuration, "sync-retry-backoff-duration", argoappv1.DefaultSyncRetryDuration, "Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h)")
 	command.Flags().DurationVar(&opts.retryBackoffMaxDuration, "sync-retry-backoff-max-duration", argoappv1.DefaultSyncRetryMaxDuration, "Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h)")
 	command.Flags().Int64Var(&opts.retryBackoffFactor, "sync-retry-backoff-factor", argoappv1.DefaultSyncRetryFactor, "Factor multiplies the base duration after each failed sync retry")

--- a/cmd/util/app.go
+++ b/cmd/util/app.go
@@ -179,7 +179,7 @@ func AddAppFlags(command *cobra.Command, opts *AppOptions) {
 	command.Flags().StringArrayVar(&opts.kustomizeApiVersions, "kustomize-api-versions", nil, "api-versions (in format [group/]version/kind) to use when running helm template (Can be repeated to set several values: --helm-api-versions traefik.io/v1alpha1/TLSOption --helm-api-versions v1/Service). If not set, use the api-versions from the destination cluster. Only applicable when Helm is enabled for Kustomize builds")
 	command.Flags().StringVar(&opts.directoryExclude, "directory-exclude", "", "Set glob expression used to exclude files from application source path")
 	command.Flags().StringVar(&opts.directoryInclude, "directory-include", "", "Set glob expression used to include files from application source path")
-	command.Flags().Int64Var(&opts.retryLimit, "sync-retry-limit", 0, "Max number of allowed sync retries")
+	command.Flags().Int64Var(&opts.retryLimit, "sync-retry-limit", 5, "Max number of allowed sync retries")
 	command.Flags().DurationVar(&opts.retryBackoffDuration, "sync-retry-backoff-duration", argoappv1.DefaultSyncRetryDuration, "Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h)")
 	command.Flags().DurationVar(&opts.retryBackoffMaxDuration, "sync-retry-backoff-max-duration", argoappv1.DefaultSyncRetryMaxDuration, "Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h)")
 	command.Flags().Int64Var(&opts.retryBackoffFactor, "sync-retry-backoff-factor", argoappv1.DefaultSyncRetryFactor, "Factor multiplies the base duration after each failed sync retry")
@@ -265,7 +265,7 @@ func SetAppSpecOptions(flags *pflag.FlagSet, spec *argoappv1.ApplicationSpec, ap
 			}
 		case "sync-retry-limit":
 			switch {
-			case appOpts.retryLimit > 0:
+			case appOpts.retryLimit >= 0:
 				if spec.SyncPolicy == nil {
 					spec.SyncPolicy = &argoappv1.SyncPolicy{}
 				}
@@ -276,12 +276,6 @@ func SetAppSpecOptions(flags *pflag.FlagSet, spec *argoappv1.ApplicationSpec, ap
 						MaxDuration: appOpts.retryBackoffMaxDuration.String(),
 						Factor:      ptr.To(appOpts.retryBackoffFactor),
 					},
-				}
-			case appOpts.retryLimit == 0:
-				if spec.SyncPolicy.IsZero() {
-					spec.SyncPolicy = nil
-				} else {
-					spec.SyncPolicy.Retry = nil
 				}
 			default:
 				log.Fatalf("Invalid sync-retry-limit [%d]", appOpts.retryLimit)

--- a/cmd/util/app_test.go
+++ b/cmd/util/app_test.go
@@ -269,11 +269,11 @@ func Test_setAppSpecOptions(t *testing.T) {
 		assert.Nil(t, f.spec.SyncPolicy)
 	})
 	t.Run("RetryLimit", func(t *testing.T) {
-		require.NoError(t, f.SetFlag("sync-retry-limit", "5"))
-		assert.Equal(t, int64(5), f.spec.SyncPolicy.Retry.Limit)
-
 		require.NoError(t, f.SetFlag("sync-retry-limit", "0"))
-		assert.Nil(t, f.spec.SyncPolicy.Retry)
+		assert.Equal(t, int64(0), f.spec.SyncPolicy.Retry.Limit)
+
+		require.NoError(t, f.SetFlag("sync-retry-limit", "10"))
+		assert.Equal(t, int64(10), f.spec.SyncPolicy.Retry.Limit)
 	})
 	t.Run("Kustomize", func(t *testing.T) {
 		require.NoError(t, f.SetFlag("kustomize-replica", "my-deployment=2"))

--- a/docs/user-guide/commands/argocd_admin_app_generate-spec.md
+++ b/docs/user-guide/commands/argocd_admin_app_generate-spec.md
@@ -106,7 +106,7 @@ argocd admin app generate-spec APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
+      --sync-retry-limit int                       Max number of allowed sync retries (Setting to 0 means disabling retries) (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --validate                                   Validation of repo and cluster (default true)

--- a/docs/user-guide/commands/argocd_admin_app_generate-spec.md
+++ b/docs/user-guide/commands/argocd_admin_app_generate-spec.md
@@ -106,7 +106,7 @@ argocd admin app generate-spec APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries
+      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --validate                                   Validation of repo and cluster (default true)

--- a/docs/user-guide/commands/argocd_app_add-source.md
+++ b/docs/user-guide/commands/argocd_app_add-source.md
@@ -83,7 +83,7 @@ argocd app add-source APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries
+      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --validate                                   Validation of repo and cluster (default true)

--- a/docs/user-guide/commands/argocd_app_add-source.md
+++ b/docs/user-guide/commands/argocd_app_add-source.md
@@ -83,7 +83,7 @@ argocd app add-source APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
+      --sync-retry-limit int                       Max number of allowed sync retries (Setting to 0 means disabling retries) (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --validate                                   Validation of repo and cluster (default true)

--- a/docs/user-guide/commands/argocd_app_create.md
+++ b/docs/user-guide/commands/argocd_app_create.md
@@ -106,7 +106,7 @@ argocd app create APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
+      --sync-retry-limit int                       Max number of allowed sync retries (Setting to 0 means disabling retries) (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --upsert                                     Allows to override application with the same name even if supplied application spec is different from existing spec

--- a/docs/user-guide/commands/argocd_app_create.md
+++ b/docs/user-guide/commands/argocd_app_create.md
@@ -106,7 +106,7 @@ argocd app create APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries
+      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --upsert                                     Allows to override application with the same name even if supplied application spec is different from existing spec

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -96,7 +96,7 @@ argocd app set APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
+      --sync-retry-limit int                       Max number of allowed sync retries (Setting to 0 means disabling retries) (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --validate                                   Validation of repo and cluster (default true)

--- a/docs/user-guide/commands/argocd_app_set.md
+++ b/docs/user-guide/commands/argocd_app_set.md
@@ -96,7 +96,7 @@ argocd app set APPNAME [flags]
       --sync-retry-backoff-duration duration       Sync retry backoff base duration. Input needs to be a duration (e.g. 2m, 1h) (default 5s)
       --sync-retry-backoff-factor int              Factor multiplies the base duration after each failed sync retry (default 2)
       --sync-retry-backoff-max-duration duration   Max sync retry backoff duration. Input needs to be a duration (e.g. 2m, 1h) (default 3m0s)
-      --sync-retry-limit int                       Max number of allowed sync retries
+      --sync-retry-limit int                       Max number of allowed sync retries (default 5)
       --sync-source-branch string                  The branch from which the app will sync
       --sync-source-path string                    The path in the repository from which the app will sync
       --validate                                   Validation of repo and cluster (default true)


### PR DESCRIPTION
Fixes [ISSUE #15624]

* Currently when setting `retry.limit` to 0 cause argocd to override to `nil` {} which internally adjusts it to `5` retries https://github.com/argoproj/argo-cd/blob/a5b57d43a245c0ea613c55899e9b872893f02c5e/controller/appcontroller.go#L2118

* This behavior makes the UI appear as if the retry is disabled, but in reality, it is set to 5.
* The PR solves it by making the default `retries` 5 to avoid causing any breaking behavior for existing users, but allows for setting retry to `0` to allow disabling retries

P.S
The PR won't solve the UI showing Retry Disabled when it's internally using 5 by default.
The PR just enables using `0` retries

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
