### PR TITLE
fix(appset): enforce strict step order in buildAppSyncMap for Rolling…

### DIFF
--- a/applicationset/controllers/applicationset_controller.go
+++ b/applicationset/controllers/applicationset_controller.go
@@ -967,6 +967,11 @@ func (r *ApplicationSetReconciler) buildAppSyncMap(applicationSet argov1alpha1.A
 
 		// detect if we need to halt before progressing to the next step
 		for _, appName := range appDependencyList[i] {
+			// if sync is disabled for any Application in the current step, we need to halt before progressing to the next step
+			if !syncEnabled {
+				break
+			}
+
 			idx := findApplicationStatusIndex(applicationSet.Status.ApplicationStatus, appName)
 			if idx == -1 {
 				// no Application status found, likely because the Application is being newly created

--- a/applicationset/controllers/applicationset_controller_test.go
+++ b/applicationset/controllers/applicationset_controller_test.go
@@ -4237,6 +4237,109 @@ func TestBuildAppSyncMap(t *testing.T) {
 			},
 		},
 		{
+			name: "handles three RollingSync applications that are OutOfSync/Synced/OutOfSync and healthy",
+			appSet: v1alpha1.ApplicationSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "argocd",
+				},
+				Spec: v1alpha1.ApplicationSetSpec{
+					Strategy: &v1alpha1.ApplicationSetStrategy{
+						Type: "RollingSync",
+						RollingSync: &v1alpha1.ApplicationSetRolloutStrategy{
+							Steps: []v1alpha1.ApplicationSetRolloutStep{
+								{
+									MatchExpressions: []v1alpha1.ApplicationMatchExpression{},
+								},
+								{
+									MatchExpressions: []v1alpha1.ApplicationMatchExpression{},
+								},
+								{
+									MatchExpressions: []v1alpha1.ApplicationMatchExpression{},
+								},
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationSetStatus{
+					ApplicationStatus: []v1alpha1.ApplicationSetApplicationStatus{
+						{
+							Application: "app1",
+							Status:      "Healthy",
+						},
+						{
+							Application: "app2",
+							Status:      "Healthy",
+						},
+						{
+							Application: "app3",
+							Status:      "Healthy",
+						},
+					},
+				},
+			},
+			appDependencyList: [][]string{
+				{"app1"},
+				{"app2"},
+				{"app3"},
+			},
+			appMap: map[string]v1alpha1.Application{
+				"app1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app1",
+					},
+					Status: v1alpha1.ApplicationStatus{
+						Health: v1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						OperationState: &v1alpha1.OperationState{
+							Phase: common.OperationSucceeded,
+						},
+						Sync: v1alpha1.SyncStatus{
+							Status: v1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+				"app2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app2",
+					},
+					Status: v1alpha1.ApplicationStatus{
+						Health: v1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						OperationState: &v1alpha1.OperationState{
+							Phase: common.OperationSucceeded,
+						},
+						Sync: v1alpha1.SyncStatus{
+							Status: v1alpha1.SyncStatusCodeSynced,
+						},
+					},
+				},
+				"app3": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "app3",
+					},
+					Status: v1alpha1.ApplicationStatus{
+						Health: v1alpha1.HealthStatus{
+							Status: health.HealthStatusHealthy,
+						},
+						OperationState: &v1alpha1.OperationState{
+							Phase: common.OperationSucceeded,
+						},
+						Sync: v1alpha1.SyncStatus{
+							Status: v1alpha1.SyncStatusCodeOutOfSync,
+						},
+					},
+				},
+			},
+			expectedMap: map[string]bool{
+				"app1": true,
+				"app2": false,
+				"app3": false,
+			},
+		},
+		{
 			name: "handles a lot of applications",
 			appSet: v1alpha1.ApplicationSet{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Problem
Previously, the buildAppSyncMap function could incorrectly allow applications from later steps (e.g., production) to be synced before applications from earlier steps (e.g., staging) had completed, even though the step order in appDependencyList was correct. This happened because the logic for enabling sync (syncEnabled) did not always properly halt progression to the next step if any application in the current step was not ready (e.g., not healthy or not finished syncing).
This led to situations where, for example, the sync map looked like:
```
map[dev:true, production:true, staging:false]
```
even though only the first step should have been enabled.
