### PR TITLE
feat(notifications): add support for getting commit metadata from multiple sources

### DIFF
--- a/util/notification/expression/repo/repo.go
+++ b/util/notification/expression/repo/repo.go
@@ -74,9 +74,9 @@ func getCommitMetadataMultipleSources(sourceIndex int, commitSHA string, app *un
 	if !ok {
 		panic(errors.New("failed to get application sources"))
 	}
-	sourceObj, ok := sources[sourceIndex].(map[string]interface{})
+	sourceObj, ok := sources[sourceIndex].(map[string]any)
 	if !ok {
-		panic(errors.New("failed to assert source to map[string]interface{}"))
+		panic(errors.New("failed to assert source to map[string]any"))
 	}
 	repoURL, ok, err := unstructured.NestedString(sourceObj, "repoURL")
 	if err != nil {
@@ -140,7 +140,7 @@ func NewExprs(argocdService service.Service, app *unstructured.Unstructured) map
 
 			return *meta
 		},
-		"GetCommitMetadataMultipleSources": func(sourceIndex int, commitSHA string) interface{} {
+		"GetCommitMetadataMultipleSources": func(sourceIndex int, commitSHA string) any {
 			meta, err := getCommitMetadataMultipleSources(sourceIndex, commitSHA, app, argocdService)
 			if err != nil {
 				panic(err)

--- a/util/notification/expression/repo/repo.go
+++ b/util/notification/expression/repo/repo.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	service "github.com/argoproj/argo-cd/v3/util/notification/argocd"
@@ -62,6 +63,39 @@ func getCommitMetadata(commitSHA string, app *unstructured.Unstructured, argocdS
 		panic(errors.New("failed to get application project"))
 	}
 
+	return getCommitMetadataByRepoURL(repoURL, project, commitSHA, argocdService)
+}
+
+func getCommitMetadataMultipleSources(sourceIndex int, commitSHA string, app *unstructured.Unstructured, argocdService service.Service) (*shared.CommitMetadata, error) {
+	sources, ok, err := unstructured.NestedSlice(app.Object, "spec", "sources")
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		panic(errors.New("failed to get application sources"))
+	}
+	sourceObj, ok := sources[sourceIndex].(map[string]interface{})
+	if !ok {
+		panic(errors.New("failed to assert source to map[string]interface{}"))
+	}
+	repoURL, ok, err := unstructured.NestedString(sourceObj, "repoURL")
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		panic(errors.New("failed to get source repo URL for index: " + strconv.Itoa(sourceIndex)))
+	}
+	project, ok, err := unstructured.NestedString(app.Object, "spec", "project")
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		panic(errors.New("failed to get application project"))
+	}
+	return getCommitMetadataByRepoURL(repoURL, project, commitSHA, argocdService)
+}
+
+func getCommitMetadataByRepoURL(repoURL, project string, commitSHA string, argocdService service.Service) (*shared.CommitMetadata, error) {
 	meta, err := argocdService.GetCommitMetadata(context.Background(), repoURL, commitSHA, project)
 	if err != nil {
 		return nil, err
@@ -104,6 +138,13 @@ func NewExprs(argocdService service.Service, app *unstructured.Unstructured) map
 				panic(err)
 			}
 
+			return *meta
+		},
+		"GetCommitMetadataMultipleSources": func(sourceIndex int, commitSHA string) interface{} {
+			meta, err := getCommitMetadataMultipleSources(sourceIndex, commitSHA, app, argocdService)
+			if err != nil {
+				panic(err)
+			}
 			return *meta
 		},
 		"GetAppDetails": func() any {


### PR DESCRIPTION
This commit adds a new function  to support retrieving commit metadata for applications with multiple sources. This enhancement allows notification templates to access commit information for each source in a multi-source application.
    
The function takes a source index and commit SHA as parameters, making it possible to get specific commit metadata for any source in the application.

For Example：
<img width="1241" alt="企业微信截图_0952b207-a445-4e67-abf8-38e5aafde01e" src="https://github.com/user-attachments/assets/461e290b-b206-4fee-908e-e6587696d5f6" />
