### PR TITLE
docs: Add RequeueAfterSeconds documentation for git generator

### DIFF
--- a/docs/operator-manual/applicationset/Generators-Git.md
+++ b/docs/operator-manual/applicationset/Generators-Git.md
@@ -385,9 +385,27 @@ In `values` we can also interpolate all fields set by the git files generator as
 
 ## Webhook Configuration
 
-When using a Git generator, ApplicationSet polls Git repositories every three minutes to detect changes. To eliminate
+When using a Git generator, ApplicationSet polls Git repositories every every `requeueAfterSeconds` interval (defaulting to every three minutes) to detect changes. To eliminate
 this delay from polling, the ApplicationSet webhook server can be configured to receive webhook events. ApplicationSet supports
 Git webhook notifications from GitHub and GitLab. The following explains how to configure a Git webhook for GitHub, but the same process should be applicable to other providers.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+  - git:
+      # When using a Git generator, the ApplicationSet controller polls every `requeueAfterSeconds` interval (defaulting to every 3 minutes) to detect changes.
+      requeueAfterSeconds: 180
+      repoURL: https://github.com/argoproj/argo-cd.git
+      revision: HEAD
+      # ...
+```
 
 !!! note
     The ApplicationSet controller webhook does not use the same webhook as the API server as defined [here](../webhook.md). ApplicationSet exposes a webhook server as a service of type ClusterIP. An ApplicationSet specific Ingress resource needs to be created to expose this service to the webhook source.

--- a/docs/operator-manual/applicationset/Generators-Git.md
+++ b/docs/operator-manual/applicationset/Generators-Git.md
@@ -385,7 +385,7 @@ In `values` we can also interpolate all fields set by the git files generator as
 
 ## Webhook Configuration
 
-When using a Git generator, ApplicationSet polls Git repositories every every `requeueAfterSeconds` interval (defaulting to every three minutes) to detect changes. To eliminate
+When using a Git generator, the ApplicationSet controller polls Git repositories every 3 minutes (this can be customized per ApplicationSet with `requeueAfterSeconds`) to detect changes. To eliminate
 this delay from polling, the ApplicationSet webhook server can be configured to receive webhook events. ApplicationSet supports
 Git webhook notifications from GitHub and GitLab. The following explains how to configure a Git webhook for GitHub, but the same process should be applicable to other providers.
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

I was confused that there was no configuration for the git generator for the poll interval mentioned in the docs. However, when checking the [code](https://github.com/argoproj/argo-cd/blob/73f68af2a623330b90fd7e73e97ee023992305d5/applicationset/generators/git.go#L44C24-L44C39), I could see that this option definitely exists. There for I added a section similar to the one of the [pull request generator](https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/Generators-Pull-Request/#pull-request-generator).
