### PR TITLE
fix: allow to use an entreprise GIthub instance and an authentication token in the same time again

### DIFF
--- a/applicationset/generators/pull_request.go
+++ b/applicationset/generators/pull_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -228,5 +229,5 @@ func (g *PullRequestGenerator) github(ctx context.Context, cfg *argoprojiov1alph
 	if err != nil {
 		return nil, fmt.Errorf("error fetching Secret token: %w", err)
 	}
-	return pullrequest.NewGithubService(token, cfg.API, cfg.Owner, cfg.Repo, cfg.Labels)
+	return pullrequest.NewGithubService(token, cfg.API, cfg.Owner, cfg.Repo, cfg.Labels, &http.Client{})
 }

--- a/applicationset/services/pull_request/github_test.go
+++ b/applicationset/services/pull_request/github_test.go
@@ -1,6 +1,10 @@
 package pull_request
 
 import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v69/github"
@@ -83,6 +87,71 @@ func TestGetGitHubPRLabelNames(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			labels := getGithubPRLabelNames(test.PullLabels)
 			require.Equal(t, test.ExpectedResult, labels)
+		})
+	}
+}
+
+type mockRoundTripper struct {
+	lastRequest *http.Request
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.lastRequest = req
+
+	// Return a dummy response
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestNewGithubService(t *testing.T) {
+	originalToken := os.Getenv("GITHUB_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+	defer t.Setenv("GITHUB_TOKEN", originalToken)
+
+	tests := []struct {
+		name         string
+		token        string
+		url          string
+		expectedHost string
+	}{
+		{"No token, no URL", "", "", "api.github.com"},
+		{"Token, no URL", "dummy-token", "", "api.github.com"},
+		{"No token, URL", "", "https://github.example.com", "github.example.com"},
+		{"Token and URL", "dummy-token", "https://github.example.com", "github.example.com"},
+	}
+
+	owner := "test-owner"
+	repo := "test-repo"
+	labels := []string{"test-label-1", "test-label-2"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTransport := &mockRoundTripper{}
+			httpClient := &http.Client{Transport: mockTransport}
+
+			service, err := NewGithubService(tt.token, tt.url, owner, repo, labels, httpClient)
+			require.NoError(t, err)
+
+			gs, ok := service.(*GithubService)
+			require.True(t, ok)
+
+			require.Equal(t, owner, gs.owner)
+			require.Equal(t, repo, gs.repo)
+			require.Equal(t, labels, gs.labels)
+
+			_, _ = gs.List(t.Context())
+
+			require.NotNil(t, mockTransport.lastRequest)
+			require.Equal(t, tt.expectedHost, mockTransport.lastRequest.URL.Host)
+
+			if tt.token != "" {
+				require.Equal(t, "Bearer "+tt.token, mockTransport.lastRequest.Header.Get("Authorization"))
+			} else {
+				require.Empty(t, mockTransport.lastRequest.Header.Get("Authorization"))
+			}
 		})
 	}
 }


### PR DESCRIPTION
Hello,

This PR fix a regression introduced in https://github.com/argoproj/argo-cd/pull/21292.
Before that, we were able to use both an URL and also an authentication token.

Best Regards.
