### PR TITLE
fix: Race condition in `nativeGitClient.LsFiles` (issue #21754)

### DIFF
--- a/util/git/client.go
+++ b/util/git/client.go
@@ -452,7 +452,7 @@ func (m *nativeGitClient) LsFiles(path string, enableNewGitFileGlobbing bool) ([
 				}
 				files = append(files, relativeFile)
 			} else {
-				log.Warnf("Absolute path for %s is outside of repository, removing it", file)
+				log.Warnf("Absolute path for %s is outside of repository, ignoring it", file)
 			}
 		}
 		return files, nil

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -422,11 +422,14 @@ func (m *nativeGitClient) Fetch(revision string) error {
 func (m *nativeGitClient) LsFiles(path string, enableNewGitFileGlobbing bool) ([]string, error) {
 	if enableNewGitFileGlobbing {
 		// This is the new way with safer globbing
-		err := os.Chdir(m.root)
+
+		// evaluating the root path for symlinks
+		realRoot, err := filepath.EvalSymlinks(m.root)
 		if err != nil {
 			return nil, err
 		}
-		allFiles, err := doublestar.FilepathGlob(path)
+		// searching for the pattern inside the root path
+		allFiles, err := doublestar.FilepathGlob(filepath.Join(realRoot, path))
 		if err != nil {
 			return nil, err
 		}
@@ -440,8 +443,14 @@ func (m *nativeGitClient) LsFiles(path string, enableNewGitFileGlobbing bool) ([
 			if err != nil {
 				return nil, err
 			}
-			if strings.HasPrefix(absPath, m.root) {
-				files = append(files, file)
+
+			if strings.HasPrefix(absPath, realRoot) {
+				// removing the repository root prefix from the file path
+				relativeFile, err := filepath.Rel(realRoot, file)
+				if err != nil {
+					return nil, err
+				}
+				files = append(files, relativeFile)
 			} else {
 				log.Warnf("Absolute path for %s is outside of repository, removing it", file)
 			}

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -991,6 +992,65 @@ func Test_nativeGitClient_runCredentialedCmd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_LsFiles_RaceCondition(t *testing.T) {
+	// Create two temporary directories and initialize them as git repositories
+	tempDir1 := t.TempDir()
+	tempDir2 := t.TempDir()
+
+	client1, err := NewClient("file://"+tempDir1, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+	client2, err := NewClient("file://"+tempDir2, NopCreds{}, true, false, "", "")
+	require.NoError(t, err)
+
+	err = client1.Init()
+	require.NoError(t, err)
+	err = client2.Init()
+	require.NoError(t, err)
+
+	// Add different files to each repository
+	file1 := filepath.Join(client1.Root(), "file1.txt")
+	err = os.WriteFile(file1, []byte("content1"), 0644)
+	require.NoError(t, err)
+	err = runCmd(client1.Root(), "git", "add", "file1.txt")
+	require.NoError(t, err)
+	err = runCmd(client1.Root(), "git", "commit", "-m", "Add file1")
+	require.NoError(t, err)
+
+	file2 := filepath.Join(client2.Root(), "file2.txt")
+	err = os.WriteFile(file2, []byte("content2"), 0644)
+	require.NoError(t, err)
+	err = runCmd(client2.Root(), "git", "add", "file2.txt")
+	require.NoError(t, err)
+	err = runCmd(client2.Root(), "git", "commit", "-m", "Add file2")
+	require.NoError(t, err)
+
+	// Assert that LsFiles returns the correct files when called sequentially
+	files1, err := client1.LsFiles("*", true)
+	require.NoError(t, err)
+	require.Contains(t, files1, "file1.txt")
+
+	files2, err := client2.LsFiles("*", true)
+	require.NoError(t, err)
+	require.Contains(t, files2, "file2.txt")
+
+	// Define a function to call LsFiles multiple times in parallel
+	var wg sync.WaitGroup
+	callLsFiles := func(client Client, expectedFile string) {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			files, err := client.LsFiles("*", true)
+			require.NoError(t, err)
+			require.Contains(t, files, expectedFile)
+		}
+	}
+
+	// Call LsFiles in parallel for both clients
+	wg.Add(2)
+	go callLsFiles(client1, "file1.txt")
+	go callLsFiles(client2, "file2.txt")
+	wg.Wait()
 }
 
 type mockCreds struct {

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -1011,7 +1011,7 @@ func Test_LsFiles_RaceCondition(t *testing.T) {
 
 	// Add different files to each repository
 	file1 := filepath.Join(client1.Root(), "file1.txt")
-	err = os.WriteFile(file1, []byte("content1"), 0644)
+	err = os.WriteFile(file1, []byte("content1"), 0o644)
 	require.NoError(t, err)
 	err = runCmd(client1.Root(), "git", "add", "file1.txt")
 	require.NoError(t, err)
@@ -1019,7 +1019,7 @@ func Test_LsFiles_RaceCondition(t *testing.T) {
 	require.NoError(t, err)
 
 	file2 := filepath.Join(client2.Root(), "file2.txt")
-	err = os.WriteFile(file2, []byte("content2"), 0644)
+	err = os.WriteFile(file2, []byte("content2"), 0o644)
 	require.NoError(t, err)
 	err = runCmd(client2.Root(), "git", "add", "file2.txt")
 	require.NoError(t, err)


### PR DESCRIPTION
Changing the current working directory is not safe for concurrent use. To avoid this, I am adding the repository root as a prefix to the pattern.

To make sure the results are relevant I also needed to evaluate symlinks in the repository root path, in case part of it is a symlink (which is the case in for temporary directories on Mac OS).

Fixes #21754. Thanks to @crenshaw-dev for providing a unit test for the race condition.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
