### PR TITLE
fix(api): skip Content-Type validation for body-less HTTP methods (#13272)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1273,7 +1273,7 @@ func enforceContentTypes(handler http.Handler, types []string) http.Handler {
 		allowedTypes[strings.ToLower(t)] = true
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet || allowedTypes[strings.ToLower(r.Header.Get("Content-Type"))] {
+		if r.Method == http.MethodGet || r.Method == http.MethodDelete || r.Method == http.MethodHead || allowedTypes[strings.ToLower(r.Header.Get("Content-Type"))] {
 			handler.ServeHTTP(w, r)
 		} else {
 			http.Error(w, "Invalid content type", http.StatusUnsupportedMediaType)


### PR DESCRIPTION
closes #13272 (which is already closed - but not fixed)