### PR TITLE
fix: code weakness of path traversal

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1413,7 +1413,7 @@ func (server *ArgoCDServer) getIndexData() ([]byte, error) {
 }
 
 func (server *ArgoCDServer) uiAssetExists(filename string) bool {
-	f, err := server.staticAssets.Open(strings.Trim(filename, "/"))
+	f, err := server.staticAssets.Open(filepath.Clean(filename))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This PR is to fix a path traversal vulnerability [CWE-22](https://cwe.mitre.org/data/definitions/22.html) where a malicious user could potentially craft a URL with special characters (like ../) to try and access files or directories outside of the intended UI asset directory

Here are logs from scanner:
```
argo_cd/app/server/server.go:1410:3: taint: The field "r.URL" is a source of untrusted data.
argo_cd/app/server/server.go:1410:3: sink: Calling "uiAssetExists". This call uses "r.URL.Path" for sensitive computation.
argo_cd/app/server/server.go:1387:12: identity: Calling "Trim". This call assigns "filename" to "<return value>".
argo_cd/app/server/server.go:1387:12: sink: Calling "Open". This call uses "Trim(filename, "/")" for sensitive computation. (The interface method resolves to "http.Dir.Open(string)".)
argo_cd/app/server/server.go:1410:3:
# 1408|           }
# 1409|   
# 1410|->         fileRequest := r.URL.Path != "/index.html" && server.uiAssetExists(r.URL.Path)
# 1411|   
# 1412|           // Set X-Frame-Options according to configuration
 ```