### PR TITLE
fix: app tree parentRef response missing version info

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -278,8 +278,14 @@ func asResourceNode(r *clustercache.Resource) appv1.ResourceNode {
 	parentRefs := make([]appv1.ResourceRef, len(r.OwnerRefs))
 	for i, ownerRef := range r.OwnerRefs {
 		ownerGvk := schema.FromAPIVersionAndKind(ownerRef.APIVersion, ownerRef.Kind)
-		ownerKey := kube.NewResourceKey(ownerGvk.Group, ownerRef.Kind, r.Ref.Namespace, ownerRef.Name)
-		parentRefs[i] = appv1.ResourceRef{Name: ownerRef.Name, Kind: ownerKey.Kind, Namespace: r.Ref.Namespace, Group: ownerKey.Group, UID: string(ownerRef.UID)}
+		parentRefs[i] = appv1.ResourceRef{
+			Group:     ownerGvk.Group,
+			Kind:      ownerGvk.Kind,
+			Version:   ownerGvk.Version,
+			Namespace: r.Ref.Namespace,
+			Name:      ownerRef.Name,
+			UID:       string(ownerRef.UID),
+		}
 	}
 	var resHealth *appv1.HealthStatus
 	resourceInfo := resInfo(r)

--- a/controller/cache/cache_test.go
+++ b/controller/cache/cache_test.go
@@ -303,14 +303,16 @@ func Test_asResourceNode_owner_refs(t *testing.T) {
 		},
 		ParentRefs: []appv1.ResourceRef{
 			{
-				Group: "",
-				Kind:  "ConfigMap",
-				Name:  "cm-1",
+				Group:   "",
+				Kind:    "ConfigMap",
+				Version: "v1",
+				Name:    "cm-1",
 			},
 			{
-				Group: "",
-				Kind:  "ConfigMap",
-				Name:  "cm-2",
+				Group:   "",
+				Kind:    "ConfigMap",
+				Version: "v1",
+				Name:    "cm-2",
 			},
 		},
 		Info:            nil,


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Currently, the application tree response is missing the version in the ParentRef. This is inconsistent with other usages of the same ResourceRef structure and also inconsistent with the appset tree , which includes the version:
https://github.com/argoproj/argo-cd/blob/31e8ff8759372199c71ade7467bc5730bbacb144/server/applicationset/applicationset.go#L399-L401

Adding this would be helpful for directly comparing the ParentRef with the resourceRef.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
