### PR TITLE
feat: add `secrets.partOfSelectorCheckEnabled` config

### DIFF
--- a/docs/operator-manual/argocd-cm.yaml
+++ b/docs/operator-manual/argocd-cm.yaml
@@ -7,6 +7,13 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
+  # ArgoCD hydrates this config map with secrets, and by default the secrets are required to be labeled with
+  # `app.kubernetes.io/part-of: argocd`.
+  # This is not always desirable, as the namespace might be dedicated to ArgoCD alone and secrets might be
+  # distributed by external tool, in which case they may not have that label.
+  # Setting this to "false" will disable this check and will allow all secrets in the namespace to be used in the configmap.
+  secrets.partOfSelectorCheckEnabled: "true"
+
   # Argo CD's externally facing base URL (optional). Required when configuring SSO
   url: https://argo-cd-demo.argoproj.io
 


### PR DESCRIPTION
This change introduces a new configuration option
`secrets.partOfSelectorCheckEnabled` to allow
ArgoCD to use secrets without the specific label
to hydrate settings when the namespace is dedicated to ArgoCD.

Motivation: The assumption that every secret will/can have a `app.kubernetes.io/part-of: argocd` label is... questionable. What if the secret is distributed by the external system that already defines `app.kubernetes.io/part-of` differently? What if the namespace is dedicated to ArgoCD (which I would imagine 99.9999% of cases), what is even a purpose of having this check? Obviously, the status quo is that - it already exists, so simply removing it is probably not a good idea. With the new option, operators may now choose to disable this behavior (by default it is still enabled), and then ArgoCD should be able to consume any secret in its namespace.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
