### PR TITLE
feat: allow overriding redirectURL in dex connectors #22731

### DIFF
--- a/docs/operator-manual/user-management/index.md
+++ b/docs/operator-manual/user-management/index.md
@@ -214,9 +214,10 @@ After saving, the changes should take affect automatically.
 
 NOTES:
 
-* There is no need to set `redirectURI` in the `connectors.config` as shown in the dex documentation.
-  Argo CD will automatically use the correct `redirectURI` for any OAuth2 connectors, to match the
-  correct external callback URL (e.g. `https://argocd.example.com/api/dex/callback`)
+* The `redirectURI` key of `connectors.config` shown in the dex documentation is optional.
+  If not given, Argo CD will automatically configure the `redirectURI` for any OAuth2
+  connector based on the value of `url`
+   (e.g. `https://argocd.example.com/api/dex/callback`).
 * When using a custom secret (e.g., `some_K8S_secret` above,) it *must* have the label `app.kubernetes.io/part-of: argocd`.
 
 ## OIDC Configuration with DEX

--- a/util/dex/config.go
+++ b/util/dex/config.go
@@ -108,10 +108,6 @@ func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTLS b
 		dexCfg["staticClients"] = []any{argoCDStaticClient, argoCDCLIStaticClient, argoCDPKCEStaticClient}
 	}
 
-	dexRedirectURL, err := argocdSettings.DexRedirectURL()
-	if err != nil {
-		return nil, err
-	}
 	connectors, ok := dexCfg["connectors"].([]any)
 	if !ok {
 		return nil, errors.New("malformed Dex configuration found")
@@ -129,7 +125,13 @@ func GenerateDexConfigYAML(argocdSettings *settings.ArgoCDSettings, disableTLS b
 		if !ok {
 			return nil, errors.New("malformed Dex configuration found")
 		}
-		connectorCfg["redirectURI"] = dexRedirectURL
+		if _, ok := connectorCfg["redirectURI"]; !ok {
+			dexRedirectURL, err := argocdSettings.DexRedirectURL()
+			if err != nil {
+				return nil, err
+			}
+			connectorCfg["redirectURI"] = dexRedirectURL
+		}
 		connector["config"] = connectorCfg
 		connectors[i] = connector
 	}


### PR DESCRIPTION
Closes #22731

## Description

Allow the user to specify `redirectURI` in the dex config. If not given, reverts to the currently used value.

Previously, the dex connector didn't allow a custom `redirectURI`.
This was incompatible with any use case involving a secondary redirect, which is especially helpful when using an OAuth provider that doesn't support multiple redirect URLs.

---

### Checklist

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes. [I created an issue but had no particular comments.]
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them. [N/A]
* [x] Does this PR require documentation updates? [Yes]
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines. [This isn't an alpha/beta leve enhancement. Perhaps this should be a bug fix?]
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
