### PR TITLE
feat: Additional audit log information for updating argocd applications (resolves #23130)

### DIFF
--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1060,7 +1060,10 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 				Message: err.Error(),
 			})
 			message := fmt.Sprintf("Unable to delete application resources: %v", err.Error())
-			ctrl.logAppEvent(context.TODO(), app, argo.EventInfo{Reason: argo.EventReasonStatusRefreshed, Type: corev1.EventTypeWarning}, message, nil)
+			logFields := map[string]any{
+				"error": err.Error(),
+			}
+			ctrl.logAppEvent(context.TODO(), app, argo.EventInfo{Reason: argo.EventReasonStatusRefreshed, Type: corev1.EventTypeWarning}, message, logFields)
 		}
 		ts.AddCheckpoint("finalize_application_deletion_ms")
 	}
@@ -2596,7 +2599,7 @@ func (ctrl *ApplicationController) getAppList(options metav1.ListOptions) (*appv
 	return appList, nil
 }
 
-func (ctrl *ApplicationController) logAppEvent(ctx context.Context, a *appv1.Application, eventInfo argo.EventInfo, message string, logFields map[string]string) {
+func (ctrl *ApplicationController) logAppEvent(ctx context.Context, a *appv1.Application, eventInfo argo.EventInfo, message string, logFields map[string]any) {
 	eventLabels := argo.GetAppEventLabels(ctx, a, applisters.NewAppProjectLister(ctrl.projInformer.GetIndexer()), ctrl.namespace, ctrl.settingsMgr, ctrl.db)
 	ctrl.auditLogger.LogAppEvent(a, eventInfo, message, "", eventLabels, logFields)
 }

--- a/controller/appcontroller.go
+++ b/controller/appcontroller.go
@@ -1060,7 +1060,7 @@ func (ctrl *ApplicationController) processAppOperationQueueItem() (processNext b
 				Message: err.Error(),
 			})
 			message := fmt.Sprintf("Unable to delete application resources: %v", err.Error())
-			ctrl.logAppEvent(context.TODO(), app, argo.EventInfo{Reason: argo.EventReasonStatusRefreshed, Type: corev1.EventTypeWarning}, message)
+			ctrl.logAppEvent(context.TODO(), app, argo.EventInfo{Reason: argo.EventReasonStatusRefreshed, Type: corev1.EventTypeWarning}, message, nil)
 		}
 		ts.AddCheckpoint("finalize_application_deletion_ms")
 	}
@@ -1578,7 +1578,7 @@ func (ctrl *ApplicationController) setOperationState(app *appv1.Application, sta
 			eventInfo.Type = corev1.EventTypeWarning
 			messages = append(messages, "failed:", state.Message)
 		}
