### PR TITLE
feat: add Fallback condition to KEDA ScaledObject health assessment

### DIFF
--- a/resource_customizations/keda.sh/ScaledObject/health.lua
+++ b/resource_customizations/keda.sh/ScaledObject/health.lua
@@ -17,6 +17,10 @@ if obj.status ~= nil then
         hs.message = condition.message
         suspended = true
       end
+      if condition.status == "True" and condition.type == "Fallback" then
+        hs.message = condition.message
+        degraded = true
+      end
     end
   end
 end

--- a/resource_customizations/keda.sh/ScaledObject/health_test.yaml
+++ b/resource_customizations/keda.sh/ScaledObject/health_test.yaml
@@ -19,3 +19,7 @@ tests:
     status: Suspended
     message: "ScaledObject is paused"
   inputPath: testdata/keda-suspended.yaml
+- healthStatus:
+    status: Degraded
+    message: "At least one trigger is falling back on this scaled object"
+  inputPath: testdata/keda-fallback.yaml

--- a/resource_customizations/keda.sh/ScaledObject/testdata/keda-fallback.yaml
+++ b/resource_customizations/keda.sh/ScaledObject/testdata/keda-fallback.yaml
@@ -1,0 +1,58 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  annotations:
+  finalizers:
+    - finalizer.keda.sh
+  labels:
+    argocd.argoproj.io/instance: keda-default
+  name: keda-with-fallback
+  namespace: keda
+  resourceVersion: '160591443'
+  uid: 83ee438a-f383-43f3-9346-b901d9773f5c
+spec:
+  maxReplicaCount: 10
+  minReplicaCount: 1
+  fallback:
+    failureThreshold: 3
+    replicas: 5
+  scaleTargetRef:
+    name: keda-service
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus-server.monitoring.svc.cluster.local
+        metricName: http_requests_total
+        threshold: '100'
+        query: sum(rate(http_requests_total{app="keda-service"}[2m]))
+status:
+  conditions:
+    - message: ScaledObject is defined correctly and is ready for scaling
+      reason: ScaledObjectReady
+      status: 'True'
+      type: Ready
+    - message: Scaling is performed because triggers are active
+      reason: ScalerActive
+      status: 'True'
+      type: Active
+    - message: At least one trigger is falling back on this scaled object
+      reason: FallbackExists
+      status: 'True'
+      type: Fallback
+    - status: 'False'
+      type: Paused
+  externalMetricNames:
+    - s0-prometheus
+  health:
+    "prometheus": 
+      numberOfFailures: 4
+      status: Failing
+  hpaName: keda-with-fallback-hpa
+  lastActiveTime: '2023-12-19T10:35:22Z'
+  originalReplicaCount: 1
+  scaleTargetGVKR:
+    group: apps
+    kind: Deployment
+    resource: deployments
+    version: v1
+  scaleTargetKind: apps/v1.Deployment


### PR DESCRIPTION
This PR enhances ArgoCD health assessment to recognize when a KEDA ScaledObject has an active Fallback condition. When fallback is active (meaning some triggers are failing), the ScaledObject will now correctly display as "Degraded" in the ArgoCD UI, providing better visibility into trigger failure scenarios.

Checklist:

* [X] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [n/a] The title of the PR states what changed and the related issues number (used for the release note).
* [n/a ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [n/a] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [n/a] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [n/a] Does this PR require documentation updates?
* [n/a] I've updated documentation as required by this PR.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [X] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [X] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [X] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [n/a] Optional. My organization is added to USERS.md.
* [n/a] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).