### PR TITLE
fix(commit-server): apply image override

### DIFF
--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -35,6 +35,10 @@ cd ${SRCROOT}/manifests/base && $KUSTOMIZE edit set image quay.io/argoproj/argoc
 cd ${SRCROOT}/manifests/ha/base && $KUSTOMIZE edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
 cd ${SRCROOT}/manifests/core-install && $KUSTOMIZE edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
 
+# Because commit-server is added as a resource outside the base, we have to explicitly set the image override here.
+# If/when commit-server is added to the base, this can be removed.
+cd ${SRCROOT}/manifests/base/commit-server && $KUSTOMIZE edit set image quay.io/argoproj/argocd=${IMAGE_NAMESPACE}/argocd:${IMAGE_TAG}
+
 echo "${AUTOGENMSG}" > "${SRCROOT}/manifests/install.yaml"
 $KUSTOMIZE build "${SRCROOT}/manifests/cluster-install" >> "${SRCROOT}/manifests/install.yaml"
 

--- a/manifests/base/commit-server/kustomization.yaml
+++ b/manifests/base/commit-server/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 - argocd-commit-server-deployment.yaml
 - argocd-commit-server-service.yaml
 - argocd-commit-server-network-policy.yaml
+
+# Because commit-server is added as a resource outside the base, we have to explicitly set the image override here.
+# If/when commit-server is added to the base, this can be removed.
+images:
+- name: quay.io/argoproj/argocd
+  newName: quay.io/argoproj/argocd
+  newTag: latest


### PR DESCRIPTION
Released manifests currently use `:latest` for the commit-server due to Kustomize order of operations.

I'm not sure if this is the cleanest fix, but it seems to work. I tested by checkout out `release-3.0-fix` and running manifest gen. It set the correct image tags.