### PR TITLE
fix(ui): avoid spurious error on hydration (#22506)

### DIFF
--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -117,13 +117,15 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                         <div className='application-status-panel__item-name'>{application.status.sourceHydrator.currentOperation.message}</div>
                     )}
                     <div className='application-status-panel__item-name'>
-                        {application.status.sourceHydrator.currentOperation.drySHA && <RevisionMetadataPanel
-                            appName={application.metadata.name}
-                            appNamespace={application.metadata.namespace}
-                            type={''}
-                            revision={application.status.sourceHydrator.currentOperation.drySHA}
-                            versionId={utils.getAppCurrentVersion(application)}
-                        />}
+                        {application.status.sourceHydrator.currentOperation.drySHA && (
+                            <RevisionMetadataPanel
+                                appName={application.metadata.name}
+                                appNamespace={application.metadata.namespace}
+                                type={''}
+                                revision={application.status.sourceHydrator.currentOperation.drySHA}
+                                versionId={utils.getAppCurrentVersion(application)}
+                            />
+                        )}
                     </div>
                 </div>
             )}

--- a/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
+++ b/ui/src/app/applications/components/application-status-panel/application-status-panel.tsx
@@ -117,13 +117,13 @@ export const ApplicationStatusPanel = ({application, showDiff, showOperation, sh
                         <div className='application-status-panel__item-name'>{application.status.sourceHydrator.currentOperation.message}</div>
                     )}
                     <div className='application-status-panel__item-name'>
-                        <RevisionMetadataPanel
+                        {application.status.sourceHydrator.currentOperation.drySHA && <RevisionMetadataPanel
                             appName={application.metadata.name}
                             appNamespace={application.metadata.namespace}
                             type={''}
                             revision={application.status.sourceHydrator.currentOperation.drySHA}
                             versionId={utils.getAppCurrentVersion(application)}
-                        />
+                        />}
                     </div>
                 </div>
             )}


### PR DESCRIPTION
Partially fixes #22506

There's a moment during hydration when the operation has started by the revision to be hydrated has not been resolved yet.

So this change just hides the revision UI element until we've resolved the revision to a SHA.