### PR TITLE
fix Arbitrary file access during archive extraction ("Zip Slip") on `tar()`

### DIFF
--- a/util/io/files/tar.go
+++ b/util/io/files/tar.go
@@ -83,7 +83,12 @@ func Untgz(dstPath string, r io.Reader, maxSize int64, preserveFileMode bool) er
 			continue
 		}
 
-		target := filepath.Join(dstPath, header.Name)
+		// Sanitize header.Name to prevent directory traversal attacks
+		cleanName := filepath.Clean(header.Name)
+		if strings.HasPrefix(cleanName, "..") || filepath.IsAbs(cleanName) {
+			return fmt.Errorf("illegal filepath in archive: %s", header.Name)
+		}
+		target := filepath.Join(dstPath, cleanName)
 		// Sanity check to protect against zip-slip
 		if !Inbound(target, dstPath) {
 			return fmt.Errorf("illegal filepath in archive: %s", target)


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/blob/eaf83ba29de44423c5e51a5baa510b75beed1181/util/io/files/tar.go#L75-L75


fix the issue will sanitize the `header.Name` field to ensure it does not contain any directory traversal elements (e.g., `..`) before constructing the `target` path. This can be achieved by normalizing the path using `filepath.Clean` and rejecting any paths that attempt to escape the `dstPath` directory. Additionally, we will ensure that symbolic links are resolved safely and do not point outside the `dstPath` directory.

The fix involves:
1. Normalizing `header.Name` using `filepath.Clean`.
2. Rejecting paths that contain `..` or attempt to escape the `dstPath` directory.
3. Ensuring that symbolic links are resolved and validated against `dstPath`.


Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths.

Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

if a zip file contains a file entry `..\argo-cd-file`, and the zip file is extracted to the directory c:\output, then naively combining the paths would result in an output file path of `c:\output\..\argo-cd-file`, which would cause the file to be written to `c:\argo-cd-file`.

## POC
In this an archive is extracted without validating file paths. If `archive.zip` contained relative paths (for instance, if it were created by something like `zip archive.zip ../file.txt`) then executing this code could write to locations outside the destination directory.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"argoproj/argo-cd"
)

func unzip(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// BAD: This could overwrite any file on the file system
		ioutil.WriteFile(p, []byte("present"), 0666)
	}
}
```
To fix this vulnerability, we need to check that the path does not contain any "`..`" elements in it.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"argoproj/argo-cd"
	"strings"
)

func unzipGood(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// GOOD: Check that path does not contain ".." before using it
		if !strings.Contains(f.Name, "..") {
			ioutil.WriteFile(p, []byte("present"), 0666)
		}
	}
}
```
## References
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)



Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [x] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