-		ctrl.logAppEvent(context.TODO(), app, eventInfo, strings.Join(messages, " "))
+		ctrl.logAppEvent(context.TODO(), app, eventInfo, strings.Join(messages, " "), nil)
 
 		destCluster, err := argo.GetDestinationCluster(context.Background(), app.Spec.Destination, ctrl.db)
 		if err != nil {
@@ -2034,7 +2034,7 @@ func (ctrl *ApplicationController) persistAppStatus(orig *appv1.Application, new
 	logCtx := log.WithFields(applog.GetAppLogFields(orig))
 	if orig.Status.Sync.Status != newStatus.Sync.Status {
 		message := fmt.Sprintf("Updated sync status: %s -> %s", orig.Status.Sync.Status, newStatus.Sync.Status)
-		ctrl.logAppEvent(context.TODO(), orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: corev1.EventTypeNormal}, message)
+		ctrl.logAppEvent(context.TODO(), orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: corev1.EventTypeNormal}, message, nil)
 	}
 	if orig.Status.Health.Status != newStatus.Health.Status {
 		// Update the last transition time to now. This should be the ONLY place in code where this is set, because it's
@@ -2043,7 +2043,7 @@ func (ctrl *ApplicationController) persistAppStatus(orig *appv1.Application, new
 		newStatus.Health.LastTransitionTime = &now
 
 		message := fmt.Sprintf("Updated health status: %s -> %s", orig.Status.Health.Status, newStatus.Health.Status)
-		ctrl.logAppEvent(context.TODO(), orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: corev1.EventTypeNormal}, message)
+		ctrl.logAppEvent(context.TODO(), orig, argo.EventInfo{Reason: argo.EventReasonResourceUpdated, Type: corev1.EventTypeNormal}, message, nil)
 	} else {
 		// make sure the last transition time is the same and populated if the health is the same
 		newStatus.Health.LastTransitionTime = orig.Status.Health.LastTransitionTime
@@ -2227,7 +2227,7 @@ func (ctrl *ApplicationController) autoSync(app *appv1.Application, syncStatus *
 	ts.AddCheckpoint("write_back_to_informer_ms")
 
 	message := fmt.Sprintf("Initiated automated sync to %s", desiredRevisions)
-	ctrl.logAppEvent(context.TODO(), app, argo.EventInfo{Reason: argo.EventReasonOperationStarted, Type: corev1.EventTypeNormal}, message)
+	ctrl.logAppEvent(context.TODO(), app, argo.EventInfo{Reason: argo.EventReasonOperationStarted, Type: corev1.EventTypeNormal}, message, nil)
 	logCtx.Info(message)
 	return nil, setOpTime
 }
@@ -2596,9 +2596,9 @@ func (ctrl *ApplicationController) getAppList(options metav1.ListOptions) (*appv
 	return appList, nil
 }
 
-func (ctrl *ApplicationController) logAppEvent(ctx context.Context, a *appv1.Application, eventInfo argo.EventInfo, message string) {
+func (ctrl *ApplicationController) logAppEvent(ctx context.Context, a *appv1.Application, eventInfo argo.EventInfo, message string, logFields map[string]string) {
 	eventLabels := argo.GetAppEventLabels(ctx, a, applisters.NewAppProjectLister(ctrl.projInformer.GetIndexer()), ctrl.namespace, ctrl.settingsMgr, ctrl.db)
-	ctrl.auditLogger.LogAppEvent(a, eventInfo, message, "", eventLabels)
+	ctrl.auditLogger.LogAppEvent(a, eventInfo, message, "", eventLabels, logFields)
 }
 
 type ClusterFilterFunction func(c *appv1.Cluster, distributionFunction sharding.DistributionFunction) bool

--- a/docs/operator-manual/security.md
+++ b/docs/operator-manual/security.md
@@ -199,9 +199,20 @@ LAST SEEN   FIRST SEEN   COUNT   NAME                         KIND          SUBO
 1m          1m           1       guestbook.157f7c651990e848   Application               Normal    ResourceUpdated      argocd-application-controller   Updated health status: Progressing -> Healthy
 ```
 
-These events can be then be persisted for longer periods of time using other tools as
+These kubernetes events can be then be persisted for longer periods of time using other tools as
 [Event Exporter](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/event-exporter) or
 [Event Router](https://github.com/heptiolabs/eventrouter).
+
+Argo CD also outputs audit logging information of system activity,
+indicating the responsible actor when applicable. For example:
+
+```bash
+kubectl get logs -n argocd argocd-server-pod
+2025-05-23T12:00:00Z level=info msg="user@argoproj.github.io updated application spec" application=argocd dest-namespace=argocd dest-server=https://kubernetes.default.svc reason=ResourceUpdated type=Normal user=user@argoproj.github.io patch="map[metadata:map[] spec:map[source:map[targetRevision:BRANCH]]]
+```
+
+These logs can then be persisted and stored using tools such as
+[Loki](https://grafana.com/oss/loki/) or [fluentbit](https://fluentbit.io/).
 
 ## WebHook Payloads
 

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -982,6 +982,10 @@ func (s *Server) waitSync(app *v1alpha1.Application) {
 }
 
 func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newApp *v1alpha1.Application, merge bool) (*v1alpha1.Application, error) {
+	diff, err := diffBetweenApplicationSpecs(&app.Spec, &newApp.Spec)
+	if err != nil {
+		return nil, err
+	}
 	for i := 0; i < 10; i++ {
 		app.Spec = newApp.Spec
 		if merge {
@@ -996,7 +1000,7 @@ func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newAp
 
 		res, err := s.appclientset.ArgoprojV1alpha1().Applications(app.Namespace).Update(ctx, app, metav1.UpdateOptions{})
 		if err == nil {
-			s.logAppEvent(ctx, app, argo.EventReasonResourceUpdated, "updated application spec")
+			s.logAppEvent(ctx, app, argo.EventReasonResourceUpdated, "updated application spec: "+diff)
 			s.waitSync(res)
 			return res, nil
 		}
@@ -1011,6 +1015,23 @@ func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newAp
 		s.inferResourcesStatusHealth(app)
 	}
 	return nil, status.Errorf(codes.Internal, "Failed to update application. Too many conflicts")
+}
+
+func diffBetweenApplicationSpecs(a *v1alpha1.ApplicationSpec, b *v1alpha1.ApplicationSpec) (string, error) {
+	aBytes, err := json.Marshal(a)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal application: %w", err)
+	}
+	bBytes, err := json.Marshal(b)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal application: %w", err)
+	}
+
+	patch, err := jsonpatch.CreateMergePatch(aBytes, bBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to create json diff between applications: %w", err)
+	}
+	return string(patch), nil
 }
 
 // Update updates an application

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -982,9 +982,9 @@ func (s *Server) waitSync(app *v1alpha1.Application) {
 }
 
 func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newApp *v1alpha1.Application, merge bool) (*v1alpha1.Application, error) {
-	applicationPatch, err := diffBetweenApplicationSpecs(&app.Spec, &newApp.Spec)
+	applicationPatch, err := getApplicationPatch(app, newApp)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get application patch while updating app: %w", err)
 	}
 	for i := 0; i < 10; i++ {
 		app.Spec = newApp.Spec
@@ -1000,8 +1000,9 @@ func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newAp
 
 		res, err := s.appclientset.ArgoprojV1alpha1().Applications(app.Namespace).Update(ctx, app, metav1.UpdateOptions{})
 		if err == nil {
-			logFields := make(map[string]string)
-			logFields["patch"] = applicationPatch
+			logFields := map[string]any{
+				"patch": applicationPatch,
+			}
 			s.logAppEvent(ctx, app, argo.EventReasonResourceUpdated, "updated application spec", logFields)
 			s.waitSync(res)
 			return res, nil
@@ -1019,21 +1020,41 @@ func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newAp
 	return nil, status.Errorf(codes.Internal, "Failed to update application. Too many conflicts")
 }
 
-func diffBetweenApplicationSpecs(a *v1alpha1.ApplicationSpec, b *v1alpha1.ApplicationSpec) (string, error) {
+func getApplicationPatch(a, b *v1alpha1.Application) (map[string]any, error) {
+	applicationSpecPatch, err := jsonDiff(&a.Spec, &b.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get diff between Applications Spec: %w", err)
+	}
+	applicationMetadataPatch, err := jsonDiff(&a.ObjectMeta, &b.ObjectMeta)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get diff between Applications Metadata: %w", err)
+	}
+	applicationDiff := map[string]any{
+		"spec":     applicationSpecPatch,
+		"metadata": applicationMetadataPatch,
+	}
+	return applicationDiff, nil
+}
+
+func jsonDiff(a, b any) (map[string]any, error) {
 	aBytes, err := json.Marshal(a)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal application: %w", err)
+		return nil, fmt.Errorf("failed to marshal %T: %w", a, err)
 	}
 	bBytes, err := json.Marshal(b)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal application: %w", err)
+		return nil, fmt.Errorf("failed to marshal %T: %w", b, err)
 	}
 
 	patch, err := jsonpatch.CreateMergePatch(aBytes, bBytes)
 	if err != nil {
-		return "", fmt.Errorf("failed to create json diff between applications: %w", err)
+		return nil, fmt.Errorf("failed to create json diff between item %T and %T : %w", a, b, err)
 	}
-	return string(patch), nil
+	var patchDict map[string]any
+	if err := json.Unmarshal(patch, &patchDict); err != nil {
+		return nil, fmt.Errorf("failed to unmarshall the json diff between item %T and %T : %w", a, b, err)
+	}
+	return patchDict, nil
 }
 
 // Update updates an application
@@ -2432,7 +2453,7 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 	return nil, status.Errorf(codes.Internal, "Failed to terminate app. Too many conflicts")
 }
 
-func (s *Server) logAppEvent(ctx context.Context, a *v1alpha1.Application, reason string, action string, logFields map[string]string) {
+func (s *Server) logAppEvent(ctx context.Context, a *v1alpha1.Application, reason string, action string, logFields map[string]any) {
 	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
@@ -2441,7 +2462,7 @@ func (s *Server) logAppEvent(ctx context.Context, a *v1alpha1.Application, reaso
 	message := fmt.Sprintf("%s %s", user, action)
 
 	if logFields == nil {
-		logFields = make(map[string]string)
+		logFields = make(map[string]any)
 	}
 	eventLabels := argo.GetAppEventLabels(ctx, a, applisters.NewAppProjectLister(s.projInformer.GetIndexer()), s.ns, s.settingsMgr, s.db)
 	s.auditLogger.LogAppEvent(a, eventInfo, message, user, eventLabels, logFields)

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -374,7 +374,7 @@ func (s *Server) Create(ctx context.Context, q *application.ApplicationCreateReq
 
 	created, err := s.appclientset.ArgoprojV1alpha1().Applications(appNs).Create(ctx, a, metav1.CreateOptions{})
 	if err == nil {
-		s.logAppEvent(ctx, created, argo.EventReasonResourceCreated, "created application")
+		s.logAppEvent(ctx, created, argo.EventReasonResourceCreated, "created application", nil)
 		s.waitSync(created)
 		return created, nil
 	}
@@ -982,7 +982,7 @@ func (s *Server) waitSync(app *v1alpha1.Application) {
 }
 
 func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newApp *v1alpha1.Application, merge bool) (*v1alpha1.Application, error) {
-	diff, err := diffBetweenApplicationSpecs(&app.Spec, &newApp.Spec)
+	applicationPatch, err := diffBetweenApplicationSpecs(&app.Spec, &newApp.Spec)
 	if err != nil {
 		return nil, err
 	}
@@ -1000,7 +1000,9 @@ func (s *Server) updateApp(ctx context.Context, app *v1alpha1.Application, newAp
 
 		res, err := s.appclientset.ArgoprojV1alpha1().Applications(app.Namespace).Update(ctx, app, metav1.UpdateOptions{})
 		if err == nil {
-			s.logAppEvent(ctx, app, argo.EventReasonResourceUpdated, "updated application spec: "+diff)
+			logFields := make(map[string]string)
+			logFields["patch"] = applicationPatch
+			s.logAppEvent(ctx, app, argo.EventReasonResourceUpdated, "updated application spec", logFields)
 			s.waitSync(res)
 			return res, nil
 		}
@@ -1203,7 +1205,7 @@ func (s *Server) Delete(ctx context.Context, q *application.ApplicationDeleteReq
 	if err != nil {
 		return nil, fmt.Errorf("error deleting application: %w", err)
 	}
-	s.logAppEvent(ctx, a, argo.EventReasonResourceDeleted, "deleted application")
+	s.logAppEvent(ctx, a, argo.EventReasonResourceDeleted, "deleted application", nil)
 	return &application.ApplicationResponse{}, nil
 }
 
@@ -1534,7 +1536,8 @@ func (s *Server) PatchResource(ctx context.Context, q *application.ApplicationRe
 	if err != nil {
 		return nil, fmt.Errorf("erro marshaling manifest object: %w", err)
 	}
-	s.logAppEvent(ctx, a, argo.EventReasonResourceUpdated, fmt.Sprintf("patched resource %s/%s '%s'", q.GetGroup(), q.GetKind(), q.GetResourceName()))
+	message := fmt.Sprintf("patched resource %s/%s '%s'", q.GetGroup(), q.GetKind(), q.GetResourceName())
+	s.logAppEvent(ctx, a, argo.EventReasonResourceUpdated, message, nil)
 	m := string(data)
 	return &application.ApplicationResourceResponse{
 		Manifest: &m,
@@ -1574,7 +1577,8 @@ func (s *Server) DeleteResource(ctx context.Context, q *application.ApplicationR
 	if err != nil {
 		return nil, fmt.Errorf("error deleting resource: %w", err)
 	}
-	s.logAppEvent(ctx, a, argo.EventReasonResourceDeleted, fmt.Sprintf("deleted resource %s/%s '%s'", q.GetGroup(), q.GetKind(), q.GetResourceName()))
+	message := fmt.Sprintf("deleted resource %s/%s '%s'", q.GetGroup(), q.GetKind(), q.GetResourceName())
+	s.logAppEvent(ctx, a, argo.EventReasonResourceDeleted, message, nil)
 	return &application.ApplicationResponse{}, nil
 }
 
@@ -2111,16 +2115,16 @@ func (s *Server) Sync(ctx context.Context, syncReq *application.ApplicationSyncR
 	if len(syncReq.Resources) > 0 {
 		partial = "partial "
 	}
-	var reason string
+	var action string
 	if a.Spec.HasMultipleSources() {
-		reason = fmt.Sprintf("initiated %ssync to %s", partial, strings.Join(displayRevisions, ","))
+		action = fmt.Sprintf("initiated %ssync to %s", partial, strings.Join(displayRevisions, ","))
 	} else {
-		reason = fmt.Sprintf("initiated %ssync to %s", partial, displayRevision)
+		action = fmt.Sprintf("initiated %ssync to %s", partial, displayRevision)
 	}
 	if syncReq.Manifests != nil {
-		reason = fmt.Sprintf("initiated %ssync locally", partial)
+		action = fmt.Sprintf("initiated %ssync locally", partial)
 	}
-	s.logAppEvent(ctx, a, argo.EventReasonOperationStarted, reason)
+	s.logAppEvent(ctx, a, argo.EventReasonOperationStarted, action, nil)
 	return a, nil
 }
 
@@ -2223,7 +2227,8 @@ func (s *Server) Rollback(ctx context.Context, rollbackReq *application.Applicat
 	if err != nil {
 		return nil, fmt.Errorf("error setting app operation: %w", err)
 	}
-	s.logAppEvent(ctx, a, argo.EventReasonOperationStarted, fmt.Sprintf("initiated rollback to %d", rollbackReq.GetId()))
+	action := fmt.Sprintf("initiated rollback to %d", rollbackReq.GetId())
+	s.logAppEvent(ctx, a, argo.EventReasonOperationStarted, action, nil)
 	return a, nil
 }
 
@@ -2411,7 +2416,7 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 		updated, err := s.appclientset.ArgoprojV1alpha1().Applications(appNs).Update(ctx, a, metav1.UpdateOptions{})
 		if err == nil {
 			s.waitSync(updated)
-			s.logAppEvent(ctx, a, argo.EventReasonResourceUpdated, "terminated running operation")
+			s.logAppEvent(ctx, a, argo.EventReasonResourceUpdated, "terminated running operation", nil)
 			return &application.OperationTerminateResponse{}, nil
 		}
 		if !apierrors.IsConflict(err) {
@@ -2427,15 +2432,19 @@ func (s *Server) TerminateOperation(ctx context.Context, termOpReq *application.
 	return nil, status.Errorf(codes.Internal, "Failed to terminate app. Too many conflicts")
 }
 
-func (s *Server) logAppEvent(ctx context.Context, a *v1alpha1.Application, reason string, action string) {
+func (s *Server) logAppEvent(ctx context.Context, a *v1alpha1.Application, reason string, action string, logFields map[string]string) {
 	eventInfo := argo.EventInfo{Type: corev1.EventTypeNormal, Reason: reason}
 	user := session.Username(ctx)
 	if user == "" {
 		user = "Unknown user"
 	}
 	message := fmt.Sprintf("%s %s", user, action)
+
+	if logFields == nil {
+		logFields = make(map[string]string)
+	}
 	eventLabels := argo.GetAppEventLabels(ctx, a, applisters.NewAppProjectLister(s.projInformer.GetIndexer()), s.ns, s.settingsMgr, s.db)
-	s.auditLogger.LogAppEvent(a, eventInfo, message, user, eventLabels)
+	s.auditLogger.LogAppEvent(a, eventInfo, message, user, eventLabels, logFields)
 }
 
 func (s *Server) logResourceEvent(ctx context.Context, res *v1alpha1.ResourceNode, reason string, action string) {
@@ -2650,9 +2659,11 @@ func (s *Server) RunResourceActionV2(ctx context.Context, q *application.Resourc
 	}
 
 	if res == nil {
-		s.logAppEvent(ctx, a, argo.EventReasonResourceActionRan, "ran action "+q.GetAction())
+		action := "ran action " + q.GetAction()
+		s.logAppEvent(ctx, a, argo.EventReasonResourceActionRan, action, nil)
 	} else {
-		s.logAppEvent(ctx, a, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s on resource %s/%s/%s", q.GetAction(), res.Group, res.Kind, res.Name))
+		action := fmt.Sprintf("ran action %s on resource %s/%s/%s", q.GetAction(), res.Group, res.Kind, res.Name)
+		s.logAppEvent(ctx, a, argo.EventReasonResourceActionRan, action, nil)
 		s.logResourceEvent(ctx, res, argo.EventReasonResourceActionRan, "ran action "+q.GetAction())
 	}
 	return &application.ApplicationResponse{}, nil

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"io"
@@ -3849,7 +3850,8 @@ func TestServerSideDiff(t *testing.T) {
 	})
 }
 
-func TestDiffBetweenAppSpec(t *testing.T) {
+func TestGetApplicationPatch(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name         string
 		original     *v1alpha1.Application
@@ -3861,23 +3863,23 @@ func TestDiffBetweenAppSpec(t *testing.T) {
 			name:         "Test that identical apps show no difference",
 			original:     newTestApp(),
 			updated:      newTestApp(),
-			testMutation: func(original, updated *v1alpha1.Application) {},
-			expectedDiff: "{}",
+			testMutation: func(_, _ *v1alpha1.Application) {},
+			expectedDiff: "{\"metadata\": {}, \"spec\": {}}",
 		},
 		{
 			name:     "Test that targetRevision displays correctly",
 			original: newTestApp(),
 			updated:  newTestApp(),
-			testMutation: func(original, updated *v1alpha1.Application) {
+			testMutation: func(_, updated *v1alpha1.Application) {
 				updated.Spec.Source.TargetRevision = "BRANCH"
 			},
-			expectedDiff: "{\"source\":{\"targetRevision\":\"BRANCH\"}}",
+			expectedDiff: "{\"metadata\": {}, \"spec\": {\"source\":{\"targetRevision\":\"BRANCH\"}}}",
 		},
 		{
 			name:     "Test that Helm Parameters displays correctly",
 			original: newTestApp(),
 			updated:  newTestApp(),
-			testMutation: func(original, updated *v1alpha1.Application) {
+			testMutation: func(_, updated *v1alpha1.Application) {
 				updated.Spec.Source.Helm = &v1alpha1.ApplicationSourceHelm{
 					Parameters: []v1alpha1.HelmParameter{
 						{
@@ -3887,7 +3889,35 @@ func TestDiffBetweenAppSpec(t *testing.T) {
 					},
 				}
 			},
-			expectedDiff: "{\"source\":{\"helm\":{\"parameters\": [{\"name\": \"foo\", \"value\": \"bar\"}]}}}",
+			expectedDiff: "{\"metadata\": {}, \"spec\": {\"source\":{\"helm\":{\"parameters\": [{\"name\": \"foo\", \"value\": \"bar\"}]}}}}",
+		},
+		{
+			name:     "Test that Metadata updates displays correctly",
+			original: newTestApp(),
+			updated:  newTestApp(),
+			testMutation: func(_, updated *v1alpha1.Application) {
+				updated.SetAnnotations(map[string]string{"foo": "bar"})
+			},
+			expectedDiff: "{\"metadata\": {\"annotations\":{\"foo\": \"bar\"}}, \"spec\": {}}",
+		},
+		{
+			name:     "Test that Metadata removals displays correctly",
+			original: newTestApp(),
+			updated:  newTestApp(),
+			testMutation: func(original, _ *v1alpha1.Application) {
+				original.SetAnnotations(map[string]string{"foo": "bar"})
+			},
+			expectedDiff: "{\"metadata\": {\"annotations\": null}, \"spec\": {}}",
+		},
+		{
+			name:     "Test that Metadata partial removals displays correctly",
+			original: newTestApp(),
+			updated:  newTestApp(),
+			testMutation: func(original, modified *v1alpha1.Application) {
+				original.SetAnnotations(map[string]string{"foo": "bar", "baz": "foobar"})
+				modified.SetAnnotations(map[string]string{"foo": "bar"})
+			},
+			expectedDiff: "{\"metadata\": {\"annotations\": {\"baz\": null}}, \"spec\": {}}",
 		},
 	}
 	for _, tc := range testCases {
@@ -3895,9 +3925,12 @@ func TestDiffBetweenAppSpec(t *testing.T) {
 		t.Run(tcc.name, func(t *testing.T) {
 			t.Parallel()
 			tcc.testMutation(tcc.original, tcc.updated)
-			actualDiff, err := diffBetweenApplicationSpecs(&tcc.original.Spec, &tcc.updated.Spec)
+			diff, err := getApplicationPatch(tcc.original, tcc.updated)
 			require.NoError(t, err)
-			assert.JSONEq(t, tcc.expectedDiff, actualDiff)
+
+			actual, err := json.Marshal(diff)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tcc.expectedDiff), string(actual))
 		})
 	}
 }

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -3848,3 +3848,15 @@ func TestServerSideDiff(t *testing.T) {
 		assert.Contains(t, err.Error(), "application")
 	})
 }
+
+func TestDiffBetweenAppSpec(t *testing.T) {
+	original := newTestApp()
+	updated := newTestApp()
+
+	updated.Spec.Source.TargetRevision = "BRANCH"
+
+	expectedDiff := "{\"source\":{\"targetRevision\":\"BRANCH\"}}"
+	actualDiff, err := diffBetweenApplicationSpecs(&original.Spec, &updated.Spec)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedDiff, actualDiff)
+}

--- a/server/application/application_test.go
+++ b/server/application/application_test.go
@@ -3850,13 +3850,54 @@ func TestServerSideDiff(t *testing.T) {
 }
 
 func TestDiffBetweenAppSpec(t *testing.T) {
-	original := newTestApp()
-	updated := newTestApp()
-
-	updated.Spec.Source.TargetRevision = "BRANCH"
-
-	expectedDiff := "{\"source\":{\"targetRevision\":\"BRANCH\"}}"
-	actualDiff, err := diffBetweenApplicationSpecs(&original.Spec, &updated.Spec)
-	require.NoError(t, err)
-	assert.JSONEq(t, expectedDiff, actualDiff)
+	testCases := []struct {
+		name         string
+		original     *v1alpha1.Application
+		updated      *v1alpha1.Application
+		testMutation func(original, updated *v1alpha1.Application)
+		expectedDiff string
+	}{
+		{
+			name:         "Test that identical apps show no difference",
+			original:     newTestApp(),
+			updated:      newTestApp(),
+			testMutation: func(original, updated *v1alpha1.Application) {},
+			expectedDiff: "{}",
+		},
+		{
+			name:     "Test that targetRevision displays correctly",
+			original: newTestApp(),
+			updated:  newTestApp(),
+			testMutation: func(original, updated *v1alpha1.Application) {
+				updated.Spec.Source.TargetRevision = "BRANCH"
+			},
+			expectedDiff: "{\"source\":{\"targetRevision\":\"BRANCH\"}}",
+		},
+		{
+			name:     "Test that Helm Parameters displays correctly",
+			original: newTestApp(),
+			updated:  newTestApp(),
+			testMutation: func(original, updated *v1alpha1.Application) {
+				updated.Spec.Source.Helm = &v1alpha1.ApplicationSourceHelm{
+					Parameters: []v1alpha1.HelmParameter{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+					},
+				}
+			},
+			expectedDiff: "{\"source\":{\"helm\":{\"parameters\": [{\"name\": \"foo\", \"value\": \"bar\"}]}}}",
+		},
+	}
+	for _, tc := range testCases {
+		tcc := tc
+		t.Run(tcc.name, func(t *testing.T) {
+			t.Parallel()
+			tcc.testMutation(tcc.original, tcc.updated)
+			actualDiff, err := diffBetweenApplicationSpecs(&tcc.original.Spec, &tcc.updated.Spec)
+			require.NoError(t, err)
+			assert.JSONEq(t, tcc.expectedDiff, actualDiff)
+		})
+	}
 }

--- a/util/argo/audit_logger_test.go
+++ b/util/argo/audit_logger_test.go
@@ -106,7 +106,7 @@ func TestLogAppEvent(t *testing.T) {
 	}
 
 	output := captureLogEntries(func() {
-		logger.LogAppEvent(&app, ei, "This is a test message", "", nil)
+		logger.LogAppEvent(&app, ei, "This is a test message", "", nil, nil)
 	})
 
 	assert.Contains(t, output, "level=info")
@@ -121,7 +121,7 @@ func TestLogAppEvent(t *testing.T) {
 
 	// If K8s Event Disable Log
 	output = captureLogEntries(func() {
-		logger.LogAppEvent(&app, ei, "This is a test message", "", nil)
+		logger.LogAppEvent(&app, ei, "This is a test message", "", nil, nil)
 	})
 
 	assert.Empty(t, output)


### PR DESCRIPTION
When users update applications in the argocd ui, the audit log should be clear about what was changed in the application/applicationset. This change allows auditors to understand the difference in an update.

For example, if a user sets a helm parameter override, or points the application at a branch in the webui. Auditing should reflect that.

This information will not get included in the kubernetes event log, you can include very large differences in a `spec.source.helm.values` field, and it would clutter the kubernetes event log.

This change also adds logFields to the various calls to logAppEvent to allow future developers to add arbitrary contents to the audit logs.

Log Output (changed)
![image](https://github.com/user-attachments/assets/0140f0d0-982d-4f8b-b372-02b6b7938413)

Kubernetes Event Output (unchanged)
![image](https://github.com/user-attachments/assets/1ab1fafe-50d0-42b2-8a4e-7362751ada9e)
![image](https://github.com/user-attachments/assets/2b09e81e-6b9c-4052-a351-0e4c27b776c9)

Closes [ISSUE #23130]

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [x] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
