### PR TITLE
fix(cli): diff command crash when --local and --server-side-generate are used with --grpc-web

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -1270,6 +1270,10 @@ func NewApplicationDiffCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 				errors.Fatal(errors.ErrorGeneric, "While using --revisions and --source-names, length of values for both flags should be same.")
 			}
 
+			if local != "" && serverSideGenerate && clientOpts.GRPCWeb {
+				errors.Fatal(errors.ErrorGeneric, "The combination of --local and --server-side-generate requires client-side streaming, which is not supported when using --grpc-web. Please disable --grpc-web instead.")
+			}
+
 			clientset := headless.NewClientOrDie(clientOpts, c)
 			conn, appIf := clientset.NewApplicationClientOrDie()
 			defer argoio.Close(conn)


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
## What this PR does / why we need it
This PR implements the short-term workaround I proposed in [#22773](https://github.com/argoproj/argo-cd/issues/22773).

Specifically, it prevents the `argocd app diff` command from accepting an invalid combination of flags: `--local`, `--server-side-generate`, and `--grpc-web`. This combination requires `client-side streaming`, which is not supported by `gRPC-Web`. The PR adds a clear validation error to guide users away from this unsupported usage.

In [#22773](https://github.com/argoproj/argo-cd/issues/22773), I suggested both:

- A long-term fix: adding a unary RPC alternative to make `--grpc-web` fully compatible with diff.
- A short-term fix: adding validation to fail early when the invalid combination is used.

This PR focuses on the short-term fix to address the user confusion more immediately.

Checklist:

* [x]  This is a bug fix
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.(Related to #22773)
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
