### PR TITLE
fix(manifest): using wrong container registry for non-ha redis

### DIFF
--- a/manifests/base/redis/kustomization.yaml
+++ b/manifests/base/redis/kustomization.yaml
@@ -2,9 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- argocd-redis-deployment.yaml
-- argocd-redis-sa.yaml
-- argocd-redis-service.yaml
-- argocd-redis-network-policy.yaml
-- argocd-redis-role.yaml
-- argocd-redis-rolebinding.yaml
+  - argocd-redis-deployment.yaml
+  - argocd-redis-sa.yaml
+  - argocd-redis-service.yaml
+  - argocd-redis-network-policy.yaml
+  - argocd-redis-role.yaml
+  - argocd-redis-rolebinding.yaml
+
+images:
+  - name: redis
+    newName: public.ecr.aws/docker/library/redis

--- a/manifests/core-install-with-hydrator.yaml
+++ b/manifests/core-install-with-hydrator.yaml
@@ -24927,7 +24927,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: redis:7.2.7-alpine
+        image: public.ecr.aws/docker/library/redis:7.2.7-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/core-install.yaml
+++ b/manifests/core-install.yaml
@@ -24739,7 +24739,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: redis:7.2.7-alpine
+        image: public.ecr.aws/docker/library/redis:7.2.7-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/install-with-hydrator.yaml
+++ b/manifests/install-with-hydrator.yaml
@@ -25608,7 +25608,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: redis:7.2.7-alpine
+        image: public.ecr.aws/docker/library/redis:7.2.7-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -25420,7 +25420,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: redis:7.2.7-alpine
+        image: public.ecr.aws/docker/library/redis:7.2.7-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/namespace-install-with-hydrator.yaml
+++ b/manifests/namespace-install-with-hydrator.yaml
@@ -1437,7 +1437,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: redis:7.2.7-alpine
+        image: public.ecr.aws/docker/library/redis:7.2.7-alpine
         imagePullPolicy: Always
         name: redis
         ports:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1249,7 +1249,7 @@ spec:
             secretKeyRef:
               key: auth
               name: argocd-redis
-        image: redis:7.2.7-alpine
+        image: public.ecr.aws/docker/library/redis:7.2.7-alpine
         imagePullPolicy: Always
         name: redis
         ports:


### PR DESCRIPTION
Fixes #23005 


Use kustomize image override feature because it is clearer