### PR TITLE
fix: disable golang caching on releases to harden against cache poisoning

### DIFF
--- a/.github/workflows/image-reuse.yaml
+++ b/.github/workflows/image-reuse.yaml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ inputs.go-version }}
+          cache: false
 
       - name: Install cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ env.GOLANG_VERSION }}
+          cache: false
 
       - name: Set GORELEASER_PREVIOUS_TAG # Workaround, GoReleaser uses 'git-describe' to determine a previous tag. Our tags are created in release branches.
         run: |
@@ -155,6 +156,7 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ env.GOLANG_VERSION }}
+          cache: false
 
       - name: Generate SBOM (spdx)
         id: spdx-builder


### PR DESCRIPTION
By default, the `actions/setup-go` Action uses [caching](https://github.com/actions/setup-go/blob/dca8468d37b6d090cde2c7b97b738a37134f5ffb/action.yml#L15-L17). In order to truly harden releases and maintain SLSA Level 3 compliance, caching should not be used as poisoning the Actions can can lead to supply chain attacks through a compromised release process.

<img width="760" alt="Screenshot 2025-04-16 at 1 38 10 PM" src="https://github.com/user-attachments/assets/a982df32-68ed-42df-9993-72d637d19106" />

> [Read more here](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/)
